### PR TITLE
fix(docs): Use automatic links in docs 

### DIFF
--- a/zebra-chain/src/parameters/network/tests/prop.rs
+++ b/zebra-chain/src/parameters/network/tests/prop.rs
@@ -35,7 +35,5 @@ proptest! {
 
         assert!(Network::Mainnet.is_max_block_time_enforced(height));
         assert_eq!(Network::Testnet.is_max_block_time_enforced(height), TESTNET_MAX_TIME_START_HEIGHT <= height);
-
-
     }
 }

--- a/zebra-consensus/src/parameters/subsidy.rs
+++ b/zebra-consensus/src/parameters/subsidy.rs
@@ -201,12 +201,12 @@ pub const FUNDING_STREAM_ECC_ADDRESSES_MAINNET: [&str; FUNDING_STREAMS_NUM_ADDRE
 /// Functionality specific to block subsidy-related consensus rules
 pub trait ParameterSubsidy {
     /// Number of addresses for each funding stream in the Network.
-    /// [7.10]: https://zips.z.cash/protocol/protocol.pdf#fundingstreams
+    /// [7.10]: <https://zips.z.cash/protocol/protocol.pdf#fundingstreams>
     fn num_funding_streams(&self) -> usize;
     /// Returns the minimum height after the first halving
     /// as described in [protocol specification §7.10][7.10]
     ///
-    /// [7.10]: https://zips.z.cash/protocol/protocol.pdf#fundingstreams
+    /// [7.10]: <https://zips.z.cash/protocol/protocol.pdf#fundingstreams>
     fn height_for_first_halving(&self) -> Height;
 }
 
@@ -221,7 +221,7 @@ impl ParameterSubsidy for Network {
     fn height_for_first_halving(&self) -> Height {
         // First halving on Mainnet is at Canopy
         // while in Testnet is at block constant height of `1_116_000`
-        // https://zips.z.cash/protocol/protocol.pdf#zip214fundingstreams
+        // <https://zips.z.cash/protocol/protocol.pdf#zip214fundingstreams>
         match self {
             Network::Mainnet => NetworkUpgrade::Canopy
                 .activation_height(*self)


### PR DESCRIPTION
## Motivation

The non-hyperlink URLs are causing a CI failure on main.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Wrap the URLs in angled brackets

Related cleanups:
- Removes a couple newlines in a new proptest, apparently rustfmt is is ignoring that macro again.

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._