### PR TITLE
fix(rpc): Refactor the serialization of note commitment trees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6191,7 +6191,7 @@ dependencies = [
  "tower",
  "tracing",
  "zcash_address",
- "zcash_primitives 0.13.0",
+ "zcash_primitives 0.14.0",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6191,7 +6191,7 @@ dependencies = [
  "tower",
  "tracing",
  "zcash_address",
- "zcash_primitives",
+ "zcash_primitives 0.13.0",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6191,6 +6191,7 @@ dependencies = [
  "tower",
  "tracing",
  "zcash_address",
+ "zcash_primitives",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6191,7 +6191,7 @@ dependencies = [
  "tower",
  "tracing",
  "zcash_address",
- "zcash_primitives 0.14.0",
+ "zcash_primitives 0.13.0",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",

--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -15,7 +15,6 @@ use std::{
     fmt,
     hash::{Hash, Hasher},
     io,
-    sync::Arc,
 };
 
 use bitvec::prelude::*;
@@ -25,7 +24,6 @@ use incrementalmerkletree::{frontier::Frontier, Hashable};
 
 use lazy_static::lazy_static;
 use thiserror::Error;
-use zcash_encoding::{Optional, Vector};
 use zcash_primitives::merkle_tree::HashSer;
 
 use super::commitment::pedersen_hashes::pedersen_hash;
@@ -38,7 +36,7 @@ use crate::{
 };
 
 pub mod legacy;
-use legacy::{LegacyLeaf, LegacyNoteCommitmentTree};
+use legacy::LegacyNoteCommitmentTree;
 
 /// The type that is used to update the note commitment tree.
 ///
@@ -219,7 +217,7 @@ impl ToHex for Node {
     }
 }
 
-/// Required to convert [`NoteCommitmentTree`] into [`SerializedTree`].
+/// Required to serialize [`NoteCommitmentTree`]s in a format compatible with `zcashd`.
 ///
 /// Zebra stores Sapling note commitment trees as [`Frontier`]s while the
 /// [`z_gettreestate`][1] RPC requires [`CommitmentTree`][2]s. Implementing
@@ -614,7 +612,21 @@ impl NoteCommitmentTree {
         assert_eq!(self.inner, other.inner);
 
         // Check the RPC serialization format (not the same as the Zebra database format)
-        assert_eq!(SerializedTree::from(self), SerializedTree::from(other));
+        assert_eq!(self.to_rpc_bytes(), other.to_rpc_bytes());
+    }
+
+    /// Serializes [`Self`] to a format compatible with `zcashd`'s RPCs.
+    pub fn to_rpc_bytes(&self) -> Vec<u8> {
+        // Convert the tree from [`Frontier`](bridgetree::Frontier) to
+        // [`CommitmentTree`](merkle_tree::CommitmentTree).
+        let tree = incrementalmerkletree::frontier::CommitmentTree::from_frontier(&self.inner);
+
+        let mut rpc_bytes = vec![];
+
+        zcash_primitives::merkle_tree::write_commitment_tree(&tree, &mut rpc_bytes)
+            .expect("serializable tree");
+
+        rpc_bytes
     }
 }
 
@@ -668,137 +680,5 @@ impl From<Vec<jubjub::Fq>> for NoteCommitmentTree {
         }
 
         tree
-    }
-}
-
-/// A serialized Sapling note commitment tree.
-///
-/// The format of the serialized data is compatible with
-/// [`CommitmentTree`](incrementalmerkletree::frontier::CommitmentTree) from `librustzcash` and not
-/// with [`Frontier`] from the crate
-/// [`incrementalmerkletree`]. Zebra follows the former format in order to stay
-/// consistent with `zcashd` in RPCs. Note that [`NoteCommitmentTree`] itself is
-/// represented as [`Frontier`].
-///
-/// The formats are semantically equivalent. The primary difference between them
-/// is that in [`Frontier`], the vector of parents is
-/// dense (we know where the gaps are from the position of the leaf in the
-/// overall tree); whereas in [`CommitmentTree`](incrementalmerkletree::frontier::CommitmentTree),
-/// the vector of parent hashes is sparse with [`None`] values in the gaps.
-///
-/// The sparse format, used in this implementation, allows representing invalid
-/// commitment trees while the dense format allows representing only valid
-/// commitment trees.
-///
-/// It is likely that the dense format will be used in future RPCs, in which
-/// case the current implementation will have to change and use the format
-/// compatible with [`Frontier`] instead.
-#[derive(Clone, Debug, Default, Eq, PartialEq, serde::Serialize)]
-pub struct SerializedTree(Vec<u8>);
-
-impl From<&NoteCommitmentTree> for SerializedTree {
-    fn from(tree: &NoteCommitmentTree) -> Self {
-        let mut serialized_tree = vec![];
-
-        //
-        let legacy_tree = LegacyNoteCommitmentTree::from(tree.clone());
-
-        // Convert the note commitment tree represented as a frontier into the
-        // format compatible with `zcashd`.
-        //
-        // `librustzcash` has a function [`from_frontier()`][1], which returns a
-        // commitment tree in the sparse format. However, the returned tree
-        // always contains [`MERKLE_DEPTH`] parent nodes, even though some
-        // trailing parents are empty. Such trees are incompatible with Sapling
-        // commitment trees returned by `zcashd` because `zcashd` returns
-        // Sapling commitment trees without empty trailing parents. For this
-        // reason, Zebra implements its own conversion between the dense and
-        // sparse formats for Sapling.
-        //
-        // [1]: <https://github.com/zcash/librustzcash/blob/a63a37a/zcash_primitives/src/merkle_tree.rs#L125>
-        if let Some(frontier) = legacy_tree.inner.frontier {
-            let (left_leaf, right_leaf) = match frontier.leaf {
-                LegacyLeaf::Left(left_value) => (Some(left_value), None),
-                LegacyLeaf::Right(left_value, right_value) => (Some(left_value), Some(right_value)),
-            };
-
-            // Ommers are siblings of parent nodes along the branch from the
-            // most recent leaf to the root of the tree.
-            let mut ommers_iter = frontier.ommers.iter();
-
-            // Set bits in the binary representation of the position indicate
-            // the presence of ommers along the branch from the most recent leaf
-            // node to the root of the tree, except for the lowest bit.
-            let mut position: u64 = (frontier.position.0)
-                .try_into()
-                .expect("old usize position always fit in u64");
-
-            // The lowest bit does not indicate the presence of any ommers. We
-            // clear it so that we can test if there are no set bits left in
-            // [`position`].
-            position &= !1;
-
-            // Run through the bits of [`position`], and push an ommer for each
-            // set bit, or `None` otherwise. In contrast to the 'zcashd' code
-            // linked above, we want to skip any trailing `None` parents at the
-            // top of the tree. To do that, we clear the bits as we go through
-            // them, and break early if the remaining bits are all zero (i.e.
-            // [`position`] is zero).
-            let mut parents = vec![];
-            for i in 1..MERKLE_DEPTH {
-                // Test each bit in [`position`] individually. Don't test the
-                // lowest bit since it doesn't actually indicate the position of
-                // any ommer.
-                let bit_mask = 1 << i;
-
-                if position & bit_mask == 0 {
-                    parents.push(None);
-                } else {
-                    parents.push(ommers_iter.next());
-                    // Clear the set bit so that we can test if there are no set
-                    // bits left.
-                    position &= !bit_mask;
-                    // If there are no set bits left, exit early so that there
-                    // are no empty trailing parent nodes in the serialized
-                    // tree.
-                    if position == 0 {
-                        break;
-                    }
-                }
-            }
-
-            // Serialize the converted note commitment tree.
-            Optional::write(&mut serialized_tree, left_leaf, |tree, leaf| {
-                leaf.write(tree)
-            })
-            .expect("A leaf in a note commitment tree should be serializable");
-
-            Optional::write(&mut serialized_tree, right_leaf, |tree, leaf| {
-                leaf.write(tree)
-            })
-            .expect("A leaf in a note commitment tree should be serializable");
-
-            Vector::write(&mut serialized_tree, &parents, |tree, parent| {
-                Optional::write(tree, *parent, |tree, parent| parent.write(tree))
-            })
-            .expect("Parent nodes in a note commitment tree should be serializable");
-        }
-
-        Self(serialized_tree)
-    }
-}
-
-impl From<Option<Arc<NoteCommitmentTree>>> for SerializedTree {
-    fn from(maybe_tree: Option<Arc<NoteCommitmentTree>>) -> Self {
-        match maybe_tree {
-            Some(tree) => tree.as_ref().into(),
-            None => Self(vec![]),
-        }
-    }
-}
-
-impl AsRef<[u8]> for SerializedTree {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
     }
 }

