### PR TITLE
fix(codespell): typos

### DIFF
--- a/book/src/dev/rfcs/0009-zebra-client.md
+++ b/book/src/dev/rfcs/0009-zebra-client.md
@@ -189,7 +189,7 @@ A specific set of _privileged_ RPC endpoints:
   via a firewall)
 
 Support for sending tx's via _non-privileged_ RPC endpoints, or via Stolon:
-  - sendTransaction: once you author a transcation you can gossip it via any
+  - sendTransaction: once you author a transaction you can gossip it via any
     Zcash node, not just a specific instance of zebrad
 
 ## Wallet functionality

--- a/zebra-grpc/src/tests/snapshot.rs
+++ b/zebra-grpc/src/tests/snapshot.rs
@@ -1,7 +1,7 @@
 //! Snapshot tests for Zebra Scan gRPC responses.
 //!
 //! Currently we snapshot the `get_info` and `get_results` responses for both mainnet and testnet with a
-//! mocked scanner database. Calls that return `Empty` responses are not snapshoted in this suite.
+//! mocked scanner database. Calls that return `Empty` responses are not snapshotted in this suite.
 //!
 //! To update these snapshots, run:
 //! ```sh


### PR DESCRIPTION
## Motivation

We have some annotations generated by codespell in our main branch. This PR fixes the typos.
