### PR TITLE
fix(rpc): Avoid possibly returning data from different blocks in `z_get_treestate` RPC method

### DIFF
--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1098,6 +1098,11 @@ where
                     data: None,
                 })?;
 
+            // # Concurrency
+            //
+            // For consistency, this lookup must be performed first, then all the other
+            // lookups must be based on the hash.
+
             // Fetch the block referenced by [`hash_or_height`] from the state.
             // TODO: If this RPC is called a lot, just get the block header,
             // rather than the whole block.
@@ -1128,6 +1133,9 @@ where
                 _ => unreachable!("unmatched response to a block request"),
             };
 
+            let hash = hash_or_height.hash().unwrap_or_else(|| block.hash());
+            let hash_or_height = hash.into();
+
             // Fetch the Sapling & Orchard treestates referenced by
             // [`hash_or_height`] from the state.
 
@@ -1155,8 +1163,6 @@ where
 
             // We've got all the data we need for the RPC response, so we
             // assemble the response.
-
-            let hash = block.hash();
 
             let height = block
                 .coinbase_height()


### PR DESCRIPTION
## Motivation

This avoids a concurrency bug where the `z_get_treestate` RPC method could return the note commitment trees for a different block than the one used to return the block hash and time.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Use the block hash to read Sapling/Orchard trees in `z_get_treestate` RPC method.

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

- BlockQuery state request?