--- a/zebra-chain/src/sapling/tree.rs
+++ b/zebra-chain/src/sapling/tree.rs
@@ -217,7 +217,7 @@ impl ToHex for Node {
     }
 }
 
-/// Required to serialize [`NoteCommitmentTree`]s in a format compatible with `zcashd`.
+/// Required to serialize [`NoteCommitmentTree`]s in a format matching `zcashd`.
 ///
 /// Zebra stores Sapling note commitment trees as [`Frontier`]s while the
 /// [`z_gettreestate`][1] RPC requires [`CommitmentTree`][2]s. Implementing
@@ -615,7 +615,7 @@ impl NoteCommitmentTree {
         assert_eq!(self.to_rpc_bytes(), other.to_rpc_bytes());
     }
 
-    /// Serializes [`Self`] to a format compatible with `zcashd`'s RPCs.
+    /// Serializes [`Self`] to a format matching `zcashd`'s RPCs.
     pub fn to_rpc_bytes(&self) -> Vec<u8> {
         // Convert the tree from [`Frontier`](bridgetree::Frontier) to
         // [`CommitmentTree`](merkle_tree::CommitmentTree).

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -64,7 +64,7 @@ tracing = "0.1.39"
 hex = { version = "0.4.3", features = ["serde"] }
 serde = { version = "1.0.201", features = ["serde_derive"] }
 
-zcash_primitives = { version = "0.13.0" }
+zcash_primitives = { version = "0.14.0" }
 
 # Experimental feature getblocktemplate-rpcs
 rand = { version = "0.8.5", optional = true }

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -64,7 +64,7 @@ tracing = "0.1.39"
 hex = { version = "0.4.3", features = ["serde"] }
 serde = { version = "1.0.202", features = ["serde_derive"] }
 
-zcash_primitives = { version = "0.14.0" }
+zcash_primitives = { version = "0.13.0" }
 
 # Experimental feature getblocktemplate-rpcs
 rand = { version = "0.8.5", optional = true }

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -64,6 +64,8 @@ tracing = "0.1.39"
 hex = { version = "0.4.3", features = ["serde"] }
 serde = { version = "1.0.201", features = ["serde_derive"] }
 
+zcash_primitives = { version = "0.13.0" }
+
 # Experimental feature getblocktemplate-rpcs
 rand = { version = "0.8.5", optional = true }
 # ECC deps used by getblocktemplate-rpcs feature

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -33,7 +33,7 @@ use zebra_state::{HashOrHeight, MinedTx, OutputIndex, OutputLocation, Transactio
 
 use crate::{
     constants::{INVALID_PARAMETERS_ERROR_CODE, MISSING_BLOCK_ERROR_CODE},
-    methods::trees::{GetSubtrees, SubtreeRpcData},
+    methods::trees::{GetSubtrees, GetTreestate, SubtreeRpcData},
     queue::Queue,
 };
 
@@ -49,8 +49,6 @@ pub mod get_block_template_rpcs;
 
 #[cfg(feature = "getblocktemplate-rpcs")]
 pub use get_block_template_rpcs::{GetBlockTemplateRpc, GetBlockTemplateRpcImpl};
-
-use self::trees::GetTreestate;
 
 #[cfg(test)]
 mod tests;

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1078,7 +1078,7 @@ where
                 match state
                     .ready()
                     .and_then(|service| {
-                        service.call(zebra_state::ReadRequest::SaplingTree(height.into()))
+                        service.call(zebra_state::ReadRequest::SaplingTree(hash.into()))
                     })
                     .await
                     .map_err(to_error)?
@@ -1095,7 +1095,7 @@ where
                 match state
                     .ready()
                     .and_then(|service| {
-                        service.call(zebra_state::ReadRequest::OrchardTree(height.into()))
+                        service.call(zebra_state::ReadRequest::OrchardTree(hash.into()))
                     })
                     .await
                     .map_err(to_error)?

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1041,8 +1041,7 @@ where
             // For consistency, this lookup must be performed first, then all the other lookups must
             // be based on the hash.
             //
-            // TODO: If this RPC is called a lot, just get the block header, rather than the whole
-            // block.
+            // TODO: If this RPC is called a lot, just get the block header, rather than the whole block.
             let block = match state
                 .ready()
                 .and_then(|service| service.call(zebra_state::ReadRequest::Block(hash_or_height)))
@@ -1066,7 +1065,7 @@ where
 
             let height = hash_or_height
                 .height_or_else(|_| block.coinbase_height())
-                .expect("block height");
+                .expect("verified blocks have a coinbase height");
 
             let time = u32::try_from(block.header.time.timestamp())
                 .expect("Timestamps of valid blocks always fit into u32.");

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -656,7 +656,6 @@ where
     // TODO:
     // - use `height_from_signed_int()` to handle negative heights
     //   (this might be better in the state request, because it needs the state height)
-    // - create a function that handles block hashes or heights, and use it in `z_get_treestate()`
     fn get_block(
         &self,
         hash_or_height: String,

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1028,11 +1028,6 @@ where
         .boxed()
     }
 
-    // TODO:
-    // - use a generic error constructor (#5548)
-    // - use `height_from_signed_int()` to handle negative heights
-    //   (this might be better in the state request, because it needs the state height)
-    // - create a function that handles block hashes or heights, and use it in `get_block()`
     fn z_get_treestate(&self, hash_or_height: String) -> BoxFuture<Result<GetTreestate>> {
         let mut state = self.state.clone();
         let network = self.network.clone();

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -22,7 +22,6 @@ use zebra_chain::{
     block::{self, Height, SerializedBlock},
     chain_tip::ChainTip,
     parameters::{ConsensusBranchId, Network, NetworkUpgrade},
-    sapling,
     serialization::{SerializationError, ZcashDeserialize},
     subtree::NoteCommitmentSubtreeIndex,
     transaction::{self, SerializedTransaction, Transaction, UnminedTx},
@@ -1176,17 +1175,17 @@ where
                 .expect("Timestamps of valid blocks always fit into u32.");
 
             let sapling = match sapling_response {
-                zebra_state::ReadResponse::SaplingTree(maybe_tree) => {
-                    sapling::tree::SerializedTree::from(maybe_tree)
+                zebra_state::ReadResponse::SaplingTree(tree) => {
+                    tree.map_or(vec![], |t| t.to_rpc_bytes())
                 }
-                _ => unreachable!("unmatched response to a sapling tree request"),
+                _ => unreachable!("unmatched response to a Sapling tree request"),
             };
 
             let orchard = match orchard_response {
                 zebra_state::ReadResponse::OrchardTree(tree) => {
                     tree.map_or(vec![], |t| t.to_rpc_bytes())
                 }
-                _ => unreachable!("unmatched response to an orchard tree request"),
+                _ => unreachable!("unmatched response to an Orchard tree request"),
             };
 
             Ok(GetTreestate::from_parts(

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -873,11 +873,7 @@ where
         self.latest_chain_tip
             .best_tip_hash()
             .map(GetBlockHash)
-            .ok_or(Error {
-                code: ErrorCode::ServerError(0),
-                message: "No blocks in state".to_string(),
-                data: None,
-            })
+            .ok_or_server_error("No blocks in state")
     }
 
     // TODO: use a generic error constructor (#5548)

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1099,14 +1099,17 @@ where
                     data: None,
                 })?;
 
+            // TODO: Return early if we're below Sapling AH.
+
             // # Concurrency
             //
-            // For consistency, this lookup must be performed first, then all the other
-            // lookups must be based on the hash.
-
+            // For consistency, this lookup must be performed first, then all the other lookups must
+            // be based on the hash.
+            //
             // Fetch the block referenced by [`hash_or_height`] from the state.
-            // TODO: If this RPC is called a lot, just get the block header,
-            // rather than the whole block.
+            //
+            // TODO: If this RPC is called a lot, just get the block header, rather than the whole
+            // block.
             let block_request = zebra_state::ReadRequest::Block(hash_or_height);
             let block_response = state
                 .ready()
@@ -1118,10 +1121,9 @@ where
                     data: None,
                 })?;
 
-            // The block hash, height, and time are all required fields in the
-            // RPC response. For this reason, we throw an error early if the
-            // state didn't return the requested block so that we prevent
-            // further state queries.
+            // The block hash, height, and time are all required fields in the RPC response. For
+            // this reason, we throw an error early if the state didn't return the requested block
+            // so that we prevent further state queries.
             let block = match block_response {
                 zebra_state::ReadResponse::Block(Some(block)) => block,
                 zebra_state::ReadResponse::Block(None) => {

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1021,6 +1021,9 @@ where
         .boxed()
     }
 
+    // TODO:
+    // - use `height_from_signed_int()` to handle negative heights
+    //   (this might be better in the state request, because it needs the state height)
     fn z_get_treestate(&self, hash_or_height: String) -> BoxFuture<Result<GetTreestate>> {
         let mut state = self.state.clone();
         let network = self.network.clone();

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -505,7 +505,7 @@ where
         let (tip_height, tip_hash) = self
             .latest_chain_tip
             .best_tip_height_and_hash()
-            .ok_or(to_error("No Chain tip available yet"))?;
+            .ok_or_server_error("No Chain tip available yet")?;
 
         // `estimated_height` field
         let current_block_time = self

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -11,7 +11,7 @@ use insta::dynamic_redaction;
 use tower::buffer::Buffer;
 
 use zebra_chain::{
-    block::Block, chain_tip::mock::MockChainTip, parameters::Network::Mainnet,
+    block::Block, chain_tip::mock::MockChainTip, orchard, parameters::Network::Mainnet,
     serialization::ZcashDeserializeInto, subtree::NoteCommitmentSubtreeData,
 };
 use zebra_state::{ReadRequest, ReadResponse, MAX_ON_DISK_HEIGHT};

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -107,40 +107,46 @@ async fn test_z_get_treestate() {
     );
 
     // Request the treestate by a hash.
-    let rsp = rpc
+    let tree_state = rpc
         .z_get_treestate(blocks[0].hash().to_string())
         .await
         .expect("genesis treestate = no treestate");
-    settings.bind(|| insta::assert_json_snapshot!("z_get_treestate_by_hash", rsp));
+    settings.bind(|| insta::assert_json_snapshot!("z_get_treestate_by_hash", tree_state));
 
     // Request the treestate by a hash for a block which is not in the state.
-    let rsp = rpc.z_get_treestate(block::Hash([0; 32]).to_string()).await;
-    settings.bind(|| insta::assert_json_snapshot!("z_get_treestate_by_non_existent_hash", rsp));
+    let tree_state = rpc.z_get_treestate(block::Hash([0; 32]).to_string()).await;
+    settings
+        .bind(|| insta::assert_json_snapshot!("z_get_treestate_by_non_existent_hash", tree_state));
 
     // Request the treestate before Sapling activation.
-    let rsp = rpc
+    let tree_state = rpc
         .z_get_treestate((SAPLING_ACTIVATION_HEIGHT - 1).to_string())
         .await
         .expect("no Sapling treestate and no Orchard treestate");
-    settings.bind(|| insta::assert_json_snapshot!("z_get_treestate_no_treestate", rsp));
+    settings.bind(|| insta::assert_json_snapshot!("z_get_treestate_no_treestate", tree_state));
 
     // Request the treestate at Sapling activation.
-    let rsp = rpc
+    let tree_state = rpc
         .z_get_treestate(SAPLING_ACTIVATION_HEIGHT.to_string())
         .await
         .expect("empty Sapling treestate and no Orchard treestate");
-    settings.bind(|| insta::assert_json_snapshot!("z_get_treestate_empty_Sapling_treestate", rsp));
+    settings.bind(|| {
+        insta::assert_json_snapshot!("z_get_treestate_empty_Sapling_treestate", tree_state)
+    });
 
     // Request the treestate for an invalid height.
-    let rsp = rpc
+    let tree_state = rpc
         .z_get_treestate(EXCESSIVE_BLOCK_HEIGHT.to_string())
         .await;
-    settings.bind(|| insta::assert_json_snapshot!("z_get_treestate_excessive_block_height", rsp));
+    settings.bind(|| {
+        insta::assert_json_snapshot!("z_get_treestate_excessive_block_height", tree_state)
+    });
 
     // Request the treestate for an unparsable hash or height.
-    let rsp = rpc.z_get_treestate("Do you even shield?".to_string()).await;
-    settings
-        .bind(|| insta::assert_json_snapshot!("z_get_treestate_unparsable_hash_or_height", rsp));
+    let tree_state = rpc.z_get_treestate("Do you even shield?".to_string()).await;
+    settings.bind(|| {
+        insta::assert_json_snapshot!("z_get_treestate_unparsable_hash_or_height", tree_state)
+    });
 
     // TODO:
     // 1. Request a non-empty Sapling treestate.

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -107,45 +107,44 @@ async fn test_z_get_treestate() {
     );
 
     // Request the treestate by a hash.
-    let tree_state = rpc
+    let treestate = rpc
         .z_get_treestate(blocks[0].hash().to_string())
         .await
         .expect("genesis treestate = no treestate");
-    settings.bind(|| insta::assert_json_snapshot!("z_get_treestate_by_hash", tree_state));
+    settings.bind(|| insta::assert_json_snapshot!("z_get_treestate_by_hash", treestate));
 
     // Request the treestate by a hash for a block which is not in the state.
-    let tree_state = rpc.z_get_treestate(block::Hash([0; 32]).to_string()).await;
+    let treestate = rpc.z_get_treestate(block::Hash([0; 32]).to_string()).await;
     settings
-        .bind(|| insta::assert_json_snapshot!("z_get_treestate_by_non_existent_hash", tree_state));
+        .bind(|| insta::assert_json_snapshot!("z_get_treestate_by_non_existent_hash", treestate));
 
     // Request the treestate before Sapling activation.
-    let tree_state = rpc
+    let treestate = rpc
         .z_get_treestate((SAPLING_ACTIVATION_HEIGHT - 1).to_string())
         .await
         .expect("no Sapling treestate and no Orchard treestate");
-    settings.bind(|| insta::assert_json_snapshot!("z_get_treestate_no_treestate", tree_state));
+    settings.bind(|| insta::assert_json_snapshot!("z_get_treestate_no_treestate", treestate));
 
     // Request the treestate at Sapling activation.
-    let tree_state = rpc
+    let treestate = rpc
         .z_get_treestate(SAPLING_ACTIVATION_HEIGHT.to_string())
         .await
         .expect("empty Sapling treestate and no Orchard treestate");
     settings.bind(|| {
-        insta::assert_json_snapshot!("z_get_treestate_empty_Sapling_treestate", tree_state)
+        insta::assert_json_snapshot!("z_get_treestate_empty_Sapling_treestate", treestate)
     });
 
     // Request the treestate for an invalid height.
-    let tree_state = rpc
+    let treestate = rpc
         .z_get_treestate(EXCESSIVE_BLOCK_HEIGHT.to_string())
         .await;
-    settings.bind(|| {
-        insta::assert_json_snapshot!("z_get_treestate_excessive_block_height", tree_state)
-    });
+    settings
+        .bind(|| insta::assert_json_snapshot!("z_get_treestate_excessive_block_height", treestate));
 
     // Request the treestate for an unparsable hash or height.
-    let tree_state = rpc.z_get_treestate("Do you even shield?".to_string()).await;
+    let treestate = rpc.z_get_treestate("Do you even shield?".to_string()).await;
     settings.bind(|| {
-        insta::assert_json_snapshot!("z_get_treestate_unparsable_hash_or_height", tree_state)
+        insta::assert_json_snapshot!("z_get_treestate_unparsable_hash_or_height", treestate)
     });
 
     // TODO:

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -11,7 +11,7 @@ use insta::dynamic_redaction;
 use tower::buffer::Buffer;
 
 use zebra_chain::{
-    block::Block, chain_tip::mock::MockChainTip, orchard, parameters::Network::Mainnet,
+    block::Block, chain_tip::mock::MockChainTip, orchard, parameters::Network::Mainnet, sapling,
     serialization::ZcashDeserializeInto, subtree::NoteCommitmentSubtreeData,
 };
 use zebra_state::{ReadRequest, ReadResponse, MAX_ON_DISK_HEIGHT};

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -11,9 +11,18 @@ use insta::dynamic_redaction;
 use tower::buffer::Buffer;
 
 use zebra_chain::{
-    block::Block, chain_tip::mock::MockChainTip, orchard, parameters::Network::Mainnet, sapling,
-    serialization::ZcashDeserializeInto, subtree::NoteCommitmentSubtreeData,
+    block::Block,
+    chain_tip::mock::MockChainTip,
+    orchard,
+    parameters::{
+        testnet::{ConfiguredActivationHeights, Parameters},
+        Network::Mainnet,
+    },
+    sapling,
+    serialization::ZcashDeserializeInto,
+    subtree::NoteCommitmentSubtreeData,
 };
+use zebra_node_services::BoxError;
 use zebra_state::{ReadRequest, ReadResponse, MAX_ON_DISK_HEIGHT};
 use zebra_test::mock_service::MockService;
 
@@ -38,6 +47,105 @@ async fn test_rpc_response_data() {
         test_mocked_rpc_response_data_for_network(&Mainnet),
         test_mocked_rpc_response_data_for_network(&default_testnet),
     );
+}
+
+/// Checks the output of the [`z_get_treestate`] RPC.
+///
+/// TODO:
+/// 1. Check a non-empty Sapling treestate.
+/// 2. Check an empty Orchard treestate at NU5 activation height.
+/// 3. Check a non-empty Orchard treestate.
+///
+/// To implement the todos above, we need to:
+///
+/// 1. Have a block containing Sapling note commitmnets in the state.
+/// 2. Activate NU5 at a height for which we have a block in the state.
+/// 3. Have a block containing Orchard note commitments in the state.
+#[tokio::test]
+async fn test_z_get_treestate() {
+    let _init_guard = zebra_test::init();
+    const SAPLING_ACTIVATION_HEIGHT: u32 = 2;
+
+    let testnet = Parameters::build()
+        .with_activation_heights(ConfiguredActivationHeights {
+            sapling: Some(SAPLING_ACTIVATION_HEIGHT),
+            // We need to set the NU5 activation height higher than the height of the last block for
+            // this test because we currently have only the first 10 blocks from the public Testnet,
+            // none of which are compatible with NU5 due to the following consensus rule:
+            //
+            // > [NU5 onward] hashBlockCommitments MUST be set to the value of
+            // > hashBlockCommitments for this block, as specified in [ZIP-244].
+            //
+            // Activating NU5 at a lower height and using the 10 blocks causes a failure in
+            // [`zebra_state::populated_state`].
+            nu5: Some(10),
+            ..Default::default()
+        })
+        .with_network_name("custom_testnet")
+        .to_network();
+
+    // Initiate the snapshots of the RPC responses.
+    let mut settings = insta::Settings::clone_current();
+    settings.set_snapshot_suffix(network_string(&testnet).to_string());
+
+    let blocks: Vec<_> = testnet
+        .blockchain_iter()
+        .map(|(_, block_bytes)| block_bytes.zcash_deserialize_into().unwrap())
+        .collect();
+
+    let (_, state, tip, _) = zebra_state::populated_state(blocks.clone(), &testnet).await;
+
+    let (rpc, _) = RpcImpl::new(
+        "",
+        "",
+        testnet,
+        false,
+        true,
+        Buffer::new(MockService::build().for_unit_tests::<_, _, BoxError>(), 1),
+        state,
+        tip,
+    );
+
+    // Request the treestate by a hash.
+    let rsp = rpc
+        .z_get_treestate(blocks[0].hash().to_string())
+        .await
+        .expect("genesis treestate = no treestate");
+    settings.bind(|| insta::assert_json_snapshot!("z_get_treestate_by_hash", rsp));
+
+    // Request the treestate by a hash for a block which is not in the state.
+    let rsp = rpc.z_get_treestate(block::Hash([0; 32]).to_string()).await;
+    settings.bind(|| insta::assert_json_snapshot!("z_get_treestate_by_non_existent_hash", rsp));
+
+    // Request the treestate before Sapling activation.
+    let rsp = rpc
+        .z_get_treestate((SAPLING_ACTIVATION_HEIGHT - 1).to_string())
+        .await
+        .expect("no Sapling treestate and no Orchard treestate");
+    settings.bind(|| insta::assert_json_snapshot!("z_get_treestate_no_treestate", rsp));
+
+    // Request the treestate at Sapling activation.
+    let rsp = rpc
+        .z_get_treestate(SAPLING_ACTIVATION_HEIGHT.to_string())
+        .await
+        .expect("empty Sapling treestate and no Orchard treestate");
+    settings.bind(|| insta::assert_json_snapshot!("z_get_treestate_empty_Sapling_treestate", rsp));
+
+    // Request the treestate for an invalid height.
+    let rsp = rpc
+        .z_get_treestate(EXCESSIVE_BLOCK_HEIGHT.to_string())
+        .await;
+    settings.bind(|| insta::assert_json_snapshot!("z_get_treestate_excessive_block_height", rsp));
+
+    // Request the treestate for an unparsable hash or height.
+    let rsp = rpc.z_get_treestate("Do you even shield?".to_string()).await;
+    settings
+        .bind(|| insta::assert_json_snapshot!("z_get_treestate_unparsable_hash_or_height", rsp));
+
+    // TODO:
+    // 1. Request a non-empty Sapling treestate.
+    // 2. Request an empty Orchard treestate at an NU5 activation height.
+    // 3. Request a non-empty Orchard treestate.
 }
 
 async fn test_rpc_response_data_for_network(network: &Network) {
@@ -240,18 +348,6 @@ async fn test_rpc_response_data_for_network(network: &Network) {
     let get_raw_mempool = response.expect("We should have a GetRawTransaction struct");
 
     snapshot_rpc_getrawmempool(get_raw_mempool, &settings);
-
-    // `z_gettreestate`
-    let tree_state = rpc
-        .z_get_treestate(BLOCK_HEIGHT.to_string())
-        .await
-        .expect("We should have a GetTreestate struct");
-    snapshot_rpc_z_gettreestate_valid(tree_state, &settings);
-
-    let tree_state = rpc
-        .z_get_treestate(EXCESSIVE_BLOCK_HEIGHT.to_string())
-        .await;
-    snapshot_rpc_z_gettreestate_invalid("excessive_height", tree_state, &settings);
 
     // `getrawtransaction` verbosity=0
     //
@@ -499,22 +595,6 @@ fn snapshot_rpc_getbestblockhash(tip_hash: GetBlockHash, settings: &insta::Setti
 /// Snapshot `getrawmempool` response, using `cargo insta` and JSON serialization.
 fn snapshot_rpc_getrawmempool(raw_mempool: Vec<String>, settings: &insta::Settings) {
     settings.bind(|| insta::assert_json_snapshot!("get_raw_mempool", raw_mempool));
-}
-
-/// Snapshot a valid `z_gettreestate` response, using `cargo insta` and JSON serialization.
-fn snapshot_rpc_z_gettreestate_valid(tree_state: GetTreestate, settings: &insta::Settings) {
-    settings.bind(|| insta::assert_json_snapshot!(format!("z_get_treestate_valid"), tree_state));
-}
-
-/// Snapshot an invalid `z_gettreestate` response, using `cargo insta` and JSON serialization.
-fn snapshot_rpc_z_gettreestate_invalid(
-    variant: &'static str,
-    tree_state: Result<GetTreestate>,
-    settings: &insta::Settings,
-) {
-    settings.bind(|| {
-        insta::assert_json_snapshot!(format!("z_get_treestate_invalid_{variant}"), tree_state)
-    });
 }
 
 /// Snapshot `getrawtransaction` response, using `cargo insta` and JSON serialization.

--- a/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_by_hash@custom_testnet.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_by_hash@custom_testnet.snap
@@ -1,6 +1,6 @@
 ---
 source: zebra-rpc/src/methods/tests/snapshot.rs
-expression: rsp
+expression: treestate
 ---
 {
   "hash": "05a60a92d99d85997cce3b87616c089f6124d7342af37106edc76126334a2c38",

--- a/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_by_hash@custom_testnet.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_by_hash@custom_testnet.snap
@@ -1,0 +1,9 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+expression: rsp
+---
+{
+  "hash": "05a60a92d99d85997cce3b87616c089f6124d7342af37106edc76126334a2c38",
+  "height": 0,
+  "time": 1477648033
+}

--- a/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_by_non_existent_hash@custom_testnet.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_by_non_existent_hash@custom_testnet.snap
@@ -1,6 +1,6 @@
 ---
 source: zebra-rpc/src/methods/tests/snapshot.rs
-expression: tree_state
+expression: rsp
 ---
 {
   "Err": {

--- a/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_by_non_existent_hash@custom_testnet.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_by_non_existent_hash@custom_testnet.snap
@@ -1,6 +1,6 @@
 ---
 source: zebra-rpc/src/methods/tests/snapshot.rs
-expression: rsp
+expression: treestate
 ---
 {
   "Err": {

--- a/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_empty_Sapling_treestate@custom_testnet.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_empty_Sapling_treestate@custom_testnet.snap
@@ -1,0 +1,14 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+expression: rsp
+---
+{
+  "hash": "00f1a49e54553ac3ef735f2eb1d8247c9a87c22a47dbd7823ae70adcd6c21a18",
+  "height": 2,
+  "time": 1477676169,
+  "sapling": {
+    "commitments": {
+      "finalState": "000000"
+    }
+  }
+}

--- a/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_empty_Sapling_treestate@custom_testnet.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_empty_Sapling_treestate@custom_testnet.snap
@@ -1,6 +1,6 @@
 ---
 source: zebra-rpc/src/methods/tests/snapshot.rs
-expression: rsp
+expression: treestate
 ---
 {
   "hash": "00f1a49e54553ac3ef735f2eb1d8247c9a87c22a47dbd7823ae70adcd6c21a18",

--- a/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_excessive_block_height@custom_testnet.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_excessive_block_height@custom_testnet.snap
@@ -1,6 +1,6 @@
 ---
 source: zebra-rpc/src/methods/tests/snapshot.rs
-expression: tree_state
+expression: rsp
 ---
 {
   "Err": {

--- a/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_excessive_block_height@custom_testnet.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_excessive_block_height@custom_testnet.snap
@@ -1,6 +1,6 @@
 ---
 source: zebra-rpc/src/methods/tests/snapshot.rs
-expression: rsp
+expression: treestate
 ---
 {
   "Err": {

--- a/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_no_treestate@custom_testnet.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_no_treestate@custom_testnet.snap
@@ -1,6 +1,6 @@
 ---
 source: zebra-rpc/src/methods/tests/snapshot.rs
-expression: tree_state
+expression: rsp
 ---
 {
   "hash": "025579869bcf52a989337342f5f57a84f3a28b968f7d6a8307902b065a668d23",

--- a/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_no_treestate@custom_testnet.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_no_treestate@custom_testnet.snap
@@ -1,6 +1,6 @@
 ---
 source: zebra-rpc/src/methods/tests/snapshot.rs
-expression: rsp
+expression: treestate
 ---
 {
   "hash": "025579869bcf52a989337342f5f57a84f3a28b968f7d6a8307902b065a668d23",

--- a/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_unparsable_hash_or_height@custom_testnet.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_unparsable_hash_or_height@custom_testnet.snap
@@ -1,0 +1,10 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+expression: rsp
+---
+{
+  "Err": {
+    "code": 0,
+    "message": "parse error: could not convert the input string to a hash or height"
+  }
+}

--- a/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_unparsable_hash_or_height@custom_testnet.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_unparsable_hash_or_height@custom_testnet.snap
@@ -1,6 +1,6 @@
 ---
 source: zebra-rpc/src/methods/tests/snapshot.rs
-expression: rsp
+expression: treestate
 ---
 {
   "Err": {

--- a/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_valid@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_valid@mainnet_10.snap
@@ -1,9 +1,0 @@
----
-source: zebra-rpc/src/methods/tests/snapshot.rs
-expression: tree_state
----
-{
-  "hash": "0007bc227e1c57a4a70e237cad00e7b7ce565155ab49166bc57397a26d339283",
-  "height": 1,
-  "time": 1477671596
-}

--- a/zebra-rpc/src/methods/trees.rs
+++ b/zebra-rpc/src/methods/trees.rs
@@ -52,10 +52,12 @@ pub struct GetTreestate {
     time: u32,
 
     /// A treestate containing a Sapling note commitment tree, hex-encoded.
-    sapling: Treestate<Vec<u8>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sapling: Option<Treestate<Vec<u8>>>,
 
     /// A treestate containing an Orchard note commitment tree, hex-encoded.
-    orchard: Treestate<Vec<u8>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    orchard: Option<Treestate<Vec<u8>>>,
 }
 
 impl GetTreestate {
@@ -64,43 +66,22 @@ impl GetTreestate {
         hash: Hash,
         height: Height,
         time: u32,
-        sapling: Vec<u8>,
-        orchard: Vec<u8>,
+        sapling: Option<Vec<u8>>,
+        orchard: Option<Vec<u8>>,
     ) -> Self {
+        let sapling = sapling.map(|tree| Treestate {
+            commitments: Commitments { final_state: tree },
+        });
+        let orchard = orchard.map(|tree| Treestate {
+            commitments: Commitments { final_state: tree },
+        });
+
         Self {
             hash,
             height,
             time,
-            sapling: Treestate {
-                commitments: Commitments {
-                    final_state: sapling,
-                },
-            },
-            orchard: Treestate {
-                commitments: Commitments {
-                    final_state: orchard,
-                },
-            },
-        }
-    }
-}
-
-impl Default for GetTreestate {
-    fn default() -> Self {
-        GetTreestate {
-            hash: Hash([0; 32]),
-            height: Height(0),
-            time: 0,
-            sapling: Treestate {
-                commitments: Commitments {
-                    final_state: vec![],
-                },
-            },
-            orchard: Treestate {
-                commitments: Commitments {
-                    final_state: vec![],
-                },
-            },
+            sapling,
+            orchard,
         }
     }
 }

--- a/zebra-rpc/src/methods/trees.rs
+++ b/zebra-rpc/src/methods/trees.rs
@@ -34,8 +34,19 @@ pub struct GetSubtrees {
 
 /// Response to a `z_gettreestate` RPC request.
 ///
-/// Contains the hex-encoded Sapling & Orchard note commitment trees, and their corresponding
+/// Contains hex-encoded Sapling & Orchard note commitment trees and their corresponding
 /// [`struct@Hash`], [`Height`], and block time.
+///
+/// The format of the serialized trees represents `CommitmentTree`s from the crate
+/// `incrementalmerkletree` and not `Frontier`s from the same crate, even though `zebrad`'s
+/// `NoteCommitmentTree`s are implemented using `Frontier`s. Zebra follows the former format to stay
+/// consistent with `zcashd`'s RPCs.
+///
+/// The formats are semantically equivalent. The difference is that in `Frontier`s, the vector of
+/// ommers is dense (we know where the gaps are from the position of the leaf in the overall tree);
+/// whereas in `CommitmentTree`, the vector of ommers is sparse with [`None`] values in the gaps.
+///
+/// The dense format might be used in future RPCs.
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
 pub struct GetTreestate {
     /// The block hash corresponding to the treestate, hex-encoded.

--- a/zebra-rpc/src/methods/trees.rs
+++ b/zebra-rpc/src/methods/trees.rs
@@ -3,7 +3,6 @@
 use zebra_chain::{
     block::Hash,
     block::Height,
-    sapling,
     subtree::{NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex},
 };
 
@@ -53,8 +52,7 @@ pub struct GetTreestate {
     time: u32,
 
     /// A treestate containing a Sapling note commitment tree, hex-encoded.
-    #[serde(skip_serializing_if = "Treestate::is_empty")]
-    sapling: Treestate<sapling::tree::SerializedTree>,
+    sapling: Treestate<Vec<u8>>,
 
     /// A treestate containing an Orchard note commitment tree, hex-encoded.
     orchard: Treestate<Vec<u8>>,
@@ -66,7 +64,7 @@ impl GetTreestate {
         hash: Hash,
         height: Height,
         time: u32,
-        sapling: sapling::tree::SerializedTree,
+        sapling: Vec<u8>,
         orchard: Vec<u8>,
     ) -> Self {
         Self {
@@ -95,7 +93,7 @@ impl Default for GetTreestate {
             time: 0,
             sapling: Treestate {
                 commitments: Commitments {
-                    final_state: sapling::tree::SerializedTree::default(),
+                    final_state: vec![],
                 },
             },
             orchard: Treestate {
@@ -129,11 +127,4 @@ struct Commitments<Tree: AsRef<[u8]>> {
     #[serde(with = "hex")]
     #[serde(rename = "finalState")]
     final_state: Tree,
-}
-
-impl<Tree: AsRef<[u8]>> Treestate<Tree> {
-    /// Returns `true` if there's no serialized commitment tree.
-    fn is_empty(&self) -> bool {
-        self.commitments.final_state.as_ref().is_empty()
-    }
 }

--- a/zebra-rpc/src/methods/trees.rs
+++ b/zebra-rpc/src/methods/trees.rs
@@ -36,7 +36,7 @@ pub struct GetSubtrees {
 ///
 /// Contains the hex-encoded Sapling & Orchard note commitment trees, and their
 /// corresponding [`block::Hash`], [`Height`], and block time.
-#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, Default)]
 pub struct GetTreestate {
     /// The block hash corresponding to the treestate, hex-encoded.
     #[serde(with = "hex")]

--- a/zebra-rpc/src/methods/trees.rs
+++ b/zebra-rpc/src/methods/trees.rs
@@ -36,7 +36,7 @@ pub struct GetSubtrees {
 ///
 /// Contains the hex-encoded Sapling & Orchard note commitment trees, and their corresponding
 /// [`struct@Hash`], [`Height`], and block time.
-#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, Default)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
 pub struct GetTreestate {
     /// The block hash corresponding to the treestate, hex-encoded.
     #[serde(with = "hex")]
@@ -82,6 +82,18 @@ impl GetTreestate {
             time,
             sapling,
             orchard,
+        }
+    }
+}
+
+impl Default for GetTreestate {
+    fn default() -> Self {
+        Self {
+            hash: Hash([0; 32]),
+            height: Height::MIN,
+            time: Default::default(),
+            sapling: Default::default(),
+            orchard: Default::default(),
         }
     }
 }

--- a/zebra-rpc/src/methods/trees.rs
+++ b/zebra-rpc/src/methods/trees.rs
@@ -34,8 +34,8 @@ pub struct GetSubtrees {
 
 /// Response to a `z_gettreestate` RPC request.
 ///
-/// Contains the hex-encoded Sapling & Orchard note commitment trees, and their
-/// corresponding [`block::Hash`], [`Height`], and block time.
+/// Contains the hex-encoded Sapling & Orchard note commitment trees, and their corresponding
+/// [`struct@Hash`], [`Height`], and block time.
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, Default)]
 pub struct GetTreestate {
     /// The block hash corresponding to the treestate, hex-encoded.

--- a/zebra-rpc/src/methods/trees.rs
+++ b/zebra-rpc/src/methods/trees.rs
@@ -1,8 +1,11 @@
 //! Types and functions for note commitment tree RPCs.
-//
-// TODO: move the *Tree and *Commitment types into this module.
 
-use zebra_chain::subtree::{NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex};
+use zebra_chain::{
+    block::Hash,
+    block::Height,
+    sapling,
+    subtree::{NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex},
+};
 
 /// A subtree data type that can hold Sapling or Orchard subtree roots.
 pub type SubtreeRpcData = NoteCommitmentSubtreeData<String>;
@@ -28,4 +31,109 @@ pub struct GetSubtrees {
     // TODO: is this needed?
     //#[serde(skip_serializing_if = "Vec::is_empty")]
     pub subtrees: Vec<SubtreeRpcData>,
+}
+
+/// Response to a `z_gettreestate` RPC request.
+///
+/// Contains the hex-encoded Sapling & Orchard note commitment trees, and their
+/// corresponding [`block::Hash`], [`Height`], and block time.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+pub struct GetTreestate {
+    /// The block hash corresponding to the treestate, hex-encoded.
+    #[serde(with = "hex")]
+    hash: Hash,
+
+    /// The block height corresponding to the treestate, numeric.
+    height: Height,
+
+    /// Unix time when the block corresponding to the treestate was mined,
+    /// numeric.
+    ///
+    /// UTC seconds since the Unix 1970-01-01 epoch.
+    time: u32,
+
+    /// A treestate containing a Sapling note commitment tree, hex-encoded.
+    #[serde(skip_serializing_if = "Treestate::is_empty")]
+    sapling: Treestate<sapling::tree::SerializedTree>,
+
+    /// A treestate containing an Orchard note commitment tree, hex-encoded.
+    orchard: Treestate<Vec<u8>>,
+}
+
+impl GetTreestate {
+    /// Constructs [`GetTreestate`] from its constituent parts.
+    pub fn from_parts(
+        hash: Hash,
+        height: Height,
+        time: u32,
+        sapling: sapling::tree::SerializedTree,
+        orchard: Vec<u8>,
+    ) -> Self {
+        Self {
+            hash,
+            height,
+            time,
+            sapling: Treestate {
+                commitments: Commitments {
+                    final_state: sapling,
+                },
+            },
+            orchard: Treestate {
+                commitments: Commitments {
+                    final_state: orchard,
+                },
+            },
+        }
+    }
+}
+
+impl Default for GetTreestate {
+    fn default() -> Self {
+        GetTreestate {
+            hash: Hash([0; 32]),
+            height: Height(0),
+            time: 0,
+            sapling: Treestate {
+                commitments: Commitments {
+                    final_state: sapling::tree::SerializedTree::default(),
+                },
+            },
+            orchard: Treestate {
+                commitments: Commitments {
+                    final_state: vec![],
+                },
+            },
+        }
+    }
+}
+
+/// A treestate that is included in the [`z_gettreestate`][1] RPC response.
+///
+/// [1]: https://zcash.github.io/rpc/z_gettreestate.html
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+struct Treestate<Tree: AsRef<[u8]>> {
+    /// Contains an Orchard or Sapling serialized note commitment tree,
+    /// hex-encoded.
+    commitments: Commitments<Tree>,
+}
+
+/// A wrapper that contains either an Orchard or Sapling note commitment tree.
+///
+/// Note that in the original [`z_gettreestate`][1] RPC, [`Commitments`] also
+/// contains the field `finalRoot`. Zebra does *not* use this field.
+///
+/// [1]: https://zcash.github.io/rpc/z_gettreestate.html
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+struct Commitments<Tree: AsRef<[u8]>> {
+    /// Orchard or Sapling serialized note commitment tree, hex-encoded.
+    #[serde(with = "hex")]
+    #[serde(rename = "finalState")]
+    final_state: Tree,
+}
+
+impl<Tree: AsRef<[u8]>> Treestate<Tree> {
+    /// Returns `true` if there's no serialized commitment tree.
+    fn is_empty(&self) -> bool {
+        self.commitments.final_state.as_ref().is_empty()
+    }
 }

--- a/zebra-utils/src/bin/openapi-generator/main.rs
+++ b/zebra-utils/src/bin/openapi-generator/main.rs
@@ -6,7 +6,7 @@ use quote::ToTokens;
 use serde::Serialize;
 use syn::LitStr;
 
-use zebra_rpc::methods::*;
+use zebra_rpc::methods::{trees::GetTreestate, *};
 
 // The API server
 const SERVER: &str = "http://localhost:8232";


### PR DESCRIPTION
## Motivation

Close #8471.

The bug described in #8471 is caused by an incorrect serialization of empty note commitment trees for RPCs. Zebra serializes such trees as the empty string, but `zcashd` serializes them as `000000`. This bug is related only to the `z_get_treestate` RPC. The state contains the right trees and uses a different serialization format.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

## Solution

- Remove the old RPC serialization code.
- Use an upstream code to serialize the trees for RPCs.

  Note that the serialization of non-empty Sapling treestates now differs between `zebrad` and `zcashd`. We can see this in the results of the manual tests below. The difference is that `zebrad`'s non-empty Sapling treestates contain trailing zeros, whereas `zcashd`'s ones don't. Both serializations deserialize to the same frontier and use the sparse format, which permits the omission or inclusion of the trailing zeros. See https://discord.com/channels/809218587167293450/809251012610752513/1240372877358792755 for more details.
- Cleanups.



## Testing

### Snapshots

- Remove old test snapshots and add new ones.

<details>
<summary>

### Results of manual tests
</summary>

The results below compare the responses from `z_gettreestate` to `zcashd`. Note that `zebrad` doesn't provide the `finalState` object, and when an object is empty, `zebrad` skips its serialization.

#### Sapling

`zcash-cli z_gettreestate 419199 | jq`

`zebrad`:

```json
{
  "hash": "00000000025c3b19eb08bbc0d74c0c5e798fcd58b38ecdcdda6b83e5c5945295",
  "height": 419199,
  "time": 1540779316
}
```

`zcashd`:
```json
{
  "hash": "00000000025c3b19eb08bbc0d74c0c5e798fcd58b38ecdcdda6b83e5c5945295",
  "height": 419199,
  "time": 1540779316,
  "sapling": {
    "commitments": {
      "finalRoot": "0000000000000000000000000000000000000000000000000000000000000000"
    }
  },
  "orchard": {
    "commitments": {
      "finalRoot": "0000000000000000000000000000000000000000000000000000000000000000"
    }
  }
}
```

`zcash-cli z_gettreestate 419200 | jq`

`zebrad`:
```json
{
  "hash": "00000000025a57200d898ac7f21e26bf29028bbe96ec46e05b2c17cc9db9e4f3",
  "height": 419200,
  "time": 1540779337,
  "sapling": {
    "commitments": {
      "finalState": "000000"
    }
  }
}
```

`zcashd`:
```json
{
  "hash": "00000000025a57200d898ac7f21e26bf29028bbe96ec46e05b2c17cc9db9e4f3",
  "height": 419200,
  "time": 1540779337,
  "sapling": {
    "commitments": {
      "finalRoot": "3e49b5f954aa9d3545bc6c37744661eea48d7c34e3000d82b7f0010c30f4c2fb",
      "finalState": "000000"
    }
  },
  "orchard": {
    "commitments": {
      "finalRoot": "0000000000000000000000000000000000000000000000000000000000000000"
    }
  }
}
```

`zcash-cli z_gettreestate 419201 | jq`

`zebrad`:
```json
{
  "hash": "00000000014d117faa2ea701b24261d364a6c6a62e5bc4bc27335eb9b3c1e2a8",
  "height": 419201,
  "time": 1540779438,
  "sapling": {
    "commitments": {
      "finalState": "019eb30778ddeea84c72e69e07a1689f3c8def3dc0a1939f0edcbe47279069d931001f000150715810d52caf35471d10feb487213fbd95ff209122225b7b65d27a7fb1a44d0000000000000000000000000000000000000000000000000000000000"
    }
  }
}
```

`zcashd`:
```json
{
  "hash": "00000000014d117faa2ea701b24261d364a6c6a62e5bc4bc27335eb9b3c1e2a8",
  "height": 419201,
  "time": 1540779438,
  "sapling": {
    "commitments": {
      "finalRoot": "638d7e5ba37ab7921c51a4f3ae1b32d71c605a0ed9be7477928111a637f7421b",
      "finalState": "019eb30778ddeea84c72e69e07a1689f3c8def3dc0a1939f0edcbe47279069d9310002000150715810d52caf35471d10feb487213fbd95ff209122225b7b65d27a7fb1a44d"
    }
  },
  "orchard": {
    "commitments": {
      "finalRoot": "0000000000000000000000000000000000000000000000000000000000000000"
    }
  }
}
```

`zcash-cli z_gettreestate 1687104 | jq`

`zebrad`:
```json
{
  "hash": "0000000000d723156d9b65ffcf4984da7a19675ed7e2f06d9e5d5188af087bf8",
  "height": 1687104,
  "time": 1654019405,
  "sapling": {
    "commitments": {
      "finalState": "01b44a49543697efcf8c8f31759426c7baaea332c188a5ad2cbe0f7cdc35f5ad3f001f013cef92c19a6d24ba2e4454d018f7c7d6a64e0d7dc428a7a463617c726459230f01e8fe3507e2380ce4b17febf0bd5692883b5eff1cf9336c94fbec2153ece9e752014985ea98e1e8612a883112e794599176c1d84e5eccf531aecf7ecb0630a3ed1d01c1eacd8226ff8865f6c2495cb6c69f3e2fb71f142264dd123cad696ac4e3d35f015addd80e5152fbd8eeb49177dd46a6626b1629d4ed31a833155ca3b6cf3cb54101279f7afb4866502d697c5cbbd4a2b86bfb981dbe3c5ef29538ad1234159d3673010284d6898ca14c204611c5549bd410e6524053af5a166a6c5837653f46c3074501ae61a98ec05d976a41e46f0b7ae8dee5bda5ab490eea7b701153511a15be42590198c748a5e9516711db607e282f08013ba00b3e77bc66ec28702ca17893a5154b000139113a1e0f54d93c6180f2df7d16afbf7c320f6c7665cb10e1fc309878b0d716019a0214bcb1fd7a70e53166101992147512f3debb0fdce45ac625fffd64771010000134136b9f1f00c2e9d16dc7358ef920862511c8fc42fb7074cbc9016d8d4e8b4c015eddc191a81221b7900bbdcd8610e5df595e3cdc7fd5b3432e3825206ae35b05017eda713cd733ccc555123788692a1876f9ca292b0aa2ddf3f45ed2b47f027340000000015ec9e9b1295908beed437df4126032ca57ada8e3ebb67067cd22a73c79a840090000000000000000000000"
    }
  },
  "orchard": {
    "commitments": {
      "finalState": "000000"
    }
  }
}
```

`zcashd`:
```json
{
  "hash": "0000000000d723156d9b65ffcf4984da7a19675ed7e2f06d9e5d5188af087bf8",
  "height": 1687104,
  "time": 1654019405,
  "sapling": {
    "commitments": {
      "finalRoot": "4c0455466849dafedc0aab00f842f5ce4ef7dc1e795995d460fd072ce20f609f",
      "finalState": "01b44a49543697efcf8c8f31759426c7baaea332c188a5ad2cbe0f7cdc35f5ad3f0014013cef92c19a6d24ba2e4454d018f7c7d6a64e0d7dc428a7a463617c726459230f01e8fe3507e2380ce4b17febf0bd5692883b5eff1cf9336c94fbec2153ece9e752014985ea98e1e8612a883112e794599176c1d84e5eccf531aecf7ecb0630a3ed1d01c1eacd8226ff8865f6c2495cb6c69f3e2fb71f142264dd123cad696ac4e3d35f015addd80e5152fbd8eeb49177dd46a6626b1629d4ed31a833155ca3b6cf3cb54101279f7afb4866502d697c5cbbd4a2b86bfb981dbe3c5ef29538ad1234159d3673010284d6898ca14c204611c5549bd410e6524053af5a166a6c5837653f46c3074501ae61a98ec05d976a41e46f0b7ae8dee5bda5ab490eea7b701153511a15be42590198c748a5e9516711db607e282f08013ba00b3e77bc66ec28702ca17893a5154b000139113a1e0f54d93c6180f2df7d16afbf7c320f6c7665cb10e1fc309878b0d716019a0214bcb1fd7a70e53166101992147512f3debb0fdce45ac625fffd64771010000134136b9f1f00c2e9d16dc7358ef920862511c8fc42fb7074cbc9016d8d4e8b4c015eddc191a81221b7900bbdcd8610e5df595e3cdc7fd5b3432e3825206ae35b05017eda713cd733ccc555123788692a1876f9ca292b0aa2ddf3f45ed2b47f027340000000015ec9e9b1295908beed437df4126032ca57ada8e3ebb67067cd22a73c79a84009"
    }
  },
  "orchard": {
    "commitments": {
      "finalRoot": "ae2935f1dfd8a24aed7c70df7de3a668eb7a49b1319880dde2bbd9031ae5d82f",
      "finalState": "000000"
    }
  }
}
```

`zcash-cli z_gettreestate 1687107 | jq`

`zebrad`:
```json
{
  "hash": "00000000005a5e6f54c494b6317f3e800ce89a716584e62dcb35c2b3ace4b498",
  "height": 1687107,
  "time": 1654019794,
  "sapling": {
    "commitments": {
      "finalState": "01548d76c9708e1ea19cbfca3a0da6e368210dbe36ed022f32641416070760e750001f01a122025ebf64510a565e95a48604ff431c5cde6cb8caf9b7234066fcd1325c2a01162d1c2490d6bac0c7622d7a6aa214959367513dc2c45711a0d386bb3aafd261000000000000000138ebc51a133a60cdd2c02bdef27df1f1aa68882e0550a948fd7fb6f6b71e07210139113a1e0f54d93c6180f2df7d16afbf7c320f6c7665cb10e1fc309878b0d716019a0214bcb1fd7a70e53166101992147512f3debb0fdce45ac625fffd64771010000134136b9f1f00c2e9d16dc7358ef920862511c8fc42fb7074cbc9016d8d4e8b4c015eddc191a81221b7900bbdcd8610e5df595e3cdc7fd5b3432e3825206ae35b05017eda713cd733ccc555123788692a1876f9ca292b0aa2ddf3f45ed2b47f027340000000015ec9e9b1295908beed437df4126032ca57ada8e3ebb67067cd22a73c79a840090000000000000000000000"
    }
  },
  "orchard": {
    "commitments": {
      "finalState": "01e542b41a8a44e417521228218da39f865283ae50431c2292c36f379f6da04d2d0138fb218b939d9d6b7e906f1e68e49b4a5b9c1941fbf21c543529b19eadbcb01f1f00000000000000000000000000000000000000000000000000000000000000"
    }
  }
}
```

`zcashd`:
```json
{
  "hash": "00000000005a5e6f54c494b6317f3e800ce89a716584e62dcb35c2b3ace4b498",
  "height": 1687107,
  "time": 1654019794,
  "sapling": {
    "commitments": {
      "finalRoot": "4b013ee86a4a7b19871aa9b7a1dff0b29e0a737812c8970356c18340752957c7",
      "finalState": "01548d76c9708e1ea19cbfca3a0da6e368210dbe36ed022f32641416070760e750001401a122025ebf64510a565e95a48604ff431c5cde6cb8caf9b7234066fcd1325c2a01162d1c2490d6bac0c7622d7a6aa214959367513dc2c45711a0d386bb3aafd261000000000000000138ebc51a133a60cdd2c02bdef27df1f1aa68882e0550a948fd7fb6f6b71e07210139113a1e0f54d93c6180f2df7d16afbf7c320f6c7665cb10e1fc309878b0d716019a0214bcb1fd7a70e53166101992147512f3debb0fdce45ac625fffd64771010000134136b9f1f00c2e9d16dc7358ef920862511c8fc42fb7074cbc9016d8d4e8b4c015eddc191a81221b7900bbdcd8610e5df595e3cdc7fd5b3432e3825206ae35b05017eda713cd733ccc555123788692a1876f9ca292b0aa2ddf3f45ed2b47f027340000000015ec9e9b1295908beed437df4126032ca57ada8e3ebb67067cd22a73c79a84009"
    }
  },
  "orchard": {
    "commitments": {
      "finalRoot": "7b61fc613cea5c2c84c5e2c64d4fd4afb8c8c9d10dce9bcad49431c9cf32f131",
      "finalState": "01e542b41a8a44e417521228218da39f865283ae50431c2292c36f379f6da04d2d0138fb218b939d9d6b7e906f1e68e49b4a5b9c1941fbf21c543529b19eadbcb01f1f00000000000000000000000000000000000000000000000000000000000000"
    }
  }
}
```
</details>

### Reviewer Checklist

Check before approving the PR:
  - [x] Does the PR scope match the ticket?
  - [x] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [x] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

- #8536 