### PR TITLE
add(scan): Implement SubscribeResults request for scan service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5829,6 +5829,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tokio",
  "zebra-chain",
 ]
 

--- a/zebra-grpc/Cargo.toml
+++ b/zebra-grpc/Cargo.toml
@@ -25,7 +25,7 @@ color-eyre = "0.6.2"
 
 zcash_primitives = { version = "0.13.0-rc.1" }
 
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34", features = ["shielded-scan"] }
 
 [build-dependencies]
 tonic-build = "0.10.2"

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -34,6 +34,8 @@ rpc-client = [
     "serde_json",
 ]
 
+shielded-scan = ["tokio"]
+
 [dependencies]
 zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.34" }
 
@@ -46,6 +48,7 @@ jsonrpc-core = { version = "18.0.0", optional = true }
 reqwest = { version = "0.11.24", default-features = false, features = ["rustls-tls"], optional = true }
 serde = { version = "1.0.196", optional = true }
 serde_json = { version = "1.0.113", optional = true }
+tokio = { version = "1.36.0", features = ["time"], optional = true }
 
 [dev-dependencies]
 

--- a/zebra-node-services/src/lib.rs
+++ b/zebra-node-services/src/lib.rs
@@ -13,4 +13,5 @@ pub mod rpc_client;
 /// parameterized by 'a), *not* that the object itself has 'static lifetime.
 pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
+#[cfg(feature = "shielded-scan")]
 pub mod scan_service;

