### PR TITLE
fix(feature): Change database logs to human readable forms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,6 +1959,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "human_bytes"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f255a4535024abf7640cb288260811fc14794f62b063652ed349f9a6c2348e"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6091,6 +6097,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "howudoin",
+ "human_bytes",
  "humantime-serde",
  "indexmap 2.2.5",
  "insta",

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -53,6 +53,7 @@ futures = "0.3.30"
 hex = "0.4.3"
 hex-literal = "0.4.1"
 humantime-serde = "1.1.1"
+human_bytes = { version = "0.4.3", default-features = false }
 indexmap = "2.2.5"
 itertools = "0.12.1"
 lazy_static = "1.4.0"

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -542,24 +542,29 @@ impl DiskDb {
                 .unwrap_or(Some(0));
             total_size_in_mem += mem_table_size.unwrap_or(0);
 
-            // TODO: Consider displaying the disk and memory sizes in a human-readable format - #8380.
             write!(
                 column_families_log_string,
-                "{} (Disk: {} bytes, Memory: {} bytes)",
+                "{} (Disk: {}, Memory: {})",
                 cf_name,
-                cf_disk_size,
-                mem_table_size.unwrap_or(0)
+                human_bytes::human_bytes(cf_disk_size as f64),
+                human_bytes::human_bytes(mem_table_size.unwrap_or(0) as f64)
             )
             .unwrap();
         }
 
         debug!("{}", column_families_log_string);
-        info!("Total Database Disk Size: {} bytes", total_size_on_disk);
         info!(
-            "Total Live Data Disk Size: {} bytes",
-            total_live_size_on_disk
+            "Total Database Disk Size: {}",
+            human_bytes::human_bytes(total_size_on_disk as f64)
         );
-        info!("Total Database Memory Size: {} bytes", total_size_in_mem);
+        info!(
+            "Total Live Data Disk Size: {}",
+            human_bytes::human_bytes(total_live_size_on_disk as f64)
+        );
+        info!(
+            "Total Database Memory Size: {}",
+            human_bytes::human_bytes(total_size_in_mem as f64)
+        );
     }
 
     /// Returns a forward iterator over the items in `cf` in `range`.


### PR DESCRIPTION
## Motivation

In https://github.com/ZcashFoundation/zebra/pull/8336 we added logs for database size when zebra starts or shutdowns.

We want to change the output so they are more readable. Close https://github.com/ZcashFoundation/zebra/issues/8380

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [ ] Have you added or updated tests?
  - [ ] Is the documentation up to date?

## Solution

Added https://crates.io/crates/human_bytes as a dependency and used where needed.

New output:

```
2024-04-09T22:21:59.459266Z  INFO {zebrad="49fca30" net="Main"}: zebra_state::service::finalized_state::disk_db: Total Database Disk Size: 37.1 GB
2024-04-09T22:21:59.459312Z  INFO {zebrad="49fca30" net="Main"}: zebra_state::service::finalized_state::disk_db: Total Live Data Disk Size: 18.3 GB
2024-04-09T22:21:59.459325Z  INFO {zebrad="49fca30" net="Main"}: zebra_state::service::finalized_state::disk_db: Total Database Memory Size: 49.2 KB
```

## Review

Anyone can review.


### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
