### PR TITLE
chore: Release v1.6.0

### DIFF
--- a/.github/workflows/scripts/release-crates-dry-run.sh
+++ b/.github/workflows/scripts/release-crates-dry-run.sh
@@ -23,8 +23,8 @@ fi
 cargo release version --verbose --execute --no-confirm --allow-branch '*' --workspace --exclude zebrad --exclude zebra-scan --exclude zebra-grpc beta
 
 # Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
-cargo release version --verbose --execute --allow-branch '*' --package zebra-scan 0.1.0-alpha.5
-cargo release version --verbose --execute --allow-branch '*' --package zebra-grpc 0.1.0-alpha.3
+cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebra-scan 0.1.0-alpha.5
+cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebra-grpc 0.1.0-alpha.3
 
 # Update zebrad:
 cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebrad patch
@@ -35,6 +35,6 @@ cargo release commit --verbose --execute --no-confirm --allow-branch '*'
 # Dry run to check the release
 # Workaround for unpublished dependency version errors: https://github.com/crate-ci/cargo-release/issues/691
 # TODO: check all crates after fixing these errors
-# cargo release publish --verbose --dry-run --allow-branch '*' --workspace --exclude zebra-consensus --exclude zebra-utils --exclude zebrad
+cargo release publish --verbose --dry-run --allow-branch '*' --workspace --exclude zebra-consensus --exclude zebra-utils --exclude zebrad
 
 echo "Release process completed."

--- a/.github/workflows/scripts/release-crates-dry-run.sh
+++ b/.github/workflows/scripts/release-crates-dry-run.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+set -ex
 
 # Check if necessary tools are installed
 if ! command -v git &> /dev/null || ! command -v cargo &> /dev/null; then
@@ -21,8 +23,7 @@ fi
 cargo release version --verbose --execute --no-confirm --allow-branch '*' --workspace --exclude zebrad --exclude zebra-scan --exclude zebra-grpc beta
 # Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
 cargo release version --verbose --execute --allow-branch '*' --package zebra-scan 0.1.0-alpha.5
-# cargo release version --verbose --execute --allow-branch '*' --package zebra-scan 0.1.0-alpha.4
-# cargo release version --verbose --execute --allow-branch '*' --package zebra-grpc 0.1.0-alpha.2
+cargo release version --verbose --execute --allow-branch '*' --package zebra-grpc 0.1.0-alpha.3
 # Update zebrad:
 cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebrad patch
 # Continue with the release process:

--- a/.github/workflows/scripts/release-crates-dry-run.sh
+++ b/.github/workflows/scripts/release-crates-dry-run.sh
@@ -22,14 +22,9 @@ fi
 # Update everything except for alpha crates and zebrad:
 cargo release version --verbose --execute --no-confirm --allow-branch '*' --workspace --exclude zebrad --exclude zebra-scan --exclude zebra-grpc beta
 
-# # Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
-#
-# # TODO: Uncomment the two lines below when
-# # https://github.com/crate-ci/cargo-release/issues/691 gets resolved, and set
-# # the appropriate versions
-#
-# cargo release version --verbose --execute --allow-branch '*' --package zebra-scan 0.1.0-alpha.5
-# cargo release version --verbose --execute --allow-branch '*' --package zebra-grpc 0.1.0-alpha.3
+# Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
+cargo release version --verbose --execute --allow-branch '*' --package zebra-scan 0.1.0-alpha.5
+cargo release version --verbose --execute --allow-branch '*' --package zebra-grpc 0.1.0-alpha.3
 
 # Update zebrad:
 cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebrad patch
@@ -40,6 +35,6 @@ cargo release commit --verbose --execute --no-confirm --allow-branch '*'
 # Dry run to check the release
 # Workaround for unpublished dependency version errors: https://github.com/crate-ci/cargo-release/issues/691
 # TODO: check all crates after fixing these errors
-cargo release publish --verbose --dry-run --allow-branch '*' --workspace --exclude zebra-consensus --exclude zebra-utils --exclude zebrad
+# cargo release publish --verbose --dry-run --allow-branch '*' --workspace --exclude zebra-consensus --exclude zebra-utils --exclude zebrad
 
 echo "Release process completed."

--- a/.github/workflows/scripts/release-crates-dry-run.sh
+++ b/.github/workflows/scripts/release-crates-dry-run.sh
@@ -20,6 +20,7 @@ fi
 # Update everything except for alpha crates and zebrad:
 cargo release version --verbose --execute --no-confirm --allow-branch '*' --workspace --exclude zebrad --exclude zebra-scan --exclude zebra-grpc beta
 # Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
+cargo release version --verbose --execute --allow-branch '*' --package zebra-scan 0.1.0-alpha.5
 # cargo release version --verbose --execute --allow-branch '*' --package zebra-scan 0.1.0-alpha.4
 # cargo release version --verbose --execute --allow-branch '*' --package zebra-grpc 0.1.0-alpha.2
 # Update zebrad:

--- a/.github/workflows/scripts/release-crates-dry-run.sh
+++ b/.github/workflows/scripts/release-crates-dry-run.sh
@@ -35,6 +35,6 @@ cargo release commit --verbose --execute --no-confirm --allow-branch '*'
 # Dry run to check the release
 # Workaround for unpublished dependency version errors: https://github.com/crate-ci/cargo-release/issues/691
 # TODO: check all crates after fixing these errors
-cargo release publish --verbose --dry-run --allow-branch '*' --workspace --exclude zebra-consensus --exclude zebra-utils --exclude zebrad
+cargo release publish --verbose --dry-run --allow-branch '*' --workspace --exclude zebra-consensus --exclude zebra-utils --exclude zebrad --exclude zebra-scan
 
 echo "Release process completed."

--- a/.github/workflows/scripts/release-crates-dry-run.sh
+++ b/.github/workflows/scripts/release-crates-dry-run.sh
@@ -21,9 +21,16 @@ fi
 # with an extra `--no-confirm` argument for non-interactive testing.
 # Update everything except for alpha crates and zebrad:
 cargo release version --verbose --execute --no-confirm --allow-branch '*' --workspace --exclude zebrad --exclude zebra-scan --exclude zebra-grpc beta
-# Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
-cargo release version --verbose --execute --allow-branch '*' --package zebra-scan 0.1.0-alpha.5
-cargo release version --verbose --execute --allow-branch '*' --package zebra-grpc 0.1.0-alpha.3
+
+# # Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
+#
+# # TODO: Uncomment the two lines below when
+# # https://github.com/crate-ci/cargo-release/issues/691 gets resolved, and set
+# # the appropriate versions
+#
+# cargo release version --verbose --execute --allow-branch '*' --package zebra-scan 0.1.0-alpha.5
+# cargo release version --verbose --execute --allow-branch '*' --package zebra-grpc 0.1.0-alpha.3
+
 # Update zebrad:
 cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebrad patch
 # Continue with the release process:

--- a/.github/workflows/scripts/release-crates-dry-run.sh
+++ b/.github/workflows/scripts/release-crates-dry-run.sh
@@ -22,8 +22,8 @@ fi
 # Update everything except for alpha crates and zebrad:
 cargo release version --verbose --execute --no-confirm --allow-branch '*' --workspace --exclude zebrad --exclude zebra-scan --exclude zebra-grpc beta
 # Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
