### PR TITLE
add(consensus/network): Add an empty `Parameters` struct in `Network::Testnet`

### DIFF
--- a/zebra-chain/src/block/tests/vectors.rs
+++ b/zebra-chain/src/block/tests/vectors.rs
@@ -202,7 +202,7 @@ fn block_test_vectors_height_mainnet() {
 fn block_test_vectors_height_testnet() {
     let _init_guard = zebra_test::init();
 
-    block_test_vectors_height(Testnet);
+    block_test_vectors_height(Network::new_default_testnet());
 }
 
 /// Test that the block test vector indexes match the heights in the block data,
@@ -245,7 +245,7 @@ fn block_commitment_mainnet() {
 fn block_commitment_testnet() {
     let _init_guard = zebra_test::init();
 
-    block_commitment(Testnet);
+    block_commitment(Network::new_default_testnet());
 }
 
 /// Check that the block commitment field parses without errors.

--- a/zebra-chain/src/history_tree.rs
+++ b/zebra-chain/src/history_tree.rs
@@ -372,8 +372,8 @@ impl NonEmptyHistoryTree {
     }
 
     /// Return the network where this tree is used.
-    pub fn network(&self) -> Network {
-        self.network.clone()
+    pub fn network(&self) -> &Network {
+        &self.network
     }
 }
 

--- a/zebra-chain/src/history_tree/tests/vectors.rs
+++ b/zebra-chain/src/history_tree/tests/vectors.rs
@@ -22,10 +22,10 @@ use eyre::Result;
 /// higher level API.
 #[test]
 fn push_and_prune() -> Result<()> {
-    push_and_prune_for_network_upgrade(Network::Mainnet, NetworkUpgrade::Heartwood)?;
-    push_and_prune_for_network_upgrade(Network::Testnet, NetworkUpgrade::Heartwood)?;
-    push_and_prune_for_network_upgrade(Network::Mainnet, NetworkUpgrade::Canopy)?;
-    push_and_prune_for_network_upgrade(Network::Testnet, NetworkUpgrade::Canopy)?;
+    for network in Network::iter() {
+        push_and_prune_for_network_upgrade(network.clone(), NetworkUpgrade::Heartwood)?;
+        push_and_prune_for_network_upgrade(network, NetworkUpgrade::Canopy)?;
+    }
     Ok(())
 }
 
@@ -109,8 +109,9 @@ fn push_and_prune_for_network_upgrade(
 fn upgrade() -> Result<()> {
     // The history tree only exists Hearwood-onward, and the only upgrade for which
     // we have vectors since then is Canopy. Therefore, only test the Heartwood->Canopy upgrade.
-    upgrade_for_network_upgrade(Network::Mainnet, NetworkUpgrade::Canopy)?;
-    upgrade_for_network_upgrade(Network::Testnet, NetworkUpgrade::Canopy)?;
+    for network in Network::iter() {
+        upgrade_for_network_upgrade(network, NetworkUpgrade::Canopy)?;
+    }
     Ok(())
 }
 

--- a/zebra-chain/src/parameters.rs
+++ b/zebra-chain/src/parameters.rs
@@ -23,7 +23,7 @@ pub mod arbitrary;
 
 pub use error::*;
 pub use genesis::*;
-pub use network::Network;
+pub use network::{Network, NetworkKind};
 pub use network_upgrade::*;
 pub use transaction::*;
 

--- a/zebra-chain/src/parameters.rs
+++ b/zebra-chain/src/parameters.rs
@@ -12,6 +12,7 @@
 //! Typically, consensus parameters are accessed via a function that takes a
 //! `Network` and `block::Height`.
 
+mod error;
 mod genesis;
 mod network;
 mod network_upgrade;
@@ -20,6 +21,7 @@ mod transaction;
 #[cfg(any(test, feature = "proptest-impl"))]
 pub mod arbitrary;
 
+pub use error::*;
 pub use genesis::*;
 pub use network::Network;
 pub use network_upgrade::*;

--- a/zebra-chain/src/parameters.rs
+++ b/zebra-chain/src/parameters.rs
@@ -12,7 +12,6 @@
 //! Typically, consensus parameters are accessed via a function that takes a
 //! `Network` and `block::Height`.
 
-mod error;
 mod genesis;
 mod network;
 mod network_upgrade;
@@ -21,7 +20,6 @@ mod transaction;
 #[cfg(any(test, feature = "proptest-impl"))]
 pub mod arbitrary;
 
-pub use error::*;
 pub use genesis::*;
 pub use network::{Network, NetworkKind, NetworkParameters};
 pub use network_upgrade::*;

--- a/zebra-chain/src/parameters.rs
+++ b/zebra-chain/src/parameters.rs
@@ -21,7 +21,7 @@ mod transaction;
 pub mod arbitrary;
 
 pub use genesis::*;
-pub use network::{Network, NetworkKind, NetworkParameters};
+pub use network::{testnet, Network, NetworkKind};
 pub use network_upgrade::*;
 pub use transaction::*;
 

--- a/zebra-chain/src/parameters.rs
+++ b/zebra-chain/src/parameters.rs
@@ -23,7 +23,7 @@ pub mod arbitrary;
 
 pub use error::*;
 pub use genesis::*;
-pub use network::{Network, NetworkKind};
+pub use network::{Network, NetworkKind, NetworkParameters};
 pub use network_upgrade::*;
 pub use transaction::*;
 

--- a/zebra-chain/src/parameters/error.rs
+++ b/zebra-chain/src/parameters/error.rs
@@ -1,15 +1,8 @@
 //! Error types for zebra-chain parameters
 
-use std::fmt;
+use thiserror::Error;
 
 /// An error indicating that Zebra network is not supported in type conversions.
-#[derive(Debug)]
-pub struct UnsupportedNetwork;
-
-impl fmt::Display for UnsupportedNetwork {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "unsupported Zcash network parameters")
-    }
-}
-
-impl std::error::Error for UnsupportedNetwork {}
+#[derive(Clone, Debug, Error)]
+#[error("Unsupported Zcash network parameters: {0}")]
+pub struct UnsupportedNetwork(pub String);

--- a/zebra-chain/src/parameters/error.rs
+++ b/zebra-chain/src/parameters/error.rs
@@ -1,0 +1,15 @@
+//! Error types for zebra-chain parameters
+
+use std::fmt;
+
+/// An error indicating that Zebra network is not supported in type conversions.
+#[derive(Debug)]
+pub struct UnsupportedNetwork;
+
+impl fmt::Display for UnsupportedNetwork {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unsupported Zcash network parameters")
+    }
+}
+
+impl std::error::Error for UnsupportedNetwork {}

--- a/zebra-chain/src/parameters/error.rs
+++ b/zebra-chain/src/parameters/error.rs
@@ -1,8 +1,0 @@
-//! Error types for zebra-chain parameters
-
-use thiserror::Error;
-
-/// An error indicating that Zebra network is not supported in type conversions.
-#[derive(Clone, Debug, Error)]
-#[error("Unsupported Zcash network parameters: {0}")]
-pub struct UnsupportedNetwork(pub String);

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -4,7 +4,7 @@ use std::{fmt, str::FromStr, sync::Arc};
 
 use thiserror::Error;
 
