### PR TITLE
chore: Release v1.7.0

### DIFF
--- a/.github/workflows/scripts/release-crates-dry-run.sh
+++ b/.github/workflows/scripts/release-crates-dry-run.sh
@@ -23,8 +23,8 @@ fi
 cargo release version --verbose --execute --no-confirm --allow-branch '*' --workspace --exclude zebrad --exclude zebra-scan --exclude zebra-grpc beta
 
 # Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
-cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebra-scan 0.1.0-alpha.6
-cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebra-grpc 0.1.0-alpha.4
+cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebra-scan 0.1.0-alpha.7
+cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebra-grpc 0.1.0-alpha.5
 
 # Update zebrad:
 cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebrad patch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Zebra 1.7.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.7.0) - 2024-05-06
 
-In this release we introduce Regtest functionality to Zebra and restored Windows support. Also adjusted our Zebra release interval from 2 weeks to 4 weeks approximately.
+In this release we introduce Regtest functionality to Zebra and restored Windows support. Also adjusted our Zebra release interval from 2 weeks to 6 weeks approximately.
 
 ### Added
 
@@ -17,7 +17,7 @@ In this release we introduce Regtest functionality to Zebra and restored Windows
 
 ### Changed
 
-- Adjust estimated release interval to once every 4 weeks and the end of support from 16 to 20 weeks ([#8429](https://github.com/ZcashFoundation/zebra/pull/8429))
+- Adjust estimated release interval to once every 6 weeks and the end of support from 16 to 20 weeks ([#8429](https://github.com/ZcashFoundation/zebra/pull/8429))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Zebra 1.7.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.7.0) - 2024-05-06
+## [Zebra 1.7.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.7.0) - 2024-05-07
 
 In this release we introduce Regtest functionality to Zebra and restored Windows support. Also adjusted our Zebra release interval from 2 weeks to 6 weeks approximately.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Zebra 1.7.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.7.0) - 2024-05-04
+## [Zebra 1.7.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.7.0) - 2024-05-06
 
 In this release we introduce Regtest functionality to Zebra and restored Windows support. Also adjusted our Zebra release interval from 2 weeks to 4 weeks approximately.
 
 ### Added
 
 - Preparing for upstream `zcash_client_backend` API changes ([#8425](https://github.com/ZcashFoundation/zebra/pull/8425))
-- Regtest support ([#8383](https://github.com/ZcashFoundation/zebra/pull/8383), [#8421](https://github.com/ZcashFoundation/zebra/pull/8421), [#8368](https://github.com/ZcashFoundation/zebra/pull/8368), [#8413](https://github.com/ZcashFoundation/zebra/pull/8413), [#8475](https://github.com/ZcashFoundation/zebra/pull/8475))
+- Regtest support ([#8383](https://github.com/ZcashFoundation/zebra/pull/8383), [#8421](https://github.com/ZcashFoundation/zebra/pull/8421), [#8368](https://github.com/ZcashFoundation/zebra/pull/8368), [#8413](https://github.com/ZcashFoundation/zebra/pull/8413), [#8474](https://github.com/ZcashFoundation/zebra/pull/8474), [#8475](https://github.com/ZcashFoundation/zebra/pull/8475))
 - Allow Zebra users to contribute to the P2P network even if behind NAT or firewall ([#8488](https://github.com/ZcashFoundation/zebra/pull/8488))
 
 ### Changed
@@ -21,7 +21,6 @@ In this release we introduce Regtest functionality to Zebra and restored Windows
 
 ### Fixed
 
-- Check Equihash solutions with n=200, k=9 parameters ([#8474](https://github.com/ZcashFoundation/zebra/pull/8474))
 - Bump zcash script v0.1.15 and restore Windows support ([#8393](https://github.com/ZcashFoundation/zebra/pull/8393))
 - Avoid possibly returning data from different blocks in `z_get_treestate` RPC method ([#8460](https://github.com/ZcashFoundation/zebra/pull/8460))
 - Zebra panics with all features and no elasticsearch server available ([#8409](https://github.com/ZcashFoundation/zebra/pull/8409))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Zebra 1.7.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.7.0) - 2024-05-04
+
+In this release we introduce Regtest functionality to Zebra and restored Windows support. Also adjusted our Zebra release interval from 2 weeks to 4 weeks approximately.
+
+### Added
+
+- Preparing for upstream `zcash_client_backend` API changes ([#8425](https://github.com/ZcashFoundation/zebra/pull/8425))
+- Regtest support ([#8383](https://github.com/ZcashFoundation/zebra/pull/8383), [#8421](https://github.com/ZcashFoundation/zebra/pull/8421), [#8368](https://github.com/ZcashFoundation/zebra/pull/8368), [#8413](https://github.com/ZcashFoundation/zebra/pull/8413), [#8475](https://github.com/ZcashFoundation/zebra/pull/8475))
+- Allow Zebra users to contribute to the P2P network even if behind NAT or firewall ([#8488](https://github.com/ZcashFoundation/zebra/pull/8488))
+
+### Changed
+
+- Adjust estimated release interval to once every 4 weeks and the end of support from 16 to 20 weeks ([#8429](https://github.com/ZcashFoundation/zebra/pull/8429))
+
+### Fixed
+
+- Check Equihash solutions with n=200, k=9 parameters ([#8474](https://github.com/ZcashFoundation/zebra/pull/8474))
+- Bump zcash script v0.1.15 and restore Windows support ([#8393](https://github.com/ZcashFoundation/zebra/pull/8393))
+- Avoid possibly returning data from different blocks in `z_get_treestate` RPC method ([#8460](https://github.com/ZcashFoundation/zebra/pull/8460))
+- Zebra panics with all features and no elasticsearch server available ([#8409](https://github.com/ZcashFoundation/zebra/pull/8409))
+
+### Contributors
+
+Thank you to everyone who contributed to this release, we couldn't make Zebra without you:
+@arya2, @oxarbitrage and @upbqdn
+
+
 ## [Zebra 1.6.1](https://github.com/ZcashFoundation/zebra/releases/tag/v1.6.1) - 2024-04-15
 
 This release adds an OpenAPI specification for Zebra's RPC methods and startup logs about Zebra's storage usage and other database information. 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4883,7 +4883,7 @@ dependencies = [
 
 [[package]]
 name = "tower-batch-control"
-version = "0.2.41-beta.12"
+version = "0.2.41-beta.13"
 dependencies = [
  "color-eyre",
  "ed25519-zebra",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "tower-fallback"
-version = "0.2.41-beta.12"
+version = "0.2.41-beta.13"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -5987,7 +5987,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "1.0.0-beta.36"
+version = "1.0.0-beta.37"
 dependencies = [
  "bitflags 2.5.0",
  "bitflags-serde-legacy",
@@ -6050,7 +6050,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-consensus"
-version = "1.0.0-beta.36"
+version = "1.0.0-beta.37"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6096,7 +6096,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-grpc"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "color-eyre",
  "futures-util",
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-network"
-version = "1.0.0-beta.36"
+version = "1.0.0-beta.37"
 dependencies = [
  "bitflags 2.5.0",
  "byteorder",
@@ -6159,7 +6159,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-node-services"
-version = "1.0.0-beta.36"
+version = "1.0.0-beta.37"
 dependencies = [
  "color-eyre",
  "jsonrpc-core",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "1.0.0-beta.36"
+version = "1.0.0-beta.37"
 dependencies = [
  "chrono",
  "futures",
@@ -6203,7 +6203,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-scan"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 dependencies = [
  "bls12_381",
  "chrono",
@@ -6235,7 +6235,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-script"
-version = "1.0.0-beta.36"
+version = "1.0.0-beta.37"
 dependencies = [
  "displaydoc",
  "hex",
@@ -6248,7 +6248,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "1.0.0-beta.36"
+version = "1.0.0-beta.37"
 dependencies = [
  "bincode",
  "chrono",
@@ -6293,7 +6293,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-test"
-version = "1.0.0-beta.36"
+version = "1.0.0-beta.37"
 dependencies = [
  "color-eyre",
  "futures",
@@ -6321,7 +6321,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-utils"
-version = "1.0.0-beta.36"
+version = "1.0.0-beta.37"
 dependencies = [
  "color-eyre",
  "hex",
@@ -6350,7 +6350,7 @@ dependencies = [
 
 [[package]]
 name = "zebrad"
-version = "1.6.1"
+version = "1.7.0"
 dependencies = [
  "abscissa_core",
  "atty",

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Zebra is tested with the latest `stable` Rust version. Earlier versions are not
 supported or tested. Any Zebra release can start depending on new features in the
 latest stable Rust.
 
-Around every 4 weeks, we release a [new Zebra version](https://github.com/ZcashFoundation/zebra/releases).
+Around every 6 weeks, we release a [new Zebra version](https://github.com/ZcashFoundation/zebra/releases).
 
 Below are quick summaries for installing the dependencies on your machine.
 

--- a/README.md
+++ b/README.md
@@ -185,8 +185,6 @@ There are a few bugs in Zebra that we're still working on fixing:
 
 - Block download and verification sometimes times out during Zebra's initial sync [#5709](https://github.com/ZcashFoundation/zebra/issues/5709). The full sync still finishes reasonably quickly.
 
-- No Windows support [#3801](https://github.com/ZcashFoundation/zebra/issues/3801). We used to test with Windows Server 2019, but not any more; `zcash_script` has recently been updated to compile with MSVC, we're now waiting on a `zcash_script` release and dependency update, see the issue for details.
-
 - Experimental Tor support is disabled until Zebra upgrades to the latest `arti-client`. This happened due to a Rust dependency conflict ([#5492](https://github.com/ZcashFoundation/zebra/issues/5492)) and is still an issue due to [another dependency conflict](https://github.com/ZcashFoundation/zebra/issues/8328#issuecomment-1969989648).
 
 ## Documentation

--- a/book/src/dev/release-process.md
+++ b/book/src/dev/release-process.md
@@ -95,7 +95,7 @@ In general, expect the following release cycle:
 
 * A major release for each network upgrade, whenever there are breaking changes to Zebra (by API, severe bugs or other kind of upgrades)
 * Minor releases for significant new Zebra features or severe bug fixes
-* A patch release around every 4 weeks
+* A patch release around every 6 weeks
 
 This cadence of releases gives eager developers access to new features as soon as they are fully developed and pass through our code review and integration testing processes, while maintaining the stability and reliability of the platform for production users that prefer to receive features after they have been validated by Zcash and other developers that use the pre-release builds.
 

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -37,7 +37,7 @@ docker run -d --platform linux/amd64 \
 ### Build it locally
 
 ```shell
-git clone --depth 1 --branch v1.6.1 https://github.com/ZcashFoundation/zebra.git
+git clone --depth 1 --branch v1.7.0 https://github.com/ZcashFoundation/zebra.git
 docker build --file docker/Dockerfile --target runtime --tag zebra:local .
 docker run --detach zebra:local
 ```

--- a/book/src/user/install.md
+++ b/book/src/user/install.md
@@ -19,7 +19,7 @@ To compile Zebra directly from GitHub, or from a GitHub release source archive:
 ```sh
 git clone https://github.com/ZcashFoundation/zebra.git
 cd zebra
-git checkout v1.6.1
+git checkout v1.7.0
 ```
 
 3. Build and Run `zebrad`
@@ -32,7 +32,7 @@ target/release/zebrad start
 ### Compiling from git using cargo install
 
 ```sh
-cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.6.1 zebrad
+cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.7.0 zebrad
 ```
 
 ### Compiling on ARM

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-batch-control"
-version = "0.2.41-beta.12"
+version = "0.2.41-beta.13"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Tower middleware for batch request processing"
 # # Legal
@@ -43,7 +43,7 @@ rand = "0.8.5"
 
 tokio = { version = "1.37.0", features = ["full", "tracing", "test-util"] }
 tokio-test = "0.4.4"
-tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.12" }
+tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.13" }
 tower-test = "0.4.0"
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.36" }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.37" }

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-fallback"
-version = "0.2.41-beta.12"
+version = "0.2.41-beta.13"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Tower service combinator that sends requests to a first service, then retries processing on a second fallback service if the first service errors."
 license = "MIT OR Apache-2.0"
@@ -24,4 +24,4 @@ tracing = "0.1.39"
 [dev-dependencies]
 tokio = { version = "1.37.0", features = ["full", "tracing", "test-util"] }
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.36" }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.37" }

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-chain"
-version = "1.0.0-beta.36"
+version = "1.0.0-beta.37"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Core Zcash data structures"
 license = "MIT OR Apache-2.0"
@@ -143,7 +143,7 @@ proptest-derive = { version = "0.4.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 rand_chacha = { version = "0.3.1", optional = true }
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.36", optional = true }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.37", optional = true }
 
 [dev-dependencies]
 # Benchmarks
@@ -166,7 +166,7 @@ rand_chacha = "0.3.1"
 
 tokio = { version = "1.37.0", features = ["full", "tracing", "test-util"] }
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.36" }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.37" }
 
 [[bench]]
 name = "block"

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-consensus"
-version = "1.0.0-beta.36"
+version = "1.0.0-beta.37"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Implementation of Zcash consensus checks"
 license = "MIT OR Apache-2.0"
@@ -63,13 +63,13 @@ orchard = "0.6.0"
 zcash_proofs = { version = "0.13.0-rc.1", features = ["multicore" ] }
 wagyu-zcash-parameters = "0.2.0"
 
-tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.12" }
-tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41-beta.12" }
+tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.13" }
+tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41-beta.13" }
 
-zebra-script = { path = "../zebra-script", version = "1.0.0-beta.36" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.36" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.36" }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.36" }
+zebra-script = { path = "../zebra-script", version = "1.0.0-beta.37" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.37" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.37" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37" }
 
 # prod feature progress-bar
 howudoin = { version = "0.1.2", optional = true }
@@ -94,6 +94,6 @@ tokio = { version = "1.37.0", features = ["full", "tracing", "test-util"] }
 tracing-error = "0.2.0"
 tracing-subscriber = "0.3.18"
 
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.36", features = ["proptest-impl"] }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.36", features = ["proptest-impl"] }
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.36" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.37", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37", features = ["proptest-impl"] }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.37" }

--- a/zebra-grpc/Cargo.toml
+++ b/zebra-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-grpc"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Zebra gRPC interface"
 license = "MIT OR Apache-2.0"
@@ -28,8 +28,8 @@ color-eyre = "0.6.3"
 
 zcash_primitives = { version = "0.13.0" }
 
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.36", features = ["shielded-scan"] }
-zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.36" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.37", features = ["shielded-scan"] }
+zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.37" }
 
 [build-dependencies]
 tonic-build = "0.11.0"

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-network"
-version = "1.0.0-beta.36"
+version = "1.0.0-beta.37"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Networking code for Zebra"
 # # Legal
@@ -83,7 +83,7 @@ howudoin = { version = "0.1.2", optional = true }
 proptest = { version = "1.4.0", optional = true }
 proptest-derive = { version = "0.4.0", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.36", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37", features = ["async-error"] }
 
 [dev-dependencies]
 proptest = "1.4.0"

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-node-services"
-version = "1.0.0-beta.36"
+version = "1.0.0-beta.37"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The interfaces of some Zebra node services"
 license = "MIT OR Apache-2.0"
@@ -37,7 +37,7 @@ rpc-client = [
 shielded-scan = ["tokio"]
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.36" }
+zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.37" }
 
 # Optional dependencies
 

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-rpc"
-version = "1.0.0-beta.36"
+version = "1.0.0-beta.37"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Zebra JSON Remote Procedure Call (JSON-RPC) interface"
 license = "MIT OR Apache-2.0"
@@ -72,12 +72,12 @@ zcash_address = { version = "0.3.2", optional = true }
 # Test-only feature proptest-impl
 proptest = { version = "1.4.0", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.36", features = ["json-conversion"] }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.36" }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.36" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.36" }
-zebra-script = { path = "../zebra-script", version = "1.0.0-beta.36" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.36" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37", features = ["json-conversion"] }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.37" }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.37" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.37" }
+zebra-script = { path = "../zebra-script", version = "1.0.0-beta.37" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.37" }
 
 [dev-dependencies]
 insta = { version = "1.38.0", features = ["redactions", "json", "ron"] }
@@ -87,9 +87,9 @@ proptest = "1.4.0"
 thiserror = "1.0.59"
 tokio = { version = "1.37.0", features = ["full", "tracing", "test-util"] }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.36", features = ["proptest-impl"] }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.36", features = ["proptest-impl"] }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.36", features = ["proptest-impl"] }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.36", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37", features = ["proptest-impl"] }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.37", features = ["proptest-impl"] }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.37", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.37", features = ["proptest-impl"] }
 
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.36" }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.37" }

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-scan"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Shielded transaction scanner for the Zcash blockchain"
 license = "MIT OR Apache-2.0"
@@ -54,10 +54,10 @@ futures = "0.3.30"
 zcash_client_backend = "0.10.0-rc.1"
 zcash_primitives = "0.13.0"
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.36", features = ["shielded-scan"] }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.36", features = ["shielded-scan"] }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.36", features = ["shielded-scan"] }
-zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.3" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37", features = ["shielded-scan"] }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.37", features = ["shielded-scan"] }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.37", features = ["shielded-scan"] }
+zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.4" }
 
 chrono = { version = "0.4.38", default-features = false, features = ["clock", "std", "serde"] }
 
@@ -72,7 +72,7 @@ jubjub = { version = "0.10.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 zcash_note_encryption = { version = "0.4.0", optional = true }
 
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.36", optional = true }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.37", optional = true }
 
 [dev-dependencies]
 insta = { version = "1.38.0", features = ["ron", "redactions"] }
@@ -87,5 +87,5 @@ jubjub = "0.10.0"
 rand = "0.8.5"
 zcash_note_encryption = "0.4.0"
 
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.36", features = ["proptest-impl"] }
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.36" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.37", features = ["proptest-impl"] }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.37" }

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-script"
-version = "1.0.0-beta.36"
+version = "1.0.0-beta.37"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Zebra script verification wrapping zcashd's zcash_script library"
 license = "MIT OR Apache-2.0"
@@ -17,7 +17,7 @@ categories = ["api-bindings", "cryptography::cryptocurrencies"]
 [dependencies]
 zcash_script = "0.1.15"
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.36" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37" }
 
 thiserror = "1.0.59"
 displaydoc = "0.2.4"
@@ -25,4 +25,4 @@ displaydoc = "0.2.4"
 [dev-dependencies]
 hex = "0.4.3"
 lazy_static = "1.4.0"
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.36" }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.37" }

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-state"
-version = "1.0.0-beta.36"
+version = "1.0.0-beta.37"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "State contextual verification and storage code for Zebra"
 license = "MIT OR Apache-2.0"
@@ -77,13 +77,13 @@ tracing = "0.1.39"
 elasticsearch = { version = "8.5.0-alpha.1", default-features = false, features = ["rustls-tls"], optional = true }
 serde_json = { version = "1.0.116", package = "serde_json", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.36", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { version = "0.1.2", optional = true }
 
 # test feature proptest-impl
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.36", optional = true }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.37", optional = true }
 proptest = { version = "1.4.0", optional = true }
 proptest-derive = { version = "0.4.0", optional = true }
 
@@ -108,5 +108,5 @@ jubjub = "0.10.0"
 
 tokio = { version = "1.37.0", features = ["full", "tracing", "test-util"] }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.36", features = ["proptest-impl"] }
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.36" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37", features = ["proptest-impl"] }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.37" }

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-test"
-version = "1.0.0-beta.36"
+version = "1.0.0-beta.37"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Test harnesses and test vectors for Zebra"
 license = "MIT OR Apache-2.0"

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-utils"
-version = "1.0.0-beta.36"
+version = "1.0.0-beta.37"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Developer tools for Zebra maintenance and testing"
 license = "MIT OR Apache-2.0"
@@ -100,12 +100,12 @@ tracing-error = "0.2.0"
 tracing-subscriber = "0.3.18"
 thiserror = "1.0.59"
 
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.36" }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.36" }
-zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.4", optional = true }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.37" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37" }
+zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.6", optional = true }
 
 # These crates are needed for the block-template-to-proposal binary
-zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.36", optional = true }
+zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.37", optional = true }
 
 # These crates are needed for the zebra-checkpoints binary
 itertools = { version = "0.12.1", optional = true }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate metadata
 name = "zebrad"
-version = "1.6.1"
+version = "1.7.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The Zcash Foundation's independent, consensus-compatible implementation of a Zcash node"
 license = "MIT OR Apache-2.0"
@@ -158,18 +158,18 @@ test_sync_past_mandatory_checkpoint_mainnet = []
 test_sync_past_mandatory_checkpoint_testnet = []
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.36" }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.36" }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.36" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.36" }
-zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.36" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.36" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37" }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.37" }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.37" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.37" }
+zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.37" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.37" }
 
 # Experimental shielded-scan feature
-zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.4", optional = true }
+zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.6", optional = true }
 
 # Required for crates.io publishing, but it's only used in tests
-zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.36", optional = true }
+zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.37", optional = true }
 
 abscissa_core = "0.7.0"
 clap = { version = "4.5.4", features = ["cargo"] }
@@ -280,16 +280,16 @@ proptest-derive = "0.4.0"
 # enable span traces and track caller in tests
 color-eyre = { version = "0.6.3" }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.36", features = ["proptest-impl"] }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.36", features = ["proptest-impl"] }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.36", features = ["proptest-impl"] }
-zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.5", features = ["proptest-impl"] }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.36", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37", features = ["proptest-impl"] }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.37", features = ["proptest-impl"] }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.37", features = ["proptest-impl"] }
+zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.6", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.37", features = ["proptest-impl"] }
 
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.36", features = ["rpc-client"] }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.37", features = ["rpc-client"] }
 
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.36" }
-zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.3" }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.37" }
+zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.4" }
 
 # Used by the checkpoint generation tests via the zebra-checkpoints feature
 # (the binaries in this crate won't be built unless their features are enabled).
@@ -300,4 +300,4 @@ zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.3" }
 # When `-Z bindeps` is stabilised, enable this binary dependency instead:
 # https://github.com/rust-lang/cargo/issues/9096
 # zebra-utils { path = "../zebra-utils", artifact = "bin:zebra-checkpoints" }
-zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.36" }
+zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.37" }

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_471_000;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_495_106;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_495_106;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_496_122;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.


### PR DESCRIPTION
---
name: 'Release Checklist Template'
about: 'Checklist to create and publish a Zebra release'
title: 'Release Zebra (version)'
labels: 'A-release, C-trivial, P-Critical :ambulance:'
assignees: ''

---

# Prepare for the Release

- [x] Make sure there has been [at least one successful full sync test](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-integration-tests-gcp.yml?query=event%3Aschedule) since the last state change, or start a manual full sync.
- [x] Make sure the PRs with the new checkpoint hashes and missed dependencies are already merged.
      (See the release ticket checklist for details)


# Summarise Release Changes

These steps can be done a few days before the release, in the same PR:

## Change Log

**Important**: Any merge into `main` deletes any edits to the draft changelog.
Once you are ready to tag a release, copy the draft changelog into `CHANGELOG.md`.

We use [the Release Drafter workflow](https://github.com/marketplace/actions/release-drafter) to automatically create a [draft changelog](https://github.com/ZcashFoundation/zebra/releases). We follow the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.

To create the final change log:
- [x] Copy the **latest** draft changelog into `CHANGELOG.md` (there can be multiple draft releases)
- [x] Delete any trivial changes
    - [x] Put the list of deleted changelog entries in a PR comment to make reviewing easier
- [x] Combine duplicate changes
- [x] Edit change descriptions so they will make sense to Zebra users
- [x] Check the category for each change
  - Prefer the "Fix" category if you're not sure

## README

README updates can be skipped for urgent releases.

Update the README to:
- [x] Remove any "Known Issues" that have been fixed since the last release.
- [ ] Update the "Build and Run Instructions" with any new dependencies.
      Check for changes in the `Dockerfile` since the last tag: `git diff <previous-release-tag> docker/Dockerfile`.
- [ ] If Zebra has started using newer Rust language features or standard library APIs, update the known working Rust version in the README, book, and `Cargo.toml`s

You can use a command like:
```sh
fastmod --fixed-strings '1.58' '1.65'
```

## Create the Release PR

- [ ] Push the updated changelog and README into a new branch
      for example: `bump-v1.0.0` - this needs to be different to the tag name
- [x] Create a release PR by adding `&template=release-checklist.md` to the comparing url ([Example](https://github.com/ZcashFoundation/zebra/compare/bump-v1.0.0?expand=1&template=release-checklist.md)).
- [x] Freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [x] Mark all the release PRs as `Critical` priority, so they go in the `urgent` Mergify queue.
- [x] Mark all non-release PRs with `do-not-merge`, because Mergify checks approved PRs against every commit, even when a queue is frozen.


# Update Versions and End of Support

## Update Zebra Version

### Choose a Release Level

Zebra follows [semantic versioning](https://semver.org). Semantic versions look like: MAJOR.MINOR.PATCH[-TAG.PRE-RELEASE]

Choose a release level for `zebrad`. Release levels are based on user-visible changes from the changelog:
- Mainnet Network Upgrades are `major` releases
- significant new features or behaviour changes; changes to RPCs, command-line, or configs; and deprecations or removals are `minor` releases
- otherwise, it is a `patch` release

Zebra's Rust API doesn't have any support or stability guarantees, so we keep all the `zebra-*` and `tower-*` crates on a beta `pre-release` version.

### Update Crate Versions

If you're publishing crates for the first time, [log in to crates.io](https://github.com/ZcashFoundation/zebra/blob/doc-crate-own/book/src/dev/crate-owners.md#logging-in-to-cratesio),
and make sure you're a member of owners group.

Check that the release will work:
- [x] Update crate versions, commit the changes to the release branch, and do a release dry-run:

```sh
# Update everything except for alpha crates and zebrad:
cargo release version --verbose --execute --allow-branch '*' --workspace --exclude zebrad --exclude zebra-scan --exclude zebra-grpc beta
# Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
cargo release version --verbose --execute --allow-branch '*' --package zebra-scan 0.1.0-alpha.4
cargo release version --verbose --execute --allow-branch '*' --package zebra-grpc 0.1.0-alpha.2
# Update zebrad:
cargo release version --verbose --execute --allow-branch '*' --package zebrad patch # [ major | minor | patch ]
# Continue with the release process:
cargo release replace --verbose --execute --allow-branch '*' --package zebrad
cargo release commit --verbose --execute --allow-branch '*'
```

Crate publishing is [automatically checked in CI](https://github.com/ZcashFoundation/zebra/actions/workflows/release-crates-io.yml) using "dry run" mode, however due to a bug in `cargo-release` we need to pass exact versions to the alpha crates:

- [x] Update `zebra-scan` and `zebra-grpc` alpha crates in the [release-crates-dry-run workflow script](https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/scripts/release-crates-dry-run.sh)
- [x] Push the above version changes to the release branch.

## Update End of Support

The end of support height is calculated from the current blockchain height:
- [x] Find where the Zcash blockchain tip is now by using a [Zcash explorer](https://zcashblockexplorer.com/blocks) or other tool.
- [x] Replace `ESTIMATED_RELEASE_HEIGHT` in [`end_of_support.rs`](https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/sync/end_of_support.rs) with the height you estimate the release will be tagged.

<details>

<summary>Optional: calculate the release tagging height</summary>

- Add `1152` blocks for each day until the release
- For example, if the release is in 3 days, add `1152 * 3` to the current Mainnet block height

</details>

## Update the Release PR

- [x] Push the version increments and the release constants to the release branch.


# Publish the Zebra Release

## Create the GitHub Pre-Release

- [x] Wait for all the release PRs to be merged
- [x] Create a new release using the draft release as a base, by clicking the Edit icon in the [draft release](https://github.com/ZcashFoundation/zebra/releases)
- [x] Set the tag name to the version tag,
      for example: `v1.0.0`
- [x] Set the release to target the `main` branch
- [x] Set the release title to `Zebra ` followed by the version tag,
      for example: `Zebra 1.0.0`
- [x] Replace the prepopulated draft changelog in the release description with the final changelog you created;
      starting just _after_ the title `## [Zebra ...` of the current version being released,
      and ending just _before_ the title of the previous release.
- [x] Mark the release as 'pre-release', until it has been built and tested
- [x] Publish the pre-release to GitHub using "Publish Release"
- [x] Delete all the [draft releases from the list of releases](https://github.com/ZcashFoundation/zebra/releases)

## Test the Pre-Release

- [x] Wait until the Docker binaries have been built on `main`, and the quick tests have passed:
    - [x] [ci-unit-tests-docker.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-unit-tests-docker.yml?query=branch%3Amain)
    - [x] [ci-integration-tests-gcp.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-integration-tests-gcp.yml?query=branch%3Amain)
- [x] Wait until the [pre-release deployment machines have successfully launched](https://github.com/ZcashFoundation/zebra/actions/workflows/cd-deploy-nodes-gcp.yml?query=event%3Arelease)

## Publish Release

- [x] [Publish the release to GitHub](https://github.com/ZcashFoundation/zebra/releases) by disabling 'pre-release', then clicking "Set as the latest release"

## Publish Crates

- [x] [Run `cargo login`](https://github.com/ZcashFoundation/zebra/blob/doc-crate-own/book/src/dev/crate-owners.md#logging-in-to-cratesio)
- [ ] Run `cargo clean` in the zebra repo (optional)
- [x] Publish the crates to crates.io: `cargo release publish --verbose --workspace --execute`
- [x] Check that Zebra can be installed from `crates.io`:
      `cargo install --locked --force --version 1.minor.patch zebrad && ~/.cargo/bin/zebrad`
      and put the output in a comment on the PR.

## Publish Docker Images
- [x] Wait for the [the Docker images to be published successfully](https://github.com/ZcashFoundation/zebra/actions/workflows/release-binaries.yml?query=event%3Arelease).
- [x] Un-freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [x] Remove `do-not-merge` from the PRs you added it to

## Release Failures

If building or running fails after tagging:

<details>

<summary>Tag a new release, following these instructions...</summary>

1. Fix the bug that caused the failure
2. Start a new `patch` release
3. Skip the **Release Preparation**, and start at the **Release Changes** step
4. Update `CHANGELOG.md` with details about the fix
5. Follow the release checklist for the new Zebra version

</details>
