### PR TITLE
change(config): Allow square brackets in network config listen addr and external addr

### DIFF
--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -739,7 +739,7 @@ impl<'de> Deserialize<'de> for Config {
             }
         };
 
-        let listen_addr = match listen_addr.parse::<SocketAddr>() {
+        let listen_addr = match listen_addr.parse::<SocketAddr>().or_else(|_| format!("{listen_addr}:{}", network.default_port()).parse()) {
             Ok(socket) => Ok(socket),
             Err(_) => match listen_addr.parse::<IpAddr>() {
                 Ok(ip) => Ok(SocketAddr::new(ip, network.default_port())),
@@ -750,7 +750,7 @@ impl<'de> Deserialize<'de> for Config {
         }?;
 
         let external_socket_addr = if let Some(address) = &external_addr {
-            match address.parse::<SocketAddr>() {
+            match address.parse::<SocketAddr>().or_else(|_| format!("{address}:{}", network.default_port()).parse()) {
                 Ok(socket) => Ok(Some(socket)),
                 Err(_) => match address.parse::<IpAddr>() {
                     Ok(ip) => Ok(Some(SocketAddr::new(ip, network.default_port()))),


### PR DESCRIPTION
## Motivation

Closes #8476.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

Try adding the default port to the config value and parsing that as a `SocketAddr` before trying to parse it as an `IpAddr`

### Testing

Manually tested that the config accepts `[::]`

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._
