### PR TITLE
feat(docker): add `docker-compose` file to run CI locally

### DIFF
--- a/.github/workflows/ci-unit-tests-docker.yml
+++ b/.github/workflows/ci-unit-tests-docker.yml
@@ -137,7 +137,7 @@ jobs:
           NETWORK: ${{ inputs.network || vars.ZCASH_NETWORK }}
         run: |
           docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }}
-          docker run --tty -e NETWORK -e RUN_ALL_TESTS=1
+          docker run --tty -e NETWORK -e RUN_ALL_TESTS=1 ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }}
 
       # Run unit, basic acceptance tests, and ignored tests with experimental features.
       #
@@ -146,7 +146,7 @@ jobs:
           NETWORK: ${{ inputs.network || vars.ZCASH_NETWORK }}
         run: |
           docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }}
-          docker run --tty -e NETWORK -e RUN_ALL_EXPERIMENTAL_TESTS=1
+          docker run --tty -e NETWORK -e RUN_ALL_EXPERIMENTAL_TESTS=1 ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }}
 
   # Run state tests with fake activation heights.
   #
@@ -175,7 +175,7 @@ jobs:
           NETWORK: ${{ inputs.network || vars.ZCASH_NETWORK }}
         run: |
           docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }}
-          docker run --tty -e NETWORK -e TEST_FAKE_ACTIVATION_HEIGHTS=1
+          docker run --tty -e NETWORK -e TEST_FAKE_ACTIVATION_HEIGHTS=1 ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }}
 
   # Test that Zebra syncs and checkpoints a few thousand blocks from an empty state.
   test-empty-sync:
@@ -196,7 +196,7 @@ jobs:
           NETWORK: ${{ inputs.network || vars.ZCASH_NETWORK }}
         run: |
           docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }}
-          docker run --tty -e NETWORK -e ENTRYPOINT_FEATURES -e TEST_ZEBRA_EMPTY_SYNC=1
+          docker run --tty -e NETWORK -e ENTRYPOINT_FEATURES -e TEST_ZEBRA_EMPTY_SYNC=1 ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }}
 
   # Test launching lightwalletd with an empty lightwalletd and Zebra state.
   test-lightwalletd-integration:
@@ -217,7 +217,7 @@ jobs:
           NETWORK: ${{ inputs.network || vars.ZCASH_NETWORK }}
         run: |
           docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }}
-          docker run --tty -e NETWORK -e ZEBRA_TEST_LIGHTWALLETD=1
+          docker run --tty -e NETWORK -e ZEBRA_TEST_LIGHTWALLETD=1 ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }}
 
   # Test that Zebra works using the default config with the latest Zebra version.
   test-configuration-file:

--- a/.github/workflows/ci-unit-tests-docker.yml
+++ b/.github/workflows/ci-unit-tests-docker.yml
@@ -82,9 +82,6 @@ on:
       - '.github/workflows/sub-build-docker-image.yml'
 
 env:
-  # We need to combine the features manually because some tests don't use the Docker entrypoint
-  TEST_FEATURES: ${{ format('{0} {1}', vars.RUST_PROD_FEATURES, vars.RUST_TEST_FEATURES) }}
-  EXPERIMENTAL_FEATURES: ${{ format('{0} {1} {2}', vars.RUST_PROD_FEATURES, vars.RUST_TEST_FEATURES, vars.RUST_EXPERIMENTAL_FEATURES) }}
   RUST_LOG: ${{ vars.RUST_LOG }}
   RUST_BACKTRACE: ${{ vars.RUST_BACKTRACE }}
   RUST_LIB_BACKTRACE: ${{ vars.RUST_LIB_BACKTRACE }}
@@ -135,27 +132,21 @@ jobs:
       #
       # If some tests hang, add "-- --nocapture" for just that test, or for all the tests.
       #
-      # TODO: move this test command into entrypoint.sh
       - name: Run zebrad tests
         env:
           NETWORK: ${{ inputs.network || vars.ZCASH_NETWORK }}
         run: |
           docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }}
-          docker run -e NETWORK --name zebrad-tests --tty ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }} cargo test --locked --release --features "${{ env.TEST_FEATURES }}" --workspace -- --include-ignored
+          docker run --tty -e NETWORK -e RUN_ALL_TESTS=1
 
       # Run unit, basic acceptance tests, and ignored tests with experimental features.
       #
