### PR TITLE
fix(test): Improve error message in `non_blocking_logger` test

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1691,12 +1691,10 @@ fn non_blocking_logger() -> Result<()> {
         Ok(())
     });
 
-    // Wait until the spawned task finishes or return an error in 45 seconds
-    if done_rx.recv_timeout(Duration::from_secs(45)).is_err() {
-        return Err(eyre!("unexpected test task hang"));
+    // Wait until the spawned task finishes up to 45 seconds before shutting down tokio runtime
+    if done_rx.recv_timeout(Duration::from_secs(45)).is_ok() {
+        rt.shutdown_timeout(Duration::from_secs(3));
     }
-
-    rt.shutdown_timeout(Duration::from_secs(3));
 
     match test_task_handle.now_or_never() {
         Some(Ok(result)) => result,


### PR DESCRIPTION
## Motivation

We want to see an error message about a possible port conflict in the `non_blocking_logger` test when the spawned Zebrad finishes without being killed.

Closes #8261.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Remove early return when `done_rx.recv()` times out.

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

-  If the 'Possible port conflict' message shows up too often, consider updating tests that use a TCP port to use port 0 (OS-assigned port) and read the port from the logs (they already use an OS-assigned port, but there's a delay between picking a port and binding it)
