### PR TITLE
change(test): Disables `rejection_restores_internal_state_genesis` test on Windows

### DIFF
--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -451,6 +451,7 @@ fn finalized_equals_pushed_history_tree() -> Result<()> {
 /// Check that rejected blocks do not change the internal state of a genesis chain
 /// in a non-finalized state.
 #[test]
+#[cfg(not(target_os = "windows"))]
 fn rejection_restores_internal_state_genesis() -> Result<()> {
     let _init_guard = zebra_test::init();
 


### PR DESCRIPTION
## Motivation

@oxarbitrage originally noted this test failing on Windows, but it only fails occasionally, so we left it enabled when re-adding Windows tests in our CI.

It's been failing too frequently since then, so we want to disable it until it's been fixed.

Closes #8465.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Adds `#[cfg(not(target_os = "windows"))]` above the test.

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

#8461