### PR TITLE
add(scan): Implement `DeleteKeys` `ScanService` request

### DIFF
--- a/zebra-node-services/src/scan_service/request.rs
+++ b/zebra-node-services/src/scan_service/request.rs
@@ -13,7 +13,7 @@ pub enum Request {
     RegisterKeys(Vec<()>),
 
     /// TODO: Accept `KeyHash`es and return Ok(`Vec<KeyHash>`) with hashes of deleted keys
-    DeleteKeys(Vec<()>),
+    DeleteKeys(Vec<String>),
 
     /// TODO: Accept `KeyHash`es and return `Transaction`s
     Results(Vec<()>),

--- a/zebra-node-services/src/scan_service/request.rs
+++ b/zebra-node-services/src/scan_service/request.rs
@@ -12,7 +12,7 @@ pub enum Request {
     /// TODO: Accept `ViewingKeyWithHash`es and return Ok(()) if successful or an error
     RegisterKeys(Vec<()>),
 
-    /// TODO: Accept `KeyHash`es and return Ok(`Vec<KeyHash>`) with hashes of deleted keys
+    /// Deletes viewing keys and their results from the database.
     DeleteKeys(Vec<String>),
 
     /// TODO: Accept `KeyHash`es and return `Transaction`s

--- a/zebra-node-services/src/scan_service/response.rs
+++ b/zebra-node-services/src/scan_service/response.rs
@@ -17,9 +17,7 @@ pub enum Response {
     Results(Vec<Transaction>),
 
     /// Response to DeleteKeys request
-    ///
-    /// Includes the keys that were removed from the database.
-    DeletedKeys(Vec<String>),
+    DeletedKeys,
 
     /// Response to SubscribeResults request
     SubscribeResults(mpsc::Receiver<Arc<Transaction>>),

--- a/zebra-node-services/src/scan_service/response.rs
+++ b/zebra-node-services/src/scan_service/response.rs
@@ -16,6 +16,11 @@ pub enum Response {
     /// Response to Results request
     Results(Vec<Transaction>),
 
+    /// Response to DeleteKeys request
+    ///
+    /// Includes the keys that were removed from the database.
+    DeletedKeys(Vec<String>),
+
     /// Response to SubscribeResults request
     SubscribeResults(mpsc::Receiver<Arc<Transaction>>),
 }

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["cryptography::cryptocurrencies"]
 [[bin]] # Bin to run the Scanner gRPC server
 name = "scanner-grpc-server"
 path = "src/bin/rpc_server.rs"
+required-features = ["proptest-impl"]
 
 [features]
 

--- a/zebra-scan/src/bin/rpc_server.rs
+++ b/zebra-scan/src/bin/rpc_server.rs
@@ -2,15 +2,16 @@
 
 use tower::ServiceBuilder;
 
-use zebra_scan::service::ScanService;
+use zebra_scan::{service::ScanService, storage::Storage};
 
 #[tokio::main]
 /// Runs an RPC server with a mock ScanTask
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (config, network) = Default::default();
-    let scan_service = ServiceBuilder::new()
-        .buffer(10)
-        .service(ScanService::new_with_mock_scanner(&config, network));
+
+    let (scan_service, _cmd_receiver) =
+        ScanService::new_with_mock_scanner(Storage::new(&config, network, false));
+    let scan_service = ServiceBuilder::new().buffer(10).service(scan_service);
 
     // Start the gRPC server.
     zebra_grpc::server::init(scan_service).await?;

--- a/zebra-scan/src/init.rs
+++ b/zebra-scan/src/init.rs
@@ -1,9 +1,6 @@
 //! Initializing the scanner.
 
-use std::sync::{
-    mpsc::{self, Receiver},
-    Arc,
-};
+use std::sync::{mpsc, Arc};
 
 use color_eyre::Report;
 use tokio::{sync::oneshot, task::JoinHandle};
@@ -52,7 +49,7 @@ pub struct ScanTask {
 impl ScanTask {
     /// Spawns a new [`ScanTask`] for tests.
     #[cfg(any(test, feature = "proptest-impl"))]
-    pub fn mock() -> (Self, Receiver<ScanTaskCommand>) {
+    pub fn mock() -> (Self, mpsc::Receiver<ScanTaskCommand>) {
         let (cmd_sender, cmd_receiver) = mpsc::channel();
 
         (

--- a/zebra-scan/src/init.rs
+++ b/zebra-scan/src/init.rs
@@ -51,6 +51,7 @@ pub struct ScanTask {
 
 impl ScanTask {
     /// Spawns a new [`ScanTask`] for tests.
+    #[cfg(any(test, feature = "proptest-impl"))]
     pub fn mock() -> (Self, Receiver<ScanTaskCommand>) {
         let (cmd_sender, cmd_receiver) = mpsc::channel();
 

--- a/zebra-scan/src/init.rs
+++ b/zebra-scan/src/init.rs
@@ -93,7 +93,7 @@ impl ScanTask {
         self.cmd_sender.send(command)
     }
 
-    /// Sends a command to the scan task
+    /// Sends a message to the scan task to remove the provided viewing keys.
     pub fn remove_keys(
         &mut self,
         keys: &[String],

--- a/zebra-scan/src/init.rs
+++ b/zebra-scan/src/init.rs
@@ -1,7 +1,7 @@
 //! Initializing the scanner.
 
 use std::sync::{
-    mpsc::{self},
+    mpsc::{self, Receiver},
     Arc,
 };
 
@@ -51,13 +51,16 @@ pub struct ScanTask {
 
 impl ScanTask {
     /// Spawns a new [`ScanTask`] for tests.
-    pub fn mock() -> Self {
-        let (cmd_sender, _cmd_receiver) = mpsc::channel();
+    pub fn mock() -> (Self, Receiver<ScanTaskCommand>) {
+        let (cmd_sender, cmd_receiver) = mpsc::channel();
 
-        Self {
-            handle: Arc::new(tokio::spawn(std::future::pending())),
-            cmd_sender,
-        }
+        (
+            Self {
+                handle: Arc::new(tokio::spawn(std::future::pending())),
+                cmd_sender,
+            },
+            cmd_receiver,
+        )
     }
 
     /// Spawns a new [`ScanTask`].

--- a/zebra-scan/src/init.rs
+++ b/zebra-scan/src/init.rs
@@ -106,18 +106,6 @@ impl ScanTask {
     }
 }
 
-/// Initialize the scanner based on its config, and spawn a task for it.
-///
-/// TODO: add a test for this function.
-pub fn spawn_init(
-    config: &Config,
-    network: Network,
-    state: scan::State,
-    chain_tip_change: ChainTipChange,
-) -> ScanTask {
-    ScanTask::spawn(config, network, state, chain_tip_change)
-}
-
 /// Initialize [`ScanService`] based on its config.
 ///
 /// TODO: add a test for this function.

--- a/zebra-scan/src/init.rs
+++ b/zebra-scan/src/init.rs
@@ -71,7 +71,6 @@ impl ScanTask {
         state: scan::State,
         chain_tip_change: ChainTipChange,
     ) -> Self {
-        // TODO: Pass `_cmd_receiver` to `scan::start()` to pass it new keys after it's been spawned
         let (cmd_sender, cmd_receiver) = mpsc::channel();
 
         Self {

--- a/zebra-scan/src/lib.rs
+++ b/zebra-scan/src/lib.rs
@@ -19,4 +19,4 @@ pub mod service;
 pub mod tests;
 
 pub use config::Config;
-pub use init::{init, spawn_init};
+pub use init::{init, ScanTask};

--- a/zebra-scan/src/scan.rs
+++ b/zebra-scan/src/scan.rs
@@ -126,6 +126,8 @@ pub async fn start(
 
             match cmd {
                 ScanTaskCommand::RemoveKeys { done_tx, keys } => {
+                    // TODO: Replace with Arc::unwrap_or_clone() when it stabilises:
+                    // https://github.com/rust-lang/rust/issues/93610
                     let mut updated_parsed_keys =
                         Arc::try_unwrap(parsed_keys).unwrap_or_else(|arc| (*arc).clone());
 

--- a/zebra-scan/src/scan.rs
+++ b/zebra-scan/src/scan.rs
@@ -2,7 +2,10 @@
 
 use std::{
     collections::{BTreeMap, HashMap},
-    sync::Arc,
+    sync::{
+        mpsc::{Receiver, TryRecvError},
+        Arc,
+    },
     time::Duration,
 };
 
@@ -37,6 +40,7 @@ use zebra_chain::{
 use zebra_state::{ChainTipChange, SaplingScannedResult, TransactionIndex};
 
 use crate::{
+    init::ScanTaskCommand,
     storage::{SaplingScanningKey, Storage},
     Config,
 };
@@ -66,6 +70,7 @@ pub async fn start(
     state: State,
     chain_tip_change: ChainTipChange,
     storage: Storage,
+    cmd_receiver: Receiver<ScanTaskCommand>,
 ) -> Result<(), Report> {
     let network = storage.network();
     let sapling_activation_height = storage.min_sapling_birthday_height();
@@ -102,12 +107,42 @@ pub async fn start(
             Ok::<_, Report>((key.clone(), parsed_keys))
         })
         .try_collect()?;
-    let parsed_keys = Arc::new(parsed_keys);
+    let mut parsed_keys = Arc::new(parsed_keys);
 
     // Give empty states time to verify some blocks before we start scanning.
     tokio::time::sleep(INITIAL_WAIT).await;
 
     loop {
+        loop {
+            let cmd = match cmd_receiver.try_recv() {
+                Ok(cmd) => cmd,
+
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => {
+                    // Return early if the sender has been dropped.
+                    return Err(eyre!("command channel disconnected"));
+                }
+            };
+
+            match cmd {
+                ScanTaskCommand::RemoveKeys { done_tx, keys } => {
+                    let mut updated_parsed_keys =
+                        Arc::try_unwrap(parsed_keys).unwrap_or_else(|arc| (*arc).clone());
+
+                    for key in keys {
+                        updated_parsed_keys.remove(&key);
+                    }
+
+                    parsed_keys = Arc::new(updated_parsed_keys);
+
+                    // Ignore send errors for the done notification
+                    let _ = done_tx.send(());
+                }
+
+                _ => continue,
+            }
+        }
+
         let scanned_height = scan_height_and_store_results(
             height,
             state.clone(),
@@ -445,11 +480,12 @@ pub fn spawn_init(
     network: Network,
     state: State,
     chain_tip_change: ChainTipChange,
+    cmd_receiver: Receiver<ScanTaskCommand>,
 ) -> JoinHandle<Result<(), Report>> {
     let config = config.clone();
 
     // TODO: spawn an entirely new executor here, to avoid timing attacks.
-    tokio::spawn(init(config, network, state, chain_tip_change).in_current_span())
+    tokio::spawn(init(config, network, state, chain_tip_change, cmd_receiver).in_current_span())
 }
 
 /// Initialize the scanner based on its config.
@@ -460,11 +496,12 @@ pub async fn init(
     network: Network,
     state: State,
     chain_tip_change: ChainTipChange,
+    cmd_receiver: Receiver<ScanTaskCommand>,
 ) -> Result<(), Report> {
     let storage = tokio::task::spawn_blocking(move || Storage::new(&config, network, false))
         .wait_for_panics()
         .await;
 
     // TODO: add more tasks here?
-    start(state, chain_tip_change, storage).await
+    start(state, chain_tip_change, storage, cmd_receiver).await
 }

--- a/zebra-scan/src/service.rs
+++ b/zebra-scan/src/service.rs
@@ -1,6 +1,6 @@
 //! [`tower::Service`] for zebra-scan.
 
-use std::{future::Future, pin::Pin, sync::mpsc::Receiver, task::Poll, time::Duration};
+use std::{future::Future, pin::Pin, task::Poll, time::Duration};
 
 use futures::future::FutureExt;
 use tower::Service;
@@ -8,12 +8,7 @@ use tower::Service;
 use zebra_chain::parameters::Network;
 use zebra_state::ChainTipChange;
 
-use crate::{
-    init::{ScanTask, ScanTaskCommand},
-    scan,
-    storage::Storage,
-    Config, Request, Response,
-};
+use crate::{init::ScanTask, scan, storage::Storage, Config, Request, Response};
 
 #[cfg(test)]
 mod tests;
@@ -50,7 +45,12 @@ impl ScanService {
 
     /// Create a new [`ScanService`] with a mock `ScanTask`
     #[cfg(any(test, feature = "proptest-impl"))]
-    pub fn new_with_mock_scanner(db: Storage) -> (Self, Receiver<ScanTaskCommand>) {
+    pub fn new_with_mock_scanner(
+        db: Storage,
+    ) -> (
+        Self,
+        std::sync::mpsc::Receiver<crate::init::ScanTaskCommand>,
+    ) {
         let (scan_task, cmd_receiver) = ScanTask::mock();
         (Self { db, scan_task }, cmd_receiver)
     }

--- a/zebra-scan/src/service.rs
+++ b/zebra-scan/src/service.rs
@@ -46,6 +46,7 @@ impl ScanService {
     }
 
     /// Create a new [`ScanService`] with a mock `ScanTask`
+    #[cfg(any(test, feature = "proptest-impl"))]
     pub fn new_with_mock_scanner(db: Storage) -> (Self, Receiver<ScanTaskCommand>) {
         let (scan_task, cmd_receiver) = ScanTask::mock();
         (Self { db, scan_task }, cmd_receiver)

--- a/zebra-scan/src/service.rs
+++ b/zebra-scan/src/service.rs
@@ -90,15 +90,14 @@ impl Service<Request> for ScanService {
 
                 return async move {
                     scan_task.remove_keys(&keys)?.await?;
-                    db.delete_sapling_results(&keys);
 
-                    Ok(Response::DeletedKeys(keys))
+                    tokio::task::spawn_blocking(move || {
+                        db.delete_sapling_results(keys);
+                    });
+
+                    Ok(Response::DeletedKeys)
                 }
                 .boxed();
-
-                // TODO:
-                //  - delete these keys and their results from db
-                //  - send deleted keys to scan task
             }
 
             Request::Results(_key_hashes) => {

--- a/zebra-scan/src/service.rs
+++ b/zebra-scan/src/service.rs
@@ -84,7 +84,18 @@ impl Service<Request> for ScanService {
                 //  - send new keys to scan task
             }
 
-            Request::DeleteKeys(_key_hashes) => {
+            Request::DeleteKeys(keys) => {
+                let mut db = self.db.clone();
+                let mut scan_task = self.scan_task.clone();
+
+                return async move {
+                    scan_task.remove_keys(&keys)?.await?;
+                    db.delete_sapling_results(&keys);
+
+                    Ok(Response::DeletedKeys(keys))
+                }
+                .boxed();
+
                 // TODO:
                 //  - delete these keys and their results from db
                 //  - send deleted keys to scan task

--- a/zebra-scan/src/service/tests.rs
+++ b/zebra-scan/src/service/tests.rs
@@ -47,10 +47,13 @@ pub async fn scan_service_deletes_keys_correctly() -> Result<()> {
         .map_err(|err| eyre!(err))?
         .call(Request::DeleteKeys(vec![zec_pages_sapling_efvk.clone()]));
 
+    let expected_keys = vec![zec_pages_sapling_efvk.clone()];
     let cmd_handler_fut = tokio::task::spawn_blocking(move || {
-        let Ok(ScanTaskCommand::RemoveKeys { done_tx, .. }) = cmd_receiver.recv() else {
+        let Ok(ScanTaskCommand::RemoveKeys { done_tx, keys }) = cmd_receiver.recv() else {
             panic!("should successfully receive RemoveKeys message");
         };
+
+        assert_eq!(keys, expected_keys, "keys should match the request keys");
 
         done_tx.send(()).expect("send should succeed");
     });

--- a/zebra-scan/src/service/tests.rs
+++ b/zebra-scan/src/service/tests.rs
@@ -1,0 +1,76 @@
+//! Tests for ScanService.
+
+use tower::{Service, ServiceExt};
+
+use color_eyre::{eyre::eyre, Result};
+
+use zebra_chain::{block::Height, parameters::Network};
+use zebra_node_services::scan_service::{request::Request, response::Response};
+use zebra_state::TransactionIndex;
+
+use crate::{
+    init::ScanTaskCommand,
+    service::ScanService,
+    storage::db::tests::{fake_sapling_results, new_test_storage},
+    tests::ZECPAGES_SAPLING_VIEWING_KEY,
+};
+
+/// Tests that keys are deleted correctly
+#[tokio::test]
+pub async fn scan_service_deletes_keys_correctly() -> Result<()> {
+    let mut db = new_test_storage(Network::Mainnet);
+
+    let zec_pages_sapling_efvk = ZECPAGES_SAPLING_VIEWING_KEY.to_string();
+
+    for fake_result_height in [Height::MIN, Height(1), Height::MAX] {
+        db.insert_sapling_results(
+            &zec_pages_sapling_efvk,
+            fake_result_height,
+            fake_sapling_results([
+                TransactionIndex::MIN,
+                TransactionIndex::from_index(40),
+                TransactionIndex::MAX,
+            ]),
+        );
+    }
+
+    assert!(
+        !db.sapling_results(&zec_pages_sapling_efvk).is_empty(),
+        "there should be some results for this key in the db"
+    );
+
+    let (mut scan_service, cmd_receiver) = ScanService::new_with_mock_scanner(db);
+
+    let response_fut = scan_service
+        .ready()
+        .await
+        .map_err(|err| eyre!(err))?
+        .call(Request::DeleteKeys(vec![zec_pages_sapling_efvk.clone()]));
+
+    let cmd_handler_fut = tokio::task::spawn_blocking(move || {
+        let Ok(ScanTaskCommand::RemoveKeys { done_tx, .. }) = cmd_receiver.recv() else {
+            panic!("should successfully receive RemoveKeys message");
+        };
+
+        done_tx.send(()).expect("send should succeed");
+    });
+
+    // Poll futures
+    let (response, join_result) = tokio::join!(response_fut, cmd_handler_fut);
+    join_result?;
+
+    match response.map_err(|err| eyre!(err))? {
+        Response::DeletedKeys => {}
+        _ => panic!("scan service returned unexpected response variant"),
+    };
+
+    assert!(
+        scan_service
+            .db
+            .sapling_results(&zec_pages_sapling_efvk)
+            .is_empty(),
+        "all results for this key should have been deleted"
+    );
+
+    Ok(())
+}

--- a/zebra-scan/src/storage/db/sapling.rs
+++ b/zebra-scan/src/storage/db/sapling.rs
@@ -233,6 +233,24 @@ impl Storage {
             .write_batch()
             .expect("unexpected database write failure");
     }
+
+    pub(crate) fn delete_sapling_results(&mut self, keys: &[String]) {
+        let mut batch = self.sapling_tx_ids_cf().new_batch_for_writing();
+
+        for key in keys {
+            batch = batch.zs_delete_range(
+                &SaplingScannedDatabaseIndex::min_for_key(key),
+                // Note: It's okay to exclude the last index because the representation for block heights
+                //       should always be larger than expected block heights. The current Height::MAX is >2B,
+                //       and can be updated once the chain gets close to that height.
+                &SaplingScannedDatabaseIndex::max_for_key(key),
+            );
+        }
+
+        batch
+            .write_batch()
+            .expect("unexpected database write failure");
+    }
 }
 
 /// Utility trait for inserting sapling heights into a WriteSaplingTxIdsBatch.

--- a/zebra-scan/src/storage/db/tests.rs
+++ b/zebra-scan/src/storage/db/tests.rs
@@ -6,8 +6,9 @@ use zebra_chain::{
     block::{Block, Height},
     parameters::Network::{self, *},
     serialization::ZcashDeserializeInto,
+    transaction,
 };
-use zebra_state::TransactionIndex;
+use zebra_state::{SaplingScannedResult, TransactionIndex};
 
 use crate::{
     storage::{Storage, INSERT_CONTROL_INTERVAL},
@@ -76,4 +77,20 @@ pub fn add_fake_results(
                 .collect(),
         );
     }
+}
+
+/// Accepts an iterator of [`TransactionIndex`]es and returns a `BTreeMap` with empty results
+pub fn fake_sapling_results<T: IntoIterator<Item = TransactionIndex>>(
+    transaction_indexes: T,
+) -> BTreeMap<TransactionIndex, SaplingScannedResult> {
+    let mut fake_sapling_results = BTreeMap::new();
+
+    for transaction_index in transaction_indexes {
+        fake_sapling_results.insert(
+            transaction_index,
+            SaplingScannedResult::from(transaction::Hash::from([0; 32])),
+        );
+    }
+
+    fake_sapling_results
 }

--- a/zebra-scan/src/storage/db/tests.rs
+++ b/zebra-scan/src/storage/db/tests.rs
@@ -18,6 +18,9 @@ use crate::{
 #[cfg(test)]
 mod snapshot;
 
+#[cfg(test)]
+mod vectors;
+
 /// Returns an empty `Storage` suitable for testing.
 pub fn new_test_storage(network: Network) -> Storage {
     Storage::new(&Config::ephemeral(), network, false)

--- a/zebra-scan/src/storage/db/tests/vectors.rs
+++ b/zebra-scan/src/storage/db/tests/vectors.rs
@@ -1,11 +1,12 @@
 //! Fixed test vectors for the scanner Storage.
 
-use std::collections::BTreeMap;
+use zebra_chain::{block::Height, parameters::Network};
+use zebra_state::TransactionIndex;
 
-use zebra_chain::{block::Height, parameters::Network, transaction};
-use zebra_state::{SaplingScannedResult, TransactionIndex};
-
-use crate::{storage::db::tests::new_test_storage, tests::ZECPAGES_SAPLING_VIEWING_KEY};
+use crate::{
+    storage::db::tests::{fake_sapling_results, new_test_storage},
+    tests::ZECPAGES_SAPLING_VIEWING_KEY,
+};
 
 /// Tests that keys are deleted correctly
 #[test]
@@ -15,24 +16,14 @@ pub fn deletes_keys_and_results_correctly() {
     let zec_pages_sapling_efvk = ZECPAGES_SAPLING_VIEWING_KEY.to_string();
 
     for fake_result_height in [Height::MIN, Height(1), Height::MAX] {
-        let mut fake_sapling_results: BTreeMap<TransactionIndex, SaplingScannedResult> =
-            BTreeMap::new();
-        for transaction_index in [
-            TransactionIndex::MIN,
-            TransactionIndex::from_index(40),
-            TransactionIndex::MAX,
-        ] {
-            let fake_transaction_id = [0; 32];
-            fake_sapling_results.insert(
-                transaction_index,
-                SaplingScannedResult::from(transaction::Hash::from(fake_transaction_id)),
-            );
-        }
-
         db.insert_sapling_results(
             &zec_pages_sapling_efvk,
             fake_result_height,
-            fake_sapling_results,
+            fake_sapling_results([
+                TransactionIndex::MIN,
+                TransactionIndex::from_index(40),
+                TransactionIndex::MAX,
+            ]),
         );
     }
 

--- a/zebra-scan/src/storage/db/tests/vectors.rs
+++ b/zebra-scan/src/storage/db/tests/vectors.rs
@@ -1,0 +1,50 @@
+//! Fixed test vectors for the scanner Storage.
+
+use std::collections::BTreeMap;
+
+use zebra_chain::{block::Height, parameters::Network, transaction};
+use zebra_state::{SaplingScannedResult, TransactionIndex};
+
+use crate::{storage::db::tests::new_test_storage, tests::ZECPAGES_SAPLING_VIEWING_KEY};
+
+/// Tests that keys are deleted correctly
+#[test]
+pub fn deletes_keys_and_results_correctly() {
+    let mut db = new_test_storage(Network::Mainnet);
+
+    let zec_pages_sapling_efvk = ZECPAGES_SAPLING_VIEWING_KEY.to_string();
+
+    for fake_result_height in [Height::MIN, Height(1), Height::MAX] {
+        let mut fake_sapling_results: BTreeMap<TransactionIndex, SaplingScannedResult> =
+            BTreeMap::new();
+        for transaction_index in [
+            TransactionIndex::MIN,
+            TransactionIndex::from_index(40),
+            TransactionIndex::MAX,
+        ] {
+            let fake_transaction_id = [0; 32];
+            fake_sapling_results.insert(
+                transaction_index,
+                SaplingScannedResult::from(transaction::Hash::from(fake_transaction_id)),
+            );
+        }
+
+        db.insert_sapling_results(
+            &zec_pages_sapling_efvk,
+            fake_result_height,
+            fake_sapling_results,
+        );
+    }
+
+    assert!(
+        !db.sapling_results(&zec_pages_sapling_efvk).is_empty(),
+        "there should be some results for this key in the db"
+    );
+
+    db.delete_sapling_results(vec![zec_pages_sapling_efvk.clone()]);
+
+    assert!(
+        db.sapling_results(&zec_pages_sapling_efvk).is_empty(),
+        "all results for this key should have been deleted"
+    );
+}

--- a/zebra-scan/src/storage/db/tests/vectors.rs
+++ b/zebra-scan/src/storage/db/tests/vectors.rs
@@ -15,27 +15,39 @@ pub fn deletes_keys_and_results_correctly() {
 
     let zec_pages_sapling_efvk = ZECPAGES_SAPLING_VIEWING_KEY.to_string();
 
-    for fake_result_height in [Height::MIN, Height(1), Height::MAX] {
-        db.insert_sapling_results(
-            &zec_pages_sapling_efvk,
-            fake_result_height,
-            fake_sapling_results([
-                TransactionIndex::MIN,
-                TransactionIndex::from_index(40),
-                TransactionIndex::MAX,
-            ]),
-        );
+    // Replace the last letter of the zec_pages efvk
+    let fake_efvk = format!(
+        "{}t",
+        &ZECPAGES_SAPLING_VIEWING_KEY[..ZECPAGES_SAPLING_VIEWING_KEY.len() - 1]
+    );
+
+    let efvks = [&zec_pages_sapling_efvk, &fake_efvk];
+
+    for efvk in efvks {
+        for fake_result_height in [Height::MIN, Height(1), Height::MAX] {
+            db.insert_sapling_results(
+                efvk,
+                fake_result_height,
+                fake_sapling_results([
+                    TransactionIndex::MIN,
+                    TransactionIndex::from_index(40),
+                    TransactionIndex::MAX,
+                ]),
+            );
+        }
     }
 
-    assert!(
-        !db.sapling_results(&zec_pages_sapling_efvk).is_empty(),
-        "there should be some results for this key in the db"
-    );
+    for efvk in efvks {
+        assert!(
+            !db.sapling_results(efvk).is_empty(),
+            "there should be some results for this key in the db"
+        );
 
-    db.delete_sapling_results(vec![zec_pages_sapling_efvk.clone()]);
+        db.delete_sapling_results(vec![efvk.clone()]);
 
-    assert!(
-        db.sapling_results(&zec_pages_sapling_efvk).is_empty(),
-        "all results for this key should have been deleted"
-    );
+        assert!(
+            db.sapling_results(efvk).is_empty(),
+            "all results for this key should have been deleted"
+        );
+    }
 }

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -305,7 +305,7 @@ impl StartCmd {
             if !config.shielded_scan.sapling_keys_to_scan.is_empty() {
                 // TODO: log the number of keys and update the scan_task_starts() test
                 info!("spawning shielded scanner with configured viewing keys");
-                let scan_task = zebra_scan::spawn_init(
+                let scan_task = zebra_scan::ScanTask::spawn(
                     &config.shielded_scan,
                     config.network.network,
                     state,

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -312,7 +312,11 @@ impl StartCmd {
                     chain_tip_change,
                 );
 
-                (scan_task.handle, Some(scan_task.cmd_sender))
+                (
+                    std::sync::Arc::into_inner(scan_task.handle)
+                        .expect("should only have one reference here"),
+                    Some(scan_task.cmd_sender),
+                )
             } else {
                 (tokio::spawn(std::future::pending().in_current_span()), None)
             };

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -301,18 +301,21 @@ impl StartCmd {
 
         #[cfg(feature = "shielded-scan")]
         // Spawn never ending scan task only if we have keys to scan for.
-        let scan_task_handle = if !config.shielded_scan.sapling_keys_to_scan.is_empty() {
-            // TODO: log the number of keys and update the scan_task_starts() test
-            info!("spawning shielded scanner with configured viewing keys");
-            zebra_scan::spawn_init(
-                &config.shielded_scan,
-                config.network.network,
-                state,
-                chain_tip_change,
-            )
-        } else {
-            tokio::spawn(std::future::pending().in_current_span())
-        };
+        let (scan_task_handle, _cmd_sender) =
+            if !config.shielded_scan.sapling_keys_to_scan.is_empty() {
+                // TODO: log the number of keys and update the scan_task_starts() test
+                info!("spawning shielded scanner with configured viewing keys");
+                let scan_task = zebra_scan::spawn_init(
+                    &config.shielded_scan,
+                    config.network.network,
+                    state,
+                    chain_tip_change,
+                );
+
+                (scan_task.handle, Some(scan_task.cmd_sender))
+            } else {
+                (tokio::spawn(std::future::pending().in_current_span()), None)
+            };
 
         #[cfg(not(feature = "shielded-scan"))]
         // Spawn a dummy scan task which doesn't do anything and never finishes.


### PR DESCRIPTION
## Motivation

This PR implements the `DeleteKeys` request for `ScanService` to:
- drop keys from the scanner task
- delete keys and their results from the database

Closes #8204.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Updates request/response variant types
- Adds a new argument to `scan::start()` for the scan task channel receiver
- Adds `ScanTask::remove_keys()` method for sending a `RemoveKeys` message
- Adds `ScanTask::process_msgs()` and calls it from the loop in `scan::start()`
- Adds a `delete_sapling_keys()` method to `Storage`
- Calls `remove_keys()` and `delete_sapling_keys()` from the `ScanService` match arm for `Request::DeleteKeys`

### Testing

- Tests that the new `Storage::delete_sapling_results()` method deletes all results for a provided key
- Tests that the ScanService sends a message to the `ScanTask` to remove the keys and that it deletes the results before responding

## Review

Anyone can review. 

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

- Add a test for `ScanTask::process_msgs()`
