### PR TITLE
add(consensus): Add a `target_difficulty_limit` field on `testnet::Parameters`

### DIFF
--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -105,6 +105,15 @@ impl Default for ParametersBuilder {
                 .parse()
                 .expect("hard-coded hash parses"),
             slow_start_interval: SLOW_START_INTERVAL,
+            // Testnet PoWLimit is defined as `2^251 - 1` on page 73 of the protocol specification:
+            // <https://zips.z.cash/protocol/protocol.pdf>
+            //
+            // `zcashd` converts the PoWLimit into a compact representation before
+            // using it to perform difficulty filter checks.
+            //
+            // The Zcash specification converts to compact for the default difficulty
+            // filter, but not for testnet minimum difficulty blocks. (ZIP 205 and
+            // ZIP 208 don't specify this conversion either.) See #1277 for details.
             target_difficulty_limit: ExpandedDifficulty::from((U256::one() << 251) - 1)
                 .to_compact()
                 .to_expanded()
@@ -359,6 +368,7 @@ impl Parameters {
             network_name: "Regtest".to_string(),
             ..Self::build()
                 .with_genesis_hash(REGTEST_GENESIS_HASH)
+                // This value is chosen to match zcashd, see: <https://github.com/zcash/zcash/blob/master/src/chainparams.cpp#L654>
                 .with_target_difficulty_limit(U256::from_big_endian(&[0x0f; 32]))
                 .with_disable_pow(true)
                 .with_slow_start_interval(Height::MIN)

--- a/zebra-chain/src/work/difficulty.rs
+++ b/zebra-chain/src/work/difficulty.rs
@@ -696,9 +696,10 @@ impl ParameterDifficulty for Network {
     /// See [`ParameterDifficulty::target_difficulty_limit`]
     fn target_difficulty_limit(&self) -> ExpandedDifficulty {
         let limit: U256 = match self {
-            /* 2^243 - 1 */
+            // Mainnet PoWLimit is defined as `2^243 - 1` on page 73 of the protocol specification:
+            // <https://zips.z.cash/protocol/protocol.pdf>
             Network::Mainnet => (U256::one() << 243) - 1,
-            /* 2^251 - 1 for the default testnet */
+            // 2^251 - 1 for the default testnet, see `testnet::ParametersBuilder::default`()
             Network::Testnet(params) => return params.target_difficulty_limit(),
         };
 

--- a/zebra-chain/src/work/difficulty.rs
+++ b/zebra-chain/src/work/difficulty.rs
@@ -100,7 +100,7 @@ pub const INVALID_COMPACT_DIFFICULTY: CompactDifficulty = CompactDifficulty(u32:
 /// [section 7.7.2]: https://zips.z.cash/protocol/protocol.pdf#difficulty
 //
 // TODO: Use NonZeroU256, when available
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct ExpandedDifficulty(U256);
 
 /// A 128-bit unsigned "Work" value.
@@ -698,9 +698,8 @@ impl ParameterDifficulty for Network {
         let limit: U256 = match self {
             /* 2^243 - 1 */
             Network::Mainnet => (U256::one() << 243) - 1,
-            /* 2^251 - 1 */
-            // TODO: Add a `target_difficulty_limit` field to `testnet::Parameters` to return here. (`U256::from_big_endian(&[0x0f].repeat(8))` for Regtest)
-            Network::Testnet(_params) => (U256::one() << 251) - 1,
+            /* 2^251 - 1 for the default testnet */
+            Network::Testnet(params) => return params.target_difficulty_limit(),
         };
 
         // `zcashd` converts the PoWLimit into a compact representation before

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -176,18 +176,16 @@ where
                 Err(BlockError::MaxHeight(height, hash, block::Height::MAX))?;
             }
 
-            if !network.disable_pow() {
-                // > The block data MUST be validated and checked against the server's usual
-                // > acceptance rules (excluding the check for a valid proof-of-work).
-                // <https://en.bitcoin.it/wiki/BIP_0023#Block_Proposal>
-                if request.is_proposal() {
-                    check::difficulty_threshold_is_valid(&block.header, &network, &height, &hash)?;
-                } else {
-                    // Do the difficulty checks first, to raise the threshold for
-                    // attacks that use any other fields.
-                    check::difficulty_is_valid(&block.header, &network, &height, &hash)?;
-                    check::equihash_solution_is_valid(&block.header)?;
-                }
+            // > The block data MUST be validated and checked against the server's usual
+            // > acceptance rules (excluding the check for a valid proof-of-work).
+            // <https://en.bitcoin.it/wiki/BIP_0023#Block_Proposal>
+            if request.is_proposal() || network.disable_pow() {
+                check::difficulty_threshold_is_valid(&block.header, &network, &height, &hash)?;
+            } else {
+                // Do the difficulty checks first, to raise the threshold for
+                // attacks that use any other fields.
+                check::difficulty_is_valid(&block.header, &network, &height, &hash)?;
+                check::equihash_solution_is_valid(&block.header)?;
             }
 
             // Next, check the Merkle root validity, to ensure that

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -595,7 +595,14 @@ where
             .ok_or(VerifyCheckpointError::CoinbaseHeight { hash })?;
         self.check_height(height)?;
 
-        if !self.network.disable_pow() {
+        if self.network.disable_pow() {
+            crate::block::check::difficulty_threshold_is_valid(
+                &block.header,
+                &self.network,
+                &height,
+                &hash,
+            )?;
+        } else {
             crate::block::check::difficulty_is_valid(&block.header, &self.network, &height, &hash)?;
             crate::block::check::equihash_solution_is_valid(&block.header)?;
         }

--- a/zebra-consensus/src/lib.rs
+++ b/zebra-consensus/src/lib.rs
@@ -45,6 +45,9 @@ pub mod error;
 pub mod router;
 pub mod transaction;
 
+#[cfg(any(test, feature = "proptest-impl"))]
+pub use block::check::difficulty_threshold_is_valid;
+
 pub use block::{
     subsidy::{
         funding_streams::{

--- a/zebra-consensus/src/lib.rs
+++ b/zebra-consensus/src/lib.rs
@@ -46,7 +46,7 @@ pub mod router;
 pub mod transaction;
 
 #[cfg(any(test, feature = "proptest-impl"))]
-pub use block::check::difficulty_threshold_is_valid;
+pub use block::check::difficulty_is_valid;
 
 pub use block::{
     subsidy::{

--- a/zebrad/tests/common/regtest.rs
+++ b/zebrad/tests/common/regtest.rs
@@ -80,13 +80,9 @@ async fn submit_blocks(network: Network, rpc_address: SocketAddr) -> Result<()> 
             .coinbase_height()
             .expect("should have a coinbase height");
 
-        while zebra_consensus::difficulty_threshold_is_valid(
-            &block.header,
-            &network,
-            &height,
-            &block.hash(),
-        )
-        .is_err()
+        while !network.disable_pow()
+            && zebra_consensus::difficulty_is_valid(&block.header, &network, &height, &block.hash())
+                .is_err()
         {
             increment_big_endian(Arc::make_mut(&mut block.header).nonce.as_mut());
         }

--- a/zebrad/tests/common/regtest.rs
+++ b/zebrad/tests/common/regtest.rs
@@ -3,13 +3,14 @@
 //! This test will get block templates via the `getblocktemplate` RPC method and submit them as new blocks
 //! via the `submitblock` RPC method on Regtest.
 
-use std::{net::SocketAddr, time::Duration};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use color_eyre::eyre::{Context, Result};
 use tracing::*;
 
 use zebra_chain::{
     parameters::{testnet::REGTEST_NU5_ACTIVATION_HEIGHT, Network, NetworkUpgrade},
+    primitives::byte_array::increment_big_endian,
     serialization::ZcashSerialize,
 };
 use zebra_node_services::rpc_client::RpcRequestClient;
@@ -44,7 +45,7 @@ pub(crate) async fn submit_blocks_test() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(30)).await;
 
     info!("attempting to submit blocks");
-    submit_blocks(rpc_address).await?;
+    submit_blocks(network, rpc_address).await?;
 
     zebrad.kill(false)?;
 
@@ -58,7 +59,7 @@ pub(crate) async fn submit_blocks_test() -> Result<()> {
 }
 
 /// Get block templates and submit blocks
-async fn submit_blocks(rpc_address: SocketAddr) -> Result<()> {
+async fn submit_blocks(network: Network, rpc_address: SocketAddr) -> Result<()> {
     let client = RpcRequestClient::new(rpc_address);
 
     for height in 1..=NUM_BLOCKS_TO_SUBMIT {
@@ -73,10 +74,24 @@ async fn submit_blocks(rpc_address: SocketAddr) -> Result<()> {
             NetworkUpgrade::Nu5
         };
 
-        let block_data = hex::encode(
-            proposal_block_from_template(&block_template, TimeSource::default(), network_upgrade)?
-                .zcash_serialize_to_vec()?,
-        );
+        let mut block =
+            proposal_block_from_template(&block_template, TimeSource::default(), network_upgrade)?;
+        let height = block
+            .coinbase_height()
+            .expect("should have a coinbase height");
+
+        while zebra_consensus::difficulty_threshold_is_valid(
+            &block.header,
+            &network,
+            &height,
+            &block.hash(),
+        )
+        .is_err()
+        {
+            increment_big_endian(Arc::make_mut(&mut block.header).nonce.as_mut());
+        }
+
+        let block_data = hex::encode(block.zcash_serialize_to_vec()?);
 
         let submit_block_response = client
             .text_from_call("submitblock", format!(r#"["{block_data}"]"#))
@@ -84,7 +99,7 @@ async fn submit_blocks(rpc_address: SocketAddr) -> Result<()> {
 
         let was_submission_successful = submit_block_response.contains(r#""result":null"#);
 
-        if height % 40 == 0 {
+        if height.0 % 40 == 0 {
             info!(
                 was_submission_successful,
                 ?block_template,


### PR DESCRIPTION
## Motivation

We want to use the same `target_difficulty_limit` on Regtest as zcashd and allow for it to be configured on custom testnets.

Closes #8479.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Adds a `target_difficulty_limit` field on `testnet::Parameters`
- Returns it for Testnets in the `Network::target_difficulty_limit` method
- Checks block difficulty thresholds in block/checkpoint verifiers

### Testing

Manually tested that the internal miner still works on Regtest, and now that the block/checkpoint verifiers validate the difficulty threshold, the changes in this PR are covered by the `validate_regtest_genesis_block` and `regtest_submit_blocks` acceptance tests.

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._
