### PR TITLE
change(release.toml): new crates owners list

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -17,4 +17,4 @@ push = false
 tag = false
 
 # Owners for new crates
-owners = [ 'dconnolly', 'teor2345', 'zcashfoundation/owners' ]
+owners = [ 'oxarbitrage', 'teor2345', 'zcashfoundation/owners' ]


### PR DESCRIPTION
## Motivation

We want to replace `dconnolly` from the release.toml owners list. I replaced it with my crates.io handle as agreed in the last Zebra sync meeting.

The `owners` feature seems to be a list of valid crates.io logins that will be the crate owners if a new crate is created under the zebra workspace:

https://github.com/crate-ci/cargo-release/blob/master/CHANGELOG.md#features-4

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [ ] Have you added or updated tests?
  - [ ] Is the documentation up to date?

## Solution

Change 1 owner.

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._
