### PR TITLE
fix(scan): Fix minor concurrency bug in the `scan` gRPC method

### DIFF
--- a/zebra-grpc/src/server.rs
+++ b/zebra-grpc/src/server.rs
@@ -124,7 +124,7 @@ where
         tokio::spawn(async move {
             let mut initial_results = process_results(keys, results);
 
-            // Empty results receiver channel to filter out duplicates results between the channel and cache
+            // Empty results receiver channel to filter out duplicate results between the channel and cache
             while let Ok(ScanResult { key, height, tx_id }) = results_receiver.try_recv() {
                 let entry = initial_results
                     .entry(key)

--- a/zebra-grpc/src/server.rs
+++ b/zebra-grpc/src/server.rs
@@ -70,13 +70,24 @@ where
             .into_iter()
             .map(|KeyWithHeight { key, height }| (key, height))
             .collect();
-
-        let ScanServiceResponse::RegisteredKeys(_) = self
+        let register_keys_response_fut = self
             .scan_service
             .clone()
-            .ready()
-            .and_then(|service| service.call(ScanServiceRequest::RegisterKeys(keys.clone())))
-            .await
+            .oneshot(ScanServiceRequest::RegisterKeys(keys.clone()));
+
+        let keys: Vec<_> = keys.into_iter().map(|(key, _start_at)| key).collect();
+
+        let subscribe_results_response_fut =
+            self.scan_service
+                .clone()
+                .oneshot(ScanServiceRequest::SubscribeResults(
+                    keys.iter().cloned().collect(),
+                ));
+
+        let (register_keys_response, subscribe_results_response) =
+            tokio::join!(register_keys_response_fut, subscribe_results_response_fut);
+
+        let ScanServiceResponse::RegisteredKeys(_) = register_keys_response
             .map_err(|err| Status::unknown(format!("scan service returned error: {err}")))?
         else {
             return Err(Status::unknown(
@@ -84,7 +95,14 @@ where
             ));
         };
 
-        let keys: Vec<_> = keys.into_iter().map(|(key, _start_at)| key).collect();
+        let ScanServiceResponse::SubscribeResults(mut results_receiver) =
+            subscribe_results_response
+                .map_err(|err| Status::unknown(format!("scan service returned error: {err}")))?
+        else {
+            return Err(Status::unknown(
+                "scan service returned an unexpected response",
+            ));
+        };
 
         let ScanServiceResponse::Results(results) = self
             .scan_service
@@ -99,29 +117,31 @@ where
             ));
         };
 
