### PR TITLE
Bump `chrono` from 0.4.34 to 0.4.38

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.34"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -100,7 +100,7 @@ zcash_note_encryption = "0.4.0"
 zcash_primitives = { version = "0.13.0-rc.1", features = ["transparent-inputs"] }
 
 # Time
-chrono = { version = "0.4.34", default-features = false, features = ["clock", "std", "serde"] }
+chrono = { version = "0.4.38", default-features = false, features = ["clock", "std", "serde"] }
 humantime = "2.1.0"
 
 # Error Handling & Formatting

--- a/zebra-chain/src/block/tests/generate.rs
+++ b/zebra-chain/src/block/tests/generate.rs
@@ -1,6 +1,6 @@
 //! Generate large transparent blocks and transactions for testing.
 
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::DateTime;
 use std::sync::Arc;
 
 use crate::{
@@ -40,18 +40,6 @@ pub fn transaction() -> (Transaction, Vec<u8>) {
     let transaction_bytes = transaction.zcash_serialize_to_vec().unwrap();
 
     (transaction, transaction_bytes)
-}
-
-/// Returns a generated transparent lock time, and its canonical serialized bytes.
-pub fn lock_time() -> (LockTime, Vec<u8>) {
-    let lock_time = LockTime::Time(DateTime::<Utc>::from_naive_utc_and_offset(
-        NaiveDateTime::from_timestamp_opt(61, 0)
-            .expect("in-range number of seconds and valid nanosecond"),
-        Utc,
-    ));
-    let lock_time_bytes = lock_time.zcash_serialize_to_vec().unwrap();
-
-    (lock_time, lock_time_bytes)
 }
 
 /// Returns a generated transparent input, and its canonical serialized bytes.
@@ -182,8 +170,8 @@ fn single_transaction_block_many_inputs(oversized: bool) -> Block {
     // A block header
     let (block_header, block_header_bytes) = block_header();
 
-    // A LockTime
-    let (lock_time, lock_time_bytes) = lock_time();
+    let lock_time = LockTime::Time(DateTime::from_timestamp(61, 0).unwrap());
+    let lock_time_bytes = lock_time.zcash_serialize_to_vec().unwrap();
 
     // Calculate the number of inputs we need,
     // subtracting the bytes used to serialize the expected input count,
@@ -256,8 +244,8 @@ fn single_transaction_block_many_outputs(oversized: bool) -> Block {
     // A block header
     let (block_header, block_header_bytes) = block_header();
 
-    // A LockTime
-    let (lock_time, lock_time_bytes) = lock_time();
+    let lock_time = LockTime::Time(DateTime::from_timestamp(61, 0).unwrap());
+    let lock_time_bytes = lock_time.zcash_serialize_to_vec().unwrap();
 
     // Calculate the number of outputs we need,
     // subtracting the bytes used to serialize the expected output count,

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -1,6 +1,6 @@
 //! Fixed test vectors for transactions.
 
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::DateTime;
 use color_eyre::eyre::Result;
 use lazy_static::lazy_static;
 
@@ -221,13 +221,6 @@ fn deserialize_large_transaction() {
     let output =
         transparent::Output::zcash_deserialize(&zebra_test::vectors::DUMMY_OUTPUT1[..]).unwrap();
 
-    // Create a lock time.
-    let lock_time = LockTime::Time(DateTime::<Utc>::from_naive_utc_and_offset(
-        NaiveDateTime::from_timestamp_opt(61, 0)
-            .expect("in-range number of seconds and valid nanosecond"),
-        Utc,
-    ));
-
     // Serialize the input so that we can determine its serialized size.
     let mut input_data = Vec::new();
     input
@@ -242,14 +235,12 @@ fn deserialize_large_transaction() {
         .take(tx_inputs_num)
         .collect::<Vec<_>>();
 
-    let outputs = vec![output];
-
     // Create an oversized transaction. Adding the output and lock time causes
     // the transaction to overflow the threshold.
     let oversized_tx = Transaction::V1 {
         inputs,
-        outputs,
-        lock_time,
+        outputs: vec![output],
+        lock_time: LockTime::Time(DateTime::from_timestamp(61, 0).unwrap()),
     };
 
     // Serialize the transaction.

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -43,7 +43,7 @@ jubjub = "0.10.0"
 rand = "0.8.5"
 rayon = "1.9.0"
 
-chrono = { version = "0.4.34", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4.38", default-features = false, features = ["clock", "std"] }
 displaydoc = "0.2.4"
 lazy_static = "1.4.0"
 once_cell = "1.18.0"

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -43,7 +43,7 @@ proptest-impl = ["proptest", "proptest-derive", "zebra-chain/proptest-impl"]
 bitflags = "2.4.2"
 byteorder = "1.5.0"
 bytes = "1.5.0"
-chrono = { version = "0.4.34", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4.38", default-features = false, features = ["clock", "std"] }
 dirs = "5.0.1"
 hex = "0.4.3"
 humantime-serde = "1.1.1"

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -42,7 +42,7 @@ proptest-impl = [
 ]
 
 [dependencies]
-chrono = { version = "0.4.34", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4.38", default-features = false, features = ["clock", "std"] }
 futures = "0.3.30"
 
 # lightwalletd sends JSON-RPC requests over HTTP 1.1

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -59,7 +59,7 @@ zebra-state = { path = "../zebra-state", version = "1.0.0-beta.35", features = [
 zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.35", features = ["shielded-scan"] }
 zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.2" }
 
-chrono = { version = "0.4.34", default-features = false, features = ["clock", "std", "serde"] }
+chrono = { version = "0.4.38", default-features = false, features = ["clock", "std", "serde"] }
 
 # test feature proptest-impl
 proptest = { version = "1.4.0", optional = true }

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -47,7 +47,7 @@ elasticsearch = [
 
 [dependencies]
 bincode = "1.3.3"
-chrono = { version = "0.4.34", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4.38", default-features = false, features = ["clock", "std"] }
 dirs = "5.0.1"
 futures = "0.3.30"
 hex = "0.4.3"

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -173,7 +173,7 @@ zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.35", optional = t
 
 abscissa_core = "0.7.0"
 clap = { version = "4.5.3", features = ["cargo"] }
-chrono = { version = "0.4.34", default-features = false, features = ["clock", "std"] }
+chrono = { version = "0.4.38", default-features = false, features = ["clock", "std"] }
 humantime-serde = "1.1.1"
 indexmap = "2.2.5"
 lazy_static = "1.4.0"


### PR DESCRIPTION
## Motivation & Solution

- Bump `chrono` from 0.4.34 to 0.4.38.
- Tests:
  - Remove a deprecated fn.
  - Minor cleanups.


### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._