### PR TITLE
fix(docker): set log rotation to avoid docker bugs

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,6 +16,10 @@ services:
           memory: 16G
     env_file:
       - .env
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "5"
     #! Uncomment the `configs` mapping below to use the `zebrad.toml` config file from the host machine
     #! NOTE: This will override the zebrad.toml in the image and make some variables irrelevant
     # configs:


### PR DESCRIPTION
Containers can generate a significant amount of logs, consuming disk space over time. Here I added configuration for maximum log file size (max-size) and the number of retained log files (max-file) in the logging driver options to control disk usage and prevent log files from growing indefinitely.

## Motivation
<!--
Thank you for your Pull Request.
Does it close any issues?
-->
_What are the most important goals of the ticket or PR?_

There is a possible docker bugs which causes no logs to be saved or printed in containers with significant amount of logs, for example 3 days of zebra initial sync.

Refs:
- [issue 8262](https://github.com/ZcashFoundation/zebra/issues/8262)
- possible bugs with default [docker logging](https://forums.docker.com/t/how-to-clear-a-docker-desktop-container-log/138495/2)

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

Add logging options to docker-compose.yml to run zebra with ligthwalletd.

### Testing

Manual testing done by running `docker compose up` again from the same directory.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._