-        let ScanServiceResponse::SubscribeResults(mut results_receiver) = self
-            .scan_service
-            .clone()
-            .ready()
-            .and_then(|service| {
-                service.call(ScanServiceRequest::SubscribeResults(
-                    keys.iter().cloned().collect(),
-                ))
-            })
-            .await
-            .map_err(|err| Status::unknown(format!("scan service returned error: {err}")))?
-        else {
-            return Err(Status::unknown(
-                "scan service returned an unexpected response",
-            ));
-        };
-
         let (response_sender, response_receiver) =
             tokio::sync::mpsc::channel(SCAN_RESPONDER_BUFFER_SIZE);
         let response_stream = ReceiverStream::new(response_receiver);
 
         tokio::spawn(async move {
-            let initial_results = process_results(keys, results);
+            let mut initial_results = process_results(keys, results);
+
+            // Empty results receiver channel to filter out duplicates results between the channel and cache
+            while let Ok(ScanResult { key, height, tx_id }) = results_receiver.try_recv() {
+                let entry = initial_results
+                    .entry(key)
+                    .or_default()
+                    .by_height
+                    .entry(height.0)
+                    .or_default();
+
+                let tx_id = Transaction {
+                    hash: tx_id.to_string(),
+                };
+
+                // Add the scan result to the initial results if it's not already present.
+                if !entry.transactions.contains(&tx_id) {
+                    entry.transactions.push(tx_id);
+                }
+            }
 
             let send_result = response_sender
                 .send(Ok(ScanResponse {

--- a/zebra-grpc/src/tests/snapshot.rs
+++ b/zebra-grpc/src/tests/snapshot.rs
@@ -177,14 +177,14 @@ async fn test_mocked_rpc_response_data_for_network(network: Network, random_port
                 .respond(ScanResponse::RegisteredKeys(vec![]));
 
             mock_scan_service
-                .expect_request_that(|req| matches!(req, ScanRequest::Results(_)))
-                .await
-                .respond(ScanResponse::Results(fake_results_response));
-
-            mock_scan_service
                 .expect_request_that(|req| matches!(req, ScanRequest::SubscribeResults(_)))
                 .await
                 .respond(ScanResponse::SubscribeResults(fake_results_receiver));
+
+            mock_scan_service
+                .expect_request_that(|req| matches!(req, ScanRequest::Results(_)))
+                .await
+                .respond(ScanResponse::Results(fake_results_response));
         });
     }
 

--- a/zebra-scan/src/service.rs
+++ b/zebra-scan/src/service.rs
@@ -169,7 +169,7 @@ impl Service<Request> for ScanService {
                 let mut scan_task = self.scan_task.clone();
 
                 return async move {
-                    let results_receiver = scan_task.subscribe(keys)?;
+                    let results_receiver = scan_task.subscribe(keys).await?;
 
                     Ok(Response::SubscribeResults(results_receiver))
                 }

--- a/zebra-scan/src/service/scan_task/executor.rs
+++ b/zebra-scan/src/service/scan_task/executor.rs
@@ -1,6 +1,6 @@
 //! The scan task executor
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use color_eyre::eyre::Report;
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
@@ -19,7 +19,7 @@ use super::scan::ScanRangeTaskBuilder;
 const EXECUTOR_BUFFER_SIZE: usize = 100;
 
 pub fn spawn_init(
-    subscribed_keys_receiver: tokio::sync::watch::Receiver<HashMap<String, Sender<ScanResult>>>,
+    subscribed_keys_receiver: watch::Receiver<Arc<HashMap<String, Sender<ScanResult>>>>,
 ) -> (Sender<ScanRangeTaskBuilder>, JoinHandle<Result<(), Report>>) {
     let (scan_task_sender, scan_task_receiver) = tokio::sync::mpsc::channel(EXECUTOR_BUFFER_SIZE);
 
@@ -33,7 +33,7 @@ pub fn spawn_init(
 
 pub async fn scan_task_executor(
     mut scan_task_receiver: Receiver<ScanRangeTaskBuilder>,
-    subscribed_keys_receiver: watch::Receiver<HashMap<String, Sender<ScanResult>>>,
+    subscribed_keys_receiver: watch::Receiver<Arc<HashMap<String, Sender<ScanResult>>>>,
 ) -> Result<(), Report> {
     let mut scan_range_tasks = FuturesUnordered::new();
 

--- a/zebra-scan/src/service/scan_task/scan.rs
+++ b/zebra-scan/src/service/scan_task/scan.rs
@@ -147,7 +147,7 @@ pub async fn start(
 
         subscribed_keys.extend(new_result_senders);
         // Drop any results senders that are closed from subscribed_keys
-        subscribed_keys.retain(|_k, sender| !sender.is_closed());
+        subscribed_keys.retain(|key, sender| !sender.is_closed() && parsed_keys.contains_key(key));
 
         // Send the latest version of `subscribed_keys` before spawning the scan range task
         subscribed_keys_sender

--- a/zebra-scan/src/service/scan_task/scan.rs
+++ b/zebra-scan/src/service/scan_task/scan.rs
@@ -158,7 +158,6 @@ pub async fn start(
             let _ = rsp_tx.send(result_receiver);
         }
 
-        // TODO: Check if the `start_height` is at or above the current height
         if !new_keys.is_empty() {
             let state = state.clone();
             let storage = storage.clone();
@@ -172,7 +171,9 @@ pub async fn start(
             if was_parsed_keys_empty {
                 info!(?start_height, "setting new start height");
                 height = start_height;
-            } else if start_height < height {
+            }
+            // Skip spawning ScanRange task if `start_height` is at or above the current height
+            else if start_height < height {
                 scan_task_sender
                     .send(ScanRangeTaskBuilder::new(height, new_keys, state, storage))
                     .await

--- a/zebra-scan/src/service/scan_task/scan/scan_range.rs
+++ b/zebra-scan/src/service/scan_task/scan/scan_range.rs
@@ -56,7 +56,7 @@ impl ScanRangeTaskBuilder {
     // TODO: return a tuple with a shutdown sender
     pub fn spawn(
         self,
-        subscribed_keys_receiver: watch::Receiver<HashMap<String, Sender<ScanResult>>>,
+        subscribed_keys_receiver: watch::Receiver<Arc<HashMap<String, Sender<ScanResult>>>>,
     ) -> JoinHandle<Result<(), Report>> {
         let Self {
             height_range,
@@ -86,7 +86,7 @@ pub async fn scan_range(
     keys: HashMap<SaplingScanningKey, (Vec<DiversifiableFullViewingKey>, Vec<SaplingIvk>, Height)>,
     state: State,
     storage: Storage,
-    subscribed_keys_receiver: watch::Receiver<HashMap<String, Sender<ScanResult>>>,
+    subscribed_keys_receiver: watch::Receiver<Arc<HashMap<String, Sender<ScanResult>>>>,
 ) -> Result<(), Report> {
     let sapling_activation_height = storage.network().sapling_activation_height();
     // Do not scan and notify if we are below sapling activation height.

--- a/zebra-scan/src/service/scan_task/scan/scan_range.rs
+++ b/zebra-scan/src/service/scan_task/scan/scan_range.rs
@@ -116,7 +116,6 @@ pub async fn scan_range(
         .collect();
 
     while height < stop_before_height {
-        let subscribed_keys = subscribed_keys_receiver.borrow().clone();
         let scanned_height = scan_height_and_store_results(
             height,
             state.clone(),
@@ -124,7 +123,7 @@ pub async fn scan_range(
             storage.clone(),
             key_heights.clone(),
             parsed_keys.clone(),
-            subscribed_keys,
+            subscribed_keys_receiver.clone(),
         )
         .await?;
 

--- a/zebra-scan/src/service/scan_task/tests/vectors.rs
+++ b/zebra-scan/src/service/scan_task/tests/vectors.rs
@@ -1,6 +1,9 @@
 //! Fixed test vectors for the scan task.
 
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration,
+};
 
 use color_eyre::Report;
 
@@ -24,7 +27,7 @@ async fn scan_task_processes_messages_correctly() -> Result<(), Report> {
         sapling_keys.into_iter().zip((0..).map(Some)).collect();
     mock_scan_task.register_keys(sapling_keys_with_birth_heights.clone())?;
 
-    let (new_keys, _new_results_senders) =
+    let (new_keys, _new_results_senders, _new_results_receivers) =
         ScanTask::process_messages(&mut cmd_receiver, &mut parsed_keys, network)?;
 
     // Check that it updated parsed_keys correctly and returned the right new keys when starting with an empty state
@@ -45,7 +48,7 @@ async fn scan_task_processes_messages_correctly() -> Result<(), Report> {
 
     // Check that no key should be added if they are all already known and the heights are the same
 
-    let (new_keys, _new_results_senders) =
+    let (new_keys, _new_results_senders, _new_results_receivers) =
         ScanTask::process_messages(&mut cmd_receiver, &mut parsed_keys, network)?;
 
     assert_eq!(
@@ -71,7 +74,7 @@ async fn scan_task_processes_messages_correctly() -> Result<(), Report> {
     mock_scan_task.register_keys(sapling_keys_with_birth_heights[10..20].to_vec())?;
     mock_scan_task.register_keys(sapling_keys_with_birth_heights[10..15].to_vec())?;
 
-    let (new_keys, _new_results_senders) =
+    let (new_keys, _new_results_senders, _new_results_receivers) =
         ScanTask::process_messages(&mut cmd_receiver, &mut parsed_keys, network)?;
 
     assert_eq!(
@@ -91,7 +94,7 @@ async fn scan_task_processes_messages_correctly() -> Result<(), Report> {
     let sapling_keys = mock_sapling_scanning_keys(30, network);
     let done_rx = mock_scan_task.remove_keys(&sapling_keys)?;
 
-    let (new_keys, _new_results_senders) =
+    let (new_keys, _new_results_senders, _new_results_receivers) =
         ScanTask::process_messages(&mut cmd_receiver, &mut parsed_keys, network)?;
 
     // Check that it sends the done notification successfully before returning and dropping `done_tx`
@@ -110,7 +113,7 @@ async fn scan_task_processes_messages_correctly() -> Result<(), Report> {
 
     mock_scan_task.remove_keys(&sapling_keys)?;
 
-    let (new_keys, _new_results_senders) =
+    let (new_keys, _new_results_senders, _new_results_receivers) =
         ScanTask::process_messages(&mut cmd_receiver, &mut parsed_keys, network)?;
 
     assert!(
@@ -126,7 +129,7 @@ async fn scan_task_processes_messages_correctly() -> Result<(), Report> {
 
     mock_scan_task.register_keys(sapling_keys_with_birth_heights[..2].to_vec())?;
 
-    let (new_keys, _new_results_senders) =
+    let (new_keys, _new_results_senders, _new_results_receivers) =
         ScanTask::process_messages(&mut cmd_receiver, &mut parsed_keys, network)?;
 
     assert_eq!(
@@ -142,10 +145,30 @@ async fn scan_task_processes_messages_correctly() -> Result<(), Report> {
     );
 
     let subscribe_keys: HashSet<String> = sapling_keys[..5].iter().cloned().collect();
-    let mut result_receiver = mock_scan_task.subscribe(subscribe_keys.clone())?;
+    let result_receiver_fut = {
+        let mut mock_scan_task = mock_scan_task.clone();
+        tokio::spawn(async move { mock_scan_task.subscribe(subscribe_keys.clone()).await })
+    };
 
-    let (_new_keys, new_results_senders) =
+    // Wait for spawned task to send subscribe message
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let (_new_keys, new_results_senders, new_results_receivers) =
         ScanTask::process_messages(&mut cmd_receiver, &mut parsed_keys, network)?;
+
+    let (result_receiver, rsp_tx) = new_results_receivers
+        .into_iter()
+        .next()
+        .expect("there should be a new result receiver");
+
+    rsp_tx
+        .send(result_receiver)
+        .expect("should send response successfully");
+
+    let mut result_receiver = result_receiver_fut
+        .await
+        .expect("tokio task should join successfully")
+        .expect("should send and receive message successfully");
 
     let processed_subscribe_keys: HashSet<String> = new_results_senders.keys().cloned().collect();
     let expected_new_subscribe_keys: HashSet<String> = sapling_keys[..2].iter().cloned().collect();

--- a/zebrad/tests/common/shielded_scan/subscribe_results.rs
+++ b/zebrad/tests/common/shielded_scan/subscribe_results.rs
@@ -89,11 +89,14 @@ pub(crate) async fn run() -> Result<()> {
     scan_task.register_keys(
         keys.iter()
             .cloned()
-            .map(|key| (key, Some(736000)))
+            .map(|key| (key, Some(780_000)))
             .collect(),
     )?;
 
-    let mut result_receiver = scan_task.subscribe(keys.into_iter().collect())?;
+    let mut result_receiver = scan_task
+        .subscribe(keys.into_iter().collect())
+        .await
+        .expect("should send and receive message successfully");
 
     // Wait for the scanner to send a result in the channel
     let result = tokio::time::timeout(WAIT_FOR_RESULTS_DURATION, result_receiver.recv()).await?;


### PR DESCRIPTION
## Motivation

This PR is a follow up to #8268 and fixes an issue around missing results from a block in the `scan` gRPC method response.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Updates scan task to:
  - Notify caller after updating the `subscribed_keys` collection and sending it to the watch channel (and sending it the result receiver)
  - Check for result senders in latest version of `subscribed_keys` in watch channel before writing results to storage
- Updates `scan()` gRPC method to:
  - Call `ScanService` with a `SubscribeResults` request and to wait for the response before calling the scan service with a `Results` request
  - Empty out the `result_receiver` channel to filter out any duplicates from the `Results` response
 
Related cleanups:
- Removes outdated TODOs
- Joins `RegisterKeys` and `SubscribeResults` service call futures

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

- Test that every expected result from the `scan()` method is present and unique