### PR TITLE
add(scan): Add `ClearResults` and `DeleteKeys` gRPC methods

### DIFF
--- a/zebra-grpc/proto/scanner.proto
+++ b/zebra-grpc/proto/scanner.proto
@@ -8,8 +8,12 @@ service Scanner {
     // Get information about the scanner service.
     rpc GetInfo (Empty) returns (InfoReply);
 
+    // Clear results for a set of keys without removing the keys from the scanner.
+    // This request does not stop the scanner from scanning blocks for these keys, it
+    // only clears past results.
     rpc ClearResults(ClearResultsRequest) returns (Empty);
 
+    // Deletes a set of keys and their results from the scanner
     rpc DeleteKeys(DeleteKeysRequest) returns (Empty);
 }
 
@@ -19,10 +23,14 @@ message InfoReply {
     uint32 min_sapling_birthday_height = 1;
 }
 
+// A request for clearing past results from the scanner cache.
 message ClearResultsRequest {
+    // Keys for which to clear results.
     repeated string keys = 1;
 }
 
+// A request to delete keys, delete their results, and stop scanning for their results.
 message DeleteKeysRequest {
+    // Keys to delete from scanner.
     repeated string keys = 1;
 }

--- a/zebra-grpc/proto/scanner.proto
+++ b/zebra-grpc/proto/scanner.proto
@@ -9,6 +9,8 @@ service Scanner {
     rpc GetInfo (Empty) returns (InfoReply);
 
     rpc ClearResults(ClearResultsRequest) returns (Empty);
+
+    rpc DeleteKeys(DeleteKeysRequest) returns (Empty);
 }
 
 // A response to a GetInfo call.
@@ -18,5 +20,9 @@ message InfoReply {
 }
 
 message ClearResultsRequest {
+    repeated string keys = 1;
+}
+
+message DeleteKeysRequest {
     repeated string keys = 1;
 }

--- a/zebra-grpc/proto/scanner.proto
+++ b/zebra-grpc/proto/scanner.proto
@@ -7,10 +7,16 @@ message Empty {}
 service Scanner {
     // Get information about the scanner service.
     rpc GetInfo (Empty) returns (InfoReply);
+
+    rpc ClearResults(ClearResultsRequest) returns (Empty);
 }
 
 // A response to a GetInfo call.
 message InfoReply {
     // The minimum sapling height allowed.
     uint32 min_sapling_birthday_height = 1;
+}
+
+message ClearResultsRequest {
+    repeated string keys = 1;
 }

--- a/zebra-grpc/proto/scanner.proto
+++ b/zebra-grpc/proto/scanner.proto
@@ -13,7 +13,8 @@ service Scanner {
     // only clears past results.
     rpc ClearResults(ClearResultsRequest) returns (Empty);
 
-    // Deletes a set of keys and their results from the scanner
+    // Deletes a set of keys and their results from the scanner.
+    // This request stop the scanner from scanning blocks for the these keys.
     rpc DeleteKeys(DeleteKeysRequest) returns (Empty);
 }
 

--- a/zebra-grpc/src/server.rs
+++ b/zebra-grpc/src/server.rs
@@ -75,7 +75,7 @@ where
         let keys = request.into_inner().keys;
 
         if keys.is_empty() {
-            let msg = "must provide the keys for which to clear results";
+            let msg = "must provide at least 1 key for which to clear results";
             return Err(Status::invalid_argument(msg));
         }
 
@@ -102,7 +102,7 @@ where
         let keys = request.into_inner().keys;
 
         if keys.is_empty() {
-            let msg = "must provide the keys for which to clear results";
+            let msg = "must provide at least 1 key to delete";
             return Err(Status::invalid_argument(msg));
         }
 


### PR DESCRIPTION
## Motivation

We want to clear results and delete keys in zebra-scan via gRPC requests.

Closes #8235

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Adds the gRPC methods to the proto definition
- Implements the methods on `ScannerRPC` to call the `ScanService`

### Testing

These methods still need tests, but they're thin wrappers around scan service requests that do have tests.

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

- Add tests to `zebra-grpc`