### PR TITLE
fix(elasticsearch): Zebra panics with all features and no elasticsearch server available

### DIFF
--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -502,6 +502,12 @@ impl FinalizedState {
                 let network = self.network();
 
                 rt.block_on(async move {
+                    // Send a ping to the server to check if it is available before inserting.
+                    if client.ping().send().await.is_err() {
+                        tracing::error!("Elasticsearch is not available, skipping block indexing");
+                        return;
+                    }
+
                     let response = client
                         .bulk(elasticsearch::BulkParts::Index(
                             format!("zcash_{}", network.to_string().to_lowercase()).as_str(),


### PR DESCRIPTION
## Motivation

When Zebra is compiled with all features or the elasticsearch feature it will panics when it starts if no elasticsearch server is available in the default endpoint. We want to avoid the panic and continue running even if with errors.

Close https://github.com/ZcashFoundation/zebra/issues/8329

## Solution

Before inserting send a ping to the elasticsearch server to check if it is available, log an error to the user if not and continue running. In the next batch error will be logged again so the user running zebrad with elasticsearch feature enabled will always know that there is something wrong even if the rest of the functionality remains running. This can be annoying but i think is ok here.

```
2024-04-17T16:16:21.390620Z ERROR zebra_state::service::finalized_state: Elasticsearch is not available, skipping block indexing
2024-04-17T16:16:22.280629Z ERROR zebra_state::service::finalized_state: Elasticsearch is not available, skipping block indexing
2024-04-17T16:16:23.705238Z ERROR zebra_state::service::finalized_state: Elasticsearch is not available, skipping block indexing
2024-04-17T16:16:25.530342Z ERROR zebra_state::service::finalized_state: Elasticsearch is not available, skipping block indexing
2024-04-17T16:16:27.024986Z ERROR zebra_state::service::finalized_state: Elasticsearch is not available, skipping block indexing
2024-04-17T16:16:28.002725Z ERROR zebra_state::service::finalized_state: Elasticsearch is not available, skipping block indexing
2024-04-17T16:16:28.801490Z ERROR zebra_state::service::finalized_state: Elasticsearch is not available, skipping block indexing
2024-04-17T16:16:29.615119Z ERROR zebra_state::service::finalized_state: Elasticsearch is not available, skipping block indexing
2024-04-17T16:16:30.602919Z ERROR zebra_state::service::finalized_state: Elasticsearch is not available, skipping block indexing

```

### Testing

Manually tested with elasticsearch server running and without it.

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [x] Does the PR scope match the ticket?
  - [x] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [x] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
