### PR TITLE
fix(consensus): Update `median_timespan()` method to align with zcashd implementation

### DIFF
--- a/zebra-state/src/service/check/difficulty.rs
+++ b/zebra-state/src/service/check/difficulty.rs
@@ -295,13 +295,21 @@ impl AdjustedDifficulty {
     fn median_timespan(&self) -> Duration {
         let newer_median = self.median_time_past();
 
-        let older_times: Vec<_> = self
-            .relevant_times
-            .iter()
-            .rev()
-            .cloned()
-            .take(POW_MEDIAN_BLOCK_SPAN)
-            .collect();
+        // MedianTime(height : N) := median([ nTime(𝑖) for 𝑖 from max(0, height − PoWMedianBlockSpan) up to max(0, height − 1) ])
+        let older_times: Vec<_> = if self.relevant_times.len() > POW_AVERAGING_WINDOW {
+            self.relevant_times
+                .iter()
+                .skip(POW_AVERAGING_WINDOW)
+                .cloned()
+                .take(POW_MEDIAN_BLOCK_SPAN)
+                .collect()
+        } else {
+            vec![self
+                .relevant_times
+                .last()
+                .cloned()
+                .expect("there must be a Genesis block")]
+        };
 
         let older_median = AdjustedDifficulty::median_time(older_times);
 

--- a/zebra-state/src/service/check/difficulty.rs
+++ b/zebra-state/src/service/check/difficulty.rs
@@ -296,22 +296,22 @@ impl AdjustedDifficulty {
         let newer_median = self.median_time_past();
 
         // MedianTime(height : N) := median([ nTime(𝑖) for 𝑖 from max(0, height − PoWMedianBlockSpan) up to max(0, height − 1) ])
-        let older_times: Vec<_> = if self.relevant_times.len() > POW_AVERAGING_WINDOW {
-            self.relevant_times
+        let older_median = if self.relevant_times.len() > POW_AVERAGING_WINDOW {
+            let older_times: Vec<_> = self
+                .relevant_times
                 .iter()
                 .skip(POW_AVERAGING_WINDOW)
                 .cloned()
                 .take(POW_MEDIAN_BLOCK_SPAN)
-                .collect()
+                .collect();
+
+            AdjustedDifficulty::median_time(older_times)
         } else {
-            vec![self
-                .relevant_times
+            self.relevant_times
                 .last()
                 .cloned()
-                .expect("there must be a Genesis block")]
+                .expect("there must be a Genesis block")
         };
-
-        let older_median = AdjustedDifficulty::median_time(older_times);
 
         // `ActualTimespan` in the Zcash specification
         newer_median - older_median


### PR DESCRIPTION
## Motivation

This PR fixes a minor mistake in the `median_timespan()` method below block height 28. The bug does not affect checkpoint validation, and does not affect Mainnet or the default Testnet because Zebra requires checkpoint verification until well past block height 28 for those networks.

https://github.com/zcash/zcash/blob/master/src/pow.cpp#L47-L84

Depends-On: #8475.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

### Specifications

Section 7.7.3, page 132 of the [specification](https://zips.z.cash/protocol/protocol.pdf)

## Solution

Use the MedianTime of the genesis block as the `older_median` if there are fewer than PoWAveragingWindow blocks in the relevant chain.

Other changes:
- Fixes a typo in dependabot in this PR so CI passes.

## Review

Anyone can review, @upbqdn may be interested.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._