-cargo release version --verbose --execute --allow-branch '*' --package zebra-scan 0.1.0-alpha.4
-cargo release version --verbose --execute --allow-branch '*' --package zebra-grpc 0.1.0-alpha.2
+cargo release version --verbose --execute --allow-branch '*' --package zebra-scan 0.1.0-alpha.5
+cargo release version --verbose --execute --allow-branch '*' --package zebra-grpc 0.1.0-alpha.3
 # Update zebrad:
 cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebrad patch
 # Continue with the release process:

--- a/.github/workflows/scripts/release-crates-dry-run.sh
+++ b/.github/workflows/scripts/release-crates-dry-run.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-set -ex
 
 # Check if necessary tools are installed
 if ! command -v git &> /dev/null || ! command -v cargo &> /dev/null; then
@@ -22,8 +20,8 @@ fi
 # Update everything except for alpha crates and zebrad:
 cargo release version --verbose --execute --no-confirm --allow-branch '*' --workspace --exclude zebrad --exclude zebra-scan --exclude zebra-grpc beta
 # Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
-cargo release version --verbose --execute --allow-branch '*' --package zebra-scan 0.1.0-alpha.5
-cargo release version --verbose --execute --allow-branch '*' --package zebra-grpc 0.1.0-alpha.3
+# cargo release version --verbose --execute --allow-branch '*' --package zebra-scan 0.1.0-alpha.4
+# cargo release version --verbose --execute --allow-branch '*' --package zebra-grpc 0.1.0-alpha.2
 # Update zebrad:
 cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebrad patch
 # Continue with the release process:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,64 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Zebra 1.6.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.6.0) - 2024-02-23
