### PR TITLE
change(consensus): Allow configurable NU5 activation height on Regtest

### DIFF
--- a/zebra-chain/src/block/commitment.rs
+++ b/zebra-chain/src/block/commitment.rs
@@ -119,7 +119,7 @@ impl Commitment {
             // on Regtest for heights above height 0, it returns NU5, and it's possible for the current network upgrade
             // to be NU5 (or Canopy, or any network upgrade above Heartwood) at the Heartwood activation height.
             // TODO: Check Canopy too once Zebra can construct Canopy block templates.
-            Heartwood | Nu5 if Some(height) == Heartwood.activation_height(network) => {
+            Heartwood | Canopy | Nu5 if Some(height) == Heartwood.activation_height(network) => {
                 if bytes == CHAIN_HISTORY_ACTIVATION_RESERVED {
                     Ok(ChainHistoryActivationReserved)
                 } else {

--- a/zebra-chain/src/block/commitment.rs
+++ b/zebra-chain/src/block/commitment.rs
@@ -118,7 +118,6 @@ impl Commitment {
             // NetworkUpgrade::current() returns the latest network upgrade that's activated at the provided height, so
             // on Regtest for heights above height 0, it returns NU5, and it's possible for the current network upgrade
             // to be NU5 (or Canopy, or any network upgrade above Heartwood) at the Heartwood activation height.
-            // TODO: Check Canopy too once Zebra can construct Canopy block templates.
             Heartwood | Canopy | Nu5 if Some(height) == Heartwood.activation_height(network) => {
                 if bytes == CHAIN_HISTORY_ACTIVATION_RESERVED {
                     Ok(ChainHistoryActivationReserved)

--- a/zebra-chain/src/block/commitment.rs
+++ b/zebra-chain/src/block/commitment.rs
@@ -109,24 +109,34 @@ impl Commitment {
         use Commitment::*;
         use CommitmentError::*;
 
-        match NetworkUpgrade::current(network, height) {
-            Genesis | BeforeOverwinter | Overwinter => Ok(PreSaplingReserved(bytes)),
-            Sapling | Blossom => match sapling::tree::Root::try_from(bytes) {
+        match NetworkUpgrade::current_with_activation_height(network, height) {
+            (Genesis | BeforeOverwinter | Overwinter, _) => Ok(PreSaplingReserved(bytes)),
+            (Sapling | Blossom, _) => match sapling::tree::Root::try_from(bytes) {
                 Ok(root) => Ok(FinalSaplingRoot(root)),
                 _ => Err(InvalidSapingRootBytes),
             },
-            // NetworkUpgrade::current() returns the latest network upgrade that's activated at the provided height, so
-            // on Regtest for heights above height 0, it returns NU5, and it's possible for the current network upgrade
-            // to be NU5 (or Canopy, or any network upgrade above Heartwood) at the Heartwood activation height.
-            Heartwood | Canopy | Nu5 if Some(height) == Heartwood.activation_height(network) => {
+            (Heartwood, activation_height) if height == activation_height => {
                 if bytes == CHAIN_HISTORY_ACTIVATION_RESERVED {
                     Ok(ChainHistoryActivationReserved)
                 } else {
                     Err(InvalidChainHistoryActivationReserved { actual: bytes })
                 }
             }
-            Heartwood | Canopy => Ok(ChainHistoryRoot(ChainHistoryMmrRootHash(bytes))),
-            Nu5 => Ok(ChainHistoryBlockTxAuthCommitment(
+            // NetworkUpgrade::current() returns the latest network upgrade that's activated at the provided height, so
+            // on Regtest for heights above height 0, it returns NU5, and it's possible for the current network upgrade
+            // to be NU5 (or Canopy, or any network upgrade above Heartwood) at the Heartwood activation height.
+            (Canopy | Nu5, activation_height)
+                if height == activation_height
+                    && Some(height) == Heartwood.activation_height(network) =>
+            {
+                if bytes == CHAIN_HISTORY_ACTIVATION_RESERVED {
+                    Ok(ChainHistoryActivationReserved)
+                } else {
+                    Err(InvalidChainHistoryActivationReserved { actual: bytes })
+                }
+            }
+            (Heartwood | Canopy, _) => Ok(ChainHistoryRoot(ChainHistoryMmrRootHash(bytes))),
+            (Nu5, _) => Ok(ChainHistoryBlockTxAuthCommitment(
                 ChainHistoryBlockTxAuthCommitmentHash(bytes),
             )),
         }

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -167,8 +167,8 @@ impl Network {
     }
 
     /// Creates a new [`Network::Testnet`] with `Regtest` parameters and the provided network upgrade activation heights.
-    pub fn new_regtest() -> Self {
-        Self::new_configured_testnet(testnet::Parameters::new_regtest())
+    pub fn new_regtest(nu5_activation_height: Option<u32>) -> Self {
+        Self::new_configured_testnet(testnet::Parameters::new_regtest(nu5_activation_height))
     }
 
     /// Returns true if the network is the default Testnet, or false otherwise.

--- a/zebra-chain/src/parameters/network/tests/vectors.rs
+++ b/zebra-chain/src/parameters/network/tests/vectors.rs
@@ -136,6 +136,8 @@ fn activates_network_upgrades_correctly() {
     let expected_default_regtest_activation_heights = &[
         (Height(0), NetworkUpgrade::Genesis),
         (Height(1), NetworkUpgrade::Canopy),
+        // TODO: Remove this once the testnet parameters are being serialized.
+        (Height(100), NetworkUpgrade::Nu5),
     ];
 
     for (network, expected_activation_heights) in [

--- a/zebra-chain/src/parameters/network/tests/vectors.rs
+++ b/zebra-chain/src/parameters/network/tests/vectors.rs
@@ -135,14 +135,14 @@ fn activates_network_upgrades_correctly() {
 
     let expected_default_regtest_activation_heights = &[
         (Height(0), NetworkUpgrade::Genesis),
-        (Height(1), NetworkUpgrade::Nu5),
+        (Height(1), NetworkUpgrade::Canopy),
     ];
 
     for (network, expected_activation_heights) in [
         (Network::Mainnet, MAINNET_ACTIVATION_HEIGHTS),
         (Network::new_default_testnet(), TESTNET_ACTIVATION_HEIGHTS),
         (
-            Network::new_regtest(),
+            Network::new_regtest(None),
             expected_default_regtest_activation_heights,
         ),
     ] {
@@ -193,7 +193,7 @@ fn check_configured_network_name() {
         "Mainnet should be displayed as 'Mainnet'"
     );
     assert_eq!(
-        Network::new_regtest().to_string(),
+        Network::new_regtest(None).to_string(),
         "Regtest",
         "Regtest should be displayed as 'Regtest'"
     );
@@ -238,6 +238,7 @@ fn check_configured_sapling_hrps() {
         .expect_err("should panic when setting Sapling HRPs that are too long or contain non-alphanumeric characters (except '-')");
     }
 
+    // Restore the regular panic hook for any unexpected panics
     drop(std::panic::take_hook());
 
     // Check that Sapling HRPs can contain lowercase ascii characters and dashes.
@@ -317,6 +318,7 @@ fn check_network_name() {
         .expect_err("should panic when setting network name that's too long or contains non-alphanumeric characters (except '_')");
     }
 
+    // Restore the regular panic hook for any unexpected panics
     drop(std::panic::take_hook());
 
     // Checks that network names are displayed correctly

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -280,6 +280,19 @@ impl Network {
 }
 
 impl NetworkUpgrade {
+    /// Returns the current network upgrade and its activation height for `network` and `height`.
+    pub fn current_with_activation_height(
+        network: &Network,
+        height: block::Height,
+    ) -> (NetworkUpgrade, block::Height) {
+        network
+            .activation_list()
+            .range(..=height)
+            .map(|(&h, &nu)| (nu, h))
+            .next_back()
+            .expect("every height has a current network upgrade")
+    }
+
     /// Returns the current network upgrade for `network` and `height`.
     pub fn current(network: &Network, height: block::Height) -> NetworkUpgrade {
         network

--- a/zebra-consensus/src/checkpoint/list/tests.rs
+++ b/zebra-consensus/src/checkpoint/list/tests.rs
@@ -237,7 +237,7 @@ fn checkpoint_list_load_hard_coded() -> Result<(), BoxError> {
 
     let _ = Mainnet.checkpoint_list();
     let _ = Network::new_default_testnet().checkpoint_list();
-    let _ = Network::new_regtest().checkpoint_list();
+    let _ = Network::new_regtest(None).checkpoint_list();
 
     Ok(())
 }

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -707,7 +707,13 @@ impl<'de> Deserialize<'de> for Config {
         let network = match (network_kind, testnet_parameters) {
             (NetworkKind::Mainnet, _) => Network::Mainnet,
             (NetworkKind::Testnet, None) => Network::new_default_testnet(),
-            (NetworkKind::Regtest, _) => Network::new_regtest(),
+            (NetworkKind::Regtest, testnet_parameters) => {
+                let nu5_activation_height = testnet_parameters
+                    .and_then(|params| params.activation_heights)
+                    .and_then(|activation_height| activation_height.nu5);
+
+                Network::new_regtest(nu5_activation_height)
+            }
             (
                 NetworkKind::Testnet,
                 Some(DTestnetParameters {

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -399,7 +399,7 @@ lazy_static! {
 
         hash_map.insert(NetworkKind::Mainnet, Version::min_specified_for_upgrade(&Mainnet, Nu5));
         hash_map.insert(NetworkKind::Testnet, Version::min_specified_for_upgrade(&Network::new_default_testnet(), Nu5));
-        hash_map.insert(NetworkKind::Regtest, Version::min_specified_for_upgrade(&Network::new_regtest(), Nu5));
+        hash_map.insert(NetworkKind::Regtest, Version::min_specified_for_upgrade(&Network::new_regtest(None), Nu5));
 
         hash_map
     };

--- a/zebra-utils/src/bin/block-template-to-proposal/main.rs
+++ b/zebra-utils/src/bin/block-template-to-proposal/main.rs
@@ -10,7 +10,10 @@ use color_eyre::eyre::Result;
 use serde_json::Value;
 use structopt::StructOpt;
 
-use zebra_chain::serialization::{DateTime32, ZcashSerialize};
+use zebra_chain::{
+    parameters::NetworkUpgrade,
+    serialization::{DateTime32, ZcashSerialize},
+};
 use zebra_rpc::methods::get_block_template_rpcs::{
     get_block_template::proposal_block_from_template,
     types::{get_block_template::GetBlockTemplate, long_poll::LONG_POLL_ID_LENGTH},
@@ -96,7 +99,7 @@ fn main() -> Result<()> {
     let template: GetBlockTemplate = serde_json::from_value(template)?;
 
     // generate proposal according to arguments
-    let proposal = proposal_block_from_template(&template, time_source)?;
+    let proposal = proposal_block_from_template(&template, time_source, NetworkUpgrade::Nu5)?;
     eprintln!("{proposal:#?}");
 
     let proposal = proposal

--- a/zebrad/src/components/miner.rs
+++ b/zebrad/src/components/miner.rs
@@ -20,6 +20,7 @@ use zebra_chain::{
     chain_sync_status::ChainSyncStatus,
     chain_tip::ChainTip,
     diagnostic::task::WaitForPanics,
+    parameters::NetworkUpgrade,
     serialization::{AtLeastOne, ZcashSerialize},
     shutdown::is_shutting_down,
     work::equihash::{Solution, SolverCancelled},
@@ -290,8 +291,9 @@ where
         // Tell the next get_block_template() call to wait until the template has changed.
         parameters.long_poll_id = Some(template.long_poll_id);
 
-        let block = proposal_block_from_template(&template, TimeSource::CurTime)
-            .expect("unexpected invalid block template");
+        let block =
+            proposal_block_from_template(&template, TimeSource::CurTime, NetworkUpgrade::Nu5)
+                .expect("unexpected invalid block template");
 
         // If the template has actually changed, send an updated template.
         template_sender.send_if_modified(|old_block| {

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -3108,7 +3108,7 @@ async fn scan_task_commands() -> Result<()> {
 async fn validate_regtest_genesis_block() {
     let _init_guard = zebra_test::init();
 
-    let network = Network::new_regtest();
+    let network = Network::new_regtest(None);
     let state = zebra_state::init_test(&network);
     let (
         block_verifier_router,

--- a/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
+++ b/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
@@ -11,7 +11,10 @@ use color_eyre::eyre::{eyre, Context, Result};
 
 use futures::FutureExt;
 
-use zebra_chain::{parameters::Network, serialization::ZcashSerialize};
+use zebra_chain::{
+    parameters::{Network, NetworkUpgrade},
+    serialization::ZcashSerialize,
+};
 use zebra_node_services::rpc_client::RpcRequestClient;
 use zebra_rpc::methods::get_block_template_rpcs::{
     get_block_template::{
@@ -214,8 +217,12 @@ async fn try_validate_block_template(client: &RpcRequestClient) -> Result<()> {
             // Propose a new block with an empty solution and nonce field
 
             let raw_proposal_block = hex::encode(
-                proposal_block_from_template(&response_json_result, time_source)?
-                    .zcash_serialize_to_vec()?,
+                proposal_block_from_template(
+                    &response_json_result,
+                    time_source,
+                    NetworkUpgrade::Nu5,
+                )?
+                .zcash_serialize_to_vec()?,
             );
             let template = response_json_result.clone();
 


### PR DESCRIPTION
## Motivation

We want to allow configuring an NU5 activation height on Regtest. This was removed in a recent PR because I thought Zebra didn't support Canopy block construction, it does, it was the `proposal_block_from_template()` function used in tests and the internal-miner that only worked with NU5.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Accept a `current_network_upgrade` argument in `proposal_block_from_template()`
- Select which field from the template should be used in the block based on the current network upgrade
- Use the `testnet_parameters.activation_heights.nu5` field as the NU5 activation height on Regtest

Related Changes:
- Updates `with_activation_heights()` to overwrite activation heights for all network upgrades except Genesis
- Adds `current_with_activation_height()` method and uses it in `Commitment::from_bytes()`

### Testing

The `regtest_submit_blocks()` test was updated to submit Canopy blocks and switch to NU5 blocks at height 100

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._
