### PR TITLE
fix: Stop using `displaydoc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,17 +1252,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "document-features"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6012,7 +6001,6 @@ dependencies = [
  "chrono",
  "color-eyre",
  "criterion",
- "displaydoc",
  "ed25519-zebra",
  "equihash",
  "futures",
@@ -6070,7 +6058,6 @@ dependencies = [
  "bls12_381",
  "chrono",
  "color-eyre",
- "displaydoc",
  "futures",
  "futures-util",
  "halo2_proofs",
@@ -6255,7 +6242,6 @@ dependencies = [
 name = "zebra-script"
 version = "1.0.0-beta.37"
 dependencies = [
- "displaydoc",
  "hex",
  "lazy_static",
  "thiserror",

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -107,7 +107,6 @@ chrono = { version = "0.4.38", default-features = false, features = ["clock", "s
 humantime = "2.1.0"
 
 # Error Handling & Formatting
-displaydoc = "0.2.4"
 static_assertions = "1.1.0"
 thiserror = "1.0.61"
 tracing = "0.1.39"

--- a/zebra-chain/src/amount.rs
+++ b/zebra-chain/src/amount.rs
@@ -429,8 +429,8 @@ where
     }
 }
 
-#[derive(thiserror::Error, Debug, displaydoc::Display, Clone, PartialEq, Eq)]
 #[allow(missing_docs)]
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 /// Errors that can be returned when validating `Amount`s
 pub enum Error {
     /// input {value} is outside of valid range for zatoshi Amount, valid_range={range:?}
@@ -460,6 +460,34 @@ pub enum Error {
         partial_sum: i64,
         remaining_items: usize,
     },
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&match self {
+            Error::Constraint { value, range } => format!(
+                "input {value} is outside of valid range for zatoshi Amount, valid_range={range:?}"
+            ),
+            Error::Convert { value, .. } => {
+                format!("{value} could not be converted to an i64 Amount")
+            }
+            Error::MultiplicationOverflow {
+                amount,
+                multiplier,
+                overflowing_result,
+            } => format!(
+                "overflow when calculating {amount}i64 * {multiplier}u64 = {overflowing_result}i128"
+            ),
+            Error::DivideByZero { amount } => format!("cannot divide amount {amount} by zero"),
+            Error::SumOverflow {
+                partial_sum,
+                remaining_items,
+            } => format!(
+                "overflow when summing i64 amounts; \
+                          partial sum: {partial_sum}, number of remaining items: {remaining_items}"
+            ),
+        })
+    }
 }
 
 impl Error {

--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -6,6 +6,7 @@ use crate::{
     transparent,
 };
 
+use core::fmt;
 use std::{borrow::Borrow, collections::HashMap};
 
 #[cfg(any(test, feature = "proptest-impl"))]
@@ -385,7 +386,7 @@ impl ValueBalance<NonNegative> {
     }
 }
 
-#[derive(thiserror::Error, Debug, displaydoc::Display, Clone, PartialEq, Eq)]
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 /// Errors that can be returned when validating a [`ValueBalance`]
 pub enum ValueBalanceError {
     /// transparent amount error {0}
@@ -399,6 +400,17 @@ pub enum ValueBalanceError {
 
     /// orchard amount error {0}
     Orchard(amount::Error),
+}
+
+impl fmt::Display for ValueBalanceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&match self {
+            Transparent(e) => format!("transparent amount err: {e}"),
+            Sprout(e) => format!("sprout amount err: {e}"),
+            Sapling(e) => format!("sapling amount err: {e}"),
+            Orchard(e) => format!("orchard amount err: {e}"),
+        })
+    }
 }
 
 impl<C> std::ops::Add for ValueBalance<C>

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -44,7 +44,6 @@ rand = "0.8.5"
 rayon = "1.10.0"
 
 chrono = { version = "0.4.38", default-features = false, features = ["clock", "std"] }
-displaydoc = "0.2.4"
 lazy_static = "1.4.0"
 once_cell = "1.18.0"
 serde = { version = "1.0.203", features = ["serde_derive"] }

--- a/zebra-consensus/src/router.rs
+++ b/zebra-consensus/src/router.rs
@@ -12,13 +12,13 @@
 //! Otherwise, verification of out-of-order and invalid blocks and transactions can hang
 //! indefinitely.
 
+use core::fmt;
 use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
 
-use displaydoc::Display;
 use futures::{FutureExt, TryFutureExt};
 use thiserror::Error;
 use tokio::task::JoinHandle;
@@ -91,13 +91,26 @@ where
 /// An error while semantically verifying a block.
 //
 // One or both of these error variants are at least 140 bytes
-#[derive(Debug, Display, Error)]
+#[derive(Debug, Error)]
 #[allow(missing_docs)]
 pub enum RouterError {
     /// Block could not be checkpointed
     Checkpoint { source: Box<VerifyCheckpointError> },
     /// Block could not be full-verified
     Block { source: Box<VerifyBlockError> },
+}
+
+impl fmt::Display for RouterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&match self {
+            RouterError::Checkpoint { source } => {
+                format!("block could not be checkpointed due to: {source}")
+            }
+            RouterError::Block { source } => {
+                format!("block could not be full-verified due to: {source}")
+            }
+        })
+    }
 }
 
 impl From<VerifyCheckpointError> for RouterError {

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -20,7 +20,6 @@ zcash_script = "0.1.15"
 zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37" }
 
 thiserror = "1.0.61"
-displaydoc = "0.2.4"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -5,9 +5,9 @@
 // We allow unsafe code, so we can call zcash_script
 #![allow(unsafe_code)]
 
+use core::fmt;
 use std::sync::Arc;
 
-use displaydoc::Display;
 use thiserror::Error;
 
 use zcash_script::{
@@ -22,25 +22,37 @@ use zebra_chain::{
     transparent,
 };
 
-#[derive(Copy, Clone, Debug, Display, Error, PartialEq, Eq)]
-#[non_exhaustive]
 /// An Error type representing the error codes returned from zcash_script.
+#[derive(Copy, Clone, Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Error {
-    /// script failed to verify
+    /// script verification failed
     #[non_exhaustive]
     ScriptInvalid,
-    /// could not to deserialize tx
+    /// could not deserialize tx
     #[non_exhaustive]
     TxDeserialize,
-    /// input index out of bounds for transaction's inputs
+    /// input index out of bounds
     #[non_exhaustive]
     TxIndex,
-    /// tx is an invalid size for it's protocol
+    /// tx has an invalid size
     #[non_exhaustive]
     TxSizeMismatch,
-    /// encountered unknown error kind from zcash_script: {0}
+    /// unknown error from zcash_script: {0}
     #[non_exhaustive]
     Unknown(zcash_script_error_t),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&match self {
+            Error::ScriptInvalid => "script verification failed".to_owned(),
+            Error::TxDeserialize => "could not deserialize tx".to_owned(),
+            Error::TxIndex => "input index out of bounds".to_owned(),
+            Error::TxSizeMismatch => "tx has an invalid size".to_owned(),
+            Error::Unknown(e) => format!("unknown error from zcash_script: {e}"),
+        })
+    }
 }
 
 impl From<zcash_script_error_t> for Error {

--- a/zebra-test/src/command/arguments/tests.rs
+++ b/zebra-test/src/command/arguments/tests.rs
@@ -168,9 +168,9 @@ impl Argument {
     ///
     /// # Implementation
     ///
-    /// 1. Generate a list with less than ten random strings. Then proceed by selecting which strings
-    /// will become key value pairs, and generate a new random string for each value that needs to
-    /// be paired to an argument key.
+    /// 1. Generate a list with less than ten random strings. Then proceed by selecting which
+    ///    strings will become key value pairs, and generate a new random string for each value that
+    ///    needs to be paired to an argument key.
     pub fn list_strategy() -> impl Strategy<Value = Vec<Argument>> {
         // Generate a list with less than ten unique random strings.
         hash_set("\\PC+", 0..10)


### PR DESCRIPTION
## Motivation

Rust beta now contains a new lint (https://github.com/rust-lang/rust/pull/120393) which produces a bunch of compilation warnings in the CI. They all come from `displaydoc` (https://github.com/yaahc/displaydoc) which has an open PR (https://github.com/yaahc/displaydoc/pull/47) containing a trivial fix for the issue but hasn't been merged in more than two months.

## Solution

- Remove `displaydoc`.
- Impl `fmt::Display` manually for types that used to use `displaydoc`.
- Unrelated:
  - There's another new lint that checks the alignment in lists in comments, so I fixed that.

### Tests

The solution doesn't need tests.

### PR Author's Checklist

- [x] The PR name will make sense to users.
- [ ] ~~The PR provides a CHANGELOG summary.~~
- [ ] ~~The solution is tested.~~
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

- [x] The PR Author's checklist is complete.
- [x] The PR resolves the issue.