+
+This release exposes the shielded scanning functionality through an initial
+version of a gRPC server, documented in the [Zebra
+Book](https://zebra.zfnd.org/user/shielded-scan-grpc-server.html).
+
+> [!NOTE]
+> Building Zebra now depends on
+> [`protoc`](https://github.com/protocolbuffers/protobuf). See the [Build
+> Instructions](https://github.com/ZcashFoundation/zebra?tab=readme-ov-file#building-zebra)
+> for more details.
+
+### Added
+
+- Add `docker-compose` file to run CI locally ([#8209](https://github.com/ZcashFoundation/zebra/pull/8209))
+- Allow users to use Zebra + LWD with persistent states ([#8215](https://github.com/ZcashFoundation/zebra/pull/8215))
+
+#### Scanner
+
+- Add a new `zebra-grpc` crate ([#8167](https://github.com/ZcashFoundation/zebra/pull/8167))
+- Start scanner gRPC server with `zebrad` ([#8241](https://github.com/ZcashFoundation/zebra/pull/8241))
+- Add gRPC reflection and document how to use the gRPC server ([#8288](https://github.com/ZcashFoundation/zebra/pull/8288))
+- Add the `Getinfo` gRPC ([#8178](https://github.com/ZcashFoundation/zebra/pull/8178))
+- Add the `get_results` gRPC ([#8255](https://github.com/ZcashFoundation/zebra/pull/8255))
+- Add the `scan` gRPC ([#8268](https://github.com/ZcashFoundation/zebra/pull/8268), [#8303](https://github.com/ZcashFoundation/zebra/pull/8303))
+- Add the `RegisterKeys` gRPC ([#8266](https://github.com/ZcashFoundation/zebra/pull/8266))
+- Add the `ClearResults` and `DeleteKeys` gRPCs ([#8237](https://github.com/ZcashFoundation/zebra/pull/8237))
+- Add snapshot tests for new gRPCs ([#8277](https://github.com/ZcashFoundation/zebra/pull/8277))
+- Add unit tests for new gRPCs ([#8293](https://github.com/ZcashFoundation/zebra/pull/8293))
+- Create a tower Service in `zebra-scan` ([#8185](https://github.com/ZcashFoundation/zebra/pull/8185))
+- Implement the `SubscribeResults` scan service call ([#8253](https://github.com/ZcashFoundation/zebra/pull/8253))
+- Implement the `ClearResults` scan service call ([#8219](https://github.com/ZcashFoundation/zebra/pull/8219))
+- Implement the `DeleteKeys` scan service call ([#8217](https://github.com/ZcashFoundation/zebra/pull/8217))
+- Implement the `RegisterKeys` scan service call ([#8251](https://github.com/ZcashFoundation/zebra/pull/8251))
+- Implement the `Results` scan service call ([#8224](https://github.com/ZcashFoundation/zebra/pull/8224))
+- Test the `RegisterKeys` scan service call ([#8281](https://github.com/ZcashFoundation/zebra/pull/8281))
+- Add `ViewingKey` type in `zebra-chain` ([#8198](https://github.com/ZcashFoundation/zebra/pull/8198))
+- Handle `RegisterKeys` messages in scan task ([#8222](https://github.com/ZcashFoundation/zebra/pull/8222))
+
+### Changed
+
+- Remove `rfc.md` file ([#8228](https://github.com/ZcashFoundation/zebra/pull/8228))
+- Update Debian from Bullseye to Bookworm in Docker ([#8273](https://github.com/ZcashFoundation/zebra/pull/8273))
+- Remove Zebra RFCs from `CONTRIBUTING.md` ([#8304](https://github.com/ZcashFoundation/zebra/pull/8304))
+- Publish less tags in Docker Hub ([#8300](https://github.com/ZcashFoundation/zebra/pull/8300))
+- Add Zebra crate versions to dev-dependencies ([#8171](https://github.com/ZcashFoundation/zebra/pull/8171))
+- Update docs for building Zebra ([#8315](https://github.com/ZcashFoundation/zebra/pull/8315))
+
+### Fixed
+
+- Set log rotation to avoid docker bugs ([#8269](https://github.com/ZcashFoundation/zebra/pull/8269))
+- Improve error message in `non_blocking_logger` test ([#8276](https://github.com/ZcashFoundation/zebra/pull/8276))
+
+### Contributors
+
+Thank you to everyone who contributed to this release, we couldn't make Zebra without you:
+@arya2, @chairulakmal, @gustavovalverde, @mpguerra, @oxarbitrage and @upbqdn.
+
 ## [Zebra 1.5.2](https://github.com/ZcashFoundation/zebra/releases/tag/v1.5.2) - 2024-01-23
 
 This release serves as a hotfix for version 1.5.1, addressing issues encountered after its initial release. For more information about version 1.5.1, refer to [this link](https://github.com/ZcashFoundation/zebra/releases/tag/v1.5.2).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,21 +26,21 @@ Book](https://zebra.zfnd.org/user/shielded-scan-grpc-server.html).
 
 - Add a new `zebra-grpc` crate ([#8167](https://github.com/ZcashFoundation/zebra/pull/8167))
 - Start scanner gRPC server with `zebrad` ([#8241](https://github.com/ZcashFoundation/zebra/pull/8241))
-- Add gRPC reflection and document how to use the gRPC server ([#8288](https://github.com/ZcashFoundation/zebra/pull/8288))
-- Add the `Getinfo` gRPC ([#8178](https://github.com/ZcashFoundation/zebra/pull/8178))
-- Add the `get_results` gRPC ([#8255](https://github.com/ZcashFoundation/zebra/pull/8255))
-- Add the `scan` gRPC ([#8268](https://github.com/ZcashFoundation/zebra/pull/8268), [#8303](https://github.com/ZcashFoundation/zebra/pull/8303))
-- Add the `RegisterKeys` gRPC ([#8266](https://github.com/ZcashFoundation/zebra/pull/8266))
-- Add the `ClearResults` and `DeleteKeys` gRPCs ([#8237](https://github.com/ZcashFoundation/zebra/pull/8237))
+- Add gRPC server reflection and document how to use the gRPC server ([#8288](https://github.com/ZcashFoundation/zebra/pull/8288))
+- Add the `GetInfo` gRPC method ([#8178](https://github.com/ZcashFoundation/zebra/pull/8178))
+- Add the `GetResults` gRPC method ([#8255](https://github.com/ZcashFoundation/zebra/pull/8255))
+- Add the `Scan` gRPC method ([#8268](https://github.com/ZcashFoundation/zebra/pull/8268), [#8303](https://github.com/ZcashFoundation/zebra/pull/8303))
+- Add the `RegisterKeys` gRPC method ([#8266](https://github.com/ZcashFoundation/zebra/pull/8266))
+- Add the `ClearResults` and `DeleteKeys` gRPC methods ([#8237](https://github.com/ZcashFoundation/zebra/pull/8237))
 - Add snapshot tests for new gRPCs ([#8277](https://github.com/ZcashFoundation/zebra/pull/8277))
 - Add unit tests for new gRPCs ([#8293](https://github.com/ZcashFoundation/zebra/pull/8293))
 - Create a tower Service in `zebra-scan` ([#8185](https://github.com/ZcashFoundation/zebra/pull/8185))
-- Implement the `SubscribeResults` scan service call ([#8253](https://github.com/ZcashFoundation/zebra/pull/8253))
-- Implement the `ClearResults` scan service call ([#8219](https://github.com/ZcashFoundation/zebra/pull/8219))
-- Implement the `DeleteKeys` scan service call ([#8217](https://github.com/ZcashFoundation/zebra/pull/8217))
-- Implement the `RegisterKeys` scan service call ([#8251](https://github.com/ZcashFoundation/zebra/pull/8251))
-- Implement the `Results` scan service call ([#8224](https://github.com/ZcashFoundation/zebra/pull/8224))
-- Test the `RegisterKeys` scan service call ([#8281](https://github.com/ZcashFoundation/zebra/pull/8281))
+- Implement the `SubscribeResults` scan service request ([#8253](https://github.com/ZcashFoundation/zebra/pull/8253))
+- Implement the `ClearResults` scan service request ([#8219](https://github.com/ZcashFoundation/zebra/pull/8219))
+- Implement the `DeleteKeys` scan service request ([#8217](https://github.com/ZcashFoundation/zebra/pull/8217))
+- Implement the `RegisterKeys` scan service request ([#8251](https://github.com/ZcashFoundation/zebra/pull/8251))
+- Implement the `Results` scan service request ([#8224](https://github.com/ZcashFoundation/zebra/pull/8224))
+- Test the `RegisterKeys` scan service request ([#8281](https://github.com/ZcashFoundation/zebra/pull/8281))
 - Add `ViewingKey` type in `zebra-chain` ([#8198](https://github.com/ZcashFoundation/zebra/pull/8198))
 - Handle `RegisterKeys` messages in scan task ([#8222](https://github.com/ZcashFoundation/zebra/pull/8222))
 
@@ -49,8 +49,8 @@ Book](https://zebra.zfnd.org/user/shielded-scan-grpc-server.html).
 - Remove `rfc.md` file ([#8228](https://github.com/ZcashFoundation/zebra/pull/8228))
 - Update Debian from Bullseye to Bookworm in Docker ([#8273](https://github.com/ZcashFoundation/zebra/pull/8273))
 - Remove Zebra RFCs from `CONTRIBUTING.md` ([#8304](https://github.com/ZcashFoundation/zebra/pull/8304))
-- Publish less tags in Docker Hub ([#8300](https://github.com/ZcashFoundation/zebra/pull/8300))
-- Add Zebra crate versions to dev-dependencies ([#8171](https://github.com/ZcashFoundation/zebra/pull/8171))
+- Publish fewer tags in Docker Hub ([#8300](https://github.com/ZcashFoundation/zebra/pull/8300))
+- Add Zebra crate versions to dev-dependencies and remove circular dev-dependencies ([#8171](https://github.com/ZcashFoundation/zebra/pull/8171))
 - Update docs for building Zebra ([#8315](https://github.com/ZcashFoundation/zebra/pull/8315))
 
 ### Fixed
@@ -61,7 +61,7 @@ Book](https://zebra.zfnd.org/user/shielded-scan-grpc-server.html).
 ### Contributors
 
 Thank you to everyone who contributed to this release, we couldn't make Zebra without you:
-@arya2, @chairulakmal, @gustavovalverde, @mpguerra, @oxarbitrage and @upbqdn.
+@arya2, @bishopcheckmate, @chairulakmal, @gustavovalverde, @mpguerra, @oxarbitrage and @upbqdn.
 
 ## [Zebra 1.5.2](https://github.com/ZcashFoundation/zebra/releases/tag/v1.5.2) - 2024-01-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4684,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "tower-batch-control"
-version = "0.2.41-beta.10"
+version = "0.2.41-beta.11"
 dependencies = [
  "color-eyre",
  "ed25519-zebra",
@@ -4707,7 +4707,7 @@ dependencies = [
 
 [[package]]
 name = "tower-fallback"
-version = "0.2.41-beta.10"
+version = "0.2.41-beta.11"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 dependencies = [
  "bitflags 2.4.2",
  "bitflags-serde-legacy",
@@ -5753,7 +5753,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-consensus"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5799,7 +5799,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-grpc"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "color-eyre",
  "futures-util",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-network"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 dependencies = [
  "bitflags 2.4.2",
  "byteorder",
@@ -5862,7 +5862,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-node-services"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 dependencies = [
  "color-eyre",
  "jsonrpc-core",
@@ -5875,7 +5875,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 dependencies = [
  "chrono",
  "futures",
@@ -5906,7 +5906,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-scan"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "bls12_381",
  "chrono",
@@ -5938,7 +5938,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-script"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 dependencies = [
  "displaydoc",
  "hex",
@@ -5951,7 +5951,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 dependencies = [
  "bincode",
  "chrono",
@@ -5995,7 +5995,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-test"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 dependencies = [
  "color-eyre",
  "futures",
@@ -6023,7 +6023,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-utils"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 dependencies = [
  "color-eyre",
  "hex",
@@ -6048,7 +6048,7 @@ dependencies = [
 
 [[package]]
 name = "zebrad"
-version = "1.5.2"
+version = "1.6.0"
 dependencies = [
  "abscissa_core",
  "atty",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4684,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "tower-batch-control"
-version = "0.2.41-beta.11"
+version = "0.2.41-beta.10"
 dependencies = [
  "color-eyre",
  "ed25519-zebra",
@@ -4707,7 +4707,7 @@ dependencies = [
 
 [[package]]
 name = "tower-fallback"
-version = "0.2.41-beta.11"
+version = "0.2.41-beta.10"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "1.0.0-beta.35"
+version = "1.0.0-beta.34"
 dependencies = [
  "bitflags 2.4.2",
  "bitflags-serde-legacy",
@@ -5753,7 +5753,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-consensus"
-version = "1.0.0-beta.35"
+version = "1.0.0-beta.34"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5799,7 +5799,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-grpc"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.1"
 dependencies = [
  "color-eyre",
  "futures-util",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-network"
-version = "1.0.0-beta.35"
+version = "1.0.0-beta.34"
 dependencies = [
  "bitflags 2.4.2",
  "byteorder",
@@ -5862,7 +5862,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-node-services"
-version = "1.0.0-beta.35"
+version = "1.0.0-beta.34"
 dependencies = [
  "color-eyre",
  "jsonrpc-core",
@@ -5875,7 +5875,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "1.0.0-beta.35"
+version = "1.0.0-beta.34"
 dependencies = [
  "chrono",
  "futures",
@@ -5906,7 +5906,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-scan"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.3"
 dependencies = [
  "bls12_381",
  "chrono",
@@ -5938,7 +5938,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-script"
-version = "1.0.0-beta.35"
+version = "1.0.0-beta.34"
 dependencies = [
  "displaydoc",
  "hex",
@@ -5951,7 +5951,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "1.0.0-beta.35"
+version = "1.0.0-beta.34"
 dependencies = [
  "bincode",
  "chrono",
@@ -5995,7 +5995,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-test"
-version = "1.0.0-beta.35"
+version = "1.0.0-beta.34"
 dependencies = [
  "color-eyre",
  "futures",
@@ -6023,7 +6023,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-utils"
-version = "1.0.0-beta.35"
+version = "1.0.0-beta.34"
 dependencies = [
  "color-eyre",
  "hex",
@@ -6048,7 +6048,7 @@ dependencies = [
 
 [[package]]
 name = "zebrad"
-version = "1.6.0"
+version = "1.5.2"
 dependencies = [
  "abscissa_core",
  "atty",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4684,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "tower-batch-control"
-version = "0.2.41-beta.10"
+version = "0.2.41-beta.11"
 dependencies = [
  "color-eyre",
  "ed25519-zebra",
@@ -4708,7 +4708,7 @@ dependencies = [
 
 [[package]]
 name = "tower-fallback"
-version = "0.2.41-beta.10"
+version = "0.2.41-beta.11"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 dependencies = [
  "bitflags 2.4.2",
  "bitflags-serde-legacy",
@@ -5754,7 +5754,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-consensus"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5800,7 +5800,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-grpc"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "color-eyre",
  "futures-util",
@@ -5822,7 +5822,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-network"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 dependencies = [
  "bitflags 2.4.2",
  "byteorder",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-node-services"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 dependencies = [
  "color-eyre",
  "jsonrpc-core",
@@ -5876,7 +5876,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 dependencies = [
  "chrono",
  "futures",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-scan"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "bls12_381",
  "chrono",
@@ -5939,7 +5939,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-script"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 dependencies = [
  "displaydoc",
  "hex",
@@ -5952,7 +5952,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 dependencies = [
  "bincode",
  "chrono",
@@ -5996,7 +5996,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-test"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 dependencies = [
  "color-eyre",
  "futures",
@@ -6024,7 +6024,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-utils"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 dependencies = [
  "color-eyre",
  "hex",
@@ -6049,7 +6049,7 @@ dependencies = [
 
 [[package]]
 name = "zebrad"
-version = "1.5.2"
+version = "1.6.0"
 dependencies = [
  "abscissa_core",
  "atty",

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -37,7 +37,7 @@ docker run -d --platform linux/amd64 \
 ### Build it locally
 
 ```shell
-git clone --depth 1 --branch v1.5.2 https://github.com/ZcashFoundation/zebra.git
+git clone --depth 1 --branch v1.6.0 https://github.com/ZcashFoundation/zebra.git
 docker build --file docker/Dockerfile --target runtime --tag zebra:local .
 docker run --detach zebra:local
 ```

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -37,7 +37,7 @@ docker run -d --platform linux/amd64 \
 ### Build it locally
 
 ```shell
-git clone --depth 1 --branch v1.6.0 https://github.com/ZcashFoundation/zebra.git
+git clone --depth 1 --branch v1.5.2 https://github.com/ZcashFoundation/zebra.git
 docker build --file docker/Dockerfile --target runtime --tag zebra:local .
 docker run --detach zebra:local
 ```

--- a/book/src/user/install.md
+++ b/book/src/user/install.md
@@ -19,7 +19,7 @@ To compile Zebra directly from GitHub, or from a GitHub release source archive:
 ```sh
 git clone https://github.com/ZcashFoundation/zebra.git
 cd zebra
-git checkout v1.5.2
+git checkout v1.6.0
 ```
 
 3. Build and Run `zebrad`
@@ -32,7 +32,7 @@ target/release/zebrad start
 ### Compiling from git using cargo install
 
 ```sh
-cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.5.2 zebrad
+cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.6.0 zebrad
 ```
 
 ### Compiling on ARM

--- a/book/src/user/install.md
+++ b/book/src/user/install.md
@@ -19,7 +19,7 @@ To compile Zebra directly from GitHub, or from a GitHub release source archive:
 ```sh
 git clone https://github.com/ZcashFoundation/zebra.git
 cd zebra
-git checkout v1.6.0
+git checkout v1.5.2
 ```
 
 3. Build and Run `zebrad`
@@ -32,7 +32,7 @@ target/release/zebrad start
 ### Compiling from git using cargo install
 
 ```sh
-cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.6.0 zebrad
+cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.5.2 zebrad
 ```
 
 ### Compiling on ARM

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-batch-control"
-version = "0.2.41-beta.10"
+version = "0.2.41-beta.11"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Tower middleware for batch request processing"
 # # Legal

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-batch-control"
-version = "0.2.41-beta.11"
+version = "0.2.41-beta.10"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Tower middleware for batch request processing"
 # # Legal

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-batch-control"
-version = "0.2.41-beta.10"
+version = "0.2.41-beta.11"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Tower middleware for batch request processing"
 # # Legal
@@ -43,7 +43,7 @@ rand = "0.8.5"
 
 tokio = { version = "1.36.0", features = ["full", "tracing", "test-util"] }
 tokio-test = "0.4.3"
-tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.10" }
+tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.11" }
 tower-test = "0.4.0"
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.34" }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.35" }

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-fallback"
-version = "0.2.41-beta.10"
+version = "0.2.41-beta.11"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Tower service combinator that sends requests to a first service, then retries processing on a second fallback service if the first service errors."
 license = "MIT OR Apache-2.0"
@@ -24,4 +24,4 @@ tracing = "0.1.39"
 [dev-dependencies]
 tokio = { version = "1.36.0", features = ["full", "tracing", "test-util"] }
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.34" }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.35" }

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-fallback"
-version = "0.2.41-beta.11"
+version = "0.2.41-beta.10"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Tower service combinator that sends requests to a first service, then retries processing on a second fallback service if the first service errors."
 license = "MIT OR Apache-2.0"

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-fallback"
-version = "0.2.41-beta.10"
+version = "0.2.41-beta.11"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Tower service combinator that sends requests to a first service, then retries processing on a second fallback service if the first service errors."
 license = "MIT OR Apache-2.0"

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-chain"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Core Zcash data structures"
 license = "MIT OR Apache-2.0"
@@ -145,7 +145,7 @@ proptest-derive = { version = "0.4.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 rand_chacha = { version = "0.3.1", optional = true }
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.34", optional = true }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.35", optional = true }
 
 [dev-dependencies]
 # Benchmarks
@@ -168,7 +168,7 @@ rand_chacha = "0.3.1"
 
 tokio = { version = "1.36.0", features = ["full", "tracing", "test-util"] }
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.34" }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.35" }
 
 [[bench]]
 name = "block"

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-chain"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Core Zcash data structures"
 license = "MIT OR Apache-2.0"
@@ -145,7 +145,7 @@ proptest-derive = { version = "0.4.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 rand_chacha = { version = "0.3.1", optional = true }
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.34", optional = true }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.35", optional = true }
 
 [dev-dependencies]
 # Benchmarks

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-chain"
-version = "1.0.0-beta.35"
+version = "1.0.0-beta.34"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Core Zcash data structures"
 license = "MIT OR Apache-2.0"
@@ -145,7 +145,7 @@ proptest-derive = { version = "0.4.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 rand_chacha = { version = "0.3.1", optional = true }
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.35", optional = true }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.34", optional = true }
 
 [dev-dependencies]
 # Benchmarks

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-consensus"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Implementation of Zcash consensus checks"
 license = "MIT OR Apache-2.0"
@@ -63,13 +63,13 @@ orchard = "0.6.0"
 zcash_proofs = { version = "0.13.0-rc.1", features = ["multicore" ] }
 wagyu-zcash-parameters = "0.2.0"
 
-tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.10" }
-tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41-beta.10" }
+tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.11" }
+tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41-beta.11" }
 
-zebra-script = { path = "../zebra-script", version = "1.0.0-beta.34" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34" }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34" }
+zebra-script = { path = "../zebra-script", version = "1.0.0-beta.35" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.35" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.35" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35" }
 
 # prod feature progress-bar
 howudoin = { version = "0.1.2", optional = true }
@@ -94,6 +94,6 @@ tokio = { version = "1.36.0", features = ["full", "tracing", "test-util"] }
 tracing-error = "0.2.0"
 tracing-subscriber = "0.3.18"
 
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34", features = ["proptest-impl"] }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34", features = ["proptest-impl"] }
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.34" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.35", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35", features = ["proptest-impl"] }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.35" }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-consensus"
-version = "1.0.0-beta.35"
+version = "1.0.0-beta.34"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Implementation of Zcash consensus checks"
 license = "MIT OR Apache-2.0"
@@ -63,13 +63,13 @@ orchard = "0.6.0"
 zcash_proofs = { version = "0.13.0-rc.1", features = ["multicore" ] }
 wagyu-zcash-parameters = "0.2.0"
 
-tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.11" }
-tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41-beta.11" }
+tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.10" }
+tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41-beta.10" }
 
-zebra-script = { path = "../zebra-script", version = "1.0.0-beta.35" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.35" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.35" }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35" }
+zebra-script = { path = "../zebra-script", version = "1.0.0-beta.34" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34" }
 
 # prod feature progress-bar
 howudoin = { version = "0.1.2", optional = true }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-consensus"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Implementation of Zcash consensus checks"
 license = "MIT OR Apache-2.0"
@@ -63,13 +63,13 @@ orchard = "0.6.0"
 zcash_proofs = { version = "0.13.0-rc.1", features = ["multicore" ] }
 wagyu-zcash-parameters = "0.2.0"
 
-tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.10" }
-tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41-beta.10" }
+tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.11" }
+tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41-beta.11" }
 
-zebra-script = { path = "../zebra-script", version = "1.0.0-beta.34" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34" }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34" }
+zebra-script = { path = "../zebra-script", version = "1.0.0-beta.35" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.35" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.35" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35" }
 
 # prod feature progress-bar
 howudoin = { version = "0.1.2", optional = true }

--- a/zebra-grpc/Cargo.toml
+++ b/zebra-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-grpc"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Zebra gRPC interface"
 license = "MIT OR Apache-2.0"
@@ -28,8 +28,8 @@ color-eyre = "0.6.2"
 
 zcash_primitives = { version = "0.13.0-rc.1" }
 
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34", features = ["shielded-scan"] }
-zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.34" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.35", features = ["shielded-scan"] }
+zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.35" }
 
 [build-dependencies]
 tonic-build = "0.11.0"

--- a/zebra-grpc/Cargo.toml
+++ b/zebra-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-grpc"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.1"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Zebra gRPC interface"
 license = "MIT OR Apache-2.0"
@@ -28,8 +28,8 @@ color-eyre = "0.6.2"
 
 zcash_primitives = { version = "0.13.0-rc.1" }
 
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.35", features = ["shielded-scan"] }
-zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.35" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34", features = ["shielded-scan"] }
+zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.34" }
 
 [build-dependencies]
 tonic-build = "0.11.0"

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-network"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Networking code for Zebra"
 # # Legal
@@ -83,7 +83,7 @@ howudoin = { version = "0.1.2", optional = true }
 proptest = { version = "1.4.0", optional = true }
 proptest-derive = { version = "0.4.0", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35", features = ["async-error"] }
 
 [dev-dependencies]
 proptest = "1.4.0"

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-network"
-version = "1.0.0-beta.35"
+version = "1.0.0-beta.34"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Networking code for Zebra"
 # # Legal
@@ -83,7 +83,7 @@ howudoin = { version = "0.1.2", optional = true }
 proptest = { version = "1.4.0", optional = true }
 proptest-derive = { version = "0.4.0", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34", features = ["async-error"] }
 
 [dev-dependencies]
 proptest = "1.4.0"

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-node-services"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The interfaces of some Zebra node services"
 license = "MIT OR Apache-2.0"
@@ -37,7 +37,7 @@ rpc-client = [
 shielded-scan = ["tokio"]
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.34" }
+zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.35" }
 
 # Optional dependencies
 

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-node-services"
-version = "1.0.0-beta.35"
+version = "1.0.0-beta.34"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The interfaces of some Zebra node services"
 license = "MIT OR Apache-2.0"
@@ -37,7 +37,7 @@ rpc-client = [
 shielded-scan = ["tokio"]
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.35" }
+zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.34" }
 
 # Optional dependencies
 

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-rpc"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Zebra JSON Remote Procedure Call (JSON-RPC) interface"
 license = "MIT OR Apache-2.0"
@@ -72,12 +72,12 @@ zcash_address = { version = "0.3.1", optional = true }
 # Test-only feature proptest-impl
 proptest = { version = "1.4.0", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34", features = ["json-conversion"] }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.34" }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.34" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34" }
-zebra-script = { path = "../zebra-script", version = "1.0.0-beta.34" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35", features = ["json-conversion"] }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.35" }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.35" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.35" }
+zebra-script = { path = "../zebra-script", version = "1.0.0-beta.35" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.35" }
 
 [dev-dependencies]
 insta = { version = "1.33.0", features = ["redactions", "json", "ron"] }
@@ -87,9 +87,9 @@ proptest = "1.4.0"
 thiserror = "1.0.57"
 tokio = { version = "1.36.0", features = ["full", "tracing", "test-util"] }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34", features = ["proptest-impl"] }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.34", features = ["proptest-impl"] }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.34", features = ["proptest-impl"] }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35", features = ["proptest-impl"] }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.35", features = ["proptest-impl"] }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.35", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.35", features = ["proptest-impl"] }
 
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.34" }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.35" }

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-rpc"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Zebra JSON Remote Procedure Call (JSON-RPC) interface"
 license = "MIT OR Apache-2.0"
@@ -72,12 +72,12 @@ zcash_address = { version = "0.3.1", optional = true }
 # Test-only feature proptest-impl
 proptest = { version = "1.4.0", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34", features = ["json-conversion"] }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.34" }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.34" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34" }
-zebra-script = { path = "../zebra-script", version = "1.0.0-beta.34" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35", features = ["json-conversion"] }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.35" }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.35" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.35" }
+zebra-script = { path = "../zebra-script", version = "1.0.0-beta.35" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.35" }
 
 [dev-dependencies]
 insta = { version = "1.33.0", features = ["redactions", "json", "ron"] }

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-rpc"
-version = "1.0.0-beta.35"
+version = "1.0.0-beta.34"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Zebra JSON Remote Procedure Call (JSON-RPC) interface"
 license = "MIT OR Apache-2.0"
@@ -72,12 +72,12 @@ zcash_address = { version = "0.3.1", optional = true }
 # Test-only feature proptest-impl
 proptest = { version = "1.4.0", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35", features = ["json-conversion"] }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.35" }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.35" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.35" }
-zebra-script = { path = "../zebra-script", version = "1.0.0-beta.35" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.35" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34", features = ["json-conversion"] }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.34" }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.34" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34" }
+zebra-script = { path = "../zebra-script", version = "1.0.0-beta.34" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34" }
 
 [dev-dependencies]
 insta = { version = "1.33.0", features = ["redactions", "json", "ron"] }

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-scan"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.3"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Shielded transaction scanner for the Zcash blockchain"
 license = "MIT OR Apache-2.0"
@@ -54,10 +54,10 @@ futures = "0.3.30"
 zcash_client_backend = "0.10.0-rc.1"
 zcash_primitives = "0.13.0-rc.1"
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35", features = ["shielded-scan"] }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.35", features = ["shielded-scan"] }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.35", features = ["shielded-scan"] }
-zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.2" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34", features = ["shielded-scan"] }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34", features = ["shielded-scan"] }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34", features = ["shielded-scan"] }
+zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.1" }
 
 chrono = { version = "0.4.34", default-features = false, features = ["clock", "std", "serde"] }
 
@@ -72,7 +72,7 @@ jubjub = { version = "0.10.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 zcash_note_encryption = { version = "0.4.0", optional = true }
 
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.35", optional = true }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.34", optional = true }
 
 [dev-dependencies]
 insta = { version = "1.33.0", features = ["ron", "redactions"] }
@@ -87,5 +87,5 @@ jubjub = "0.10.0"
 rand = "0.8.5"
 zcash_note_encryption = "0.4.0"
 
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.35", features = ["proptest-impl"] }
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.35" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34", features = ["proptest-impl"] }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.34" }

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-scan"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Shielded transaction scanner for the Zcash blockchain"
 license = "MIT OR Apache-2.0"
@@ -54,10 +54,10 @@ futures = "0.3.30"
 zcash_client_backend = "0.10.0-rc.1"
 zcash_primitives = "0.13.0-rc.1"
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34", features = ["shielded-scan"] }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34", features = ["shielded-scan"] }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34", features = ["shielded-scan"] }
-zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.1" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35", features = ["shielded-scan"] }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.35", features = ["shielded-scan"] }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.35", features = ["shielded-scan"] }
+zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.2" }
 
 chrono = { version = "0.4.34", default-features = false, features = ["clock", "std", "serde"] }
 
@@ -72,7 +72,7 @@ jubjub = { version = "0.10.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 zcash_note_encryption = { version = "0.4.0", optional = true }
 
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.34", optional = true }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.35", optional = true }
 
 [dev-dependencies]
 insta = { version = "1.33.0", features = ["ron", "redactions"] }
@@ -87,5 +87,5 @@ jubjub = "0.10.0"
 rand = "0.8.5"
 zcash_note_encryption = "0.4.0"
 
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34", features = ["proptest-impl"] }
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.34" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.35", features = ["proptest-impl"] }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.35" }

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-script"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Zebra script verification wrapping zcashd's zcash_script library"
 license = "MIT OR Apache-2.0"
@@ -17,7 +17,7 @@ categories = ["api-bindings", "cryptography::cryptocurrencies"]
 [dependencies]
 zcash_script = "0.1.14"
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35" }
 
 thiserror = "1.0.57"
 displaydoc = "0.2.4"
@@ -25,4 +25,4 @@ displaydoc = "0.2.4"
 [dev-dependencies]
 hex = "0.4.3"
 lazy_static = "1.4.0"
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.34" }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.35" }

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-script"
-version = "1.0.0-beta.35"
+version = "1.0.0-beta.34"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Zebra script verification wrapping zcashd's zcash_script library"
 license = "MIT OR Apache-2.0"
@@ -17,7 +17,7 @@ categories = ["api-bindings", "cryptography::cryptocurrencies"]
 [dependencies]
 zcash_script = "0.1.14"
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34" }
 
 thiserror = "1.0.57"
 displaydoc = "0.2.4"

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-script"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Zebra script verification wrapping zcashd's zcash_script library"
 license = "MIT OR Apache-2.0"
@@ -17,7 +17,7 @@ categories = ["api-bindings", "cryptography::cryptocurrencies"]
 [dependencies]
 zcash_script = "0.1.14"
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35" }
 
 thiserror = "1.0.57"
 displaydoc = "0.2.4"

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-state"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "State contextual verification and storage code for Zebra"
 license = "MIT OR Apache-2.0"
@@ -76,13 +76,13 @@ tracing = "0.1.39"
 elasticsearch = { version = "8.5.0-alpha.1", default-features = false, features = ["rustls-tls"], optional = true }
 serde_json = { version = "1.0.113", package = "serde_json", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { version = "0.1.2", optional = true }
 
 # test feature proptest-impl
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.34", optional = true }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.35", optional = true }
 proptest = { version = "1.4.0", optional = true }
 proptest-derive = { version = "0.4.0", optional = true }
 
@@ -107,5 +107,5 @@ jubjub = "0.10.0"
 
 tokio = { version = "1.36.0", features = ["full", "tracing", "test-util"] }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34", features = ["proptest-impl"] }
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.34" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35", features = ["proptest-impl"] }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.35" }

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-state"
-version = "1.0.0-beta.35"
+version = "1.0.0-beta.34"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "State contextual verification and storage code for Zebra"
 license = "MIT OR Apache-2.0"
@@ -76,13 +76,13 @@ tracing = "0.1.39"
 elasticsearch = { version = "8.5.0-alpha.1", default-features = false, features = ["rustls-tls"], optional = true }
 serde_json = { version = "1.0.113", package = "serde_json", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { version = "0.1.2", optional = true }
 
 # test feature proptest-impl
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.35", optional = true }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.34", optional = true }
 proptest = { version = "1.4.0", optional = true }
 proptest-derive = { version = "0.4.0", optional = true }
 

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-state"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "State contextual verification and storage code for Zebra"
 license = "MIT OR Apache-2.0"
@@ -76,13 +76,13 @@ tracing = "0.1.39"
 elasticsearch = { version = "8.5.0-alpha.1", default-features = false, features = ["rustls-tls"], optional = true }
 serde_json = { version = "1.0.113", package = "serde_json", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { version = "0.1.2", optional = true }
 
 # test feature proptest-impl
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.34", optional = true }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.35", optional = true }
 proptest = { version = "1.4.0", optional = true }
 proptest-derive = { version = "0.4.0", optional = true }
 

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-test"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Test harnesses and test vectors for Zebra"
 license = "MIT OR Apache-2.0"

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-test"
-version = "1.0.0-beta.35"
+version = "1.0.0-beta.34"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Test harnesses and test vectors for Zebra"
 license = "MIT OR Apache-2.0"

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-utils"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Developer tools for Zebra maintenance and testing"
 license = "MIT OR Apache-2.0"
@@ -87,12 +87,12 @@ tracing-error = "0.2.0"
 tracing-subscriber = "0.3.18"
 thiserror = "1.0.57"
 
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34" }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34" }
-zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.3", optional = true }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.35" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35" }
+zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.4", optional = true }
 
 # These crates are needed for the block-template-to-proposal binary
-zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.34", optional = true }
+zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.35", optional = true }
 
 # These crates are needed for the zebra-checkpoints binary
 itertools = { version = "0.12.1", optional = true }

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-utils"
-version = "1.0.0-beta.35"
+version = "1.0.0-beta.34"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Developer tools for Zebra maintenance and testing"
 license = "MIT OR Apache-2.0"
@@ -87,12 +87,12 @@ tracing-error = "0.2.0"
 tracing-subscriber = "0.3.18"
 thiserror = "1.0.57"
 
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.35" }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35" }
-zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.4", optional = true }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34" }
+zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.3", optional = true }
 
 # These crates are needed for the block-template-to-proposal binary
-zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.35", optional = true }
+zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.34", optional = true }
 
 # These crates are needed for the zebra-checkpoints binary
 itertools = { version = "0.12.1", optional = true }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate metadata
 name = "zebrad"
-version = "1.5.2"
+version = "1.6.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The Zcash Foundation's independent, consensus-compatible implementation of a Zcash node"
 license = "MIT OR Apache-2.0"
@@ -158,18 +158,18 @@ test_sync_past_mandatory_checkpoint_mainnet = []
 test_sync_past_mandatory_checkpoint_testnet = []
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34" }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.34" }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.34" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34" }
-zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.34" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35" }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.35" }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.35" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.35" }
+zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.35" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.35" }
 
 # Experimental shielded-scan feature
-zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.3", optional = true }
+zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.4", optional = true }
 
 # Required for crates.io publishing, but it's only used in tests
-zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.34", optional = true }
+zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.35", optional = true }
 
 abscissa_core = "0.7.0"
 clap = { version = "4.5.1", features = ["cargo"] }
@@ -280,16 +280,16 @@ proptest-derive = "0.4.0"
 # enable span traces and track caller in tests
 color-eyre = { version = "0.6.2" }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34", features = ["proptest-impl"] }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.34", features = ["proptest-impl"] }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.34", features = ["proptest-impl"] }
-zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.3", features = ["proptest-impl"] }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35", features = ["proptest-impl"] }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.35", features = ["proptest-impl"] }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.35", features = ["proptest-impl"] }
+zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.4", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.35", features = ["proptest-impl"] }
 
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34", features = ["rpc-client"] }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.35", features = ["rpc-client"] }
 
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.34" }
-zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.1" }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.35" }
+zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.2" }
 
 # Used by the checkpoint generation tests via the zebra-checkpoints feature
 # (the binaries in this crate won't be built unless their features are enabled).
@@ -300,4 +300,4 @@ zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.1" }
 # When `-Z bindeps` is stabilised, enable this binary dependency instead:
 # https://github.com/rust-lang/cargo/issues/9096
 # zebra-utils { path = "../zebra-utils", artifact = "bin:zebra-checkpoints" }
-zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.34" }
+zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.35" }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate metadata
 name = "zebrad"
-version = "1.5.2"
+version = "1.6.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The Zcash Foundation's independent, consensus-compatible implementation of a Zcash node"
 license = "MIT OR Apache-2.0"
@@ -158,18 +158,18 @@ test_sync_past_mandatory_checkpoint_mainnet = []
 test_sync_past_mandatory_checkpoint_testnet = []
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34" }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.34" }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.34" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34" }
-zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.34" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35" }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.35" }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.35" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.35" }
+zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.35" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.35" }
 
 # Experimental shielded-scan feature
-zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.3", optional = true }
+zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.4", optional = true }
 
 # Required for crates.io publishing, but it's only used in tests
-zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.34", optional = true }
+zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.35", optional = true }
 
 abscissa_core = "0.7.0"
 clap = { version = "4.5.1", features = ["cargo"] }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate metadata
 name = "zebrad"
-version = "1.6.0"
+version = "1.5.2"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The Zcash Foundation's independent, consensus-compatible implementation of a Zcash node"
 license = "MIT OR Apache-2.0"
@@ -158,18 +158,18 @@ test_sync_past_mandatory_checkpoint_mainnet = []
 test_sync_past_mandatory_checkpoint_testnet = []
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.35" }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.35" }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.35" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.35" }
-zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.35" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.35" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.34" }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.34" }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.34" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.34" }
+zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.34" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.34" }
 
 # Experimental shielded-scan feature
-zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.4", optional = true }
+zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.3", optional = true }
 
 # Required for crates.io publishing, but it's only used in tests
-zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.35", optional = true }
+zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.34", optional = true }
 
 abscissa_core = "0.7.0"
 clap = { version = "4.5.1", features = ["cargo"] }

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_373_686;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_413_000;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.


### PR DESCRIPTION
---
name: 'Release Checklist Template'
about: 'Checklist to create and publish a Zebra release'
title: 'Release Zebra (version)'
labels: 'A-release, C-trivial, P-Critical :ambulance:'
assignees: ''

---

# Prepare for the Release

- [x] Make sure there has been [at least one successful full sync test](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-integration-tests-gcp.yml?query=event%3Aschedule) since the last state change, or start a manual full sync.
- [x] Make sure the PRs with the new checkpoint hashes and missed dependencies are already merged.
      (See the release ticket checklist for details)


# Summarise Release Changes

These steps can be done a few days before the release, in the same PR:

## Change Log

**Important**: Any merge into `main` deletes any edits to the draft changelog.
Once you are ready to tag a release, copy the draft changelog into `CHANGELOG.md`.

We use [the Release Drafter workflow](https://github.com/marketplace/actions/release-drafter) to automatically create a [draft changelog](https://github.com/ZcashFoundation/zebra/releases). We follow the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.

To create the final change log:
- [x] Copy the **latest** draft changelog into `CHANGELOG.md` (there can be multiple draft releases)
- [x] Delete any trivial changes
    - [x] Put the list of deleted changelog entries in a PR comment to make reviewing easier
- [x] Combine duplicate changes
- [x] Edit change descriptions so they will make sense to Zebra users
- [x] Check the category for each change
  - Prefer the "Fix" category if you're not sure

## README

README updates can be skipped for urgent releases.

Update the README to:
- [x] Remove any "Known Issues" that have been fixed since the last release.
- [x] Update the "Build and Run Instructions" with any new dependencies.
      Check for changes in the `Dockerfile` since the last tag: `git diff <previous-release-tag> docker/Dockerfile`.
- [x] If Zebra has started using newer Rust language features or standard library APIs, update the known working Rust version in the README, book, and `Cargo.toml`s

You can use a command like:
```sh
fastmod --fixed-strings '1.58' '1.65'
```

## Create the Release PR

- [x] Push the updated changelog and README into a new branch
      for example: `bump-v1.0.0` - this needs to be different to the tag name
- [x] Create a release PR by adding `&template=release-checklist.md` to the comparing url ([Example](https://github.com/ZcashFoundation/zebra/compare/bump-v1.0.0?expand=1&template=release-checklist.md)).
- [x] Freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [x] Mark all the release PRs as `Critical` priority, so they go in the `urgent` Mergify queue.
- [x] Mark all non-release PRs with `do-not-merge`, because Mergify checks approved PRs against every commit, even when a queue is frozen.


# Update Versions and End of Support

## Update Zebra Version

### Choose a Release Level

Zebra follows [semantic versioning](https://semver.org). Semantic versions look like: MAJOR.MINOR.PATCH[-TAG.PRE-RELEASE]

Choose a release level for `zebrad`. Release levels are based on user-visible changes from the changelog:
- Mainnet Network Upgrades are `major` releases
- significant new features or behaviour changes; changes to RPCs, command-line, or configs; and deprecations or removals are `minor` releases
- otherwise, it is a `patch` release

Zebra's Rust API doesn't have any support or stability guarantees, so we keep all the `zebra-*` and `tower-*` crates on a beta `pre-release` version.

### Update Crate Versions

If you're publishing crates for the first time, [log in to crates.io](https://github.com/ZcashFoundation/zebra/blob/doc-crate-own/book/src/dev/crate-owners.md#logging-in-to-cratesio),
and make sure you're a member of owners group.

Check that the release will work:
- [x] Update crate versions, commit the changes to the release branch, and do a release dry-run:

```sh
# Update everything except for alpha crates and zebrad:
cargo release version --verbose --execute --allow-branch '*' --workspace --exclude zebrad --exclude zebra-scan --exclude zebra-grpc beta
# Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
cargo release version --verbose --execute --allow-branch '*' --package zebra-scan 0.1.0-alpha.4
cargo release version --verbose --execute --allow-branch '*' --package zebra-grpc 0.1.0-alpha.2
# Update zebrad:
cargo release version --verbose --execute --allow-branch '*' --package zebrad patch # [ major | minor | patch ]
# Continue with the release process:
cargo release replace --verbose --execute --allow-branch '*' --package zebrad
cargo release commit --verbose --execute --allow-branch '*'
```

Crate publishing is [automatically checked in CI](https://github.com/ZcashFoundation/zebra/actions/workflows/release-crates-io.yml) using "dry run" mode, however due to a bug in `cargo-release` we need to pass exact versions to the alpha crates:

- [x] Update `zebra-scan` and `zebra-grpc` alpha crates in the [release-crates-dry-run workflow script](https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/scripts/release-crates-dry-run.sh)
- [x] Push the above version changes to the release branch.

## Update End of Support

The end of support height is calculated from the current blockchain height:
- [x] Find where the Zcash blockchain tip is now by using a [Zcash explorer](https://zcashblockexplorer.com/blocks) or other tool.
- [x] Replace `ESTIMATED_RELEASE_HEIGHT` in [`end_of_support.rs`](https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/sync/end_of_support.rs) with the height you estimate the release will be tagged.

<details>

<summary>Optional: calculate the release tagging height</summary>

- Add `1152` blocks for each day until the release
- For example, if the release is in 3 days, add `1152 * 3` to the current Mainnet block height

</details>

## Update the Release PR

- [x] Push the version increments and the release constants to the release branch.


# Publish the Zebra Release

## Create the GitHub Pre-Release

- [x] Wait for all the release PRs to be merged
- [x] Create a new release using the draft release as a base, by clicking the Edit icon in the [draft release](https://github.com/ZcashFoundation/zebra/releases)
- [x] Set the tag name to the version tag,
      for example: `v1.0.0`
- [x] Set the release to target the `main` branch
- [x] Set the release title to `Zebra ` followed by the version tag,
      for example: `Zebra 1.0.0`
- [x] Replace the prepopulated draft changelog in the release description with the final changelog you created;
      starting just _after_ the title `## [Zebra ...` of the current version being released,
      and ending just _before_ the title of the previous release.
- [x] Mark the release as 'pre-release', until it has been built and tested
- [x] Publish the pre-release to GitHub using "Publish Release"
- [x] Delete all the [draft releases from the list of releases](https://github.com/ZcashFoundation/zebra/releases)

## Test the Pre-Release

- [x] Wait until the Docker binaries have been built on `main`, and the quick tests have passed:
    - [x] [ci-unit-tests-docker.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-unit-tests-docker.yml?query=branch%3Amain)
    - [x] [ci-integration-tests-gcp.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-integration-tests-gcp.yml?query=branch%3Amain)
- [x] Wait until the [pre-release deployment machines have successfully launched](https://github.com/ZcashFoundation/zebra/actions/workflows/cd-deploy-nodes-gcp.yml?query=event%3Arelease)

## Publish Release

- [x] [Publish the release to GitHub](https://github.com/ZcashFoundation/zebra/releases) by disabling 'pre-release', then clicking "Set as the latest release"

## Publish Crates

- [x] [Run `cargo login`](https://github.com/ZcashFoundation/zebra/blob/doc-crate-own/book/src/dev/crate-owners.md#logging-in-to-cratesio)
- [x] Run `cargo clean` in the zebra repo (optional)
- [x] Publish the crates to crates.io: `cargo release publish --verbose --workspace --execute`
- [x] Check that Zebra can be installed from `crates.io`:
      `cargo install --locked --force --version 1.minor.patch zebrad && ~/.cargo/bin/zebrad`
      and put the output in a comment on the PR.

## Publish Docker Images
- [x] Wait for the [the Docker images to be published successfully](https://github.com/ZcashFoundation/zebra/actions/workflows/release-binaries.yml?query=event%3Arelease).
- [ ] Un-freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [x] Remove `do-not-merge` from the PRs you added it to

## Release Failures

If building or running fails after tagging:

<details>

<summary>Tag a new release, following these instructions...</summary>

1. Fix the bug that caused the failure
2. Start a new `patch` release
3. Skip the **Release Preparation**, and start at the **Release Changes** step
4. Update `CHANGELOG.md` with details about the fix
5. Follow the release checklist for the new Zebra version

</details>
