### PR TITLE
add(scan): Start scanner gRPC server with `zebrad`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6064,6 +6064,7 @@ dependencies = [
  "vergen",
  "zebra-chain",
  "zebra-consensus",
+ "zebra-grpc",
  "zebra-network",
  "zebra-node-services",
  "zebra-rpc",

--- a/zebra-grpc/proto/scanner.proto
+++ b/zebra-grpc/proto/scanner.proto
@@ -8,8 +8,12 @@ service Scanner {
     // Get information about the scanner service.
     rpc GetInfo (Empty) returns (InfoReply);
 
+    // Clear results for a set of keys without removing the keys from the scanner.
+    // This request does not stop the scanner from scanning blocks for these keys, it
+    // only clears past results.
     rpc ClearResults(ClearResultsRequest) returns (Empty);
 
+    // Deletes a set of keys and their results from the scanner
     rpc DeleteKeys(DeleteKeysRequest) returns (Empty);
 }
 
@@ -19,10 +23,14 @@ message InfoReply {
     uint32 min_sapling_birthday_height = 1;
 }
 
+// A request for clearing past results from the scanner cache.
 message ClearResultsRequest {
+    // Keys for which to clear results.
     repeated string keys = 1;
 }
 
+// A request to delete keys, delete their results, and stop scanning for their results.
 message DeleteKeysRequest {
+    // Keys to delete from scanner.
     repeated string keys = 1;
 }

--- a/zebra-grpc/proto/scanner.proto
+++ b/zebra-grpc/proto/scanner.proto
@@ -9,6 +9,8 @@ service Scanner {
     rpc GetInfo (Empty) returns (InfoReply);
 
     rpc ClearResults(ClearResultsRequest) returns (Empty);
+
+    rpc DeleteKeys(DeleteKeysRequest) returns (Empty);
 }
 
 // A response to a GetInfo call.
@@ -18,5 +20,9 @@ message InfoReply {
 }
 
 message ClearResultsRequest {
+    repeated string keys = 1;
+}
+
+message DeleteKeysRequest {
     repeated string keys = 1;
 }

--- a/zebra-grpc/proto/scanner.proto
+++ b/zebra-grpc/proto/scanner.proto
@@ -7,10 +7,16 @@ message Empty {}
 service Scanner {
     // Get information about the scanner service.
     rpc GetInfo (Empty) returns (InfoReply);
+
+    rpc ClearResults(ClearResultsRequest) returns (Empty);
 }
 
 // A response to a GetInfo call.
 message InfoReply {
     // The minimum sapling height allowed.
     uint32 min_sapling_birthday_height = 1;
+}
+
+message ClearResultsRequest {
+    repeated string keys = 1;
 }

--- a/zebra-grpc/proto/scanner.proto
+++ b/zebra-grpc/proto/scanner.proto
@@ -13,7 +13,8 @@ service Scanner {
     // only clears past results.
     rpc ClearResults(ClearResultsRequest) returns (Empty);
 
-    // Deletes a set of keys and their results from the scanner
+    // Deletes a set of keys and their results from the scanner.
+    // This request stop the scanner from scanning blocks for the these keys.
     rpc DeleteKeys(DeleteKeysRequest) returns (Empty);
 }
 

--- a/zebra-grpc/src/lib.rs
+++ b/zebra-grpc/src/lib.rs
@@ -5,3 +5,8 @@
 #![doc(html_root_url = "https://docs.rs/zebra_grpc")]
 
 pub mod server;
+
+/// The generated scanner proto
+pub mod scanner {
+    tonic::include_proto!("scanner");
+}

--- a/zebra-grpc/src/server.rs
+++ b/zebra-grpc/src/server.rs
@@ -4,17 +4,14 @@ use futures_util::future::TryFutureExt;
 use tonic::{transport::Server, Response, Status};
 use tower::ServiceExt;
 
-use scanner::scanner_server::{Scanner, ScannerServer};
-use scanner::{ClearResultsRequest, DeleteKeysRequest, Empty, InfoReply};
-
 use zebra_node_services::scan_service::{
     request::Request as ScanServiceRequest, response::Response as ScanServiceResponse,
 };
 
-/// The generated scanner proto
-pub mod scanner {
-    tonic::include_proto!("scanner");
-}
+use crate::scanner::{
+    scanner_server::{Scanner, ScannerServer},
+    ClearResultsRequest, DeleteKeysRequest, Empty, InfoReply,
+};
 
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
@@ -61,7 +58,7 @@ where
             ));
         };
 
