### PR TITLE
add(consensus): Adds Sapling HRPs as fields on `testnet::Parameters`

### DIFF
--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -308,43 +308,29 @@ impl zp_consensus::Parameters for Network {
     fn address_network(&self) -> Option<zcash_address::Network> {
         match self {
             Network::Mainnet => Some(zcash_address::Network::Main),
-            Network::Testnet(params) if params.is_default_testnet() => {
-                Some(zcash_address::Network::Test)
-            }
-            _other => None,
+            // TODO: Check if network is `Regtest` first, and if it is, return `zcash_address::Network::Regtest`
+            Network::Testnet(_params) => Some(zcash_address::Network::Test),
         }
     }
 
     fn hrp_sapling_extended_spending_key(&self) -> &str {
         match self {
             Network::Mainnet => zp_constants::mainnet::HRP_SAPLING_EXTENDED_SPENDING_KEY,
-            Network::Testnet(params) if params.is_default_testnet() => {
-                zp_constants::testnet::HRP_SAPLING_EXTENDED_SPENDING_KEY
-            }
-            // TODO: Add this as a field to testnet params
-            _other => "secret-extended-key-unknown-test",
+            Network::Testnet(params) => params.hrp_sapling_extended_spending_key(),
         }
     }
 
     fn hrp_sapling_extended_full_viewing_key(&self) -> &str {
         match self {
             Network::Mainnet => zp_constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
-            Network::Testnet(params) if params.is_default_testnet() => {
-                zp_constants::testnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY
-            }
-            // TODO: Add this as a field to testnet params
-            _other => "zxviewunknowntestsapling",
+            Network::Testnet(params) => params.hrp_sapling_extended_full_viewing_key(),
         }
     }
 
     fn hrp_sapling_payment_address(&self) -> &str {
         match self {
             Network::Mainnet => zp_constants::mainnet::HRP_SAPLING_PAYMENT_ADDRESS,
-            Network::Testnet(params) if params.is_default_testnet() => {
-                zp_constants::testnet::HRP_SAPLING_PAYMENT_ADDRESS
-            }
-            // TODO: Add this as a field to testnet params
-            _other => "zunknowntestsapling",
+            Network::Testnet(params) => params.hrp_sapling_payment_address(),
         }
     }
 

--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -1,6 +1,8 @@
 //! Types and implementation for Testnet consensus parameters
 use std::collections::BTreeMap;
 
+use zcash_primitives::constants as zp_constants;
+
 use crate::{
     block::Height,
     parameters::{
@@ -35,6 +37,12 @@ pub struct ConfiguredActivationHeights {
 pub struct ParametersBuilder {
     /// The network upgrade activation heights for this network, see [`Parameters::activation_heights`] for more details.
     activation_heights: BTreeMap<Height, NetworkUpgrade>,
+    /// Sapling extended spending key human-readable prefix for this network
+    hrp_sapling_extended_spending_key: String,
+    /// Sapling extended full viewing key human-readable prefix for this network
+    hrp_sapling_extended_full_viewing_key: String,
+    /// Sapling payment address human-readable prefix for this network
+    hrp_sapling_payment_address: String,
 }
 
 impl Default for ParametersBuilder {
@@ -50,6 +58,12 @@ impl Default for ParametersBuilder {
             ]
             .into_iter()
             .collect(),
+            hrp_sapling_extended_spending_key:
+                zp_constants::testnet::HRP_SAPLING_EXTENDED_SPENDING_KEY.to_string(),
+            hrp_sapling_extended_full_viewing_key:
+                zp_constants::testnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY.to_string(),
+            hrp_sapling_payment_address: zp_constants::testnet::HRP_SAPLING_PAYMENT_ADDRESS
+                .to_string(),
         }
     }
 }
@@ -120,8 +134,18 @@ impl ParametersBuilder {
 
     /// Converts the builder to a [`Parameters`] struct
     pub fn finish(self) -> Parameters {
-        let Self { activation_heights } = self;
-        Parameters { activation_heights }
+        let Self {
+            activation_heights,
+            hrp_sapling_extended_spending_key,
+            hrp_sapling_extended_full_viewing_key,
+            hrp_sapling_payment_address,
+        } = self;
+        Parameters {
+            activation_heights,
+            hrp_sapling_extended_spending_key,
+            hrp_sapling_extended_full_viewing_key,
+            hrp_sapling_payment_address,
+        }
     }
 
     /// Converts the builder to a configured [`Network::Testnet`]
@@ -139,6 +163,12 @@ pub struct Parameters {
     ///       compiled with the `zebra-test` feature flag AND the `TEST_FAKE_ACTIVATION_HEIGHTS`
     ///       environment variable is set.
     activation_heights: BTreeMap<Height, NetworkUpgrade>,
+    /// Sapling extended spending key human-readable prefix for this network
+    hrp_sapling_extended_spending_key: String,
+    /// Sapling extended full viewing key human-readable prefix for this network
+    hrp_sapling_extended_full_viewing_key: String,
+    /// Sapling payment address human-readable prefix for this network
+    hrp_sapling_payment_address: String,
 }
 
 impl Default for Parameters {
@@ -146,6 +176,12 @@ impl Default for Parameters {
     fn default() -> Self {
         Self {
             activation_heights: TESTNET_ACTIVATION_HEIGHTS.iter().cloned().collect(),
+            hrp_sapling_extended_spending_key:
+                zp_constants::testnet::HRP_SAPLING_EXTENDED_SPENDING_KEY.to_string(),
+            hrp_sapling_extended_full_viewing_key:
+                zp_constants::testnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY.to_string(),
+            hrp_sapling_payment_address: zp_constants::testnet::HRP_SAPLING_PAYMENT_ADDRESS
+                .to_string(),
         }
     }
 }
@@ -161,8 +197,23 @@ impl Parameters {
         self == &Self::default()
     }
 
-    /// Returns a reference to the network upgrade activation heights
+    /// Returns the network upgrade activation heights
     pub fn activation_heights(&self) -> &BTreeMap<Height, NetworkUpgrade> {
         &self.activation_heights
+    }
+
+    /// Returns the `hrp_sapling_extended_spending_key` field
+    pub fn hrp_sapling_extended_spending_key(&self) -> &str {
+        &self.hrp_sapling_extended_spending_key
+    }
+
+    /// Returns the `hrp_sapling_extended_full_viewing_key` field
+    pub fn hrp_sapling_extended_full_viewing_key(&self) -> &str {
+        &self.hrp_sapling_extended_full_viewing_key
+    }
+
+    /// Returns the `hrp_sapling_payment_address` field
+    pub fn hrp_sapling_payment_address(&self) -> &str {
+        &self.hrp_sapling_payment_address
     }
 }


### PR DESCRIPTION
## Motivation

We want to have these as fields to configure them for `Regtest` later.

We don't want to make these configurable for public Testnets yet, configured public Testnets will need to use the default Testnet HRPs for now.

Depends-On: #8368.
Depends-On: #8383.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Adds Sapling HRPs as fields on `testnet::{ParametersBuilder, Parameters}` structs
- Assigns the new fields the Sapling HRPs for Testnet in their `Default` impls
- Adds getter methods for the fields
- Returns the `testnet::Parameters` fields in the `zcash_primitives::consensus::Parameters` impl for Network instead of constants

### Testing

The new fields are checked by `check_parameters_impl()` test in the previous PR that implements `zcash_primitives::consensus::Parameters` for `zebra_chain::Network`.

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._
