### PR TITLE
fix(consensus): Check Equihash solutions with n=200, k=9 parameters

### DIFF
--- a/zebra-chain/src/work/equihash.rs
+++ b/zebra-chain/src/work/equihash.rs
@@ -69,11 +69,10 @@ impl Solution {
     /// Returns `Ok(())` if `EquihashSolution` is valid for `header`
     #[allow(clippy::unwrap_in_result)]
     pub fn check(&self, header: &Header) -> Result<(), Error> {
+        // TODO: Add Equihash parameters to `testnet::Parameters`
+        let n = 200;
+        let k = 9;
         let nonce = &header.nonce;
-        let (solution, n, k) = match self {
-            Solution::Common(solution) => (solution.as_slice(), 200, 9),
-            Solution::Regtest(solution) => (solution.as_slice(), 48, 5),
-        };
 
         let mut input = Vec::new();
         header
@@ -84,7 +83,7 @@ impl Solution {
         // This data is kept constant during solver runs, so the verifier API takes it separately.
         let input = &input[0..Solution::INPUT_LENGTH];
 
-        equihash::is_valid_solution(n, k, input, nonce.as_ref(), solution)?;
+        equihash::is_valid_solution(n, k, input, nonce.as_ref(), self.value())?;
 
         Ok(())
     }

--- a/zebra-chain/src/work/equihash.rs
+++ b/zebra-chain/src/work/equihash.rs
@@ -69,7 +69,9 @@ impl Solution {
     /// Returns `Ok(())` if `EquihashSolution` is valid for `header`
     #[allow(clippy::unwrap_in_result)]
     pub fn check(&self, header: &Header) -> Result<(), Error> {
-        // TODO: Add Equihash parameters to `testnet::Parameters`
+        // TODO:
+        // - Add Equihash parameters field to `testnet::Parameters`
+        // - Update `Solution::Regtest` variant to hold a `Vec` to support arbitrary parameters
         let n = 200;
         let k = 9;
         let nonce = &header.nonce;

--- a/zebra-chain/src/work/equihash.rs
+++ b/zebra-chain/src/work/equihash.rs
@@ -71,7 +71,7 @@ impl Solution {
     pub fn check(&self, header: &Header) -> Result<(), Error> {
         // TODO:
         // - Add Equihash parameters field to `testnet::Parameters`
-        // - Update `Solution::Regtest` variant to hold a `Vec` to support arbitrary parameters
+        // - Update `Solution::Regtest` variant to hold a `Vec` to support arbitrary parameters - rename to `Other`
         let n = 200;
         let k = 9;
         let nonce = &header.nonce;


### PR DESCRIPTION
## Motivation

This always checks Equihash solutions with the `Mainnet`/`Testnet` parameters, even if Zebra receives a block with a shorter Equihash solution. This is fine for Regtest for now since it skips the Proof-of-Work check altogether.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Reverts a change that allows for validating Equihash solutions with easier parameters on Mainnet and Testnet

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

Add a field on `testnet::Parameters` for defining a network's Equihash parameters