### PR TITLE
release(tests): update dry-run release commands

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -83,15 +83,22 @@ Check that the release will work:
 - [ ] Update crate versions, commit the changes to the release branch, and do a release dry-run:
 
 ```sh
-cargo release version --verbose --execute --allow-branch '*' --workspace --exclude zebrad --exclude zebra-scan beta
-# Due to a bug in cargo-release, we need to pass an exact version here
-cargo release version --verbose --execute --allow-branch '*' --package zebra-scan 0.1.0-alpha.1
+# Update everything except for alpha crates and zebrad:
+cargo release version --verbose --execute --allow-branch '*' --workspace --exclude zebrad --exclude zebra-scan --exclude zebra-grpc beta
+# Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
+cargo release version --verbose --execute --allow-branch '*' --package zebra-scan 0.1.0-alpha.4
+cargo release version --verbose --execute --allow-branch '*' --package zebra-grpc 0.1.0-alpha.2
+# Update zebrad:
 cargo release version --verbose --execute --allow-branch '*' --package zebrad patch # [ major | minor | patch ]
+# Continue with the release process:
 cargo release replace --verbose --execute --allow-branch '*' --package zebrad
 cargo release commit --verbose --execute --allow-branch '*'
 ```
 
-Crate publishing is [automatically checked in CI](https://github.com/ZcashFoundation/zebra/actions/workflows/release-crates-io.yml) using "dry run" mode.
+Crate publishing is [automatically checked in CI](https://github.com/ZcashFoundation/zebra/actions/workflows/release-crates-io.yml) using "dry run" mode, however due to a bug in `cargo-release` we need to pass exact versions to the alpha crates:
+
+- [ ] Update `zebra-scan` and `zebra-grpc` alpha crates in the [release-crates-dry-run workflow script](https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/scripts/release-crates-dry-run.sh)
+- [ ] Push the above version changes to the release branch.
 
 ## Update End of Support
 

--- a/.github/workflows/scripts/release-crates-dry-run.sh
+++ b/.github/workflows/scripts/release-crates-dry-run.sh
@@ -17,10 +17,16 @@ if ! cargo release --version &> /dev/null; then
 fi
 
 # Release process
-# Ensure to have an extra `--no-confirm` argument for non-interactive testing.
+# We use the same commands as the [release drafter](https://github.com/ZcashFoundation/zebra/blob/main/.github/PULL_REQUEST_TEMPLATE/release-checklist.md#update-crate-versions)
+# with an extra `--no-confirm` argument for non-interactive testing.
+# Update everything except for alpha crates and zebrad:
 cargo release version --verbose --execute --no-confirm --allow-branch '*' --workspace --exclude zebrad --exclude zebra-scan --exclude zebra-grpc beta
-# TODO: `zebra-scan` and `zebra-grpc` has to be updated with exact versions, we are skipping them by now.
+# Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
+cargo release version --verbose --execute --allow-branch '*' --package zebra-scan 0.1.0-alpha.4
+cargo release version --verbose --execute --allow-branch '*' --package zebra-grpc 0.1.0-alpha.2
+# Update zebrad:
 cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebrad patch
+# Continue with the release process:
 cargo release replace --verbose --execute --no-confirm --allow-branch '*' --package zebrad
 cargo release commit --verbose --execute --no-confirm --allow-branch '*'
 


### PR DESCRIPTION
## Motivation

We have some missing commands for new crates in the dry run release commands in the CI and in the release drafter template.

Close https://github.com/ZcashFoundation/zebra/issues/8199

## Solution

- Add extra commands to release drafter and workflow script.
- Unfortunately, this adds an extra step to the release process. We need to manually increase the versions in the workflow.

## Review

Anyone can review but i think @upbqdn should take a look as he will be doing the next release. Also @gustavovalverde might want to take a look, will be great to find an easier way to do it.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
