### PR TITLE
change(scan): Refactor scanning keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6251,6 +6251,7 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
+ "zcash_address",
  "zcash_client_backend",
  "zcash_keys",
  "zcash_note_encryption",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2143,9 +2143,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb1872810fb725b06b8c153dde9e86f3ec26747b9b60096da7a869883b549cbe"
 dependencies = [
  "either",
- "proptest",
- "rand 0.8.5",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2890,7 +2887,6 @@ dependencies = [
  "memuse",
  "nonempty",
  "pasta_curves",
- "proptest",
  "rand 0.8.5",
  "reddsa",
  "serde",
@@ -3924,7 +3920,6 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "memuse",
- "proptest",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "redjubjub",
@@ -5766,9 +5761,7 @@ dependencies = [
  "memuse",
  "nom",
  "nonempty",
- "orchard 0.8.0",
  "percent-encoding",
- "proptest",
  "prost",
  "rand_core 0.6.4",
  "rayon",
@@ -5824,8 +5817,6 @@ dependencies = [
  "group",
  "memuse",
  "nonempty",
- "orchard 0.8.0",
- "proptest",
  "rand_core 0.6.4",
  "sapling-crypto",
  "secrecy",
@@ -5910,7 +5901,6 @@ dependencies = [
  "memuse",
  "nonempty",
  "orchard 0.8.0",
- "proptest",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "redjubjub",
@@ -5956,9 +5946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f8189d4a304e8aa3aef3b75e89f3874bb0dc84b1cd623316a84e79e06cddabc"
 dependencies = [
  "document-features",
- "incrementalmerkletree",
  "memuse",
- "proptest",
 ]
 
 [[package]]

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -51,9 +51,10 @@ tower = "0.4.13"
 tracing = "0.1.39"
 futures = "0.3.30"
 
-zcash_client_backend = { version = "0.12.1", features = ["test-dependencies"] }
+zcash_client_backend = { version = "0.12.1" }
 zcash_keys = { version = "0.2.0", features = ["sapling"] }
 zcash_primitives = "0.14.0"
+zcash_address = "0.3.2"
 sapling = { package = "sapling-crypto", version = "0.1" }
 
 zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37", features = ["shielded-scan"] }

--- a/zebra-scan/src/service/scan_task/commands.rs
+++ b/zebra-scan/src/service/scan_task/commands.rs
@@ -8,12 +8,12 @@ use tokio::sync::{
     oneshot,
 };
 
-use sapling::{zip32::DiversifiableFullViewingKey, SaplingIvk};
+use sapling::zip32::DiversifiableFullViewingKey;
 use zebra_chain::{block::Height, parameters::Network};
 use zebra_node_services::scan_service::response::ScanResult;
 use zebra_state::SaplingScanningKey;
 
-use crate::scan::sapling_key_to_scan_block_keys;
+use crate::scan::sapling_key_to_dfvk;
 
 use super::ScanTask;
 
@@ -57,17 +57,11 @@ impl ScanTask {
     /// Returns newly registered keys for scanning.
     pub fn process_messages(
         cmd_receiver: &mut tokio::sync::mpsc::Receiver<ScanTaskCommand>,
-        registered_keys: &mut HashMap<
-            SaplingScanningKey,
-            (Vec<DiversifiableFullViewingKey>, Vec<SaplingIvk>),
-        >,
+        registered_keys: &mut HashMap<SaplingScanningKey, DiversifiableFullViewingKey>,
         network: &Network,
     ) -> Result<
         (
-            HashMap<
-                SaplingScanningKey,
-                (Vec<DiversifiableFullViewingKey>, Vec<SaplingIvk>, Height),
-            >,
+            HashMap<SaplingScanningKey, (DiversifiableFullViewingKey, Height)>,
             HashMap<SaplingScanningKey, Sender<ScanResult>>,
             Vec<(Receiver<ScanResult>, oneshot::Sender<Receiver<ScanResult>>)>,
         ),
@@ -117,9 +111,9 @@ impl ScanTask {
                                 sapling_activation_height
                             };
 
-                            sapling_key_to_scan_block_keys(&key.0, network)
+                            sapling_key_to_dfvk(&key.0, network)
                                 .ok()
-                                .map(|parsed| (key.0, (parsed.0, parsed.1, birth_height)))
+                                .map(|parsed| (key.0, (parsed, birth_height)))
                         })
                         .collect();
 
@@ -128,10 +122,7 @@ impl ScanTask {
 
                     new_keys.extend(keys.clone());
 
-                    registered_keys.extend(
-                        keys.into_iter()
-                            .map(|(key, (dfvks, ivks, _))| (key, (dfvks, ivks))),
-                    );
+                    registered_keys.extend(keys.into_iter().map(|(key, (dfvk, _))| (key, dfvk)));
                 }
 
                 ScanTaskCommand::RemoveKeys { done_tx, keys } => {

--- a/zebra-scan/src/service/scan_task/scan.rs
+++ b/zebra-scan/src/service/scan_task/scan.rs
@@ -27,7 +27,7 @@ use zcash_client_backend::{
 };
 use zcash_primitives::zip32::{AccountId, Scope};
 
-use sapling::{zip32::DiversifiableFullViewingKey, SaplingIvk};
+use sapling::zip32::DiversifiableFullViewingKey;
 
 use zebra_chain::{
     block::{Block, Height},
@@ -56,11 +56,6 @@ pub type State = Buffer<
     BoxService<zebra_state::Request, zebra_state::Response, zebra_state::BoxError>,
     zebra_state::Request,
 >;
-
-/// The key for blockchain scanning.
-///
-/// Currently contains a single key.
-pub type ScanningKey = ScanningKeys<AccountId, (AccountId, Scope)>;
 
 /// Wait a few seconds at startup for some blocks to get verified.
 ///
@@ -111,15 +106,9 @@ pub async fn start(
 
     // Parse and convert keys once, then use them to scan all blocks.
     // There is some cryptography here, but it should be fast even with thousands of keys.
-    let mut parsed_keys: HashMap<
-        SaplingScanningKey,
-        (Vec<DiversifiableFullViewingKey>, Vec<SaplingIvk>),
-    > = key_heights
+    let mut parsed_keys: HashMap<SaplingScanningKey, DiversifiableFullViewingKey> = key_heights
         .keys()
-        .map(|key| {
-            let parsed_keys = sapling_key_to_scan_block_keys(key, &network)?;
-            Ok::<_, Report>((key.clone(), parsed_keys))
-        })
+        .map(|key| Ok::<_, Report>((key.clone(), sapling_key_to_dfvk(key, &network)?)))
         .try_collect()?;
 
     let mut subscribed_keys: HashMap<SaplingScanningKey, Sender<ScanResult>> = HashMap::new();
@@ -171,7 +160,7 @@ pub async fn start(
 
             let start_height = new_keys
                 .iter()
-                .map(|(_, (_, _, height))| *height)
+                .map(|(_, (_, height))| *height)
                 .min()
                 .unwrap_or(sapling_activation_height);
 
@@ -216,21 +205,6 @@ pub async fn start(
     }
 }
 
-/// Convert keys from the Zebra parsed format to the scanning format using a dummy account and the diversifiable full viewing key.
-pub fn ready_scan_block_keys(
-    parsed_keys: HashMap<String, (Vec<DiversifiableFullViewingKey>, Vec<SaplingIvk>)>,
-) -> HashMap<String, ScanningKeys<AccountId, (AccountId, Scope)>> {
-    parsed_keys
-        .iter()
-        .flat_map(|(key, (dfvks, _))| {
-            dfvks
-                .iter()
-                .map(|dfvk| (key.clone(), scanning_key(dfvk).expect("scanning key")))
-                .collect::<Vec<_>>()
-        })
-        .collect()
-}
-
 /// Polls state service for tip height every [`CHECK_INTERVAL`] until the tip reaches the provided `tip_height`
 pub async fn wait_for_height(
     height: Height,
@@ -272,7 +246,7 @@ pub async fn scan_height_and_store_results(
     chain_tip_change: Option<ChainTipChange>,
     storage: Storage,
     key_last_scanned_heights: Arc<HashMap<SaplingScanningKey, Height>>,
-    parsed_keys: HashMap<String, (Vec<DiversifiableFullViewingKey>, Vec<SaplingIvk>)>,
+    parsed_keys: HashMap<String, DiversifiableFullViewingKey>,
     subscribed_keys_receiver: watch::Receiver<Arc<HashMap<String, Sender<ScanResult>>>>,
 ) -> Result<Option<Height>, Report> {
     let network = storage.network();
@@ -298,7 +272,7 @@ pub async fn scan_height_and_store_results(
         _ => unreachable!("unmatched response to a state::Block request"),
     };
 
-    for (key_index_in_task, (sapling_key, _scanning_keys)) in parsed_keys.iter().enumerate() {
+    for (key_index_in_task, (sapling_key, _)) in parsed_keys.iter().enumerate() {
         match key_last_scanned_heights.get(sapling_key) {
             // Only scan what was not scanned for each key
             Some(last_scanned_height) if height <= *last_scanned_height => continue,
@@ -348,22 +322,16 @@ pub async fn scan_height_and_store_results(
         let sapling_tree_size = 1 << 16;
 
         tokio::task::spawn_blocking(move || {
-            // Convert the keys to zcash_client_backend new format for `scan_block` function.
-            let ready_scan_block_keys = ready_scan_block_keys(parsed_keys);
-            let ready_scan_block_keys = ready_scan_block_keys
-                .iter()
-                .next()
-                .expect("we should have 1 ScanningKeys for each key")
-                .1;
+            let scanning_keys = scanning_keys(parsed_keys.values()).expect("scanning keys");
 
-            let dfvk_res = scan_block(&network, &block, sapling_tree_size, ready_scan_block_keys)
+            let scanned_block = scan_block(&network, &block, sapling_tree_size, &scanning_keys)
                 .map_err(|e| eyre!(e))?;
 
-            let dfvk_res = scanned_block_to_db_result(dfvk_res);
+            let scanning_result = scanned_block_to_db_result(scanned_block);
 
             let latest_subscribed_keys = subscribed_keys_receiver.borrow().clone();
             if let Some(results_sender) = latest_subscribed_keys.get(&sapling_key).cloned() {
-                for (_tx_index, tx_id) in dfvk_res.clone() {
+                for (_tx_index, tx_id) in scanning_result.clone() {
                     // TODO: Handle `SendErrors` by dropping sender from `subscribed_keys`
                     let _ = results_sender.try_send(ScanResult {
                         key: sapling_key.clone(),
@@ -373,7 +341,7 @@ pub async fn scan_height_and_store_results(
                 }
             }
 
-            storage.add_sapling_results(&sapling_key, height, dfvk_res);
+            storage.add_sapling_results(&sapling_key, height, scanning_result);
             Ok::<_, Report>(())
         })
         .wait_for_panics()
@@ -384,11 +352,6 @@ pub async fn scan_height_and_store_results(
 }
 
 /// Returns the transactions from `block` belonging to the given `scanning_keys`.
-/// This list of keys should come from a single configured `SaplingScanningKey`.
-///
-/// For example, there are two individual viewing keys for most shielded transfers:
-/// - the payment (external) key, and
-/// - the change (internal) key.
 ///
 /// # Performance / Hangs
 ///
@@ -402,7 +365,7 @@ pub fn scan_block(
     network: &Network,
     block: &Block,
     sapling_tree_size: u32,
-    scanning_key: &ScanningKey,
+    scanning_key: &ScanningKeys<AccountId, (AccountId, Scope)>,
 ) -> Result<ScannedBlock<AccountId>, ScanError> {
     // TODO: Implement a check that returns early when the block height is below the Sapling
     // activation height.
@@ -424,27 +387,17 @@ pub fn scan_block(
     )
 }
 
-/// Converts a Zebra-format scanning key into some `scan_block()` keys.
-///
-/// Currently only accepts extended full viewing keys, and returns both their diversifiable full
-/// viewing key and their individual viewing key, for testing purposes.
-///
-// TODO: work out what string format is used for SaplingIvk, if any, and support it here
-//       performance: stop returning both the dfvk and ivk for the same key
+/// Converts a Zebra-format scanning key into diversifiable full viewing key key.
 // TODO: use `ViewingKey::parse` from zebra-chain instead
-pub fn sapling_key_to_scan_block_keys(
+pub fn sapling_key_to_dfvk(
     key: &SaplingScanningKey,
     network: &Network,
-) -> Result<(Vec<DiversifiableFullViewingKey>, Vec<SaplingIvk>), Report> {
-    let efvk =
-        decode_extended_full_viewing_key(network.sapling_efvk_hrp(), key).map_err(|e| eyre!(e))?;
-
-    // Just return all the keys for now, so we can be sure our code supports them.
-    let dfvk = efvk.to_diversifiable_full_viewing_key();
-    let eivk = dfvk.to_ivk(Scope::External);
-    let iivk = dfvk.to_ivk(Scope::Internal);
-
-    Ok((vec![dfvk], vec![eivk, iivk]))
+) -> Result<DiversifiableFullViewingKey, Report> {
+    Ok(
+        decode_extended_full_viewing_key(network.sapling_efvk_hrp(), key)
+            .map_err(|e| eyre!(e))?
+            .to_diversifiable_full_viewing_key(),
+    )
 }
 
 /// Converts a zebra block and meta data into a compact block.
@@ -582,13 +535,23 @@ pub fn spawn_init(
     tokio::spawn(start(state, chain_tip_change, storage, cmd_receiver).in_current_span())
 }
 
-/// Turns a [`DiversifiableFullViewingKey`] to a [`ScanningKey`].
-pub fn scanning_key(dfvk: &DiversifiableFullViewingKey) -> Result<ScanningKey, Report> {
-    let fvk = Fvk::try_from((2, &dfvk.to_bytes()[..]))?;
-    let ufvk = Ufvk::try_from_items(vec![fvk])?;
-    let ufvk = UnifiedFullViewingKey::parse(&ufvk).map_err(|e| eyre!(e))?;
-    Ok(ScanningKeys::from_account_ufvks(vec![(
-        AccountId::ZERO,
-        ufvk,
-    )]))
+/// Turns an iterator of [`DiversifiableFullViewingKey`]s to [`ScanningKeys`].
+pub fn scanning_keys<'a>(
+    dfvks: impl IntoIterator<Item = &'a DiversifiableFullViewingKey>,
+) -> Result<ScanningKeys<AccountId, (AccountId, Scope)>, Report> {
+    dfvks
+        .into_iter()
+        .enumerate()
+        .map(|(i, dfvk)| Ok((AccountId::try_from(u32::try_from(i)?)?, dfvk_to_ufvk(dfvk)?)))
+        .try_collect::<(_, _), Vec<(_, _)>, _>()
+        .map(ScanningKeys::from_account_ufvks)
+}
+
+/// Turns a [`DiversifiableFullViewingKey`] to [`UnifiedFullViewingKey`].
+pub fn dfvk_to_ufvk(dfvk: &DiversifiableFullViewingKey) -> Result<UnifiedFullViewingKey, Report> {
+    UnifiedFullViewingKey::parse(&Ufvk::try_from_items(vec![Fvk::try_from((
+        2,
+        &dfvk.to_bytes()[..],
+    ))?])?)
+    .map_err(|e| eyre!(e))
 }

--- a/zebra-scan/src/service/scan_task/scan.rs
+++ b/zebra-scan/src/service/scan_task/scan.rs
@@ -322,6 +322,9 @@ pub async fn scan_height_and_store_results(
         let sapling_tree_size = 1 << 16;
 
         tokio::task::spawn_blocking(move || {
+            // TODO:
+            // - Wait until https://github.com/zcash/librustzcash/pull/1400 makes it to a release.
+            // - Create the scanning keys outside of this thread and move them here instead.
             let scanning_keys = scanning_keys(parsed_keys.values()).expect("scanning keys");
 
             let scanned_block = scan_block(&network, &block, sapling_tree_size, &scanning_keys)
@@ -387,7 +390,7 @@ pub fn scan_block(
     )
 }
 
-/// Converts a Zebra-format scanning key into diversifiable full viewing key key.
+/// Converts a Zebra-format scanning key into diversifiable full viewing key.
 // TODO: use `ViewingKey::parse` from zebra-chain instead
 pub fn sapling_key_to_dfvk(
     key: &SaplingScanningKey,

--- a/zebra-scan/src/service/scan_task/scan/scan_range.rs
+++ b/zebra-scan/src/service/scan_task/scan/scan_range.rs
@@ -7,7 +7,7 @@ use crate::{
     storage::Storage,
 };
 use color_eyre::eyre::Report;
-use sapling::{zip32::DiversifiableFullViewingKey, SaplingIvk};
+use sapling::zip32::DiversifiableFullViewingKey;
 use tokio::{
     sync::{mpsc::Sender, watch},
     task::JoinHandle,
@@ -24,7 +24,7 @@ pub struct ScanRangeTaskBuilder {
     height_range: std::ops::Range<Height>,
 
     /// The keys to be used for scanning blocks in this task
-    keys: HashMap<SaplingScanningKey, (Vec<DiversifiableFullViewingKey>, Vec<SaplingIvk>, Height)>,
+    keys: HashMap<SaplingScanningKey, (DiversifiableFullViewingKey, Height)>,
 
     /// A handle to the state service for reading the blocks and the chain tip height
     state: State,
@@ -37,10 +37,7 @@ impl ScanRangeTaskBuilder {
     /// Creates a new [`ScanRangeTaskBuilder`]
     pub fn new(
         stop_height: Height,
-        keys: HashMap<
-            SaplingScanningKey,
-            (Vec<DiversifiableFullViewingKey>, Vec<SaplingIvk>, Height),
-        >,
+        keys: HashMap<SaplingScanningKey, (DiversifiableFullViewingKey, Height)>,
         state: State,
         storage: Storage,
     ) -> Self {
@@ -83,7 +80,7 @@ impl ScanRangeTaskBuilder {
 // TODO: update the first parameter to `std::ops::Range<Height>`
 pub async fn scan_range(
     stop_before_height: Height,
-    keys: HashMap<SaplingScanningKey, (Vec<DiversifiableFullViewingKey>, Vec<SaplingIvk>, Height)>,
+    keys: HashMap<SaplingScanningKey, (DiversifiableFullViewingKey, Height)>,
     state: State,
     storage: Storage,
     subscribed_keys_receiver: watch::Receiver<Arc<HashMap<String, Sender<ScanResult>>>>,
@@ -99,7 +96,7 @@ pub async fn scan_range(
 
     let key_heights: HashMap<String, Height> = keys
         .iter()
-        .map(|(key, (_, _, height))| (key.clone(), *height))
+        .map(|(key, (_, height))| (key.clone(), *height))
         .collect();
 
     let mut height = get_min_height(&key_heights).unwrap_or(sapling_activation_height);
@@ -107,12 +104,9 @@ pub async fn scan_range(
     let key_heights = Arc::new(key_heights);
 
     // Parse and convert keys once, then use them to scan all blocks.
-    let parsed_keys: HashMap<
-        SaplingScanningKey,
-        (Vec<DiversifiableFullViewingKey>, Vec<SaplingIvk>),
-    > = keys
+    let parsed_keys: HashMap<SaplingScanningKey, DiversifiableFullViewingKey> = keys
         .into_iter()
-        .map(|(key, (decoded_dfvks, decoded_ivks, _h))| (key, (decoded_dfvks, decoded_ivks)))
+        .map(|(key, (dfvk, _))| (key, dfvk))
         .collect();
 
     while height < stop_before_height {

--- a/zebra-scan/src/tests/vectors.rs
+++ b/zebra-scan/src/tests/vectors.rs
@@ -11,12 +11,8 @@ use sapling::{
 use zcash_client_backend::{
     encoding::{decode_extended_full_viewing_key, encode_extended_full_viewing_key},
     proto::compact_formats::ChainMetadata,
-    scanning::ScanningKeys,
 };
-use zcash_keys::keys::UnifiedFullViewingKey;
-use zcash_primitives::{
-    constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY, zip32::AccountId,
-};
+use zcash_primitives::constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY;
 
 use zebra_chain::{
     block::{Block, Height},
@@ -27,7 +23,7 @@ use zebra_chain::{
 use zebra_state::{SaplingScannedResult, TransactionIndex};
 
 use crate::{
-    scan::{block_to_compact, scan_block, ScanningKey},
+    scan::{block_to_compact, scan_block, scanning_key},
     storage::db::tests::new_test_storage,
     tests::{fake_block, mock_sapling_efvk, ZECPAGES_SAPLING_VIEWING_KEY},
 };
@@ -46,7 +42,7 @@ async fn scanning_from_fake_generated_blocks() -> Result<()> {
 
     assert_eq!(block.transactions.len(), 4);
 
-    let scanning_keys = scanning_key(dfvk);
+    let scanning_keys = scanning_key(&dfvk).expect("scanning key");
 
     let res = scan_block(&Network::Mainnet, &block, sapling_tree_size, &scanning_keys).unwrap();
 
@@ -107,7 +103,7 @@ async fn scanning_zecpages_from_populated_zebra_state() -> Result<()> {
     let mut transactions_scanned = 0;
     let mut blocks_scanned = 0;
 
-    let scanning_keys = scanning_key(dfvk);
+    let scanning_keys = scanning_key(&dfvk).expect("scanning key");
 
     while let Some(block) = db.block(height.into()) {
         // We use a dummy size of the Sapling note commitment tree. We can't set the size to zero
@@ -188,7 +184,7 @@ fn scanning_fake_blocks_store_key_and_results() -> Result<()> {
 
     let (block, sapling_tree_size) = fake_block(1u32.into(), nf, &dfvk, 1, true, Some(0));
 
-    let scanning_keys = scanning_key(dfvk);
+    let scanning_keys = scanning_key(&dfvk).expect("scanning key");
 
     let result = scan_block(&Network::Mainnet, &block, sapling_tree_size, &scanning_keys).unwrap();
 
@@ -213,10 +209,4 @@ fn scanning_fake_blocks_store_key_and_results() -> Result<()> {
     );
 
     Ok(())
-}
-
-/// Convert from the `DiversifiableFullViewingKey` to a `ScanningKey`.
-fn scanning_key(dfvk: DiversifiableFullViewingKey) -> ScanningKey {
-    let ufvk = UnifiedFullViewingKey::new(Some(dfvk));
-    ScanningKeys::from_account_ufvks([(AccountId::ZERO, ufvk.unwrap())])
 }

--- a/zebra-scan/src/tests/vectors.rs
+++ b/zebra-scan/src/tests/vectors.rs
@@ -23,7 +23,7 @@ use zebra_chain::{
 use zebra_state::{SaplingScannedResult, TransactionIndex};
 
 use crate::{
-    scan::{block_to_compact, scan_block, scanning_key},
+    scan::{block_to_compact, scan_block, scanning_keys},
     storage::db::tests::new_test_storage,
     tests::{fake_block, mock_sapling_efvk, ZECPAGES_SAPLING_VIEWING_KEY},
 };
@@ -42,7 +42,7 @@ async fn scanning_from_fake_generated_blocks() -> Result<()> {
 
     assert_eq!(block.transactions.len(), 4);
 
-    let scanning_keys = scanning_key(&dfvk).expect("scanning key");
+    let scanning_keys = scanning_keys(&vec![dfvk]).expect("scanning key");
 
     let res = scan_block(&Network::Mainnet, &block, sapling_tree_size, &scanning_keys).unwrap();
 
@@ -103,7 +103,7 @@ async fn scanning_zecpages_from_populated_zebra_state() -> Result<()> {
     let mut transactions_scanned = 0;
     let mut blocks_scanned = 0;
 
-    let scanning_keys = scanning_key(&dfvk).expect("scanning key");
+    let scanning_keys = scanning_keys(&vec![dfvk]).expect("scanning key");
 
     while let Some(block) = db.block(height.into()) {
         // We use a dummy size of the Sapling note commitment tree. We can't set the size to zero
@@ -184,7 +184,7 @@ fn scanning_fake_blocks_store_key_and_results() -> Result<()> {
 
     let (block, sapling_tree_size) = fake_block(1u32.into(), nf, &dfvk, 1, true, Some(0));
 
-    let scanning_keys = scanning_key(&dfvk).expect("scanning key");
+    let scanning_keys = scanning_keys(&vec![dfvk]).expect("scanning key");
 
     let result = scan_block(&Network::Mainnet, &block, sapling_tree_size, &scanning_keys).unwrap();
 

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -121,7 +121,7 @@ tokio = { version = "1.37.0", features = ["full"], optional = true }
 jsonrpc = { version = "0.18.0", optional = true }
 
 zcash_primitives = { version = "0.15.0", optional = true }
-zcash_client_backend = { version = "0.12.1", optional = true, features = ["test-dependencies"] }
+zcash_client_backend = { version = "0.12.1", optional = true }
 zcash_protocol = { version = "0.1.1" }
 
 # For the openapi generator


### PR DESCRIPTION
## Motivation

Address https://github.com/ZcashFoundation/zebra/pull/8568#discussion_r1617380954.

### PR Author Checklist

- [x] Will the PR name make sense to users?
- [x] Does the PR have a priority label?
- [x] Have you added or updated tests?
- [x] Is the documentation up to date?

## Solution

- Don't use `UnifiedFullViewingKey::new` to construct ufvks so we don't need to use the `test-dependencies` feature with `zcash_client_backend` since that feature should not be used in production code.
- Refactor the construction of ufvks and their use for scanning. We were picking only the first key for scanning, which was a bug.
- Stop using `SaplingIvk` since they are covered by the new `ScanningKeys`.

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._