-      # TODO: move this test command into entrypoint.sh
       - name: Run zebrad tests with experimental features
         env:
           NETWORK: ${{ inputs.network || vars.ZCASH_NETWORK }}
         run: |
-          # GitHub doesn't allow empty variables
-          if [[ -n "${{ vars.RUST_EXPERIMENTAL_FEATURES }}" && "${{ vars.RUST_EXPERIMENTAL_FEATURES }}" != " " ]]; then
-            docker run -e NETWORK --name zebrad-tests-experimental --tty ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }} cargo test --locked --release --features "${{ env.EXPERIMENTAL_FEATURES }} " --workspace -- --include-ignored
-          else
-            echo "Experimental builds are disabled, set RUST_EXPERIMENTAL_FEATURES in GitHub actions variables to enable them"
-          fi
+          docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }}
+          docker run --tty -e NETWORK -e RUN_ALL_EXPERIMENTAL_TESTS=1
 
   # Run state tests with fake activation heights.
   #
@@ -179,15 +170,12 @@ jobs:
         with:
           short-length: 7
 
-      # TODO: move this test command into entrypoint.sh
-      #       make sure that at least one test runs, and that it doesn't skip itself due to the environmental variable
       - name: Run tests with fake activation heights
+        env:
+          NETWORK: ${{ inputs.network || vars.ZCASH_NETWORK }}
         run: |
           docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }}
-          docker run -e NETWORK -e TEST_FAKE_ACTIVATION_HEIGHTS --name zebrad-tests -t ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }} cargo test --locked --release --features "zebra-test" --package zebra-state --lib -- --nocapture --include-ignored with_fake_activation_heights
-        env:
-          TEST_FAKE_ACTIVATION_HEIGHTS: '1'
-          NETWORK: ${{ inputs.network || vars.ZCASH_NETWORK }}
+          docker run --tty -e NETWORK -e TEST_FAKE_ACTIVATION_HEIGHTS=1
 
   # Test that Zebra syncs and checkpoints a few thousand blocks from an empty state.
   test-empty-sync:
@@ -203,13 +191,12 @@ jobs:
         with:
           short-length: 7
 
-      # TODO: move this test command into entrypoint.sh
       - name: Run zebrad large sync tests
-        run: |
-          docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }}
-          docker run -e NETWORK --name zebrad-tests -t ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }} cargo test --locked --release --features "${{ env.TEST_FEATURES }}" --package zebrad --test acceptance -- --nocapture --include-ignored sync_large_checkpoints_
         env:
           NETWORK: ${{ inputs.network || vars.ZCASH_NETWORK }}
+        run: |
+          docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }}
+          docker run --tty -e NETWORK -e ENTRYPOINT_FEATURES -e TEST_ZEBRA_EMPTY_SYNC=1
 
   # Test launching lightwalletd with an empty lightwalletd and Zebra state.
   test-lightwalletd-integration:
@@ -225,14 +212,12 @@ jobs:
         with:
           short-length: 7
 
-      # TODO: move this test command into entrypoint.sh
       - name: Run tests with empty lightwalletd launch
+        env:
+          NETWORK: ${{ inputs.network || vars.ZCASH_NETWORK }}
         run: |
           docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }}
-          docker run -e NETWORK -e ZEBRA_TEST_LIGHTWALLETD --name lightwalletd-tests -t ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }} cargo test --locked --release --features "${{ env.TEST_FEATURES }}" --package zebrad --test acceptance -- --nocapture --include-ignored lightwalletd_integration
-        env:
-          ZEBRA_TEST_LIGHTWALLETD: '1'
-          NETWORK: ${{ inputs.network || vars.ZCASH_NETWORK }}
+          docker run --tty -e NETWORK -e ZEBRA_TEST_LIGHTWALLETD=1
 
   # Test that Zebra works using the default config with the latest Zebra version.
   test-configuration-file:

--- a/.github/workflows/ci-unit-tests-docker.yml
+++ b/.github/workflows/ci-unit-tests-docker.yml
@@ -196,7 +196,7 @@ jobs:
           NETWORK: ${{ inputs.network || vars.ZCASH_NETWORK }}
         run: |
           docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }}
