### PR TITLE
ci: Update Debian from Bullseye to Bookworm

### DIFF
--- a/book/src/user/supported-platforms.md
+++ b/book/src/user/supported-platforms.md
@@ -17,7 +17,7 @@ For the full requirements, see [Tier 1 platform policy](platform-tier-policy.md#
 
 | platform | os | notes | rust | artifacts
 | -------|-------|-------|-------|-------
-| `x86_64-unknown-linux-gnu` | [Debian 11](https://www.debian.org/releases/bullseye/) | 64-bit | [latest stable release](https://github.com/rust-lang/rust/releases) | Docker
+| `x86_64-unknown-linux-gnu` | [Debian 11](https://www.debian.org/releases/bookworm/) | 64-bit | [latest stable release](https://github.com/rust-lang/rust/releases) | Docker
 
 ## Tier 2
 
@@ -46,5 +46,5 @@ For the full requirements, see [Tier 3 platform policy](platform-tier-policy.md#
 
 | platform | os | notes | rust | artifacts
 | -------|-------|-------|-------|-------
-| `aarch64-unknown-linux-gnu` | [Debian 11](https://www.debian.org/releases/bullseye/) | 64-bit | [latest stable release](https://github.com/rust-lang/rust/releases) | N/A
+| `aarch64-unknown-linux-gnu` | [Debian 11](https://www.debian.org/releases/bookworm/) | 64-bit | [latest stable release](https://github.com/rust-lang/rust/releases) | N/A
 | `aarch64-apple-darwin` | latest macOS | 64-bit, Apple M1 or M2 | [latest stable release](https://github.com/rust-lang/rust/releases) | N/A

--- a/book/src/user/troubleshooting.md
+++ b/book/src/user/troubleshooting.md
@@ -7,7 +7,7 @@ for:
 - macOS,
 - Ubuntu,
 - Docker:
-  - Debian Bullseye.
+  - Debian Bookworm.
 
 ## Memory Issues
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ ARG TEST_FEATURES="lightwalletd-grpc-tests zebra-checkpoints"
 ARG EXPERIMENTAL_FEATURES=""
 
 # This stage implements cargo-chef for docker layer caching
-FROM rust:bullseye as chef
+FROM rust:bookworm as chef
 RUN cargo install cargo-chef --locked
 WORKDIR /opt/zebrad
 
@@ -181,7 +181,7 @@ RUN chmod u+x /entrypoint.sh
 #
 # To save space, this step starts from scratch using debian, and only adds the resulting
 # binary from the `release` stage
-FROM debian:bullseye-slim AS runtime
+FROM debian:bookworm-slim AS runtime
 COPY --from=release /opt/zebrad/target/release/zebrad /usr/local/bin
 COPY --from=release /entrypoint.sh /
 

--- a/docker/zcash-lightwalletd/Dockerfile
+++ b/docker/zcash-lightwalletd/Dockerfile
@@ -42,7 +42,7 @@ CMD ["--no-tls-very-insecure", "--grpc-bind-addr=0.0.0.0:9067",  "--http-bind-ad
 ##
 ## Deploy
 ##
-FROM debian:bullseye-slim as runtime
+FROM debian:bookworm-slim as runtime
 
 ARG ZCASHD_CONF_PATH
 # Maintain backward compatibility with mainstream repo using this ARGs in docker-compose


### PR DESCRIPTION
## Motivation

Close #8272. I think now is a good time to update Debian to Bookworm since it's causing issues with the current development instead of coming up with workarounds for Bullseye.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [ ] Have you added or updated tests?
  - [x] Is the documentation up to date?

### Specifications

- Debian Bookworm contains the package `protobuf-compiler` with Protocol Buffers v3.21: https://packages.debian.org/bookworm/protobuf-compiler, which supports optional fields in type definitions.

## Solution

- Replace all occurrences of `bullseye` or `Bullseye` with `bookworm` or `Bookworm`.

### Testing

Let's see if anything breaks in the CI.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._