### PR TITLE
change(test): Disables several tests on Windows to avoid port conflicts

### DIFF
--- a/zebra-grpc/src/tests/snapshot.rs
+++ b/zebra-grpc/src/tests/snapshot.rs
@@ -29,6 +29,7 @@ use crate::{
 pub const ZECPAGES_SAPLING_VIEWING_KEY: &str = "zxviews1q0duytgcqqqqpqre26wkl45gvwwwd706xw608hucmvfalr759ejwf7qshjf5r9aa7323zulvz6plhttp5mltqcgs9t039cx2d09mgq05ts63n8u35hyv6h9nc9ctqqtue2u7cer2mqegunuulq2luhq3ywjcz35yyljewa4mgkgjzyfwh6fr6jd0dzd44ghk0nxdv2hnv4j5nxfwv24rwdmgllhe0p8568sgqt9ckt02v2kxf5ahtql6s0ltjpkckw8gtymxtxuu9gcr0swvz";
 
 #[tokio::test(flavor = "multi_thread")]
+#[cfg(not(target_os = "windows"))]
 async fn test_grpc_response_data() {
     let _init_guard = zebra_test::init();
 

--- a/zebra-grpc/src/tests/vectors.rs
+++ b/zebra-grpc/src/tests/vectors.rs
@@ -26,6 +26,7 @@ pub const ZECPAGES_SAPLING_VIEWING_KEY: &str = "zxviews1q0duytgcqqqqpqre26wkl45g
 
 /// Test the gRPC methods with mocked responses
 #[tokio::test(flavor = "multi_thread")]
+#[cfg(not(target_os = "windows"))]
 async fn test_grpc_methods_mocked() {
     let _init_guard = zebra_test::init();
 

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -145,6 +145,7 @@ async fn local_listener_unspecified_port_localhost_addr_v6() {
 
 /// Test that zebra-network propagates fixed localhost listener ports to the `AddressBook`.
 #[tokio::test]
+#[cfg(not(target_os = "windows"))]
 async fn local_listener_fixed_port_localhost_addr_v4() {
     let _init_guard = zebra_test::init();
 
@@ -161,6 +162,7 @@ async fn local_listener_fixed_port_localhost_addr_v4() {
 
 /// Test that zebra-network propagates fixed localhost listener ports to the `AddressBook`.
 #[tokio::test]
+#[cfg(not(target_os = "windows"))]
 async fn local_listener_fixed_port_localhost_addr_v6() {
     let _init_guard = zebra_test::init();
 

--- a/zebra-rpc/src/server/tests/vectors.rs
+++ b/zebra-rpc/src/server/tests/vectors.rs
@@ -30,6 +30,7 @@ fn rpc_server_spawn_single_thread() {
 
 /// Test that the JSON-RPC server spawns when configured with multiple threads.
 #[test]
+#[cfg(not(target_os = "windows"))]
 fn rpc_server_spawn_parallel_threads() {
     rpc_server_spawn(true)
 }

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1395,7 +1395,7 @@ fn full_sync_testnet() -> Result<()> {
     )
 }
 
-#[cfg(feature = "prometheus")]
+#[cfg(all(feature = "prometheus", not(target_os = "windows")))]
 #[tokio::test]
 async fn metrics_endpoint() -> Result<()> {
     use hyper::Client;
@@ -1451,7 +1451,7 @@ async fn metrics_endpoint() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "filter-reload")]
+#[cfg(all(feature = "filter-reload", not(target_os = "windows")))]
 #[tokio::test]
 async fn tracing_endpoint() -> Result<()> {
     use hyper::{Body, Client, Request};
@@ -1549,6 +1549,7 @@ async fn tracing_endpoint() -> Result<()> {
 /// Test that the JSON-RPC endpoint responds to a request,
 /// when configured with a single thread.
 #[tokio::test]
+#[cfg(not(target_os = "windows"))]
 async fn rpc_endpoint_single_thread() -> Result<()> {
     rpc_endpoint(false).await
 }
@@ -1556,6 +1557,7 @@ async fn rpc_endpoint_single_thread() -> Result<()> {
 /// Test that the JSON-RPC endpoint responds to a request,
 /// when configured with multiple threads.
 #[tokio::test]
+#[cfg(not(target_os = "windows"))]
 async fn rpc_endpoint_parallel_threads() -> Result<()> {
     rpc_endpoint(true).await
 }
@@ -1623,6 +1625,7 @@ async fn rpc_endpoint(parallel_cpu_threads: bool) -> Result<()> {
 ///
 /// https://zcash.github.io/rpc/getblockchaininfo.html
 #[tokio::test]
+#[cfg(not(target_os = "windows"))]
 async fn rpc_endpoint_client_content_type() -> Result<()> {
     let _init_guard = zebra_test::init();
     if zebra_test::net::zebra_skip_network_tests() {
@@ -2148,6 +2151,7 @@ fn lightwalletd_integration_test(test_type: TestType) -> Result<()> {
 /// It is expected that the first node spawned will get exclusive use of the port.
 /// The second node will panic with the Zcash listener conflict hint added in #1535.
 #[test]
+#[cfg(not(target_os = "windows"))]
 fn zebra_zcash_listener_conflict() -> Result<()> {
     let _init_guard = zebra_test::init();
 
@@ -2176,7 +2180,7 @@ fn zebra_zcash_listener_conflict() -> Result<()> {
 /// exclusive use of the port. The second node will panic with the Zcash metrics
 /// conflict hint added in #1535.
 #[test]
-#[cfg(feature = "prometheus")]
+#[cfg(all(feature = "prometheus", not(target_os = "windows")))]
 fn zebra_metrics_conflict() -> Result<()> {
     let _init_guard = zebra_test::init();
 
@@ -2205,7 +2209,7 @@ fn zebra_metrics_conflict() -> Result<()> {
 /// exclusive use of the port. The second node will panic with the Zcash tracing
 /// conflict hint added in #1535.
 #[test]
-#[cfg(feature = "filter-reload")]
+#[cfg(all(feature = "filter-reload", not(target_os = "windows")))]
 fn zebra_tracing_conflict() -> Result<()> {
     let _init_guard = zebra_test::init();
 
@@ -2944,7 +2948,7 @@ fn scan_task_starts() -> Result<()> {
 
 /// Test that the scanner gRPC server starts when the node starts.
 #[tokio::test]
-#[cfg(feature = "shielded-scan")]
+#[cfg(all(feature = "shielded-scan", not(target_os = "windows")))]
 async fn scan_rpc_server_starts() -> Result<()> {
     use zebra_grpc::scanner::{scanner_client::ScannerClient, Empty};
 


### PR DESCRIPTION
## Motivation

We want to disable these tests to reduce the likelihood of port conflicts in CI for Windows.

There may be a few more tests that use a random known port, but this should be enough for now so that CI passes more consistently while we make changes to allow for using an OS-assigned port on Windows and more reliably using an available port on other platforms.

Closes #8499.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [x] Have you added or updated tests?
  - [x] Is the documentation up to date?

##### For significant changes:
  - [x] Is there a summary in the CHANGELOG?
  - [x] Can these changes be split into multiple PRs?

_If a checkbox isn't relevant to the PR, mark it as done._

## Solution

Disables most tests that use `random_known_port()` directly or indirectly.

## Review

Anyone can review.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._

## Follow Up Work

Use OS assigned ports whenever binding a `TcpListener` and get the socket address directly from the `TcpListener`:
- Return the listen address from `open_listener()` in the peer set `init()` function and use it instead of the random known port
- Use the `address()` method on `Server` in zebra-rpc (`server_instance.address()`)
- Bind a `TcpListener` in zebra-grpc, return the address (maybe via a oneshot channel? Or by spawning a tokio task and returning the value from the init function) and replace the call to `Router.serve()` with `serve_with_incoming()`
- Use port 0 for the RPC listen addr and read the RPC socket address from the Zebra's logs when spawning `TestChild`s instead of using the config value