### PR TITLE
fix(ci): Uses lightwalletd v0.4.16 in tests

### DIFF
--- a/.github/workflows/sub-build-lightwalletd.yml
+++ b/.github/workflows/sub-build-lightwalletd.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           # Note: check service.proto when modifying lightwalletd repo
           repository: zcash/lightwalletd
-          ref: 'master'
+          ref: 'v0.4.16'
           persist-credentials: false
 
       - uses: actions/checkout@v4.1.1


### PR DESCRIPTION
## Motivation

This PR is meant to fix the lightwalletd build issue in CI: https://github.com/ZcashFoundation/zebra/actions/runs/7787452464/job/21234637136?pr=8230#step:11:689

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Builds lightwalletd v0.4.16 instead of the latest code on master

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._