--- a/zebra-node-services/src/scan_service/request.rs
+++ b/zebra-node-services/src/scan_service/request.rs
@@ -25,7 +25,7 @@ pub enum Request {
     /// Accept keys and return transaction data
     Results(Vec<String>),
 
-    /// TODO: Accept `KeyHash`es and return a channel receiver
+    /// Accept keys and return a channel receiver for transaction data
     SubscribeResults(HashSet<String>),
 
     /// Clear the results for a set of viewing keys

--- a/zebra-node-services/src/scan_service/request.rs
+++ b/zebra-node-services/src/scan_service/request.rs
@@ -1,5 +1,7 @@
 //! `zebra_scan::service::ScanService` request types.
 
+use std::collections::HashSet;
+
 use crate::BoxError;
 
 /// The maximum number of keys that may be included in a request to the scan service
@@ -24,7 +26,7 @@ pub enum Request {
     Results(Vec<String>),
 
     /// TODO: Accept `KeyHash`es and return a channel receiver
-    SubscribeResults(Vec<()>),
+    SubscribeResults(HashSet<String>),
 
     /// Clear the results for a set of viewing keys
     ClearResults(Vec<String>),

--- a/zebra-node-services/src/scan_service/response.rs
+++ b/zebra-node-services/src/scan_service/response.rs
@@ -1,6 +1,6 @@
 //! `zebra_scan::service::ScanService` response types.
 
-use std::{collections::BTreeMap, sync::mpsc};
+use std::collections::BTreeMap;
 
 use zebra_chain::{block::Height, transaction};
 
@@ -30,5 +30,5 @@ pub enum Response {
     ClearedResults,
 
     /// Response to [`SubscribeResults`](super::request::Request::SubscribeResults) request
-    SubscribeResults(mpsc::Receiver<transaction::Hash>),
+    SubscribeResults(tokio::sync::mpsc::Receiver<transaction::Hash>),
 }

--- a/zebra-node-services/src/scan_service/response.rs
+++ b/zebra-node-services/src/scan_service/response.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::BTreeMap, sync::mpsc};
 
-use zebra_chain::{block::Height, transaction::Hash};
+use zebra_chain::{block::Height, transaction};
 
 #[derive(Debug)]
 /// Response types for `zebra_scan::service::ScanService`
@@ -21,7 +21,7 @@ pub enum Response {
     /// Response to [`Results`](super::request::Request::Results) request
     ///
     /// We use the nested `BTreeMap` so we don't repeat any piece of response data.
-    Results(BTreeMap<String, BTreeMap<Height, Vec<Hash>>>),
+    Results(BTreeMap<String, BTreeMap<Height, Vec<transaction::Hash>>>),
 
     /// Response to [`DeleteKeys`](super::request::Request::DeleteKeys) request
     DeletedKeys,
@@ -29,6 +29,6 @@ pub enum Response {
     /// Response to [`ClearResults`](super::request::Request::ClearResults) request
     ClearedResults,
 
-    /// Response to `SubscribeResults` request
-    SubscribeResults(mpsc::Receiver<Hash>),
+    /// Response to [`SubscribeResults`](super::request::Request::SubscribeResults) request
+    SubscribeResults(mpsc::Receiver<transaction::Hash>),
 }

--- a/zebra-node-services/src/scan_service/response.rs
+++ b/zebra-node-services/src/scan_service/response.rs
@@ -4,6 +4,20 @@ use std::collections::BTreeMap;
 
 use zebra_chain::{block::Height, transaction};
 
+/// A relevant transaction for a key and the block height where it was found.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScanResult {
+    /// The key that successfully decrypts the transaction
+    pub key: String,
+
+    /// The height of the block with the transaction
+    pub height: Height,
+
+    /// A transaction ID, which uniquely identifies mined v5 transactions,
+    /// and all v1-v4 transactions.
+    pub tx_id: transaction::Hash,
+}
+
 #[derive(Debug)]
 /// Response types for `zebra_scan::service::ScanService`
 pub enum Response {
@@ -30,5 +44,5 @@ pub enum Response {
     ClearedResults,
 
     /// Response to [`SubscribeResults`](super::request::Request::SubscribeResults) request
-    SubscribeResults(tokio::sync::mpsc::Receiver<transaction::Hash>),
+    SubscribeResults(tokio::sync::mpsc::Receiver<ScanResult>),
 }

--- a/zebra-node-services/src/scan_service/response.rs
+++ b/zebra-node-services/src/scan_service/response.rs
@@ -1,9 +1,6 @@
 //! `zebra_scan::service::ScanService` response types.
 
-use std::{
-    collections::BTreeMap,
-    sync::{mpsc, Arc},
-};
+use std::{collections::BTreeMap, sync::mpsc};
 
 use zebra_chain::{block::Height, transaction::Hash};
 
@@ -28,5 +25,5 @@ pub enum Response {
     ClearedResults,
 
     /// Response to SubscribeResults request
-    SubscribeResults(mpsc::Receiver<Arc<Hash>>),
+    SubscribeResults(mpsc::Receiver<Hash>),
 }

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -56,7 +56,7 @@ zcash_primitives = "0.13.0-rc.1"
 
 zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34" }
 zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34", features = ["shielded-scan"] }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.33" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34", features = ["shielded-scan"] }
 zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.1" }
 
 chrono = { version = "0.4.33", default-features = false, features = ["clock", "std", "serde"] }

--- a/zebra-scan/src/init.rs
+++ b/zebra-scan/src/init.rs
@@ -57,7 +57,7 @@ pub fn spawn_init(
                     tokio::task::spawn_blocking(move || Storage::new(&config, network, false))
                         .wait_for_panics()
                         .await;
-                let (_cmd_sender, cmd_receiver) = std::sync::mpsc::channel();
+                let (_cmd_sender, cmd_receiver) = tokio::sync::mpsc::channel(1);
                 scan::start(state, chain_tip_change, storage, cmd_receiver).await
             }
             .in_current_span(),

--- a/zebra-scan/src/service.rs
+++ b/zebra-scan/src/service.rs
@@ -160,8 +160,15 @@ impl Service<Request> for ScanService {
                 .boxed();
             }
 
-            Request::SubscribeResults(_key_hashes) => {
-                // TODO: send key_hashes and mpsc::Sender to scanner task, return mpsc::Receiver to caller
+            Request::SubscribeResults(keys) => {
+                let mut scan_task = self.scan_task.clone();
+
+                return async move {
+                    let results_receiver = scan_task.subscribe(keys)?;
+
+                    Ok(Response::SubscribeResults(results_receiver))
+                }
+                .boxed();
             }
 
             Request::ClearResults(keys) => {

--- a/zebra-scan/src/service.rs
+++ b/zebra-scan/src/service.rs
@@ -19,7 +19,7 @@ pub mod scan_task;
 pub use scan_task::{ScanTask, ScanTaskCommand};
 
 #[cfg(any(test, feature = "proptest-impl"))]
-use std::sync::mpsc::Receiver;
+use tokio::sync::mpsc::Receiver;
 
 /// Zebra-scan [`tower::Service`]
 #[derive(Debug)]

--- a/zebra-scan/src/service/scan_task.rs
+++ b/zebra-scan/src/service/scan_task.rs
@@ -1,6 +1,6 @@
 //! Types and method implementations for [`ScanTask`]
 
-use std::sync::{mpsc, Arc};
+use std::sync::Arc;
 
 use color_eyre::Report;
 use tokio::task::JoinHandle;
@@ -25,14 +25,16 @@ pub struct ScanTask {
     pub handle: Arc<JoinHandle<Result<(), Report>>>,
 
     /// Task command channel sender
-    pub cmd_sender: mpsc::Sender<ScanTaskCommand>,
+    pub cmd_sender: tokio::sync::mpsc::Sender<ScanTaskCommand>,
 }
+
+const SCAN_TASK_BUFFER_SIZE: usize = 100;
 
 impl ScanTask {
     /// Spawns a new [`ScanTask`].
     pub fn spawn(db: Storage, state: scan::State, chain_tip_change: ChainTipChange) -> Self {
         // TODO: Use a bounded channel or move this logic to the scan service or another service.
-        let (cmd_sender, cmd_receiver) = mpsc::channel();
+        let (cmd_sender, cmd_receiver) = tokio::sync::mpsc::channel(SCAN_TASK_BUFFER_SIZE);
 
         Self {
             handle: Arc::new(scan::spawn_init(db, state, chain_tip_change, cmd_receiver)),

--- a/zebra-scan/src/service/scan_task.rs
+++ b/zebra-scan/src/service/scan_task.rs
@@ -28,6 +28,7 @@ pub struct ScanTask {
     pub cmd_sender: tokio::sync::mpsc::Sender<ScanTaskCommand>,
 }
 
+/// The size of the command channel buffer
 const SCAN_TASK_BUFFER_SIZE: usize = 100;
 
 impl ScanTask {

--- a/zebra-scan/src/service/scan_task/commands.rs
+++ b/zebra-scan/src/service/scan_task/commands.rs
@@ -9,8 +9,8 @@ use color_eyre::{eyre::eyre, Report};
 use tokio::sync::oneshot;
 
 use zcash_primitives::{sapling::SaplingIvk, zip32::DiversifiableFullViewingKey};
-use zebra_chain::block::Height;
-use zebra_state::{SaplingScannedResult, SaplingScanningKey};
+use zebra_chain::{block::Height, transaction};
+use zebra_state::SaplingScanningKey;
 
 use super::ScanTask;
 
@@ -40,7 +40,7 @@ pub enum ScanTaskCommand {
     SubscribeResults {
         /// Sender for results
         // TODO: Update type to return full `WalletTx`
-        result_sender: mpsc::Sender<SaplingScannedResult>,
+        result_sender: mpsc::Sender<transaction::Hash>,
 
         /// Key hashes to send the results of to result channel
         keys: HashSet<String>,
@@ -65,7 +65,7 @@ impl ScanTask {
                 SaplingScanningKey,
                 (Vec<DiversifiableFullViewingKey>, Vec<SaplingIvk>, Height),
             >,
-            HashMap<SaplingScanningKey, mpsc::Sender<SaplingScannedResult>>,
+            HashMap<SaplingScanningKey, mpsc::Sender<transaction::Hash>>,
         ),
         Report,
     > {
@@ -175,7 +175,7 @@ impl ScanTask {
     pub fn subscribe(
         &mut self,
         keys: HashSet<SaplingScanningKey>,
-    ) -> Result<Receiver<SaplingScannedResult>, mpsc::SendError<ScanTaskCommand>> {
+    ) -> Result<Receiver<transaction::Hash>, mpsc::SendError<ScanTaskCommand>> {
         // TODO: Use a bounded channel
         let (result_sender, result_receiver) = mpsc::channel();
 

--- a/zebra-scan/src/service/scan_task/commands.rs
+++ b/zebra-scan/src/service/scan_task/commands.rs
@@ -37,10 +37,8 @@ pub enum ScanTaskCommand {
     },
 
     /// Start sending results for key hashes to `result_sender`
-    // TODO: Implement this command (#8206)
     SubscribeResults {
         /// Sender for results
-        // TODO: Update type to return full `WalletTx`
         result_sender: mpsc::Sender<transaction::Hash>,
 
         /// Key hashes to send the results of to result channel

--- a/zebra-scan/src/service/scan_task/commands.rs
+++ b/zebra-scan/src/service/scan_task/commands.rs
@@ -9,7 +9,8 @@ use tokio::sync::{
 };
 
 use zcash_primitives::{sapling::SaplingIvk, zip32::DiversifiableFullViewingKey};
-use zebra_chain::{block::Height, parameters::Network, transaction};
+use zebra_chain::{block::Height, parameters::Network};
+use zebra_node_services::scan_service::response::ScanResult;
 use zebra_state::SaplingScanningKey;
 
 use crate::scan::sapling_key_to_scan_block_keys;
@@ -41,7 +42,7 @@ pub enum ScanTaskCommand {
     /// Start sending results for key hashes to `result_sender`
     SubscribeResults {
         /// Sender for results
-        result_sender: Sender<transaction::Hash>,
+        result_sender: Sender<ScanResult>,
 
         /// Key hashes to send the results of to result channel
         keys: HashSet<String>,
@@ -67,7 +68,7 @@ impl ScanTask {
                 SaplingScanningKey,
                 (Vec<DiversifiableFullViewingKey>, Vec<SaplingIvk>, Height),
             >,
-            HashMap<SaplingScanningKey, Sender<transaction::Hash>>,
+            HashMap<SaplingScanningKey, Sender<ScanResult>>,
         ),
         Report,
     > {
@@ -202,7 +203,7 @@ impl ScanTask {
     pub fn subscribe(
         &mut self,
         keys: HashSet<SaplingScanningKey>,
-    ) -> Result<Receiver<transaction::Hash>, TrySendError<ScanTaskCommand>> {
+    ) -> Result<Receiver<ScanResult>, TrySendError<ScanTaskCommand>> {
         // TODO: Use a bounded channel
         let (result_sender, result_receiver) =
             tokio::sync::mpsc::channel(RESULTS_SENDER_BUFFER_SIZE);

--- a/zebra-scan/src/service/scan_task/commands.rs
+++ b/zebra-scan/src/service/scan_task/commands.rs
@@ -9,11 +9,7 @@ use color_eyre::{eyre::eyre, Report};
 use tokio::sync::oneshot;
 
 use zcash_primitives::{sapling::SaplingIvk, zip32::DiversifiableFullViewingKey};
-use zebra_chain::{
-    block::Height,
-    parameters::Network,
-    transaction::{self, Transaction},
-};
+use zebra_chain::{block::Height, parameters::Network, transaction};
 use zebra_state::SaplingScanningKey;
 
 use crate::scan::sapling_key_to_scan_block_keys;

--- a/zebra-scan/src/service/scan_task/commands.rs
+++ b/zebra-scan/src/service/scan_task/commands.rs
@@ -59,12 +59,18 @@ impl ScanTask {
             SaplingScanningKey,
             (Vec<DiversifiableFullViewingKey>, Vec<SaplingIvk>),
         >,
-        subscribed_keys: &mut HashMap<SaplingScanningKey, mpsc::Sender<SaplingScannedResult>>,
     ) -> Result<
-        HashMap<SaplingScanningKey, (Vec<DiversifiableFullViewingKey>, Vec<SaplingIvk>, Height)>,
+        (
+            HashMap<
+                SaplingScanningKey,
+                (Vec<DiversifiableFullViewingKey>, Vec<SaplingIvk>, Height),
+            >,
+            HashMap<SaplingScanningKey, mpsc::Sender<SaplingScannedResult>>,
+        ),
         Report,
     > {
         let mut new_keys = HashMap::new();
+        let mut new_result_senders = HashMap::new();
 
         loop {
             let cmd = match cmd_receiver.try_recv() {
@@ -118,13 +124,13 @@ impl ScanTask {
                         .filter(|key| registered_keys.contains_key(key));
 
                     for key in keys {
-                        subscribed_keys.insert(key, result_sender.clone());
+                        new_result_senders.insert(key, result_sender.clone());
                     }
                 }
             }
         }
 
-        Ok(new_keys)
+        Ok((new_keys, new_result_senders))
     }
 
     /// Sends a command to the scan task

--- a/zebra-scan/src/service/scan_task/executor.rs
+++ b/zebra-scan/src/service/scan_task/executor.rs
@@ -9,7 +9,7 @@ use tokio::{
     task::JoinHandle,
 };
 use tracing::Instrument;
-use zebra_state::SaplingScannedResult;
+use zebra_chain::transaction;
 
 use super::scan::ScanRangeTaskBuilder;
 
@@ -17,7 +17,7 @@ const EXECUTOR_BUFFER_SIZE: usize = 100;
 
 pub fn spawn_init(
     subscribed_keys_receiver: tokio::sync::watch::Receiver<
-        HashMap<String, std::sync::mpsc::Sender<SaplingScannedResult>>,
+        HashMap<String, std::sync::mpsc::Sender<transaction::Hash>>,
     >,
 ) -> (Sender<ScanRangeTaskBuilder>, JoinHandle<Result<(), Report>>) {
     // TODO: Use a bounded channel.
@@ -34,7 +34,7 @@ pub fn spawn_init(
 pub async fn scan_task_executor(
     mut scan_task_receiver: Receiver<ScanRangeTaskBuilder>,
     subscribed_keys_receiver: tokio::sync::watch::Receiver<
-        HashMap<String, std::sync::mpsc::Sender<SaplingScannedResult>>,
+        HashMap<String, std::sync::mpsc::Sender<transaction::Hash>>,
     >,
 ) -> Result<(), Report> {
     let mut scan_range_tasks = FuturesUnordered::new();

--- a/zebra-scan/src/service/scan_task/executor.rs
+++ b/zebra-scan/src/service/scan_task/executor.rs
@@ -12,16 +12,14 @@ use tokio::{
     task::JoinHandle,
 };
 use tracing::Instrument;
-use zebra_chain::transaction;
+use zebra_node_services::scan_service::response::ScanResult;
 
 use super::scan::ScanRangeTaskBuilder;
 
 const EXECUTOR_BUFFER_SIZE: usize = 100;
 
 pub fn spawn_init(
-    subscribed_keys_receiver: tokio::sync::watch::Receiver<
-        HashMap<String, Sender<transaction::Hash>>,
-    >,
+    subscribed_keys_receiver: tokio::sync::watch::Receiver<HashMap<String, Sender<ScanResult>>>,
 ) -> (Sender<ScanRangeTaskBuilder>, JoinHandle<Result<(), Report>>) {
     let (scan_task_sender, scan_task_receiver) = tokio::sync::mpsc::channel(EXECUTOR_BUFFER_SIZE);
 
@@ -35,7 +33,7 @@ pub fn spawn_init(
 
 pub async fn scan_task_executor(
     mut scan_task_receiver: Receiver<ScanRangeTaskBuilder>,
-    subscribed_keys_receiver: watch::Receiver<HashMap<String, Sender<transaction::Hash>>>,
+    subscribed_keys_receiver: watch::Receiver<HashMap<String, Sender<ScanResult>>>,
 ) -> Result<(), Report> {
     let mut scan_range_tasks = FuturesUnordered::new();
 

--- a/zebra-scan/src/service/scan_task/executor.rs
+++ b/zebra-scan/src/service/scan_task/executor.rs
@@ -20,7 +20,6 @@ pub fn spawn_init(
         HashMap<String, std::sync::mpsc::Sender<transaction::Hash>>,
     >,
 ) -> (Sender<ScanRangeTaskBuilder>, JoinHandle<Result<(), Report>>) {
-    // TODO: Use a bounded channel.
     let (scan_task_sender, scan_task_receiver) = tokio::sync::mpsc::channel(EXECUTOR_BUFFER_SIZE);
 
     (

--- a/zebra-scan/src/service/scan_task/scan.rs
+++ b/zebra-scan/src/service/scan_task/scan.rs
@@ -136,6 +136,8 @@ pub async fn start(
             }
         }
 
+        let was_parsed_keys_empty = parsed_keys.is_empty();
+
         let (new_keys, new_result_senders) =
             ScanTask::process_messages(&mut cmd_receiver, &mut parsed_keys, network)?;
 
@@ -157,7 +159,7 @@ pub async fn start(
                 .min()
                 .unwrap_or(sapling_activation_height);
 
-            if parsed_keys.len() == new_keys.len() {
+            if was_parsed_keys_empty {
                 info!(?start_height, "setting new start height");
                 height = start_height;
             } else if start_height < height {

--- a/zebra-scan/src/service/scan_task/scan.rs
+++ b/zebra-scan/src/service/scan_task/scan.rs
@@ -35,7 +35,7 @@ use zebra_chain::{
     diagnostic::task::WaitForPanics,
     parameters::Network,
     serialization::ZcashSerialize,
-    transaction::Transaction,
+    transaction::{self, Transaction},
 };
 use zebra_state::{ChainTipChange, SaplingScannedResult, TransactionIndex};
 
@@ -110,7 +110,7 @@ pub async fn start(
         })
         .try_collect()?;
 
-    let mut subscribed_keys: HashMap<SaplingScanningKey, mpsc::Sender<SaplingScannedResult>> =
+    let mut subscribed_keys: HashMap<SaplingScanningKey, mpsc::Sender<transaction::Hash>> =
         HashMap::new();
 
     let (subscribed_keys_sender, subscribed_keys_receiver) =
@@ -214,7 +214,7 @@ pub async fn scan_height_and_store_results(
     storage: Storage,
     key_last_scanned_heights: Arc<HashMap<SaplingScanningKey, Height>>,
     parsed_keys: HashMap<SaplingScanningKey, (Vec<DiversifiableFullViewingKey>, Vec<SaplingIvk>)>,
-    subscribed_keys: HashMap<SaplingScanningKey, Sender<SaplingScannedResult>>,
+    subscribed_keys: HashMap<SaplingScanningKey, Sender<transaction::Hash>>,
 ) -> Result<Option<Height>, Report> {
     let network = storage.network();
 
@@ -294,7 +294,7 @@ pub async fn scan_height_and_store_results(
 
                 for (_tx_index, &tx_id) in results {
                     // TODO: Handle `SendErrors`
-                    let _ = results_sender.send(tx_id);
+                    let _ = results_sender.send(tx_id.into());
                 }
             }
 

--- a/zebra-scan/src/service/scan_task/scan/scan_range.rs
+++ b/zebra-scan/src/service/scan_task/scan/scan_range.rs
@@ -109,6 +109,7 @@ pub async fn scan_range(
             storage.clone(),
             key_heights.clone(),
             parsed_keys.clone(),
+            HashMap::new(),
         )
         .await?;
 

--- a/zebra-scan/src/service/scan_task/scan/scan_range.rs
+++ b/zebra-scan/src/service/scan_task/scan/scan_range.rs
@@ -13,7 +13,8 @@ use tokio::{
 };
 use tracing::Instrument;
 use zcash_primitives::{sapling::SaplingIvk, zip32::DiversifiableFullViewingKey};
-use zebra_chain::{block::Height, transaction};
+use zebra_chain::block::Height;
+use zebra_node_services::scan_service::response::ScanResult;
 use zebra_state::SaplingScanningKey;
 
 /// A builder for a scan until task
@@ -55,7 +56,7 @@ impl ScanRangeTaskBuilder {
     // TODO: return a tuple with a shutdown sender
     pub fn spawn(
         self,
-        subscribed_keys_receiver: watch::Receiver<HashMap<String, Sender<transaction::Hash>>>,
+        subscribed_keys_receiver: watch::Receiver<HashMap<String, Sender<ScanResult>>>,
     ) -> JoinHandle<Result<(), Report>> {
         let Self {
             height_range,
@@ -85,7 +86,7 @@ pub async fn scan_range(
     keys: HashMap<SaplingScanningKey, (Vec<DiversifiableFullViewingKey>, Vec<SaplingIvk>, Height)>,
     state: State,
     storage: Storage,
-    subscribed_keys_receiver: watch::Receiver<HashMap<String, Sender<transaction::Hash>>>,
+    subscribed_keys_receiver: watch::Receiver<HashMap<String, Sender<ScanResult>>>,
 ) -> Result<(), Report> {
     let sapling_activation_height = storage.network().sapling_activation_height();
     // Do not scan and notify if we are below sapling activation height.

--- a/zebra-scan/src/service/scan_task/scan/scan_range.rs
+++ b/zebra-scan/src/service/scan_task/scan/scan_range.rs
@@ -2,10 +2,11 @@
 
 use std::{collections::HashMap, sync::Arc};
 
+use color_eyre::eyre::Report;
 use tokio::task::JoinHandle;
 use tracing::Instrument;
 use zcash_primitives::{sapling::SaplingIvk, zip32::DiversifiableFullViewingKey};
-use zebra_chain::{block::Height, BoxError};
+use zebra_chain::block::Height;
 use zebra_state::SaplingScanningKey;
 
 use crate::{
@@ -50,7 +51,7 @@ impl ScanRangeTaskBuilder {
 
     /// Spawns a `scan_range()` task and returns its [`JoinHandle`]
     // TODO: return a tuple with a shutdown sender
-    pub fn spawn(self) -> JoinHandle<Result<(), BoxError>> {
+    pub fn spawn(self) -> JoinHandle<Result<(), Report>> {
         let Self {
             height_range,
             keys,
@@ -70,7 +71,7 @@ pub async fn scan_range(
     keys: HashMap<SaplingScanningKey, (Vec<DiversifiableFullViewingKey>, Vec<SaplingIvk>, Height)>,
     state: State,
     storage: Storage,
-) -> Result<(), BoxError> {
+) -> Result<(), Report> {
     let sapling_activation_height = storage.min_sapling_birthday_height();
     // Do not scan and notify if we are below sapling activation height.
     wait_for_height(

--- a/zebra-scan/src/service/scan_task/tests.rs
+++ b/zebra-scan/src/service/scan_task/tests.rs
@@ -1,9 +1,6 @@
 //! Tests for the scan task.
 
-use std::sync::{
-    mpsc::{self, Receiver},
-    Arc,
-};
+use std::sync::Arc;
 
 use super::{ScanTask, ScanTaskCommand};
 
@@ -12,8 +9,8 @@ mod vectors;
 
 impl ScanTask {
     /// Spawns a new [`ScanTask`] for tests.
-    pub fn mock() -> (Self, Receiver<ScanTaskCommand>) {
-        let (cmd_sender, cmd_receiver) = mpsc::channel();
+    pub fn mock() -> (Self, tokio::sync::mpsc::Receiver<ScanTaskCommand>) {
+        let (cmd_sender, cmd_receiver) = tokio::sync::mpsc::channel(1);
 
         (
             Self {

--- a/zebra-scan/src/service/scan_task/tests.rs
+++ b/zebra-scan/src/service/scan_task/tests.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use super::{ScanTask, ScanTaskCommand};
+use super::{ScanTask, ScanTaskCommand, SCAN_TASK_BUFFER_SIZE};
 
 #[cfg(test)]
 mod vectors;
@@ -10,7 +10,7 @@ mod vectors;
 impl ScanTask {
     /// Spawns a new [`ScanTask`] for tests.
     pub fn mock() -> (Self, tokio::sync::mpsc::Receiver<ScanTaskCommand>) {
-        let (cmd_sender, cmd_receiver) = tokio::sync::mpsc::channel(1);
+        let (cmd_sender, cmd_receiver) = tokio::sync::mpsc::channel(SCAN_TASK_BUFFER_SIZE);
 
         (
             Self {

--- a/zebra-scan/src/service/scan_task/tests/vectors.rs
+++ b/zebra-scan/src/service/scan_task/tests/vectors.rs
@@ -139,14 +139,14 @@ async fn scan_task_processes_messages_correctly() -> Result<(), Report> {
         "should add 2 keys to parsed_keys after removals"
     );
 
-    let subscribe_keys: HashSet<String> = (0..5).map(|i| i.to_string()).collect();
+    let subscribe_keys: HashSet<String> = sapling_keys[..5].iter().cloned().collect();
     let result_receiver = mock_scan_task.subscribe(subscribe_keys.clone())?;
 
     let (_new_keys, new_results_senders) =
         ScanTask::process_messages(&cmd_receiver, &mut parsed_keys, network)?;
 
     let processed_subscribe_keys: HashSet<String> = new_results_senders.keys().cloned().collect();
-    let expected_new_subscribe_keys: HashSet<String> = (0..2).map(|i| i.to_string()).collect();
+    let expected_new_subscribe_keys: HashSet<String> = sapling_keys[..2].iter().cloned().collect();
 
     assert_eq!(
         processed_subscribe_keys, expected_new_subscribe_keys,

--- a/zebra-scan/src/service/scan_task/tests/vectors.rs
+++ b/zebra-scan/src/service/scan_task/tests/vectors.rs
@@ -183,7 +183,7 @@ async fn scan_task_processes_messages_correctly() -> Result<(), Report> {
 
     for sender in new_results_senders.values() {
         // send a fake tx id for each key
-        sender.send(transaction::Hash([0; 32]).into())?;
+        sender.send(transaction::Hash([0; 32]))?;
     }
 
     let results: Vec<_> = result_receiver.try_iter().collect();

--- a/zebra-scan/src/service/scan_task/tests/vectors.rs
+++ b/zebra-scan/src/service/scan_task/tests/vectors.rs
@@ -4,7 +4,8 @@ use std::collections::{HashMap, HashSet};
 
 use color_eyre::Report;
 
-use zebra_chain::transaction;
+use zebra_chain::{block::Height, transaction};
+use zebra_node_services::scan_service::response::ScanResult;
 
 use crate::{service::ScanTask, tests::mock_sapling_scanning_keys};
 
@@ -155,7 +156,13 @@ async fn scan_task_processes_messages_correctly() -> Result<(), Report> {
 
     for sender in new_results_senders.values() {
         // send a fake tx id for each key
-        sender.send(transaction::Hash([0; 32])).await?;
+        sender
+            .send(ScanResult {
+                key: String::new(),
+                height: Height::MIN,
+                tx_id: transaction::Hash([0; 32]),
+            })
+            .await?;
     }
 
     let mut num_results = 0;

--- a/zebra-scan/src/service/scan_task/tests/vectors.rs
+++ b/zebra-scan/src/service/scan_task/tests/vectors.rs
@@ -1,11 +1,10 @@
 //! Fixed test vectors for the scan task.
 
-use std::{collections::HashMap, sync::mpsc};
+use std::collections::HashMap;
 
 use color_eyre::Report;
 
 use zebra_chain::block::Height;
-use zebra_state::{SaplingScannedResult, SaplingScanningKey};
 
 use crate::service::ScanTask;
 
@@ -14,8 +13,6 @@ use crate::service::ScanTask;
 async fn scan_task_processes_messages_correctly() -> Result<(), Report> {
     let (mut mock_scan_task, cmd_receiver) = ScanTask::mock();
     let mut parsed_keys = HashMap::new();
-    let mut subscribed_keys: HashMap<SaplingScanningKey, mpsc::Sender<SaplingScannedResult>> =
-        HashMap::new();
 
     // Send some keys to be registered
     let num_keys = 10;
@@ -25,8 +22,8 @@ async fn scan_task_processes_messages_correctly() -> Result<(), Report> {
             .collect(),
     )?;
 
-    let new_keys =
-        ScanTask::process_messages(&cmd_receiver, &mut parsed_keys, &mut subscribed_keys)?;
+    let (new_keys, _new_results_senders) =
+        ScanTask::process_messages(&cmd_receiver, &mut parsed_keys)?;
 
     // Check that it updated parsed_keys correctly and returned the right new keys when starting with an empty state
 
@@ -50,8 +47,8 @@ async fn scan_task_processes_messages_correctly() -> Result<(), Report> {
 
     // Check that no key should be added if they are all already known and the heights are the same
 
-    let new_keys =
-        ScanTask::process_messages(&cmd_receiver, &mut parsed_keys, &mut subscribed_keys)?;
+    let (new_keys, _new_results_senders) =
+        ScanTask::process_messages(&cmd_receiver, &mut parsed_keys)?;
 
     assert_eq!(
         parsed_keys.len(),
@@ -78,8 +75,8 @@ async fn scan_task_processes_messages_correctly() -> Result<(), Report> {
             .collect(),
     )?;
 
-    let new_keys =
-        ScanTask::process_messages(&cmd_receiver, &mut parsed_keys, &mut subscribed_keys)?;
+    let (new_keys, _new_results_senders) =
+        ScanTask::process_messages(&cmd_receiver, &mut parsed_keys)?;
 
     assert_eq!(
         parsed_keys.len(),
@@ -108,8 +105,8 @@ async fn scan_task_processes_messages_correctly() -> Result<(), Report> {
     let done_rx =
         mock_scan_task.remove_keys(&(0..200).map(|i| i.to_string()).collect::<Vec<_>>())?;
 
-    let new_keys =
-        ScanTask::process_messages(&cmd_receiver, &mut parsed_keys, &mut subscribed_keys)?;
+    let (new_keys, _new_results_senders) =
+        ScanTask::process_messages(&cmd_receiver, &mut parsed_keys)?;
 
     // Check that it sends the done notification successfully before returning and dropping `done_tx`
     done_rx.await?;
@@ -131,8 +128,8 @@ async fn scan_task_processes_messages_correctly() -> Result<(), Report> {
 
     mock_scan_task.remove_keys(&(0..200).map(|i| i.to_string()).collect::<Vec<_>>())?;
 
-    let new_keys =
-        ScanTask::process_messages(&cmd_receiver, &mut parsed_keys, &mut subscribed_keys)?;
+    let (new_keys, _new_results_senders) =
+        ScanTask::process_messages(&cmd_receiver, &mut parsed_keys)?;
 
     assert!(
         new_keys.is_empty(),
@@ -155,8 +152,8 @@ async fn scan_task_processes_messages_correctly() -> Result<(), Report> {
             .collect(),
     )?;
 
-    let new_keys =
-        ScanTask::process_messages(&cmd_receiver, &mut parsed_keys, &mut subscribed_keys)?;
+    let (new_keys, _new_results_senders) =
+        ScanTask::process_messages(&cmd_receiver, &mut parsed_keys)?;
 
     assert_eq!(
         new_keys.len(),

--- a/zebra-scan/src/service/tests.rs
+++ b/zebra-scan/src/service/tests.rs
@@ -99,7 +99,7 @@ pub async fn scan_service_subscribes_to_results_correctly() -> Result<()> {
             keys,
         }) = cmd_receiver.recv()
         else {
-            panic!("should successfully receive RemoveKeys message");
+            panic!("should successfully receive SubscribeResults message");
         };
 
         assert_eq!(keys, expected_keys, "keys should match the request keys");

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -128,6 +128,12 @@
 //! ZEBRA_CACHED_STATE_DIR=/path/to/zebra/state cargo test scans_for_new_key --features shielded-scan --release -- --ignored --nocapture
 //! ```
 //!
+//! Example of how to run the scan_subscribe_results test:
+//!
+//! ```console
+//! ZEBRA_CACHED_STATE_DIR=/path/to/zebra/state cargo test scan_subscribe_results --features shielded-scan --release -- --ignored --nocapture
+//! ```
+//!
 //! ## Checkpoint Generation Tests
 //!
 //! Generate checkpoints on mainnet and testnet using a cached state:
@@ -3011,11 +3017,22 @@ fn scan_start_where_left() -> Result<()> {
 
 /// Test successful registration of a new key in the scan task.
 ///
-/// See [`common::shielded_scan::register_key`] for more information.
+/// See [`common::shielded_scan::scans_for_new_key`] for more information.
 // TODO: Add this test to CI (#8236)
 #[tokio::test]
 #[ignore]
 #[cfg(feature = "shielded-scan")]
 async fn scans_for_new_key() -> Result<()> {
     common::shielded_scan::scans_for_new_key::run().await
+}
+
+/// Tests SubscribeResults ScanService request.
+///
+/// See [`common::shielded_scan::subscribe_results`] for more information.
+// TODO: Add this test to CI (#8236)
+#[tokio::test]
+#[ignore]
+#[cfg(feature = "shielded-scan")]
+async fn scan_subscribe_results() -> Result<()> {
+    common::shielded_scan::subscribe_results::run().await
 }

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -131,7 +131,7 @@
 //! Example of how to run the scan_subscribe_results test:
 //!
 //! ```console
-//! ZEBRA_CACHED_STATE_DIR=/path/to/zebra/state cargo test scan_subscribe_results --features shielded-scan --release -- --ignored --nocapture
+//! ZEBRA_CACHED_STATE_DIR=/path/to/zebra/state cargo test scan_subscribe_results --features shielded-scan -- --ignored --nocapture
 //! ```
 //!
 //! ## Checkpoint Generation Tests

--- a/zebrad/tests/common/shielded_scan.rs
+++ b/zebrad/tests/common/shielded_scan.rs
@@ -1,3 +1,4 @@
 //! Acceptance tests for `shielded-scan`` feature in zebrad.
 
 pub(crate) mod scans_for_new_key;
+pub(crate) mod subscribe_results;

--- a/zebrad/tests/common/shielded_scan/scans_for_new_key.rs
+++ b/zebrad/tests/common/shielded_scan/scans_for_new_key.rs
@@ -27,7 +27,7 @@ use crate::common::{
 const REQUIRED_MIN_TIP_HEIGHT: Height = Height(1_000_000);
 
 /// How long this test waits after registering keys to check if there are any results.
-const WAIT_FOR_RESULTS_DURATION: Duration = Duration::from_secs(10 * 60);
+const WAIT_FOR_RESULTS_DURATION: Duration = Duration::from_secs(60);
 
 /// Initialize Zebra's state service with a cached state, add a new key to the scan task, and
 /// check that it stores results for the new key without errors.
@@ -107,6 +107,8 @@ pub(crate) async fn run() -> Result<()> {
     let storage = Storage::new(&shielded_scan_config, network, true);
 
     let results = storage.sapling_results(&ZECPAGES_SAPLING_VIEWING_KEY.to_string());
+
+    tracing::info!(?results, "got the results");
 
     // Check that some results were added for the zecpages key that was not in the config or the db when ScanTask started.
     assert!(

--- a/zebrad/tests/common/shielded_scan/subscribe_results.rs
+++ b/zebrad/tests/common/shielded_scan/subscribe_results.rs
@@ -4,7 +4,7 @@
 //! Sapling activation height and [`REQUIRED_MIN_TIP_HEIGHT`]
 //!
 //! export ZEBRA_CACHED_STATE_DIR="/path/to/zebra/state"
-//! cargo test scan_subscribe_results --release --features="shielded-scan" -- --ignored --nocapture
+//! cargo test scan_subscribe_results --features="shielded-scan" -- --ignored --nocapture
 
 use std::time::Duration;
 

--- a/zebrad/tests/common/shielded_scan/subscribe_results.rs
+++ b/zebrad/tests/common/shielded_scan/subscribe_results.rs
@@ -92,13 +92,11 @@ pub(crate) async fn run() -> Result<()> {
             .map(|key| (key, Some(736000)))
             .collect(),
     )?;
-    let result_receiver = scan_task.subscribe(keys.into_iter().collect())?;
+
+    let mut result_receiver = scan_task.subscribe(keys.into_iter().collect())?;
 
     // Wait for the scanner to send a result in the channel
-    let result = tokio::task::spawn_blocking(move || {
-        result_receiver.recv_timeout(WAIT_FOR_RESULTS_DURATION)
-    })
-    .await??;
+    let result = tokio::time::timeout(WAIT_FOR_RESULTS_DURATION, result_receiver.recv()).await?;
 
     tracing::info!(?result, "received a result from the channel");
 

--- a/zebrad/tests/common/shielded_scan/subscribe_results.rs
+++ b/zebrad/tests/common/shielded_scan/subscribe_results.rs
@@ -6,7 +6,7 @@
 //! export ZEBRA_CACHED_STATE_DIR="/path/to/zebra/state"
 //! cargo test scan_subscribe_results --release --features="shielded-scan" -- --ignored --nocapture
 
-use std::{collections::HashMap, time::Duration};
+use std::time::Duration;
 
 use color_eyre::{eyre::eyre, Result};
 
@@ -17,12 +17,7 @@ use zebra_chain::{
     parameters::{Network, NetworkUpgrade},
 };
 
-use zebra_scan::{
-    scan::sapling_key_to_scan_block_keys, service::ScanTask, storage::Storage,
-    tests::ZECPAGES_SAPLING_VIEWING_KEY, DiversifiableFullViewingKey, SaplingIvk,
-};
-
-use zebra_state::SaplingScanningKey;
+use zebra_scan::{service::ScanTask, storage::Storage, tests::ZECPAGES_SAPLING_VIEWING_KEY};
 
 use crate::common::{
     cached_state::start_state_service_with_cache_dir, launch::can_spawn_zebrad_for_test_type,
@@ -92,23 +87,11 @@ pub(crate) async fn run() -> Result<()> {
 
     let mut scan_task = ScanTask::spawn(storage, state, chain_tip_change);
 
-    let (zecpages_dfvks, zecpages_ivks) =
-        sapling_key_to_scan_block_keys(&ZECPAGES_SAPLING_VIEWING_KEY.to_string(), network)?;
-
-    let mut parsed_keys: HashMap<
-        SaplingScanningKey,
-        (Vec<DiversifiableFullViewingKey>, Vec<SaplingIvk>, Height),
-    > = HashMap::new();
-
-    parsed_keys.insert(
-        ZECPAGES_SAPLING_VIEWING_KEY.to_string(),
-        (zecpages_dfvks, zecpages_ivks, Height::MIN),
-    );
-
     tracing::info!("started scan task, sending register/subscribe keys messages with zecpages key to start scanning for a new key",);
 
-    scan_task.register_keys(parsed_keys.clone())?;
-    let result_receiver = scan_task.subscribe(parsed_keys.keys().cloned().collect())?;
+    let keys = [ZECPAGES_SAPLING_VIEWING_KEY.to_string()];
+    scan_task.register_keys(keys.iter().cloned().map(|key| (key, None)).collect())?;
+    let result_receiver = scan_task.subscribe(keys.into_iter().collect())?;
 
     // Wait for the scanner to send a result in the channel
     let _result = result_receiver.recv_timeout(WAIT_FOR_RESULTS_DURATION)?;


### PR DESCRIPTION
## Motivation

We want to be able to subscribe to new scan results to stream to RPC clients.

Closes #8206.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Updates `process_messages()` function to return a list of subscribed keys and their result senders
- Adds a watch channel for sending `subscribed_keys` to `scan_range()` tasks
- Checks if there's a `result_sender` for a key and sends it new results if there are any

### Testing

- Updates test vector for `process_messages()` to check that it processes `SubscribeResults` messages correctly
- Adds a test for the `ScanService` to see that it sends the message correctly
- Adds an acceptance test for checking that the results channel receives new relevant transactions

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

- #8250
- #8259
- #8256 