-        let reply = scanner::InfoReply {
+        let reply = InfoReply {
             min_sapling_birthday_height: min_sapling_birthday_height.0,
         };
 

--- a/zebra-grpc/src/server.rs
+++ b/zebra-grpc/src/server.rs
@@ -75,7 +75,7 @@ where
         let keys = request.into_inner().keys;
 
         if keys.is_empty() {
-            let msg = "must provide the keys for which to clear results";
+            let msg = "must provide at least 1 key for which to clear results";
             return Err(Status::invalid_argument(msg));
         }
 
@@ -102,7 +102,7 @@ where
         let keys = request.into_inner().keys;
 
         if keys.is_empty() {
-            let msg = "must provide the keys for which to clear results";
+            let msg = "must provide at least 1 key to delete";
             return Err(Status::invalid_argument(msg));
         }
 

--- a/zebra-scan/src/bin/rpc_server.rs
+++ b/zebra-scan/src/bin/rpc_server.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let scan_service = ServiceBuilder::new().buffer(10).service(scan_service);
 
     // Start the gRPC server.
-    zebra_grpc::server::init(scan_service).await?;
+    zebra_grpc::server::init("127.0.0.1:8231".parse()?, scan_service).await?;
 
     Ok(())
 }

--- a/zebra-scan/src/config.rs
+++ b/zebra-scan/src/config.rs
@@ -41,6 +41,8 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             sapling_keys_to_scan: IndexMap::new(),
+
+            // TODO: Add a const generic for specifying the default cache_dir path, like 'zebra' or 'zebra-scan'?
             db_config: DbConfig::default(),
         }
     }