-          docker run --tty -e NETWORK -e ENTRYPOINT_FEATURES -e TEST_ZEBRA_EMPTY_SYNC=1 ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }}
+          docker run --tty -e NETWORK -e TEST_ZEBRA_EMPTY_SYNC=1 ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ needs.build.outputs.image_digest }}
 
   # Test launching lightwalletd with an empty lightwalletd and Zebra state.
   test-lightwalletd-integration:

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -30,6 +30,36 @@ See [Building Zebra](https://github.com/ZcashFoundation/zebra#building-zebra) fo
 
 You're able to specify various parameters when building or launching the Docker image, which are meant to be used by developers and CI pipelines. For example, specifying the Network where Zebra will run (Mainnet, Testnet, etc), or enabling features like metrics with Prometheus.
 
+For example, if we'd like to enable metrics on the image, we'd build it using the following `build-arg`:
+
+```shell
+docker build -f ./docker/Dockerfile --target runtime --build-arg FEATURES='default-release-binaries prometheus' --tag local/zebra.mining:latest .
+```
+
+To increase the log output we can optionally add these `build-arg`s:
+
+```shell
+--build-arg RUST_BACKTRACE=full --build-arg RUST_LOG=debug --build-arg COLORBT_SHOW_HIDDEN=1
+```
+
+And after our image has been built, we can run it on `Mainnet` with the following command, which will expose the metrics endpoint on port `9999` and force the logs to be colored:
+
+```shell
+docker run --env LOG_COLOR="true" -p 9999:9999 local/zebra.mining
+```
+
+Based on our actual `entrypoint.sh` script, the following configuration file will be generated (on the fly, at startup) and used by Zebra:
+
+```toml
+[network]
+network = "Mainnet"
+listen_addr = "0.0.0.0"
+[state]
+cache_dir = "/var/cache/zebrad-cache"
+[metrics]
+endpoint_addr = "127.0.0.1:9999"
+```
+
 > [!WARNING]
 > To fully use and display the metrics, you'll need to run a Prometheus and Grafana server, and configure it to scrape and visualize the metrics endpoint. This is explained in more detailed in the [Metrics](https://zebra.zfnd.org/user/metrics.html#zebra-metrics) section of the User Guide.
 

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -32,6 +32,9 @@ You're able to specify various parameters when building or launching the Docker 
 
 For example, if we'd like to enable metrics on the image, we'd build it using the following `build-arg`:
 
+> [!WARNING]
+> To fully use and display the metrics, you'll need to run a Prometheus and Grafana server, and configure it to scrape and visualize the metrics endpoint. This is explained in more detailed in the [Metrics](https://zebra.zfnd.org/user/metrics.html#zebra-metrics) section of the User Guide.
+
 ```shell
 docker build -f ./docker/Dockerfile --target runtime --build-arg FEATURES='default-release-binaries prometheus' --tag local/zebra.mining:latest .
 ```
@@ -59,9 +62,6 @@ cache_dir = "/var/cache/zebrad-cache"
 [metrics]
 endpoint_addr = "127.0.0.1:9999"
 ```
-
-> [!WARNING]
-> To fully use and display the metrics, you'll need to run a Prometheus and Grafana server, and configure it to scrape and visualize the metrics endpoint. This is explained in more detailed in the [Metrics](https://zebra.zfnd.org/user/metrics.html#zebra-metrics) section of the User Guide.
 
 ### CI/CD Local Testing
 
@@ -98,8 +98,13 @@ This approach ensures you can run the same tests locally that are run in CI, pro
 
 #### Build Time Arguments
 
+#### Configuration
+
 - `FEATURES`: Specifies the features to build `zebrad` with. Example: `"default-release-binaries getblocktemplate-rpcs"`
 - `TEST_FEATURES`: Specifies the features for tests. Example: `"lightwalletd-grpc-tests zebra-checkpoints"`
+
+#### Logging
+
 - `RUST_LOG`: Sets the trace log level. Example: `"debug"`
 - `RUST_BACKTRACE`: Enables or disables backtraces. Example: `"full"`
 - `RUST_LIB_BACKTRACE`: Enables or disables library backtraces. Example: `1`
@@ -110,8 +115,6 @@ This approach ensures you can run the same tests locally that are run in CI, pro
 - `TEST_FEATURES`: Specifies the features for tests. Example: `"lightwalletd-grpc-tests zebra-checkpoints"`
 - `ZEBRA_SKIP_IPV6_TESTS`: Skips IPv6 tests. Example: `1`
 - `ENTRYPOINT_FEATURES`: Overrides the specific features used to run tests in `entrypoint.sh`. Example: `"default-release-binaries lightwalletd-grpc-tests"`
-
-Specific tests are defined in `docker/test.env` file and can be enabled by setting the corresponding environment variable to `1`.
 
 #### CI/CD
 
@@ -141,6 +144,8 @@ Specific tests are defined in `docker/test.env` file and can be enabled by setti
 - `LOG_COLOR`: Enables or disables log color. Example: `false`
 - `TRACING_ENDPOINT_ADDR`: Address for tracing endpoint. Example: `"0.0.0.0"`
 - `TRACING_ENDPOINT_PORT`: Port for tracing endpoint. Example: `3000`
+
+Specific tests are defined in `docker/test.env` file and can be enabled by setting the corresponding environment variable to `1`.
 
 ## Registries
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -143,7 +143,7 @@ RUN chmod u+x /entrypoint.sh
 # Entrypoint environment variables
 ENV ENTRYPOINT_FEATURES=${ENTRYPOINT_FEATURES}
 # We repeat the ARGs here, so they are available in the entrypoint.sh script for $RUN_ALL_EXPERIMENTAL_TESTS
-ARG EXPERIMENTAL_FEATURES="elasticsearch journald prometheus filter-reload"
+ARG EXPERIMENTAL_FEATURES="shielded-scan journald prometheus filter-reload"
 ENV ENTRYPOINT_FEATURES_EXPERIMENTAL="${ENTRYPOINT_FEATURES} ${EXPERIMENTAL_FEATURES}"
 
 # By default, runs the entrypoint tests specified by the environmental variables (if any are set)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@
 # Keep these argument defaults in sync with GitHub vars.RUST_PROD_FEATURES and vars.RUST_TEST_FEATURES
 # https://github.com/ZcashFoundation/zebra/settings/variables/actions
 ARG FEATURES="default-release-binaries"
-ARG TEST_FEATURES="lightwalletd-grpc-tests zebra-checkpoints shielded-scan"
+ARG TEST_FEATURES="lightwalletd-grpc-tests zebra-checkpoints"
 ARG EXPERIMENTAL_FEATURES=""
 
 # This stage implements cargo-chef for docker layer caching
@@ -114,7 +114,7 @@ ARG FEATURES
 ARG TEST_FEATURES
 ARG EXPERIMENTAL_FEATURES
 # ${EXPERIMENTAL_FEATURES} is empty, so this is equivalent to ${FEATURES} ${TEST_FEATURES} by default
-ARG ENTRYPOINT_FEATURES="${FEATURES} ${TEST_FEATURES} ${EXPERIMENTAL_FEATURES}"
+ARG ENTRYPOINT_FEATURES="${FEATURES} ${TEST_FEATURES}"
 
 # Re-hydrate the minimum project skeleton identified by `cargo chef prepare` in the planner stage,
 # over the top of the original source files,
@@ -125,7 +125,6 @@ ARG ENTRYPOINT_FEATURES="${FEATURES} ${TEST_FEATURES} ${EXPERIMENTAL_FEATURES}"
 #
 # TODO: add --locked when cargo-chef supports it
 RUN cargo chef cook --tests --release --features "${ENTRYPOINT_FEATURES}" --workspace --recipe-path recipe.json
-
 # Undo the source file changes made by cargo-chef.
 # rsync invalidates the cargo cache for the changed files only, by updating their timestamps.
 # This makes sure the fake empty binaries created by cargo-chef are rebuilt.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -113,7 +113,7 @@ ENV ZEBRA_SKIP_IPV6_TESTS=${ZEBRA_SKIP_IPV6_TESTS:-1}
 ARG FEATURES
 ARG TEST_FEATURES
 ARG EXPERIMENTAL_FEATURES
-# ${EXPERIMENTAL_FEATURES} is empty, so this is equivalent to ${FEATURES} ${TEST_FEATURES} by default
+# TODO: add empty $EXPERIMENTAL_FEATURES when we can avoid adding an extra space to the end of the string
 ARG ENTRYPOINT_FEATURES="${FEATURES} ${TEST_FEATURES}"
 
 # Re-hydrate the minimum project skeleton identified by `cargo chef prepare` in the planner stage,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,8 @@
 # Keep these argument defaults in sync with GitHub vars.RUST_PROD_FEATURES and vars.RUST_TEST_FEATURES
 # https://github.com/ZcashFoundation/zebra/settings/variables/actions
 ARG FEATURES="default-release-binaries"
-ARG TEST_FEATURES="lightwalletd-grpc-tests zebra-checkpoints"
+ARG TEST_FEATURES="lightwalletd-grpc-tests zebra-checkpoints shielded-scan"
+ARG EXPERIMENTAL_FEATURES=""
 
 # This stage implements cargo-chef for docker layer caching
 FROM rust:bullseye as chef
@@ -111,7 +112,9 @@ ENV ZEBRA_SKIP_IPV6_TESTS=${ZEBRA_SKIP_IPV6_TESTS:-1}
 # separately from the test and production image builds.
 ARG FEATURES
 ARG TEST_FEATURES
-ARG ENTRYPOINT_FEATURES="${FEATURES} ${TEST_FEATURES}"
+ARG EXPERIMENTAL_FEATURES
+# ${EXPERIMENTAL_FEATURES} is empty, so this is equivalent to ${FEATURES} ${TEST_FEATURES} by default
+ARG ENTRYPOINT_FEATURES="${FEATURES} ${TEST_FEATURES} ${EXPERIMENTAL_FEATURES}"
 
 # Re-hydrate the minimum project skeleton identified by `cargo chef prepare` in the planner stage,
 # over the top of the original source files,
@@ -140,6 +143,9 @@ RUN chmod u+x /entrypoint.sh
 
 # Entrypoint environment variables
 ENV ENTRYPOINT_FEATURES=${ENTRYPOINT_FEATURES}
+# We repeat the ARGs here, so they are available in the entrypoint.sh script for $RUN_ALL_EXPERIMENTAL_TESTS
+ARG EXPERIMENTAL_FEATURES="elasticsearch journald prometheus filter-reload"
+ENV ENTRYPOINT_FEATURES_EXPERIMENTAL="${ENTRYPOINT_FEATURES} ${EXPERIMENTAL_FEATURES}"
 
 # By default, runs the entrypoint tests specified by the environmental variables (if any are set)
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -12,7 +12,7 @@ services:
         reservations:
           cpus: "4"
           memory: 16G
-    # Change this to the commmand you want to run, respecting the entrypoint.sh
+    # Change this to the command you want to run, respecting the entrypoint.sh
     # For example, to run the tests, use the following command:
     # command: ["cargo", "test", "--locked", "--release", "--features", "${TEST_FEATURES}", "--package", "zebrad", "--test", "acceptance", "--", "--nocapture", "--include-ignored", "sync_large_checkpoints_"]
     volumes:
@@ -23,6 +23,8 @@ services:
       - "8232:8232" # Opens an RPC endpoint (for wallet storing and mining)
       - "8233:8233" # Mainnet Network (for peer connections)
       - "18233:18233" # Testnet Network
+      # - "9999:9999" # Metrics
+      # - "3000:3000" # Tracing
     env_file:
       - test.env
 

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -23,8 +23,6 @@ services:
       - "8232:8232" # Opens an RPC endpoint (for wallet storing and mining)
       - "8233:8233" # Mainnet Network (for peer connections)
       - "18233:18233" # Testnet Network
-      # - "9999:9999" # Metrics
-      # - "3000:3000" # Tracing
     env_file:
       - test.env
 

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,0 +1,36 @@
+version: "3.8"
+
+services:
+  zebra:
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile
+      target: tests
+    restart: unless-stopped
+    deploy:
+      resources:
+        reservations:
+          cpus: "4"
+          memory: 16G
+    # Change this to the commmand you want to run, respecting the entrypoint.sh
+    # For example, to run the tests, use the following command:
+    # command: ["cargo", "test", "--locked", "--release", "--features", "${TEST_FEATURES}", "--package", "zebrad", "--test", "acceptance", "--", "--nocapture", "--include-ignored", "sync_large_checkpoints_"]
+    volumes:
+      - zebrad-cache:/var/cache/zebrad-cache
+      - lwd-cache:/var/cache/lwd-cache
+    ports:
+      # Zebra uses the following inbound and outbound TCP ports
+      - "8232:8232" # Opens an RPC endpoint (for wallet storing and mining)
+      - "8233:8233" # Mainnet Network (for peer connections)
+      - "18233:18233" # Testnet Network
+      # - "9999:9999" # Metrics
+      # - "3000:3000" # Tracing
+    env_file:
+      - test.env
+
+volumes:
+  zebrad-cache:
+    driver: local
+
+  lwd-cache:
+    driver: local

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -58,6 +58,9 @@ fi
 ####
 
 : "${RUN_ALL_TESTS:=}"
+: "${RUN_ALL_EXPERIMENTAL_TESTS:=}"
+: "${TEST_FAKE_ACTIVATION_HEIGHTS:=}"
+: "${TEST_ZEBRA_EMPTY_SYNC:=}"
 : "${ZEBRA_TEST_LIGHTWALLETD:=}"
 : "${FULL_SYNC_MAINNET_TIMEOUT_MINUTES:=}"
 : "${FULL_SYNC_TESTNET_TIMEOUT_MINUTES:=}"
@@ -220,12 +223,27 @@ case "$1" in
       # For these tests, we activate the test features to avoid recompiling `zebrad`,
       # but we don't actually run any gRPC tests.
       if [[ "${RUN_ALL_TESTS}" -eq "1" ]]; then
-          # Run all the available tests for the current environment.
-          # If the lightwalletd environmental variables are set, we will also run those tests.
-          exec cargo test --locked --release --features "${ENTRYPOINT_FEATURES}" --workspace -- --nocapture --include-ignored
+        # Run unit, basic acceptance tests, and ignored tests, only showing command output if the test fails.
+        # If the lightwalletd environmental variables are set, we will also run those tests.
+        exec cargo test --locked --release --features "${ENTRYPOINT_FEATURES}" --workspace -- --nocapture --include-ignored
 
-      # For these tests, we activate the gRPC feature to avoid recompiling `zebrad`,
-      # but we don't actually run any gRPC tests.
+      elif [[ "${RUN_ALL_EXPERIMENTAL_TESTS}" -eq "1" ]]; then
+        # Run unit, basic acceptance tests, and ignored tests with experimental features.
+        # If the lightwalletd environmental variables are set, we will also run those tests.
+        exec cargo test --locked --release --features "${ENTRYPOINT_FEATURES_EXPERIMENTAL}" --workspace -- --nocapture --include-ignored
+
+      elif [[ "${TEST_FAKE_ACTIVATION_HEIGHTS}" -eq "1" ]]; then
+        # Run state tests with fake activation heights.
+        exec cargo test --locked --release --features "zebra-test" --package zebra-state --lib -- --nocapture --include-ignored with_fake_activation_heights
+
+      elif [[ "${TEST_ZEBRA_EMPTY_SYNC}" -eq "1" ]]; then
+        # Test that Zebra syncs and checkpoints a few thousand blocks from an empty state.
+        run_cargo_test "${ENTRYPOINT_FEATURES}" "sync_large_checkpoints_"
+
+      elif [[ "${ZEBRA_TEST_LIGHTWALLETD}" -eq "1" ]]; then
+        # Test launching lightwalletd with an empty lightwalletd and Zebra state.
+        run_cargo_test "${ENTRYPOINT_FEATURES}" "lightwalletd_integration"
+
       elif [[ -n "${FULL_SYNC_MAINNET_TIMEOUT_MINUTES}" ]]; then
         # Run a Zebra full sync test on mainnet.
         run_cargo_test "${ENTRYPOINT_FEATURES}" "full_sync_mainnet"

--- a/docker/test.env
+++ b/docker/test.env
@@ -1,5 +1,7 @@
+RUST_LOG=info
 # This variable forces the use of color in the logs
 ZEBRA_FORCE_USE_COLOR=1
+LOG_COLOR=true
 
 ###
 # Configuration Variables

--- a/docker/test.env
+++ b/docker/test.env
@@ -1,0 +1,68 @@
+# This variable forces the use of color in the logs
+ZEBRA_FORCE_USE_COLOR=1
+
+###
+# Configuration Variables
+# These variables are used to configure the zebra node
+# Check the entrypoint.sh script for more details
+###
+
+# Path and name of the config file. These two have defaults set in the Dockerfile.
+ZEBRA_CONF_PATH=/etc/zebrad/zebrad.toml
+# [network]
+NETWORK=Mainnet
+ZEBRA_LISTEN_ADDR=0.0.0.0
+# [consensus]
+ZEBRA_CHECKPOINT_SYNC=true
+# [state]
+# Set this to change the default cached state directory
+ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache
+LIGHTWALLETD_DATA_DIR=/var/cache/lwd-cache
+# [metrics]
+METRICS_ENDPOINT_ADDR=0.0.0.0
+METRICS_ENDPOINT_PORT=9999
+# [tracing]
+LOG_COLOR=false
+TRACING_ENDPOINT_ADDR=0.0.0.0
+TRACING_ENDPOINT_PORT=3000
+# [rpc]
+RPC_LISTEN_ADDR=0.0.0.0
+# if ${RPC_PORT} is not set, it will use the default value for the current network
+# RPC_PORT=
+
+####
+# Test Variables
+# These variables are used to run tests in the Dockerfile
+# Check the entrypoint.sh script for more details
+####
+
+# Unit tests
+# TODO: These variables are evaluated to any value, even setting a NULL value will evaluate to true
+# TEST_FAKE_ACTIVATION_HEIGHTS=
+# ZEBRA_SKIP_NETWORK_TESTS
+# ZEBRA_SKIP_IPV6_TESTS
+RUN_ALL_TESTS=
+RUN_ALL_EXPERIMENTAL_TESTS=
+TEST_ZEBRA_EMPTY_SYNC=
+ZEBRA_TEST_LIGHTWALLETD=
+# Integration Tests
+# Most of these tests require a cached state directory to save the network state
+TEST_DISK_REBUILD=
+# These tests needs a Zebra cached state
+TEST_CHECKPOINT_SYNC=
+GENERATE_CHECKPOINTS_MAINNET=
+GENERATE_CHECKPOINTS_TESTNET=
+TEST_UPDATE_SYNC=
+# These tests need a Lightwalletd binary + a Zebra cached state
+TEST_LWD_RPC_CALL=
+TEST_GET_BLOCK_TEMPLATE=
+TEST_SUBMIT_BLOCK=
+# These tests need a Lightwalletd binary + Lightwalletd cached state + a Zebra cached state
+TEST_LWD_UPDATE_SYNC=
+TEST_LWD_GRPC=
+TEST_LWD_TRANSACTIONS=
+# Full sync tests
+# These tests could take a long time to run, depending on the network
+FULL_SYNC_MAINNET_TIMEOUT_MINUTES=
+FULL_SYNC_TESTNET_TIMEOUT_MINUTES=
+TEST_LWD_FULL_SYNC=


### PR DESCRIPTION
## Motivation

We'd like to allow developers to run CI locally easily, using a similar approach to how we run it in our GitHub Actions, but without having to remember each specific command needed to run a specific test.

This would allow developers to confirm if an issue is specific to GitHub or GCP, or if it also reflects locally, and allow them to debug it easier.

Fixes #4464 
Fixes #7534
This sets the ground for #8023


_What are the most important goals of the ticket or PR?_


### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [ X ] Will the PR name make sense to users?
  - [ X ] Does the PR have a priority label?
  - [ X ] Have you added or updated tests?
  - [ X ] Is the documentation up to date?

##### For significant changes:
  - [ ] Is there a summary in the CHANGELOG?
  - [ ] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

### Complex Code or Requirements

- Needs docker-compose https://docs.docker.com/compose/install/ 

## Solution

- Create a `docker-compose.test.yml` which can be used to run tests with a simple command
- Add a `test.env` file to avoid adding all these variables to the compose file.
- Create documentation on how to use CI locally


### Testing

- Run at least one test locally following the provided documentation


## Review

The whole @ZcashFoundation/devops-reviewers should at least try this.


### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
