### PR TITLE
change(release): Adjust estimated release interval and end of support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Zebra is tested with the latest `stable` Rust version. Earlier versions are not
 supported or tested. Any Zebra release can start depending on new features in the
 latest stable Rust.
 
-Every few weeks, we release a [new Zebra version](https://github.com/ZcashFoundation/zebra/releases).
+Around every 4 weeks, we release a [new Zebra version](https://github.com/ZcashFoundation/zebra/releases).
 
 Below are quick summaries for installing the dependencies on your machine.
 

--- a/book/src/dev/release-process.md
+++ b/book/src/dev/release-process.md
@@ -33,7 +33,7 @@ The pre-release version is denoted by appending a hyphen and a series of dot sep
 
 ### Supported Releases
 
-Every Zebra version released by the Zcash Foundation is supported up to a specific height. Currently we support each version for about **16 weeks** but this can change from release to release.
+Every Zebra version released by the Zcash Foundation is supported up to a specific height. Currently we support each version for about **20 weeks** but this can change from release to release.
 
 When the Zcash chain reaches this end of support height, `zebrad` will shut down and the binary will refuse to start.
 
@@ -95,7 +95,7 @@ In general, expect the following release cycle:
 
 * A major release for each network upgrade, whenever there are breaking changes to Zebra (by API, severe bugs or other kind of upgrades)
 * Minor releases for significant new Zebra features or severe bug fixes
-* A patch release every few weeks
+* A patch release around every 4 weeks
 
 This cadence of releases gives eager developers access to new features as soon as they are fully developed and pass through our code review and integration testing processes, while maintaining the stability and reliability of the platform for production users that prefer to receive features after they have been validated by Zcash and other developers that use the pre-release builds.
 

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -22,7 +22,8 @@ pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_471_000;
 ///
 /// - Zebra will exit with a panic if the current tip height is bigger than the `ESTIMATED_RELEASE_HEIGHT`
 ///  plus this number of days.
-pub const EOS_PANIC_AFTER: u32 = 112;
+/// - Currently set to 20 weeks.
+pub const EOS_PANIC_AFTER: u32 = 140;
 
 /// The number of days before the end of support where Zebra will display warnings.
 pub const EOS_WARN_AFTER: u32 = EOS_PANIC_AFTER - 14;


### PR DESCRIPTION
## Motivation

In the last Zebra team meeting we discussed to adjust the release interval to one every month instead of every 2 weeks or so.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

## Solution

Extend the end of support from 16 weeks to 20 weeks and update the documents for doing release every 4 weeks instead of 2.


### Testing

End of support tests remain working as they use the updated `EOS_PANIC_AFTER` constant.

## Review

@mpguerra might want to take a look at this, i can do changes if needed.


### Reviewer Checklist

Check before approving the PR:
  - [x] Does the PR scope match the ticket?
  - [x] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [x] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

<!--
Is there anything missing from the solution?
-->
