### PR TITLE
chore: Remove Zebra RFCs from `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,6 @@
 * [Running and Debugging](#running-and-debugging)
 * [Bug Reports](#bug-reports)
 * [Pull Requests](#pull-requests)
-* [Zebra RFCs](#zebra-rfcs)
 
 ## Running and Debugging
 [running-and-debugging]: #running-and-debugging
@@ -49,40 +48,3 @@ to the "re-run jobs" button on the `Coverage (+nightly)` CI job's tab
 
 To access a report download and extract the zip artifact then open the top
 level `index.html`.
-
-## Zebra RFCs
-[zebra-rfcs]: #zebra-rfcs
-
-Significant changes to the Zebra codebase are planned using Zebra RFCs. These
-allow structured discussion about a proposed change and provide a record of
-the planned design.
-
-To make a Zebra RFC:
-
-1. Choose a short feature name like `my-feature`.
-
-2. Copy the `book/src/dev/rfcs/0000-template.md` file to
-`book/src/dev/rfcs/drafts/xxxx-my-feature.md`.
-
-3. Edit the template header to add the feature name and the date, but leave
-the other fields blank for now.
-
-4. Write the design! The template has a suggested list of sections that are a
-useful guide.
-
-5. Create an design PR using the RFC template.
-
-6. After creating an RFC PR, update the RFC header and the PR description
-with the PR number.
-
-7. Make changes to the RFC in collaboration with the Zebra team.
-
-8. When the RFC is merged, take the next available RFC number (not conflicting
-with any existing RFCs or design PRs) and name the RFC file accordingly, e.g.,
-`0027-my-feature.md` for number 27.
-
-9. Make sure that `book/src/SUMMARY.md` links to the new number for the RFC.
-
-10. After the RFC is accepted, create an issue for the implementation of the
-design, and update the RFC header and PR description with the implementation
-issue number.


### PR DESCRIPTION
We have deprecated the RFC process

## Motivation
<!--
Thank you for your Pull Request.
Does it close any issues?
-->
_What are the most important goals of the ticket or PR?_


### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [ ] Does the PR have a priority label?
  - [ ] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [ ] Is there a summary in the CHANGELOG?
  - [ ] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

### Specifications

<!--
If this PR changes consensus rules, quote them, and link to the Zcash spec or ZIP:
https://zips.z.cash/#nu5-zips
-->


### Complex Code or Requirements

<!--
Does this PR change concurrency, unsafe code, or complex consensus rules?
If it does, label this PR with `extra-reviews`.
-->


## Solution

<!--
Summarize the changes in this PR.
-->


### Testing

<!--
Which tests were changed or added in this PR? Were there manual tests?
-->


## Review

<!--
Is this PR blocking any other work?
If you want specific reviewers for this PR, tag them here.
-->


### Reviewer Checklist

Check before approving the PR:
  - [x] Does the PR scope match the ticket?
  - [x] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [x] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
