### PR TITLE
chore: Bump `zcash_primitives`, `orchard` and `zcash_proofs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   This means `zebrad` no longer contains users' viewing keys.
 - We're no longer using general conditional compilation attributes for `tor`,
   but only feature flags instead.
-- Fixed a bug with trailing characters in the openapi spec method descriptions((#8597)[https://github.com/ZcashFoundation/zebra/pull/8597])
+- Custom testnets don't support custom HRPs anymore.
+- Fixed a bug with trailing characters in the openapi spec method descriptions ([#8597](https://github.com/ZcashFoundation/zebra/pull/8597))
 
 ## [Zebra 1.7.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.7.0) - 2024-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   This means `zebrad` no longer contains users' viewing keys.
 - We're no longer using general conditional compilation attributes for `tor`,
   but only feature flags instead.
-- Custom testnets don't support custom HRPs anymore.
 - Fixed a bug with trailing characters in the openapi spec method descriptions ([#8597](https://github.com/ZcashFoundation/zebra/pull/8597))
 
 ## [Zebra 1.7.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.7.0) - 2024-05-07

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2745,36 +2745,6 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb255c3ffdccd3c84fe9ebed72aef64fdc72e6a3e4180dd411002d47abaad42"
-dependencies = [
- "aes",
- "bitvec",
- "blake2b_simd",
- "ff",
- "fpe",
- "group",
- "halo2_gadgets",
- "halo2_proofs",
- "hex",
- "incrementalmerkletree",
- "lazy_static",
- "memuse",
- "nonempty",
- "pasta_curves",
- "rand 0.8.5",
- "reddsa",
- "serde",
- "subtle",
- "tracing",
- "zcash_note_encryption",
- "zcash_spec",
- "zip32",
-]
-
-[[package]]
-name = "orchard"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0462569fc8b0d1b158e4d640571867a4e4319225ebee2ab6647e60c70af19ae3"
@@ -5763,7 +5733,7 @@ dependencies = [
  "jubjub",
  "memuse",
  "nonempty",
- "orchard 0.8.0",
+ "orchard",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "redjubjub",
@@ -5860,7 +5830,7 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "num-integer",
- "orchard 0.8.0",
+ "orchard",
  "primitive-types",
  "proptest",
  "proptest-derive",
@@ -5915,7 +5885,7 @@ dependencies = [
  "metrics",
  "num-integer",
  "once_cell",
- "orchard 0.7.1",
+ "orchard",
  "proptest",
  "proptest-derive",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5895,6 +5895,7 @@ dependencies = [
  "ff",
  "fpe",
  "group",
+ "hdwallet",
  "hex",
  "incrementalmerkletree",
  "jubjub",
@@ -5904,7 +5905,9 @@ dependencies = [
  "rand 0.8.5",
  "rand_core 0.6.4",
  "redjubjub",
+ "ripemd",
  "sapling-crypto",
+ "secp256k1",
  "sha2",
  "subtle",
  "tracing",
@@ -5937,6 +5940,29 @@ dependencies = [
  "tracing",
  "xdg",
  "zcash_primitives 0.14.0",
+]
+
+[[package]]
+name = "zcash_proofs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5163a1110f4265cc5f2fdf87ac4497fd1e014b6ce0760ca8d16d8e3853a5c0f7"
+dependencies = [
+ "bellman",
+ "blake2b_simd",
+ "bls12_381",
+ "document-features",
+ "group",
+ "home",
+ "jubjub",
+ "known-folders",
+ "lazy_static",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "tracing",
+ "xdg",
+ "zcash_primitives 0.15.0",
 ]
 
 [[package]]
@@ -5985,7 +6011,7 @@ dependencies = [
  "zcash_encoding",
  "zcash_note_encryption",
  "zcash_primitives 0.14.0",
- "zcash_proofs",
+ "zcash_proofs 0.14.0",
 ]
 
 [[package]]
@@ -6025,7 +6051,7 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "num-integer",
- "orchard 0.7.1",
+ "orchard 0.8.0",
  "primitive-types",
  "proptest",
  "proptest-derive",
@@ -6056,7 +6082,7 @@ dependencies = [
  "zcash_encoding",
  "zcash_history",
  "zcash_note_encryption",
- "zcash_primitives 0.14.0",
+ "zcash_primitives 0.15.0",
  "zcash_protocol",
  "zebra-test",
 ]
@@ -6100,7 +6126,7 @@ dependencies = [
  "tracing-futures",
  "tracing-subscriber",
  "wagyu-zcash-parameters",
- "zcash_proofs",
+ "zcash_proofs 0.15.0",
  "zebra-chain",
  "zebra-node-services",
  "zebra-script",
@@ -6123,7 +6149,7 @@ dependencies = [
  "tonic-build 0.11.0",
  "tonic-reflection",
  "tower",
- "zcash_primitives 0.14.0",
+ "zcash_primitives 0.15.0",
  "zebra-chain",
  "zebra-node-services",
  "zebra-state",
@@ -6206,7 +6232,7 @@ dependencies = [
  "tower",
  "tracing",
  "zcash_address",
- "zcash_primitives 0.14.0",
+ "zcash_primitives 0.15.0",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",
@@ -6243,7 +6269,7 @@ dependencies = [
  "zcash_client_backend",
  "zcash_keys",
  "zcash_note_encryption",
- "zcash_primitives 0.14.0",
+ "zcash_primitives 0.15.0",
  "zebra-chain",
  "zebra-grpc",
  "zebra-node-services",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5677,7 +5677,7 @@ dependencies = [
  "zcash_encoding",
  "zcash_keys",
  "zcash_note_encryption",
- "zcash_primitives 0.15.0",
+ "zcash_primitives",
  "zcash_protocol",
  "zip32",
 ]
@@ -5724,7 +5724,7 @@ dependencies = [
  "tracing",
  "zcash_address",
  "zcash_encoding",
- "zcash_primitives 0.15.0",
+ "zcash_primitives",
  "zcash_protocol",
  "zip32",
 ]
@@ -5740,44 +5740,6 @@ dependencies = [
  "cipher",
  "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "zcash_primitives"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9070e084570bb78aed4f8d71fd6254492e62c87a5d01e084183980e98117092d"
-dependencies = [
- "aes",
- "bip0039",
- "blake2b_simd",
- "byteorder",
- "document-features",
- "equihash",
- "ff",
- "fpe",
- "group",
- "hdwallet",
- "hex",
- "incrementalmerkletree",
- "jubjub",
- "memuse",
- "nonempty",
- "orchard 0.7.1",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "redjubjub",
- "ripemd",
- "sapling-crypto",
- "secp256k1",
- "sha2",
- "subtle",
- "tracing",
- "zcash_address",
- "zcash_encoding",
- "zcash_note_encryption",
- "zcash_spec",
- "zip32",
 ]
 
 [[package]]
@@ -5821,29 +5783,6 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a02eb1f151d9b9a6e16408d2c55ff440bd2fb232b7377277146d0fa2df9bc8"
-dependencies = [
- "bellman",
- "blake2b_simd",
- "bls12_381",
- "document-features",
- "group",
- "home",
- "jubjub",
- "known-folders",
- "lazy_static",
- "rand_core 0.6.4",
- "redjubjub",
- "sapling-crypto",
- "tracing",
- "xdg",
- "zcash_primitives 0.14.0",
-]
-
-[[package]]
-name = "zcash_proofs"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5163a1110f4265cc5f2fdf87ac4497fd1e014b6ce0760ca8d16d8e3853a5c0f7"
@@ -5862,7 +5801,7 @@ dependencies = [
  "sapling-crypto",
  "tracing",
  "xdg",
- "zcash_primitives 0.15.0",
+ "zcash_primitives",
 ]
 
 [[package]]
@@ -5952,7 +5891,7 @@ dependencies = [
  "zcash_encoding",
  "zcash_history",
  "zcash_note_encryption",
- "zcash_primitives 0.15.0",
+ "zcash_primitives",
  "zcash_protocol",
  "zebra-test",
 ]
@@ -5995,7 +5934,7 @@ dependencies = [
  "tracing-futures",
  "tracing-subscriber",
  "wagyu-zcash-parameters",
- "zcash_proofs 0.15.0",
+ "zcash_proofs",
  "zebra-chain",
  "zebra-node-services",
  "zebra-script",
@@ -6018,7 +5957,7 @@ dependencies = [
  "tonic-build 0.11.0",
  "tonic-reflection",
  "tower",
- "zcash_primitives 0.15.0",
+ "zcash_primitives",
  "zebra-chain",
  "zebra-node-services",
  "zebra-state",
@@ -6101,7 +6040,7 @@ dependencies = [
  "tower",
  "tracing",
  "zcash_address",
- "zcash_primitives 0.15.0",
+ "zcash_primitives",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",
@@ -6138,7 +6077,7 @@ dependencies = [
  "zcash_client_backend",
  "zcash_keys",
  "zcash_note_encryption",
- "zcash_primitives 0.15.0",
+ "zcash_primitives",
  "zebra-chain",
  "zebra-grpc",
  "zebra-node-services",
@@ -6253,7 +6192,7 @@ dependencies = [
  "tracing-error",
  "tracing-subscriber",
  "zcash_client_backend",
- "zcash_primitives 0.15.0",
+ "zcash_primitives",
  "zcash_protocol",
  "zebra-chain",
  "zebra-node-services",

--- a/deny.toml
+++ b/deny.toml
@@ -85,7 +85,6 @@ skip-tree = [
 
     # wait for zcash_client_backend
     { name = "orchard", version = "=0.7.0" },
-    { name = "zcash_primitives", version = "=0.14.0" },
 
     # wait for hdwallet to upgrade
     { name = "ring", version = "=0.16.20" },

--- a/deny.toml
+++ b/deny.toml
@@ -83,9 +83,6 @@ skip-tree = [
 
     # ECC crates
 
-    # wait for zcash_client_backend
-    { name = "orchard", version = "=0.7.0" },
-
     # wait for hdwallet to upgrade
     { name = "ring", version = "=0.16.20" },
 

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -93,11 +93,11 @@ x25519-dalek = { version = "2.0.1", features = ["serde"] }
 
 # ECC deps
 halo2 = { package = "halo2_proofs", version = "0.3.0" }
-orchard = "0.7.0"
+orchard = "0.8.0"
 zcash_encoding = "0.2.0"
 zcash_history = "0.4.0"
 zcash_note_encryption = "0.4.0"
-zcash_primitives = { version = "0.14.0", features = ["transparent-inputs"] }
+zcash_primitives = { version = "0.15.0", features = ["transparent-inputs"] }
 sapling = { package = "sapling-crypto", version = "0.1" }
 zcash_protocol = { version = "0.1.1" }
 zcash_address = { version = "0.3.2" }

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -305,68 +305,6 @@ impl FromStr for Network {
 #[error("Invalid network: {0}")]
 pub struct InvalidNetworkError(String);
 
-impl zcash_primitives::consensus::Parameters for Network {
-    fn activation_height(
-        &self,
-        nu: zcash_primitives::consensus::NetworkUpgrade,
-    ) -> Option<zcash_primitives::consensus::BlockHeight> {
-        // Heights are hard-coded below Height::MAX or checked when the config is parsed.
-        NetworkUpgrade::from(nu)
-            .activation_height(self)
-            .map(|Height(h)| zcash_primitives::consensus::BlockHeight::from_u32(h))
-    }
-
-    fn coin_type(&self) -> u32 {
-        match self {
-            Network::Mainnet => zcash_primitives::constants::mainnet::COIN_TYPE,
-            // The regtest cointype reuses the testnet cointype,
-            // See <https://github.com/satoshilabs/slips/blob/master/slip-0044.md>
-            Network::Testnet(_) => zcash_primitives::constants::testnet::COIN_TYPE,
-        }
-    }
-
-    fn address_network(&self) -> Option<zcash_address::Network> {
-        match self {
-            Network::Mainnet => Some(zcash_address::Network::Main),
-            // TODO: Check if network is `Regtest` first, and if it is, return `zcash_address::Network::Regtest`
-            Network::Testnet(_params) => Some(zcash_address::Network::Test),
-        }
-    }
-
-    fn hrp_sapling_extended_spending_key(&self) -> &str {
-        match self {
-            Network::Mainnet => {
-                zcash_primitives::constants::mainnet::HRP_SAPLING_EXTENDED_SPENDING_KEY
-            }
-            Network::Testnet(params) => params.hrp_sapling_extended_spending_key(),
-        }
-    }
-
-    fn hrp_sapling_extended_full_viewing_key(&self) -> &str {
-        match self {
-            Network::Mainnet => {
-                zcash_primitives::constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY
-            }
-            Network::Testnet(params) => params.hrp_sapling_extended_full_viewing_key(),
-        }
-    }
-
-    fn hrp_sapling_payment_address(&self) -> &str {
-        match self {
-            Network::Mainnet => zcash_primitives::constants::mainnet::HRP_SAPLING_PAYMENT_ADDRESS,
-            Network::Testnet(params) => params.hrp_sapling_payment_address(),
-        }
-    }
-
-    fn b58_pubkey_address_prefix(&self) -> [u8; 2] {
-        self.kind().b58_pubkey_address_prefix()
-    }
-
-    fn b58_script_address_prefix(&self) -> [u8; 2] {
-        self.kind().b58_script_address_prefix()
-    }
-}
-
 impl zcash_protocol::consensus::Parameters for Network {
     fn network_type(&self) -> zcash_address::Network {
         self.kind().into()

--- a/zebra-chain/src/parameters/network/tests/vectors.rs
+++ b/zebra-chain/src/parameters/network/tests/vectors.rs
@@ -4,6 +4,7 @@ use zcash_primitives::{
     consensus::{self as zp_consensus, Parameters},
     constants as zp_constants,
 };
+use zcash_protocol::consensus::NetworkConstants as _;
 
 use crate::{
     block::Height,

--- a/zebra-chain/src/parameters/network/tests/vectors.rs
+++ b/zebra-chain/src/parameters/network/tests/vectors.rs
@@ -1,17 +1,13 @@
 //! Fixed test vectors for the network consensus parameters.
 
-use zcash_primitives::{
-    consensus::{self as zp_consensus, Parameters},
-    constants as zp_constants,
-};
+use zcash_primitives::consensus::{self as zp_consensus, Parameters};
 use zcash_protocol::consensus::NetworkConstants as _;
 
 use crate::{
     block::Height,
     parameters::{
         testnet::{
-            self, ConfiguredActivationHeights, MAX_HRP_LENGTH, MAX_NETWORK_NAME_LENGTH,
-            RESERVED_NETWORK_NAMES,
+            self, ConfiguredActivationHeights, MAX_NETWORK_NAME_LENGTH, RESERVED_NETWORK_NAMES,
         },
         Network, NetworkUpgrade, MAINNET_ACTIVATION_HEIGHTS, NETWORK_UPGRADES_IN_ORDER,
         TESTNET_ACTIVATION_HEIGHTS,
@@ -215,85 +211,6 @@ fn check_configured_network_name() {
         expected_name,
         "network must be displayed as configured network name"
     );
-}
-
-/// Checks that configured Sapling human-readable prefixes (HRPs) are validated and used correctly.
-#[test]
-fn check_configured_sapling_hrps() {
-    // Sets a no-op panic hook to avoid long output.
-    std::panic::set_hook(Box::new(|_| {}));
-
-    // Check that configured Sapling HRPs must be unique.
-    std::panic::catch_unwind(|| {
-        testnet::Parameters::build().with_sapling_hrps("", "", "");
-    })
-    .expect_err("should panic when setting non-unique Sapling HRPs");
-
-    // Check that max length is enforced, and that network names may only contain lowecase ASCII characters and dashes.
-    for invalid_hrp in [
-        "a".repeat(MAX_NETWORK_NAME_LENGTH + 1),
-        "!!!!non-alphabetical-name".to_string(),
-        "A".to_string(),
-    ] {
-        std::panic::catch_unwind(|| {
-            testnet::Parameters::build().with_sapling_hrps(invalid_hrp, "dummy-hrp-a", "dummy-hrp-b");
-        })
-        .expect_err("should panic when setting Sapling HRPs that are too long or contain non-alphanumeric characters (except '-')");
-    }
-
-    // Restore the regular panic hook for any unexpected panics
-    drop(std::panic::take_hook());
-
-    // Check that Sapling HRPs can contain lowercase ascii characters and dashes.
-    let expected_hrp_sapling_extended_spending_key = "sapling-hrp-a";
-    let expected_hrp_sapling_extended_full_viewing_key = "sapling-hrp-b";
-    let expected_hrp_sapling_payment_address = "sapling-hrp-c";
-
-    let network = testnet::Parameters::build()
-        // Check that Sapling HRPs can contain `MAX_HRP_LENGTH` characters
-        .with_sapling_hrps("a".repeat(MAX_HRP_LENGTH), "dummy-hrp-a", "dummy-hrp-b")
-        .with_sapling_hrps(
-            expected_hrp_sapling_extended_spending_key,
-            expected_hrp_sapling_extended_full_viewing_key,
-            expected_hrp_sapling_payment_address,
-        )
-        .to_network();
-
-    // Check that configured Sapling HRPs are returned by `Parameters` trait methods
-    assert_eq!(
-        network.hrp_sapling_extended_spending_key(),
-        expected_hrp_sapling_extended_spending_key,
-        "should return expected Sapling extended spending key HRP"
-    );
-    assert_eq!(
-        network.hrp_sapling_extended_full_viewing_key(),
-        expected_hrp_sapling_extended_full_viewing_key,
-        "should return expected Sapling EFVK HRP"
-    );
-    assert_eq!(
-        network.hrp_sapling_payment_address(),
-        expected_hrp_sapling_payment_address,
-        "should return expected Sapling payment address HRP"
-    );
-
-    // Check that default Mainnet, Testnet, and Regtest HRPs are valid, these calls will panic
-    // if any of the values fail validation.
-    testnet::Parameters::build()
-        .with_sapling_hrps(
-            zp_constants::mainnet::HRP_SAPLING_EXTENDED_SPENDING_KEY,
-            zp_constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
-            zp_constants::mainnet::HRP_SAPLING_PAYMENT_ADDRESS,
-        )
-        .with_sapling_hrps(
-            zp_constants::testnet::HRP_SAPLING_EXTENDED_SPENDING_KEY,
-            zp_constants::testnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
-            zp_constants::testnet::HRP_SAPLING_PAYMENT_ADDRESS,
-        )
-        .with_sapling_hrps(
-            zp_constants::regtest::HRP_SAPLING_EXTENDED_SPENDING_KEY,
-            zp_constants::regtest::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
-            zp_constants::regtest::HRP_SAPLING_PAYMENT_ADDRESS,
-        );
 }
 
 /// Checks that configured testnet names are validated and used correctly.

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -515,19 +515,6 @@ impl From<zcash_protocol::consensus::NetworkUpgrade> for NetworkUpgrade {
     }
 }
 
-impl From<zcash_primitives::consensus::NetworkUpgrade> for NetworkUpgrade {
-    fn from(value: zcash_primitives::consensus::NetworkUpgrade) -> Self {
-        match value {
-            zcash_primitives::consensus::NetworkUpgrade::Overwinter => NetworkUpgrade::Overwinter,
-            zcash_primitives::consensus::NetworkUpgrade::Sapling => NetworkUpgrade::Sapling,
-            zcash_primitives::consensus::NetworkUpgrade::Blossom => NetworkUpgrade::Blossom,
-            zcash_primitives::consensus::NetworkUpgrade::Heartwood => NetworkUpgrade::Heartwood,
-            zcash_primitives::consensus::NetworkUpgrade::Canopy => NetworkUpgrade::Canopy,
-            zcash_primitives::consensus::NetworkUpgrade::Nu5 => NetworkUpgrade::Nu5,
-        }
-    }
-}
-
 impl ConsensusBranchId {
     /// The value used by `zcashd` RPCs for missing consensus branch IDs.
     ///

--- a/zebra-chain/src/primitives/zcash_primitives.rs
+++ b/zebra-chain/src/primitives/zcash_primitives.rs
@@ -4,6 +4,7 @@
 use std::{io, ops::Deref};
 
 use zcash_primitives::transaction as zp_tx;
+use zcash_protocol::value::BalanceError;
 
 use crate::{
     amount::{Amount, NonNegative},
@@ -207,7 +208,7 @@ impl TryFrom<transparent::Output> for zp_tx::components::TxOut {
 
 /// Convert a Zebra non-negative Amount into a librustzcash one.
 impl TryFrom<Amount<NonNegative>> for zp_tx::components::amount::NonNegativeAmount {
-    type Error = ();
+    type Error = BalanceError;
 
     fn try_from(amount: Amount<NonNegative>) -> Result<Self, Self::Error> {
         zp_tx::components::amount::NonNegativeAmount::from_nonnegative_i64(amount.into())

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -58,7 +58,7 @@ tracing = "0.1.39"
 tracing-futures = "0.2.5"
 
 sapling = { package = "sapling-crypto", version = "0.1" }
-orchard = "0.7.0"
+orchard = "0.8.0"
 
 zcash_proofs = { version = "0.15.0", features = ["multicore" ] }
 wagyu-zcash-parameters = "0.2.0"

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -61,7 +61,7 @@ tracing-futures = "0.2.5"
 sapling = { package = "sapling-crypto", version = "0.1" }
 orchard = "0.7.0"
 
-zcash_proofs = { version = "0.14.0", features = ["multicore" ] }
+zcash_proofs = { version = "0.15.0", features = ["multicore" ] }
 wagyu-zcash-parameters = "0.2.0"
 
 tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.13" }

--- a/zebra-grpc/Cargo.toml
+++ b/zebra-grpc/Cargo.toml
@@ -26,7 +26,7 @@ tokio-stream = "0.1.15"
 tower = { version = "0.4.13", features = ["util", "buffer"] }
 color-eyre = "0.6.3"
 
-zcash_primitives = { version = "0.14.0" }
+zcash_primitives = { version = "0.15.0" }
 
 zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.37", features = ["shielded-scan"] }
 zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.37" }

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -64,7 +64,7 @@ tracing = "0.1.39"
 hex = { version = "0.4.3", features = ["serde"] }
 serde = { version = "1.0.203", features = ["serde_derive"] }
 
-zcash_primitives = { version = "0.14.0" }
+zcash_primitives = { version = "0.15.0" }
 
 # Experimental feature getblocktemplate-rpcs
 rand = { version = "0.8.5", optional = true }

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -53,7 +53,7 @@ futures = "0.3.30"
 
 zcash_client_backend = { version = "0.12.1" }
 zcash_keys = { version = "0.2.0", features = ["sapling"] }
-zcash_primitives = "0.14.0"
+zcash_primitives = "0.15.0"
 zcash_address = "0.3.2"
 sapling = { package = "sapling-crypto", version = "0.1" }
 


### PR DESCRIPTION
## Solution

- Bump `orchard` from 0.7 to 0.8.
- Bump `zcash_primitives` from 0.14 to 0.15
  - The new version moves the methods previously in `zcash_primitives::consensus::Parameters` to `zcash_protocol::consensus::NetworkConstants`, which is now blanket-implemented for Zebra's `Network`, so I removed our implementation of `zcash_primitives::consensus::Parameters` because of conflicting method names. The blanket implementation of `NetworkConstants` returns hard-coded HRPs, so we lost the ability to return custom ones. We don't need custom HRPs now, so I removed them.
- Bump `zcash_proofs` from 0.14 to 0.15.

### Tests

Existing tests should suffice.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] ~~The PR provides a CHANGELOG summary.~~
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.