### PR TITLE
fix(state): Always return updated trees in `NoteCommitmentTree` update methods

### DIFF
--- a/zebra-chain/src/parallel/tree.rs
+++ b/zebra-chain/src/parallel/tree.rs
@@ -132,10 +132,10 @@ impl NoteCommitmentTrees {
     /// Update the sprout note commitment tree.
     /// This method modifies the tree inside the `Arc`, if the `Arc` only has one reference.
     fn update_sprout_note_commitment_tree(
-        mut sprout: Arc<sprout::tree::NoteCommitmentTree>,
+        sprout: Arc<sprout::tree::NoteCommitmentTree>,
         sprout_note_commitments: Vec<sprout::NoteCommitment>,
     ) -> Result<Arc<sprout::tree::NoteCommitmentTree>, NoteCommitmentTreeError> {
-        let sprout_nct = Arc::make_mut(&mut sprout);
+        let mut sprout_nct = Arc::unwrap_or_clone(sprout);
 
         for sprout_note_commitment in sprout_note_commitments {
             sprout_nct.append(sprout_note_commitment)?;
@@ -144,14 +144,14 @@ impl NoteCommitmentTrees {
         // Re-calculate and cache the tree root.
         let _ = sprout_nct.root();
 
-        Ok(sprout)
+        Ok(Arc::new(sprout_nct))
     }
 
     /// Update the sapling note commitment tree.
     /// This method modifies the tree inside the `Arc`, if the `Arc` only has one reference.
     #[allow(clippy::unwrap_in_result)]
     pub fn update_sapling_note_commitment_tree(
-        mut sapling: Arc<sapling::tree::NoteCommitmentTree>,
+        sapling: Arc<sapling::tree::NoteCommitmentTree>,
         sapling_note_commitments: Vec<sapling::tree::NoteCommitmentUpdate>,
     ) -> Result<
         (
@@ -160,7 +160,7 @@ impl NoteCommitmentTrees {
         ),
         NoteCommitmentTreeError,
     > {
-        let sapling_nct = Arc::make_mut(&mut sapling);
+        let mut sapling_nct = Arc::unwrap_or_clone(sapling);
 
         // It is impossible for blocks to contain more than one level 16 sapling root:
         // > [NU5 onward] nSpendsSapling, nOutputsSapling, and nActionsOrchard MUST all be less than 2^16.
@@ -187,14 +187,14 @@ impl NoteCommitmentTrees {
         // Re-calculate and cache the tree root.
         let _ = sapling_nct.root();
 
-        Ok((sapling, subtree_root))
+        Ok((Arc::new(sapling_nct), subtree_root))
     }
 
     /// Update the orchard note commitment tree.
     /// This method modifies the tree inside the `Arc`, if the `Arc` only has one reference.
     #[allow(clippy::unwrap_in_result)]
     pub fn update_orchard_note_commitment_tree(
-        mut orchard: Arc<orchard::tree::NoteCommitmentTree>,
+        orchard: Arc<orchard::tree::NoteCommitmentTree>,
         orchard_note_commitments: Vec<orchard::tree::NoteCommitmentUpdate>,
     ) -> Result<
         (
@@ -203,7 +203,7 @@ impl NoteCommitmentTrees {
         ),
         NoteCommitmentTreeError,
     > {
-        let orchard_nct = Arc::make_mut(&mut orchard);
+        let mut orchard_nct = Arc::unwrap_or_clone(orchard);
 
         // It is impossible for blocks to contain more than one level 16 orchard root:
         // > [NU5 onward] nSpendsSapling, nOutputsSapling, and nActionsOrchard MUST all be less than 2^16.
@@ -224,6 +224,6 @@ impl NoteCommitmentTrees {
         // Re-calculate and cache the tree root.
         let _ = orchard_nct.root();
 
-        Ok((orchard, subtree_root))
+        Ok((Arc::new(orchard_nct), subtree_root))
     }
 }

--- a/zebra-chain/src/parallel/tree.rs
+++ b/zebra-chain/src/parallel/tree.rs
@@ -79,9 +79,6 @@ impl NoteCommitmentTrees {
         let mut sapling_result = None;
         let mut orchard_result = None;
 
-        // Note: Only updating the note commitment trees when there are more notes that
-        //       need to be appended to the tree prevents unnecessarily duplicating note commitment
-        //       tree data in the non-finalized state.
         let has_sprout_notes = !sprout_note_commitments.is_empty();
         let has_sapling_notes = !sapling_note_commitments.is_empty();
         let has_orchard_notes = !orchard_note_commitments.is_empty();


### PR DESCRIPTION
## Motivation

This PR makes the code a bit more clear.

~`Arc::make_mut()` will clone the value if there are other references to the value, so if a note commitment tree is being updated after its been requested from the state service but before its been dropped, it could, in rare cases, drop the updated note commitment tree and add the new block to the state with the previous note commitment tree.~

~This only affects the non-finalized state, and note commitment trees are only read by the `getblock` and `z_gettreestate` RPC methods.~

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Use `.unwrap_or_clone()` instead to get a copy of the note commitment trees
- Update and return the local copy of the note commitment trees

Related Cleanups:
- Avoids creating a rayon scope if there are no note commitments in the block

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._