### PR TITLE
fix(ci): keep `gcloud` arguments consistency

### DIFF
--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -197,7 +197,7 @@ jobs:
           echo "cached_disk_name=${CACHED_DISK_NAME}" >> "${GITHUB_OUTPUT}"
           echo "STATE_VERSION=${LOCAL_STATE_VERSION}" >> "${GITHUB_ENV}"
           echo "CACHED_DISK_NAME=${CACHED_DISK_NAME}" >> "${GITHUB_ENV}"
-          echo "DISK_OPTION=image=${CACHED_DISK_NAME,}" >> "${GITHUB_ENV}"
+          echo "DISK_OPTION=image=$CACHED_DISK_NAME," >> "${GITHUB_ENV}"
 
 
       # Create a Compute Engine virtual machine and attach a cached state disk using the

--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -197,7 +197,7 @@ jobs:
           echo "cached_disk_name=${CACHED_DISK_NAME}" >> "${GITHUB_OUTPUT}"
           echo "STATE_VERSION=${LOCAL_STATE_VERSION}" >> "${GITHUB_ENV}"
           echo "CACHED_DISK_NAME=${CACHED_DISK_NAME}" >> "${GITHUB_ENV}"
-          echo "DISK_OPTION=image=${CACHED_DISK_NAME}" >> "${GITHUB_ENV}"
+          echo "DISK_OPTION=image=${CACHED_DISK_NAME,}" >> "${GITHUB_ENV}"
 
 
       # Create a Compute Engine virtual machine and attach a cached state disk using the
@@ -212,7 +212,7 @@ jobs:
           --boot-disk-type pd-ssd \
           --image-project=cos-cloud \
           --image-family=cos-stable \
-          --create-disk=${DISK_OPTION},name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=400GB,type=pd-ssd \
+          --create-disk=${DISK_OPTION}name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",device-name="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}",size=400GB,type=pd-ssd \
           --container-image=gcr.io/google-containers/busybox \
           --machine-type ${{ vars.GCP_LARGE_MACHINE }} \
           --network-interface=subnet=${{ vars.GCP_SUBNETWORK }} \


### PR DESCRIPTION
## Motivation

When working with the big workflow refactors to use scripts files a comma (**,**) was added to the GCP CLI arguments, as it was missing from the refactored `$DISK_OPTION` variable, causing instances without a cached disk to fail, mainly the full sync tests. Issue source: https://github.com/ZcashFoundation/zebra/pull/8005/files#diff-822f5cf974be53d74a55e0cc766088ec19a291f2dd5e56428ebb858ed4f810c7L267

Fixes #8302

_What are the most important goals of the ticket or PR?_


### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [ ] Will the PR name make sense to users?
  - [ ] Does the PR have a priority label?
  - [ ] Have you added or updated tests?
  - [ ] Is the documentation up to date?

##### For significant changes:
  - [ ] Is there a summary in the CHANGELOG?
  - [ ] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Add the comma to the variable instead of the `gcloud` command, to avoid having an extra comma as an argument if `$DISK_OPTION` is not set

### Testing

We must confirm the instance is being created when running a full sync:
https://github.com/ZcashFoundation/zebra/actions/runs/7989045712

## Review

@upbqdn found the root cause, so it would be nice if he can confirm this solves the issue. But it should be very straightforward to validate. 

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._
