### PR TITLE
Enable optional fields for Protocol Buffers older than v3.15.0

### DIFF
--- a/zebra-grpc/build.rs
+++ b/zebra-grpc/build.rs
@@ -3,6 +3,7 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .btree_map(["."])
+        .protoc_arg("--experimental_allow_proto3_optional")
         .type_attribute(".", "#[derive(serde::Deserialize, serde::Serialize)]")
         .compile(&["proto/scanner.proto"], &[""])?;
     Ok(())


### PR DESCRIPTION
## Motivation

Close #8278.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Is the documentation up to date?

## Solution

- Enable the `experimental_allow_proto3_optional` flag for `protoc`.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._