### PR TITLE
fix(test): Increases timeout for non-blocking logger test

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1757,7 +1757,7 @@ fn non_blocking_logger() -> Result<()> {
     });
 
     // Wait until the spawned task finishes up to 45 seconds before shutting down tokio runtime
-    if done_rx.recv_timeout(Duration::from_secs(45)).is_ok() {
+    if done_rx.recv_timeout(Duration::from_secs(90)).is_ok() {
         rt.shutdown_timeout(Duration::from_secs(3));
     }
 


### PR DESCRIPTION
## Motivation

I've seen this test timeout multiple times in the past couple days:
https://github.com/ZcashFoundation/zebra/actions/runs/8819285519/job/24210114095#step:12:7111

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Increase the timeout for waiting on the done notification in this test from 45 seconds to 90 seconds

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._
