### PR TITLE
Adds `debug_validate_without_checkpoints` field to `testnet::Parameters` and ignores the ZIP-212 grace period on Regtest

### DIFF
--- a/zebra-chain/src/block/tests/vectors.rs
+++ b/zebra-chain/src/block/tests/vectors.rs
@@ -223,7 +223,7 @@ fn block_test_vectors_height(network: Network) {
         if height
             >= Sapling
                 .activation_height(&network)
-                .expect("sapling activation height is set")
+                .expect("sapling activation height is set on default network")
                 .0
         {
             assert!(

--- a/zebra-chain/src/chain_tip/tests/prop.rs
+++ b/zebra-chain/src/chain_tip/tests/prop.rs
@@ -25,7 +25,7 @@ proptest! {
         let (chain_tip, mock_chain_tip_sender) = MockChainTip::new();
         let blossom_activation_height = NetworkUpgrade::Blossom
             .activation_height(&network)
-            .expect("Blossom activation height is missing");
+            .expect("Blossom activation height is missing on default network");
 
         block_heights.sort();
         let current_height = block_heights[0];

--- a/zebra-chain/src/history_tree.rs
+++ b/zebra-chain/src/history_tree.rs
@@ -428,9 +428,11 @@ impl HistoryTree {
         sapling_root: &sapling::tree::Root,
         orchard_root: &orchard::tree::Root,
     ) -> Result<Self, HistoryTreeError> {
-        let heartwood_height = NetworkUpgrade::Heartwood
-            .activation_height(network)
-            .expect("Heartwood height is known");
+        let Some(heartwood_height) = NetworkUpgrade::Heartwood.activation_height(network) else {
+            // Return early if there is no Heartwood activation height.
+            return Ok(HistoryTree(None));
+        };
+
         match block
             .coinbase_height()
             .expect("must have height")

--- a/zebra-chain/src/history_tree/tests/vectors.rs
+++ b/zebra-chain/src/history_tree/tests/vectors.rs
@@ -35,7 +35,10 @@ fn push_and_prune_for_network_upgrade(
 ) -> Result<()> {
     let (blocks, sapling_roots) = network.block_sapling_roots_map();
 
-    let height = network_upgrade.activation_height(&network).unwrap().0;
+    let height = network_upgrade
+        .activation_height(&network)
+        .expect("network upgrade activation height is missing on default network")
+        .0;
 
     // Load first block (activation block of the given network upgrade)
     let first_block = Arc::new(
@@ -118,7 +121,10 @@ fn upgrade() -> Result<()> {
 fn upgrade_for_network_upgrade(network: Network, network_upgrade: NetworkUpgrade) -> Result<()> {
     let (blocks, sapling_roots) = network.block_sapling_roots_map();
 
-    let height = network_upgrade.activation_height(&network).unwrap().0;
+    let height = network_upgrade
+        .activation_height(&network)
+        .expect("network upgrade activation height is missing on default network")
+        .0;
 
     // Load previous block (the block before the activation block of the given network upgrade)
     let block_prev = Arc::new(

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -11,8 +11,6 @@ use crate::{
     parameters::NetworkUpgrade,
 };
 
-use self::testnet::ConfiguredActivationHeights;
-
 pub mod testnet;
 
 #[cfg(test)]
@@ -167,8 +165,9 @@ impl Network {
     }
 
     /// Creates a new [`Network::Testnet`] with `Regtest` parameters and the provided network upgrade activation heights.
-    pub fn new_regtest(activation_heights: ConfiguredActivationHeights) -> Self {
-        Self::new_configured_testnet(testnet::Parameters::new_regtest(activation_heights))
+    // TODO: Support constructing pre-Canopy block templates and accept more activation heights (#8434)
+    pub fn new_regtest(nu5_activation_height: Option<u32>) -> Self {
+        Self::new_configured_testnet(testnet::Parameters::new_regtest(nu5_activation_height))
     }
 
     /// Returns true if the network is Mainnet or the default Testnet, or false otherwise.

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -267,6 +267,12 @@ impl Network {
         //
         // See the `ZIP_212_GRACE_PERIOD_DURATION` documentation for more information.
 
+        // TODO:
+        // - Support constructing pre-Canopy coinbase tx and block templates and return `Height::MAX` instead of panicking
+        //   when Canopy activation height is `None` (#8434)
+        // - Add semantic block validation during the ZIP-212 grace period and update this method to return the lesser of
+        //   `canopy_activation + ZIP_212_GRACE_PERIOD_DURATION` or the NU5 activation height. (#8430)
+
         let canopy_activation = NetworkUpgrade::Canopy
             .activation_height(self)
             .expect("Canopy activation height must be present for both networks");
@@ -296,10 +302,8 @@ impl Network {
     }
 
     /// Returns the Sapling activation height for this network.
-    pub fn sapling_activation_height(&self) -> Height {
-        super::NetworkUpgrade::Sapling
-            .activation_height(self)
-            .expect("Sapling activation height needs to be set")
+    pub fn sapling_activation_height(&self) -> Option<Height> {
+        super::NetworkUpgrade::Sapling.activation_height(self)
     }
 }
 

--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -73,6 +73,9 @@ pub struct ParametersBuilder {
     hrp_sapling_payment_address: String,
     /// A flag for disabling proof-of-work checks when Zebra is validating blocks
     disable_pow: bool,
+    /// A flag for allowing Zebra to try contextually validating the first queued block
+    /// for a given height below the mandatory checkpoint height.
+    debug_validate_without_checkpoints: bool,
 }
 
 impl Default for ParametersBuilder {
@@ -94,6 +97,7 @@ impl Default for ParametersBuilder {
                 .parse()
                 .expect("hard-coded hash parses"),
             disable_pow: false,
+            debug_validate_without_checkpoints: false,
         }
     }
 }
@@ -240,6 +244,15 @@ impl ParametersBuilder {
         self
     }
 
+    /// Sets the `debug_validate_without_checkpoints` flag to be used in the [`Parameters`] being built.
+    pub fn with_debug_validate_without_checkpoints(
+        mut self,
+        debug_validate_without_checkpoints: bool,
+    ) -> Self {
+        self.debug_validate_without_checkpoints = debug_validate_without_checkpoints;
+        self
+    }
+
     /// Converts the builder to a [`Parameters`] struct
     pub fn finish(self) -> Parameters {
         let Self {
@@ -250,6 +263,7 @@ impl ParametersBuilder {
             hrp_sapling_extended_full_viewing_key,
             hrp_sapling_payment_address,
             disable_pow,
+            debug_validate_without_checkpoints,
         } = self;
         Parameters {
             network_name,
@@ -259,6 +273,7 @@ impl ParametersBuilder {
             hrp_sapling_extended_full_viewing_key,
             hrp_sapling_payment_address,
             disable_pow,
+            debug_validate_without_checkpoints,
         }
     }
 
@@ -289,6 +304,9 @@ pub struct Parameters {
     hrp_sapling_payment_address: String,
     /// A flag for disabling proof-of-work checks when Zebra is validating blocks
     disable_pow: bool,
+    /// A flag for allowing Zebra to try contextually validating the first queued block
+    /// for a given height below the mandatory checkpoint height.
+    debug_validate_without_checkpoints: bool,
 }
 
 impl Default for Parameters {
@@ -316,6 +334,7 @@ impl Parameters {
             ..Self::build()
                 .with_genesis_hash(REGTEST_GENESIS_HASH)
                 .with_disable_pow(true)
+                .with_debug_validate_without_checkpoints(true)
                 .with_sapling_hrps(
                     zp_constants::regtest::HRP_SAPLING_EXTENDED_SPENDING_KEY,
                     zp_constants::regtest::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
@@ -344,6 +363,7 @@ impl Parameters {
             hrp_sapling_extended_full_viewing_key,
             hrp_sapling_payment_address,
             disable_pow,
+            debug_validate_without_checkpoints,
         } = Self::new_regtest(ConfiguredActivationHeights::default());
 
         self.network_name == network_name
@@ -352,6 +372,7 @@ impl Parameters {
             && self.hrp_sapling_extended_full_viewing_key == hrp_sapling_extended_full_viewing_key
             && self.hrp_sapling_payment_address == hrp_sapling_payment_address
             && self.disable_pow == disable_pow
+            && self.debug_validate_without_checkpoints == debug_validate_without_checkpoints
     }
 
     /// Returns the network name
@@ -387,5 +408,10 @@ impl Parameters {
     /// Returns true if proof-of-work validation should be disabled for this network
     pub fn disable_pow(&self) -> bool {
         self.disable_pow
+    }
+
+    /// Returns true if blocks should be contextually validated without checkpoints on this network
+    pub fn debug_validate_without_checkpoints(&self) -> bool {
+        self.debug_validate_without_checkpoints
     }
 }

--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -328,7 +328,7 @@ impl Parameters {
     /// Accepts a [`ConfiguredActivationHeights`].
     ///
     /// Creates an instance of [`Parameters`] with `Regtest` values.
-    pub fn new_regtest(activation_heights: ConfiguredActivationHeights) -> Self {
+    pub fn new_regtest(nu5_activation_height: Option<u32>) -> Self {
         Self {
             network_name: "Regtest".to_string(),
             ..Self::build()
@@ -342,7 +342,11 @@ impl Parameters {
                 )
                 // Removes default Testnet activation heights if not configured,
                 // most network upgrades are disabled by default for Regtest in zcashd
-                .with_activation_heights(activation_heights)
+                .with_activation_heights(ConfiguredActivationHeights {
+                    canopy: Some(1),
+                    nu5: nu5_activation_height,
+                    ..Default::default()
+                })
                 .finish()
         }
     }
@@ -364,7 +368,7 @@ impl Parameters {
             hrp_sapling_payment_address,
             disable_pow,
             debug_validate_without_checkpoints,
-        } = Self::new_regtest(ConfiguredActivationHeights::default());
+        } = Self::new_regtest(None);
 
         self.network_name == network_name
             && self.genesis_hash == genesis_hash

--- a/zebra-chain/src/parameters/network/tests/prop.rs
+++ b/zebra-chain/src/parameters/network/tests/prop.rs
@@ -19,7 +19,7 @@ proptest! {
 
         let canopy_activation = NetworkUpgrade::Canopy
             .activation_height(&network)
-            .expect("Canopy activation height is set");
+            .expect("Canopy activation height is set on default networks");
 
         let grace_period_end_height = (canopy_activation + ZIP_212_GRACE_PERIOD_DURATION)
             .expect("ZIP-212 grace period ends in a valid block height");

--- a/zebra-chain/src/parameters/network/tests/vectors.rs
+++ b/zebra-chain/src/parameters/network/tests/vectors.rs
@@ -134,7 +134,7 @@ fn activates_network_upgrades_correctly() {
 
     let expected_default_regtest_activation_heights = &[
         (Height(0), NetworkUpgrade::Genesis),
-        (Height(1), NetworkUpgrade::BeforeOverwinter),
+        (Height(1), NetworkUpgrade::Canopy),
     ];
 
     for (network, expected_activation_heights) in [

--- a/zebra-chain/src/parameters/network/tests/vectors.rs
+++ b/zebra-chain/src/parameters/network/tests/vectors.rs
@@ -112,7 +112,7 @@ fn activates_network_upgrades_correctly() {
 
     let genesis_activation_height = NetworkUpgrade::Genesis
         .activation_height(&network)
-        .expect("must return an activation height");
+        .expect("must always return an activation height for Genesis network upgrade");
 
     assert_eq!(
         genesis_activation_height,
@@ -123,7 +123,7 @@ fn activates_network_upgrades_correctly() {
     for nu in NETWORK_UPGRADES_IN_ORDER.into_iter().skip(1) {
         let activation_height = nu
             .activation_height(&network)
-            .expect("must return an activation height");
+            .expect("must return an activation height for all network upgrades when there's an NU5 activation height");
 
         assert_eq!(
             activation_height, Height(expected_activation_height),

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -402,14 +402,10 @@ impl NetworkUpgrade {
             ),
         ]
         .into_iter()
-        .map(move |(upgrade, spacing_seconds)| {
-            let activation_height = upgrade
-                .activation_height(network)
-                .expect("missing activation height for target spacing change");
-
+        .filter_map(move |(upgrade, spacing_seconds)| {
+            let activation_height = upgrade.activation_height(network)?;
             let target_spacing = Duration::seconds(spacing_seconds);
-
-            (activation_height, target_spacing)
+            Some((activation_height, target_spacing))
         })
     }
 

--- a/zebra-chain/src/parameters/tests.rs
+++ b/zebra-chain/src/parameters/tests.rs
@@ -127,7 +127,7 @@ fn activation_consistent(network: Network) {
     for &network_upgrade in network_upgrades {
         let height = network_upgrade
             .activation_height(&network)
-            .expect("activations must have a height");
+            .expect("activations must have a height on default networks");
         assert!(NetworkUpgrade::is_activation_height(&network, height));
 
         if height > block::Height(0) {

--- a/zebra-chain/src/primitives/zcash_history/tests/vectors.rs
+++ b/zebra-chain/src/primitives/zcash_history/tests/vectors.rs
@@ -21,7 +21,10 @@ fn tree() -> Result<()> {
 fn tree_for_network_upgrade(network: &Network, network_upgrade: NetworkUpgrade) -> Result<()> {
     let (blocks, sapling_roots) = network.block_sapling_roots_map();
 
-    let height = network_upgrade.activation_height(network).unwrap().0;
+    let height = network_upgrade
+        .activation_height(network)
+        .expect("must have activation height on default network")
+        .0;
 
     // Load Block 0 (activation block of the given network upgrade)
     let block0 = Arc::new(

--- a/zebra-chain/src/sapling/tests/tree.rs
+++ b/zebra-chain/src/sapling/tests/tree.rs
@@ -62,7 +62,7 @@ fn incremental_roots_with_blocks_for_network(network: Network) -> Result<()> {
 
     let height = NetworkUpgrade::Sapling
         .activation_height(&network)
-        .unwrap()
+        .expect("must have activation height on default network")
         .0;
 
     // Build empty note commitment tree

--- a/zebra-chain/src/sprout/tests/tree.rs
+++ b/zebra-chain/src/sprout/tests/tree.rs
@@ -92,7 +92,7 @@ fn incremental_roots_with_blocks_for_network(network: Network) -> Result<()> {
     // Load the Genesis height.
     let genesis_height = NetworkUpgrade::Genesis
         .activation_height(&network)
-        .unwrap()
+        .expect("must have activation height on default network")
         .0;
 
     // Load the Genesis block.

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -352,7 +352,7 @@ fn fake_v5_round_trip_for_network(network: Network) {
 
     let overwinter_activation_height = NetworkUpgrade::Overwinter
         .activation_height(&network)
-        .expect("a valid height")
+        .expect("must have activation height on default network")
         .0;
 
     // skip blocks that are before overwinter as they will not have a valid consensus branch id
@@ -500,7 +500,7 @@ fn fake_v5_librustzcash_round_trip_for_network(network: Network) {
 
     let overwinter_activation_height = NetworkUpgrade::Overwinter
         .activation_height(&network)
-        .expect("a valid height")
+        .expect("must have activation height on default network")
         .0;
 
     let nu5_activation_height = NetworkUpgrade::Nu5

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -155,7 +155,7 @@ pub fn subsidy_is_valid(block: &Block, network: &Network) -> Result<(), BlockErr
 
     let canopy_activation_height = NetworkUpgrade::Canopy
         .activation_height(network)
-        .expect("Canopy activation height is known");
+        .expect("Canopy activation height is required for semantic block validation");
 
     if height < SLOW_START_INTERVAL {
         unreachable!(

--- a/zebra-consensus/src/block/subsidy/funding_streams.rs
+++ b/zebra-consensus/src/block/subsidy/funding_streams.rs
@@ -25,7 +25,9 @@ pub fn funding_stream_values(
     height: Height,
     network: &Network,
 ) -> Result<HashMap<FundingStreamReceiver, Amount<NonNegative>>, Error> {
-    let canopy_height = Canopy.activation_height(network).unwrap();
+    let canopy_height = Canopy
+        .activation_height(network)
+        .expect("requires Canopy activation height");
     let mut results = HashMap::new();
 
     if height >= canopy_height {

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -777,6 +777,19 @@ where
                     .hash(height)
                     .expect("every checkpoint height must have a hash"),
             ),
+            // Contextually validate and commit the first queued block for a height below the mandatory checkpoint height if
+            // `debug_validate_without_checkpoints` is true for this network.
+            WaitingForBlocks if self.network.debug_validate_without_checkpoints() => {
+                if let Some((height, hash)) = self
+                    .queued
+                    .first_key_value()
+                    .and_then(|(h, blocks)| blocks.first().map(|block| (*h, block.block.hash)))
+                {
+                    (height, hash)
+                } else {
+                    return;
+                }
+            }
             WaitingForBlocks => {
                 return;
             }

--- a/zebra-consensus/src/parameters/subsidy.rs
+++ b/zebra-consensus/src/parameters/subsidy.rs
@@ -230,7 +230,7 @@ impl ParameterSubsidy for Network {
         match self {
             Network::Mainnet => NetworkUpgrade::Canopy
                 .activation_height(self)
-                .expect("canopy activation height should be available"),
+                .expect("Canopy activation height should be available"),
             // TODO: Check what zcashd does here, consider adding a field to `testnet::Parameters` to make this configurable.
             Network::Testnet(_params) => FIRST_HALVING_TESTNET,
         }

--- a/zebra-consensus/src/router.rs
+++ b/zebra-consensus/src/router.rs
@@ -369,9 +369,13 @@ pub fn init_checkpoint_list(config: Config, network: &Network) -> (CheckpointLis
 
     let max_checkpoint_height = if config.checkpoint_sync {
         list.max_height()
-    } else {
+    } else if network.is_a_default_network() {
         list.min_height_in_range(network.mandatory_checkpoint_height()..)
             .expect("hardcoded checkpoint list extends past canopy activation")
+    } else {
+        // Allow for validating blocks below mandatory checkpoint height on configured Testnets and Regtest without
+        // actually checking the checkpoints if checkpoint sync is disabled.
+        network.mandatory_checkpoint_height()
     };
 
     (list, max_checkpoint_height)

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -356,7 +356,6 @@ pub fn coinbase_expiry_height(
 ) -> Result<(), TransactionError> {
     let expiry_height = coinbase.expiry_height();
 
-    // TODO: replace `if let` with `expect` after NU5 mainnet activation
     if let Some(nu5_activation_height) = NetworkUpgrade::Nu5.activation_height(network) {
         // # Consensus
         //

--- a/zebra-grpc/src/tests/snapshot.rs
+++ b/zebra-grpc/src/tests/snapshot.rs
@@ -88,7 +88,9 @@ async fn test_mocked_rpc_response_data_for_network(network: Network, random_port
                 .expect_request_that(|req| matches!(req, ScanRequest::Info))
                 .await
                 .respond(ScanResponse::Info {
-                    min_sapling_birthday_height: network.sapling_activation_height(),
+                    min_sapling_birthday_height: network
+                        .sapling_activation_height()
+                        .expect("must have Sapling activation height for default network"),
                 })
         });
     }

--- a/zebra-grpc/src/tests/vectors.rs
+++ b/zebra-grpc/src/tests/vectors.rs
@@ -57,7 +57,10 @@ async fn test_mocked_getinfo_for_network(
     // test the response
     assert_eq!(
         get_info_response.into_inner().min_sapling_birthday_height,
-        network.sapling_activation_height().0,
+        network
+            .sapling_activation_height()
+            .expect("must have Sapling activation height for default network")
+            .0,
         "get_info response min sapling height should match network sapling activation height"
     );
 }
@@ -396,7 +399,9 @@ async fn call_get_info(
             .expect_request_that(|req| matches!(req, ScanRequest::Info))
             .await
             .respond(ScanResponse::Info {
-                min_sapling_birthday_height: network.sapling_activation_height(),
+                min_sapling_birthday_height: network
+                    .sapling_activation_height()
+                    .expect("must have Sapling activation height for default network"),
             })
     });
 

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -672,8 +672,8 @@ impl<'de> Deserialize<'de> for Config {
             network: network_kind,
             testnet_parameters,
             regtest_activation_heights,
-            initial_mainnet_peers,
-            initial_testnet_peers,
+            mut initial_mainnet_peers,
+            mut initial_testnet_peers,
             cache_dir,
             peerset_initial_target_size,
             crawl_new_peer_interval,
@@ -700,7 +700,11 @@ impl<'de> Deserialize<'de> for Config {
         let network = match (network_kind, testnet_parameters) {
             (NetworkKind::Mainnet, _) => Network::Mainnet,
             (NetworkKind::Testnet, None) => Network::new_default_testnet(),
-            (NetworkKind::Regtest, _) => Network::new_regtest(regtest_activation_heights),
+            (NetworkKind::Regtest, _) => {
+                initial_mainnet_peers = Default::default();
+                initial_testnet_peers = Default::default();
+                Network::new_regtest(regtest_activation_heights)
+            }
             (
                 NetworkKind::Testnet,
                 Some(DTestnetParameters {

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -675,8 +675,8 @@ impl<'de> Deserialize<'de> for Config {
             network: network_kind,
             testnet_parameters,
             regtest_nu5_activation_height,
-            mut initial_mainnet_peers,
-            mut initial_testnet_peers,
+            initial_mainnet_peers,
+            initial_testnet_peers,
             cache_dir,
             peerset_initial_target_size,
             crawl_new_peer_interval,
@@ -703,11 +703,7 @@ impl<'de> Deserialize<'de> for Config {
         let network = match (network_kind, testnet_parameters) {
             (NetworkKind::Mainnet, _) => Network::Mainnet,
             (NetworkKind::Testnet, None) => Network::new_default_testnet(),
-            (NetworkKind::Regtest, _) => {
-                initial_mainnet_peers = Default::default();
-                initial_testnet_peers = Default::default();
-                Network::new_regtest(regtest_nu5_activation_height)
-            }
+            (NetworkKind::Regtest, _) => Network::new_regtest(regtest_nu5_activation_height),
             (
                 NetworkKind::Testnet,
                 Some(DTestnetParameters {

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -639,7 +639,7 @@ impl<'de> Deserialize<'de> for Config {
             listen_addr: String,
             network: NetworkKind,
             testnet_parameters: Option<DTestnetParameters>,
-            regtest_activation_heights: ConfiguredActivationHeights,
+            regtest_nu5_activation_height: Option<u32>,
             initial_mainnet_peers: IndexSet<String>,
             initial_testnet_peers: IndexSet<String>,
             cache_dir: CacheDir,
@@ -656,7 +656,7 @@ impl<'de> Deserialize<'de> for Config {
                     listen_addr: "0.0.0.0".to_string(),
                     network: Default::default(),
                     testnet_parameters: None,
-                    regtest_activation_heights: ConfiguredActivationHeights::default(),
+                    regtest_nu5_activation_height: None,
                     initial_mainnet_peers: config.initial_mainnet_peers,
                     initial_testnet_peers: config.initial_testnet_peers,
                     cache_dir: config.cache_dir,
@@ -671,7 +671,7 @@ impl<'de> Deserialize<'de> for Config {
             listen_addr,
             network: network_kind,
             testnet_parameters,
-            regtest_activation_heights,
+            regtest_nu5_activation_height,
             mut initial_mainnet_peers,
             mut initial_testnet_peers,
             cache_dir,
@@ -703,7 +703,7 @@ impl<'de> Deserialize<'de> for Config {
             (NetworkKind::Regtest, _) => {
                 initial_mainnet_peers = Default::default();
                 initial_testnet_peers = Default::default();
-                Network::new_regtest(regtest_activation_heights)
+                Network::new_regtest(regtest_nu5_activation_height)
             }
             (
                 NetworkKind::Testnet,

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -638,7 +638,10 @@ where
                 //
                 // Optional TODO:
                 // - add `async changed()` method to ChainSyncStatus (like `ChainTip`)
-                check_synced_to_tip(&network, latest_chain_tip.clone(), sync_status.clone())?;
+                // TODO: Add a `disable_peers` field to `Network` to check instead of `disable_pow()` (#8361)
+                if !network.disable_pow() {
+                    check_synced_to_tip(&network, latest_chain_tip.clone(), sync_status.clone())?;
+                }
 
                 // TODO: return an error if we have no peers, like `zcashd` does,
                 //       and add a developer config that mines regardless of how many peers we have.

--- a/zebra-scan/src/service.rs
+++ b/zebra-scan/src/service.rs
@@ -95,7 +95,10 @@ impl Service<Request> for ScanService {
 
                 return async move {
                     Ok(Response::Info {
-                        min_sapling_birthday_height: db.network().sapling_activation_height(),
+                        min_sapling_birthday_height: db
+                            .network()
+                            .sapling_activation_height()
+                            .ok_or("missing Sapling activation height")?,
                     })
                 }
                 .boxed();

--- a/zebra-scan/src/service/scan_task/commands.rs
+++ b/zebra-scan/src/service/scan_task/commands.rs
@@ -78,7 +78,9 @@ impl ScanTask {
         let mut new_keys = HashMap::new();
         let mut new_result_senders = HashMap::new();
         let mut new_result_receivers = Vec::new();
-        let sapling_activation_height = network.sapling_activation_height();
+        let sapling_activation_height = network.sapling_activation_height().ok_or(eyre!(
+            "must have Sapling activation height for default network"
+        ))?;
 
         loop {
             let cmd = match cmd_receiver.try_recv() {

--- a/zebra-scan/src/service/scan_task/scan.rs
+++ b/zebra-scan/src/service/scan_task/scan.rs
@@ -79,7 +79,9 @@ pub async fn start(
     mut cmd_receiver: tokio::sync::mpsc::Receiver<ScanTaskCommand>,
 ) -> Result<(), Report> {
     let network = storage.network();
-    let sapling_activation_height = network.sapling_activation_height();
+    let sapling_activation_height = network
+        .sapling_activation_height()
+        .ok_or(eyre!("missing Sapling activation height"))?;
 
     info!(?network, "starting scan task");
 

--- a/zebra-scan/src/service/scan_task/scan/scan_range.rs
+++ b/zebra-scan/src/service/scan_task/scan/scan_range.rs
@@ -6,7 +6,7 @@ use crate::{
     scan::{get_min_height, scan_height_and_store_results, wait_for_height, State, CHECK_INTERVAL},
     storage::Storage,
 };
-use color_eyre::eyre::Report;
+use color_eyre::eyre::{eyre, Report};
 use tokio::{
     sync::{mpsc::Sender, watch},
     task::JoinHandle,
@@ -88,7 +88,10 @@ pub async fn scan_range(
     storage: Storage,
     subscribed_keys_receiver: watch::Receiver<Arc<HashMap<String, Sender<ScanResult>>>>,
 ) -> Result<(), Report> {
-    let sapling_activation_height = storage.network().sapling_activation_height();
+    let sapling_activation_height = storage
+        .network()
+        .sapling_activation_height()
+        .ok_or(eyre!("missing Sapling activation height"))?;
     // Do not scan and notify if we are below sapling activation height.
     wait_for_height(
         sapling_activation_height,

--- a/zebra-scan/src/storage/db/sapling.rs
+++ b/zebra-scan/src/storage/db/sapling.rs
@@ -213,7 +213,10 @@ impl Storage {
         sapling_key: &SaplingScanningKey,
         birthday_height: Option<Height>,
     ) {
-        let min_birthday_height = self.network().sapling_activation_height();
+        let min_birthday_height = self
+            .network()
+            .sapling_activation_height()
+            .unwrap_or(Height(1));
 
         // The birthday height must be at least the minimum height for that pool.
         let birthday_height = birthday_height

--- a/zebra-scan/src/tests/vectors.rs
+++ b/zebra-scan/src/tests/vectors.rs
@@ -170,7 +170,9 @@ fn scanning_fake_blocks_store_key_and_results() -> Result<()> {
             .expect("height is stored")
             .next()
             .expect("height is not maximum"),
-        network.sapling_activation_height()
+        network
+            .sapling_activation_height()
+            .expect("should have Sapling activation height on default networks")
     );
 
     let nf = Nullifier([7; 32]);

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -423,9 +423,7 @@ impl StateService {
         let timer = CodeTimer::start();
 
         if let Some(tip) = state.best_tip() {
-            let nu5_activation_height = NetworkUpgrade::Nu5
-                .activation_height(network)
-                .expect("NU5 activation height is set");
+            let nu5_activation_height = NetworkUpgrade::Nu5.activation_height(network);
 
             if let Err(error) = check::legacy_chain(
                 nu5_activation_height,

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -395,7 +395,7 @@ impl StateService {
             - HeightDiff::try_from(checkpoint_verify_concurrency_limit)
                 .expect("fits in HeightDiff");
         let full_verifier_utxo_lookahead =
-            full_verifier_utxo_lookahead.expect("unexpected negative height");
+            full_verifier_utxo_lookahead.unwrap_or(block::Height::MIN);
 
         let non_finalized_state_queued_blocks = QueuedBlocks::default();
         let pending_utxos = PendingUtxos::default();

--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -306,7 +306,7 @@ fn difficulty_threshold_and_time_are_valid(
 /// `max_legacy_chain_blocks` should be [`MAX_LEGACY_CHAIN_BLOCKS`](crate::constants::MAX_LEGACY_CHAIN_BLOCKS).
 /// They are only changed from the defaults for testing.
 pub(crate) fn legacy_chain<I>(
-    nu5_activation_height: block::Height,
+    nu5_activation_height: Option<block::Height>,
     ancestors: I,
     network: &Network,
     max_legacy_chain_blocks: usize,
@@ -323,11 +323,7 @@ where
         //
         // If the cached tip is close to NU5 activation, but there aren't any V5 transactions in the
         // chain yet, we could reach MAX_BLOCKS_TO_CHECK in Canopy, and incorrectly return an error.
-        if block
-            .coinbase_height()
-            .expect("valid blocks have coinbase heights")
-            < nu5_activation_height
-        {
+        if block.coinbase_height() < nu5_activation_height {
             return Ok(());
         }
 

--- a/zebra-state/src/service/read/find.rs
+++ b/zebra-state/src/service/read/find.rs
@@ -607,6 +607,8 @@ fn best_relevant_chain(
         .into_iter()
         .take(POW_MEDIAN_BLOCK_SPAN)
         .collect();
+
+    // TODO: Find out what zcashd does here.
     let best_relevant_chain = best_relevant_chain.try_into().map_err(|_error| {
         "Zebra's state only has a few blocks, wait until it syncs to the chain tip"
     })?;

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -306,7 +306,7 @@ proptest! {
     fn some_block_less_than_network_upgrade(
         (network, nu_activation_height, chain) in partial_nu5_chain_strategy(4, true, UNDER_LEGACY_CHAIN_LIMIT, NetworkUpgrade::Canopy)
     ) {
-        let response = crate::service::check::legacy_chain(nu_activation_height, chain.into_iter().rev(), &network, TEST_LEGACY_CHAIN_LIMIT)
+        let response = crate::service::check::legacy_chain(Some(nu_activation_height), chain.into_iter().rev(), &network, TEST_LEGACY_CHAIN_LIMIT)
             .map_err(|error| error.to_string());
 
         prop_assert_eq!(response, Ok(()));
@@ -323,7 +323,7 @@ proptest! {
             .coinbase_height()
             .expect("chain contains valid blocks");
 
-        let response = crate::service::check::legacy_chain(nu_activation_height, chain.into_iter().rev(), &network, TEST_LEGACY_CHAIN_LIMIT)
+        let response = crate::service::check::legacy_chain(Some(nu_activation_height), chain.into_iter().rev(), &network, TEST_LEGACY_CHAIN_LIMIT)
             .map_err(|error| error.to_string());
 
         prop_assert_eq!(
@@ -360,7 +360,7 @@ proptest! {
         );
 
         let response = crate::service::check::legacy_chain(
-            nu_activation_height,
+            Some(nu_activation_height),
             chain.clone().into_iter().rev(),
             &network,
             TEST_LEGACY_CHAIN_LIMIT,
@@ -380,7 +380,7 @@ proptest! {
     fn at_least_one_transaction_with_valid_network_upgrade(
         (network, nu_activation_height, chain) in partial_nu5_chain_strategy(5, true, UNDER_LEGACY_CHAIN_LIMIT, NetworkUpgrade::Canopy)
     ) {
-        let response = crate::service::check::legacy_chain(nu_activation_height, chain.into_iter().rev(), &network, TEST_LEGACY_CHAIN_LIMIT)
+        let response = crate::service::check::legacy_chain(Some(nu_activation_height), chain.into_iter().rev(), &network, TEST_LEGACY_CHAIN_LIMIT)
             .map_err(|error| error.to_string());
 
         prop_assert_eq!(response, Ok(()));

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -1136,7 +1136,7 @@ where
 
     /// Returns `true` if the hash is present in the state, and `false`
     /// if the hash is not present in the state.
-    async fn state_contains(&mut self, hash: block::Hash) -> Result<bool, Report> {
+    pub(crate) async fn state_contains(&mut self, hash: block::Hash) -> Result<bool, Report> {
         match self
             .state
             .ready()

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -3126,3 +3126,15 @@ async fn validate_regtest_genesis_block() {
         "validated block hash should match network genesis hash"
     )
 }
+
+/// Test successful `getblocktemplate` and `submitblock` RPC calls on Regtest on Canopy and NU5.
+///
+/// See [`common::regtest::submit_blocks`] for more information.
+#[tokio::test]
+#[cfg(feature = "getblocktemplate-rpcs")]
+async fn regtest_submit_block() -> Result<()> {
+    for nu5_activation_height in [None, Some(1), Some(1_000)] {
+        common::regtest::submit_blocks::run(nu5_activation_height).await?;
+    }
+    Ok(())
+}

--- a/zebrad/tests/common/configs/v1.7.0.toml
+++ b/zebrad/tests/common/configs/v1.7.0.toml
@@ -59,20 +59,12 @@ listen_addr = "0.0.0.0:8233"
 max_connections_per_ip = 1
 network = "Regtest"
 peerset_initial_target_size = 25
+regtest_nu5_activation_height = 1
 
 [network.testnet_parameters]
 network_name = "ConfiguredTestnet_1"
 
 [network.testnet_parameters.activation_heights]
-BeforeOverwinter = 1
-Overwinter = 207_500
-Sapling = 280_000
-Blossom = 584_000
-Heartwood = 903_800
-Canopy = 1_028_500
-NU5 = 1_842_420
-
-[network.regtest_activation_heights]
 BeforeOverwinter = 1
 Overwinter = 207_500
 Sapling = 280_000

--- a/zebrad/tests/common/mod.rs
+++ b/zebrad/tests/common/mod.rs
@@ -24,5 +24,8 @@ pub mod checkpoints;
 #[cfg(feature = "getblocktemplate-rpcs")]
 pub mod get_block_template_rpcs;
 
+#[cfg(feature = "getblocktemplate-rpcs")]
+pub mod regtest;
+
 #[cfg(feature = "shielded-scan")]
 pub mod shielded_scan;

--- a/zebrad/tests/common/regtest.rs
+++ b/zebrad/tests/common/regtest.rs
@@ -1,0 +1,3 @@
+//! Acceptance tests for Regtest in Zebra.
+
+pub(crate) mod submit_blocks;

--- a/zebrad/tests/common/regtest/submit_blocks.rs
+++ b/zebrad/tests/common/regtest/submit_blocks.rs
@@ -1,0 +1,88 @@
+//! Test submitblock RPC method on Regtest.
+//!
+//! This test will get block templates via the `getblocktemplate` RPC method and submit them as new blocks
+//! via the `submitblock` RPC method on Regtest.
+
+use std::{net::SocketAddr, sync::Arc, time::Duration};
+
+use color_eyre::eyre::Result;
+use tokio::task::JoinHandle;
+use tracing::*;
+
+use zebra_chain::{parameters::Network, serialization::ZcashSerialize};
+use zebra_node_services::rpc_client::RpcRequestClient;
+use zebra_rpc::methods::get_block_template_rpcs::get_block_template::{
+    proposal::TimeSource, proposal_block_from_template, GetBlockTemplate,
+};
+
+use crate::common::config::random_known_rpc_port_config;
+use zebrad::commands::StartCmd;
+
+/// Number of blocks that should be submitted before the test is considered successful.
+const NUM_BLOCKS_TO_SUBMIT: usize = 2_000;
+
+/// - Starts Zebrad
+/// - Calls `getblocktemplate` RPC method and submits blocks with empty equihash solutions
+/// - Checks that blocks were validated and committed successfully
+// TODO: Implement custom serialization for `zebra_network::Config` and spawn a zebrad child process instead?
+pub(crate) async fn run(nu5_activation_height: Option<u32>) -> Result<()> {
+    let _init_guard = zebra_test::init();
+    info!("starting regtest submit_blocks test");
+
+    let network = Network::new_regtest(nu5_activation_height);
+    let config = random_known_rpc_port_config(false, &network)?;
+    let rpc_address = config.rpc.listen_addr.unwrap();
+
+    info!("starting zebrad");
+    let _zebrad_start_task: JoinHandle<_> = tokio::task::spawn_blocking(|| {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("runtime building should not fail");
+        let start_cmd = StartCmd::default();
+
+        let _ = rt.block_on(start_cmd.start(Arc::new(config)));
+    });
+
+    info!("waiting for zebrad to start");
+
+    tokio::time::sleep(Duration::from_secs(30)).await;
+
+    info!("attempting to submit blocks");
+    submit_blocks(rpc_address).await?;
+
+    Ok(())
+}
+
+/// Get block templates and submit blocks
+async fn submit_blocks(rpc_address: SocketAddr) -> Result<()> {
+    let client = RpcRequestClient::new(rpc_address);
+
+    for _ in 0..NUM_BLOCKS_TO_SUBMIT {
+        let block_template: GetBlockTemplate = client
+            .json_result_from_call("getblocktemplate", "[]".to_string())
+            .await
+            .expect("response should be success output with a serialized `GetBlockTemplate`");
+
+        let block_data = hex::encode(
+            proposal_block_from_template(&block_template, TimeSource::default())?
+                .zcash_serialize_to_vec()?,
+        );
+
+        let submit_block_response = client
+            .text_from_call("submitblock", format!(r#"["{block_data}"]"#))
+            .await?;
+
+        let was_submission_successful = submit_block_response.contains(r#""result":null"#);
+
+        info!(was_submission_successful, "submitted block");
+
+        // Check that the block was validated and committed.
+        assert!(
+            submit_block_response.contains(r#""result":null"#),
+            "unexpected response from submitblock RPC, should be null, was: {submit_block_response}"
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

This PR allows for committing unvalidated blocks below the mandatory checkpoint height on Regtest and custom Testnets so their transaction outputs could be used in later blocks that _are_ validated.

~We may want to allow for committing pre-Canopy blocks on Regtest and custom Testnets, or we may want to disable pre-Canopy blocks on Regtest and custom Testnets.~

We may want to skip the ZIP-212 grace period on Regtest and custom Testnets, or we may want to add full semantic validation for blocks during the ZIP-212 grace period.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [ ] Will the PR name make sense to users?
  - [ ] Does the PR have a priority label?
  - [ ] Have you added or updated tests?
  - [ ] Is the documentation up to date?

##### For significant changes:
  - [ ] Is there a summary in the CHANGELOG?
  - [ ] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

### Specifications

[ZIP-212](https://zips.z.cash/zip-0212#changes-to-the-process-of-receiving-sapling-or-orchard-notes)

## Solution

- Adds a `debug_validate_without_checkpoints` field to `testnet::Parameters`
- In the checkpoint verifier, sends the first queued block for a block height to the state service to be contextually validated and committed when the `debug_validate_without_checkpoints` field is set
- Skips the ZIP-212 grace period in the `mandatory_checkpoint_height()` method for non-default networks, this means Zebra likely won't support the ZIP-212 grace period on Regtest/custom-Testnets.

Related:
- Clears any initial peers when the network is set to `Regtest` so Zebra is isolated.

### Testing

This PR doesn't have any tests yet, I'll add tests if we want to go in this direction.

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