-use zcash_primitives::consensus::{Network as ZcashPrimitivesNetwork, Parameters as _};
+use zcash_primitives::constants;
 
 use crate::{
     block::{self, Height, HeightDiff},
@@ -107,13 +107,19 @@ impl NetworkKind {
     /// Returns the human-readable prefix for Base58Check-encoded transparent
     /// pay-to-public-key-hash payment addresses for the network.
     pub fn b58_pubkey_address_prefix(self) -> [u8; 2] {
-        <ZcashPrimitivesNetwork>::from(self).b58_pubkey_address_prefix()
+        match self {
+            Self::Mainnet => constants::mainnet::B58_PUBKEY_ADDRESS_PREFIX,
+            Self::Testnet | Self::Regtest => constants::testnet::B58_PUBKEY_ADDRESS_PREFIX,
+        }
     }
 
     /// Returns the human-readable prefix for Base58Check-encoded transparent pay-to-script-hash
     /// payment addresses for the network.
     pub fn b58_script_address_prefix(self) -> [u8; 2] {
-        <ZcashPrimitivesNetwork>::from(self).b58_script_address_prefix()
+        match self {
+            Self::Mainnet => constants::mainnet::B58_SCRIPT_ADDRESS_PREFIX,
+            Self::Testnet | Self::Regtest => constants::testnet::B58_SCRIPT_ADDRESS_PREFIX,
+        }
     }
 
     /// Return the network name as defined in

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -135,7 +135,9 @@ impl NetworkKind {
 
 impl From<NetworkKind> for &'static str {
     fn from(network: NetworkKind) -> &'static str {
-        // These should be different from the `Display` impl for `Network`
+        // These should be different from the `Display` impl for `Network` so that its lowercase form
+        // can't be parsed as the default Testnet in the `Network` `FromStr` impl, it's easy to
+        // distinguish them in logs, and so it's generally harder to confuse the two.
         match network {
             NetworkKind::Mainnet => "MainnetKind",
             NetworkKind::Testnet => "TestnetKind",
@@ -271,6 +273,7 @@ impl Network {
     }
 }
 
+// This is used for parsing a command-line argument for the `TipHeight` command in zebrad.
 impl FromStr for Network {
     type Err = InvalidNetworkError;
 

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -65,11 +65,11 @@ impl NetworkParameters {
     }
 }
 
-#[derive(Copy, Clone, Default, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 /// An enum describing the kind of network, whether it's the production mainnet or a testnet.
 // Note: The order of these variants is important for correct bincode (de)serialization
 //       of history trees in the db format.
 // TODO: Replace bincode (de)serialization of `HistoryTreeParts` in a db format upgrade?
+#[derive(Copy, Clone, Default, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum NetworkKind {
     /// The production mainnet.
     #[default]

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -11,6 +11,8 @@ use crate::{
     parameters::NetworkUpgrade::Canopy,
 };
 
+pub mod testnet;
+
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
 
@@ -53,18 +55,6 @@ mod tests;
 /// after the grace period.
 const ZIP_212_GRACE_PERIOD_DURATION: HeightDiff = 32_256;
 
-/// Network consensus parameters for test networks such as Regtest and the default Testnet.
-#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
-#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
-pub struct NetworkParameters {}
-
-impl NetworkParameters {
-    /// Returns true if the instance of [`NetworkParameters`] represents the default public Testnet.
-    pub fn is_default_testnet(&self) -> bool {
-        self == &Self::default()
-    }
-}
-
 /// An enum describing the kind of network, whether it's the production mainnet or a testnet.
 // Note: The order of these variants is important for correct bincode (de)serialization
 //       of history trees in the db format.
@@ -100,7 +90,7 @@ pub enum Network {
 
     /// A test network such as the default public testnet,
     /// a configured testnet, or Regtest.
-    Testnet(Arc<NetworkParameters>),
+    Testnet(Arc<testnet::Parameters>),
 }
 
 impl NetworkKind {
@@ -172,13 +162,13 @@ impl fmt::Display for Network {
 }
 
 impl Network {
-    /// Creates a new [`Network::Testnet`] with the default Testnet [`NetworkParameters`].
+    /// Creates a new [`Network::Testnet`] with the default Testnet [`testnet::Parameters`].
     pub fn new_default_testnet() -> Self {
-        Self::Testnet(Arc::new(NetworkParameters::default()))
+        Self::Testnet(Arc::new(testnet::Parameters::default()))
     }
 
-    /// Creates a new configured [`Network::Testnet`] with the provided Testnet [`NetworkParameters`].
-    pub fn new_configured_testnet(params: NetworkParameters) -> Self {
+    /// Creates a new configured [`Network::Testnet`] with the provided Testnet [`testnet::Parameters`].
+    pub fn new_configured_testnet(params: testnet::Parameters) -> Self {
         Self::Testnet(Arc::new(params))
     }
 
@@ -217,7 +207,7 @@ impl Network {
     pub fn is_max_block_time_enforced(&self, height: block::Height) -> bool {
         match self {
             Network::Mainnet => true,
-            // TODO: Move `TESTNET_MAX_TIME_START_HEIGHT` to a field on NetworkParameters (#8364)
+            // TODO: Move `TESTNET_MAX_TIME_START_HEIGHT` to a field on testnet::Parameters (#8364)
             Network::Testnet(_params) => height >= super::TESTNET_MAX_TIME_START_HEIGHT,
         }
     }
@@ -226,7 +216,7 @@ impl Network {
     pub fn default_port(&self) -> u16 {
         match self {
             Network::Mainnet => 8233,
-            // TODO: Add a `default_port` field to `NetworkParameters` to return here. (zcashd uses 18344 for Regtest)
+            // TODO: Add a `default_port` field to `testnet::Parameters` to return here. (zcashd uses 18344 for Regtest)
             Network::Testnet(_params) => 18233,
         }
     }

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -78,7 +78,8 @@ pub enum NetworkKind {
     /// A test network.
     Testnet,
 
-    /// Regtest mode
+    /// Regtest mode, not yet implemented
+    // TODO: Add `new_regtest()` and `is_regtest` methods on `Network`.
     Regtest,
 }
 

--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -1,0 +1,16 @@
+//! Types and implementation for Testnet consensus parameters
+
+#[cfg(any(test, feature = "proptest-impl"))]
+use proptest_derive::Arbitrary;
+
+/// Network consensus parameters for test networks such as Regtest and the default Testnet.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
+pub struct Parameters {}
+
+impl Parameters {
+    /// Returns true if the instance of [`Parameters`] represents the default public Testnet.
+    pub fn is_default_testnet(&self) -> bool {
+        self == &Self::default()
+    }
+}

--- a/zebra-chain/src/parameters/network/tests/prop.rs
+++ b/zebra-chain/src/parameters/network/tests/prop.rs
@@ -34,6 +34,6 @@ proptest! {
         let _init_guard = zebra_test::init();
 
         assert!(Network::Mainnet.is_max_block_time_enforced(height));
-        assert_eq!(Network::Testnet.is_max_block_time_enforced(height), TESTNET_MAX_TIME_START_HEIGHT <= height);
+        assert_eq!(Network::new_default_testnet().is_max_block_time_enforced(height), TESTNET_MAX_TIME_START_HEIGHT <= height);
     }
 }

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -271,7 +271,7 @@ impl Network {
         };
         match self {
             Mainnet => mainnet_heights,
-            // TODO: Add an `activation_heights` field to `NetworkParameters` to return here. (#7970)
+            // TODO: Add an `activation_heights` field to `testnet::Parameters` to return here. (#7970)
             Testnet(_params) => testnet_heights,
         }
         .iter()
@@ -395,7 +395,7 @@ impl NetworkUpgrade {
         height: block::Height,
     ) -> Option<Duration> {
         match (network, height) {
-            // TODO: Move `TESTNET_MINIMUM_DIFFICULTY_START_HEIGHT` to a field on NetworkParameters (#8364)
+            // TODO: Move `TESTNET_MINIMUM_DIFFICULTY_START_HEIGHT` to a field on testnet::Parameters (#8364)
             (Network::Testnet(_params), height)
                 if height < TESTNET_MINIMUM_DIFFICULTY_START_HEIGHT =>
             {

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -271,7 +271,8 @@ impl Network {
         };
         match self {
             Mainnet => mainnet_heights,
-            Testnet => testnet_heights,
+            // TODO: Add an `activation_heights` field to `NetworkParameters` to return here. (#7970)
+            Testnet(_params) => testnet_heights,
         }
         .iter()
         .cloned()
@@ -394,9 +395,14 @@ impl NetworkUpgrade {
         height: block::Height,
     ) -> Option<Duration> {
         match (network, height) {
-            (Network::Testnet, height) if height < TESTNET_MINIMUM_DIFFICULTY_START_HEIGHT => None,
+            // TODO: Move `TESTNET_MINIMUM_DIFFICULTY_START_HEIGHT` to a field on NetworkParameters (#8364)
+            (Network::Testnet(_params), height)
+                if height < TESTNET_MINIMUM_DIFFICULTY_START_HEIGHT =>
+            {
+                None
+            }
             (Network::Mainnet, _) => None,
-            (Network::Testnet, _) => {
+            (Network::Testnet(_params), _) => {
                 let network_upgrade = NetworkUpgrade::current(network, height);
                 Some(network_upgrade.target_spacing() * TESTNET_MINIMUM_DIFFICULTY_GAP_MULTIPLIER)
             }

--- a/zebra-chain/src/parameters/tests.rs
+++ b/zebra-chain/src/parameters/tests.rs
@@ -21,7 +21,7 @@ fn activation_bijective() {
     let mainnet_nus: HashSet<&NetworkUpgrade> = mainnet_activations.values().collect();
     assert_eq!(MAINNET_ACTIVATION_HEIGHTS.len(), mainnet_nus.len());
 
-    let testnet_activations = Testnet.activation_list();
+    let testnet_activations = Network::new_default_testnet().activation_list();
     let testnet_heights: HashSet<&block::Height> = testnet_activations.keys().collect();
     assert_eq!(TESTNET_ACTIVATION_HEIGHTS.len(), testnet_heights.len());
 
@@ -38,7 +38,7 @@ fn activation_extremes_mainnet() {
 #[test]
 fn activation_extremes_testnet() {
     let _init_guard = zebra_test::init();
-    activation_extremes(Testnet)
+    activation_extremes(Network::new_default_testnet())
 }
 
 /// Test the activation_list, activation_height, current, and next functions
@@ -115,7 +115,7 @@ fn activation_consistent_mainnet() {
 #[test]
 fn activation_consistent_testnet() {
     let _init_guard = zebra_test::init();
-    activation_consistent(Testnet)
+    activation_consistent(Network::new_default_testnet())
 }
 
 /// Check that the `activation_height`, `is_activation_height`,
@@ -178,7 +178,7 @@ fn branch_id_extremes_mainnet() {
 #[test]
 fn branch_id_extremes_testnet() {
     let _init_guard = zebra_test::init();
-    branch_id_extremes(Testnet)
+    branch_id_extremes(Network::new_default_testnet())
 }
 
 /// Test the branch_id_list, branch_id, and current functions for `network` with
@@ -217,7 +217,7 @@ fn branch_id_consistent_mainnet() {
 #[test]
 fn branch_id_consistent_testnet() {
     let _init_guard = zebra_test::init();
-    branch_id_consistent(Testnet)
+    branch_id_consistent(Network::new_default_testnet())
 }
 
 /// Check that the branch_id and current functions are consistent for `network`.

--- a/zebra-chain/src/primitives/address.rs
+++ b/zebra-chain/src/primitives/address.rs
@@ -135,7 +135,7 @@ impl Address {
     /// Returns the network for the address.
     pub fn network(&self) -> NetworkKind {
         match &self {
-            Self::Transparent(address) => address.network(),
+            Self::Transparent(address) => address.network_kind(),
             Self::Sapling { network, .. } | Self::Unified { network, .. } => *network,
         }
     }

--- a/zebra-chain/src/primitives/address.rs
+++ b/zebra-chain/src/primitives/address.rs
@@ -51,6 +51,7 @@ impl TryFrom<zcash_address::Network> for Network {
         match network {
             zcash_address::Network::Main => Ok(Network::Mainnet),
             zcash_address::Network::Test => Ok(Network::new_default_testnet()),
+            // TODO: Add conversion to regtest (#7839)
             zcash_address::Network::Regtest => Err("unsupported Zcash network parameters".into()),
         }
     }

--- a/zebra-chain/src/primitives/address.rs
+++ b/zebra-chain/src/primitives/address.rs
@@ -5,10 +5,7 @@
 use zcash_address::unified::{self, Container};
 use zcash_primitives::sapling;
 
-use crate::{
-    parameters::{Network, NetworkKind, UnsupportedNetwork},
-    transparent, BoxError,
-};
+use crate::{parameters::NetworkKind, transparent, BoxError};
 
 /// Zcash address variants
 pub enum Address {
@@ -41,39 +38,6 @@ pub enum Address {
         /// Transparent address
         transparent: Option<transparent::Address>,
     },
-}
-
-impl TryFrom<zcash_address::Network> for Network {
-    // TODO: better error type
-    type Error = BoxError;
-
-    fn try_from(network: zcash_address::Network) -> Result<Self, Self::Error> {
-        match network {
-            zcash_address::Network::Main => Ok(Network::Mainnet),
-            zcash_address::Network::Test => Ok(Network::new_default_testnet()),
-            // TODO: Add conversion to regtest (#7839)
-            zcash_address::Network::Regtest => Err("unsupported Zcash network parameters".into()),
-        }
-    }
-}
-
-impl TryFrom<&Network> for zcash_address::Network {
-    type Error = UnsupportedNetwork;
-
-    fn try_from(network: &Network) -> Result<Self, Self::Error> {
-        match network {
-            Network::Mainnet => Ok(zcash_address::Network::Main),
-            Network::Testnet(_params) if network.is_default_testnet() => {
-                Ok(zcash_address::Network::Test)
-            }
-            // TODO: If the network parameters match `Regtest` parameters, convert to
-            //       `zcash_address::Network::Regtest instead of returning `UnsupportedAddress` error.
-            //       (#7119, #7839)
-            Network::Testnet(_params) => Err(UnsupportedNetwork(
-                "could not convert configured testnet to zcash_address::Network".to_string(),
-            )),
-        }
-    }
 }
 
 impl zcash_address::TryFromAddress for Address {

--- a/zebra-chain/src/primitives/zcash_history/tests/vectors.rs
+++ b/zebra-chain/src/primitives/zcash_history/tests/vectors.rs
@@ -11,10 +11,10 @@ use eyre::Result;
 /// and its next block.
 #[test]
 fn tree() -> Result<()> {
-    tree_for_network_upgrade(&Network::Mainnet, NetworkUpgrade::Heartwood)?;
-    tree_for_network_upgrade(&Network::Testnet, NetworkUpgrade::Heartwood)?;
-    tree_for_network_upgrade(&Network::Mainnet, NetworkUpgrade::Canopy)?;
-    tree_for_network_upgrade(&Network::Testnet, NetworkUpgrade::Canopy)?;
+    for network in Network::iter() {
+        tree_for_network_upgrade(&network, NetworkUpgrade::Heartwood)?;
+        tree_for_network_upgrade(&network, NetworkUpgrade::Canopy)?;
+    }
     Ok(())
 }
 

--- a/zebra-chain/src/primitives/zcash_note_encryption.rs
+++ b/zebra-chain/src/primitives/zcash_note_encryption.rs
@@ -26,7 +26,9 @@ pub fn decrypts_successfully(transaction: &Transaction, network: &Network, heigh
     if let Some(bundle) = alt_tx.sapling_bundle() {
         for output in bundle.shielded_outputs().iter() {
             let recovery = zcash_primitives::sapling::note_encryption::try_sapling_output_recovery(
-                &<zcash_primitives::consensus::Network>::from(network),
+                // TODO: Implement `Parameters` trait for `Network` and pass network here without conversion (#8365)
+                &<zcash_primitives::consensus::Network>::try_from(network)
+                    .expect("network must match zcash_primitives network"),
                 alt_height,
                 &null_sapling_ovk,
                 output,

--- a/zebra-chain/src/primitives/zcash_note_encryption.rs
+++ b/zebra-chain/src/primitives/zcash_note_encryption.rs
@@ -22,25 +22,27 @@ pub fn decrypts_successfully(transaction: &Transaction, network: &Network, heigh
 
     let alt_height = height.0.into();
     let null_sapling_ovk = zcash_primitives::keys::OutgoingViewingKey([0u8; 32]);
+    let network = match network {
+        Network::Mainnet => zcash_primitives::consensus::Network::MainNetwork,
+        Network::Testnet(params) => {
+            // # Correctness:
+            //
+            // There are differences between the `TestNetwork` parameters and those returned by
+            // `CRegTestParams()` in zcashd, so this function can't return `TestNetwork` unless
+            // Zebra is using the default public Testnet.
+            //
+            // TODO: Remove this conversion by implementing `zcash_primitives::consensus::Parameters`
+            //       for `Network` (#8365).
+            assert!(
+                params.is_default_testnet(),
+                "could not convert configured testnet to zcash_primitives::consensus::Network"
+            );
+            zcash_primitives::consensus::Network::TestNetwork
+        }
+    };
 
     if let Some(bundle) = alt_tx.sapling_bundle() {
         for output in bundle.shielded_outputs().iter() {
-            let network = match network {
-                Network::Mainnet => zcash_primitives::consensus::Network::MainNetwork,
-                Network::Testnet(params) => {
-                    // # Correctness:
-                    //
-                    // There are differences between the `TestNetwork` parameters and those returned by
-                    // `CRegTestParams()` in zcashd, so this function can't return `TestNetwork` unless
-                    // Zebra is using the default public Testnet.
-                    //
-                    // TODO: Remove this conversion by implementing `zcash_primitives::consensus::Parameters`
-                    //       for `Network` (#8365).
-                    assert!(params.is_default_testnet(), "could not convert configured testnet to zcash_primitives::consensus::Network");
-                    zcash_primitives::consensus::Network::TestNetwork
-                }
-            };
-
             let recovery = zcash_primitives::sapling::note_encryption::try_sapling_output_recovery(
                 &network,
                 alt_height,

--- a/zebra-chain/src/primitives/zcash_primitives.rs
+++ b/zebra-chain/src/primitives/zcash_primitives.rs
@@ -343,11 +343,14 @@ impl TryFrom<&Network> for zcash_primitives::consensus::Network {
     fn try_from(network: &Network) -> Result<Self, Self::Error> {
         match network {
             Network::Mainnet => Ok(zcash_primitives::consensus::Network::MainNetwork),
-            // Note: There are differences between the `TestNetwork` parameters and those returned by
-            //       `CRegTestParams()` in zcashd, so this function can't return `TestNetwork` unless
-            //       Zebra is using the default public Testnet.
-            // TODO: Try to remove this conversion, if possible, by implementing `zcash_primitives::consensus::Parameters`
-            //       on `Network` (#8365).
+            // # Correctness:
+            //
+            // There are differences between the `TestNetwork` parameters and those returned by
+            // `CRegTestParams()` in zcashd, so this function can't return `TestNetwork` unless
+            // Zebra is using the default public Testnet.
+            //
+            // TODO: Remove this conversion by implementing `zcash_primitives::consensus::Parameters`
+            //       for `Network` (#8365).
             Network::Testnet(_params) if network.is_default_testnet() => {
                 Ok(zcash_primitives::consensus::Network::TestNetwork)
             }
@@ -366,15 +369,6 @@ impl From<NetworkKind> for zcash_primitives::consensus::Network {
             NetworkKind::Testnet | NetworkKind::Regtest => {
                 zcash_primitives::consensus::Network::TestNetwork
             }
-        }
-    }
-}
-
-impl From<zcash_primitives::consensus::Network> for Network {
-    fn from(network: zcash_primitives::consensus::Network) -> Self {
-        match network {
-            zcash_primitives::consensus::Network::MainNetwork => Network::Mainnet,
-            zcash_primitives::consensus::Network::TestNetwork => Network::new_default_testnet(),
         }
     }
 }

--- a/zebra-chain/src/primitives/zcash_primitives.rs
+++ b/zebra-chain/src/primitives/zcash_primitives.rs
@@ -7,7 +7,7 @@ use zcash_primitives::transaction as zp_tx;
 
 use crate::{
     amount::{Amount, NonNegative},
-    parameters::{Network, NetworkUpgrade},
+    parameters::{Network, NetworkUpgrade, UnsupportedNetwork},
     serialization::ZcashSerialize,
     transaction::{AuthDigest, HashType, SigHash, Transaction},
     transparent::{self, Script},
@@ -337,11 +337,21 @@ pub(crate) fn transparent_output_address(
     }
 }
 
-impl From<&Network> for zcash_primitives::consensus::Network {
-    fn from(network: &Network) -> Self {
+impl TryFrom<&Network> for zcash_primitives::consensus::Network {
+    type Error = UnsupportedNetwork;
+
+    fn try_from(network: &Network) -> Result<Self, Self::Error> {
         match network {
-            Network::Mainnet => zcash_primitives::consensus::Network::MainNetwork,
-            Network::Testnet => zcash_primitives::consensus::Network::TestNetwork,
+            Network::Mainnet => Ok(zcash_primitives::consensus::Network::MainNetwork),
+            // Note: There are differences between the `TestNetwork` parameters and those returned by
+            //       `CRegTestParams()` in zcashd, so this function can't return `TestNetwork` unless
+            //       Zebra is using the default public Testnet.
+            // TODO: Try to remove this conversion, if possible, by implementing `zcash_primitives::consensus::Parameters`
+            //       on `Network` (#8365).
+            Network::Testnet(_params) if network.is_default_testnet() => {
+                Ok(zcash_primitives::consensus::Network::TestNetwork)
+            }
+            Network::Testnet(_params) => Err(UnsupportedNetwork),
         }
     }
 }
@@ -350,7 +360,7 @@ impl From<zcash_primitives::consensus::Network> for Network {
     fn from(network: zcash_primitives::consensus::Network) -> Self {
         match network {
             zcash_primitives::consensus::Network::MainNetwork => Network::Mainnet,
-            zcash_primitives::consensus::Network::TestNetwork => Network::Testnet,
+            zcash_primitives::consensus::Network::TestNetwork => Network::new_default_testnet(),
         }
     }
 }

--- a/zebra-chain/src/primitives/zcash_primitives.rs
+++ b/zebra-chain/src/primitives/zcash_primitives.rs
@@ -7,7 +7,7 @@ use zcash_primitives::transaction as zp_tx;
 
 use crate::{
     amount::{Amount, NonNegative},
-    parameters::{Network, NetworkKind, NetworkUpgrade, UnsupportedNetwork},
+    parameters::{Network, NetworkUpgrade, UnsupportedNetwork},
     serialization::ZcashSerialize,
     transaction::{AuthDigest, HashType, SigHash, Transaction},
     transparent::{self, Script},
@@ -358,17 +358,6 @@ impl TryFrom<&Network> for zcash_primitives::consensus::Network {
                 "could not convert configured testnet to zcash_primitives::consensus::Network"
                     .to_string(),
             )),
-        }
-    }
-}
-
-impl From<NetworkKind> for zcash_primitives::consensus::Network {
-    fn from(network: NetworkKind) -> Self {
-        match network {
-            NetworkKind::Mainnet => zcash_primitives::consensus::Network::MainNetwork,
-            NetworkKind::Testnet | NetworkKind::Regtest => {
-                zcash_primitives::consensus::Network::TestNetwork
-            }
         }
     }
 }

--- a/zebra-chain/src/primitives/zcash_primitives.rs
+++ b/zebra-chain/src/primitives/zcash_primitives.rs
@@ -351,7 +351,10 @@ impl TryFrom<&Network> for zcash_primitives::consensus::Network {
             Network::Testnet(_params) if network.is_default_testnet() => {
                 Ok(zcash_primitives::consensus::Network::TestNetwork)
             }
-            Network::Testnet(_params) => Err(UnsupportedNetwork),
+            Network::Testnet(_params) => Err(UnsupportedNetwork(
+                "could not convert configured testnet to zcash_primitives::consensus::Network"
+                    .to_string(),
+            )),
         }
     }
 }
@@ -360,7 +363,9 @@ impl From<NetworkKind> for zcash_primitives::consensus::Network {
     fn from(network: NetworkKind) -> Self {
         match network {
             NetworkKind::Mainnet => zcash_primitives::consensus::Network::MainNetwork,
-            NetworkKind::Testnet => zcash_primitives::consensus::Network::TestNetwork,
+            NetworkKind::Testnet | NetworkKind::Regtest => {
+                zcash_primitives::consensus::Network::TestNetwork
+            }
         }
     }
 }

--- a/zebra-chain/src/primitives/zcash_primitives.rs
+++ b/zebra-chain/src/primitives/zcash_primitives.rs
@@ -7,7 +7,7 @@ use zcash_primitives::transaction as zp_tx;
 
 use crate::{
     amount::{Amount, NonNegative},
-    parameters::{Network, NetworkUpgrade, UnsupportedNetwork},
+    parameters::{Network, NetworkKind, NetworkUpgrade, UnsupportedNetwork},
     serialization::ZcashSerialize,
     transaction::{AuthDigest, HashType, SigHash, Transaction},
     transparent::{self, Script},
@@ -328,11 +328,11 @@ pub(crate) fn transparent_output_address(
 
     match alt_addr {
         Some(zcash_primitives::legacy::TransparentAddress::PublicKey(pub_key_hash)) => Some(
-            transparent::Address::from_pub_key_hash(network, pub_key_hash),
+            transparent::Address::from_pub_key_hash(network.kind(), pub_key_hash),
         ),
-        Some(zcash_primitives::legacy::TransparentAddress::Script(script_hash)) => {
-            Some(transparent::Address::from_script_hash(network, script_hash))
-        }
+        Some(zcash_primitives::legacy::TransparentAddress::Script(script_hash)) => Some(
+            transparent::Address::from_script_hash(network.kind(), script_hash),
+        ),
         None => None,
     }
 }
@@ -352,6 +352,15 @@ impl TryFrom<&Network> for zcash_primitives::consensus::Network {
                 Ok(zcash_primitives::consensus::Network::TestNetwork)
             }
             Network::Testnet(_params) => Err(UnsupportedNetwork),
+        }
+    }
+}
+
+impl From<NetworkKind> for zcash_primitives::consensus::Network {
+    fn from(network: NetworkKind) -> Self {
+        match network {
+            NetworkKind::Mainnet => zcash_primitives::consensus::Network::MainNetwork,
+            NetworkKind::Testnet => zcash_primitives::consensus::Network::TestNetwork,
         }
     }
 }

--- a/zebra-chain/src/primitives/zcash_primitives.rs
+++ b/zebra-chain/src/primitives/zcash_primitives.rs
@@ -7,7 +7,7 @@ use zcash_primitives::transaction as zp_tx;
 
 use crate::{
     amount::{Amount, NonNegative},
-    parameters::{Network, NetworkUpgrade, UnsupportedNetwork},
+    parameters::{Network, NetworkUpgrade},
     serialization::ZcashSerialize,
     transaction::{AuthDigest, HashType, SigHash, Transaction},
     transparent::{self, Script},
@@ -334,30 +334,5 @@ pub(crate) fn transparent_output_address(
             transparent::Address::from_script_hash(network.kind(), script_hash),
         ),
         None => None,
-    }
-}
-
-impl TryFrom<&Network> for zcash_primitives::consensus::Network {
-    type Error = UnsupportedNetwork;
-
-    fn try_from(network: &Network) -> Result<Self, Self::Error> {
-        match network {
-            Network::Mainnet => Ok(zcash_primitives::consensus::Network::MainNetwork),
-            // # Correctness:
-            //
-            // There are differences between the `TestNetwork` parameters and those returned by
-            // `CRegTestParams()` in zcashd, so this function can't return `TestNetwork` unless
-            // Zebra is using the default public Testnet.
-            //
-            // TODO: Remove this conversion by implementing `zcash_primitives::consensus::Parameters`
-            //       for `Network` (#8365).
-            Network::Testnet(_params) if network.is_default_testnet() => {
-                Ok(zcash_primitives::consensus::Network::TestNetwork)
-            }
-            Network::Testnet(_params) => Err(UnsupportedNetwork(
-                "could not convert configured testnet to zcash_primitives::consensus::Network"
-                    .to_string(),
-            )),
-        }
     }
 }

--- a/zebra-chain/src/sapling/tests/tree.rs
+++ b/zebra-chain/src/sapling/tests/tree.rs
@@ -51,8 +51,9 @@ fn incremental_roots() {
 
 #[test]
 fn incremental_roots_with_blocks() -> Result<()> {
-    incremental_roots_with_blocks_for_network(Network::Mainnet)?;
-    incremental_roots_with_blocks_for_network(Network::Testnet)?;
+    for network in Network::iter() {
+        incremental_roots_with_blocks_for_network(network)?;
+    }
     Ok(())
 }
 

--- a/zebra-chain/src/sprout/tests/tree.rs
+++ b/zebra-chain/src/sprout/tests/tree.rs
@@ -79,9 +79,9 @@ fn incremental_roots() {
 
 #[test]
 fn incremental_roots_with_blocks() -> Result<()> {
-    incremental_roots_with_blocks_for_network(Network::Mainnet)?;
-    incremental_roots_with_blocks_for_network(Network::Testnet)?;
-
+    for network in Network::iter() {
+        incremental_roots_with_blocks_for_network(network)?;
+    }
     Ok(())
 }
 

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -343,9 +343,9 @@ fn empty_v5_librustzcash_round_trip() {
 #[test]
 fn fake_v5_round_trip() {
     let _init_guard = zebra_test::init();
-
-    fake_v5_round_trip_for_network(Network::Mainnet);
-    fake_v5_round_trip_for_network(Network::Testnet);
+    for network in Network::iter() {
+        fake_v5_round_trip_for_network(network);
+    }
 }
 
 fn fake_v5_round_trip_for_network(network: Network) {
@@ -491,9 +491,9 @@ fn invalid_orchard_nullifier() {
 #[test]
 fn fake_v5_librustzcash_round_trip() {
     let _init_guard = zebra_test::init();
-
-    fake_v5_librustzcash_round_trip_for_network(Network::Mainnet);
-    fake_v5_librustzcash_round_trip_for_network(Network::Testnet);
+    for network in Network::iter() {
+        fake_v5_librustzcash_round_trip_for_network(network);
+    }
 }
 
 fn fake_v5_librustzcash_round_trip_for_network(network: Network) {
@@ -931,9 +931,9 @@ fn zip244_sighash() -> Result<()> {
 #[test]
 fn binding_signatures() {
     let _init_guard = zebra_test::init();
-
-    binding_signatures_for_network(Network::Mainnet);
-    binding_signatures_for_network(Network::Testnet);
+    for network in Network::iter() {
+        binding_signatures_for_network(network);
+    }
 }
 
 fn binding_signatures_for_network(network: Network) {

--- a/zebra-chain/src/transparent/address.rs
+++ b/zebra-chain/src/transparent/address.rs
@@ -33,7 +33,7 @@ pub enum Address {
     /// P2SH (Pay to Script Hash) addresses
     PayToScriptHash {
         /// Production, test, or other network
-        network: NetworkKind,
+        network_kind: NetworkKind,
         /// 20 bytes specifying a script hash.
         script_hash: [u8; 20],
     },
@@ -41,7 +41,7 @@ pub enum Address {
     /// P2PKH (Pay to Public Key Hash) addresses
     PayToPublicKeyHash {
         /// Production, test, or other network
-        network: NetworkKind,
+        network_kind: NetworkKind,
         /// 20 bytes specifying a public key hash, which is a RIPEMD-160
         /// hash of a SHA-256 hash of a compressed ECDSA key encoding.
         pub_key_hash: [u8; 20],
@@ -54,17 +54,17 @@ impl fmt::Debug for Address {
 
         match self {
             Address::PayToScriptHash {
-                network,
+                network_kind,
                 script_hash,
             } => debug_struct
-                .field("network", network)
+                .field("network_kind", network_kind)
                 .field("script_hash", &hex::encode(script_hash))
                 .finish(),
             Address::PayToPublicKeyHash {
-                network,
+                network_kind,
                 pub_key_hash,
             } => debug_struct
-                .field("network", network)
+                .field("network_kind", network_kind)
                 .field("pub_key_hash", &hex::encode(pub_key_hash))
                 .finish(),
         }
@@ -97,17 +97,17 @@ impl ZcashSerialize for Address {
     fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
         match self {
             Address::PayToScriptHash {
-                network,
+                network_kind,
                 script_hash,
             } => {
-                writer.write_all(&network.b58_script_address_prefix())?;
+                writer.write_all(&network_kind.b58_script_address_prefix())?;
                 writer.write_all(script_hash)?
             }
             Address::PayToPublicKeyHash {
-                network,
+                network_kind,
                 pub_key_hash,
             } => {
-                writer.write_all(&network.b58_pubkey_address_prefix())?;
+                writer.write_all(&network_kind.b58_pubkey_address_prefix())?;
                 writer.write_all(pub_key_hash)?
             }
         }
@@ -127,25 +127,25 @@ impl ZcashDeserialize for Address {
         match version_bytes {
             zcash_primitives::constants::mainnet::B58_SCRIPT_ADDRESS_PREFIX => {
                 Ok(Address::PayToScriptHash {
-                    network: NetworkKind::Mainnet,
+                    network_kind: NetworkKind::Mainnet,
                     script_hash: hash_bytes,
                 })
             }
             zcash_primitives::constants::testnet::B58_SCRIPT_ADDRESS_PREFIX => {
                 Ok(Address::PayToScriptHash {
-                    network: NetworkKind::Testnet,
+                    network_kind: NetworkKind::Testnet,
                     script_hash: hash_bytes,
                 })
             }
             zcash_primitives::constants::mainnet::B58_PUBKEY_ADDRESS_PREFIX => {
                 Ok(Address::PayToPublicKeyHash {
-                    network: NetworkKind::Mainnet,
+                    network_kind: NetworkKind::Mainnet,
                     pub_key_hash: hash_bytes,
                 })
             }
             zcash_primitives::constants::testnet::B58_PUBKEY_ADDRESS_PREFIX => {
                 Ok(Address::PayToPublicKeyHash {
-                    network: NetworkKind::Testnet,
+                    network_kind: NetworkKind::Testnet,
                     pub_key_hash: hash_bytes,
                 })
             }
@@ -160,18 +160,18 @@ trait ToAddressWithNetwork {
 }
 
 impl ToAddressWithNetwork for Script {
-    fn to_address(&self, network: NetworkKind) -> Address {
+    fn to_address(&self, network_kind: NetworkKind) -> Address {
         Address::PayToScriptHash {
-            network,
+            network_kind,
             script_hash: Address::hash_payload(self.as_raw_bytes()),
         }
     }
 }
 
 impl ToAddressWithNetwork for PublicKey {
-    fn to_address(&self, network: NetworkKind) -> Address {
+    fn to_address(&self, network_kind: NetworkKind) -> Address {
         Address::PayToPublicKeyHash {
-            network,
+            network_kind,
             pub_key_hash: Address::hash_payload(&self.serialize()[..]),
         }
     }
@@ -179,26 +179,26 @@ impl ToAddressWithNetwork for PublicKey {
 
 impl Address {
     /// Create an address for the given public key hash and network.
-    pub fn from_pub_key_hash(network: NetworkKind, pub_key_hash: [u8; 20]) -> Self {
+    pub fn from_pub_key_hash(network_kind: NetworkKind, pub_key_hash: [u8; 20]) -> Self {
         Self::PayToPublicKeyHash {
-            network,
+            network_kind,
             pub_key_hash,
         }
     }
 
     /// Create an address for the given script hash and network.
-    pub fn from_script_hash(network: NetworkKind, script_hash: [u8; 20]) -> Self {
+    pub fn from_script_hash(network_kind: NetworkKind, script_hash: [u8; 20]) -> Self {
         Self::PayToScriptHash {
-            network,
+            network_kind,
             script_hash,
         }
     }
 
     /// Returns the network kind for this address.
-    pub fn network(&self) -> NetworkKind {
+    pub fn network_kind(&self) -> NetworkKind {
         match self {
-            Address::PayToScriptHash { network, .. } => *network,
-            Address::PayToPublicKeyHash { network, .. } => *network,
+            Address::PayToScriptHash { network_kind, .. } => *network_kind,
+            Address::PayToPublicKeyHash { network_kind, .. } => *network_kind,
         }
     }
 
@@ -338,7 +338,7 @@ mod tests {
 
         assert_eq!(
             format!("{t_addr:?}"),
-            "TransparentAddress { network: Mainnet, script_hash: \"7d46a730d31f97b1930d3368a967c309bd4d136a\" }"
+            "TransparentAddress { network_kind: Mainnet, script_hash: \"7d46a730d31f97b1930d3368a967c309bd4d136a\" }"
         );
     }
 }

--- a/zebra-chain/src/transparent/address.rs
+++ b/zebra-chain/src/transparent/address.rs
@@ -137,7 +137,8 @@ impl ZcashDeserialize for Address {
             }
             zcash_primitives::constants::testnet::B58_SCRIPT_ADDRESS_PREFIX => {
                 Ok(Address::PayToScriptHash {
-                    network: Network::Testnet,
+                    // TODO: Replace `network` field on `Address` with the prefix and a method for checking if it's the mainnet prefix.
+                    network: Network::new_default_testnet(),
                     script_hash: hash_bytes,
                 })
             }
@@ -149,7 +150,8 @@ impl ZcashDeserialize for Address {
             }
             zcash_primitives::constants::testnet::B58_PUBKEY_ADDRESS_PREFIX => {
                 Ok(Address::PayToPublicKeyHash {
-                    network: Network::Testnet,
+                    // TODO: Replace `network` field on `Address` with the prefix and a method for checking if it's the mainnet prefix.
+                    network: Network::new_default_testnet(),
                     pub_key_hash: hash_bytes,
                 })
             }

--- a/zebra-chain/src/transparent/address.rs
+++ b/zebra-chain/src/transparent/address.rs
@@ -29,10 +29,6 @@ use proptest::prelude::*;
 #[derive(
     Clone, Eq, PartialEq, Hash, serde_with::SerializeDisplay, serde_with::DeserializeFromStr,
 )]
-#[cfg_attr(
-    any(test, feature = "proptest-impl"),
-    derive(proptest_derive::Arbitrary)
-)]
 pub enum Address {
     /// P2SH (Pay to Script Hash) addresses
     PayToScriptHash {

--- a/zebra-chain/src/transparent/address.rs
+++ b/zebra-chain/src/transparent/address.rs
@@ -300,7 +300,7 @@ mod tests {
         ])
         .expect("A PublicKey from slice");
 
-        let t_addr = pub_key.to_address(Network::Testnet);
+        let t_addr = pub_key.to_address(Network::new_default_testnet());
 
         assert_eq!(format!("{t_addr}"), "tmTc6trRhbv96kGfA99i7vrFwb5p7BVFwc3");
     }
@@ -322,7 +322,7 @@ mod tests {
 
         let script = Script::new(&[0; 20]);
 
-        let t_addr = script.to_address(Network::Testnet);
+        let t_addr = script.to_address(Network::new_default_testnet());
 
         assert_eq!(format!("{t_addr}"), "t2L51LcmpA43UMvKTw2Lwtt9LMjwyqU2V1P");
     }

--- a/zebra-chain/src/transparent/arbitrary.rs
+++ b/zebra-chain/src/transparent/arbitrary.rs
@@ -1,8 +1,8 @@
 use proptest::{arbitrary::any, collection::vec, prelude::*};
 
-use crate::{block, LedgerState};
+use crate::{block, parameters::NetworkKind, LedgerState};
 
-use super::{CoinbaseData, Input, OutPoint, Script, GENESIS_COINBASE_DATA};
+use super::{Address, CoinbaseData, Input, OutPoint, Script, GENESIS_COINBASE_DATA};
 
 impl Input {
     /// Construct a strategy for creating valid-ish vecs of Inputs.
@@ -42,6 +42,30 @@ impl Arbitrary for Input {
                 })
                 .boxed()
         }
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
+impl Arbitrary for Address {
+    type Parameters = ();
+
+    fn arbitrary_with(_args: ()) -> Self::Strategy {
+        any::<(bool, bool, [u8; 20])>()
+            .prop_map(|(is_mainnet, is_p2pkh, hash_bytes)| {
+                let network = if is_mainnet {
+                    NetworkKind::Mainnet
+                } else {
+                    NetworkKind::Testnet
+                };
+
+                if is_p2pkh {
+                    Address::from_pub_key_hash(network, hash_bytes)
+                } else {
+                    Address::from_script_hash(network, hash_bytes)
+                }
+            })
+            .boxed()
     }
 
     type Strategy = BoxedStrategy<Self>;

--- a/zebra-chain/src/transparent/tests/vectors.rs
+++ b/zebra-chain/src/transparent/tests/vectors.rs
@@ -67,15 +67,17 @@ fn get_transparent_output_address() -> Result<()> {
     let addr = transparent_output_address(&transaction.outputs()[0], &Network::Mainnet)
         .expect("should return address");
     assert_eq!(addr.to_string(), "t3M5FDmPfWNRG3HRLddbicsuSCvKuk9hxzZ");
-    let addr = transparent_output_address(&transaction.outputs()[0], &Network::Testnet)
-        .expect("should return address");
+    let addr =
+        transparent_output_address(&transaction.outputs()[0], &Network::new_default_testnet())
+            .expect("should return address");
     assert_eq!(addr.to_string(), "t294SGSVoNq2daz15ZNbmAW65KQZ5e3nN5G");
     // Public key hash e4ff5512ffafe9287992a1cd177ca6e408e03003
     let addr = transparent_output_address(&transaction.outputs()[1], &Network::Mainnet)
         .expect("should return address");
     assert_eq!(addr.to_string(), "t1ekRwsd4LaSsd6NXgsx66q2HxQWTLCF44y");
-    let addr = transparent_output_address(&transaction.outputs()[1], &Network::Testnet)
-        .expect("should return address");
+    let addr =
+        transparent_output_address(&transaction.outputs()[1], &Network::new_default_testnet())
+            .expect("should return address");
     assert_eq!(addr.to_string(), "tmWbBGi7TjExNmLZyMcFpxVh3ZPbGrpbX3H");
 
     Ok(())
@@ -84,9 +86,9 @@ fn get_transparent_output_address() -> Result<()> {
 #[test]
 fn get_transparent_output_address_with_blocks() {
     let _init_guard = zebra_test::init();
-
-    get_transparent_output_address_with_blocks_for_network(Network::Mainnet);
-    get_transparent_output_address_with_blocks_for_network(Network::Testnet);
+    for network in Network::iter() {
+        get_transparent_output_address_with_blocks_for_network(network);
+    }
 }
 
 /// Test that the block test vector indexes match the heights in the block data,

--- a/zebra-chain/src/work/difficulty.rs
+++ b/zebra-chain/src/work/difficulty.rs
@@ -699,7 +699,8 @@ impl ParameterDifficulty for Network {
             /* 2^243 - 1 */
             Network::Mainnet => (U256::one() << 243) - 1,
             /* 2^251 - 1 */
-            Network::Testnet => (U256::one() << 251) - 1,
+            // TODO: Add a `target_difficulty_limit` field to `NetworkParameters` to return here.
+            Network::Testnet(_params) => (U256::one() << 251) - 1,
         };
 
         // `zcashd` converts the PoWLimit into a compact representation before

--- a/zebra-chain/src/work/difficulty.rs
+++ b/zebra-chain/src/work/difficulty.rs
@@ -699,7 +699,7 @@ impl ParameterDifficulty for Network {
             /* 2^243 - 1 */
             Network::Mainnet => (U256::one() << 243) - 1,
             /* 2^251 - 1 */
-            // TODO: Add a `target_difficulty_limit` field to `NetworkParameters` to return here.
+            // TODO: Add a `target_difficulty_limit` field to `testnet::Parameters` to return here.
             Network::Testnet(_params) => (U256::one() << 251) - 1,
         };
 

--- a/zebra-chain/src/work/difficulty/tests/vectors.rs
+++ b/zebra-chain/src/work/difficulty/tests/vectors.rs
@@ -263,8 +263,9 @@ fn compact_bitcoin_test_vectors() {
 /// Test blocks using CompactDifficulty.
 #[test]
 fn block_difficulty() -> Result<(), Report> {
-    block_difficulty_for_network(Network::Mainnet)?;
-    block_difficulty_for_network(Network::Testnet)?;
+    for network in Network::iter() {
+        block_difficulty_for_network(network)?;
+    }
 
     Ok(())
 }
@@ -349,8 +350,9 @@ fn block_difficulty_for_network(network: Network) -> Result<(), Report> {
 /// Test that the genesis block threshold is PowLimit
 #[test]
 fn genesis_block_difficulty() -> Result<(), Report> {
-    genesis_block_difficulty_for_network(Network::Mainnet)?;
-    genesis_block_difficulty_for_network(Network::Testnet)?;
+    for network in Network::iter() {
+        genesis_block_difficulty_for_network(network)?;
+    }
 
     Ok(())
 }
@@ -454,7 +456,10 @@ fn check_testnet_minimum_difficulty_block(height: block::Height) -> Result<(), R
         // threshold, as documented in ZIP-205 and ZIP-208:
         // https://zips.z.cash/zip-0205#change-to-difficulty-adjustment-on-testnet
         // https://zips.z.cash/zip-0208#minimum-difficulty-blocks-on-testnet
-        match NetworkUpgrade::minimum_difficulty_spacing_for_height(&Network::Testnet, height) {
+        match NetworkUpgrade::minimum_difficulty_spacing_for_height(
+            &Network::new_default_testnet(),
+            height,
+        ) {
             None => Err(eyre!("the minimum difficulty rule is not active"))?,
             Some(spacing) if (time_gap <= spacing) => Err(eyre!(
                 "minimum difficulty block times must be more than 6 target spacing intervals apart"
@@ -477,12 +482,12 @@ fn check_testnet_minimum_difficulty_block(height: block::Height) -> Result<(), R
 
     /// SPANDOC: Check that the testnet minimum difficulty is the PoWLimit {?height, ?threshold, ?hash}
     {
-        assert_eq!(threshold, Network::Testnet.target_difficulty_limit(),
+        assert_eq!(threshold, Network::new_default_testnet().target_difficulty_limit(),
                    "testnet minimum difficulty thresholds should be equal to the PoWLimit. Hint: Blocks with large gaps are allowed to have the minimum difficulty, but it's not required.");
         // all blocks pass the minimum difficulty threshold, even if they aren't minimum
         // difficulty blocks, because it's the lowest permitted difficulty
         assert!(
-            hash <= Network::Testnet.target_difficulty_limit(),
+            hash <= Network::new_default_testnet().target_difficulty_limit(),
             "testnet minimum difficulty hashes must be less than the PoWLimit"
         );
     }

--- a/zebra-consensus/src/block/subsidy/funding_streams.rs
+++ b/zebra-consensus/src/block/subsidy/funding_streams.rs
@@ -29,9 +29,7 @@ pub fn funding_stream_values(
     let mut results = HashMap::new();
 
     if height >= canopy_height {
-        let range = FUNDING_STREAM_HEIGHT_RANGES
-            .get(&network.bip70_network_name())
-            .unwrap();
+        let range = FUNDING_STREAM_HEIGHT_RANGES.get(&network.kind()).unwrap();
         if range.contains(&height) {
             let block_subsidy = block_subsidy(height, network)?;
             for (&receiver, &numerator) in FUNDING_STREAM_RECEIVER_NUMERATORS.iter() {
@@ -86,7 +84,7 @@ fn funding_stream_address_index(height: Height, network: &Network) -> usize {
         .expect("no overflow should happen in this sum")
         .checked_sub(funding_stream_address_period(
             FUNDING_STREAM_HEIGHT_RANGES
-                .get(&network.bip70_network_name())
+                .get(&network.kind())
                 .unwrap()
                 .start,
             network,
@@ -110,7 +108,7 @@ pub fn funding_stream_address(
 ) -> transparent::Address {
     let index = funding_stream_address_index(height, network);
     let address = &FUNDING_STREAM_ADDRESSES
-        .get(&network.bip70_network_name())
+        .get(&network.kind())
         .expect("there is always another hash map as value for a given valid network")
         .get(&receiver)
         .expect("in the inner hash map there is always a vector of strings with addresses")[index];

--- a/zebra-consensus/src/block/subsidy/funding_streams.rs
+++ b/zebra-consensus/src/block/subsidy/funding_streams.rs
@@ -29,7 +29,9 @@ pub fn funding_stream_values(
     let mut results = HashMap::new();
 
     if height >= canopy_height {
-        let range = FUNDING_STREAM_HEIGHT_RANGES.get(network).unwrap();
+        let range = FUNDING_STREAM_HEIGHT_RANGES
+            .get(&network.bip70_network_name())
+            .unwrap();
         if range.contains(&height) {
             let block_subsidy = block_subsidy(height, network)?;
             for (&receiver, &numerator) in FUNDING_STREAM_RECEIVER_NUMERATORS.iter() {
@@ -83,7 +85,10 @@ fn funding_stream_address_index(height: Height, network: &Network) -> usize {
         .checked_add(funding_stream_address_period(height, network))
         .expect("no overflow should happen in this sum")
         .checked_sub(funding_stream_address_period(
-            FUNDING_STREAM_HEIGHT_RANGES.get(network).unwrap().start,
+            FUNDING_STREAM_HEIGHT_RANGES
+                .get(&network.bip70_network_name())
+                .unwrap()
+                .start,
             network,
         ))
         .expect("no overflow should happen in this sub") as usize;
@@ -105,7 +110,7 @@ pub fn funding_stream_address(
 ) -> transparent::Address {
     let index = funding_stream_address_index(height, network);
     let address = &FUNDING_STREAM_ADDRESSES
-        .get(network)
+        .get(&network.bip70_network_name())
         .expect("there is always another hash map as value for a given valid network")
         .get(&receiver)
         .expect("in the inner hash map there is always a vector of strings with addresses")[index];

--- a/zebra-consensus/src/block/subsidy/funding_streams/tests.rs
+++ b/zebra-consensus/src/block/subsidy/funding_streams/tests.rs
@@ -44,9 +44,7 @@ fn test_funding_stream_values() -> Result<(), Report> {
     );
 
     // funding stream period is ending
-    let range = FUNDING_STREAM_HEIGHT_RANGES
-        .get(&network.bip70_network_name())
-        .unwrap();
+    let range = FUNDING_STREAM_HEIGHT_RANGES.get(&network.kind()).unwrap();
     let end = range.end;
     let last = end - 1;
 
@@ -70,7 +68,7 @@ fn test_funding_stream_addresses() -> Result<(), Report> {
                 let address =
                     transparent::Address::from_str(address).expect("address should deserialize");
                 assert_eq!(
-                    &address.network().bip70_network_name(),
+                    &address.network(),
                     network,
                     "incorrect network for {receiver:?} funding stream address constant: {address}",
                 );

--- a/zebra-consensus/src/block/subsidy/funding_streams/tests.rs
+++ b/zebra-consensus/src/block/subsidy/funding_streams/tests.rs
@@ -68,7 +68,7 @@ fn test_funding_stream_addresses() -> Result<(), Report> {
                 let address =
                     transparent::Address::from_str(address).expect("address should deserialize");
                 assert_eq!(
-                    &address.network(),
+                    &address.network_kind(),
                     network,
                     "incorrect network for {receiver:?} funding stream address constant: {address}",
                 );

--- a/zebra-consensus/src/block/subsidy/funding_streams/tests.rs
+++ b/zebra-consensus/src/block/subsidy/funding_streams/tests.rs
@@ -70,7 +70,7 @@ fn test_funding_stream_addresses() -> Result<(), Report> {
                 let address =
                     transparent::Address::from_str(address).expect("address should deserialize");
                 assert_eq!(
-                    &address.network(),
+                    &address.network().bip70_network_name(),
                     network,
                     "incorrect network for {receiver:?} funding stream address constant: {address}",
                 );

--- a/zebra-consensus/src/block/subsidy/funding_streams/tests.rs
+++ b/zebra-consensus/src/block/subsidy/funding_streams/tests.rs
@@ -44,7 +44,9 @@ fn test_funding_stream_values() -> Result<(), Report> {
     );
 
     // funding stream period is ending
-    let range = FUNDING_STREAM_HEIGHT_RANGES.get(network).unwrap();
+    let range = FUNDING_STREAM_HEIGHT_RANGES
+        .get(&network.bip70_network_name())
+        .unwrap();
     let end = range.end;
     let last = end - 1;
 

--- a/zebra-consensus/src/block/subsidy/general.rs
+++ b/zebra-consensus/src/block/subsidy/general.rs
@@ -122,9 +122,9 @@ mod test {
     #[test]
     fn halving_test() -> Result<(), Report> {
         let _init_guard = zebra_test::init();
-
-        halving_for_network(&Network::Mainnet)?;
-        halving_for_network(&Network::Testnet)?;
+        for network in Network::iter() {
+            halving_for_network(&network)?;
+        }
 
         Ok(())
     }
@@ -249,8 +249,9 @@ mod test {
     fn block_subsidy_test() -> Result<(), Report> {
         let _init_guard = zebra_test::init();
 
-        block_subsidy_for_network(&Network::Mainnet)?;
-        block_subsidy_for_network(&Network::Testnet)?;
+        for network in Network::iter() {
+            block_subsidy_for_network(&network)?;
+        }
 
         Ok(())
     }

--- a/zebra-consensus/src/block/tests.rs
+++ b/zebra-consensus/src/block/tests.rs
@@ -181,9 +181,9 @@ fn coinbase_is_first_for_historical_blocks() -> Result<(), Report> {
 #[test]
 fn difficulty_is_valid_for_historical_blocks() -> Result<(), Report> {
     let _init_guard = zebra_test::init();
-
-    difficulty_is_valid_for_network(Network::Mainnet)?;
-    difficulty_is_valid_for_network(Network::Testnet)?;
+    for network in Network::iter() {
+        difficulty_is_valid_for_network(network)?;
+    }
 
     Ok(())
 }
@@ -285,9 +285,9 @@ fn equihash_is_valid_for_historical_blocks() -> Result<(), Report> {
 #[test]
 fn subsidy_is_valid_for_historical_blocks() -> Result<(), Report> {
     let _init_guard = zebra_test::init();
-
-    subsidy_is_valid_for_network(Network::Mainnet)?;
-    subsidy_is_valid_for_network(Network::Testnet)?;
+    for network in Network::iter() {
+        subsidy_is_valid_for_network(network)?;
+    }
 
     Ok(())
 }
@@ -388,9 +388,9 @@ fn coinbase_validation_failure() -> Result<(), Report> {
 #[test]
 fn funding_stream_validation() -> Result<(), Report> {
     let _init_guard = zebra_test::init();
-
-    funding_stream_validation_for_network(Network::Mainnet)?;
-    funding_stream_validation_for_network(Network::Testnet)?;
+    for network in Network::iter() {
+        funding_stream_validation_for_network(network)?;
+    }
 
     Ok(())
 }
@@ -463,9 +463,9 @@ fn funding_stream_validation_failure() -> Result<(), Report> {
 #[test]
 fn miner_fees_validation_success() -> Result<(), Report> {
     let _init_guard = zebra_test::init();
-
-    miner_fees_validation_for_network(Network::Mainnet)?;
-    miner_fees_validation_for_network(Network::Testnet)?;
+    for network in Network::iter() {
+        miner_fees_validation_for_network(network)?;
+    }
 
     Ok(())
 }
@@ -546,12 +546,14 @@ fn merkle_root_is_valid() -> Result<(), Report> {
     let _init_guard = zebra_test::init();
 
     // test all original blocks available, all blocks validate
-    merkle_root_is_valid_for_network(Network::Mainnet)?;
-    merkle_root_is_valid_for_network(Network::Testnet)?;
+    for network in Network::iter() {
+        merkle_root_is_valid_for_network(network)?;
+    }
 
     // create and test fake blocks with v5 transactions, all blocks fail validation
-    merkle_root_fake_v5_for_network(Network::Mainnet)?;
-    merkle_root_fake_v5_for_network(Network::Testnet)?;
+    for network in Network::iter() {
+        merkle_root_fake_v5_for_network(network)?;
+    }
 
     Ok(())
 }
@@ -683,8 +685,9 @@ fn legacy_sigops_count_for_historic_blocks() {
 fn transaction_expiration_height_validation() -> Result<(), Report> {
     let _init_guard = zebra_test::init();
 
-    transaction_expiration_height_for_network(&Network::Mainnet)?;
-    transaction_expiration_height_for_network(&Network::Testnet)?;
+    for network in Network::iter() {
+        transaction_expiration_height_for_network(&network)?;
+    }
 
     Ok(())
 }

--- a/zebra-consensus/src/checkpoint/list.rs
+++ b/zebra-consensus/src/checkpoint/list.rs
@@ -57,7 +57,7 @@ impl ParameterCheckpoint for Network {
             // zcash-cli getblockhash 0
             Network::Mainnet => "00040fe8ec8471911baa1db1266ea15dd06b4a8a5c453883c000b031973dce08",
             // zcash-cli -testnet getblockhash 0
-            // TODO: Add a `genesis_hash` field to `NetworkParameters` and return it here (#8366)
+            // TODO: Add a `genesis_hash` field to `testnet::Parameters` and return it here (#8366)
             Network::Testnet(_params) => {
                 "05a60a92d99d85997cce3b87616c089f6124d7342af37106edc76126334a2c38"
             }
@@ -69,7 +69,7 @@ impl ParameterCheckpoint for Network {
     fn checkpoint_list(&self) -> CheckpointList {
         // parse calls CheckpointList::from_list
         // TODO:
-        // - Add a `genesis_hash` field to `NetworkParameters` and return it here (#8366)
+        // - Add a `genesis_hash` field to `testnet::Parameters` and return it here (#8366)
         // - Try to disable checkpoints entirely for regtest and custom testnets
         let checkpoint_list: CheckpointList = match self {
             Network::Mainnet => MAINNET_CHECKPOINTS

--- a/zebra-consensus/src/checkpoint/list.rs
+++ b/zebra-consensus/src/checkpoint/list.rs
@@ -70,8 +70,7 @@ impl ParameterCheckpoint for Network {
         // parse calls CheckpointList::from_list
         // TODO:
         // - Add a `genesis_hash` field to `NetworkParameters` and return it here (#8366)
-        // - Consider adding a `CUSTOM_TESTNET_CHECKPOINTS` constant to enable building with another checkpoints list
-        //   when using a configured testnet?
+        // - Try to disable checkpoints entirely for regtest and custom testnets
         let checkpoint_list: CheckpointList = match self {
             Network::Mainnet => MAINNET_CHECKPOINTS
                 .parse()
@@ -149,7 +148,8 @@ impl CheckpointList {
 
         // Check that the list starts with the correct genesis block
         match checkpoints.iter().next() {
-            // TODO: Move this check to `<Network as ParameterCheckpoint>::checkpoint_list(&network)` method above (#8366),
+            // TODO: If required (we may not need checkpoints at all in Regtest or custom testnets):
+            //       move this check to `<Network as ParameterCheckpoint>::checkpoint_list(&network)` method above (#8366),
             //       See <https://github.com/ZcashFoundation/zebra/pull/7924#discussion_r1385865347>
             Some((block::Height(0), hash))
                 if (hash == &Network::Mainnet.genesis_hash()

--- a/zebra-consensus/src/checkpoint/list/tests.rs
+++ b/zebra-consensus/src/checkpoint/list/tests.rs
@@ -236,7 +236,7 @@ fn checkpoint_list_load_hard_coded() -> Result<(), BoxError> {
         .expect("hard-coded Testnet checkpoint list should parse");
 
     let _ = Mainnet.checkpoint_list();
-    let _ = Testnet.checkpoint_list();
+    let _ = Network::new_default_testnet().checkpoint_list();
 
     Ok(())
 }
@@ -248,7 +248,7 @@ fn checkpoint_list_hard_coded_mandatory_mainnet() -> Result<(), BoxError> {
 
 #[test]
 fn checkpoint_list_hard_coded_mandatory_testnet() -> Result<(), BoxError> {
-    checkpoint_list_hard_coded_mandatory(Testnet)
+    checkpoint_list_hard_coded_mandatory(Network::new_default_testnet())
 }
 
 /// Check that the hard-coded lists cover the mandatory checkpoint
@@ -274,7 +274,7 @@ fn checkpoint_list_hard_coded_max_gap_mainnet() -> Result<(), BoxError> {
 
 #[test]
 fn checkpoint_list_hard_coded_max_gap_testnet() -> Result<(), BoxError> {
-    checkpoint_list_hard_coded_max_gap(Testnet)
+    checkpoint_list_hard_coded_max_gap(Network::new_default_testnet())
 }
 
 /// Check that the hard-coded checkpoints are within [`MAX_CHECKPOINT_HEIGHT_GAP`],

--- a/zebra-consensus/src/checkpoint/tests.rs
+++ b/zebra-consensus/src/checkpoint/tests.rs
@@ -205,18 +205,30 @@ async fn multi_item_checkpoint_list() -> Result<(), Report> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn continuous_blockchain_no_restart() -> Result<(), Report> {
-    continuous_blockchain(None, Mainnet).await?;
-    continuous_blockchain(None, Testnet).await?;
+    for network in Network::iter() {
+        continuous_blockchain(None, network).await?;
+    }
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn continuous_blockchain_restart() -> Result<(), Report> {
-    for height in 0..zebra_test::vectors::CONTINUOUS_MAINNET_BLOCKS.len() {
-        continuous_blockchain(Some(block::Height(height.try_into().unwrap())), Mainnet).await?;
-    }
-    for height in 0..zebra_test::vectors::CONTINUOUS_TESTNET_BLOCKS.len() {
-        continuous_blockchain(Some(block::Height(height.try_into().unwrap())), Testnet).await?;
+    for network in Network::iter() {
+        for height in 0..zebra_test::vectors::CONTINUOUS_MAINNET_BLOCKS.len() {
+            continuous_blockchain(
+                Some(block::Height(height.try_into().unwrap())),
+                network.clone(),
+            )
+            .await?;
+        }
+
+        for height in 0..zebra_test::vectors::CONTINUOUS_TESTNET_BLOCKS.len() {
+            continuous_blockchain(
+                Some(block::Height(height.try_into().unwrap())),
+                network.clone(),
+            )
+            .await?;
+        }
     }
     Ok(())
 }

--- a/zebra-consensus/src/checkpoint/tests.rs
+++ b/zebra-consensus/src/checkpoint/tests.rs
@@ -213,22 +213,15 @@ async fn continuous_blockchain_no_restart() -> Result<(), Report> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn continuous_blockchain_restart() -> Result<(), Report> {
-    for network in Network::iter() {
-        for height in 0..zebra_test::vectors::CONTINUOUS_MAINNET_BLOCKS.len() {
-            continuous_blockchain(
-                Some(block::Height(height.try_into().unwrap())),
-                network.clone(),
-            )
-            .await?;
-        }
-
-        for height in 0..zebra_test::vectors::CONTINUOUS_TESTNET_BLOCKS.len() {
-            continuous_blockchain(
-                Some(block::Height(height.try_into().unwrap())),
-                network.clone(),
-            )
-            .await?;
-        }
+    for height in 0..zebra_test::vectors::CONTINUOUS_MAINNET_BLOCKS.len() {
+        continuous_blockchain(Some(block::Height(height.try_into().unwrap())), Mainnet).await?;
+    }
+    for height in 0..zebra_test::vectors::CONTINUOUS_TESTNET_BLOCKS.len() {
+        continuous_blockchain(
+            Some(block::Height(height.try_into().unwrap())),
+            Network::new_default_testnet(),
+        )
+        .await?;
     }
     Ok(())
 }

--- a/zebra-consensus/src/parameters/subsidy.rs
+++ b/zebra-consensus/src/parameters/subsidy.rs
@@ -104,7 +104,7 @@ lazy_static! {
     /// as described in [protocol specification §7.10.1][7.10.1].
     ///
     /// [7.10.1]: https://zips.z.cash/protocol/protocol.pdf#zip214fundingstreams
-    // TODO: Move the value here to a field on `NetworkParameters` (#8367)
+    // TODO: Move the value here to a field on `testnet::Parameters` (#8367)
     pub static ref FUNDING_STREAM_HEIGHT_RANGES: HashMap<NetworkKind, std::ops::Range<Height>> = {
         let mut hash_map = HashMap::new();
         hash_map.insert(NetworkKind::Mainnet, Height(1_046_400)..Height(2_726_400));
@@ -113,7 +113,7 @@ lazy_static! {
     };
 
     /// Convenient storage for all addresses, for all receivers and networks
-    // TODO: Move the value here to a field on `NetworkParameters` (#8367)
+    // TODO: Move the value here to a field on `testnet::Parameters` (#8367)
     //       There are no funding stream addresses on Regtest in zcashd, zebrad should do the same for compatibility.
     pub static ref FUNDING_STREAM_ADDRESSES: HashMap<NetworkKind, HashMap<FundingStreamReceiver, Vec<String>>> = {
         let mut addresses_by_network = HashMap::with_capacity(2);
@@ -231,7 +231,7 @@ impl ParameterSubsidy for Network {
             Network::Mainnet => NetworkUpgrade::Canopy
                 .activation_height(self)
                 .expect("canopy activation height should be available"),
-            // TODO: Check what zcashd does here, consider adding a field to `NetworkParameters` to make this configurable.
+            // TODO: Check what zcashd does here, consider adding a field to `testnet::Parameters` to make this configurable.
             Network::Testnet(_params) => FIRST_HALVING_TESTNET,
         }
     }

--- a/zebra-consensus/src/parameters/subsidy.rs
+++ b/zebra-consensus/src/parameters/subsidy.rs
@@ -231,7 +231,6 @@ impl ParameterSubsidy for Network {
             Network::Mainnet => NetworkUpgrade::Canopy
                 .activation_height(self)
                 .expect("canopy activation height should be available"),
-
             // TODO: Check what zcashd does here, consider adding a field to `NetworkParamters` to make this configurable.
             Network::Testnet(_params) => FIRST_HALVING_TESTNET,
         }

--- a/zebra-consensus/src/parameters/subsidy.rs
+++ b/zebra-consensus/src/parameters/subsidy.rs
@@ -231,7 +231,7 @@ impl ParameterSubsidy for Network {
             Network::Mainnet => NetworkUpgrade::Canopy
                 .activation_height(self)
                 .expect("canopy activation height should be available"),
-            // TODO: Check what zcashd does here, consider adding a field to `NetworkParamters` to make this configurable.
+            // TODO: Check what zcashd does here, consider adding a field to `NetworkParameters` to make this configurable.
             Network::Testnet(_params) => FIRST_HALVING_TESTNET,
         }
     }

--- a/zebra-consensus/src/parameters/subsidy.rs
+++ b/zebra-consensus/src/parameters/subsidy.rs
@@ -7,7 +7,7 @@ use lazy_static::lazy_static;
 use zebra_chain::{
     amount::COIN,
     block::{Height, HeightDiff},
-    parameters::{Network, NetworkUpgrade},
+    parameters::{Network, NetworkKind, NetworkUpgrade},
 };
 
 /// An initial period from Genesis to this Height where the block subsidy is gradually incremented. [What is slow-start mining][slow-mining]
@@ -105,16 +105,17 @@ lazy_static! {
     ///
     /// [7.10.1]: https://zips.z.cash/protocol/protocol.pdf#zip214fundingstreams
     // TODO: Move the value here to a field on `NetworkParameters` (#8367)
-    pub static ref FUNDING_STREAM_HEIGHT_RANGES: HashMap<String, std::ops::Range<Height>> = {
+    pub static ref FUNDING_STREAM_HEIGHT_RANGES: HashMap<NetworkKind, std::ops::Range<Height>> = {
         let mut hash_map = HashMap::new();
-        hash_map.insert(Network::Mainnet.bip70_network_name(), Height(1_046_400)..Height(2_726_400));
-        hash_map.insert(Network::new_default_testnet().bip70_network_name(), Height(1_028_500)..Height(2_796_000));
+        hash_map.insert(NetworkKind::Mainnet, Height(1_046_400)..Height(2_726_400));
+        hash_map.insert(NetworkKind::Testnet, Height(1_028_500)..Height(2_796_000));
         hash_map
     };
 
     /// Convenient storage for all addresses, for all receivers and networks
     // TODO: Move the value here to a field on `NetworkParameters` (#8367)
-    pub static ref FUNDING_STREAM_ADDRESSES: HashMap<String, HashMap<FundingStreamReceiver, Vec<String>>> = {
+    //       There are no funding stream addresses on Regtest in zcashd, zebrad should do the same for compatibility.
+    pub static ref FUNDING_STREAM_ADDRESSES: HashMap<NetworkKind, HashMap<FundingStreamReceiver, Vec<String>>> = {
         let mut addresses_by_network = HashMap::with_capacity(2);
 
         // Mainnet addresses
@@ -122,14 +123,14 @@ lazy_static! {
         mainnet_addresses.insert(FundingStreamReceiver::Ecc, FUNDING_STREAM_ECC_ADDRESSES_MAINNET.iter().map(|a| a.to_string()).collect());
         mainnet_addresses.insert(FundingStreamReceiver::ZcashFoundation, FUNDING_STREAM_ZF_ADDRESSES_MAINNET.iter().map(|a| a.to_string()).collect());
         mainnet_addresses.insert(FundingStreamReceiver::MajorGrants, FUNDING_STREAM_MG_ADDRESSES_MAINNET.iter().map(|a| a.to_string()).collect());
-        addresses_by_network.insert(Network::Mainnet.bip70_network_name(), mainnet_addresses);
+        addresses_by_network.insert(NetworkKind::Mainnet, mainnet_addresses);
 
         // Testnet addresses
         let mut testnet_addresses = HashMap::with_capacity(3);
         testnet_addresses.insert(FundingStreamReceiver::Ecc, FUNDING_STREAM_ECC_ADDRESSES_TESTNET.iter().map(|a| a.to_string()).collect());
         testnet_addresses.insert(FundingStreamReceiver::ZcashFoundation, FUNDING_STREAM_ZF_ADDRESSES_TESTNET.iter().map(|a| a.to_string()).collect());
         testnet_addresses.insert(FundingStreamReceiver::MajorGrants, FUNDING_STREAM_MG_ADDRESSES_TESTNET.iter().map(|a| a.to_string()).collect());
-        addresses_by_network.insert(Network::new_default_testnet().bip70_network_name(), testnet_addresses);
+        addresses_by_network.insert(NetworkKind::Testnet, testnet_addresses);
 
         addresses_by_network
     };

--- a/zebra-consensus/src/router.rs
+++ b/zebra-consensus/src/router.rs
@@ -240,13 +240,9 @@ where
 
     // Make sure the state contains the known best chain checkpoints, in a separate thread.
 
-    let (checkpoint_state_service, checkpoint_sync, network_clone) = {
-        let checkpoint_state_service = state_service.clone();
-        let checkpoint_sync = config.checkpoint_sync;
-        let network_clone = network.clone();
-
-        (checkpoint_state_service, checkpoint_sync, network_clone)
-    };
+    let checkpoint_state_service = state_service.clone();
+    let checkpoint_sync = config.checkpoint_sync;
+    let checkpoint_network = network.clone();
 
     let state_checkpoint_verify_handle = tokio::task::spawn(
         // TODO: move this into an async function?
@@ -269,7 +265,7 @@ where
             // > activation block hashes given in § 3.12 ‘Mainnet and Testnet’ on p. 20.
             //
             // <https://zips.z.cash/protocol/protocol.pdf#blockchain>
-            let full_checkpoints = network_clone.checkpoint_list();
+            let full_checkpoints = checkpoint_network.checkpoint_list();
             let mut already_warned = false;
 
             for (height, checkpoint_hash) in full_checkpoints.iter() {

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -42,13 +42,8 @@ mod prop;
 fn v5_fake_transactions() -> Result<(), Report> {
     let _init_guard = zebra_test::init();
 
-    let networks = vec![
-        (Network::Mainnet, zebra_test::vectors::MAINNET_BLOCKS.iter()),
-        (Network::Testnet, zebra_test::vectors::TESTNET_BLOCKS.iter()),
-    ];
-
-    for (network, blocks) in networks {
-        for transaction in fake_v5_transactions_for_network(&network, blocks) {
+    for network in Network::iter() {
+        for transaction in fake_v5_transactions_for_network(&network, network.block_iter()) {
             match check::has_inputs_and_outputs(&transaction) {
                 Ok(()) => (),
                 Err(TransactionError::NoInputs) | Err(TransactionError::NoOutputs) => (),
@@ -858,16 +853,12 @@ async fn v5_transaction_is_rejected_before_nu5_activation() {
     const V5_TRANSACTION_VERSION: u32 = 5;
 
     let canopy = NetworkUpgrade::Canopy;
-    let networks = vec![
-        (Network::Mainnet, zebra_test::vectors::MAINNET_BLOCKS.iter()),
-        (Network::Testnet, zebra_test::vectors::TESTNET_BLOCKS.iter()),
-    ];
 
-    for (network, blocks) in networks {
+    for network in Network::iter() {
         let state_service = service_fn(|_| async { unreachable!("Service should not be called") });
         let verifier = Verifier::new(&network, state_service);
 
-        let transaction = fake_v5_transactions_for_network(&network, blocks)
+        let transaction = fake_v5_transactions_for_network(&network, network.block_iter())
             .next_back()
             .expect("At least one fake V5 transaction in the test vectors");
 
@@ -899,7 +890,7 @@ fn v5_transaction_is_accepted_after_nu5_activation_mainnet() {
 
 #[test]
 fn v5_transaction_is_accepted_after_nu5_activation_testnet() {
-    v5_transaction_is_accepted_after_nu5_activation_for_network(Network::Testnet)
+    v5_transaction_is_accepted_after_nu5_activation_for_network(Network::new_default_testnet())
 }
 
 fn v5_transaction_is_accepted_after_nu5_activation_for_network(network: Network) {
@@ -1544,7 +1535,7 @@ fn v4_transaction_with_conflicting_sprout_nullifier_across_joinsplits_is_rejecte
 /// Test if V5 transaction with transparent funds is accepted.
 #[tokio::test]
 async fn v5_transaction_with_transparent_transfer_is_accepted() {
-    let network = Network::Testnet;
+    let network = Network::new_default_testnet();
     let network_upgrade = NetworkUpgrade::Nu5;
 
     let nu5_activation_height = network_upgrade
@@ -1601,12 +1592,13 @@ async fn v5_transaction_with_transparent_transfer_is_accepted() {
 /// accepted.
 #[tokio::test]
 async fn v5_transaction_with_last_valid_expiry_height() {
+    let network = Network::new_default_testnet();
     let state_service =
         service_fn(|_| async { unreachable!("State service should not be called") });
-    let verifier = Verifier::new(&Network::Testnet, state_service);
+    let verifier = Verifier::new(&network, state_service);
 
     let block_height = NetworkUpgrade::Nu5
-        .activation_height(&Network::Testnet)
+        .activation_height(&network)
         .expect("Nu5 activation height for testnet is specified");
     let fund_height = (block_height - 1).expect("fake source fund block height is too small");
     let (input, output, known_utxos) = mock_transparent_transfer(
@@ -1646,12 +1638,13 @@ async fn v5_transaction_with_last_valid_expiry_height() {
 /// is equal to the height of the block the transaction belongs to.
 #[tokio::test]
 async fn v5_coinbase_transaction_expiry_height() {
+    let network = Network::new_default_testnet();
     let state_service =
         service_fn(|_| async { unreachable!("State service should not be called") });
-    let verifier = Verifier::new(&Network::Testnet, state_service);
+    let verifier = Verifier::new(&network, state_service);
 
     let block_height = NetworkUpgrade::Nu5
-        .activation_height(&Network::Testnet)
+        .activation_height(&network)
         .expect("Nu5 activation height for testnet is specified");
 
     let (input, output) = mock_coinbase_transparent_output(block_height);
@@ -1761,12 +1754,14 @@ async fn v5_coinbase_transaction_expiry_height() {
 /// Tests if an expired non-coinbase V5 transaction is rejected.
 #[tokio::test]
 async fn v5_transaction_with_too_low_expiry_height() {
+    let network = Network::new_default_testnet();
+
     let state_service =
         service_fn(|_| async { unreachable!("State service should not be called") });
-    let verifier = Verifier::new(&Network::Testnet, state_service);
+    let verifier = Verifier::new(&network, state_service);
 
     let block_height = NetworkUpgrade::Nu5
-        .activation_height(&Network::Testnet)
+        .activation_height(&network)
         .expect("Nu5 activation height for testnet is specified");
     let fund_height = (block_height - 1).expect("fake source fund block height is too small");
     let (input, output, known_utxos) = mock_transparent_transfer(
@@ -1864,7 +1859,7 @@ async fn v5_transaction_with_exceeding_expiry_height() {
 /// Test if V5 coinbase transaction is accepted.
 #[tokio::test]
 async fn v5_coinbase_transaction_is_accepted() {
-    let network = Network::Testnet;
+    let network = Network::new_default_testnet();
     let network_upgrade = NetworkUpgrade::Nu5;
 
     let nu5_activation_height = network_upgrade
@@ -1916,7 +1911,7 @@ async fn v5_coinbase_transaction_is_accepted() {
 /// script prevents spending the source UTXO.
 #[tokio::test]
 async fn v5_transaction_with_transparent_transfer_is_rejected_by_the_script() {
-    let network = Network::Testnet;
+    let network = Network::new_default_testnet();
     let network_upgrade = NetworkUpgrade::Nu5;
 
     let nu5_activation_height = network_upgrade
@@ -2759,8 +2754,9 @@ fn add_to_sprout_pool_after_nu() {
 fn coinbase_outputs_are_decryptable_for_historical_blocks() -> Result<(), Report> {
     let _init_guard = zebra_test::init();
 
-    coinbase_outputs_are_decryptable_for_historical_blocks_for_network(Network::Mainnet)?;
-    coinbase_outputs_are_decryptable_for_historical_blocks_for_network(Network::Testnet)?;
+    for network in Network::iter() {
+        coinbase_outputs_are_decryptable_for_historical_blocks_for_network(network)?;
+    }
 
     Ok(())
 }
@@ -2844,7 +2840,7 @@ fn fill_action_with_note_encryption_test_vector(
 /// viewing key.
 #[test]
 fn coinbase_outputs_are_decryptable_for_fake_v5_blocks() {
-    let network = Network::Testnet;
+    let network = Network::new_default_testnet();
 
     for v in zebra_test::vectors::ORCHARD_NOTE_ENCRYPTION_ZERO_VECTOR.iter() {
         // Find a transaction with no inputs or outputs to use as base
@@ -2886,7 +2882,7 @@ fn coinbase_outputs_are_decryptable_for_fake_v5_blocks() {
 /// viewing key.
 #[test]
 fn shielded_outputs_are_not_decryptable_for_fake_v5_blocks() {
-    let network = Network::Testnet;
+    let network = Network::new_default_testnet();
 
     for v in zebra_test::vectors::ORCHARD_NOTE_ENCRYPTION_VECTOR.iter() {
         // Find a transaction with no inputs or outputs to use as base

--- a/zebra-grpc/src/tests/snapshot.rs
+++ b/zebra-grpc/src/tests/snapshot.rs
@@ -38,7 +38,7 @@ async fn test_grpc_response_data() {
             zebra_test::net::random_known_port()
         ),
         test_mocked_rpc_response_data_for_network(
-            Network::Testnet,
+            Network::new_default_testnet(),
             zebra_test::net::random_known_port()
         ),
     );

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -15,7 +15,7 @@ use tempfile::NamedTempFile;
 use tokio::{fs, io::AsyncWriteExt};
 use tracing::Span;
 
-use zebra_chain::parameters::{Network, NetworkKind, NetworkParameters};
+use zebra_chain::parameters::{testnet, Network, NetworkKind};
 
 use crate::{
     constants::{
@@ -630,7 +630,7 @@ impl<'de> Deserialize<'de> for Config {
         struct DConfig {
             listen_addr: String,
             network: NetworkKind,
-            testnet_parameters: Option<NetworkParameters>,
+            testnet_parameters: Option<testnet::Parameters>,
             initial_mainnet_peers: IndexSet<String>,
             initial_testnet_peers: IndexSet<String>,
             cache_dir: CacheDir,

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -682,7 +682,12 @@ impl<'de> Deserialize<'de> for Config {
 
             Network::new_configured_testnet(network_params)
         } else {
-            Network::from_kind(network_kind)
+            // Convert to default `Network` for a `NetworkKind` if there are no testnet parameters.
+            match network_kind {
+                NetworkKind::Mainnet => Network::Mainnet,
+                NetworkKind::Testnet => Network::new_default_testnet(),
+                NetworkKind::Regtest => unimplemented!("Regtest is not yet implemented in Zebra"),
+            }
         };
 
         let listen_addr = match listen_addr.parse::<SocketAddr>() {

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -393,7 +393,7 @@ lazy_static! {
     ///
     /// The minimum network protocol version typically changes after Mainnet and
     /// Testnet network upgrades.
-    // TODO: Move the value here to a field on `NetworkParameters` (#8367)
+    // TODO: Move the value here to a field on `testnet::Parameters` (#8367)
     pub static ref INITIAL_MIN_NETWORK_PROTOCOL_VERSION: HashMap<NetworkKind, Version> = {
         let mut hash_map = HashMap::new();
 

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -392,11 +392,12 @@ lazy_static! {
     ///
     /// The minimum network protocol version typically changes after Mainnet and
     /// Testnet network upgrades.
-    pub static ref INITIAL_MIN_NETWORK_PROTOCOL_VERSION: HashMap<Network, Version> = {
+    // TODO: Move the value here to a field on `NetworkParameters` (#8367)
+    pub static ref INITIAL_MIN_NETWORK_PROTOCOL_VERSION: HashMap<String, Version> = {
         let mut hash_map = HashMap::new();
 
-        hash_map.insert(Mainnet, Version::min_specified_for_upgrade(&Mainnet, Nu5));
-        hash_map.insert(Testnet, Version::min_specified_for_upgrade(&Testnet, Nu5));
+        hash_map.insert(Mainnet.bip70_network_name(), Version::min_specified_for_upgrade(&Mainnet, Nu5));
+        hash_map.insert(Network::new_default_testnet().bip70_network_name(), Version::min_specified_for_upgrade(&Network::new_default_testnet(), Nu5));
 
         hash_map
     };

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -16,6 +16,7 @@ use crate::protocol::external::types::*;
 use zebra_chain::{
     parameters::{
         Network::{self, *},
+        NetworkKind,
         NetworkUpgrade::*,
     },
     serialization::Duration32,
@@ -393,11 +394,11 @@ lazy_static! {
     /// The minimum network protocol version typically changes after Mainnet and
     /// Testnet network upgrades.
     // TODO: Move the value here to a field on `NetworkParameters` (#8367)
-    pub static ref INITIAL_MIN_NETWORK_PROTOCOL_VERSION: HashMap<String, Version> = {
+    pub static ref INITIAL_MIN_NETWORK_PROTOCOL_VERSION: HashMap<NetworkKind, Version> = {
         let mut hash_map = HashMap::new();
 
-        hash_map.insert(Mainnet.bip70_network_name(), Version::min_specified_for_upgrade(&Mainnet, Nu5));
-        hash_map.insert(Network::new_default_testnet().bip70_network_name(), Version::min_specified_for_upgrade(&Network::new_default_testnet(), Nu5));
+        hash_map.insert(NetworkKind::Mainnet, Version::min_specified_for_upgrade(&Mainnet, Nu5));
+        hash_map.insert(NetworkKind::Testnet, Version::min_specified_for_upgrade(&Network::new_default_testnet(), Nu5));
 
         hash_map
     };

--- a/zebra-network/src/isolated/tests/vectors.rs
+++ b/zebra-network/src/isolated/tests/vectors.rs
@@ -14,8 +14,6 @@ use crate::{
 
 use super::super::*;
 
-use Network::*;
-
 /// Test that `connect_isolated` sends a version message with minimal distinguishing features,
 /// when sent over TCP.
 #[tokio::test]
@@ -26,8 +24,9 @@ async fn connect_isolated_sends_anonymised_version_message_tcp() {
         return;
     }
 
-    connect_isolated_sends_anonymised_version_message_tcp_net(Mainnet).await;
-    connect_isolated_sends_anonymised_version_message_tcp_net(Testnet).await;
+    for network in Network::iter() {
+        connect_isolated_sends_anonymised_version_message_tcp_net(network).await;
+    }
 }
 
 async fn connect_isolated_sends_anonymised_version_message_tcp_net(network: Network) {
@@ -82,9 +81,9 @@ async fn connect_isolated_sends_anonymised_version_message_tcp_net(network: Netw
 #[tokio::test]
 async fn connect_isolated_sends_anonymised_version_message_mem() {
     let _init_guard = zebra_test::init();
-
-    connect_isolated_sends_anonymised_version_message_mem_net(Mainnet).await;
-    connect_isolated_sends_anonymised_version_message_mem_net(Testnet).await;
+    for network in Network::iter() {
+        connect_isolated_sends_anonymised_version_message_mem_net(network).await;
+    }
 }
 
 async fn connect_isolated_sends_anonymised_version_message_mem_net(network: Network) {

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -80,8 +80,9 @@ async fn local_listener_unspecified_port_unspecified_addr_v4() {
 
     // these tests might fail on machines with no configured IPv4 addresses
     // (localhost should be enough)
-    local_listener_port_with("0.0.0.0:0".parse().unwrap(), Mainnet).await;
-    local_listener_port_with("0.0.0.0:0".parse().unwrap(), Testnet).await;
+    for network in Network::iter() {
+        local_listener_port_with("0.0.0.0:0".parse().unwrap(), network).await;
+    }
 }
 
 /// Test that zebra-network discovers dynamic bind-to-all-interfaces listener ports,
@@ -101,8 +102,9 @@ async fn local_listener_unspecified_port_unspecified_addr_v6() {
     }
 
     // these tests might fail on machines with no configured IPv6 addresses
-    local_listener_port_with("[::]:0".parse().unwrap(), Mainnet).await;
-    local_listener_port_with("[::]:0".parse().unwrap(), Testnet).await;
+    for network in Network::iter() {
+        local_listener_port_with("[::]:0".parse().unwrap(), network).await;
+    }
 }
 
 /// Test that zebra-network discovers dynamic localhost listener ports,
@@ -116,8 +118,9 @@ async fn local_listener_unspecified_port_localhost_addr_v4() {
     }
 
     // these tests might fail on machines with unusual IPv4 localhost configs
-    local_listener_port_with("127.0.0.1:0".parse().unwrap(), Mainnet).await;
-    local_listener_port_with("127.0.0.1:0".parse().unwrap(), Testnet).await;
+    for network in Network::iter() {
+        local_listener_port_with("127.0.0.1:0".parse().unwrap(), network).await;
+    }
 }
 
 /// Test that zebra-network discovers dynamic localhost listener ports,
@@ -135,8 +138,9 @@ async fn local_listener_unspecified_port_localhost_addr_v6() {
     }
 
     // these tests might fail on machines with no configured IPv6 addresses
-    local_listener_port_with("[::1]:0".parse().unwrap(), Mainnet).await;
-    local_listener_port_with("[::1]:0".parse().unwrap(), Testnet).await;
+    for network in Network::iter() {
+        local_listener_port_with("[::1]:0".parse().unwrap(), network).await;
+    }
 }
 
 /// Test that zebra-network propagates fixed localhost listener ports to the `AddressBook`.
@@ -150,8 +154,9 @@ async fn local_listener_fixed_port_localhost_addr_v4() {
         return;
     }
 
-    local_listener_port_with(SocketAddr::new(localhost_v4, random_known_port()), Mainnet).await;
-    local_listener_port_with(SocketAddr::new(localhost_v4, random_known_port()), Testnet).await;
+    for network in Network::iter() {
+        local_listener_port_with(SocketAddr::new(localhost_v4, random_known_port()), network).await;
+    }
 }
 
 /// Test that zebra-network propagates fixed localhost listener ports to the `AddressBook`.
@@ -169,8 +174,9 @@ async fn local_listener_fixed_port_localhost_addr_v6() {
         return;
     }
 
-    local_listener_port_with(SocketAddr::new(localhost_v6, random_known_port()), Mainnet).await;
-    local_listener_port_with(SocketAddr::new(localhost_v6, random_known_port()), Testnet).await;
+    for network in Network::iter() {
+        local_listener_port_with(SocketAddr::new(localhost_v6, random_known_port()), network).await;
+    }
 }
 
 /// Test zebra-network with a peer limit of zero peers on mainnet.
@@ -207,8 +213,15 @@ async fn peer_limit_zero_testnet() {
     let unreachable_inbound_service =
         service_fn(|_| async { unreachable!("inbound service should never be called") });
 
-    let address_book =
-        init_with_peer_limit(0, unreachable_inbound_service, Testnet, None, None).await;
+    let address_book = init_with_peer_limit(
+        0,
+        unreachable_inbound_service,
+        Network::new_default_testnet(),
+        None,
+        None,
+    )
+    .await;
+
     assert_eq!(
         address_book.lock().unwrap().peers().count(),
         0,
@@ -247,7 +260,14 @@ async fn peer_limit_one_testnet() {
 
     let nil_inbound_service = service_fn(|_| async { Ok(Response::Nil) });
 
-    let _ = init_with_peer_limit(1, nil_inbound_service, Testnet, None, None).await;
+    let _ = init_with_peer_limit(
+        1,
+        nil_inbound_service,
+        Network::new_default_testnet(),
+        None,
+        None,
+    )
+    .await;
 
     // Let the crawler run for a while.
     tokio::time::sleep(CRAWLER_TEST_DURATION).await;
@@ -285,7 +305,14 @@ async fn peer_limit_two_testnet() {
 
     let nil_inbound_service = service_fn(|_| async { Ok(Response::Nil) });
 
-    let _ = init_with_peer_limit(2, nil_inbound_service, Testnet, None, None).await;
+    let _ = init_with_peer_limit(
+        2,
+        nil_inbound_service,
+        Network::new_default_testnet(),
+        None,
+        None,
+    )
+    .await;
 
     // Let the crawler run for a while.
     tokio::time::sleep(CRAWLER_TEST_DURATION).await;

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -207,7 +207,7 @@ mod test {
 
     #[test]
     fn version_extremes_testnet() {
-        version_extremes(&Testnet)
+        version_extremes(&Network::new_default_testnet())
     }
 
     /// Test the min_specified_for_upgrade and min_specified_for_height functions for `network` with
@@ -235,7 +235,7 @@ mod test {
 
     #[test]
     fn version_consistent_testnet() {
-        version_consistent(&Testnet)
+        version_consistent(&Network::new_default_testnet())
     }
 
     /// Check that the min_specified_for_upgrade and min_specified_for_height functions

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -31,7 +31,7 @@ impl ParameterMagic for Network {
     fn magic_value(&self) -> Magic {
         match self {
             Network::Mainnet => magics::MAINNET,
-            // TODO: Move `Magic` struct definition to `zebra-chain`, add it as a field in `NetworkParameters`, and return it here.
+            // TODO: Move `Magic` struct definition to `zebra-chain`, add it as a field in `testnet::Parameters`, and return it here.
             Network::Testnet(_params) => magics::TESTNET,
         }
     }

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -8,7 +8,7 @@ use zebra_chain::{
     },
 };
 
-use crate::constants::{self, magics};
+use crate::constants::{self, magics, CURRENT_NETWORK_PROTOCOL_VERSION};
 
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
@@ -31,7 +31,8 @@ impl ParameterMagic for Network {
     fn magic_value(&self) -> Magic {
         match self {
             Network::Mainnet => magics::MAINNET,
-            Network::Testnet => magics::TESTNET,
+            // TODO: Move `Magic` struct definition to `zebra-chain`, add it as a field in `NetworkParameters`, and return it here.
+            Network::Testnet(_params) => magics::TESTNET,
         }
     }
 }
@@ -80,7 +81,7 @@ impl Version {
     /// - after Zebra's local network is slow or shut down.
     fn initial_min_for_network(network: &Network) -> Version {
         *constants::INITIAL_MIN_NETWORK_PROTOCOL_VERSION
-            .get(network)
+            .get(&network.bip70_network_name())
             .expect("We always have a value for testnet or mainnet")
     }
 
@@ -103,17 +104,22 @@ impl Version {
         //       sync? zcashd accepts 170_002 or later during its initial sync.
         Version(match (network, network_upgrade) {
             (_, Genesis) | (_, BeforeOverwinter) => 170_002,
-            (Testnet, Overwinter) => 170_003,
+            (Testnet(params), Overwinter) if params.is_default_testnet() => 170_003,
             (Mainnet, Overwinter) => 170_005,
+            // TODO: Use 170_006 for (Testnet(params), Sapling) if params.is_regtest() (`Regtest` in zcashd uses
+            //       version 170_006 for Sapling, and the same values as Testnet for other network upgrades.)
             (_, Sapling) => 170_007,
-            (Testnet, Blossom) => 170_008,
+            (Testnet(params), Blossom) if params.is_default_testnet() => 170_008,
             (Mainnet, Blossom) => 170_009,
-            (Testnet, Heartwood) => 170_010,
+            (Testnet(params), Heartwood) if params.is_default_testnet() => 170_010,
             (Mainnet, Heartwood) => 170_011,
-            (Testnet, Canopy) => 170_012,
+            (Testnet(params), Canopy) if params.is_default_testnet() => 170_012,
             (Mainnet, Canopy) => 170_013,
-            (Testnet, Nu5) => 170_050,
+            (Testnet(params), Nu5) if params.is_default_testnet() => 170_050,
             (Mainnet, Nu5) => 170_100,
+
+            // It should be fine to reject peers with earlier network protocol versions on custom testnets for now.
+            (Testnet(_params), _) => CURRENT_NETWORK_PROTOCOL_VERSION.0,
         })
     }
 }

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -81,7 +81,7 @@ impl Version {
     /// - after Zebra's local network is slow or shut down.
     fn initial_min_for_network(network: &Network) -> Version {
         *constants::INITIAL_MIN_NETWORK_PROTOCOL_VERSION
-            .get(&network.bip70_network_name())
+            .get(&network.kind())
             .expect("We always have a value for testnet or mainnet")
     }
 

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -450,11 +450,11 @@ where
         // Prevent loss of miner funds due to an unsupported or incorrect address type.
         if let Some(miner_address) = mining_config.miner_address.clone() {
             assert_eq!(
-                miner_address.network(),
+                miner_address.network_kind(),
                 network.kind(),
                 "incorrect miner address config: {miner_address} \
                          network.network {network} and miner address network {} must match",
-                miner_address.network(),
+                miner_address.network_kind(),
             );
         }
 

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -451,7 +451,7 @@ where
         if let Some(miner_address) = mining_config.miner_address.clone() {
             assert_eq!(
                 miner_address.network(),
-                network.clone(),
+                network.kind(),
                 "incorrect miner address config: {miner_address} \
                          network.network {network} and miner address network {} must match",
                 miner_address.network(),
@@ -1084,7 +1084,7 @@ where
                 return Ok(validate_address::Response::invalid());
             }
 
-            if address.network() == network {
+            if address.network() == network.kind() {
                 Ok(validate_address::Response {
                     address: Some(raw_address),
                     is_valid: true,
@@ -1124,7 +1124,7 @@ where
                     }
                 };
 
-            if address.network() == network {
+            if address.network() == network.kind() {
                 Ok(z_validate_address::Response {
                     is_valid: true,
                     address: Some(raw_address),

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -11,11 +11,8 @@ use insta::dynamic_redaction;
 use tower::buffer::Buffer;
 
 use zebra_chain::{
-    block::Block,
-    chain_tip::mock::MockChainTip,
-    parameters::Network::{Mainnet, Testnet},
-    serialization::ZcashDeserializeInto,
-    subtree::NoteCommitmentSubtreeData,
+    block::Block, chain_tip::mock::MockChainTip, parameters::Network::Mainnet,
+    serialization::ZcashDeserializeInto, subtree::NoteCommitmentSubtreeData,
 };
 use zebra_state::{ReadRequest, ReadResponse, MAX_ON_DISK_HEIGHT};
 use zebra_test::mock_service::MockService;
@@ -33,12 +30,13 @@ pub const EXCESSIVE_BLOCK_HEIGHT: u32 = MAX_ON_DISK_HEIGHT.0 + 1;
 #[tokio::test(flavor = "multi_thread")]
 async fn test_rpc_response_data() {
     let _init_guard = zebra_test::init();
+    let default_testnet = Network::new_default_testnet();
 
     tokio::join!(
         test_rpc_response_data_for_network(&Mainnet),
-        test_rpc_response_data_for_network(&Testnet),
+        test_rpc_response_data_for_network(&default_testnet),
         test_mocked_rpc_response_data_for_network(&Mainnet),
-        test_mocked_rpc_response_data_for_network(&Testnet),
+        test_mocked_rpc_response_data_for_network(&default_testnet),
     );
 }
 

--- a/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
@@ -94,7 +94,10 @@ pub async fn test_responses<State, ReadState>(
 
     #[allow(clippy::unnecessary_struct_initialization)]
     let mining_config = crate::config::mining::Config {
-        miner_address: Some(transparent::Address::from_script_hash(network, [0xad; 20])),
+        miner_address: Some(transparent::Address::from_script_hash(
+            network.kind(),
+            [0xad; 20],
+        )),
         extra_coinbase_data: None,
         debug_like_zcashd: true,
         // TODO: Use default field values when optional features are enabled in tests #8183

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -654,7 +654,7 @@ async fn rpc_getaddresstxids_invalid_arguments() {
 async fn rpc_getaddresstxids_response() {
     let _init_guard = zebra_test::init();
 
-    for network in [Mainnet, Testnet] {
+    for network in Network::iter() {
         let blocks: Vec<Arc<Block>> = network
             .blockchain_map()
             .iter()

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -1193,6 +1193,7 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
         amount::NonNegative,
         block::{Hash, MAX_BLOCK_BYTES, ZCASH_BLOCK_VERSION},
         chain_sync_status::MockSyncStatus,
+        parameters::NetworkKind,
         serialization::DateTime32,
         transaction::{zip317, VerifiedUnminedTx},
         work::difficulty::{CompactDifficulty, ExpandedDifficulty, U256},
@@ -1223,11 +1224,10 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
     let mut mock_sync_status = MockSyncStatus::default();
     mock_sync_status.set_is_close_to_tip(true);
 
+    let network = NetworkKind::Mainnet;
     let miner_address = match use_p2pkh {
-        false => Some(transparent::Address::from_script_hash(&Mainnet, [0x7e; 20])),
-        true => Some(transparent::Address::from_pub_key_hash(
-            &Mainnet, [0x7e; 20],
-        )),
+        false => Some(transparent::Address::from_script_hash(network, [0x7e; 20])),
+        true => Some(transparent::Address::from_pub_key_hash(network, [0x7e; 20])),
     };
 
     #[allow(clippy::unnecessary_struct_initialization)]

--- a/zebra-scan/src/service/scan_task/scan.rs
+++ b/zebra-scan/src/service/scan_task/scan.rs
@@ -384,7 +384,10 @@ pub fn scan_block<K: ScanningKey>(
     // TODO: Implement a check that returns early when the block height is below the Sapling
     // activation height.
 
-    let network: zcash_primitives::consensus::Network = network.into();
+    // TODO: Implement `zcash_primitives::consensus::Parameters` for `Network` and remove this conversion (#8365)
+    let network: zcash_primitives::consensus::Network = network
+        .try_into()
+        .expect("must match zcash_primitives network");
 
     let chain_metadata = ChainMetadata {
         sapling_commitment_tree_size: sapling_tree_size,

--- a/zebra-scan/src/service/scan_task/scan.rs
+++ b/zebra-scan/src/service/scan_task/scan.rs
@@ -384,10 +384,24 @@ pub fn scan_block<K: ScanningKey>(
     // TODO: Implement a check that returns early when the block height is below the Sapling
     // activation height.
 
-    // TODO: Implement `zcash_primitives::consensus::Parameters` for `Network` and remove this conversion (#8365)
-    let network: zcash_primitives::consensus::Network = network
-        .try_into()
-        .expect("must match zcash_primitives network");
+    let network = match network {
+        Network::Mainnet => zcash_primitives::consensus::Network::MainNetwork,
+        Network::Testnet(params) => {
+            // # Correctness:
+            //
+            // There are differences between the `TestNetwork` parameters and those returned by
+            // `CRegTestParams()` in zcashd, so this function can't return `TestNetwork` unless
+            // Zebra is using the default public Testnet.
+            //
+            // TODO: Remove this conversion by implementing `zcash_primitives::consensus::Parameters`
+            //       for `Network` (#8365).
+            assert!(
+                params.is_default_testnet(),
+                "could not convert configured testnet to zcash_primitives::consensus::Network"
+            );
+            zcash_primitives::consensus::Network::TestNetwork
+        }
+    };
 
     let chain_metadata = ChainMetadata {
         sapling_commitment_tree_size: sapling_tree_size,

--- a/zebra-scan/src/storage/db/tests/snapshot.rs
+++ b/zebra-scan/src/storage/db/tests/snapshot.rs
@@ -28,10 +28,7 @@ use std::collections::BTreeMap;
 
 use itertools::Itertools;
 
-use zebra_chain::{
-    block::Height,
-    parameters::Network::{self, *},
-};
+use zebra_chain::{block::Height, parameters::Network};
 use zebra_state::{RawBytes, ReadDisk, SaplingScannedDatabaseIndex, TransactionLocation, KV};
 
 use crate::storage::{db::ScannerDb, Storage};
@@ -45,8 +42,9 @@ use crate::storage::{db::ScannerDb, Storage};
 fn test_database_format() {
     let _init_guard = zebra_test::init();
 
-    test_database_format_with_network(Mainnet);
-    test_database_format_with_network(Testnet);
+    for network in Network::iter() {
+        test_database_format_with_network(network);
+    }
 }
 
 /// Snapshot raw and typed database formats for `network`.

--- a/zebra-state/src/service/arbitrary.rs
+++ b/zebra-state/src/service/arbitrary.rs
@@ -89,13 +89,14 @@ impl PreparedChain {
         // The history tree only works with Heartwood onward.
         // Since the network will be chosen later, we pick the larger
         // between the mainnet and testnet Heartwood activation heights.
-        let main_height = NetworkUpgrade::Heartwood
-            .activation_height(&Network::Mainnet)
-            .expect("must have height");
-        let test_height = NetworkUpgrade::Heartwood
-            .activation_height(&Network::Testnet)
-            .expect("must have height");
-        let height = std::cmp::max(main_height, test_height);
+        let height = Network::iter()
+            .map(|network| {
+                NetworkUpgrade::Heartwood
+                    .activation_height(&network)
+                    .expect("must have height")
+            })
+            .max()
+            .expect("Network::iter() must return non-empty iterator");
 
         PreparedChain {
             ledger_strategy: Some(LedgerState::height_strategy(

--- a/zebra-state/src/service/check/difficulty.rs
+++ b/zebra-state/src/service/check/difficulty.rs
@@ -183,10 +183,9 @@ impl AdjustedDifficulty {
             self.candidate_time,
             self.relevant_times[0],
         ) {
-            assert_eq!(
-                self.network,
-                Network::Testnet,
-                "invalid network: the minimum difficulty rule only applies on testnet"
+            assert!(
+                self.network.is_a_test_network(),
+                "invalid network: the minimum difficulty rule only applies on test networks"
             );
             self.network.target_difficulty_limit().to_compact()
         } else {

--- a/zebra-state/src/service/finalized_state/disk_format/chain.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/chain.rs
@@ -44,7 +44,7 @@ impl FromDisk for ValueBalance<NonNegative> {
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct HistoryTreeParts {
-    network: NetworkKind,
+    network_kind: NetworkKind,
     size: u32,
     peaks: BTreeMap<u32, zcash_history::Entry>,
     current_height: Height,
@@ -57,7 +57,7 @@ impl HistoryTreeParts {
         network: &Network,
     ) -> Result<NonEmptyHistoryTree, HistoryTreeError> {
         assert_eq!(
-            self.network,
+            self.network_kind,
             network.kind(),
             "history tree network kind should match current network"
         );
@@ -69,7 +69,7 @@ impl HistoryTreeParts {
 impl From<&NonEmptyHistoryTree> for HistoryTreeParts {
     fn from(history_tree: &NonEmptyHistoryTree) -> Self {
         HistoryTreeParts {
-            network: history_tree.network().kind(),
+            network_kind: history_tree.network().kind(),
             size: history_tree.size(),
             peaks: history_tree.peaks().clone(),
             current_height: history_tree.current_height(),

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshot.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshot.rs
@@ -29,11 +29,7 @@
 
 use std::{collections::BTreeMap, sync::Arc};
 
-use zebra_chain::{
-    block::Block,
-    parameters::Network::{self, *},
-    serialization::ZcashDeserializeInto,
-};
+use zebra_chain::{block::Block, parameters::Network, serialization::ZcashDeserializeInto};
 
 use crate::{
     service::finalized_state::{
@@ -50,9 +46,9 @@ use crate::{
 #[test]
 fn test_raw_rocksdb_column_families() {
     let _init_guard = zebra_test::init();
-
-    test_raw_rocksdb_column_families_with_network(Mainnet);
-    test_raw_rocksdb_column_families_with_network(Testnet);
+    for network in Network::iter() {
+        test_raw_rocksdb_column_families_with_network(network);
+    }
 }
 
 /// Snapshot raw column families for `network`.

--- a/zebra-state/src/service/finalized_state/disk_format/transparent.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/transparent.rs
@@ -498,14 +498,17 @@ impl AddressTransaction {
 
 /// Returns a byte representing the [`transparent::Address`] variant.
 fn address_variant(address: &transparent::Address) -> u8 {
+    use NetworkKind::*;
     // Return smaller values for more common variants.
     //
     // (This probably doesn't matter, but it might help slightly with data compression.)
     match (address.network(), address) {
-        (NetworkKind::Mainnet, PayToPublicKeyHash { .. }) => 0,
-        (NetworkKind::Mainnet, PayToScriptHash { .. }) => 1,
-        (NetworkKind::Testnet, PayToPublicKeyHash { .. }) => 2,
-        (NetworkKind::Testnet, PayToScriptHash { .. }) => 3,
+        (Mainnet, PayToPublicKeyHash { .. }) => 0,
+        (Mainnet, PayToScriptHash { .. }) => 1,
+        // There's no way to distinguish between Regtest and Testnet for encoded transparent addresses,
+        // so the network kind should always be `Mainnet` or `Testnet`.
+        (Testnet | Regtest, PayToPublicKeyHash { .. }) => 2,
+        (Testnet | Regtest, PayToScriptHash { .. }) => 3,
     }
 }
 
@@ -531,7 +534,6 @@ impl FromDisk for transparent::Address {
         let network = if address_variant < 2 {
             NetworkKind::Mainnet
         } else {
-            // TODO: Replace `network` field on `Address` with the prefix and a method for checking if it's the mainnet prefix.
             NetworkKind::Testnet
         };
 

--- a/zebra-state/src/service/finalized_state/disk_format/transparent.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/transparent.rs
@@ -502,7 +502,7 @@ fn address_variant(address: &transparent::Address) -> u8 {
     // Return smaller values for more common variants.
     //
     // (This probably doesn't matter, but it might help slightly with data compression.)
-    match (address.network(), address) {
+    match (address.network_kind(), address) {
         (Mainnet, PayToPublicKeyHash { .. }) => 0,
         (Mainnet, PayToScriptHash { .. }) => 1,
         // There's no way to distinguish between Regtest and Testnet for encoded transparent addresses,

--- a/zebra-state/src/service/finalized_state/disk_format/transparent.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/transparent.rs
@@ -506,7 +506,8 @@ fn address_variant(address: &transparent::Address) -> u8 {
         (Mainnet, PayToPublicKeyHash { .. }) => 0,
         (Mainnet, PayToScriptHash { .. }) => 1,
         // There's no way to distinguish between Regtest and Testnet for encoded transparent addresses,
-        // so the network kind should always be `Mainnet` or `Testnet`.
+        // we can consider `Regtest` to use `Testnet` transparent addresses, so it's okay to use the `Testnet`
+        // address variant for `Regtest` transparent addresses in the db format
         (Testnet | Regtest, PayToPublicKeyHash { .. }) => 2,
         (Testnet | Regtest, PayToScriptHash { .. }) => 3,
     }

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -215,7 +215,7 @@ impl ZebraDb {
 
     /// Returns the configured network for this database.
     pub fn network(&self) -> Network {
-        self.db.network().clone()
+        self.db.network()
     }
 
     /// Returns the `Path` where the files used by this database are located.

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
@@ -37,7 +37,7 @@ use serde::Serialize;
 use zebra_chain::{
     block::{self, Block, Height, SerializedBlock},
     orchard,
-    parameters::Network::{self, *},
+    parameters::Network,
     sapling,
     serialization::{ZcashDeserializeInto, ZcashSerialize},
     transaction::{self, Transaction},
@@ -153,9 +153,9 @@ impl TransactionData {
 #[test]
 fn test_block_and_transaction_data() {
     let _init_guard = zebra_test::init();
-
-    test_block_and_transaction_data_with_network(Mainnet);
-    test_block_and_transaction_data_with_network(Testnet);
+    for network in Network::iter() {
+        test_block_and_transaction_data_with_network(network);
+    }
 }
 
 /// Snapshot finalized block and transaction data for `network`.

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
@@ -318,7 +318,7 @@ fn snapshot_block_and_transaction_data(state: &FinalizedState) {
                 // Skip these checks for empty history trees.
                 if let Some(history_tree_at_tip) = history_tree_at_tip.as_ref().as_ref() {
                     assert_eq!(history_tree_at_tip.current_height(), max_height);
-                    assert_eq!(history_tree_at_tip.network(), state.network());
+                    assert_eq!(history_tree_at_tip.network(), &state.network());
                 }
             }
 

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
@@ -43,7 +43,7 @@ fn test_block_db_round_trip() {
         .map(|(_height, block)| block.zcash_deserialize_into().unwrap());
 
     test_block_db_round_trip_with(&Mainnet, mainnet_test_cases);
-    test_block_db_round_trip_with(&Testnet, testnet_test_cases);
+    test_block_db_round_trip_with(&Network::new_default_testnet(), testnet_test_cases);
 
     // It doesn't matter if these blocks are mainnet or testnet,
     // because there is no validation at this level of the database.

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -134,8 +134,9 @@ fn ord_matches_work() -> Result<()> {
 fn best_chain_wins() -> Result<()> {
     let _init_guard = zebra_test::init();
 
-    best_chain_wins_for_network(Network::Mainnet)?;
-    best_chain_wins_for_network(Network::Testnet)?;
+    for network in Network::iter() {
+        best_chain_wins_for_network(network)?;
+    }
 
     Ok(())
 }
@@ -172,8 +173,9 @@ fn best_chain_wins_for_network(network: Network) -> Result<()> {
 fn finalize_pops_from_best_chain() -> Result<()> {
     let _init_guard = zebra_test::init();
 
-    finalize_pops_from_best_chain_for_network(Network::Mainnet)?;
-    finalize_pops_from_best_chain_for_network(Network::Testnet)?;
+    for network in Network::iter() {
+        finalize_pops_from_best_chain_for_network(network)?;
+    }
 
     Ok(())
 }
@@ -219,8 +221,9 @@ fn finalize_pops_from_best_chain_for_network(network: Network) -> Result<()> {
 fn commit_block_extending_best_chain_doesnt_drop_worst_chains() -> Result<()> {
     let _init_guard = zebra_test::init();
 
-    commit_block_extending_best_chain_doesnt_drop_worst_chains_for_network(Network::Mainnet)?;
-    commit_block_extending_best_chain_doesnt_drop_worst_chains_for_network(Network::Testnet)?;
+    for network in Network::iter() {
+        commit_block_extending_best_chain_doesnt_drop_worst_chains_for_network(network)?;
+    }
 
     Ok(())
 }
@@ -264,10 +267,9 @@ fn commit_block_extending_best_chain_doesnt_drop_worst_chains_for_network(
 #[test]
 fn shorter_chain_can_be_best_chain() -> Result<()> {
     let _init_guard = zebra_test::init();
-
-    shorter_chain_can_be_best_chain_for_network(Network::Mainnet)?;
-    shorter_chain_can_be_best_chain_for_network(Network::Testnet)?;
-
+    for network in Network::iter() {
+        shorter_chain_can_be_best_chain_for_network(network)?;
+    }
     Ok(())
 }
 
@@ -307,9 +309,9 @@ fn shorter_chain_can_be_best_chain_for_network(network: Network) -> Result<()> {
 #[test]
 fn longer_chain_with_more_work_wins() -> Result<()> {
     let _init_guard = zebra_test::init();
-
-    longer_chain_with_more_work_wins_for_network(Network::Mainnet)?;
-    longer_chain_with_more_work_wins_for_network(Network::Testnet)?;
+    for network in Network::iter() {
+        longer_chain_with_more_work_wins_for_network(network)?;
+    }
 
     Ok(())
 }
@@ -355,8 +357,9 @@ fn longer_chain_with_more_work_wins_for_network(network: Network) -> Result<()> 
 fn equal_length_goes_to_more_work() -> Result<()> {
     let _init_guard = zebra_test::init();
 
-    equal_length_goes_to_more_work_for_network(Network::Mainnet)?;
-    equal_length_goes_to_more_work_for_network(Network::Testnet)?;
+    for network in Network::iter() {
+        equal_length_goes_to_more_work_for_network(network)?;
+    }
 
     Ok(())
 }
@@ -394,8 +397,9 @@ fn equal_length_goes_to_more_work_for_network(network: Network) -> Result<()> {
 
 #[test]
 fn history_tree_is_updated() -> Result<()> {
-    history_tree_is_updated_for_network_upgrade(Network::Mainnet, NetworkUpgrade::Heartwood)?;
-    history_tree_is_updated_for_network_upgrade(Network::Testnet, NetworkUpgrade::Heartwood)?;
+    for network in Network::iter() {
+        history_tree_is_updated_for_network_upgrade(network, NetworkUpgrade::Heartwood)?;
+    }
     // TODO: we can't test other upgrades until we have a method for creating a FinalizedState
     // with a HistoryTree.
     Ok(())
@@ -497,8 +501,9 @@ fn history_tree_is_updated_for_network_upgrade(
 
 #[test]
 fn commitment_is_validated() {
-    commitment_is_validated_for_network_upgrade(Network::Mainnet, NetworkUpgrade::Heartwood);
-    commitment_is_validated_for_network_upgrade(Network::Testnet, NetworkUpgrade::Heartwood);
+    for network in Network::iter() {
+        commitment_is_validated_for_network_upgrade(network, NetworkUpgrade::Heartwood);
+    }
     // TODO: we can't test other upgrades until we have a method for creating a FinalizedState
     // with a HistoryTree.
 }

--- a/zebra-state/tests/basic.rs
+++ b/zebra-state/tests/basic.rs
@@ -63,7 +63,7 @@ async fn check_transcripts_mainnet() -> Result<(), Report> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn check_transcripts_testnet() -> Result<(), Report> {
-    check_transcripts(Network::Testnet).await
+    check_transcripts(Network::new_default_testnet()).await
 }
 
 #[spandoc::spandoc]

--- a/zebra-utils/src/bin/scanning-results-reader/main.rs
+++ b/zebra-utils/src/bin/scanning-results-reader/main.rs
@@ -41,8 +41,9 @@ use zebra_scan::{storage::Storage, Config};
 /// - The transaction fetched via RPC cannot be deserialized from raw bytes.
 #[allow(clippy::print_stdout)]
 pub fn main() {
+    // TODO: Implement `zcash_primitives::consensus::Parameters` for `Network` and remove this variable (#8365).
     let network = zcash_primitives::consensus::Network::MainNetwork;
-    let zebra_network: zebra_chain::parameters::Network = network.into();
+    let zebra_network = zebra_chain::parameters::Network::Mainnet;
     let storage = Storage::new(&Config::default(), &zebra_network, true);
     // If the first memo is empty, it doesn't get printed. But we never print empty memos anyway.
     let mut prev_memo = "".to_owned();

--- a/zebrad/src/components/mempool/storage/tests/vectors.rs
+++ b/zebrad/src/components/mempool/storage/tests/vectors.rs
@@ -60,8 +60,9 @@ fn mempool_storage_basic() -> Result<()> {
 
     // Test multiple times to catch intermittent bugs since eviction is randomized
     for _ in 0..10 {
-        mempool_storage_basic_for_network(Network::Mainnet)?;
-        mempool_storage_basic_for_network(Network::Testnet)?;
+        for network in Network::iter() {
+            mempool_storage_basic_for_network(network)?;
+        }
     }
 
     Ok(())
@@ -236,10 +237,9 @@ fn mempool_storage_crud_same_effects_mainnet() {
 #[test]
 fn mempool_expired_basic() -> Result<()> {
     let _init_guard = zebra_test::init();
-
-    mempool_expired_basic_for_network(Network::Mainnet)?;
-    mempool_expired_basic_for_network(Network::Testnet)?;
-
+    for network in Network::iter() {
+        mempool_expired_basic_for_network(network)?;
+    }
     Ok(())
 }
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1051,7 +1051,7 @@ fn sync_one_checkpoint_mainnet() -> Result<()> {
 fn sync_one_checkpoint_testnet() -> Result<()> {
     sync_until(
         TINY_CHECKPOINT_TEST_HEIGHT,
-        &Testnet,
+        &Network::new_default_testnet(),
         STOP_AT_HEIGHT_REGEX,
         TINY_CHECKPOINT_TIMEOUT,
         None,
@@ -1271,7 +1271,7 @@ fn sync_to_mandatory_checkpoint_mainnet() -> Result<()> {
 #[cfg_attr(feature = "test_sync_to_mandatory_checkpoint_testnet", test)]
 fn sync_to_mandatory_checkpoint_testnet() -> Result<()> {
     let _init_guard = zebra_test::init();
-    let network = Testnet;
+    let network = Network::new_default_testnet();
     create_cached_database(network)
 }
 
@@ -1297,7 +1297,7 @@ fn sync_past_mandatory_checkpoint_mainnet() -> Result<()> {
 #[cfg_attr(feature = "test_sync_past_mandatory_checkpoint_testnet", test)]
 fn sync_past_mandatory_checkpoint_testnet() -> Result<()> {
     let _init_guard = zebra_test::init();
-    let network = Testnet;
+    let network = Network::new_default_testnet();
     sync_past_mandatory_checkpoint(network)
 }
 
@@ -1322,7 +1322,10 @@ fn full_sync_mainnet() -> Result<()> {
 #[ignore]
 fn full_sync_testnet() -> Result<()> {
     // TODO: add "ZEBRA" at the start of this env var, to avoid clashes
-    full_sync_test(Testnet, "FULL_SYNC_TESTNET_TIMEOUT_MINUTES")
+    full_sync_test(
+        Network::new_default_testnet(),
+        "FULL_SYNC_TESTNET_TIMEOUT_MINUTES",
+    )
 }
 
 #[cfg(feature = "prometheus")]
@@ -2529,14 +2532,14 @@ async fn generate_checkpoints_mainnet() -> Result<()> {
 #[ignore]
 #[cfg(feature = "zebra-checkpoints")]
 async fn generate_checkpoints_testnet() -> Result<()> {
-    common::checkpoints::run(Testnet).await
+    common::checkpoints::run(Network::new_default_testnet()).await
 }
 
 /// Check that new states are created with the current state format version,
 /// and that restarting `zebrad` doesn't change the format version.
 #[tokio::test]
 async fn new_state_format() -> Result<()> {
-    for network in [Mainnet, Testnet] {
+    for network in Network::iter() {
         state_format_test("new_state_format_test", &network, 2, None).await?;
     }
 
@@ -2554,7 +2557,7 @@ async fn update_state_format() -> Result<()> {
     fake_version.minor = 0;
     fake_version.patch = 0;
 
-    for network in [Mainnet, Testnet] {
+    for network in Network::iter() {
         state_format_test("update_state_format_test", &network, 3, Some(&fake_version)).await?;
     }
 
@@ -2571,7 +2574,7 @@ async fn downgrade_state_format() -> Result<()> {
     fake_version.minor = u16::MAX.into();
     fake_version.patch = 0;
 
-    for network in [Mainnet, Testnet] {
+    for network in Network::iter() {
         state_format_test(
             "downgrade_state_format_test",
             &network,

--- a/zebrad/tests/common/checkpoints.rs
+++ b/zebrad/tests/common/checkpoints.rs
@@ -15,7 +15,7 @@ use tempfile::TempDir;
 
 use zebra_chain::{
     block::{Height, HeightDiff, TryIntoHeight},
-    parameters::Network::{self, *},
+    parameters::Network,
     transparent::MIN_TRANSPARENT_COINBASE_MATURITY,
 };
 use zebra_consensus::MAX_CHECKPOINT_HEIGHT_GAP;
@@ -82,7 +82,7 @@ pub async fn run(network: Network) -> Result<()> {
     // Wait for the upgrade if needed.
     // Currently we only write an image for testnet, which is quick.
     // (Mainnet would need to wait at the end of this function, if the upgrade is long.)
-    if network == Testnet {
+    if network.is_a_test_network() {
         let state_version_message = wait_for_state_version_message(&mut zebrad)?;
 
         // Before we write a cached state image, wait for a database upgrade.

--- a/zebrad/tests/common/configs/v1.7.0.toml
+++ b/zebrad/tests/common/configs/v1.7.0.toml
@@ -1,0 +1,84 @@
+# Default configuration for zebrad.
+#
+# This file can be used as a skeleton for custom configs.
+#
+# Unspecified fields use default values. Optional fields are Some(field) if the
+# field is present and None if it is absent.
+#
+# This file is generated as an example using zebrad's current defaults.
+# You should set only the config options you want to keep, and delete the rest.
+# Only a subset of fields are present in the skeleton, since optional values
+# whose default is None are omitted.
+#
+# The config format (including a complete list of sections and fields) is
+# documented here:
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
+#
+# zebrad attempts to load configs in the following order:
+#
+# 1. The -c flag on the command line, e.g., `zebrad -c myconfig.toml start`;
+# 2. The file `zebrad.toml` in the users's preference directory (platform-dependent);
+# 3. The default config.
+#
+# The user's preference directory and the default path to the `zebrad` config are platform dependent,
+# based on `dirs::preference_dir`, see https://docs.rs/dirs/latest/dirs/fn.preference_dir.html :
+#
+# | Platform | Value                                 | Example                                        |
+# | -------- | ------------------------------------- | ---------------------------------------------- |
+# | Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/zebrad.toml`              |
+# | macOS    | `$HOME/Library/Preferences`           | `/Users/Alice/Library/Preferences/zebrad.toml` |
+# | Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Local\zebrad.toml`     |
+
+[consensus]
+checkpoint_sync = true
+
+[mempool]
+eviction_memory_time = "1h"
+tx_cost_limit = 80000000
+
+[metrics]
+
+[mining]
+debug_like_zcashd = true
+
+[network]
+cache_dir = true
+crawl_new_peer_interval = "1m 1s"
+initial_mainnet_peers = [
+    "dnsseed.z.cash:8233",
+    "dnsseed.str4d.xyz:8233",
+    "mainnet.seeder.zfnd.org:8233",
+    "mainnet.is.yolo.money:8233",
+]
+initial_testnet_peers = [
+    "dnsseed.testnet.z.cash:18233",
+    "testnet.seeder.zfnd.org:18233",
+    "testnet.is.yolo.money:18233",
+]
+listen_addr = "0.0.0.0:8233"
+max_connections_per_ip = 1
+network = "Testnet"
+peerset_initial_target_size = 25
+
+[network.testnet_parameters]
+
+[rpc]
+debug_force_finished_sync = false
+parallel_cpu_threads = 0
+
+[state]
+cache_dir = "cache_dir"
+delete_old_database = true
+ephemeral = false
+
+[sync]
+checkpoint_verify_concurrency_limit = 1000
+download_concurrency_limit = 50
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+
+[tracing]
+buffer_limit = 128000
+force_use_color = false
+use_color = true
+use_journald = false


### PR DESCRIPTION
## Motivation

We want to add configurable network parameters to `Network` for supporting `Regtest` and custom Testnets to be used in integration tests.

Closes #7968.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

### Complex Code or Requirements

The db format for `HistoryTree`s and `transparent::Address`es are the same across any test networks, this could mean that a `Regtest` cache or a custom `Testnet` cache could be used on the default `Testnet`. We may want to follow up this PR with a change that ensures Zebra panics if it's configured to run on the default public testnet with a `Regtest` cache, or we may want to make that change in this PR.

I'd like special attention to changes in:
- The db format upgrade code where a `network == Testnet` condition was replaced with `network.is_a_test_network()`
- Tests where `Network::iter()` was used instead of running with `Mainnet` and `Testnet` being applicable to `Regtest`

## Solution

- Adds a `NetworkParameters` struct and includes it in `Network::Testnet`
- Adds a `new_default_testnet()` method for creating the default public `Testnet`
- Updates a condition in the db format upgrade to be true for any test network
- Updates the key types in:
  - `FUNDING_STREAM_HEIGHT_RANGES`, 
  - `FUNDING_STREAM_ADDRESSES`, and
  - `INITIAL_MIN_NETWORK_PROTOCOL_VERSION`
- Updates production code matching on `Testnet` to return appropriate values
- Adds TODOs to production code where changes are needed when adding new fields
- Uses `Network::iter()` in tests that run equivalent code for both `Mainnet` and `Testnet`
- Replaces instances of the `Testnet` constructor with `Network::new_default_testnet()`
- Changes type of `network` field on `transparent::Address` and `HistoryTreeParts` to `NetworkKind`

### Testing

`Network::iter()` was used in most tests that check both `Mainnet` and `Testnet` so they'll cover any new networks we return from that function.

This PR may still need a test for the custom deserialization of `Network` or other changes.

## Review

Anyone can review.

This PR may be easier to review by commit:
- [Minor/trivial cleanup](https://github.com/ZcashFoundation/zebra/commit/1c9dc314b1c6cf9bbc85d5481d031e6d990bd20b)
- [Changes to production code](https://github.com/ZcashFoundation/zebra/commit/bf9cbf34f3b4e707bbce431d152e7e25980ada91)
- [Test updates](https://github.com/ZcashFoundation/zebra/commit/4ed8a71035b3c980af486b190dac47bf706da635)
- [Adds `NetworkKind` and uses it instead of `Network` in `transparent::Address` and `HistoryTreeParts`
](https://github.com/ZcashFoundation/zebra/pull/8368/commits/dbf32960639e5741bd9f02ec163534de18c45c5b)
### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

- Start adding fields to `NetworkParameters`, starting with `activation_heights` (#7970)