--- a/zebra-scan/src/config.rs
+++ b/zebra-scan/src/config.rs
@@ -29,7 +29,7 @@ pub struct Config {
     /// listen_addr = '127.0.0.1:8231'
     /// ```
     ///
-    /// The recommended ports for the RPC server are:
+    /// The recommended ports for the gRPC server are:
     /// - Mainnet: 127.0.0.1:8231
     /// - Testnet: 127.0.0.1:18231
     pub listen_addr: Option<SocketAddr>,

--- a/zebra-scan/src/config.rs
+++ b/zebra-scan/src/config.rs
@@ -1,6 +1,6 @@
 //! Configuration for blockchain scanning tasks.
 
-use std::fmt::Debug;
+use std::{fmt::Debug, net::SocketAddr};
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -19,6 +19,20 @@ pub struct Config {
     //
     // TODO: allow keys without birthdays
     pub sapling_keys_to_scan: IndexMap<SaplingScanningKey, u32>,
+
+    /// IP address and port for the zebra-scan gRPC server.
+    ///
+    /// Note: The gRPC server is disabled by default.
+    /// To enable the gRPC server, set a listen address in the config:
+    /// ```toml
+    /// [shielded-scan]
+    /// listen_addr = '127.0.0.1:8231'
+    /// ```
+    ///
+    /// The recommended ports for the RPC server are:
+    /// - Mainnet: 127.0.0.1:8231
+    /// - Testnet: 127.0.0.1:18231
+    pub listen_addr: Option<SocketAddr>,
 
     /// The scanner results database config.
     //
@@ -41,6 +55,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             sapling_keys_to_scan: IndexMap::new(),
+            listen_addr: None,
 
             // TODO: Add a const generic for specifying the default cache_dir path, like 'zebra' or 'zebra-scan'?
             db_config: DbConfig::default(),

--- a/zebra-scan/src/init.rs
+++ b/zebra-scan/src/init.rs
@@ -1,5 +1,7 @@
 //! Initializing the scanner and gRPC server.
 
+use std::net::SocketAddr;
+
 use color_eyre::Report;
 use tokio::task::JoinHandle;
 use tower::ServiceBuilder;
@@ -13,7 +15,8 @@ use crate::{scan, service::ScanService, Config};
 /// Initialize [`ScanService`] based on its config.
 ///
 /// TODO: add a test for this function.
-pub async fn init(
+pub async fn init_with_server(
+    listen_addr: SocketAddr,
     config: Config,
     network: Network,
     state: scan::State,
@@ -31,7 +34,7 @@ pub async fn init(
     info!("starting scan gRPC server");
 
     // Start the gRPC server.
-    zebra_grpc::server::init(scan_service).await?;
+    zebra_grpc::server::init(listen_addr, scan_service).await?;
 
     Ok(())
 }
@@ -43,6 +46,20 @@ pub fn spawn_init(
     state: scan::State,
     chain_tip_change: ChainTipChange,
 ) -> JoinHandle<Result<(), Report>> {
-    // TODO: spawn an entirely new executor here, to avoid timing attacks.
-    tokio::spawn(init(config, network, state, chain_tip_change).in_current_span())
+    if let Some(listen_addr) = config.listen_addr {
+        // TODO: spawn an entirely new executor here, to avoid timing attacks.
+        tokio::spawn(
+            init_with_server(listen_addr, config, network, state, chain_tip_change)
+                .in_current_span(),
+        )
+    } else {
+        // TODO: spawn an entirely new executor here, to avoid timing attacks.
+        tokio::spawn(
+            async move {
+                let (_cmd_sender, cmd_receiver) = std::sync::mpsc::channel();
+                scan::init(config, network, state, chain_tip_change, cmd_receiver).await
+            }
+            .in_current_span(),
+        )
+    }
 }

--- a/zebra-scan/src/init.rs
+++ b/zebra-scan/src/init.rs
@@ -1,8 +1,10 @@
 //! Initializing the scanner and gRPC server.
 
 use color_eyre::Report;
+use tokio::task::JoinHandle;
 use tower::ServiceBuilder;
 
+use tracing::Instrument;
 use zebra_chain::parameters::Network;
 use zebra_state::ChainTipChange;
 
@@ -17,6 +19,7 @@ pub async fn init(
     state: scan::State,
     chain_tip_change: ChainTipChange,
 ) -> Result<(), Report> {
+    info!(?config, "starting scan service");
     let scan_service = ServiceBuilder::new().buffer(10).service(ScanService::new(
         &config,
         network,
@@ -24,8 +27,22 @@ pub async fn init(
         chain_tip_change,
     ));
 
+    // TODO: move this to zebra-grpc init() function and include addr
+    info!("starting scan gRPC server");
+
     // Start the gRPC server.
     zebra_grpc::server::init(scan_service).await?;
 
     Ok(())
+}
+
+/// Initialize the scanner and its gRPC server based on its config, and spawn a task for it.
+pub fn spawn_init(
+    config: Config,
+    network: Network,
+    state: scan::State,
+    chain_tip_change: ChainTipChange,
+) -> JoinHandle<Result<(), Report>> {
+    // TODO: spawn an entirely new executor here, to avoid timing attacks.
+    tokio::spawn(init(config, network, state, chain_tip_change).in_current_span())
 }

--- a/zebra-scan/src/lib.rs
+++ b/zebra-scan/src/lib.rs
@@ -21,6 +21,6 @@ pub use service::scan_task::scan;
 pub mod tests;
 
 pub use config::Config;
-pub use init::{init, spawn_init};
+pub use init::{init_with_server, spawn_init};
 
 pub use zcash_primitives::{sapling::SaplingIvk, zip32::DiversifiableFullViewingKey};

--- a/zebra-scan/src/lib.rs
+++ b/zebra-scan/src/lib.rs
@@ -21,6 +21,6 @@ pub use service::scan_task::scan;
 pub mod tests;
 
 pub use config::Config;
-pub use init::init;
+pub use init::{init, spawn_init};
 
 pub use zcash_primitives::{sapling::SaplingIvk, zip32::DiversifiableFullViewingKey};

--- a/zebra-scan/src/service.rs
+++ b/zebra-scan/src/service.rs
@@ -42,9 +42,11 @@ impl ScanService {
         state: scan::State,
         chain_tip_change: ChainTipChange,
     ) -> Self {
+        let db = Storage::new(config, network, false);
+
         Self {
-            db: Storage::new(config, network, false),
-            scan_task: ScanTask::spawn(config, network, state, chain_tip_change),
+            scan_task: ScanTask::spawn(db.clone(), state, chain_tip_change),
+            db,
         }
     }
 

--- a/zebra-scan/src/service.rs
+++ b/zebra-scan/src/service.rs
@@ -5,7 +5,7 @@ use std::{collections::BTreeMap, future::Future, pin::Pin, task::Poll, time::Dur
 use futures::future::FutureExt;
 use tower::Service;
 
-use zebra_chain::{parameters::Network, transaction::Hash};
+use zebra_chain::{diagnostic::task::WaitForPanics, parameters::Network, transaction::Hash};
 
 use zebra_state::ChainTipChange;
 
@@ -36,17 +36,20 @@ const DELETE_KEY_TIMEOUT: Duration = Duration::from_secs(15);
 
 impl ScanService {
     /// Create a new [`ScanService`].
-    pub fn new(
+    pub async fn new(
         config: &Config,
         network: Network,
         state: scan::State,
         chain_tip_change: ChainTipChange,
     ) -> Self {
-        let db = Storage::new(config, network, false);
+        let config = config.clone();
+        let storage = tokio::task::spawn_blocking(move || Storage::new(&config, network, false))
+            .wait_for_panics()
+            .await;
 
         Self {
-            scan_task: ScanTask::spawn(db.clone(), state, chain_tip_change),
-            db,
+            scan_task: ScanTask::spawn(storage.clone(), state, chain_tip_change),
+            db: storage,
         }
     }
 

--- a/zebra-scan/src/service/scan_task.rs
+++ b/zebra-scan/src/service/scan_task.rs
@@ -5,10 +5,9 @@ use std::sync::{mpsc, Arc};
 use color_eyre::Report;
 use tokio::task::JoinHandle;
 
-use zebra_chain::parameters::Network;
 use zebra_state::ChainTipChange;
 
-use crate::Config;
+use crate::storage::Storage;
 
 mod commands;
 mod executor;
@@ -31,23 +30,12 @@ pub struct ScanTask {
 
 impl ScanTask {
     /// Spawns a new [`ScanTask`].
-    pub fn spawn(
-        config: &Config,
-        network: Network,
-        state: scan::State,
-        chain_tip_change: ChainTipChange,
-    ) -> Self {
+    pub fn spawn(db: Storage, state: scan::State, chain_tip_change: ChainTipChange) -> Self {
         // TODO: Use a bounded channel or move this logic to the scan service or another service.
         let (cmd_sender, cmd_receiver) = mpsc::channel();
 
         Self {
-            handle: Arc::new(scan::spawn_init(
-                config,
-                network,
-                state,
-                chain_tip_change,
-                cmd_receiver,
-            )),
+            handle: Arc::new(scan::spawn_init(db, state, chain_tip_change, cmd_receiver)),
             cmd_sender,
         }
     }

--- a/zebra-scan/src/service/scan_task/scan.rs
+++ b/zebra-scan/src/service/scan_task/scan.rs
@@ -497,7 +497,6 @@ pub fn spawn_init(
 ) -> JoinHandle<Result<(), Report>> {
     let config = config.clone();
 
-    // TODO: spawn an entirely new executor here, to avoid timing attacks.
     tokio::spawn(init(config, network, state, chain_tip_change, cmd_receiver).in_current_span())
 }
 

--- a/zebra-scan/src/service/scan_task/scan.rs
+++ b/zebra-scan/src/service/scan_task/scan.rs
@@ -39,7 +39,6 @@ use zebra_state::{ChainTipChange, SaplingScannedResult, TransactionIndex};
 use crate::{
     service::{ScanTask, ScanTaskCommand},
     storage::{SaplingScanningKey, Storage},
-    Config,
 };
 
 use super::executor;
@@ -489,31 +488,10 @@ async fn tip_height(mut state: State) -> Result<Height, Report> {
 ///
 /// TODO: add a test for this function.
 pub fn spawn_init(
-    config: &Config,
-    network: Network,
+    storage: Storage,
     state: State,
     chain_tip_change: ChainTipChange,
     cmd_receiver: Receiver<ScanTaskCommand>,
 ) -> JoinHandle<Result<(), Report>> {
-    let config = config.clone();
-
-    tokio::spawn(init(config, network, state, chain_tip_change, cmd_receiver).in_current_span())
-}
-
-/// Initialize the scanner based on its config.
-///
-/// TODO: add a test for this function.
-pub async fn init(
-    config: Config,
-    network: Network,
-    state: State,
-    chain_tip_change: ChainTipChange,
-    cmd_receiver: Receiver<ScanTaskCommand>,
-) -> Result<(), Report> {
-    let storage = tokio::task::spawn_blocking(move || Storage::new(&config, network, false))
-        .wait_for_panics()
-        .await;
-
-    // TODO: add more tasks here?
-    start(state, chain_tip_change, storage, cmd_receiver).await
+    tokio::spawn(start(state, chain_tip_change, storage, cmd_receiver).in_current_span())
 }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -289,6 +289,7 @@ zebra-scan = { path = "../zebra-scan", features = ["proptest-impl"] }
 zebra-node-services = { path = "../zebra-node-services", features = ["rpc-client"] }
 
 zebra-test = { path = "../zebra-test" }
+zebra-grpc = { path = "../zebra-grpc" }
 
 # Used by the checkpoint generation tests via the zebra-checkpoints feature
 # (the binaries in this crate won't be built unless their features are enabled).

--- a/zebrad/tests/common/config.rs
+++ b/zebrad/tests/common/config.rs
@@ -82,7 +82,8 @@ pub fn default_test_config(net: Network) -> Result<ZebradConfig> {
 
     #[cfg(feature = "shielded-scan")]
     {
-        let shielded_scan = zebra_scan::Config::ephemeral();
+        let mut shielded_scan = zebra_scan::Config::ephemeral();
+        shielded_scan.db_config_mut().cache_dir = "zebra-scan".into();
 
         let config = ZebradConfig {
             network,

--- a/zebrad/tests/common/shielded_scan/scans_for_new_key.rs
+++ b/zebrad/tests/common/shielded_scan/scans_for_new_key.rs
@@ -82,15 +82,13 @@ pub(crate) async fn run() -> Result<()> {
 
     tracing::info!("opened state service with valid chain tip height, deleting any past keys in db and starting scan task",);
 
-    {
-        // Before spawning `ScanTask`, delete past results for the zecpages key, if any.
-        let mut storage = Storage::new(&shielded_scan_config, network, false);
-        storage.delete_sapling_keys(vec![ZECPAGES_SAPLING_VIEWING_KEY.to_string()]);
-    }
+    // Before spawning `ScanTask`, delete past results for the zecpages key, if any.
+    let mut storage = Storage::new(&shielded_scan_config, network, false);
+    storage.delete_sapling_keys(vec![ZECPAGES_SAPLING_VIEWING_KEY.to_string()]);
 
     let state = ServiceBuilder::new().buffer(10).service(state_service);
 
-    let mut scan_task = ScanTask::spawn(&shielded_scan_config, network, state, chain_tip_change);
+    let mut scan_task = ScanTask::spawn(storage, state, chain_tip_change);
 
     let (zecpages_dfvks, zecpages_ivks) =
         sapling_key_to_scan_block_keys(&ZECPAGES_SAPLING_VIEWING_KEY.to_string(), network)?;


### PR DESCRIPTION
## Motivation

We want the zebrad start command to start the scanner gRPC server.

Closes #8242

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Add a `spawn_init()` fn for the root `init()` fn in `zebra_scan`
- Replace the call to `ScanTask::spawn()` in zebrad start command with the new `spawn_init()` fn

### Testing

- This was for manual testing of the ClearResults and DeleteKeys RPC methods and worked as expected.
- Tests that the scanner RPC server is running, accepts connections, and responds to the GetInfo method.

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._
