### PR TITLE
ref(docker): publish less tags in Docker Hub

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -18,7 +18,7 @@ jobs:
   # Each time this workflow is executed, a build will be triggered to create a new image
   # with the corresponding tags using information from git
 
-  # The image will be named `zebra:<semver>.experimental`
+  # The image will be named `zebra:<semver>-experimental`
   build-experimental:
     name: Build Experimental Features Release Docker
     uses: ./.github/workflows/sub-build-docker-image.yml
@@ -26,7 +26,7 @@ jobs:
       dockerfile_path: ./docker/Dockerfile
       dockerfile_target: runtime
       image_name: zebra
-      tag_suffix: .experimental
+      tag_suffix: -experimental
       features: ${{ format('{0} {1}', vars.RUST_PROD_FEATURES, vars.RUST_EXPERIMENTAL_FEATURES) }}
       rust_log: ${{ vars.RUST_LOG }}
     # This step needs access to Docker Hub secrets to run successfully

--- a/.github/workflows/sub-build-docker-image.yml
+++ b/.github/workflows/sub-build-docker-image.yml
@@ -103,14 +103,7 @@ jobs:
           tags: |
             # These DockerHub release tags support the following use cases:
             # - `latest`: always use the latest Zebra release when you pull or update
-            # - `1`: use the latest Zebra release, but require manual intervention for the next network upgrade
-            # - `1.x`: update to bug fix releases, but don't add any new features or incompatibilities
             # - `v1.x.y` or `1.x.y`: always use the exact version, don't automatically upgrade
-            # - `sha-zzzzzz`: always use the exact commit (the same as `1.x.y`, but also used in CI and production image tests)
-            #
-            # Stopping publishing some tags is a silently breaking change:
-            # - `1`: doesn't get expected new consensus-compatible releases or bug fixes
-            # - `1.x`: doesn't get expected bug fixes
             #
             # `semver` adds a "latest" tag if `inputs.latest_tag` is `true`.
             type=semver,pattern={{version}}
@@ -119,7 +112,7 @@ jobs:
             type=ref,event=tag
             # DockerHub release and CI tags.
             # This tag makes sure tests are using exactly the right image, even when multiple PRs run at the same time.
-            type=sha
+            type=sha,event=push
             # These CI-only tags support CI on PRs, the main branch, and scheduled full syncs. 
             # These tags do not appear on DockerHub, because DockerHub images are only published on the release event.
             type=ref,event=pr

--- a/.github/workflows/sub-build-docker-image.yml
+++ b/.github/workflows/sub-build-docker-image.yml
@@ -107,8 +107,6 @@ jobs:
             #
             # `semver` adds a "latest" tag if `inputs.latest_tag` is `true`.
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
             type=ref,event=tag
             # DockerHub release and CI tags.
             # This tag makes sure tests are using exactly the right image, even when multiple PRs run at the same time.


### PR DESCRIPTION
## Motivation

Fixes #7891

_What are the most important goals of the ticket or PR?_

- Making our image tags less confusing.
- Make our Docker Hub easier to navigate.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [ ] Will the PR name make sense to users?
  - [ ] Does the PR have a priority label?
  - [ ] Have you added or updated tests?
  - [ ] Is the documentation up to date?

##### For significant changes:
  - [ ] Is there a summary in the CHANGELOG?
  - [ ] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._


## Solution
- Change `.experimental` with `-experimental`
- Just add the `SHA` on github pushes (to main or branches)
- Remove extra versions tags using extra `major` and `major.minor`


### Testing

Sadly, there's no way to test this until we make the release :/ 


### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._
