### PR TITLE
fix: General conditional compilation attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Changed
 
 - We realized that a longer than `zcashd` end of support could be problematic in some cases so we reverted back from 20 to 16 weeks ([#8530](https://github.com/ZcashFoundation/zebra/pull/8530))
-- We're no longer using general conditional compilation attributes.
+- We're no longer using general conditional compilation attributes for `tor`,
+  but only feature flags instead.
 
 ## [Zebra 1.7.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.7.0) - 2024-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Changed
 
 - We realized that a longer than `zcashd` end of support could be problematic in some cases so we reverted back from 20 to 16 weeks ([#8530](https://github.com/ZcashFoundation/zebra/pull/8530))
-
+- We're no longer using general conditional compilation attributes.
 
 ## [Zebra 1.7.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.7.0) - 2024-05-07
 

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -47,3 +47,6 @@ tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.13" }
 tower-test = "0.4.0"
 
 zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.37" }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }

--- a/zebra-network/src/isolated.rs
+++ b/zebra-network/src/isolated.rs
@@ -16,8 +16,7 @@ use crate::{
 
 // Wait until `arti-client`'s dependency `x25519-dalek v1.2.0` is updated to a higher version. (#5492)
 // #[cfg(feature = "tor")]
-#[cfg(tor)]
-pub(crate) mod tor;
+// pub(crate) mod tor;
 
 #[cfg(test)]
 mod tests;

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -165,13 +165,11 @@ mod protocol;
 
 // Wait until `arti-client`'s dependency `x25519-dalek v1.2.0` is updated to a higher version. (#5492)
 // #[cfg(feature = "tor")]
-#[cfg(tor)]
-pub use crate::isolated::tor::connect_isolated_tor;
+// pub use crate::isolated::tor::connect_isolated_tor;
 
 // Wait until `arti-client`'s dependency `x25519-dalek v1.2.0` is updated to a higher version. (#5492)
 // #[cfg(all(feature = "tor", any(test, feature = "proptest-impl")))]
-#[cfg(tor)]
-pub use crate::isolated::tor::connect_isolated_tor_with_inbound;
+// pub use crate::isolated::tor::connect_isolated_tor_with_inbound;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 pub use crate::{

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -301,3 +301,6 @@ zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.4" }
 # https://github.com/rust-lang/cargo/issues/9096
 # zebra-utils { path = "../zebra-utils", artifact = "bin:zebra-checkpoints" }
 zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.37" }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }


### PR DESCRIPTION
## Motivation

See https://blog.rust-lang.org/2024/05/06/check-cfg.html

This change in `beta` causes CI errors in docs compilation.

### PR Author Checklist

#### Check before marking the PR as ready for review:
  - [x] Will the PR name make sense to users?
  - [x] Does the PR have a priority label?
  - [ ] Have you added or updated tests?
  - [x] Is the documentation up to date?
  - [ ] Is there a summary in the CHANGELOG?
  - [ ] Can these changes be split into multiple PRs?

## Solution

- Remove the `[cfg(tor)]` conditional compilation attributes.
  The conditional compilation attributes for tor were redundant since we can do fine using only features.
- [Add `tokio_unstable` to `unexpected_cfgs`](https://github.com/ZcashFoundation/zebra/pull/8602/commits/58d561ca20dfc34c811a9a2bd0792aa8cb2519e6).
- [Fix `tokio_unstable` in `zebrad`](https://github.com/ZcashFoundation/zebra/pull/8602/commits/405a44f8e04abb1b1cfc8c37aaf50a22f4e48ecb).

### Reviewer Checklist

Check before approving the PR:
  - [ ] Does the PR scope match the ticket?
  - [ ] Are there enough tests to make sure it works? Do the tests cover the PR motivation?
  - [ ] Are all the PR blockers dealt with?
        PR blockers can be dealt with in new tickets or PRs.

_And check the PR Author checklist is complete._