### PR TITLE
fix(ci): Add missing jobs to workflows patch

### DIFF
--- a/.github/workflows/cd-deploy-nodes-gcp.patch-external.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.patch-external.yml
@@ -30,6 +30,13 @@ jobs:
     steps:
       - run: 'echo "Skipping job on fork"'
 
+  test-configuration-file-testnet:
+    name: Test CD testnet Docker config file / Test default-conf in Docker
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "Skipping job on fork"'
+
   test-zebra-conf-path:
     name: Test CD custom Docker config file / Test custom-conf in Docker
     needs: build

--- a/.github/workflows/cd-deploy-nodes-gcp.patch.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.patch.yml
@@ -40,6 +40,13 @@ jobs:
     steps:
       - run: 'echo "No build required"'
 
+  test-configuration-file-testnet:
+    name: Test CD testnet Docker config file / Test default-conf in Docker
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
+
   test-zebra-conf-path:
     name: Test CD custom Docker config file / Test custom-conf in Docker
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-unit-tests-docker.patch-external.yml
+++ b/.github/workflows/ci-unit-tests-docker.patch-external.yml
@@ -57,6 +57,13 @@ jobs:
     steps:
       - run: 'echo "Skipping job on fork"'
 
+  test-configuration-file-testnet:
+    name: Test CI testnet Docker config file / Test default-conf in Docker
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "Skipping job on fork"'
+
   test-zebra-conf-path:
     name: Test CI custom Docker config file / Test custom-conf in Docker
     needs: build

--- a/.github/workflows/ci-unit-tests-docker.patch.yml
+++ b/.github/workflows/ci-unit-tests-docker.patch.yml
@@ -66,6 +66,12 @@ jobs:
     steps:
       - run: 'echo "No build required"'
 
+  test-configuration-file-testnet:
+    name: Test CI testnet Docker config file / Test default-conf in Docker
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'
+
   test-zebra-conf-path:
     name: Test CI custom Docker config file / Test custom-conf in Docker
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-unit-tests-os.patch.yml
+++ b/.github/workflows/ci-unit-tests-os.patch.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         rust: [stable, beta]
         features: [""]
         exclude:


### PR DESCRIPTION
## Motivation

Some jobs has been recently added, but the workflows patch were not updated, causing some PRs to be halted and not being able to merge them as this jobs were not triggered by the changed files.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [ ] Will the PR name make sense to users?
  - [ ] Does the PR have a priority label?
  - [ ] Have you added or updated tests?
  - [ ] Is the documentation up to date?

## Solution

- Add missing jobs to patch workflows

### Testing

- This PR should not show pending tests

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.
