### PR TITLE
Fix formatting in `proptest` macros

### DIFF
--- a/zebra-chain/src/work/tests/prop.rs
+++ b/zebra-chain/src/work/tests/prop.rs
@@ -18,15 +18,15 @@ fn equihash_solution_roundtrip() {
     let _init_guard = zebra_test::init();
 
     proptest!(|(solution in any::<equihash::Solution>())| {
-            let data = solution
-                .zcash_serialize_to_vec()
-                .expect("randomized EquihashSolution should serialize");
-            let solution2 = data
-                .zcash_deserialize_into()
-                .expect("randomized EquihashSolution should deserialize");
+        let data = solution
+            .zcash_serialize_to_vec()
+            .expect("randomized EquihashSolution should serialize");
+        let solution2 = data
+            .zcash_deserialize_into()
+            .expect("randomized EquihashSolution should deserialize");
 
-            prop_assert_eq![solution, solution2];
-        });
+        prop_assert_eq![solution, solution2];
+    });
 }
 
 prop_compose! {
@@ -94,10 +94,10 @@ fn equihash_prop_test_nonce() -> color_eyre::eyre::Result<()> {
         block.header.solution.check(&block.header)?;
 
         proptest!(|(fake_header in randomized_nonce(*block.header.as_ref()))| {
-                fake_header.solution
-                    .check(&fake_header)
-                    .expect_err("block header should not validate on randomized nonce");
-            });
+            fake_header.solution
+                .check(&fake_header)
+                .expect_err("block header should not validate on randomized nonce");
+        });
     }
 
     Ok(())


### PR DESCRIPTION
## Motivation

It looks like `rustfmt` started checking the contents of `proptest` macros: https://github.com/ZcashFoundation/zebra/actions/runs/7836983037/job/21385757962?pr=8251#step:6:15. Note that the PR didn't edit the files where the reported errors occur.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?


### Complex Code or Requirements


## Solution

- Fix the formatting of the affected files.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._