### PR TITLE
bump(deps): Update what we can from the prod group of deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4028,9 +4028,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
@@ -4046,9 +4046,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4452,18 +4452,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4472,9 +4472,9 @@ dependencies = [
 
 [[package]]
 name = "thread-priority"
-version = "0.16.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a617e9eeeb20448b01a8e2427fb80dfbc9c49d79a1de3b11f25731edbf547e3c"
+checksum = "599e8e829c2314b750ecade9309ecc6cf9a48c2e62fe25680b6c1d2172463ca3"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if 1.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -250,7 +250,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -415,7 +415,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.59",
+ "syn 2.0.60",
  "which",
 ]
 
@@ -811,7 +811,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1072,7 +1072,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1096,7 +1096,7 @@ dependencies = [
  "codespan-reporting",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1113,7 +1113,7 @@ checksum = "2fa16a70dd58129e4dfffdff535fb1bce66673f7bbeec4a5a1765a504e1ccd84"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1161,7 +1161,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1183,7 +1183,7 @@ checksum = "c5a91391accf613803c2a9bf9abccdbaa07c54b4244a5b64883f9c3c137c86be"
 dependencies = [
  "darling_core 0.20.6",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1256,7 +1256,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1561,7 +1561,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2629,7 +2629,7 @@ checksum = "38b4faf00617defe497754acde3024865bc143d44a86799b24e191ecff91354f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3064,7 +3064,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3105,7 +3105,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3206,7 +3206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3329,7 +3329,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.59",
+ "syn 2.0.60",
  "tempfile",
  "which",
 ]
@@ -3344,7 +3344,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4052,14 +4052,14 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
@@ -4137,7 +4137,7 @@ dependencies = [
  "darling 0.20.6",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4366,9 +4366,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.59"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6531ffc7b071655e4ce2e04bd464c4830bb585a61cabb96cf808f05172615a"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4467,7 +4467,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4590,7 +4590,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4774,7 +4774,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4787,7 +4787,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4917,7 +4917,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5355,7 +5355,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
  "wasm-bindgen-shared",
 ]
 
@@ -5389,7 +5389,7 @@ checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6187,7 +6187,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "structopt",
- "syn 2.0.59",
+ "syn 2.0.60",
  "thiserror",
  "tinyvec",
  "tokio",
@@ -6288,7 +6288,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -6308,5 +6308,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -106,12 +106,12 @@ humantime = "2.1.0"
 # Error Handling & Formatting
 displaydoc = "0.2.4"
 static_assertions = "1.1.0"
-thiserror = "1.0.58"
+thiserror = "1.0.59"
 tracing = "0.1.39"
 
 # Serialization
 hex = { version = "0.4.3", features = ["serde"] }
-serde = { version = "1.0.197", features = ["serde_derive", "rc"] }
+serde = { version = "1.0.198", features = ["serde_derive", "rc"] }
 serde_with = "3.7.0"
 serde-big-array = "0.5.1"
 

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -111,7 +111,7 @@ tracing = "0.1.39"
 
 # Serialization
 hex = { version = "0.4.3", features = ["serde"] }
-serde = { version = "1.0.196", features = ["serde_derive", "rc"] }
+serde = { version = "1.0.197", features = ["serde_derive", "rc"] }
 serde_with = "3.7.0"
 serde-big-array = "0.5.1"
 
@@ -126,7 +126,7 @@ redjubjub = "0.7.0"
 reddsa = "0.5.1"
 
 # Production feature json-conversion
-serde_json = { version = "1.0.115", optional = true }
+serde_json = { version = "1.0.116", optional = true }
 
 # Production feature async-error and testing feature proptest-impl
 tokio = { version = "1.37.0", optional = true }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -47,7 +47,7 @@ chrono = { version = "0.4.38", default-features = false, features = ["clock", "s
 displaydoc = "0.2.4"
 lazy_static = "1.4.0"
 once_cell = "1.18.0"
-serde = { version = "1.0.196", features = ["serde_derive"] }
+serde = { version = "1.0.197", features = ["serde_derive"] }
 
 futures = "0.3.30"
 futures-util = "0.3.28"

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -47,12 +47,12 @@ chrono = { version = "0.4.38", default-features = false, features = ["clock", "s
 displaydoc = "0.2.4"
 lazy_static = "1.4.0"
 once_cell = "1.18.0"
-serde = { version = "1.0.197", features = ["serde_derive"] }
+serde = { version = "1.0.198", features = ["serde_derive"] }
 
 futures = "0.3.30"
 futures-util = "0.3.28"
 metrics = "0.22.3"
-thiserror = "1.0.58"
+thiserror = "1.0.59"
 tokio = { version = "1.37.0", features = ["time", "sync", "tracing", "rt-multi-thread"] }
 tower = { version = "0.4.13", features = ["timeout", "util", "buffer"] }
 tracing = "0.1.39"

--- a/zebra-grpc/Cargo.toml
+++ b/zebra-grpc/Cargo.toml
@@ -20,7 +20,7 @@ futures-util = "0.3.28"
 tonic = "0.11.0"
 tonic-reflection = "0.11.0"
 prost = "0.12.4"
-serde = { version = "1.0.196", features = ["serde_derive"] }
+serde = { version = "1.0.197", features = ["serde_derive"] }
 tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1.15"
 tower = { version = "0.4.13", features = ["util", "buffer"] }

--- a/zebra-grpc/Cargo.toml
+++ b/zebra-grpc/Cargo.toml
@@ -20,7 +20,7 @@ futures-util = "0.3.28"
 tonic = "0.11.0"
 tonic-reflection = "0.11.0"
 prost = "0.12.4"
-serde = { version = "1.0.197", features = ["serde_derive"] }
+serde = { version = "1.0.198", features = ["serde_derive"] }
 tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1.15"
 tower = { version = "0.4.13", features = ["util", "buffer"] }

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -56,7 +56,7 @@ pin-project = "1.1.5"
 rand = "0.8.5"
 rayon = "1.10.0"
 regex = "1.10.4"
-serde = { version = "1.0.196", features = ["serde_derive"] }
+serde = { version = "1.0.197", features = ["serde_derive"] }
 tempfile = "3.10.1"
 thiserror = "1.0.58"
 

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -56,9 +56,9 @@ pin-project = "1.1.5"
 rand = "0.8.5"
 rayon = "1.10.0"
 regex = "1.10.4"
-serde = { version = "1.0.197", features = ["serde_derive"] }
+serde = { version = "1.0.198", features = ["serde_derive"] }
 tempfile = "3.10.1"
-thiserror = "1.0.58"
+thiserror = "1.0.59"
 
 futures = "0.3.30"
 tokio = { version = "1.37.0", features = ["fs", "io-util", "net", "time", "tracing", "macros", "rt-multi-thread"] }

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -46,7 +46,7 @@ color-eyre = { version = "0.6.3", optional = true }
 jsonrpc-core = { version = "18.0.0", optional = true }
 # Security: avoid default dependency on openssl
 reqwest = { version = "0.11.26", default-features = false, features = ["rustls-tls"], optional = true }
-serde = { version = "1.0.197", optional = true }
+serde = { version = "1.0.198", optional = true }
 serde_json = { version = "1.0.116", optional = true }
 tokio = { version = "1.37.0", features = ["time"], optional = true }
 
@@ -55,5 +55,5 @@ tokio = { version = "1.37.0", features = ["time"], optional = true }
 color-eyre = "0.6.3"
 jsonrpc-core = "18.0.0"
 reqwest = { version = "0.11.26", default-features = false, features = ["rustls-tls"] }
-serde = "1.0.197"
+serde = "1.0.198"
 serde_json = "1.0.116"

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -46,8 +46,8 @@ color-eyre = { version = "0.6.3", optional = true }
 jsonrpc-core = { version = "18.0.0", optional = true }
 # Security: avoid default dependency on openssl
 reqwest = { version = "0.11.26", default-features = false, features = ["rustls-tls"], optional = true }
-serde = { version = "1.0.196", optional = true }
-serde_json = { version = "1.0.115", optional = true }
+serde = { version = "1.0.197", optional = true }
+serde_json = { version = "1.0.116", optional = true }
 tokio = { version = "1.37.0", features = ["time"], optional = true }
 
 [dev-dependencies]
@@ -55,5 +55,5 @@ tokio = { version = "1.37.0", features = ["time"], optional = true }
 color-eyre = "0.6.3"
 jsonrpc-core = "18.0.0"
 reqwest = { version = "0.11.26", default-features = false, features = ["rustls-tls"] }
-serde = "1.0.196"
-serde_json = "1.0.115"
+serde = "1.0.197"
+serde_json = "1.0.116"

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -62,7 +62,7 @@ tower = "0.4.13"
 tracing = "0.1.39"
 
 hex = { version = "0.4.3", features = ["serde"] }
-serde = { version = "1.0.197", features = ["serde_derive"] }
+serde = { version = "1.0.198", features = ["serde_derive"] }
 
 # Experimental feature getblocktemplate-rpcs
 rand = { version = "0.8.5", optional = true }
@@ -84,7 +84,7 @@ insta = { version = "1.38.0", features = ["redactions", "json", "ron"] }
 
 proptest = "1.4.0"
 
-thiserror = "1.0.58"
+thiserror = "1.0.59"
 tokio = { version = "1.37.0", features = ["full", "tracing", "test-util"] }
 
 zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.36", features = ["proptest-impl"] }

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -53,7 +53,7 @@ jsonrpc-derive = "18.0.0"
 jsonrpc-http-server = "18.0.0"
 
 # zebra-rpc needs the preserve_order feature in serde_json, which is a dependency of jsonrpc-core
-serde_json = { version = "1.0.115", features = ["preserve_order"] }
+serde_json = { version = "1.0.116", features = ["preserve_order"] }
 indexmap = { version = "2.2.6", features = ["serde"] }
 
 tokio = { version = "1.37.0", features = ["time", "rt-multi-thread", "macros", "tracing"] }
@@ -62,7 +62,7 @@ tower = "0.4.13"
 tracing = "0.1.39"
 
 hex = { version = "0.4.3", features = ["serde"] }
-serde = { version = "1.0.196", features = ["serde_derive"] }
+serde = { version = "1.0.197", features = ["serde_derive"] }
 
 # Experimental feature getblocktemplate-rpcs
 rand = { version = "0.8.5", optional = true }

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -45,7 +45,7 @@ color-eyre = "0.6.3"
 indexmap = { version = "2.2.6", features = ["serde"] }
 itertools = "0.12.1"
 semver = "1.0.22"
-serde = { version = "1.0.197", features = ["serde_derive"] }
+serde = { version = "1.0.198", features = ["serde_derive"] }
 tokio = { version = "1.37.0", features = ["time"] }
 tower = "0.4.13"
 tracing = "0.1.39"

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -45,7 +45,7 @@ color-eyre = "0.6.3"
 indexmap = { version = "2.2.6", features = ["serde"] }
 itertools = "0.12.1"
 semver = "1.0.22"
-serde = { version = "1.0.196", features = ["serde_derive"] }
+serde = { version = "1.0.197", features = ["serde_derive"] }
 tokio = { version = "1.37.0", features = ["time"] }
 tower = "0.4.13"
 tracing = "0.1.39"

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -19,7 +19,7 @@ zcash_script = "0.1.14"
 
 zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.36" }
 
-thiserror = "1.0.58"
+thiserror = "1.0.59"
 displaydoc = "0.2.4"
 
 [dev-dependencies]

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -63,7 +63,7 @@ regex = "1.10.4"
 rlimit = "0.10.1"
 rocksdb = { version = "0.22.0", default-features = false, features = ["lz4"] }
 semver = "1.0.22"
-serde = { version = "1.0.196", features = ["serde_derive"] }
+serde = { version = "1.0.197", features = ["serde_derive"] }
 tempfile = "3.10.1"
 thiserror = "1.0.58"
 
@@ -75,7 +75,7 @@ tracing = "0.1.39"
 # elasticsearch specific dependencies.
 # Security: avoid default dependency on openssl
 elasticsearch = { version = "8.5.0-alpha.1", default-features = false, features = ["rustls-tls"], optional = true }
-serde_json = { version = "1.0.115", package = "serde_json", optional = true }
+serde_json = { version = "1.0.116", package = "serde_json", optional = true }
 
 zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.36", features = ["async-error"] }
 

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -63,9 +63,9 @@ regex = "1.10.4"
 rlimit = "0.10.1"
 rocksdb = { version = "0.22.0", default-features = false, features = ["lz4"] }
 semver = "1.0.22"
-serde = { version = "1.0.197", features = ["serde_derive"] }
+serde = { version = "1.0.198", features = ["serde_derive"] }
 tempfile = "3.10.1"
-thiserror = "1.0.58"
+thiserror = "1.0.59"
 
 rayon = "1.10.0"
 tokio = { version = "1.37.0", features = ["rt-multi-thread", "sync", "tracing"] }

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -37,7 +37,7 @@ tinyvec = { version = "1.6.0", features = ["rustc_1_55"] }
 humantime = "2.1.0"
 owo-colors = "4.0.0"
 spandoc = "0.2.2"
-thiserror = "1.0.58"
+thiserror = "1.0.59"
 
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracing-error = "0.2.0"

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -95,7 +95,7 @@ tinyvec = { version = "1.6.0", features = ["rustc_1_55"] }
 
 structopt = "0.3.26"
 hex = "0.4.3"
-serde_json = "1.0.115"
+serde_json = "1.0.116"
 tracing-error = "0.2.0"
 tracing-subscriber = "0.3.18"
 thiserror = "1.0.58"
@@ -124,7 +124,7 @@ zcash_primitives = { version = "0.13.0-rc.1", optional = true }
 zcash_client_backend = {version = "0.10.0-rc.1", optional = true}
 
 # For the openapi generator
-syn = { version = "2.0.58", features = ["full"], optional = true }
+syn = { version = "2.0.60", features = ["full"], optional = true }
 quote = { version = "1.0.36", optional = true }
 serde_yaml = { version = "0.9.34+deprecated", optional = true }
-serde = { version = "1.0.196", features = ["serde_derive"], optional = true }
+serde = { version = "1.0.197", features = ["serde_derive"], optional = true }

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -98,7 +98,7 @@ hex = "0.4.3"
 serde_json = "1.0.116"
 tracing-error = "0.2.0"
 tracing-subscriber = "0.3.18"
-thiserror = "1.0.58"
+thiserror = "1.0.59"
 
 zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.36" }
 zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.36" }
@@ -127,4 +127,4 @@ zcash_client_backend = {version = "0.10.0-rc.1", optional = true}
 syn = { version = "2.0.60", features = ["full"], optional = true }
 quote = { version = "1.0.36", optional = true }
 serde_yaml = { version = "0.9.34+deprecated", optional = true }
-serde = { version = "1.0.197", features = ["serde_derive"], optional = true }
+serde = { version = "1.0.198", features = ["serde_derive"], optional = true }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -178,7 +178,7 @@ humantime-serde = "1.1.1"
 indexmap = "2.2.6"
 lazy_static = "1.4.0"
 semver = "1.0.22"
-serde = { version = "1.0.197", features = ["serde_derive"] }
+serde = { version = "1.0.198", features = ["serde_derive"] }
 toml = "0.8.11"
 
 futures = "0.3.30"
@@ -193,7 +193,7 @@ color-eyre = { version = "0.6.3", default-features = false, features = ["issue-u
 # Enable a feature that makes tinyvec compile much faster.
 tinyvec = { version = "1.6.0", features = ["rustc_1_55"] }
 
-thiserror = "1.0.58"
+thiserror = "1.0.59"
 
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracing-appender = "0.2.3"
@@ -210,7 +210,7 @@ num-integer = "0.1.46"
 rand = "0.8.5"
 
 # prod feature internal-miner
-thread-priority = { version = "0.16.0", optional = true }
+thread-priority = { version = "1.0.0", optional = true }
 
 # prod feature sentry
 sentry = { version = "0.32.2", default-features = false, features = ["backtrace", "contexts", "reqwest", "rustls", "tracing"], optional = true }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -178,7 +178,7 @@ humantime-serde = "1.1.1"
 indexmap = "2.2.6"
 lazy_static = "1.4.0"
 semver = "1.0.22"
-serde = { version = "1.0.196", features = ["serde_derive"] }
+serde = { version = "1.0.197", features = ["serde_derive"] }
 toml = "0.8.11"
 
 futures = "0.3.30"
@@ -261,7 +261,7 @@ regex = "1.10.4"
 insta = { version = "1.38.0", features = ["json"] }
 
 # zebra-rpc needs the preserve_order feature, it also makes test results more stable
-serde_json = { version = "1.0.115", features = ["preserve_order"] }
+serde_json = { version = "1.0.116", features = ["preserve_order"] }
 tempfile = "3.10.1"
 
 hyper = { version = "0.14.28", features = ["http1", "http2", "server"]}


### PR DESCRIPTION
## Motivation

In https://github.com/ZcashFoundation/zebra/pull/8420 depandabot suggest 6 updates but we can't update the ECC ones.

Replace https://github.com/ZcashFoundation/zebra/pull/8420 and https://github.com/ZcashFoundation/zebra/pull/8424 by updating the dependencies we can, which are the non-ECC ones.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [ ] Have you added or updated tests?
  - [ ] Is the documentation up to date?

## Solution

Update `serde`, `serde-json`, `syn`, `thiserror` and `thread-priority` to their last versions. Ignore `zcash_primitives`, `zcash_client_backend` and `zcash_proofs`.

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

Should we split the ECC updates in a new group ? It seems that ECC updates will almost always require much more attention.