### PR TITLE
change(network): Allow custom testnets to make peer connections and configure more parameters

### DIFF
--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -284,8 +284,12 @@ impl ParametersBuilder {
 
     /// Sets the target difficulty limit to be used in the [`Parameters`] being built.
     // TODO: Accept a hex-encoded String instead?
-    pub fn with_target_difficulty_limit(mut self, target_difficulty_limit: U256) -> Self {
-        self.target_difficulty_limit = ExpandedDifficulty::from(target_difficulty_limit)
+    pub fn with_target_difficulty_limit(
+        mut self,
+        target_difficulty_limit: impl Into<ExpandedDifficulty>,
+    ) -> Self {
+        self.target_difficulty_limit = target_difficulty_limit
+            .into()
             .to_compact()
             .to_expanded()
             .expect("difficulty limits are valid expanded values");

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -768,16 +768,11 @@ impl<'de> Deserialize<'de> for Config {
                 }
 
                 if let Some(target_difficulty_limit) = target_difficulty_limit {
-                    params_builder = params_builder.with_target_difficulty_limit(U256::from(
-                        <[u8; 32]>::try_from(
-                            hex::decode(target_difficulty_limit).map_err(de::Error::custom)?,
-                        )
-                        .map_err(|err| {
-                            de::Error::custom(format!(
-                                "hex-encoded target difficulty must be 64 chars: {err:?}"
-                            ))
-                        })?,
-                    ));
+                    params_builder = params_builder.with_target_difficulty_limit(
+                        target_difficulty_limit
+                            .parse::<U256>()
+                            .map_err(de::Error::custom)?,
+                    );
                 }
 
                 if let Some(disable_pow) = disable_pow {

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -14,9 +14,12 @@ use tempfile::NamedTempFile;
 use tokio::{fs, io::AsyncWriteExt};
 use tracing::Span;
 
-use zebra_chain::parameters::{
-    testnet::{self, ConfiguredActivationHeights},
-    Magic, Network, NetworkKind,
+use zebra_chain::{
+    parameters::{
+        testnet::{self, ConfiguredActivationHeights},
+        Magic, Network, NetworkKind,
+    },
+    work::difficulty::U256,
 };
 
 use crate::{
@@ -235,10 +238,8 @@ impl Config {
     pub fn initial_peer_hostnames(&self) -> IndexSet<String> {
         match &self.network {
             Network::Mainnet => self.initial_mainnet_peers.clone(),
-            Network::Testnet(params) if params.is_default_testnet() => {
-                self.initial_testnet_peers.clone()
-            }
-            // TODO: Add a `disable_peers` field to `Network` to check instead of `is_default_testnet()` (#8361)
+            Network::Testnet(params) if !params.is_regtest() => self.initial_testnet_peers.clone(),
+            // TODO: Add a `disable_peers` field to `Network` to check instead of `is_regtest()` (#8361)
             Network::Testnet(_params) => IndexSet::new(),
         }
     }
@@ -250,6 +251,11 @@ impl Config {
     ///
     /// If a configured address is an invalid [`SocketAddr`] or DNS name.
     pub async fn initial_peers(&self) -> HashSet<PeerSocketAddr> {
+        // Return early if network is regtest in case there are somehow any entries in the peer cache
+        if self.network.is_regtest() {
+            return HashSet::new();
+        }
+
         // TODO: do DNS and disk in parallel if startup speed becomes important
         let dns_peers =
             Config::resolve_peers(&self.initial_peer_hostnames().iter().cloned().collect()).await;
@@ -636,8 +642,11 @@ impl<'de> Deserialize<'de> for Config {
     {
         #[derive(Deserialize)]
         struct DTestnetParameters {
-            network_magic: Option<[u8; 4]>,
             network_name: Option<String>,
+            network_magic: Option<[u8; 4]>,
+            slow_start_interval: Option<u32>,
+            target_difficulty_limit: Option<String>,
+            disable_pow: Option<bool>,
             activation_heights: Option<ConfiguredActivationHeights>,
         }
 
@@ -720,12 +729,19 @@ impl<'de> Deserialize<'de> for Config {
                 Some(DTestnetParameters {
                     network_name,
                     network_magic,
+                    slow_start_interval,
+                    target_difficulty_limit,
+                    disable_pow,
                     activation_heights,
                 }),
             ) => {
                 let mut params_builder = testnet::Parameters::build();
-                let should_avoid_default_peers =
-                    network_magic.is_some() || activation_heights.is_some();
+                // TODO: allow default peers when fields match default testnet values?
+                let should_avoid_default_peers = network_magic.is_some()
+                    || slow_start_interval.is_some()
+                    || target_difficulty_limit.is_some()
+                    || disable_pow == Some(true)
+                    || activation_heights.is_some();
 
                 // Return an error if the initial testnet peers includes any of the default initial Mainnet or Testnet
                 // peers while activation heights or a custom network magic is configured.
@@ -743,6 +759,29 @@ impl<'de> Deserialize<'de> for Config {
 
                 if let Some(network_magic) = network_magic {
                     params_builder = params_builder.with_network_magic(Magic(network_magic));
+                }
+
+                if let Some(slow_start_interval) = slow_start_interval {
+                    params_builder = params_builder.with_slow_start_interval(
+                        slow_start_interval.try_into().map_err(de::Error::custom)?,
+                    );
+                }
+
+                if let Some(target_difficulty_limit) = target_difficulty_limit {
+                    params_builder = params_builder.with_target_difficulty_limit(U256::from(
+                        <[u8; 32]>::try_from(
+                            hex::decode(target_difficulty_limit).map_err(de::Error::custom)?,
+                        )
+                        .map_err(|err| {
+                            de::Error::custom(format!(
+                                "hex-encoded target difficulty limit is too long: {err:?}"
+                            ))
+                        })?,
+                    ));
+                }
+
+                if let Some(disable_pow) = disable_pow {
+                    params_builder = params_builder.with_disable_pow(disable_pow);
                 }
 
                 // Retain default Testnet activation heights unless there's an empty [testnet_parameters.activation_heights] section.

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -774,7 +774,7 @@ impl<'de> Deserialize<'de> for Config {
                         )
                         .map_err(|err| {
                             de::Error::custom(format!(
-                                "hex-encoded target difficulty limit is too long: {err:?}"
+                                "hex-encoded target difficulty must be 64 chars: {err:?}"
                             ))
                         })?,
                     ));

--- a/zebrad/tests/common/configs/v1.8.0.toml
+++ b/zebrad/tests/common/configs/v1.8.0.toml
@@ -59,6 +59,9 @@ peerset_initial_target_size = 25
 [network.testnet_parameters]
 network_name = "ConfiguredTestnet_1"
 network_magic = [0, 0, 0, 0]
+slow_start_interval = 0
+target_difficulty_limit = "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"
+disable_pow = true
 
 [network.testnet_parameters.activation_heights]
 BeforeOverwinter = 1


### PR DESCRIPTION
## Motivation

We want to support configuring more custom testnet parameters and to allow Zebra to make peer connections on custom testnets.

Depends-On: #8524

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

- Replace check for `is_default_testnet()` in `initial_peer_hostnames()` with `!is_regtest()`
- Add the remaining configurable parameters in `testnet::Parameters` to config deserialization

Related changes:
-  Return early with an empty set from `initial_peers()` when `network.is_regtest()` (Zebra shouldn't ever add any peers to the peer cache on Regtest, because it has no initial peers, but it the file could be edited outside Zebra)

### Testing

Updated the latest stored test config

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._
