### PR TITLE
fix(openapi): Add defaults to rpc methods where needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   This means `zebrad` no longer contains users' viewing keys.
 - We're no longer using general conditional compilation attributes for `tor`,
   but only feature flags instead.
-- Fixed a bug with trailing characters in the openapi spec method descriptions((#8597)[https://github.com/ZcashFoundation/zebra/pull/8597])
+- Fixed a bug with trailing characters in the openapi spec method descriptions([#8597](https://github.com/ZcashFoundation/zebra/pull/8597))
+- Added default constructions for several RPC method responses([#8616](https://github.com/ZcashFoundation/zebra/pull/8616))
 
 ## [Zebra 1.7.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.7.0) - 2024-05-07
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6346,6 +6346,7 @@ dependencies = [
  "itertools 0.13.0",
  "jsonrpc",
  "quote",
+ "rand 0.8.5",
  "regex",
  "reqwest",
  "serde",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,44 +11,6 @@ info:
 servers:
   - url: http://localhost:8232
 paths:
-  /getblocktemplate:
-    post:
-      tags:
-      - mining
-      description: |-
-        Returns a block template for mining new Zcash blocks.
-
-        **Request body `params` arguments:**
-
-        - `jsonrequestobject` - A JSON object containing arguments.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getblocktemplate
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
   /sendrawtransaction:
     post:
       tags:
@@ -66,6 +28,9 @@ paths:
             schema:
               type: object
               properties:
+                method:
+                  type: string
+                  default: sendrawtransaction
                 id:
                   type: number
                   default: '123'
@@ -73,20 +38,7 @@ paths:
                   type: array
                   items: {}
                   default: '["signedhex"]'
-                method:
-                  type: string
-                  default: sendrawtransaction
       responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
         '200':
           description: OK
           content:
@@ -97,6 +49,16 @@ paths:
                   result:
                     type: object
                     default: '{}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
   /getpeerinfo:
     post:
       tags:
@@ -109,12 +71,12 @@ paths:
             schema:
               type: object
               properties:
-                method:
-                  type: string
-                  default: getpeerinfo
                 id:
                   type: number
                   default: '123'
+                method:
+                  type: string
+                  default: getpeerinfo
                 params:
                   type: array
                   items: {}
@@ -130,39 +92,6 @@ paths:
                   result:
                     type: object
                     default: '{"addr":"0.0.0.0:0"}'
-  /getmininginfo:
-    post:
-      tags:
-      - mining
-      description: Returns mining-related information.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getmininginfo
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
   /validateaddress:
     post:
       tags:
@@ -180,6 +109,9 @@ paths:
             schema:
               type: object
               properties:
+                method:
+                  type: string
+                  default: validateaddress
                 id:
                   type: number
                   default: '123'
@@ -187,9 +119,6 @@ paths:
                   type: array
                   items: {}
                   default: '[]'
-                method:
-                  type: string
-                  default: validateaddress
       responses:
         '200':
           description: OK
@@ -200,7 +129,7 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{}'
+                    default: '{"isvalid":false}'
   /getblocksubsidy:
     post:
       tags:
@@ -218,9 +147,6 @@ paths:
             schema:
               type: object
               properties:
-                id:
-                  type: number
-                  default: '123'
                 method:
                   type: string
                   default: getblocksubsidy
@@ -228,6 +154,9 @@ paths:
                   type: array
                   items: {}
                   default: '[1]'
+                id:
+                  type: number
+                  default: '123'
       responses:
         '200':
           description: OK
@@ -249,11 +178,188 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getblockchaininfo:
+  /getaddressutxos:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns all unspent outputs for a list of addresses.
+
+        **Request body `params` arguments:**
+
+        - `addresses` - The addresses to get outputs from.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getaddressutxos
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"address":"t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs","txid":"0000000000000000000000000000000000000000000000000000000000000000","outputIndex":0,"script":"00000000000000000000","satoshis":0,"height":0}'
+  /getrawmempool:
     post:
       tags:
       - blockchain
-      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
+      description: Returns all transaction ids in the memory pool, as a JSON array.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getrawmempool
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getblockhash:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns the hash of the block of a given height iff the index argument correspond
+
+        **Request body `params` arguments:**
+
+        - `index` - The block index.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[1]'
+                method:
+                  type: string
+                  default: getblockhash
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getaddressbalance:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns the total balance of a provided `addresses` in an [`AddressBalance`] instance.
+
+        **Request body `params` arguments:**
+
+        - `address_strings` - A JSON map with a single entry
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getaddressbalance
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"balance":0}'
+  /getinfo:
+    post:
+      tags:
+      - control
+      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
       requestBody:
         required: true
         content:
@@ -267,10 +373,81 @@ paths:
                   default: '[]'
                 method:
                   type: string
+                  default: getinfo
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"build":"some build version","subversion":"some subversion"}'
+  /submitblock:
+    post:
+      tags:
+      - mining
+      description: |-
+        Submits block to the node to be validated and committed.
+
+        **Request body `params` arguments:**
+
+        - `jsonparametersobject` - - currently ignored
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: submitblock
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getblockchaininfo:
+    post:
+      tags:
+      - blockchain
+      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
                   default: getblockchaininfo
                 id:
                   type: number
                   default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
       responses:
         '200':
           description: OK
@@ -301,9 +478,47 @@ paths:
             schema:
               type: object
               properties:
+                id:
+                  type: number
+                  default: '123'
                 method:
                   type: string
                   default: z_getsubtreesbyindex
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getblocktemplate:
+    post:
+      tags:
+      - mining
+      description: |-
+        Returns a block template for mining new Zcash blocks.
+
+        **Request body `params` arguments:**
+
+        - `jsonrequestobject` - A JSON object containing arguments.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblocktemplate
                 params:
                   type: array
                   items: {}
@@ -322,11 +537,11 @@ paths:
                   result:
                     type: object
                     default: '{}'
-  /getrawmempool:
+  /getblockcount:
     post:
       tags:
       - blockchain
-      description: Returns all transaction ids in the memory pool, as a JSON array.
+      description: Returns the height of the most recent block in the best valid block chain (equivalently,
       requestBody:
         required: true
         content:
@@ -339,7 +554,7 @@ paths:
                   default: '123'
                 method:
                   type: string
-                  default: getrawmempool
+                  default: getblockcount
                 params:
                   type: array
                   items: {}
@@ -354,7 +569,323 @@ paths:
                 properties:
                   result:
                     type: object
+                    default: '0'
+  /getrawtransaction:
+    post:
+      tags:
+      - transaction
+      description: |-
+        Returns the raw transaction data, as a [`GetRawTransaction`] JSON string or structure.
+
+        **Request body `params` arguments:**
+
+        - `txid` - The transaction ID of the transaction to be returned.
+        - `verbose` - If 0, return a string of hex-encoded data, otherwise return a JSON object.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getrawtransaction
+                params:
+                  type: array
+                  items: {}
+                  default: '["mytxid", 1]'
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
                     default: '{}'
+  /getblock:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
+
+        **Request body `params` arguments:**
+
+        - `hash_or_height` - The hash or height for the block to be returned.
+        - `verbosity` - 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblock
+                params:
+                  type: array
+                  items: {}
+                  default: '["1", 1]'
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getmininginfo:
+    post:
+      tags:
+      - mining
+      description: Returns mining-related information.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getmininginfo
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
+  /getdifficulty:
+    post:
+      tags:
+      - blockchain
+      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getdifficulty
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getaddresstxids:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns the transaction ids made by the provided transparent addresses.
+
+        **Request body `params` arguments:**
+
+        - `request` - A struct with the following named fields:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
+                method:
+                  type: string
+                  default: getaddresstxids
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '[]'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getnetworksolps:
+    post:
+      tags:
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getnetworksolps
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getbestblockhash:
+    post:
+      tags:
+      - blockchain
+      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getbestblockhash
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+  /z_validateaddress:
+    post:
+      tags:
+      - util
+      description: |-
+        Checks if a zcash address is valid.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash address to validate.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: z_validateaddress
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"isvalid":false}'
   /z_gettreestate:
     post:
       tags:
@@ -403,16 +934,11 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getaddresstxids:
+  /getnetworkhashps:
     post:
       tags:
-      - address
-      description: |-
-        Returns the transaction ids made by the provided transparent addresses.
-
-        **Request body `params` arguments:**
-
-        - `request` - A struct with the following named fields:
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
       requestBody:
         required: true
         content:
@@ -423,13 +949,13 @@ paths:
                 params:
                   type: array
                   items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
-                method:
-                  type: string
-                  default: getaddresstxids
+                  default: '[]'
                 id:
                   type: number
                   default: '123'
+                method:
+                  type: string
+                  default: getnetworkhashps
       responses:
         '200':
           description: OK
@@ -440,17 +966,7 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '[]'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
+                    default: '{}'
   /z_listunifiedreceivers:
     post:
       tags:
@@ -489,519 +1005,3 @@ paths:
                   result:
                     type: object
                     default: '{}'
-  /getrawtransaction:
-    post:
-      tags:
-      - transaction
-      description: |-
-        Returns the raw transaction data, as a [`GetRawTransaction`] JSON string or structure.
-
-        **Request body `params` arguments:**
-
-        - `txid` - The transaction ID of the transaction to be returned.
-        - `verbose` - If 0, return a string of hex-encoded data, otherwise return a JSON object.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '["mytxid", 1]'
-                method:
-                  type: string
-                  default: getrawtransaction
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getinfo:
-    post:
-      tags:
-      - control
-      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getinfo
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"build":"some build version","subversion":"some subversion"}'
-  /getaddressbalance:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns the total balance of a provided `addresses` in an [`AddressBalance`] instance.
-
-        **Request body `params` arguments:**
-
-        - `address_strings` - A JSON map with a single entry
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getaddressbalance
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"balance":0}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getnetworksolps:
-    post:
-      tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getnetworksolps
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getdifficulty:
-    post:
-      tags:
-      - blockchain
-      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getdifficulty
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getblockhash:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns the hash of the block of a given height iff the index argument correspond
-
-        **Request body `params` arguments:**
-
-        - `index` - The block index.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getblockhash
-                params:
-                  type: array
-                  items: {}
-                  default: '[1]'
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-  /getnetworkhashps:
-    post:
-      tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getnetworkhashps
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /z_validateaddress:
-    post:
-      tags:
-      - util
-      description: |-
-        Checks if a zcash address is valid.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash address to validate.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: z_validateaddress
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getaddressutxos:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns all unspent outputs for a list of addresses.
-
-        **Request body `params` arguments:**
-
-        - `addresses` - The addresses to get outputs from.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getaddressutxos
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"address":"t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs","txid":"0000000000000000000000000000000000000000000000000000000000000000","outputIndex":0,"script":"00000000000000000000","satoshis":0,"height":0}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getbestblockhash:
-    post:
-      tags:
-      - blockchain
-      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getbestblockhash
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-  /submitblock:
-    post:
-      tags:
-      - mining
-      description: |-
-        Submits block to the node to be validated and committed.
-
-        **Request body `params` arguments:**
-
-        - `jsonparametersobject` - - currently ignored
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: submitblock
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getblockcount:
-    post:
-      tags:
-      - blockchain
-      description: Returns the height of the most recent block in the best valid block chain (equivalently,
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblockcount
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0'
-  /getblock:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
-
-        **Request body `params` arguments:**
-
-        - `hash_or_height` - The hash or height for the block to be returned.
-        - `verbosity` - 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '["1", 1]'
-                method:
-                  type: string
-                  default: getblock
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,46 +11,6 @@ info:
 servers:
   - url: http://localhost:8232
 paths:
-  /z_getsubtreesbyindex:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns information about a range of Sapling or Orchard subtrees.
-
-        **Request body `params` arguments:**
-
-        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
-        - `start_index` - The index of the first 2^16-leaf subtree to return.
-        - `limit` - The maximum number of subtree values to return.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: z_getsubtreesbyindex
-                id:
-                  type: number
-                  default: EoYdKA8KlS
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"pool":"","start_index":0,"subtrees":[]}'
   /getblock:
     post:
       tags:
@@ -69,27 +29,17 @@ paths:
             schema:
               type: object
               properties:
-                method:
-                  type: string
-                  default: getblock
                 params:
                   type: array
                   items: {}
                   default: '["1", 1]'
+                method:
+                  type: string
+                  default: getblock
                 id:
-                  type: number
-                  default: yzmtph9UW7
+                  type: string
+                  default: ZIRjKWa3u3
       responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
         '400':
           description: Bad request
           content:
@@ -100,29 +50,6 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getnetworkhashps:
-    post:
-      tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getnetworkhashps
-                id:
-                  type: number
-                  default: 2QeVVBuEQJ
-      responses:
         '200':
           description: OK
           content:
@@ -132,12 +59,12 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '0'
-  /getnetworksolps:
+                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
+  /getinfo:
     post:
       tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      - control
+      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
       requestBody:
         required: true
         content:
@@ -147,10 +74,10 @@ paths:
               properties:
                 method:
                   type: string
-                  default: getnetworksolps
+                  default: getinfo
                 id:
-                  type: number
-                  default: yVVEVf5JRR
+                  type: string
+                  default: bnMfmMTZg2
                 params:
                   type: array
                   items: {}
@@ -165,17 +92,17 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '0'
-  /z_listunifiedreceivers:
+                    default: '{"build":"some build version","subversion":"some subversion"}'
+  /getaddresstxids:
     post:
       tags:
-      - wallet
+      - address
       description: |-
-        Returns the list of individual payment addresses given a unified address.
+        Returns the transaction ids made by the provided transparent addresses.
 
         **Request body `params` arguments:**
 
-        - `address` - The zcash unified address to get the list from.
+        - `request` - A struct with the following named fields:
       requestBody:
         required: true
         content:
@@ -183,16 +110,64 @@ paths:
             schema:
               type: object
               properties:
+                method:
+                  type: string
+                  default: getaddresstxids
+                id:
+                  type: string
+                  default: B8VMAM4QVE
                 params:
                   type: array
                   items: {}
-                  default: '[]'
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '[]'
+  /getaddressbalance:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns the total balance of a provided `addresses` in an [`AddressBalance`] instance.
+
+        **Request body `params` arguments:**
+
+        - `address_strings` - A JSON map with a single entry
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
                 method:
                   type: string
-                  default: z_listunifiedreceivers
+                  default: getaddressbalance
                 id:
-                  type: number
-                  default: gfWPG76VmE
+                  type: string
+                  default: NA7pOvDSEt
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
       responses:
         '200':
           description: OK
@@ -203,7 +178,17 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{"orchard":"orchard address if any","sapling":"sapling address if any","p2pkh":"p2pkh address if any","p2sh":"p2sh address if any"}'
+                    default: '{"balance":0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
   /z_gettreestate:
     post:
       tags:
@@ -221,16 +206,16 @@ paths:
             schema:
               type: object
               properties:
-                id:
-                  type: number
-                  default: t5Gqe1Ldwp
-                method:
-                  type: string
-                  default: z_gettreestate
                 params:
                   type: array
                   items: {}
                   default: '["00000000febc373a1da2bd9f887b105ad79ddc26ac26c2b28652d64e5207c5b5"]'
+                method:
+                  type: string
+                  default: z_gettreestate
+                id:
+                  type: string
+                  default: 7fsifMJFvD
       responses:
         '400':
           description: Bad request
@@ -252,105 +237,6 @@ paths:
                   result:
                     type: object
                     default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","height":0,"time":0}'
-  /getdifficulty:
-    post:
-      tags:
-      - blockchain
-      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getdifficulty
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: XD5004uOFO
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0.0'
-  /getinfo:
-    post:
-      tags:
-      - control
-      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getinfo
-                id:
-                  type: number
-                  default: nWKQogai3i
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"build":"some build version","subversion":"some subversion"}'
-  /getblockcount:
-    post:
-      tags:
-      - blockchain
-      description: Returns the height of the most recent block in the best valid block chain (equivalently,
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: A2NwqDNFw5
-                method:
-                  type: string
-                  default: getblockcount
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0'
   /getblocktemplate:
     post:
       tags:
@@ -368,12 +254,12 @@ paths:
             schema:
               type: object
               properties:
+                id:
+                  type: string
+                  default: 434jrn4jzN
                 method:
                   type: string
                   default: getblocktemplate
-                id:
-                  type: number
-                  default: h26t6n7Hlr
                 params:
                   type: array
                   items: {}
@@ -389,130 +275,11 @@ paths:
                   result:
                     type: object
                     default: '{}'
-  /submitblock:
-    post:
-      tags:
-      - mining
-      description: |-
-        Submits block to the node to be validated and committed.
-
-        **Request body `params` arguments:**
-
-        - `jsonparametersobject` - - currently ignored
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: submitblock
-                id:
-                  type: number
-                  default: 9Mgvqee3ws
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"rejected"'
-  /getpeerinfo:
-    post:
-      tags:
-      - network
-      description: Returns data about each connected network node.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getpeerinfo
-                id:
-                  type: number
-                  default: 7Pul86u6Kk
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"addr":"0.0.0.0:0"}'
-  /sendrawtransaction:
-    post:
-      tags:
-      - transaction
-      description: |-
-        Sends the raw bytes of a signed transaction to the local node''s mempool, if the transaction is valid.
-
-        **Request body `params` arguments:**
-
-        - `raw_transaction_hex` - The hex-encoded raw transaction bytes.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: dFgkpAoOAf
-                params:
-                  type: array
-                  items: {}
-                  default: '["signedhex"]'
-                method:
-                  type: string
-                  default: sendrawtransaction
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getrawmempool:
+  /getblockcount:
     post:
       tags:
       - blockchain
-      description: Returns all transaction ids in the memory pool, as a JSON array.
+      description: Returns the height of the most recent block in the best valid block chain (equivalently,
       requestBody:
         required: true
         content:
@@ -520,16 +287,16 @@ paths:
             schema:
               type: object
               properties:
-                id:
-                  type: number
-                  default: pX3oJfdTmR
                 params:
                   type: array
                   items: {}
                   default: '[]'
+                id:
+                  type: string
+                  default: OAVHYYvbys
                 method:
                   type: string
-                  default: getrawmempool
+                  default: getblockcount
       responses:
         '200':
           description: OK
@@ -540,45 +307,7 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '[]'
-  /z_validateaddress:
-    post:
-      tags:
-      - util
-      description: |-
-        Checks if a zcash address is valid.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash address to validate.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: OpPOfL9KtU
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: z_validateaddress
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"isvalid":false}'
+                    default: '0'
   /getrawtransaction:
     post:
       tags:
@@ -597,16 +326,16 @@ paths:
             schema:
               type: object
               properties:
-                method:
-                  type: string
-                  default: getrawtransaction
-                id:
-                  type: number
-                  default: HFGYoSO2Y9
                 params:
                   type: array
                   items: {}
                   default: '["mytxid", 1]'
+                method:
+                  type: string
+                  default: getrawtransaction
+                id:
+                  type: string
+                  default: oFXx0njb3Q
       responses:
         '200':
           description: OK
@@ -617,7 +346,7 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{"hex":"0000000000000000000000000000000000000000","height":0,"confirmations":0}'
+                    default: '{"hex":"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","height":0,"confirmations":0}'
         '400':
           description: Bad request
           content:
@@ -628,6 +357,191 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
+  /getmininginfo:
+    post:
+      tags:
+      - mining
+      description: Returns mining-related information.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  default: 6JMrKCulfK
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getmininginfo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
+  /getnetworksolps:
+    post:
+      tags:
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getnetworksolps
+                id:
+                  type: string
+                  default: njhGtG4nug
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
+  /getblocksubsidy:
+    post:
+      tags:
+      - mining
+      description: |-
+        Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
+
+        **Request body `params` arguments:**
+
+        - `height` - Can be any valid current or future height.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[1]'
+                id:
+                  type: string
+                  default: o9on8TUcxC
+                method:
+                  type: string
+                  default: getblocksubsidy
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"fundingstreams":[],"miner":0.0,"founders":0.0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getdifficulty:
+    post:
+      tags:
+      - blockchain
+      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: string
+                  default: mZ3lenrWTl
+                method:
+                  type: string
+                  default: getdifficulty
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0.0'
+  /z_listunifiedreceivers:
+    post:
+      tags:
+      - wallet
+      description: |-
+        Returns the list of individual payment addresses given a unified address.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash unified address to get the list from.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  default: lv1vEXiEVB
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: z_listunifiedreceivers
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"orchard":"orchard address if any","sapling":"sapling address if any","p2pkh":"p2pkh address if any","p2sh":"p2sh address if any"}'
   /validateaddress:
     post:
       tags:
@@ -653,8 +567,8 @@ paths:
                   type: string
                   default: validateaddress
                 id:
-                  type: number
-                  default: Yi9rWQB16V
+                  type: string
+                  default: v8H0x69zSY
       responses:
         '200':
           description: OK
@@ -666,16 +580,11 @@ paths:
                   result:
                     type: object
                     default: '{"isvalid":false}'
-  /getaddresstxids:
+  /getblockchaininfo:
     post:
       tags:
-      - address
-      description: |-
-        Returns the transaction ids made by the provided transparent addresses.
-
-        **Request body `params` arguments:**
-
-        - `request` - A struct with the following named fields:
+      - blockchain
+      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
       requestBody:
         required: true
         content:
@@ -683,16 +592,16 @@ paths:
             schema:
               type: object
               properties:
-                method:
-                  type: string
-                  default: getaddresstxids
-                id:
-                  type: number
-                  default: nV40sjZsiu
                 params:
                   type: array
                   items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
+                  default: '[]'
+                method:
+                  type: string
+                  default: getblockchaininfo
+                id:
+                  type: string
+                  default: zRjGZZwAnV
       responses:
         '200':
           description: OK
@@ -703,7 +612,35 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '[]'
+                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
+  /sendrawtransaction:
+    post:
+      tags:
+      - transaction
+      description: |-
+        Sends the raw bytes of a signed transaction to the local node''s mempool, if the transaction is valid.
+
+        **Request body `params` arguments:**
+
+        - `raw_transaction_hex` - The hex-encoded raw transaction bytes.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  default: Jfjekl0y9o
+                method:
+                  type: string
+                  default: sendrawtransaction
+                params:
+                  type: array
+                  items: {}
+                  default: '["signedhex"]'
+      responses:
         '400':
           description: Bad request
           content:
@@ -714,6 +651,16 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
   /getaddressutxos:
     post:
       tags:
@@ -732,8 +679,8 @@ paths:
               type: object
               properties:
                 id:
-                  type: number
-                  default: ruJjg52Kdg
+                  type: string
+                  default: z9RH4BT3dD
                 params:
                   type: array
                   items: {}
@@ -762,11 +709,11 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getmininginfo:
+  /getnetworkhashps:
     post:
       tags:
       - mining
-      description: Returns mining-related information.
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
       requestBody:
         required: true
         content:
@@ -775,15 +722,15 @@ paths:
               type: object
               properties:
                 id:
-                  type: number
-                  default: jn9BNyjQz7
+                  type: string
+                  default: 5DEifPkJXG
+                method:
+                  type: string
+                  default: getnetworkhashps
                 params:
                   type: array
                   items: {}
                   default: '[]'
-                method:
-                  type: string
-                  default: getmininginfo
       responses:
         '200':
           description: OK
@@ -794,7 +741,7 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
+                    default: '0'
   /getblockhash:
     post:
       tags:
@@ -812,13 +759,13 @@ paths:
             schema:
               type: object
               properties:
-                id:
-                  type: number
-                  default: 2o22V6qOwH
                 params:
                   type: array
                   items: {}
                   default: '[1]'
+                id:
+                  type: string
+                  default: FEsc1mYWNA
                 method:
                   type: string
                   default: getblockhash
@@ -843,11 +790,16 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getblockchaininfo:
+  /submitblock:
     post:
       tags:
-      - blockchain
-      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
+      - mining
+      description: |-
+        Submits block to the node to be validated and committed.
+
+        **Request body `params` arguments:**
+
+        - `jsonparametersobject` - - currently ignored
       requestBody:
         required: true
         content:
@@ -855,16 +807,16 @@ paths:
             schema:
               type: object
               properties:
-                method:
-                  type: string
-                  default: getblockchaininfo
                 params:
                   type: array
                   items: {}
                   default: '[]'
+                method:
+                  type: string
+                  default: submitblock
                 id:
-                  type: number
-                  default: bhPxzpuFy0
+                  type: string
+                  default: YSNgpz5kOl
       responses:
         '200':
           description: OK
@@ -875,7 +827,151 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
+                    default: '"rejected"'
+  /z_validateaddress:
+    post:
+      tags:
+      - util
+      description: |-
+        Checks if a zcash address is valid.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash address to validate.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: z_validateaddress
+                id:
+                  type: string
+                  default: 0m8Q1ZRXFa
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"isvalid":false}'
+  /z_getsubtreesbyindex:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns information about a range of Sapling or Orchard subtrees.
+
+        **Request body `params` arguments:**
+
+        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
+        - `start_index` - The index of the first 2^16-leaf subtree to return.
+        - `limit` - The maximum number of subtree values to return.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  default: TCjABbbF6x
+                method:
+                  type: string
+                  default: z_getsubtreesbyindex
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"pool":"sapling | orchard","start_index":0,"subtrees":[]}'
+  /getrawmempool:
+    post:
+      tags:
+      - blockchain
+      description: Returns all transaction ids in the memory pool, as a JSON array.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getrawmempool
+                id:
+                  type: string
+                  default: 3KcsXMidC9
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '[]'
+  /getpeerinfo:
+    post:
+      tags:
+      - network
+      description: Returns data about each connected network node.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getpeerinfo
+                id:
+                  type: string
+                  default: dPCf95i0af
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"addr":"0.0.0.0:0"}'
   /getbestblockhash:
     post:
       tags:
@@ -896,8 +992,8 @@ paths:
                   type: string
                   default: getbestblockhash
                 id:
-                  type: number
-                  default: UO1gg5esHr
+                  type: string
+                  default: iqmITz3oTr
       responses:
         '200':
           description: OK
@@ -909,99 +1005,3 @@ paths:
                   result:
                     type: object
                     default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-  /getaddressbalance:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns the total balance of a provided `addresses` in an [`AddressBalance`] instance.
-
-        **Request body `params` arguments:**
-
-        - `address_strings` - A JSON map with a single entry
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: V6hljf9wni
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
-                method:
-                  type: string
-                  default: getaddressbalance
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"balance":0}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getblocksubsidy:
-    post:
-      tags:
-      - mining
-      description: |-
-        Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
-
-        **Request body `params` arguments:**
-
-        - `height` - Can be any valid current or future height.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: K3CavEZ6uI
-                params:
-                  type: array
-                  items: {}
-                  default: '[1]'
-                method:
-                  type: string
-                  default: getblocksubsidy
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"fundingstreams":[],"miner":0.0,"founders":0.0}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,153 +11,17 @@ info:
 servers:
   - url: http://localhost:8232
 paths:
-  /getnetworksolps:
-    post:
-      tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getnetworksolps
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0'
-  /z_validateaddress:
-    post:
-      tags:
-      - util
-      description: |-
-        Checks if a zcash address is valid.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash address to validate.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: z_validateaddress
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"isvalid":false}'
-  /getrawmempool:
+  /getblock:
     post:
       tags:
       - blockchain
-      description: Returns all transaction ids in the memory pool, as a JSON array.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getrawmempool
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '[]'
-  /getdifficulty:
-    post:
-      tags:
-      - blockchain
-      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getdifficulty
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0.0'
-  /z_listunifiedreceivers:
-    post:
-      tags:
-      - wallet
       description: |-
-        Returns the list of individual payment addresses given a unified address.
+        Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
 
         **Request body `params` arguments:**
 
-        - `address` - The zcash unified address to get the list from.
+        - `hash_or_height` - The hash or height for the block to be returned.
+        - `verbosity` - 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.
       requestBody:
         required: true
         content:
@@ -165,65 +29,17 @@ paths:
             schema:
               type: object
               properties:
-                method:
-                  type: string
-                  default: z_listunifiedreceivers
                 id:
                   type: number
                   default: '123'
                 params:
                   type: array
                   items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"orchard":"orchard address if any","sapling":"sapling address if any","p2pkh":"p2pkh address if any","p2sh":"p2sh address if any"}'
-  /getaddresstxids:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns the transaction ids made by the provided transparent addresses.
-
-        **Request body `params` arguments:**
-
-        - `request` - A struct with the following named fields:
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
+                  default: '["1", 1]'
                 method:
                   type: string
-                  default: getaddresstxids
-                id:
-                  type: number
-                  default: '123'
+                  default: getblock
       responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '[]'
         '400':
           description: Bad request
           content:
@@ -234,34 +50,6 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getblockhash:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns the hash of the block of a given height iff the index argument correspond
-
-        **Request body `params` arguments:**
-
-        - `index` - The block index.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblockhash
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[1]'
-      responses:
         '200':
           description: OK
           content:
@@ -271,7 +59,36 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
+  /getrawtransaction:
+    post:
+      tags:
+      - transaction
+      description: |-
+        Returns the raw transaction data, as a [`GetRawTransaction`] JSON string or structure.
+
+        **Request body `params` arguments:**
+
+        - `txid` - The transaction ID of the transaction to be returned.
+        - `verbose` - If 0, return a string of hex-encoded data, otherwise return a JSON object.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getrawtransaction
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '["mytxid", 1]'
+      responses:
         '400':
           description: Bad request
           content:
@@ -282,11 +99,21 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getbestblockhash:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"hex":"0000000000000000000000000000000000000000","height":0,"confirmations":0}'
+  /getblockchaininfo:
     post:
       tags:
       - blockchain
-      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
+      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
       requestBody:
         required: true
         content:
@@ -294,12 +121,12 @@ paths:
             schema:
               type: object
               properties:
-                method:
-                  type: string
-                  default: getbestblockhash
                 id:
                   type: number
                   default: '123'
+                method:
+                  type: string
+                  default: getblockchaininfo
                 params:
                   type: array
                   items: {}
@@ -314,7 +141,7 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
   /z_gettreestate:
     post:
       tags:
@@ -332,16 +159,16 @@ paths:
             schema:
               type: object
               properties:
+                method:
+                  type: string
+                  default: z_gettreestate
+                id:
+                  type: number
+                  default: '123'
                 params:
                   type: array
                   items: {}
                   default: '["00000000febc373a1da2bd9f887b105ad79ddc26ac26c2b28652d64e5207c5b5"]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: z_gettreestate
       responses:
         '200':
           description: OK
@@ -363,410 +190,6 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getaddressutxos:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns all unspent outputs for a list of addresses.
-
-        **Request body `params` arguments:**
-
-        - `addresses` - The addresses to get outputs from.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getaddressutxos
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"address":"t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs","txid":"0000000000000000000000000000000000000000000000000000000000000000","outputIndex":0,"script":"00000000000000000000","satoshis":0,"height":0}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getblockcount:
-    post:
-      tags:
-      - blockchain
-      description: Returns the height of the most recent block in the best valid block chain (equivalently,
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getblockcount
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0'
-  /getblocksubsidy:
-    post:
-      tags:
-      - mining
-      description: |-
-        Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
-
-        **Request body `params` arguments:**
-
-        - `height` - Can be any valid current or future height.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[1]'
-                method:
-                  type: string
-                  default: getblocksubsidy
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"fundingstreams":[],"miner":0.0,"founders":0.0}'
-  /getrawtransaction:
-    post:
-      tags:
-      - transaction
-      description: |-
-        Returns the raw transaction data, as a [`GetRawTransaction`] JSON string or structure.
-
-        **Request body `params` arguments:**
-
-        - `txid` - The transaction ID of the transaction to be returned.
-        - `verbose` - If 0, return a string of hex-encoded data, otherwise return a JSON object.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '["mytxid", 1]'
-                method:
-                  type: string
-                  default: getrawtransaction
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"hex":"0000000000000000000000000000000000000000","height":0,"confirmations":0}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getmininginfo:
-    post:
-      tags:
-      - mining
-      description: Returns mining-related information.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getmininginfo
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
-  /getblock:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
-
-        **Request body `params` arguments:**
-
-        - `hash_or_height` - The hash or height for the block to be returned.
-        - `verbosity` - 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblock
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '["1", 1]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /z_getsubtreesbyindex:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns information about a range of Sapling or Orchard subtrees.
-
-        **Request body `params` arguments:**
-
-        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
-        - `start_index` - The index of the first 2^16-leaf subtree to return.
-        - `limit` - The maximum number of subtree values to return.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: z_getsubtreesbyindex
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getblocktemplate:
-    post:
-      tags:
-      - mining
-      description: |-
-        Returns a block template for mining new Zcash blocks.
-
-        **Request body `params` arguments:**
-
-        - `jsonrequestobject` - A JSON object containing arguments.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getblocktemplate
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getinfo:
-    post:
-      tags:
-      - control
-      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getinfo
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"build":"some build version","subversion":"some subversion"}'
-  /getblockchaininfo:
-    post:
-      tags:
-      - blockchain
-      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getblockchaininfo
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
   /getaddressbalance:
     post:
       tags:
@@ -815,6 +238,327 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
+  /getaddresstxids:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns the transaction ids made by the provided transparent addresses.
+
+        **Request body `params` arguments:**
+
+        - `request` - A struct with the following named fields:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
+                method:
+                  type: string
+                  default: getaddresstxids
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '[]'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getmininginfo:
+    post:
+      tags:
+      - mining
+      description: Returns mining-related information.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getmininginfo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
+  /sendrawtransaction:
+    post:
+      tags:
+      - transaction
+      description: |-
+        Sends the raw bytes of a signed transaction to the local node''s mempool, if the transaction is valid.
+
+        **Request body `params` arguments:**
+
+        - `raw_transaction_hex` - The hex-encoded raw transaction bytes.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: sendrawtransaction
+                params:
+                  type: array
+                  items: {}
+                  default: '["signedhex"]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getblockcount:
+    post:
+      tags:
+      - blockchain
+      description: Returns the height of the most recent block in the best valid block chain (equivalently,
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblockcount
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
+  /z_validateaddress:
+    post:
+      tags:
+      - util
+      description: |-
+        Checks if a zcash address is valid.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash address to validate.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: z_validateaddress
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"isvalid":false}'
+  /getblockhash:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns the hash of the block of a given height iff the index argument correspond
+
+        **Request body `params` arguments:**
+
+        - `index` - The block index.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getblockhash
+                params:
+                  type: array
+                  items: {}
+                  default: '[1]'
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+  /z_getsubtreesbyindex:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns information about a range of Sapling or Orchard subtrees.
+
+        **Request body `params` arguments:**
+
+        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
+        - `start_index` - The index of the first 2^16-leaf subtree to return.
+        - `limit` - The maximum number of subtree values to return.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: z_getsubtreesbyindex
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"pool":"","start_index":0,"subtrees":[]}'
+  /getnetworkhashps:
+    post:
+      tags:
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getnetworkhashps
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
   /getpeerinfo:
     post:
       tags:
@@ -827,13 +571,13 @@ paths:
             schema:
               type: object
               properties:
+                method:
+                  type: string
+                  default: getpeerinfo
                 params:
                   type: array
                   items: {}
                   default: '[]'
-                method:
-                  type: string
-                  default: getpeerinfo
                 id:
                   type: number
                   default: '123'
@@ -868,13 +612,13 @@ paths:
                 id:
                   type: number
                   default: '123'
+                method:
+                  type: string
+                  default: validateaddress
                 params:
                   type: array
                   items: {}
                   default: '[]'
-                method:
-                  type: string
-                  default: validateaddress
       responses:
         '200':
           description: OK
@@ -886,16 +630,11 @@ paths:
                   result:
                     type: object
                     default: '{"isvalid":false}'
-  /sendrawtransaction:
+  /getnetworksolps:
     post:
       tags:
-      - transaction
-      description: |-
-        Sends the raw bytes of a signed transaction to the local node''s mempool, if the transaction is valid.
-
-        **Request body `params` arguments:**
-
-        - `raw_transaction_hex` - The hex-encoded raw transaction bytes.
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
       requestBody:
         required: true
         content:
@@ -905,14 +644,123 @@ paths:
               properties:
                 method:
                   type: string
-                  default: sendrawtransaction
+                  default: getnetworksolps
                 id:
                   type: number
                   default: '123'
                 params:
                   type: array
                   items: {}
-                  default: '["signedhex"]'
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
+  /submitblock:
+    post:
+      tags:
+      - mining
+      description: |-
+        Submits block to the node to be validated and committed.
+
+        **Request body `params` arguments:**
+
+        - `jsonparametersobject` - - currently ignored
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: submitblock
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"rejected"'
+  /getinfo:
+    post:
+      tags:
+      - control
+      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getinfo
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"build":"some build version","subversion":"some subversion"}'
+  /getblocksubsidy:
+    post:
+      tags:
+      - mining
+      description: |-
+        Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
+
+        **Request body `params` arguments:**
+
+        - `height` - Can be any valid current or future height.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblocksubsidy
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[1]'
       responses:
         '400':
           description: Bad request
@@ -933,17 +781,164 @@ paths:
                 properties:
                   result:
                     type: object
+                    default: '{"fundingstreams":[],"miner":0.0,"founders":0.0}'
+  /getdifficulty:
+    post:
+      tags:
+      - blockchain
+      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getdifficulty
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0.0'
+  /getbestblockhash:
+    post:
+      tags:
+      - blockchain
+      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getbestblockhash
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
                     default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-  /submitblock:
+  /getrawmempool:
+    post:
+      tags:
+      - blockchain
+      description: Returns all transaction ids in the memory pool, as a JSON array.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getrawmempool
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '[]'
+  /getaddressutxos:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns all unspent outputs for a list of addresses.
+
+        **Request body `params` arguments:**
+
+        - `addresses` - The addresses to get outputs from.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
+                method:
+                  type: string
+                  default: getaddressutxos
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"address":"t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs","txid":"0000000000000000000000000000000000000000000000000000000000000000","outputIndex":0,"script":"00000000000000000000","satoshis":0,"height":0}'
+  /getblocktemplate:
     post:
       tags:
       - mining
       description: |-
-        Submits block to the node to be validated and committed.
+        Returns a block template for mining new Zcash blocks.
 
         **Request body `params` arguments:**
 
-        - `jsonparametersobject` - - currently ignored
+        - `jsonrequestobject` - A JSON object containing arguments.
       requestBody:
         required: true
         content:
@@ -951,6 +946,9 @@ paths:
             schema:
               type: object
               properties:
+                method:
+                  type: string
+                  default: getblocktemplate
                 id:
                   type: number
                   default: '123'
@@ -958,9 +956,6 @@ paths:
                   type: array
                   items: {}
                   default: '[]'
-                method:
-                  type: string
-                  default: submitblock
       responses:
         '200':
           description: OK
@@ -971,12 +966,17 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '"rejected"'
-  /getnetworkhashps:
+                    default: '{}'
+  /z_listunifiedreceivers:
     post:
       tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      - wallet
+      description: |-
+        Returns the list of individual payment addresses given a unified address.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash unified address to get the list from.
       requestBody:
         required: true
         content:
@@ -986,7 +986,7 @@ paths:
               properties:
                 method:
                   type: string
-                  default: getnetworkhashps
+                  default: z_listunifiedreceivers
                 params:
                   type: array
                   items: {}
@@ -1004,4 +1004,4 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '0'
+                    default: '{"orchard":"orchard address if any","sapling":"sapling address if any","p2pkh":"p2pkh address if any","p2sh":"p2sh address if any"}'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,39 +11,6 @@ info:
 servers:
   - url: http://localhost:8232
 paths:
-  /getpeerinfo:
-    post:
-      tags:
-      - network
-      description: Returns data about each connected network node.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getpeerinfo
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
   /getmininginfo:
     post:
       tags:
@@ -59,6 +26,36 @@ paths:
                 method:
                   type: string
                   default: getmininginfo
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getdifficulty:
+    post:
+      tags:
+      - blockchain
+      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
                 id:
                   type: number
                   default: '123'
@@ -66,6 +63,123 @@ paths:
                   type: array
                   items: {}
                   default: '[]'
+                method:
+                  type: string
+                  default: getdifficulty
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getinfo:
+    post:
+      tags:
+      - control
+      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getinfo
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"build":"some build version","subversion":"some subversion"}'
+  /z_gettreestate:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns information about the given block''s Sapling & Orchard tree state.
+
+        **Request body `params` arguments:**
+
+        - `hash | height` - The block hash or height.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '["00000000febc373a1da2bd9f887b105ad79ddc26ac26c2b28652d64e5207c5b5"]'
+                method:
+                  type: string
+                  default: z_gettreestate
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","height":0,"time":0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getrawmempool:
+    post:
+      tags:
+      - blockchain
+      description: Returns all transaction ids in the memory pool, as a JSON array.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getrawmempool
+                id:
+                  type: number
+                  default: '123'
       responses:
         '200':
           description: OK
@@ -105,16 +219,6 @@ paths:
                   items: {}
                   default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
       responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
         '200':
           description: OK
           content:
@@ -125,16 +229,21 @@ paths:
                   result:
                     type: object
                     default: '{}'
-  /validateaddress:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getnetworkhashps:
     post:
       tags:
-      - util
-      description: |-
-        Checks if a zcash address is valid.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash address to validate.
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
       requestBody:
         required: true
         content:
@@ -142,13 +251,51 @@ paths:
             schema:
               type: object
               properties:
+                id:
+                  type: number
+                  default: '123'
                 params:
                   type: array
                   items: {}
                   default: '[]'
                 method:
                   type: string
-                  default: validateaddress
+                  default: getnetworkhashps
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getblocksubsidy:
+    post:
+      tags:
+      - mining
+      description: |-
+        Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
+
+        **Request body `params` arguments:**
+
+        - `height` - Can be any valid current or future height.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[1]'
+                method:
+                  type: string
+                  default: getblocksubsidy
                 id:
                   type: number
                   default: '123'
@@ -162,18 +309,95 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{}'
-  /getblock:
+                    default: '{"fundingstreams":[],"miner":0.0,"founders":0.0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getbestblockhash:
+    post:
+      tags:
+      - blockchain
+      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getbestblockhash
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+  /z_getsubtreesbyindex:
     post:
       tags:
       - blockchain
       description: |-
-        Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
+        Returns information about a range of Sapling or Orchard subtrees.
 
         **Request body `params` arguments:**
 
-        - `hash_or_height` - The hash or height for the block to be returned.
-        - `verbosity` - 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.
+        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
+        - `start_index` - The index of the first 2^16-leaf subtree to return.
+        - `limit` - The maximum number of subtree values to return.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: z_getsubtreesbyindex
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getblockcount:
+    post:
+      tags:
+      - blockchain
+      description: Returns the height of the most recent block in the best valid block chain (equivalently,
       requestBody:
         required: true
         content:
@@ -187,10 +411,10 @@ paths:
                 params:
                   type: array
                   items: {}
-                  default: '["1", 1]'
+                  default: '[]'
                 method:
                   type: string
-                  default: getblock
+                  default: getblockcount
       responses:
         '200':
           description: OK
@@ -201,17 +425,7 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
+                    default: '{}'
   /getaddresstxids:
     post:
       tags:
@@ -229,12 +443,12 @@ paths:
             schema:
               type: object
               properties:
-                method:
-                  type: string
-                  default: getaddresstxids
                 id:
                   type: number
                   default: '123'
+                method:
+                  type: string
+                  default: getaddresstxids
                 params:
                   type: array
                   items: {}
@@ -260,6 +474,44 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
+  /getblocktemplate:
+    post:
+      tags:
+      - mining
+      description: |-
+        Returns a block template for mining new Zcash blocks.
+
+        **Request body `params` arguments:**
+
+        - `jsonrequestobject` - A JSON object containing arguments.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getblocktemplate
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
   /getaddressutxos:
     post:
       tags:
@@ -277,65 +529,16 @@ paths:
             schema:
               type: object
               properties:
-                id:
-                  type: number
-                  default: '123'
                 params:
                   type: array
                   items: {}
                   default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
-                method:
-                  type: string
-                  default: getaddressutxos
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getrawtransaction:
-    post:
-      tags:
-      - transaction
-      description: |-
-        Returns the raw transaction data, as a [`GetRawTransaction`] JSON string or structure.
-
-        **Request body `params` arguments:**
-
-        - `txid` - The transaction ID of the transaction to be returned.
-        - `verbose` - If 0, return a string of hex-encoded data, otherwise return a JSON object.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '["mytxid", 1]'
                 id:
                   type: number
                   default: '123'
                 method:
                   type: string
-                  default: getrawtransaction
+                  default: getaddressutxos
       responses:
         '200':
           description: OK
@@ -374,6 +577,9 @@ paths:
             schema:
               type: object
               properties:
+                id:
+                  type: number
+                  default: '123'
                 method:
                   type: string
                   default: submitblock
@@ -381,9 +587,6 @@ paths:
                   type: array
                   items: {}
                   default: '[]'
-                id:
-                  type: number
-                  default: '123'
       responses:
         '200':
           description: OK
@@ -395,49 +598,16 @@ paths:
                   result:
                     type: object
                     default: '{}'
-  /getnetworkhashps:
+  /getblockhash:
     post:
       tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getnetworkhashps
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getblocksubsidy:
-    post:
-      tags:
-      - mining
+      - blockchain
       description: |-
-        Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
+        Returns the hash of the block of a given height iff the index argument correspond
 
         **Request body `params` arguments:**
 
-        - `height` - Can be any valid current or future height.
+        - `index` - The block index.
       requestBody:
         required: true
         content:
@@ -447,7 +617,7 @@ paths:
               properties:
                 method:
                   type: string
-                  default: getblocksubsidy
+                  default: getblockhash
                 id:
                   type: number
                   default: '123'
@@ -456,6 +626,16 @@ paths:
                   items: {}
                   default: '[1]'
       responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
         '400':
           description: Bad request
           content:
@@ -466,6 +646,82 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
+  /sendrawtransaction:
+    post:
+      tags:
+      - transaction
+      description: |-
+        Sends the raw bytes of a signed transaction to the local node''s mempool, if the transaction is valid.
+
+        **Request body `params` arguments:**
+
+        - `raw_transaction_hex` - The hex-encoded raw transaction bytes.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '["signedhex"]'
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: sendrawtransaction
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /z_validateaddress:
+    post:
+      tags:
+      - util
+      description: |-
+        Checks if a zcash address is valid.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash address to validate.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: z_validateaddress
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
         '200':
           description: OK
           content:
@@ -488,16 +744,16 @@ paths:
             schema:
               type: object
               properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
                 method:
                   type: string
                   default: getnetworksolps
                 id:
                   type: number
                   default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
       responses:
         '200':
           description: OK
@@ -509,18 +765,11 @@ paths:
                   result:
                     type: object
                     default: '{}'
-  /z_getsubtreesbyindex:
+  /getpeerinfo:
     post:
       tags:
-      - blockchain
-      description: |-
-        Returns information about a range of Sapling or Orchard subtrees.
-
-        **Request body `params` arguments:**
-
-        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
-        - `start_index` - The index of the first 2^16-leaf subtree to return.
-        - `limit` - The maximum number of subtree values to return.
+      - network
+      description: Returns data about each connected network node.
       requestBody:
         required: true
         content:
@@ -528,6 +777,9 @@ paths:
             schema:
               type: object
               properties:
+                method:
+                  type: string
+                  default: getpeerinfo
                 params:
                   type: array
                   items: {}
@@ -535,9 +787,6 @@ paths:
                 id:
                   type: number
                   default: '123'
-                method:
-                  type: string
-                  default: z_getsubtreesbyindex
       responses:
         '200':
           description: OK
@@ -548,208 +797,8 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{}'
-  /getblockchaininfo:
-    post:
-      tags:
-      - blockchain
-      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblockchaininfo
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
-  /getbestblockhash:
-    post:
-      tags:
-      - blockchain
-      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getbestblockhash
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-  /z_gettreestate:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns information about the given block''s Sapling & Orchard tree state.
-
-        **Request body `params` arguments:**
-
-        - `hash | height` - The block hash or height.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: z_gettreestate
-                params:
-                  type: array
-                  items: {}
-                  default: '["00000000febc373a1da2bd9f887b105ad79ddc26ac26c2b28652d64e5207c5b5"]'
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","height":0,"time":0}'
-  /getblockhash:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns the hash of the block of a given height iff the index argument correspond
-
-        **Request body `params` arguments:**
-
-        - `index` - The block index.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblockhash
-                params:
-                  type: array
-                  items: {}
-                  default: '[1]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getblocktemplate:
-    post:
-      tags:
-      - mining
-      description: |-
-        Returns a block template for mining new Zcash blocks.
-
-        **Request body `params` arguments:**
-
-        - `jsonrequestobject` - A JSON object containing arguments.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getblocktemplate
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /z_validateaddress:
+                    default: '{"addr":"0.0.0.0:0"}'
+  /validateaddress:
     post:
       tags:
       - util
@@ -766,6 +815,9 @@ paths:
             schema:
               type: object
               properties:
+                method:
+                  type: string
+                  default: validateaddress
                 params:
                   type: array
                   items: {}
@@ -773,42 +825,6 @@ paths:
                 id:
                   type: number
                   default: '123'
-                method:
-                  type: string
-                  default: z_validateaddress
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getdifficulty:
-    post:
-      tags:
-      - blockchain
-      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getdifficulty
       responses:
         '200':
           description: OK
@@ -841,12 +857,12 @@ paths:
                   type: array
                   items: {}
                   default: '[]'
+                id:
+                  type: number
+                  default: '123'
                 method:
                   type: string
                   default: z_listunifiedreceivers
-                id:
-                  type: number
-                  default: '123'
       responses:
         '200':
           description: OK
@@ -858,11 +874,17 @@ paths:
                   result:
                     type: object
                     default: '{}'
-  /getrawmempool:
+  /getblock:
     post:
       tags:
       - blockchain
-      description: Returns all transaction ids in the memory pool, as a JSON array.
+      description: |-
+        Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
+
+        **Request body `params` arguments:**
+
+        - `hash_or_height` - The hash or height for the block to be returned.
+        - `verbosity` - 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.
       requestBody:
         required: true
         content:
@@ -870,16 +892,16 @@ paths:
             schema:
               type: object
               properties:
-                method:
-                  type: string
-                  default: getrawmempool
                 params:
                   type: array
                   items: {}
-                  default: '[]'
+                  default: '["1", 1]'
                 id:
                   type: number
                   default: '123'
+                method:
+                  type: string
+                  default: getblock
       responses:
         '200':
           description: OK
@@ -890,50 +912,28 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{}'
-  /getblockcount:
-    post:
-      tags:
-      - blockchain
-      description: Returns the height of the most recent block in the best valid block chain (equivalently,
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblockcount
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
+                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
+        '400':
+          description: Bad request
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /sendrawtransaction:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getrawtransaction:
     post:
       tags:
       - transaction
       description: |-
-        Sends the raw bytes of a signed transaction to the local node''s mempool, if the transaction is valid.
+        Returns the raw transaction data, as a [`GetRawTransaction`] JSON string or structure.
 
         **Request body `params` arguments:**
 
-        - `raw_transaction_hex` - The hex-encoded raw transaction bytes.
+        - `txid` - The transaction ID of the transaction to be returned.
+        - `verbose` - If 0, return a string of hex-encoded data, otherwise return a JSON object.
       requestBody:
         required: true
         content:
@@ -941,16 +941,16 @@ paths:
             schema:
               type: object
               properties:
-                id:
-                  type: number
-                  default: '123'
                 params:
                   type: array
                   items: {}
-                  default: '["signedhex"]'
+                  default: '["mytxid", 1]'
                 method:
                   type: string
-                  default: sendrawtransaction
+                  default: getrawtransaction
+                id:
+                  type: number
+                  default: '123'
       responses:
         '200':
           description: OK
@@ -972,11 +972,11 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getinfo:
+  /getblockchaininfo:
     post:
       tags:
-      - control
-      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
+      - blockchain
+      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
       requestBody:
         required: true
         content:
@@ -984,16 +984,16 @@ paths:
             schema:
               type: object
               properties:
-                method:
-                  type: string
-                  default: getinfo
-                id:
-                  type: number
-                  default: '123'
                 params:
                   type: array
                   items: {}
                   default: '[]'
+                method:
+                  type: string
+                  default: getblockchaininfo
+                id:
+                  type: number
+                  default: '123'
       responses:
         '200':
           description: OK
@@ -1004,4 +1004,4 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{"build":"some build version","subversion":"some subversion"}'
+                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,44 +11,11 @@ info:
 servers:
   - url: http://localhost:8232
 paths:
-  /getmininginfo:
-    post:
-      tags:
-      - mining
-      description: Returns mining-related information.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getmininginfo
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getdifficulty:
+  /getbestblockhash:
     post:
       tags:
       - blockchain
-      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
+      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
       requestBody:
         required: true
         content:
@@ -59,13 +26,13 @@ paths:
                 id:
                   type: number
                   default: '123'
+                method:
+                  type: string
+                  default: getbestblockhash
                 params:
                   type: array
                   items: {}
                   default: '[]'
-                method:
-                  type: string
-                  default: getdifficulty
       responses:
         '200':
           description: OK
@@ -76,7 +43,7 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{}'
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
   /getinfo:
     post:
       tags:
@@ -110,16 +77,16 @@ paths:
                   result:
                     type: object
                     default: '{"build":"some build version","subversion":"some subversion"}'
-  /z_gettreestate:
+  /getblockhash:
     post:
       tags:
       - blockchain
       description: |-
-        Returns information about the given block''s Sapling & Orchard tree state.
+        Returns the hash of the block of a given height iff the index argument correspond
 
         **Request body `params` arguments:**
 
-        - `hash | height` - The block hash or height.
+        - `index` - The block index.
       requestBody:
         required: true
         content:
@@ -127,27 +94,17 @@ paths:
             schema:
               type: object
               properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '["00000000febc373a1da2bd9f887b105ad79ddc26ac26c2b28652d64e5207c5b5"]'
                 method:
                   type: string
-                  default: z_gettreestate
+                  default: getblockhash
                 id:
                   type: number
                   default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[1]'
       responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","height":0,"time":0}'
         '400':
           description: Bad request
           content:
@@ -158,11 +115,130 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getrawmempool:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+  /getblocktemplate:
+    post:
+      tags:
+      - mining
+      description: |-
+        Returns a block template for mining new Zcash blocks.
+
+        **Request body `params` arguments:**
+
+        - `jsonrequestobject` - A JSON object containing arguments.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblocktemplate
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getnetworkhashps:
+    post:
+      tags:
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getnetworkhashps
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getblockcount:
     post:
       tags:
       - blockchain
-      description: Returns all transaction ids in the memory pool, as a JSON array.
+      description: Returns the height of the most recent block in the best valid block chain (equivalently,
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblockcount
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /z_validateaddress:
+    post:
+      tags:
+      - util
+      description: |-
+        Checks if a zcash address is valid.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash address to validate.
       requestBody:
         required: true
         content:
@@ -174,12 +250,215 @@ paths:
                   type: array
                   items: {}
                   default: '[]'
-                method:
-                  type: string
-                  default: getrawmempool
                 id:
                   type: number
                   default: '123'
+                method:
+                  type: string
+                  default: z_validateaddress
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getdifficulty:
+    post:
+      tags:
+      - blockchain
+      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getdifficulty
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getpeerinfo:
+    post:
+      tags:
+      - network
+      description: Returns data about each connected network node.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getpeerinfo
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"addr":"0.0.0.0:0"}'
+  /sendrawtransaction:
+    post:
+      tags:
+      - transaction
+      description: |-
+        Sends the raw bytes of a signed transaction to the local node''s mempool, if the transaction is valid.
+
+        **Request body `params` arguments:**
+
+        - `raw_transaction_hex` - The hex-encoded raw transaction bytes.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: sendrawtransaction
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '["signedhex"]'
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getrawtransaction:
+    post:
+      tags:
+      - transaction
+      description: |-
+        Returns the raw transaction data, as a [`GetRawTransaction`] JSON string or structure.
+
+        **Request body `params` arguments:**
+
+        - `txid` - The transaction ID of the transaction to be returned.
+        - `verbose` - If 0, return a string of hex-encoded data, otherwise return a JSON object.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '["mytxid", 1]'
+                method:
+                  type: string
+                  default: getrawtransaction
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /z_getsubtreesbyindex:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns information about a range of Sapling or Orchard subtrees.
+
+        **Request body `params` arguments:**
+
+        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
+        - `start_index` - The index of the first 2^16-leaf subtree to return.
+        - `limit` - The maximum number of subtree values to return.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: z_getsubtreesbyindex
       responses:
         '200':
           description: OK
@@ -219,16 +498,6 @@ paths:
                   items: {}
                   default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
       responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
         '400':
           description: Bad request
           content:
@@ -239,11 +508,26 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getnetworkhashps:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /validateaddress:
     post:
       tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      - util
+      description: |-
+        Checks if a zcash address is valid.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash address to validate.
       requestBody:
         required: true
         content:
@@ -254,13 +538,13 @@ paths:
                 id:
                   type: number
                   default: '123'
+                method:
+                  type: string
+                  default: validateaddress
                 params:
                   type: array
                   items: {}
                   default: '[]'
-                method:
-                  type: string
-                  default: getnetworkhashps
       responses:
         '200':
           description: OK
@@ -289,27 +573,17 @@ paths:
             schema:
               type: object
               properties:
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getblocksubsidy
                 params:
                   type: array
                   items: {}
                   default: '[1]'
-                method:
-                  type: string
-                  default: getblocksubsidy
-                id:
-                  type: number
-                  default: '123'
       responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"fundingstreams":[],"miner":0.0,"founders":0.0}'
         '400':
           description: Bad request
           content:
@@ -320,11 +594,21 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getbestblockhash:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"fundingstreams":[],"miner":0.0,"founders":0.0}'
+  /getblockchaininfo:
     post:
       tags:
       - blockchain
-      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
+      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
       requestBody:
         required: true
         content:
@@ -334,7 +618,7 @@ paths:
               properties:
                 method:
                   type: string
-                  default: getbestblockhash
+                  default: getblockchaininfo
                 id:
                   type: number
                   default: '123'
@@ -352,19 +636,55 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-  /z_getsubtreesbyindex:
+                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
+  /submitblock:
+    post:
+      tags:
+      - mining
+      description: |-
+        Submits block to the node to be validated and committed.
+
+        **Request body `params` arguments:**
+
+        - `jsonparametersobject` - - currently ignored
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: submitblock
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /z_gettreestate:
     post:
       tags:
       - blockchain
       description: |-
-        Returns information about a range of Sapling or Orchard subtrees.
+        Returns information about the given block''s Sapling & Orchard tree state.
 
         **Request body `params` arguments:**
 
-        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
-        - `start_index` - The index of the first 2^16-leaf subtree to return.
-        - `limit` - The maximum number of subtree values to return.
+        - `hash | height` - The block hash or height.
       requestBody:
         required: true
         content:
@@ -372,17 +692,27 @@ paths:
             schema:
               type: object
               properties:
+                method:
+                  type: string
+                  default: z_gettreestate
                 id:
                   type: number
                   default: '123'
-                method:
-                  type: string
-                  default: z_getsubtreesbyindex
                 params:
                   type: array
                   items: {}
-                  default: '[]'
+                  default: '["00000000febc373a1da2bd9f887b105ad79ddc26ac26c2b28652d64e5207c5b5"]'
       responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
         '200':
           description: OK
           content:
@@ -392,12 +722,17 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{}'
-  /getblockcount:
+                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","height":0,"time":0}'
+  /getaddressutxos:
     post:
       tags:
-      - blockchain
-      description: Returns the height of the most recent block in the best valid block chain (equivalently,
+      - address
+      description: |-
+        Returns all unspent outputs for a list of addresses.
+
+        **Request body `params` arguments:**
+
+        - `addresses` - The addresses to get outputs from.
       requestBody:
         required: true
         content:
@@ -408,13 +743,13 @@ paths:
                 id:
                   type: number
                   default: '123'
+                method:
+                  type: string
+                  default: getaddressutxos
                 params:
                   type: array
                   items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getblockcount
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
       responses:
         '200':
           description: OK
@@ -426,6 +761,16 @@ paths:
                   result:
                     type: object
                     default: '{}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
   /getaddresstxids:
     post:
       tags:
@@ -443,12 +788,12 @@ paths:
             schema:
               type: object
               properties:
-                id:
-                  type: number
-                  default: '123'
                 method:
                   type: string
                   default: getaddresstxids
+                id:
+                  type: number
+                  default: '123'
                 params:
                   type: array
                   items: {}
@@ -474,102 +819,11 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getblocktemplate:
+  /getmininginfo:
     post:
       tags:
       - mining
-      description: |-
-        Returns a block template for mining new Zcash blocks.
-
-        **Request body `params` arguments:**
-
-        - `jsonrequestobject` - A JSON object containing arguments.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getblocktemplate
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getaddressutxos:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns all unspent outputs for a list of addresses.
-
-        **Request body `params` arguments:**
-
-        - `addresses` - The addresses to get outputs from.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getaddressutxos
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /submitblock:
-    post:
-      tags:
-      - mining
-      description: |-
-        Submits block to the node to be validated and committed.
-
-        **Request body `params` arguments:**
-
-        - `jsonparametersobject` - - currently ignored
+      description: Returns mining-related information.
       requestBody:
         required: true
         content:
@@ -582,7 +836,7 @@ paths:
                   default: '123'
                 method:
                   type: string
-                  default: submitblock
+                  default: getmininginfo
                 params:
                   type: array
                   items: {}
@@ -597,141 +851,7 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{}'
-  /getblockhash:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns the hash of the block of a given height iff the index argument correspond
-
-        **Request body `params` arguments:**
-
-        - `index` - The block index.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblockhash
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[1]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /sendrawtransaction:
-    post:
-      tags:
-      - transaction
-      description: |-
-        Sends the raw bytes of a signed transaction to the local node''s mempool, if the transaction is valid.
-
-        **Request body `params` arguments:**
-
-        - `raw_transaction_hex` - The hex-encoded raw transaction bytes.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '["signedhex"]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: sendrawtransaction
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /z_validateaddress:
-    post:
-      tags:
-      - util
-      description: |-
-        Checks if a zcash address is valid.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash address to validate.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: z_validateaddress
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
+                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
   /getnetworksolps:
     post:
       tags:
@@ -744,87 +864,16 @@ paths:
             schema:
               type: object
               properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
                 method:
                   type: string
                   default: getnetworksolps
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getpeerinfo:
-    post:
-      tags:
-      - network
-      description: Returns data about each connected network node.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getpeerinfo
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"addr":"0.0.0.0:0"}'
-  /validateaddress:
-    post:
-      tags:
-      - util
-      description: |-
-        Checks if a zcash address is valid.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash address to validate.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: validateaddress
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
       responses:
         '200':
           description: OK
@@ -853,16 +902,16 @@ paths:
             schema:
               type: object
               properties:
+                method:
+                  type: string
+                  default: z_listunifiedreceivers
+                id:
+                  type: number
+                  default: '123'
                 params:
                   type: array
                   items: {}
                   default: '[]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: z_listunifiedreceivers
       responses:
         '200':
           description: OK
@@ -896,23 +945,13 @@ paths:
                   type: array
                   items: {}
                   default: '["1", 1]'
-                id:
-                  type: number
-                  default: '123'
                 method:
                   type: string
                   default: getblock
+                id:
+                  type: number
+                  default: '123'
       responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
         '400':
           description: Bad request
           content:
@@ -923,17 +962,21 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getrawtransaction:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
+  /getrawmempool:
     post:
       tags:
-      - transaction
-      description: |-
-        Returns the raw transaction data, as a [`GetRawTransaction`] JSON string or structure.
-
-        **Request body `params` arguments:**
-
-        - `txid` - The transaction ID of the transaction to be returned.
-        - `verbose` - If 0, return a string of hex-encoded data, otherwise return a JSON object.
+      - blockchain
+      description: Returns all transaction ids in the memory pool, as a JSON array.
       requestBody:
         required: true
         content:
@@ -944,10 +987,10 @@ paths:
                 params:
                   type: array
                   items: {}
-                  default: '["mytxid", 1]'
+                  default: '[]'
                 method:
                   type: string
-                  default: getrawtransaction
+                  default: getrawmempool
                 id:
                   type: number
                   default: '123'
@@ -962,46 +1005,3 @@ paths:
                   result:
                     type: object
                     default: '{}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getblockchaininfo:
-    post:
-      tags:
-      - blockchain
-      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getblockchaininfo
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,514 +11,6 @@ info:
 servers:
   - url: http://localhost:8232
 paths:
-  /getrawtransaction:
-    post:
-      tags:
-      - transaction
-      description: |-
-        Returns the raw transaction data, as a [`GetRawTransaction`] JSON string or structure.
-
-        **Request body `params` arguments:**
-
-        - `txid` - The transaction ID of the transaction to be returned.
-        - `verbose` - If 0, return a string of hex-encoded data, otherwise return a JSON object.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '["mytxid", 1]'
-                method:
-                  type: string
-                  default: getrawtransaction
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getaddressbalance:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns the total balance of a provided `addresses` in an [`AddressBalance`] instance.
-
-        **Request body `params` arguments:**
-
-        - `address_strings` - A JSON map with a single entry
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getaddressbalance
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getblockhash:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns the hash of the block of a given height iff the index argument correspond
-
-        **Request body `params` arguments:**
-
-        - `index` - The block index.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[1]'
-                method:
-                  type: string
-                  default: getblockhash
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /submitblock:
-    post:
-      tags:
-      - mining
-      description: |-
-        Submits block to the node to be validated and committed.
-
-        **Request body `params` arguments:**
-
-        - `jsonparametersobject` - - currently ignored
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: submitblock
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getblock:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
-
-        **Request body `params` arguments:**
-
-        - `hash_or_height` - The hash or height for the block to be returned.
-        - `verbosity` - 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '["1", 1]'
-                method:
-                  type: string
-                  default: getblock
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getaddressutxos:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns all unspent outputs for a list of addresses.
-
-        **Request body `params` arguments:**
-
-        - `addresses` - The addresses to get outputs from.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
-                method:
-                  type: string
-                  default: getaddressutxos
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getnetworkhashps:
-    post:
-      tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getnetworkhashps
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getpeerinfo:
-    post:
-      tags:
-      - network
-      description: Returns data about each connected network node.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getpeerinfo
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"addr":"0.0.0.0:0"}'
-  /getdifficulty:
-    post:
-      tags:
-      - blockchain
-      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getdifficulty
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /z_gettreestate:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns information about the given block''s Sapling & Orchard tree state.
-
-        **Request body `params` arguments:**
-
-        - `hash | height` - The block hash or height.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: z_gettreestate
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '["00000000febc373a1da2bd9f887b105ad79ddc26ac26c2b28652d64e5207c5b5"]'
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","height":0,"time":0}'
-  /getaddresstxids:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns the transaction ids made by the provided transparent addresses.
-
-        **Request body `params` arguments:**
-
-        - `request` - A struct with the following named fields:
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getaddresstxids
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getinfo:
-    post:
-      tags:
-      - control
-      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getinfo
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"build":"some build version","subversion":"some subversion"}'
   /getblocktemplate:
     post:
       tags:
@@ -536,279 +28,16 @@ paths:
             schema:
               type: object
               properties:
+                id:
+                  type: number
+                  default: '123'
                 method:
                   type: string
                   default: getblocktemplate
-                id:
-                  type: number
-                  default: '123'
                 params:
                   type: array
                   items: {}
                   default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getbestblockhash:
-    post:
-      tags:
-      - blockchain
-      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getbestblockhash
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-  /z_getsubtreesbyindex:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns information about a range of Sapling or Orchard subtrees.
-
-        **Request body `params` arguments:**
-
-        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
-        - `start_index` - The index of the first 2^16-leaf subtree to return.
-        - `limit` - The maximum number of subtree values to return.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: z_getsubtreesbyindex
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getblockcount:
-    post:
-      tags:
-      - blockchain
-      description: Returns the height of the most recent block in the best valid block chain (equivalently,
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getblockcount
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0'
-  /getblocksubsidy:
-    post:
-      tags:
-      - mining
-      description: |-
-        Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
-
-        **Request body `params` arguments:**
-
-        - `height` - Can be any valid current or future height.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblocksubsidy
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[1]'
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"fundingstreams":[],"miner":0.0,"founders":0.0}'
-  /validateaddress:
-    post:
-      tags:
-      - util
-      description: |-
-        Checks if a zcash address is valid.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash address to validate.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: validateaddress
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /z_listunifiedreceivers:
-    post:
-      tags:
-      - wallet
-      description: |-
-        Returns the list of individual payment addresses given a unified address.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash unified address to get the list from.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: z_listunifiedreceivers
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getrawmempool:
-    post:
-      tags:
-      - blockchain
-      description: Returns all transaction ids in the memory pool, as a JSON array.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getrawmempool
-                id:
-                  type: number
-                  default: '123'
       responses:
         '200':
           description: OK
@@ -868,6 +97,39 @@ paths:
                   result:
                     type: object
                     default: '{}'
+  /getpeerinfo:
+    post:
+      tags:
+      - network
+      description: Returns data about each connected network node.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getpeerinfo
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"addr":"0.0.0.0:0"}'
   /getmininginfo:
     post:
       tags:
@@ -901,11 +163,16 @@ paths:
                   result:
                     type: object
                     default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
-  /getnetworksolps:
+  /validateaddress:
     post:
       tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      - util
+      description: |-
+        Checks if a zcash address is valid.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash address to validate.
       requestBody:
         required: true
         content:
@@ -913,16 +180,16 @@ paths:
             schema:
               type: object
               properties:
+                id:
+                  type: number
+                  default: '123'
                 params:
                   type: array
                   items: {}
                   default: '[]'
-                id:
-                  type: number
-                  default: '123'
                 method:
                   type: string
-                  default: getnetworksolps
+                  default: validateaddress
       responses:
         '200':
           description: OK
@@ -934,6 +201,54 @@ paths:
                   result:
                     type: object
                     default: '{}'
+  /getblocksubsidy:
+    post:
+      tags:
+      - mining
+      description: |-
+        Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
+
+        **Request body `params` arguments:**
+
+        - `height` - Can be any valid current or future height.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getblocksubsidy
+                params:
+                  type: array
+                  items: {}
+                  default: '[1]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"fundingstreams":[],"miner":0.0,"founders":0.0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
   /getblockchaininfo:
     post:
       tags:
@@ -946,13 +261,13 @@ paths:
             schema:
               type: object
               properties:
-                method:
-                  type: string
-                  default: getblockchaininfo
                 params:
                   type: array
                   items: {}
                   default: '[]'
+                method:
+                  type: string
+                  default: getblockchaininfo
                 id:
                   type: number
                   default: '123'
@@ -967,6 +282,490 @@ paths:
                   result:
                     type: object
                     default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
+  /z_getsubtreesbyindex:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns information about a range of Sapling or Orchard subtrees.
+
+        **Request body `params` arguments:**
+
+        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
+        - `start_index` - The index of the first 2^16-leaf subtree to return.
+        - `limit` - The maximum number of subtree values to return.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: z_getsubtreesbyindex
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getrawmempool:
+    post:
+      tags:
+      - blockchain
+      description: Returns all transaction ids in the memory pool, as a JSON array.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getrawmempool
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /z_gettreestate:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns information about the given block''s Sapling & Orchard tree state.
+
+        **Request body `params` arguments:**
+
+        - `hash | height` - The block hash or height.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: z_gettreestate
+                params:
+                  type: array
+                  items: {}
+                  default: '["00000000febc373a1da2bd9f887b105ad79ddc26ac26c2b28652d64e5207c5b5"]'
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","height":0,"time":0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getaddresstxids:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns the transaction ids made by the provided transparent addresses.
+
+        **Request body `params` arguments:**
+
+        - `request` - A struct with the following named fields:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
+                method:
+                  type: string
+                  default: getaddresstxids
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '[]'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /z_listunifiedreceivers:
+    post:
+      tags:
+      - wallet
+      description: |-
+        Returns the list of individual payment addresses given a unified address.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash unified address to get the list from.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: z_listunifiedreceivers
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getrawtransaction:
+    post:
+      tags:
+      - transaction
+      description: |-
+        Returns the raw transaction data, as a [`GetRawTransaction`] JSON string or structure.
+
+        **Request body `params` arguments:**
+
+        - `txid` - The transaction ID of the transaction to be returned.
+        - `verbose` - If 0, return a string of hex-encoded data, otherwise return a JSON object.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '["mytxid", 1]'
+                method:
+                  type: string
+                  default: getrawtransaction
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getinfo:
+    post:
+      tags:
+      - control
+      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getinfo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"build":"some build version","subversion":"some subversion"}'
+  /getaddressbalance:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns the total balance of a provided `addresses` in an [`AddressBalance`] instance.
+
+        **Request body `params` arguments:**
+
+        - `address_strings` - A JSON map with a single entry
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getaddressbalance
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"balance":0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getnetworksolps:
+    post:
+      tags:
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getnetworksolps
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getdifficulty:
+    post:
+      tags:
+      - blockchain
+      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getdifficulty
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getblockhash:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns the hash of the block of a given height iff the index argument correspond
+
+        **Request body `params` arguments:**
+
+        - `index` - The block index.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getblockhash
+                params:
+                  type: array
+                  items: {}
+                  default: '[1]'
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+  /getnetworkhashps:
+    post:
+      tags:
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getnetworkhashps
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
   /z_validateaddress:
     post:
       tags:
@@ -984,9 +783,90 @@ paths:
             schema:
               type: object
               properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
                 method:
                   type: string
                   default: z_validateaddress
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getaddressutxos:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns all unspent outputs for a list of addresses.
+
+        **Request body `params` arguments:**
+
+        - `addresses` - The addresses to get outputs from.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getaddressutxos
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"address":"t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs","txid":"0000000000000000000000000000000000000000000000000000000000000000","outputIndex":0,"script":"00000000000000000000","satoshis":0,"height":0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getbestblockhash:
+    post:
+      tags:
+      - blockchain
+      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getbestblockhash
                 id:
                   type: number
                   default: '123'
@@ -1004,4 +884,124 @@ paths:
                 properties:
                   result:
                     type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+  /submitblock:
+    post:
+      tags:
+      - mining
+      description: |-
+        Submits block to the node to be validated and committed.
+
+        **Request body `params` arguments:**
+
+        - `jsonparametersobject` - - currently ignored
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: submitblock
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
                     default: '{}'
+  /getblockcount:
+    post:
+      tags:
+      - blockchain
+      description: Returns the height of the most recent block in the best valid block chain (equivalently,
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblockcount
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
+  /getblock:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
+
+        **Request body `params` arguments:**
+
+        - `hash_or_height` - The hash or height for the block to be returned.
+        - `verbosity` - 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '["1", 1]'
+                method:
+                  type: string
+                  default: getblock
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,614 +11,6 @@ info:
 servers:
   - url: http://localhost:8232
 paths:
-  /sendrawtransaction:
-    post:
-      tags:
-      - transaction
-      description: |-
-        Sends the raw bytes of a signed transaction to the local node''s mempool, if the transaction is valid.
-
-        **Request body `params` arguments:**
-
-        - `raw_transaction_hex` - The hex-encoded raw transaction bytes.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: sendrawtransaction
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '["signedhex"]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getpeerinfo:
-    post:
-      tags:
-      - network
-      description: Returns data about each connected network node.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getpeerinfo
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"addr":"0.0.0.0:0"}'
-  /validateaddress:
-    post:
-      tags:
-      - util
-      description: |-
-        Checks if a zcash address is valid.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash address to validate.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: validateaddress
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"isvalid":false}'
-  /getblocksubsidy:
-    post:
-      tags:
-      - mining
-      description: |-
-        Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
-
-        **Request body `params` arguments:**
-
-        - `height` - Can be any valid current or future height.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblocksubsidy
-                params:
-                  type: array
-                  items: {}
-                  default: '[1]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"fundingstreams":[],"miner":0.0,"founders":0.0}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getaddressutxos:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns all unspent outputs for a list of addresses.
-
-        **Request body `params` arguments:**
-
-        - `addresses` - The addresses to get outputs from.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getaddressutxos
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"address":"t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs","txid":"0000000000000000000000000000000000000000000000000000000000000000","outputIndex":0,"script":"00000000000000000000","satoshis":0,"height":0}'
-  /getrawmempool:
-    post:
-      tags:
-      - blockchain
-      description: Returns all transaction ids in the memory pool, as a JSON array.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getrawmempool
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getblockhash:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns the hash of the block of a given height iff the index argument correspond
-
-        **Request body `params` arguments:**
-
-        - `index` - The block index.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[1]'
-                method:
-                  type: string
-                  default: getblockhash
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getaddressbalance:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns the total balance of a provided `addresses` in an [`AddressBalance`] instance.
-
-        **Request body `params` arguments:**
-
-        - `address_strings` - A JSON map with a single entry
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getaddressbalance
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"balance":0}'
-  /getinfo:
-    post:
-      tags:
-      - control
-      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getinfo
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"build":"some build version","subversion":"some subversion"}'
-  /submitblock:
-    post:
-      tags:
-      - mining
-      description: |-
-        Submits block to the node to be validated and committed.
-
-        **Request body `params` arguments:**
-
-        - `jsonparametersobject` - - currently ignored
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: submitblock
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getblockchaininfo:
-    post:
-      tags:
-      - blockchain
-      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblockchaininfo
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
-  /z_getsubtreesbyindex:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns information about a range of Sapling or Orchard subtrees.
-
-        **Request body `params` arguments:**
-
-        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
-        - `start_index` - The index of the first 2^16-leaf subtree to return.
-        - `limit` - The maximum number of subtree values to return.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: z_getsubtreesbyindex
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getblocktemplate:
-    post:
-      tags:
-      - mining
-      description: |-
-        Returns a block template for mining new Zcash blocks.
-
-        **Request body `params` arguments:**
-
-        - `jsonrequestobject` - A JSON object containing arguments.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblocktemplate
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getblockcount:
-    post:
-      tags:
-      - blockchain
-      description: Returns the height of the most recent block in the best valid block chain (equivalently,
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getblockcount
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0'
-  /getrawtransaction:
-    post:
-      tags:
-      - transaction
-      description: |-
-        Returns the raw transaction data, as a [`GetRawTransaction`] JSON string or structure.
-
-        **Request body `params` arguments:**
-
-        - `txid` - The transaction ID of the transaction to be returned.
-        - `verbose` - If 0, return a string of hex-encoded data, otherwise return a JSON object.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getrawtransaction
-                params:
-                  type: array
-                  items: {}
-                  default: '["mytxid", 1]'
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
   /getblock:
     post:
       tags:
@@ -668,44 +60,11 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getmininginfo:
-    post:
-      tags:
-      - mining
-      description: Returns mining-related information.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getmininginfo
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
-  /getdifficulty:
+  /getblockchaininfo:
     post:
       tags:
       - blockchain
-      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
+      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
       requestBody:
         required: true
         content:
@@ -722,7 +81,7 @@ paths:
                   default: '[]'
                 method:
                   type: string
-                  default: getdifficulty
+                  default: getblockchaininfo
       responses:
         '200':
           description: OK
@@ -733,7 +92,7 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{}'
+                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
   /getaddresstxids:
     post:
       tags:
@@ -782,11 +141,11 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getnetworksolps:
+  /getblockcount:
     post:
       tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      - blockchain
+      description: Returns the height of the most recent block in the best valid block chain (equivalently,
       requestBody:
         required: true
         content:
@@ -794,16 +153,16 @@ paths:
             schema:
               type: object
               properties:
+                id:
+                  type: number
+                  default: '123'
                 params:
                   type: array
                   items: {}
                   default: '[]'
                 method:
                   type: string
-                  default: getnetworksolps
-                id:
-                  type: number
-                  default: '123'
+                  default: getblockcount
       responses:
         '200':
           description: OK
@@ -814,7 +173,7 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{}'
+                    default: '0'
   /getbestblockhash:
     post:
       tags:
@@ -848,7 +207,7 @@ paths:
                   result:
                     type: object
                     default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-  /z_validateaddress:
+  /validateaddress:
     post:
       tags:
       - util
@@ -868,13 +227,13 @@ paths:
                 id:
                   type: number
                   default: '123'
+                method:
+                  type: string
+                  default: validateaddress
                 params:
                   type: array
                   items: {}
                   default: '[]'
-                method:
-                  type: string
-                  default: z_validateaddress
       responses:
         '200':
           description: OK
@@ -886,16 +245,17 @@ paths:
                   result:
                     type: object
                     default: '{"isvalid":false}'
-  /z_gettreestate:
+  /getrawtransaction:
     post:
       tags:
-      - blockchain
+      - transaction
       description: |-
-        Returns information about the given block''s Sapling & Orchard tree state.
+        Returns the raw transaction data, as a [`GetRawTransaction`] JSON string or structure.
 
         **Request body `params` arguments:**
 
-        - `hash | height` - The block hash or height.
+        - `txid` - The transaction ID of the transaction to be returned.
+        - `verbose` - If 0, return a string of hex-encoded data, otherwise return a JSON object.
       requestBody:
         required: true
         content:
@@ -905,11 +265,11 @@ paths:
               properties:
                 method:
                   type: string
-                  default: z_gettreestate
+                  default: getrawtransaction
                 params:
                   type: array
                   items: {}
-                  default: '["00000000febc373a1da2bd9f887b105ad79ddc26ac26c2b28652d64e5207c5b5"]'
+                  default: '["mytxid", 1]'
                 id:
                   type: number
                   default: '123'
@@ -923,7 +283,7 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","height":0,"time":0}'
+                    default: '{}'
         '400':
           description: Bad request
           content:
@@ -946,6 +306,9 @@ paths:
             schema:
               type: object
               properties:
+                method:
+                  type: string
+                  default: getnetworkhashps
                 params:
                   type: array
                   items: {}
@@ -953,9 +316,6 @@ paths:
                 id:
                   type: number
                   default: '123'
-                method:
-                  type: string
-                  default: getnetworkhashps
       responses:
         '200':
           description: OK
@@ -967,6 +327,287 @@ paths:
                   result:
                     type: object
                     default: '{}'
+  /z_validateaddress:
+    post:
+      tags:
+      - util
+      description: |-
+        Checks if a zcash address is valid.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash address to validate.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: z_validateaddress
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"isvalid":false}'
+  /getinfo:
+    post:
+      tags:
+      - control
+      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getinfo
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"build":"some build version","subversion":"some subversion"}'
+  /getrawmempool:
+    post:
+      tags:
+      - blockchain
+      description: Returns all transaction ids in the memory pool, as a JSON array.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getrawmempool
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '[]'
+  /z_gettreestate:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns information about the given block''s Sapling & Orchard tree state.
+
+        **Request body `params` arguments:**
+
+        - `hash | height` - The block hash or height.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '["00000000febc373a1da2bd9f887b105ad79ddc26ac26c2b28652d64e5207c5b5"]'
+                method:
+                  type: string
+                  default: z_gettreestate
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","height":0,"time":0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getaddressbalance:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns the total balance of a provided `addresses` in an [`AddressBalance`] instance.
+
+        **Request body `params` arguments:**
+
+        - `address_strings` - A JSON map with a single entry
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getaddressbalance
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"balance":0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getnetworksolps:
+    post:
+      tags:
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getnetworksolps
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getaddressutxos:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns all unspent outputs for a list of addresses.
+
+        **Request body `params` arguments:**
+
+        - `addresses` - The addresses to get outputs from.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getaddressutxos
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"address":"t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs","txid":"0000000000000000000000000000000000000000000000000000000000000000","outputIndex":0,"script":"00000000000000000000","satoshis":0,"height":0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
   /z_listunifiedreceivers:
     post:
       tags:
@@ -984,9 +625,272 @@ paths:
             schema:
               type: object
               properties:
+                id:
+                  type: number
+                  default: '123'
                 method:
                   type: string
                   default: z_listunifiedreceivers
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getblocktemplate:
+    post:
+      tags:
+      - mining
+      description: |-
+        Returns a block template for mining new Zcash blocks.
+
+        **Request body `params` arguments:**
+
+        - `jsonrequestobject` - A JSON object containing arguments.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getblocktemplate
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getpeerinfo:
+    post:
+      tags:
+      - network
+      description: Returns data about each connected network node.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getpeerinfo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"addr":"0.0.0.0:0"}'
+  /getdifficulty:
+    post:
+      tags:
+      - blockchain
+      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getdifficulty
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0.0'
+  /submitblock:
+    post:
+      tags:
+      - mining
+      description: |-
+        Submits block to the node to be validated and committed.
+
+        **Request body `params` arguments:**
+
+        - `jsonparametersobject` - - currently ignored
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: submitblock
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getmininginfo:
+    post:
+      tags:
+      - mining
+      description: Returns mining-related information.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getmininginfo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
+  /getblocksubsidy:
+    post:
+      tags:
+      - mining
+      description: |-
+        Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
+
+        **Request body `params` arguments:**
+
+        - `height` - Can be any valid current or future height.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[1]'
+                method:
+                  type: string
+                  default: getblocksubsidy
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"fundingstreams":[],"miner":0.0,"founders":0.0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /z_getsubtreesbyindex:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns information about a range of Sapling or Orchard subtrees.
+
+        **Request body `params` arguments:**
+
+        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
+        - `start_index` - The index of the first 2^16-leaf subtree to return.
+        - `limit` - The maximum number of subtree values to return.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: z_getsubtreesbyindex
                 id:
                   type: number
                   default: '123'
@@ -1005,3 +909,99 @@ paths:
                   result:
                     type: object
                     default: '{}'
+  /sendrawtransaction:
+    post:
+      tags:
+      - transaction
+      description: |-
+        Sends the raw bytes of a signed transaction to the local node''s mempool, if the transaction is valid.
+
+        **Request body `params` arguments:**
+
+        - `raw_transaction_hex` - The hex-encoded raw transaction bytes.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: sendrawtransaction
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '["signedhex"]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getblockhash:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns the hash of the block of a given height iff the index argument correspond
+
+        **Request body `params` arguments:**
+
+        - `index` - The block index.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblockhash
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[1]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,17 +11,11 @@ info:
 servers:
   - url: http://localhost:8232
 paths:
-  /getblock:
+  /getbestblockhash:
     post:
       tags:
       - blockchain
-      description: |-
-        Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
-
-        **Request body `params` arguments:**
-
-        - `hash_or_height` - The hash or height for the block to be returned.
-        - `verbosity` - 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.
+      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
       requestBody:
         required: true
         content:
@@ -35,21 +29,11 @@ paths:
                 params:
                   type: array
                   items: {}
-                  default: '["1", 1]'
+                  default: '[]'
                 method:
                   type: string
-                  default: getblock
+                  default: getbestblockhash
       responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
         '200':
           description: OK
           content:
@@ -59,7 +43,45 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+  /z_validateaddress:
+    post:
+      tags:
+      - util
+      description: |-
+        Checks if a zcash address is valid.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash address to validate.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: z_validateaddress
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"isvalid":false}'
   /getrawtransaction:
     post:
       tags:
@@ -78,9 +100,6 @@ paths:
             schema:
               type: object
               properties:
-                method:
-                  type: string
-                  default: getrawtransaction
                 id:
                   type: number
                   default: '123'
@@ -88,6 +107,9 @@ paths:
                   type: array
                   items: {}
                   default: '["mytxid", 1]'
+                method:
+                  type: string
+                  default: getrawtransaction
       responses:
         '400':
           description: Bad request
@@ -109,11 +131,11 @@ paths:
                   result:
                     type: object
                     default: '{"hex":"0000000000000000000000000000000000000000","height":0,"confirmations":0}'
-  /getblockchaininfo:
+  /getinfo:
     post:
       tags:
-      - blockchain
-      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
+      - control
+      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
       requestBody:
         required: true
         content:
@@ -124,13 +146,13 @@ paths:
                 id:
                   type: number
                   default: '123'
-                method:
-                  type: string
-                  default: getblockchaininfo
                 params:
                   type: array
                   items: {}
                   default: '[]'
+                method:
+                  type: string
+                  default: getinfo
       responses:
         '200':
           description: OK
@@ -141,55 +163,7 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
-  /z_gettreestate:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns information about the given block''s Sapling & Orchard tree state.
-
-        **Request body `params` arguments:**
-
-        - `hash | height` - The block hash or height.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: z_gettreestate
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '["00000000febc373a1da2bd9f887b105ad79ddc26ac26c2b28652d64e5207c5b5"]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","height":0,"time":0}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
+                    default: '{"build":"some build version","subversion":"some subversion"}'
   /getaddressbalance:
     post:
       tags:
@@ -207,12 +181,12 @@ paths:
             schema:
               type: object
               properties:
-                method:
-                  type: string
-                  default: getaddressbalance
                 id:
                   type: number
                   default: '123'
+                method:
+                  type: string
+                  default: getaddressbalance
                 params:
                   type: array
                   items: {}
@@ -238,16 +212,16 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getaddresstxids:
+  /getaddressutxos:
     post:
       tags:
       - address
       description: |-
-        Returns the transaction ids made by the provided transparent addresses.
+        Returns all unspent outputs for a list of addresses.
 
         **Request body `params` arguments:**
 
-        - `request` - A struct with the following named fields:
+        - `addresses` - The addresses to get outputs from.
       requestBody:
         required: true
         content:
@@ -255,16 +229,16 @@ paths:
             schema:
               type: object
               properties:
-                id:
-                  type: number
-                  default: '123'
                 params:
                   type: array
                   items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
                 method:
                   type: string
-                  default: getaddresstxids
+                  default: getaddressutxos
+                id:
+                  type: number
+                  default: '123'
       responses:
         '200':
           description: OK
@@ -275,7 +249,7 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '[]'
+                    default: '{"address":"t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs","txid":"0000000000000000000000000000000000000000000000000000000000000000","outputIndex":0,"script":"00000000000000000000","satoshis":0,"height":0}'
         '400':
           description: Bad request
           content:
@@ -286,383 +260,6 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getmininginfo:
-    post:
-      tags:
-      - mining
-      description: Returns mining-related information.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getmininginfo
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
-  /sendrawtransaction:
-    post:
-      tags:
-      - transaction
-      description: |-
-        Sends the raw bytes of a signed transaction to the local node''s mempool, if the transaction is valid.
-
-        **Request body `params` arguments:**
-
-        - `raw_transaction_hex` - The hex-encoded raw transaction bytes.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: sendrawtransaction
-                params:
-                  type: array
-                  items: {}
-                  default: '["signedhex"]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getblockcount:
-    post:
-      tags:
-      - blockchain
-      description: Returns the height of the most recent block in the best valid block chain (equivalently,
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblockcount
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0'
-  /z_validateaddress:
-    post:
-      tags:
-      - util
-      description: |-
-        Checks if a zcash address is valid.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash address to validate.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: z_validateaddress
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"isvalid":false}'
-  /getblockhash:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns the hash of the block of a given height iff the index argument correspond
-
-        **Request body `params` arguments:**
-
-        - `index` - The block index.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getblockhash
-                params:
-                  type: array
-                  items: {}
-                  default: '[1]'
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-  /z_getsubtreesbyindex:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns information about a range of Sapling or Orchard subtrees.
-
-        **Request body `params` arguments:**
-
-        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
-        - `start_index` - The index of the first 2^16-leaf subtree to return.
-        - `limit` - The maximum number of subtree values to return.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: z_getsubtreesbyindex
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"pool":"","start_index":0,"subtrees":[]}'
-  /getnetworkhashps:
-    post:
-      tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getnetworkhashps
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0'
-  /getpeerinfo:
-    post:
-      tags:
-      - network
-      description: Returns data about each connected network node.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getpeerinfo
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"addr":"0.0.0.0:0"}'
-  /validateaddress:
-    post:
-      tags:
-      - util
-      description: |-
-        Checks if a zcash address is valid.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash address to validate.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: validateaddress
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"isvalid":false}'
-  /getnetworksolps:
-    post:
-      tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getnetworksolps
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0'
   /submitblock:
     post:
       tags:
@@ -701,11 +298,11 @@ paths:
                   result:
                     type: object
                     default: '"rejected"'
-  /getinfo:
+  /getmininginfo:
     post:
       tags:
-      - control
-      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
+      - mining
+      description: Returns mining-related information.
       requestBody:
         required: true
         content:
@@ -713,13 +310,13 @@ paths:
             schema:
               type: object
               properties:
-                method:
-                  type: string
-                  default: getinfo
                 params:
                   type: array
                   items: {}
                   default: '[]'
+                method:
+                  type: string
+                  default: getmininginfo
                 id:
                   type: number
                   default: '123'
@@ -733,17 +330,50 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{"build":"some build version","subversion":"some subversion"}'
-  /getblocksubsidy:
+                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
+  /getpeerinfo:
     post:
       tags:
-      - mining
+      - network
+      description: Returns data about each connected network node.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getpeerinfo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"addr":"0.0.0.0:0"}'
+  /z_gettreestate:
+    post:
+      tags:
+      - blockchain
       description: |-
-        Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
+        Returns information about the given block''s Sapling & Orchard tree state.
 
         **Request body `params` arguments:**
 
-        - `height` - Can be any valid current or future height.
+        - `hash | height` - The block hash or height.
       requestBody:
         required: true
         content:
@@ -753,7 +383,142 @@ paths:
               properties:
                 method:
                   type: string
-                  default: getblocksubsidy
+                  default: z_gettreestate
+                params:
+                  type: array
+                  items: {}
+                  default: '["00000000febc373a1da2bd9f887b105ad79ddc26ac26c2b28652d64e5207c5b5"]'
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","height":0,"time":0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getblock:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
+
+        **Request body `params` arguments:**
+
+        - `hash_or_height` - The hash or height for the block to be returned.
+        - `verbosity` - 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblock
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '["1", 1]'
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
+  /getblocktemplate:
+    post:
+      tags:
+      - mining
+      description: |-
+        Returns a block template for mining new Zcash blocks.
+
+        **Request body `params` arguments:**
+
+        - `jsonrequestobject` - A JSON object containing arguments.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getblocktemplate
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getblockhash:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns the hash of the block of a given height iff the index argument correspond
+
+        **Request body `params` arguments:**
+
+        - `index` - The block index.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblockhash
                 id:
                   type: number
                   default: '123'
@@ -781,12 +546,12 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{"fundingstreams":[],"miner":0.0,"founders":0.0}'
-  /getdifficulty:
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+  /getnetworkhashps:
     post:
       tags:
-      - blockchain
-      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
       requestBody:
         required: true
         content:
@@ -794,16 +559,16 @@ paths:
             schema:
               type: object
               properties:
-                id:
-                  type: number
-                  default: '123'
                 method:
                   type: string
-                  default: getdifficulty
+                  default: getnetworkhashps
                 params:
                   type: array
                   items: {}
                   default: '[]'
+                id:
+                  type: number
+                  default: '123'
       responses:
         '200':
           description: OK
@@ -814,12 +579,17 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '0.0'
-  /getbestblockhash:
+                    default: '0'
+  /sendrawtransaction:
     post:
       tags:
-      - blockchain
-      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
+      - transaction
+      description: |-
+        Sends the raw bytes of a signed transaction to the local node''s mempool, if the transaction is valid.
+
+        **Request body `params` arguments:**
+
+        - `raw_transaction_hex` - The hex-encoded raw transaction bytes.
       requestBody:
         required: true
         content:
@@ -827,16 +597,16 @@ paths:
             schema:
               type: object
               properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
                 id:
                   type: number
                   default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '["signedhex"]'
                 method:
                   type: string
-                  default: getbestblockhash
+                  default: sendrawtransaction
       responses:
         '200':
           description: OK
@@ -848,6 +618,102 @@ paths:
                   result:
                     type: object
                     default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /validateaddress:
+    post:
+      tags:
+      - util
+      description: |-
+        Checks if a zcash address is valid.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash address to validate.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: validateaddress
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"isvalid":false}'
+  /getblocksubsidy:
+    post:
+      tags:
+      - mining
+      description: |-
+        Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
+
+        **Request body `params` arguments:**
+
+        - `height` - Can be any valid current or future height.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[1]'
+                method:
+                  type: string
+                  default: getblocksubsidy
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"fundingstreams":[],"miner":0.0,"founders":0.0}'
   /getrawmempool:
     post:
       tags:
@@ -881,16 +747,11 @@ paths:
                   result:
                     type: object
                     default: '[]'
-  /getaddressutxos:
+  /getdifficulty:
     post:
       tags:
-      - address
-      description: |-
-        Returns all unspent outputs for a list of addresses.
-
-        **Request body `params` arguments:**
-
-        - `addresses` - The addresses to get outputs from.
+      - blockchain
+      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
       requestBody:
         required: true
         content:
@@ -898,57 +759,6 @@ paths:
             schema:
               type: object
               properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
-                method:
-                  type: string
-                  default: getaddressutxos
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"address":"t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs","txid":"0000000000000000000000000000000000000000000000000000000000000000","outputIndex":0,"script":"00000000000000000000","satoshis":0,"height":0}'
-  /getblocktemplate:
-    post:
-      tags:
-      - mining
-      description: |-
-        Returns a block template for mining new Zcash blocks.
-
-        **Request body `params` arguments:**
-
-        - `jsonrequestobject` - A JSON object containing arguments.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblocktemplate
                 id:
                   type: number
                   default: '123'
@@ -956,6 +766,9 @@ paths:
                   type: array
                   items: {}
                   default: '[]'
+                method:
+                  type: string
+                  default: getdifficulty
       responses:
         '200':
           description: OK
@@ -966,7 +779,47 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{}'
+                    default: '0.0'
+  /z_getsubtreesbyindex:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns information about a range of Sapling or Orchard subtrees.
+
+        **Request body `params` arguments:**
+
+        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
+        - `start_index` - The index of the first 2^16-leaf subtree to return.
+        - `limit` - The maximum number of subtree values to return.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: z_getsubtreesbyindex
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"pool":"","start_index":0,"subtrees":[]}'
   /z_listunifiedreceivers:
     post:
       tags:
@@ -1005,3 +858,150 @@ paths:
                   result:
                     type: object
                     default: '{"orchard":"orchard address if any","sapling":"sapling address if any","p2pkh":"p2pkh address if any","p2sh":"p2sh address if any"}'
+  /getblockcount:
+    post:
+      tags:
+      - blockchain
+      description: Returns the height of the most recent block in the best valid block chain (equivalently,
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getblockcount
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
+  /getnetworksolps:
+    post:
+      tags:
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getnetworksolps
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
+  /getblockchaininfo:
+    post:
+      tags:
+      - blockchain
+      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getblockchaininfo
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
+  /getaddresstxids:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns the transaction ids made by the provided transparent addresses.
+
+        **Request body `params` arguments:**
+
+        - `request` - A struct with the following named fields:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
+                method:
+                  type: string
+                  default: getaddresstxids
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '[]'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,11 +11,209 @@ info:
 servers:
   - url: http://localhost:8232
 paths:
-  /getbestblockhash:
+  /z_getsubtreesbyindex:
     post:
       tags:
       - blockchain
-      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
+      description: |-
+        Returns information about a range of Sapling or Orchard subtrees.
+
+        **Request body `params` arguments:**
+
+        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
+        - `start_index` - The index of the first 2^16-leaf subtree to return.
+        - `limit` - The maximum number of subtree values to return.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: z_getsubtreesbyindex
+                id:
+                  type: number
+                  default: EoYdKA8KlS
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"pool":"","start_index":0,"subtrees":[]}'
+  /getblock:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
+
+        **Request body `params` arguments:**
+
+        - `hash_or_height` - The hash or height for the block to be returned.
+        - `verbosity` - 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblock
+                params:
+                  type: array
+                  items: {}
+                  default: '["1", 1]'
+                id:
+                  type: number
+                  default: yzmtph9UW7
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getnetworkhashps:
+    post:
+      tags:
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getnetworkhashps
+                id:
+                  type: number
+                  default: 2QeVVBuEQJ
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
+  /getnetworksolps:
+    post:
+      tags:
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getnetworksolps
+                id:
+                  type: number
+                  default: yVVEVf5JRR
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
+  /z_listunifiedreceivers:
+    post:
+      tags:
+      - wallet
+      description: |-
+        Returns the list of individual payment addresses given a unified address.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash unified address to get the list from.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: z_listunifiedreceivers
+                id:
+                  type: number
+                  default: gfWPG76VmE
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"orchard":"orchard address if any","sapling":"sapling address if any","p2pkh":"p2pkh address if any","p2sh":"p2sh address if any"}'
+  /z_gettreestate:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns information about the given block''s Sapling & Orchard tree state.
+
+        **Request body `params` arguments:**
+
+        - `hash | height` - The block hash or height.
       requestBody:
         required: true
         content:
@@ -25,14 +223,270 @@ paths:
               properties:
                 id:
                   type: number
-                  default: '123'
+                  default: t5Gqe1Ldwp
+                method:
+                  type: string
+                  default: z_gettreestate
+                params:
+                  type: array
+                  items: {}
+                  default: '["00000000febc373a1da2bd9f887b105ad79ddc26ac26c2b28652d64e5207c5b5"]'
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","height":0,"time":0}'
+  /getdifficulty:
+    post:
+      tags:
+      - blockchain
+      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getdifficulty
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: XD5004uOFO
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0.0'
+  /getinfo:
+    post:
+      tags:
+      - control
+      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
                 params:
                   type: array
                   items: {}
                   default: '[]'
                 method:
                   type: string
-                  default: getbestblockhash
+                  default: getinfo
+                id:
+                  type: number
+                  default: nWKQogai3i
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"build":"some build version","subversion":"some subversion"}'
+  /getblockcount:
+    post:
+      tags:
+      - blockchain
+      description: Returns the height of the most recent block in the best valid block chain (equivalently,
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: A2NwqDNFw5
+                method:
+                  type: string
+                  default: getblockcount
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
+  /getblocktemplate:
+    post:
+      tags:
+      - mining
+      description: |-
+        Returns a block template for mining new Zcash blocks.
+
+        **Request body `params` arguments:**
+
+        - `jsonrequestobject` - A JSON object containing arguments.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblocktemplate
+                id:
+                  type: number
+                  default: h26t6n7Hlr
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /submitblock:
+    post:
+      tags:
+      - mining
+      description: |-
+        Submits block to the node to be validated and committed.
+
+        **Request body `params` arguments:**
+
+        - `jsonparametersobject` - - currently ignored
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: submitblock
+                id:
+                  type: number
+                  default: 9Mgvqee3ws
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"rejected"'
+  /getpeerinfo:
+    post:
+      tags:
+      - network
+      description: Returns data about each connected network node.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getpeerinfo
+                id:
+                  type: number
+                  default: 7Pul86u6Kk
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"addr":"0.0.0.0:0"}'
+  /sendrawtransaction:
+    post:
+      tags:
+      - transaction
+      description: |-
+        Sends the raw bytes of a signed transaction to the local node''s mempool, if the transaction is valid.
+
+        **Request body `params` arguments:**
+
+        - `raw_transaction_hex` - The hex-encoded raw transaction bytes.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: dFgkpAoOAf
+                params:
+                  type: array
+                  items: {}
+                  default: '["signedhex"]'
+                method:
+                  type: string
+                  default: sendrawtransaction
       responses:
         '200':
           description: OK
@@ -44,6 +498,49 @@ paths:
                   result:
                     type: object
                     default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getrawmempool:
+    post:
+      tags:
+      - blockchain
+      description: Returns all transaction ids in the memory pool, as a JSON array.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: pX3oJfdTmR
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getrawmempool
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '[]'
   /z_validateaddress:
     post:
       tags:
@@ -63,7 +560,7 @@ paths:
               properties:
                 id:
                   type: number
-                  default: '123'
+                  default: OpPOfL9KtU
                 params:
                   type: array
                   items: {}
@@ -100,27 +597,17 @@ paths:
             schema:
               type: object
               properties:
+                method:
+                  type: string
+                  default: getrawtransaction
                 id:
                   type: number
-                  default: '123'
+                  default: HFGYoSO2Y9
                 params:
                   type: array
                   items: {}
                   default: '["mytxid", 1]'
-                method:
-                  type: string
-                  default: getrawtransaction
       responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
         '200':
           description: OK
           content:
@@ -131,493 +618,6 @@ paths:
                   result:
                     type: object
                     default: '{"hex":"0000000000000000000000000000000000000000","height":0,"confirmations":0}'
-  /getinfo:
-    post:
-      tags:
-      - control
-      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getinfo
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"build":"some build version","subversion":"some subversion"}'
-  /getaddressbalance:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns the total balance of a provided `addresses` in an [`AddressBalance`] instance.
-
-        **Request body `params` arguments:**
-
-        - `address_strings` - A JSON map with a single entry
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getaddressbalance
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"balance":0}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getaddressutxos:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns all unspent outputs for a list of addresses.
-
-        **Request body `params` arguments:**
-
-        - `addresses` - The addresses to get outputs from.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
-                method:
-                  type: string
-                  default: getaddressutxos
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"address":"t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs","txid":"0000000000000000000000000000000000000000000000000000000000000000","outputIndex":0,"script":"00000000000000000000","satoshis":0,"height":0}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /submitblock:
-    post:
-      tags:
-      - mining
-      description: |-
-        Submits block to the node to be validated and committed.
-
-        **Request body `params` arguments:**
-
-        - `jsonparametersobject` - - currently ignored
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: submitblock
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"rejected"'
-  /getmininginfo:
-    post:
-      tags:
-      - mining
-      description: Returns mining-related information.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getmininginfo
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
-  /getpeerinfo:
-    post:
-      tags:
-      - network
-      description: Returns data about each connected network node.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getpeerinfo
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"addr":"0.0.0.0:0"}'
-  /z_gettreestate:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns information about the given block''s Sapling & Orchard tree state.
-
-        **Request body `params` arguments:**
-
-        - `hash | height` - The block hash or height.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: z_gettreestate
-                params:
-                  type: array
-                  items: {}
-                  default: '["00000000febc373a1da2bd9f887b105ad79ddc26ac26c2b28652d64e5207c5b5"]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","height":0,"time":0}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getblock:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
-
-        **Request body `params` arguments:**
-
-        - `hash_or_height` - The hash or height for the block to be returned.
-        - `verbosity` - 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblock
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '["1", 1]'
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
-  /getblocktemplate:
-    post:
-      tags:
-      - mining
-      description: |-
-        Returns a block template for mining new Zcash blocks.
-
-        **Request body `params` arguments:**
-
-        - `jsonrequestobject` - A JSON object containing arguments.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getblocktemplate
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getblockhash:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns the hash of the block of a given height iff the index argument correspond
-
-        **Request body `params` arguments:**
-
-        - `index` - The block index.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblockhash
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[1]'
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-  /getnetworkhashps:
-    post:
-      tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getnetworkhashps
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0'
-  /sendrawtransaction:
-    post:
-      tags:
-      - transaction
-      description: |-
-        Sends the raw bytes of a signed transaction to the local node''s mempool, if the transaction is valid.
-
-        **Request body `params` arguments:**
-
-        - `raw_transaction_hex` - The hex-encoded raw transaction bytes.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '["signedhex"]'
-                method:
-                  type: string
-                  default: sendrawtransaction
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
         '400':
           description: Bad request
           content:
@@ -645,16 +645,16 @@ paths:
             schema:
               type: object
               properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: validateaddress
                 params:
                   type: array
                   items: {}
                   default: '[]'
+                method:
+                  type: string
+                  default: validateaddress
+                id:
+                  type: number
+                  default: Yi9rWQB16V
       responses:
         '200':
           description: OK
@@ -666,6 +666,297 @@ paths:
                   result:
                     type: object
                     default: '{"isvalid":false}'
+  /getaddresstxids:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns the transaction ids made by the provided transparent addresses.
+
+        **Request body `params` arguments:**
+
+        - `request` - A struct with the following named fields:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getaddresstxids
+                id:
+                  type: number
+                  default: nV40sjZsiu
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '[]'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getaddressutxos:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns all unspent outputs for a list of addresses.
+
+        **Request body `params` arguments:**
+
+        - `addresses` - The addresses to get outputs from.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: ruJjg52Kdg
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
+                method:
+                  type: string
+                  default: getaddressutxos
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"address":"t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs","txid":"0000000000000000000000000000000000000000000000000000000000000000","outputIndex":0,"script":"00000000000000000000","satoshis":0,"height":0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getmininginfo:
+    post:
+      tags:
+      - mining
+      description: Returns mining-related information.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: jn9BNyjQz7
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getmininginfo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
+  /getblockhash:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns the hash of the block of a given height iff the index argument correspond
+
+        **Request body `params` arguments:**
+
+        - `index` - The block index.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: 2o22V6qOwH
+                params:
+                  type: array
+                  items: {}
+                  default: '[1]'
+                method:
+                  type: string
+                  default: getblockhash
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getblockchaininfo:
+    post:
+      tags:
+      - blockchain
+      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblockchaininfo
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: bhPxzpuFy0
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
+  /getbestblockhash:
+    post:
+      tags:
+      - blockchain
+      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getbestblockhash
+                id:
+                  type: number
+                  default: UO1gg5esHr
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+  /getaddressbalance:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns the total balance of a provided `addresses` in an [`AddressBalance`] instance.
+
+        **Request body `params` arguments:**
+
+        - `address_strings` - A JSON map with a single entry
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: V6hljf9wni
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
+                method:
+                  type: string
+                  default: getaddressbalance
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"balance":0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
   /getblocksubsidy:
     post:
       tags:
@@ -685,7 +976,7 @@ paths:
               properties:
                 id:
                   type: number
-                  default: '123'
+                  default: K3CavEZ6uI
                 params:
                   type: array
                   items: {}
@@ -694,16 +985,6 @@ paths:
                   type: string
                   default: getblocksubsidy
       responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
         '200':
           description: OK
           content:
@@ -714,277 +995,6 @@ paths:
                   result:
                     type: object
                     default: '{"fundingstreams":[],"miner":0.0,"founders":0.0}'
-  /getrawmempool:
-    post:
-      tags:
-      - blockchain
-      description: Returns all transaction ids in the memory pool, as a JSON array.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getrawmempool
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '[]'
-  /getdifficulty:
-    post:
-      tags:
-      - blockchain
-      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getdifficulty
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0.0'
-  /z_getsubtreesbyindex:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns information about a range of Sapling or Orchard subtrees.
-
-        **Request body `params` arguments:**
-
-        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
-        - `start_index` - The index of the first 2^16-leaf subtree to return.
-        - `limit` - The maximum number of subtree values to return.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: z_getsubtreesbyindex
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"pool":"","start_index":0,"subtrees":[]}'
-  /z_listunifiedreceivers:
-    post:
-      tags:
-      - wallet
-      description: |-
-        Returns the list of individual payment addresses given a unified address.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash unified address to get the list from.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: z_listunifiedreceivers
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"orchard":"orchard address if any","sapling":"sapling address if any","p2pkh":"p2pkh address if any","p2sh":"p2sh address if any"}'
-  /getblockcount:
-    post:
-      tags:
-      - blockchain
-      description: Returns the height of the most recent block in the best valid block chain (equivalently,
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getblockcount
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0'
-  /getnetworksolps:
-    post:
-      tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getnetworksolps
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0'
-  /getblockchaininfo:
-    post:
-      tags:
-      - blockchain
-      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getblockchaininfo
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
-  /getaddresstxids:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns the transaction ids made by the provided transparent addresses.
-
-        **Request body `params` arguments:**
-
-        - `request` - A struct with the following named fields:
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
-                method:
-                  type: string
-                  default: getaddresstxids
-                id:
-                  type: number
-                  default: '123'
-      responses:
         '400':
           description: Bad request
           content:
@@ -995,13 +1005,3 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '[]'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,6 +11,217 @@ info:
 servers:
   - url: http://localhost:8232
 paths:
+  /getblockchaininfo:
+    post:
+      tags:
+      - blockchain
+      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblockchaininfo
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
+  /sendrawtransaction:
+    post:
+      tags:
+      - transaction
+      description: |-
+        Sends the raw bytes of a signed transaction to the local node''s mempool, if the transaction is valid.
+
+        **Request body `params` arguments:**
+
+        - `raw_transaction_hex` - The hex-encoded raw transaction bytes.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '["signedhex"]'
+                method:
+                  type: string
+                  default: sendrawtransaction
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+  /getblock:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
+
+        **Request body `params` arguments:**
+
+        - `hash_or_height` - The hash or height for the block to be returned.
+        - `verbosity` - 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblock
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '["1", 1]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getblockcount:
+    post:
+      tags:
+      - blockchain
+      description: Returns the height of the most recent block in the best valid block chain (equivalently,
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblockcount
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
+  /getblockhash:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns the hash of the block of a given height iff the index argument correspond
+
+        **Request body `params` arguments:**
+
+        - `index` - The block index.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblockhash
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[1]'
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
   /getblocktemplate:
     post:
       tags:
@@ -49,16 +260,18 @@ paths:
                   result:
                     type: object
                     default: '{}'
-  /validateaddress:
+  /z_getsubtreesbyindex:
     post:
       tags:
-      - util
+      - blockchain
       description: |-
-        Checks if a zcash address is valid.
+        Returns information about a range of Sapling or Orchard subtrees.
 
         **Request body `params` arguments:**
 
-        - `address` - The zcash address to validate.
+        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
+        - `start_index` - The index of the first 2^16-leaf subtree to return.
+        - `limit` - The maximum number of subtree values to return.
       requestBody:
         required: true
         content:
@@ -75,7 +288,7 @@ paths:
                   default: '[]'
                 method:
                   type: string
-                  default: validateaddress
+                  default: z_getsubtreesbyindex
       responses:
         '200':
           description: OK
@@ -86,18 +299,111 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{"isvalid":false}'
-  /getblock:
+                    default: '{}'
+  /getmininginfo:
+    post:
+      tags:
+      - mining
+      description: Returns mining-related information.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getmininginfo
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
+  /getpeerinfo:
+    post:
+      tags:
+      - network
+      description: Returns data about each connected network node.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getpeerinfo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"addr":"0.0.0.0:0"}'
+  /getnetworksolps:
+    post:
+      tags:
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getnetworksolps
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
+  /getdifficulty:
     post:
       tags:
       - blockchain
-      description: |-
-        Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
-
-        **Request body `params` arguments:**
-
-        - `hash_or_height` - The hash or height for the block to be returned.
-        - `verbosity` - 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.
+      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
       requestBody:
         required: true
         content:
@@ -107,11 +413,11 @@ paths:
               properties:
                 method:
                   type: string
-                  default: getblock
+                  default: getdifficulty
                 params:
                   type: array
                   items: {}
-                  default: '["1", 1]'
+                  default: '[]'
                 id:
                   type: number
                   default: '123'
@@ -125,17 +431,7 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
+                    default: '0.0'
   /getrawmempool:
     post:
       tags:
@@ -169,371 +465,6 @@ paths:
                   result:
                     type: object
                     default: '[]'
-  /z_validateaddress:
-    post:
-      tags:
-      - util
-      description: |-
-        Checks if a zcash address is valid.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash address to validate.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: z_validateaddress
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"isvalid":false}'
-  /getbestblockhash:
-    post:
-      tags:
-      - blockchain
-      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getbestblockhash
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-  /getaddresstxids:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns the transaction ids made by the provided transparent addresses.
-
-        **Request body `params` arguments:**
-
-        - `request` - A struct with the following named fields:
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
-                method:
-                  type: string
-                  default: getaddresstxids
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '[]'
-  /getinfo:
-    post:
-      tags:
-      - control
-      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getinfo
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"build":"some build version","subversion":"some subversion"}'
-  /getdifficulty:
-    post:
-      tags:
-      - blockchain
-      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getdifficulty
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0.0'
-  /getblockcount:
-    post:
-      tags:
-      - blockchain
-      description: Returns the height of the most recent block in the best valid block chain (equivalently,
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblockcount
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0'
-  /getblockchaininfo:
-    post:
-      tags:
-      - blockchain
-      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getblockchaininfo
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
-  /z_gettreestate:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns information about the given block''s Sapling & Orchard tree state.
-
-        **Request body `params` arguments:**
-
-        - `hash | height` - The block hash or height.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '["00000000febc373a1da2bd9f887b105ad79ddc26ac26c2b28652d64e5207c5b5"]'
-                method:
-                  type: string
-                  default: z_gettreestate
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","height":0,"time":0}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getnetworksolps:
-    post:
-      tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getnetworksolps
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getpeerinfo:
-    post:
-      tags:
-      - network
-      description: Returns data about each connected network node.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getpeerinfo
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"addr":"0.0.0.0:0"}'
   /getaddressutxos:
     post:
       tags:
@@ -555,12 +486,12 @@ paths:
                   type: array
                   items: {}
                   default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
-                id:
-                  type: number
-                  default: '123'
                 method:
                   type: string
                   default: getaddressutxos
+                id:
+                  type: number
+                  default: '123'
       responses:
         '200':
           description: OK
@@ -572,6 +503,450 @@ paths:
                   result:
                     type: object
                     default: '{"address":"t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs","txid":"0000000000000000000000000000000000000000000000000000000000000000","outputIndex":0,"script":"00000000000000000000","satoshis":0,"height":0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /validateaddress:
+    post:
+      tags:
+      - util
+      description: |-
+        Checks if a zcash address is valid.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash address to validate.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: validateaddress
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"isvalid":false}'
+  /getnetworkhashps:
+    post:
+      tags:
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getnetworkhashps
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
+  /getaddresstxids:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns the transaction ids made by the provided transparent addresses.
+
+        **Request body `params` arguments:**
+
+        - `request` - A struct with the following named fields:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getaddresstxids
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '[]'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getbestblockhash:
+    post:
+      tags:
+      - blockchain
+      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getbestblockhash
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+  /submitblock:
+    post:
+      tags:
+      - mining
+      description: |-
+        Submits block to the node to be validated and committed.
+
+        **Request body `params` arguments:**
+
+        - `jsonparametersobject` - - currently ignored
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: submitblock
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /z_validateaddress:
+    post:
+      tags:
+      - util
+      description: |-
+        Checks if a zcash address is valid.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash address to validate.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: z_validateaddress
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"isvalid":false}'
+  /z_listunifiedreceivers:
+    post:
+      tags:
+      - wallet
+      description: |-
+        Returns the list of individual payment addresses given a unified address.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash unified address to get the list from.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: z_listunifiedreceivers
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getaddressbalance:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns the total balance of a provided `addresses` in an [`AddressBalance`] instance.
+
+        **Request body `params` arguments:**
+
+        - `address_strings` - A JSON map with a single entry
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
+                method:
+                  type: string
+                  default: getaddressbalance
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"balance":0}'
+  /getinfo:
+    post:
+      tags:
+      - control
+      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getinfo
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"build":"some build version","subversion":"some subversion"}'
+  /getrawtransaction:
+    post:
+      tags:
+      - transaction
+      description: |-
+        Returns the raw transaction data, as a [`GetRawTransaction`] JSON string or structure.
+
+        **Request body `params` arguments:**
+
+        - `txid` - The transaction ID of the transaction to be returned.
+        - `verbose` - If 0, return a string of hex-encoded data, otherwise return a JSON object.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getrawtransaction
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '["mytxid", 1]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"hex":"0000000000000000000000000000000000000000","height":0,"confirmations":0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /z_gettreestate:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns information about the given block''s Sapling & Orchard tree state.
+
+        **Request body `params` arguments:**
+
+        - `hash | height` - The block hash or height.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: z_gettreestate
+                params:
+                  type: array
+                  items: {}
+                  default: '["00000000febc373a1da2bd9f887b105ad79ddc26ac26c2b28652d64e5207c5b5"]'
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","height":0,"time":0}'
         '400':
           description: Bad request
           content:
@@ -602,13 +977,13 @@ paths:
                 method:
                   type: string
                   default: getblocksubsidy
-                id:
-                  type: number
-                  default: '123'
                 params:
                   type: array
                   items: {}
                   default: '[1]'
+                id:
+                  type: number
+                  default: '123'
       responses:
         '400':
           description: Bad request
@@ -630,378 +1005,3 @@ paths:
                   result:
                     type: object
                     default: '{"fundingstreams":[],"miner":0.0,"founders":0.0}'
-  /getnetworkhashps:
-    post:
-      tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getnetworkhashps
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /submitblock:
-    post:
-      tags:
-      - mining
-      description: |-
-        Submits block to the node to be validated and committed.
-
-        **Request body `params` arguments:**
-
-        - `jsonparametersobject` - - currently ignored
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: submitblock
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /z_listunifiedreceivers:
-    post:
-      tags:
-      - wallet
-      description: |-
-        Returns the list of individual payment addresses given a unified address.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash unified address to get the list from.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: z_listunifiedreceivers
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /sendrawtransaction:
-    post:
-      tags:
-      - transaction
-      description: |-
-        Sends the raw bytes of a signed transaction to the local node''s mempool, if the transaction is valid.
-
-        **Request body `params` arguments:**
-
-        - `raw_transaction_hex` - The hex-encoded raw transaction bytes.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: sendrawtransaction
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '["signedhex"]'
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-  /getrawtransaction:
-    post:
-      tags:
-      - transaction
-      description: |-
-        Returns the raw transaction data, as a [`GetRawTransaction`] JSON string or structure.
-
-        **Request body `params` arguments:**
-
-        - `txid` - The transaction ID of the transaction to be returned.
-        - `verbose` - If 0, return a string of hex-encoded data, otherwise return a JSON object.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '["mytxid", 1]'
-                method:
-                  type: string
-                  default: getrawtransaction
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"hex":"0000000000000000000000000000000000000000","height":0,"confirmations":0}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getblockhash:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns the hash of the block of a given height iff the index argument correspond
-
-        **Request body `params` arguments:**
-
-        - `index` - The block index.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblockhash
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[1]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getaddressbalance:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns the total balance of a provided `addresses` in an [`AddressBalance`] instance.
-
-        **Request body `params` arguments:**
-
-        - `address_strings` - A JSON map with a single entry
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getaddressbalance
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"balance":0}'
-  /getmininginfo:
-    post:
-      tags:
-      - mining
-      description: Returns mining-related information.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getmininginfo
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
-  /z_getsubtreesbyindex:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns information about a range of Sapling or Orchard subtrees.
-
-        **Request body `params` arguments:**
-
-        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
-        - `start_index` - The index of the first 2^16-leaf subtree to return.
-        - `limit` - The maximum number of subtree values to return.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: z_getsubtreesbyindex
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,11 +11,49 @@ info:
 servers:
   - url: http://localhost:8232
 paths:
-  /getblockchaininfo:
+  /getnetworksolps:
     post:
       tags:
-      - blockchain
-      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getnetworksolps
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
+  /z_validateaddress:
+    post:
+      tags:
+      - util
+      description: |-
+        Checks if a zcash address is valid.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash address to validate.
       requestBody:
         required: true
         content:
@@ -25,7 +63,7 @@ paths:
               properties:
                 method:
                   type: string
-                  default: getblockchaininfo
+                  default: z_validateaddress
                 id:
                   type: number
                   default: '123'
@@ -43,17 +81,121 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
-  /sendrawtransaction:
+                    default: '{"isvalid":false}'
+  /getrawmempool:
     post:
       tags:
-      - transaction
+      - blockchain
+      description: Returns all transaction ids in the memory pool, as a JSON array.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getrawmempool
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '[]'
+  /getdifficulty:
+    post:
+      tags:
+      - blockchain
+      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getdifficulty
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0.0'
+  /z_listunifiedreceivers:
+    post:
+      tags:
+      - wallet
       description: |-
-        Sends the raw bytes of a signed transaction to the local node''s mempool, if the transaction is valid.
+        Returns the list of individual payment addresses given a unified address.
 
         **Request body `params` arguments:**
 
-        - `raw_transaction_hex` - The hex-encoded raw transaction bytes.
+        - `address` - The zcash unified address to get the list from.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: z_listunifiedreceivers
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"orchard":"orchard address if any","sapling":"sapling address if any","p2pkh":"p2pkh address if any","p2sh":"p2sh address if any"}'
+  /getaddresstxids:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns the transaction ids made by the provided transparent addresses.
+
+        **Request body `params` arguments:**
+
+        - `request` - A struct with the following named fields:
       requestBody:
         required: true
         content:
@@ -64,13 +206,271 @@ paths:
                 params:
                   type: array
                   items: {}
-                  default: '["signedhex"]'
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
                 method:
                   type: string
-                  default: sendrawtransaction
+                  default: getaddresstxids
                 id:
                   type: number
                   default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '[]'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getblockhash:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns the hash of the block of a given height iff the index argument correspond
+
+        **Request body `params` arguments:**
+
+        - `index` - The block index.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblockhash
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[1]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getbestblockhash:
+    post:
+      tags:
+      - blockchain
+      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getbestblockhash
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+  /z_gettreestate:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns information about the given block''s Sapling & Orchard tree state.
+
+        **Request body `params` arguments:**
+
+        - `hash | height` - The block hash or height.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '["00000000febc373a1da2bd9f887b105ad79ddc26ac26c2b28652d64e5207c5b5"]'
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: z_gettreestate
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","height":0,"time":0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getaddressutxos:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns all unspent outputs for a list of addresses.
+
+        **Request body `params` arguments:**
+
+        - `addresses` - The addresses to get outputs from.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getaddressutxos
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"address":"t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs","txid":"0000000000000000000000000000000000000000000000000000000000000000","outputIndex":0,"script":"00000000000000000000","satoshis":0,"height":0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getblockcount:
+    post:
+      tags:
+      - blockchain
+      description: Returns the height of the most recent block in the best valid block chain (equivalently,
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getblockcount
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
+  /getblocksubsidy:
+    post:
+      tags:
+      - mining
+      description: |-
+        Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
+
+        **Request body `params` arguments:**
+
+        - `height` - Can be any valid current or future height.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[1]'
+                method:
+                  type: string
+                  default: getblocksubsidy
       responses:
         '400':
           description: Bad request
@@ -91,7 +491,89 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+                    default: '{"fundingstreams":[],"miner":0.0,"founders":0.0}'
+  /getrawtransaction:
+    post:
+      tags:
+      - transaction
+      description: |-
+        Returns the raw transaction data, as a [`GetRawTransaction`] JSON string or structure.
+
+        **Request body `params` arguments:**
+
+        - `txid` - The transaction ID of the transaction to be returned.
+        - `verbose` - If 0, return a string of hex-encoded data, otherwise return a JSON object.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '["mytxid", 1]'
+                method:
+                  type: string
+                  default: getrawtransaction
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"hex":"0000000000000000000000000000000000000000","height":0,"confirmations":0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getmininginfo:
+    post:
+      tags:
+      - mining
+      description: Returns mining-related information.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getmininginfo
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
   /getblock:
     post:
       tags:
@@ -141,125 +623,6 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getblockcount:
-    post:
-      tags:
-      - blockchain
-      description: Returns the height of the most recent block in the best valid block chain (equivalently,
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblockcount
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0'
-  /getblockhash:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns the hash of the block of a given height iff the index argument correspond
-
-        **Request body `params` arguments:**
-
-        - `index` - The block index.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblockhash
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[1]'
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-  /getblocktemplate:
-    post:
-      tags:
-      - mining
-      description: |-
-        Returns a block template for mining new Zcash blocks.
-
-        **Request body `params` arguments:**
-
-        - `jsonrequestobject` - A JSON object containing arguments.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblocktemplate
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
   /z_getsubtreesbyindex:
     post:
       tags:
@@ -300,11 +663,49 @@ paths:
                   result:
                     type: object
                     default: '{}'
-  /getmininginfo:
+  /getblocktemplate:
     post:
       tags:
       - mining
-      description: Returns mining-related information.
+      description: |-
+        Returns a block template for mining new Zcash blocks.
+
+        **Request body `params` arguments:**
+
+        - `jsonrequestobject` - A JSON object containing arguments.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getblocktemplate
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getinfo:
+    post:
+      tags:
+      - control
+      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
       requestBody:
         required: true
         content:
@@ -317,7 +718,7 @@ paths:
                   default: '123'
                 method:
                   type: string
-                  default: getmininginfo
+                  default: getinfo
                 params:
                   type: array
                   items: {}
@@ -332,7 +733,88 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
+                    default: '{"build":"some build version","subversion":"some subversion"}'
+  /getblockchaininfo:
+    post:
+      tags:
+      - blockchain
+      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getblockchaininfo
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
+  /getaddressbalance:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns the total balance of a provided `addresses` in an [`AddressBalance`] instance.
+
+        **Request body `params` arguments:**
+
+        - `address_strings` - A JSON map with a single entry
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getaddressbalance
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"balance":0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
   /getpeerinfo:
     post:
       tags:
@@ -345,9 +827,6 @@ paths:
             schema:
               type: object
               properties:
-                id:
-                  type: number
-                  default: '123'
                 params:
                   type: array
                   items: {}
@@ -355,6 +834,9 @@ paths:
                 method:
                   type: string
                   default: getpeerinfo
+                id:
+                  type: number
+                  default: '123'
       responses:
         '200':
           description: OK
@@ -366,153 +848,6 @@ paths:
                   result:
                     type: object
                     default: '{"addr":"0.0.0.0:0"}'
-  /getnetworksolps:
-    post:
-      tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getnetworksolps
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0'
-  /getdifficulty:
-    post:
-      tags:
-      - blockchain
-      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getdifficulty
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0.0'
-  /getrawmempool:
-    post:
-      tags:
-      - blockchain
-      description: Returns all transaction ids in the memory pool, as a JSON array.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getrawmempool
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '[]'
-  /getaddressutxos:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns all unspent outputs for a list of addresses.
-
-        **Request body `params` arguments:**
-
-        - `addresses` - The addresses to get outputs from.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
-                method:
-                  type: string
-                  default: getaddressutxos
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"address":"t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs","txid":"0000000000000000000000000000000000000000000000000000000000000000","outputIndex":0,"script":"00000000000000000000","satoshis":0,"height":0}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
   /validateaddress:
     post:
       tags:
@@ -530,9 +865,6 @@ paths:
             schema:
               type: object
               properties:
-                method:
-                  type: string
-                  default: validateaddress
                 id:
                   type: number
                   default: '123'
@@ -540,6 +872,9 @@ paths:
                   type: array
                   items: {}
                   default: '[]'
+                method:
+                  type: string
+                  default: validateaddress
       responses:
         '200':
           description: OK
@@ -551,6 +886,92 @@ paths:
                   result:
                     type: object
                     default: '{"isvalid":false}'
+  /sendrawtransaction:
+    post:
+      tags:
+      - transaction
+      description: |-
+        Sends the raw bytes of a signed transaction to the local node''s mempool, if the transaction is valid.
+
+        **Request body `params` arguments:**
+
+        - `raw_transaction_hex` - The hex-encoded raw transaction bytes.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: sendrawtransaction
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '["signedhex"]'
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+  /submitblock:
+    post:
+      tags:
+      - mining
+      description: |-
+        Submits block to the node to be validated and committed.
+
+        **Request body `params` arguments:**
+
+        - `jsonparametersobject` - - currently ignored
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: submitblock
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"rejected"'
   /getnetworkhashps:
     post:
       tags:
@@ -584,424 +1005,3 @@ paths:
                   result:
                     type: object
                     default: '0'
-  /getaddresstxids:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns the transaction ids made by the provided transparent addresses.
-
-        **Request body `params` arguments:**
-
-        - `request` - A struct with the following named fields:
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getaddresstxids
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '[]'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getbestblockhash:
-    post:
-      tags:
-      - blockchain
-      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getbestblockhash
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-  /submitblock:
-    post:
-      tags:
-      - mining
-      description: |-
-        Submits block to the node to be validated and committed.
-
-        **Request body `params` arguments:**
-
-        - `jsonparametersobject` - - currently ignored
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: submitblock
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /z_validateaddress:
-    post:
-      tags:
-      - util
-      description: |-
-        Checks if a zcash address is valid.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash address to validate.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: z_validateaddress
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"isvalid":false}'
-  /z_listunifiedreceivers:
-    post:
-      tags:
-      - wallet
-      description: |-
-        Returns the list of individual payment addresses given a unified address.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash unified address to get the list from.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: z_listunifiedreceivers
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getaddressbalance:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns the total balance of a provided `addresses` in an [`AddressBalance`] instance.
-
-        **Request body `params` arguments:**
-
-        - `address_strings` - A JSON map with a single entry
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
-                method:
-                  type: string
-                  default: getaddressbalance
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"balance":0}'
-  /getinfo:
-    post:
-      tags:
-      - control
-      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getinfo
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"build":"some build version","subversion":"some subversion"}'
-  /getrawtransaction:
-    post:
-      tags:
-      - transaction
-      description: |-
-        Returns the raw transaction data, as a [`GetRawTransaction`] JSON string or structure.
-
-        **Request body `params` arguments:**
-
-        - `txid` - The transaction ID of the transaction to be returned.
-        - `verbose` - If 0, return a string of hex-encoded data, otherwise return a JSON object.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getrawtransaction
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '["mytxid", 1]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"hex":"0000000000000000000000000000000000000000","height":0,"confirmations":0}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /z_gettreestate:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns information about the given block''s Sapling & Orchard tree state.
-
-        **Request body `params` arguments:**
-
-        - `hash | height` - The block hash or height.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: z_gettreestate
-                params:
-                  type: array
-                  items: {}
-                  default: '["00000000febc373a1da2bd9f887b105ad79ddc26ac26c2b28652d64e5207c5b5"]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","height":0,"time":0}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getblocksubsidy:
-    post:
-      tags:
-      - mining
-      description: |-
-        Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
-
-        **Request body `params` arguments:**
-
-        - `height` - Can be any valid current or future height.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblocksubsidy
-                params:
-                  type: array
-                  items: {}
-                  default: '[1]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"fundingstreams":[],"miner":0.0,"founders":0.0}'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,6 +11,82 @@ info:
 servers:
   - url: http://localhost:8232
 paths:
+  /getblocktemplate:
+    post:
+      tags:
+      - mining
+      description: |-
+        Returns a block template for mining new Zcash blocks.
+
+        **Request body `params` arguments:**
+
+        - `jsonrequestobject` - A JSON object containing arguments.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblocktemplate
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /validateaddress:
+    post:
+      tags:
+      - util
+      description: |-
+        Checks if a zcash address is valid.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash address to validate.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: validateaddress
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"isvalid":false}'
   /getblock:
     post:
       tags:
@@ -60,11 +136,11 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getblockchaininfo:
+  /getrawmempool:
     post:
       tags:
       - blockchain
-      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
+      description: Returns all transaction ids in the memory pool, as a JSON array.
       requestBody:
         required: true
         content:
@@ -72,54 +148,16 @@ paths:
             schema:
               type: object
               properties:
-                id:
-                  type: number
-                  default: '123'
+                method:
+                  type: string
+                  default: getrawmempool
                 params:
                   type: array
                   items: {}
                   default: '[]'
-                method:
-                  type: string
-                  default: getblockchaininfo
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
-  /getaddresstxids:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns the transaction ids made by the provided transparent addresses.
-
-        **Request body `params` arguments:**
-
-        - `request` - A struct with the following named fields:
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
                 id:
                   type: number
                   default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
-                method:
-                  type: string
-                  default: getaddresstxids
       responses:
         '200':
           description: OK
@@ -131,202 +169,6 @@ paths:
                   result:
                     type: object
                     default: '[]'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getblockcount:
-    post:
-      tags:
-      - blockchain
-      description: Returns the height of the most recent block in the best valid block chain (equivalently,
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getblockcount
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0'
-  /getbestblockhash:
-    post:
-      tags:
-      - blockchain
-      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getbestblockhash
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-  /validateaddress:
-    post:
-      tags:
-      - util
-      description: |-
-        Checks if a zcash address is valid.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash address to validate.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: validateaddress
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"isvalid":false}'
-  /getrawtransaction:
-    post:
-      tags:
-      - transaction
-      description: |-
-        Returns the raw transaction data, as a [`GetRawTransaction`] JSON string or structure.
-
-        **Request body `params` arguments:**
-
-        - `txid` - The transaction ID of the transaction to be returned.
-        - `verbose` - If 0, return a string of hex-encoded data, otherwise return a JSON object.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getrawtransaction
-                params:
-                  type: array
-                  items: {}
-                  default: '["mytxid", 1]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getnetworkhashps:
-    post:
-      tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getnetworkhashps
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
   /z_validateaddress:
     post:
       tags:
@@ -365,6 +207,87 @@ paths:
                   result:
                     type: object
                     default: '{"isvalid":false}'
+  /getbestblockhash:
+    post:
+      tags:
+      - blockchain
+      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getbestblockhash
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+  /getaddresstxids:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns the transaction ids made by the provided transparent addresses.
+
+        **Request body `params` arguments:**
+
+        - `request` - A struct with the following named fields:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
+                method:
+                  type: string
+                  default: getaddresstxids
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '[]'
   /getinfo:
     post:
       tags:
@@ -377,12 +300,12 @@ paths:
             schema:
               type: object
               properties:
-                method:
-                  type: string
-                  default: getinfo
                 id:
                   type: number
                   default: '123'
+                method:
+                  type: string
+                  default: getinfo
                 params:
                   type: array
                   items: {}
@@ -398,11 +321,11 @@ paths:
                   result:
                     type: object
                     default: '{"build":"some build version","subversion":"some subversion"}'
-  /getrawmempool:
+  /getdifficulty:
     post:
       tags:
       - blockchain
-      description: Returns all transaction ids in the memory pool, as a JSON array.
+      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
       requestBody:
         required: true
         content:
@@ -412,7 +335,7 @@ paths:
               properties:
                 method:
                   type: string
-                  default: getrawmempool
+                  default: getdifficulty
                 id:
                   type: number
                   default: '123'
@@ -430,7 +353,73 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '[]'
+                    default: '0.0'
+  /getblockcount:
+    post:
+      tags:
+      - blockchain
+      description: Returns the height of the most recent block in the best valid block chain (equivalently,
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblockcount
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
+  /getblockchaininfo:
+    post:
+      tags:
+      - blockchain
+      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getblockchaininfo
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
   /z_gettreestate:
     post:
       tags:
@@ -479,54 +468,6 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getaddressbalance:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns the total balance of a provided `addresses` in an [`AddressBalance`] instance.
-
-        **Request body `params` arguments:**
-
-        - `address_strings` - A JSON map with a single entry
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getaddressbalance
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"balance":0}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
   /getnetworksolps:
     post:
       tags:
@@ -560,6 +501,39 @@ paths:
                   result:
                     type: object
                     default: '{}'
+  /getpeerinfo:
+    post:
+      tags:
+      - network
+      description: Returns data about each connected network node.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getpeerinfo
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"addr":"0.0.0.0:0"}'
   /getaddressutxos:
     post:
       tags:
@@ -577,16 +551,16 @@ paths:
             schema:
               type: object
               properties:
-                method:
-                  type: string
-                  default: getaddressutxos
-                id:
-                  type: number
-                  default: '123'
                 params:
                   type: array
                   items: {}
                   default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getaddressutxos
       responses:
         '200':
           description: OK
@@ -608,54 +582,16 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /z_listunifiedreceivers:
-    post:
-      tags:
-      - wallet
-      description: |-
-        Returns the list of individual payment addresses given a unified address.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash unified address to get the list from.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: z_listunifiedreceivers
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getblocktemplate:
+  /getblocksubsidy:
     post:
       tags:
       - mining
       description: |-
-        Returns a block template for mining new Zcash blocks.
+        Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
 
         **Request body `params` arguments:**
 
-        - `jsonrequestobject` - A JSON object containing arguments.
+        - `height` - Can be any valid current or future height.
       requestBody:
         required: true
         content:
@@ -663,16 +599,59 @@ paths:
             schema:
               type: object
               properties:
+                method:
+                  type: string
+                  default: getblocksubsidy
                 id:
                   type: number
                   default: '123'
                 params:
                   type: array
                   items: {}
+                  default: '[1]'
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"fundingstreams":[],"miner":0.0,"founders":0.0}'
+  /getnetworkhashps:
+    post:
+      tags:
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
                   default: '[]'
                 method:
                   type: string
-                  default: getblocktemplate
+                  default: getnetworkhashps
+                id:
+                  type: number
+                  default: '123'
       responses:
         '200':
           description: OK
@@ -684,72 +663,6 @@ paths:
                   result:
                     type: object
                     default: '{}'
-  /getpeerinfo:
-    post:
-      tags:
-      - network
-      description: Returns data about each connected network node.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getpeerinfo
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"addr":"0.0.0.0:0"}'
-  /getdifficulty:
-    post:
-      tags:
-      - blockchain
-      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getdifficulty
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0.0'
   /submitblock:
     post:
       tags:
@@ -788,49 +701,16 @@ paths:
                   result:
                     type: object
                     default: '{}'
-  /getmininginfo:
+  /z_listunifiedreceivers:
     post:
       tags:
-      - mining
-      description: Returns mining-related information.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getmininginfo
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
-  /getblocksubsidy:
-    post:
-      tags:
-      - mining
+      - wallet
       description: |-
-        Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
+        Returns the list of individual payment addresses given a unified address.
 
         **Request body `params` arguments:**
 
-        - `height` - Can be any valid current or future height.
+        - `address` - The zcash unified address to get the list from.
       requestBody:
         required: true
         content:
@@ -841,59 +721,9 @@ paths:
                 id:
                   type: number
                   default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[1]'
                 method:
                   type: string
-                  default: getblocksubsidy
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"fundingstreams":[],"miner":0.0,"founders":0.0}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /z_getsubtreesbyindex:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns information about a range of Sapling or Orchard subtrees.
-
-        **Request body `params` arguments:**
-
-        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
-        - `start_index` - The index of the first 2^16-leaf subtree to return.
-        - `limit` - The maximum number of subtree values to return.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: z_getsubtreesbyindex
-                id:
-                  type: number
-                  default: '123'
+                  default: z_listunifiedreceivers
                 params:
                   type: array
                   items: {}
@@ -937,6 +767,16 @@ paths:
                   items: {}
                   default: '["signedhex"]'
       responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
         '200':
           description: OK
           content:
@@ -946,7 +786,46 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{}'
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+  /getrawtransaction:
+    post:
+      tags:
+      - transaction
+      description: |-
+        Returns the raw transaction data, as a [`GetRawTransaction`] JSON string or structure.
+
+        **Request body `params` arguments:**
+
+        - `txid` - The transaction ID of the transaction to be returned.
+        - `verbose` - If 0, return a string of hex-encoded data, otherwise return a JSON object.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '["mytxid", 1]'
+                method:
+                  type: string
+                  default: getrawtransaction
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"hex":"0000000000000000000000000000000000000000","height":0,"confirmations":0}'
         '400':
           description: Bad request
           content:
@@ -1005,3 +884,124 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
+  /getaddressbalance:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns the total balance of a provided `addresses` in an [`AddressBalance`] instance.
+
+        **Request body `params` arguments:**
+
+        - `address_strings` - A JSON map with a single entry
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getaddressbalance
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"balance":0}'
+  /getmininginfo:
+    post:
+      tags:
+      - mining
+      description: Returns mining-related information.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getmininginfo
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
+  /z_getsubtreesbyindex:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns information about a range of Sapling or Orchard subtrees.
+
+        **Request body `params` arguments:**
+
+        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
+        - `start_index` - The index of the first 2^16-leaf subtree to return.
+        - `limit` - The maximum number of subtree values to return.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: z_getsubtreesbyindex
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,376 +11,6 @@ info:
 servers:
   - url: http://localhost:8232
 paths:
-  /getbestblockhash:
-    post:
-      tags:
-      - blockchain
-      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getbestblockhash
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-  /getinfo:
-    post:
-      tags:
-      - control
-      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getinfo
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"build":"some build version","subversion":"some subversion"}'
-  /getblockhash:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns the hash of the block of a given height iff the index argument correspond
-
-        **Request body `params` arguments:**
-
-        - `index` - The block index.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblockhash
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[1]'
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-  /getblocktemplate:
-    post:
-      tags:
-      - mining
-      description: |-
-        Returns a block template for mining new Zcash blocks.
-
-        **Request body `params` arguments:**
-
-        - `jsonrequestobject` - A JSON object containing arguments.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblocktemplate
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getnetworkhashps:
-    post:
-      tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getnetworkhashps
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getblockcount:
-    post:
-      tags:
-      - blockchain
-      description: Returns the height of the most recent block in the best valid block chain (equivalently,
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblockcount
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /z_validateaddress:
-    post:
-      tags:
-      - util
-      description: |-
-        Checks if a zcash address is valid.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash address to validate.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: z_validateaddress
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getdifficulty:
-    post:
-      tags:
-      - blockchain
-      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getdifficulty
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getpeerinfo:
-    post:
-      tags:
-      - network
-      description: Returns data about each connected network node.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getpeerinfo
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"addr":"0.0.0.0:0"}'
-  /sendrawtransaction:
-    post:
-      tags:
-      - transaction
-      description: |-
-        Sends the raw bytes of a signed transaction to the local node''s mempool, if the transaction is valid.
-
-        **Request body `params` arguments:**
-
-        - `raw_transaction_hex` - The hex-encoded raw transaction bytes.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: sendrawtransaction
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '["signedhex"]'
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
   /getrawtransaction:
     post:
       tags:
@@ -430,46 +60,6 @@ paths:
                   result:
                     type: object
                     default: '{}'
-  /z_getsubtreesbyindex:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns information about a range of Sapling or Orchard subtrees.
-
-        **Request body `params` arguments:**
-
-        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
-        - `start_index` - The index of the first 2^16-leaf subtree to return.
-        - `limit` - The maximum number of subtree values to return.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: z_getsubtreesbyindex
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
   /getaddressbalance:
     post:
       tags:
@@ -487,16 +77,16 @@ paths:
             schema:
               type: object
               properties:
-                method:
-                  type: string
-                  default: getaddressbalance
-                id:
-                  type: number
-                  default: '123'
                 params:
                   type: array
                   items: {}
                   default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getaddressbalance
       responses:
         '400':
           description: Bad request
@@ -518,16 +108,16 @@ paths:
                   result:
                     type: object
                     default: '{}'
-  /validateaddress:
+  /getblockhash:
     post:
       tags:
-      - util
+      - blockchain
       description: |-
-        Checks if a zcash address is valid.
+        Returns the hash of the block of a given height iff the index argument correspond
 
         **Request body `params` arguments:**
 
-        - `address` - The zcash address to validate.
+        - `index` - The block index.
       requestBody:
         required: true
         content:
@@ -538,52 +128,24 @@ paths:
                 id:
                   type: number
                   default: '123'
-                method:
-                  type: string
-                  default: validateaddress
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getblocksubsidy:
-    post:
-      tags:
-      - mining
-      description: |-
-        Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
-
-        **Request body `params` arguments:**
-
-        - `height` - Can be any valid current or future height.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getblocksubsidy
                 params:
                   type: array
                   items: {}
                   default: '[1]'
+                method:
+                  type: string
+                  default: getblockhash
       responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
         '400':
           description: Bad request
           content:
@@ -594,49 +156,6 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"fundingstreams":[],"miner":0.0,"founders":0.0}'
-  /getblockchaininfo:
-    post:
-      tags:
-      - blockchain
-      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblockchaininfo
-                id:
-                  type: number
-                  default: '123'
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
   /submitblock:
     post:
       tags:
@@ -661,6 +180,202 @@ paths:
                 method:
                   type: string
                   default: submitblock
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getblock:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
+
+        **Request body `params` arguments:**
+
+        - `hash_or_height` - The hash or height for the block to be returned.
+        - `verbosity` - 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '["1", 1]'
+                method:
+                  type: string
+                  default: getblock
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getaddressutxos:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns all unspent outputs for a list of addresses.
+
+        **Request body `params` arguments:**
+
+        - `addresses` - The addresses to get outputs from.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
+                method:
+                  type: string
+                  default: getaddressutxos
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getnetworkhashps:
+    post:
+      tags:
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getnetworkhashps
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getpeerinfo:
+    post:
+      tags:
+      - network
+      description: Returns data about each connected network node.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getpeerinfo
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"addr":"0.0.0.0:0"}'
+  /getdifficulty:
+    post:
+      tags:
+      - blockchain
+      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getdifficulty
                 id:
                   type: number
                   default: '123'
@@ -723,54 +438,6 @@ paths:
                   result:
                     type: object
                     default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","height":0,"time":0}'
-  /getaddressutxos:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns all unspent outputs for a list of addresses.
-
-        **Request body `params` arguments:**
-
-        - `addresses` - The addresses to get outputs from.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                  default: '123'
-                method:
-                  type: string
-                  default: getaddressutxos
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
   /getaddresstxids:
     post:
       tags:
@@ -791,13 +458,94 @@ paths:
                 method:
                   type: string
                   default: getaddresstxids
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getinfo:
+    post:
+      tags:
+      - control
+      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getinfo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"build":"some build version","subversion":"some subversion"}'
+  /getblocktemplate:
+    post:
+      tags:
+      - mining
+      description: |-
+        Returns a block template for mining new Zcash blocks.
+
+        **Request body `params` arguments:**
+
+        - `jsonrequestobject` - A JSON object containing arguments.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblocktemplate
                 id:
                   type: number
                   default: '123'
                 params:
                   type: array
                   items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
+                  default: '[]'
       responses:
         '200':
           description: OK
@@ -809,21 +557,11 @@ paths:
                   result:
                     type: object
                     default: '{}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getmininginfo:
+  /getbestblockhash:
     post:
       tags:
-      - mining
-      description: Returns mining-related information.
+      - blockchain
+      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
       requestBody:
         required: true
         content:
@@ -831,12 +569,12 @@ paths:
             schema:
               type: object
               properties:
+                method:
+                  type: string
+                  default: getbestblockhash
                 id:
                   type: number
                   default: '123'
-                method:
-                  type: string
-                  default: getmininginfo
                 params:
                   type: array
                   items: {}
@@ -851,12 +589,19 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
-  /getnetworksolps:
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+  /z_getsubtreesbyindex:
     post:
       tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      - blockchain
+      description: |-
+        Returns information about a range of Sapling or Orchard subtrees.
+
+        **Request body `params` arguments:**
+
+        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
+        - `start_index` - The index of the first 2^16-leaf subtree to return.
+        - `limit` - The maximum number of subtree values to return.
       requestBody:
         required: true
         content:
@@ -864,6 +609,128 @@ paths:
             schema:
               type: object
               properties:
+                method:
+                  type: string
+                  default: z_getsubtreesbyindex
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getblockcount:
+    post:
+      tags:
+      - blockchain
+      description: Returns the height of the most recent block in the best valid block chain (equivalently,
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getblockcount
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
+  /getblocksubsidy:
+    post:
+      tags:
+      - mining
+      description: |-
+        Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
+
+        **Request body `params` arguments:**
+
+        - `height` - Can be any valid current or future height.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblocksubsidy
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[1]'
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"fundingstreams":[],"miner":0.0,"founders":0.0}'
+  /validateaddress:
+    post:
+      tags:
+      - util
+      description: |-
+        Checks if a zcash address is valid.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash address to validate.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: validateaddress
                 id:
                   type: number
                   default: '123'
@@ -871,9 +738,6 @@ paths:
                   type: array
                   items: {}
                   default: '[]'
-                method:
-                  type: string
-                  default: getnetworksolps
       responses:
         '200':
           description: OK
@@ -923,55 +787,6 @@ paths:
                   result:
                     type: object
                     default: '{}'
-  /getblock:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
-
-        **Request body `params` arguments:**
-
-        - `hash_or_height` - The hash or height for the block to be returned.
-        - `verbosity` - 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '["1", 1]'
-                method:
-                  type: string
-                  default: getblock
-                id:
-                  type: number
-                  default: '123'
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
   /getrawmempool:
     post:
       tags:
@@ -994,6 +809,191 @@ paths:
                 id:
                   type: number
                   default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /sendrawtransaction:
+    post:
+      tags:
+      - transaction
+      description: |-
+        Sends the raw bytes of a signed transaction to the local node''s mempool, if the transaction is valid.
+
+        **Request body `params` arguments:**
+
+        - `raw_transaction_hex` - The hex-encoded raw transaction bytes.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '["signedhex"]'
+                method:
+                  type: string
+                  default: sendrawtransaction
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getmininginfo:
+    post:
+      tags:
+      - mining
+      description: Returns mining-related information.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getmininginfo
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
+  /getnetworksolps:
+    post:
+      tags:
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+                method:
+                  type: string
+                  default: getnetworksolps
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getblockchaininfo:
+    post:
+      tags:
+      - blockchain
+      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblockchaininfo
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: number
+                  default: '123'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
+  /z_validateaddress:
+    post:
+      tags:
+      - util
+      description: |-
+        Checks if a zcash address is valid.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash address to validate.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: z_validateaddress
+                id:
+                  type: number
+                  default: '123'
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
       responses:
         '200':
           description: OK

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1492,6 +1492,12 @@ struct TipConsensusBranch {
 #[derive(Copy, Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SentTransactionHash(#[serde(with = "hex")] transaction::Hash);
 
+impl Default for SentTransactionHash {
+    fn default() -> Self {
+        Self(transaction::Hash::from([0; 32]))
+    }
+}
+
 /// Response to a `getblock` RPC request.
 ///
 /// See the notes for the [`Rpc::get_block`] method.
@@ -1575,6 +1581,16 @@ pub enum GetRawTransaction {
         /// or 0 if the transaction is in the mempool.
         confirmations: u32,
     },
+}
+
+impl Default for GetRawTransaction {
+    fn default() -> Self {
+        Self::Object {
+            hex: SerializedTransaction::from([0u8; 20].to_vec()),
+            height: i32::default(),
+            confirmations: u32::default(),
+        }
+    }
 }
 
 /// Response to a `getaddressutxos` RPC request.

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1423,6 +1423,14 @@ pub struct AddressBalance {
     balance: u64,
 }
 
+impl Default for AddressBalance {
+    fn default() -> Self {
+        Self {
+            balance: u64::default(),
+        }
+    }
+}
+
 /// A hex-encoded [`ConsensusBranchId`] string.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
 struct ConsensusBranchIdHex(#[serde(with = "hex")] ConsensusBranchId);
@@ -1596,6 +1604,22 @@ pub struct GetAddressUtxos {
     ///
     /// We put this field last, to match the zcashd order.
     height: Height,
+}
+
+impl Default for GetAddressUtxos {
+    fn default() -> Self {
+        Self {
+            address: transparent::Address::from_pub_key_hash(
+                zebra_chain::parameters::NetworkKind::default(),
+                [0u8; 20],
+            ),
+            txid: transaction::Hash::from([0; 32]),
+            output_index: OutputIndex::from_u64(0),
+            script: transparent::Script::new(&[0u8; 10]),
+            satoshis: u64::default(),
+            height: Height(0),
+        }
+    }
 }
 
 /// A struct to use as parameter of the `getaddresstxids`.

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1578,7 +1578,9 @@ pub enum GetRawTransaction {
 impl Default for GetRawTransaction {
     fn default() -> Self {
         Self::Object {
-            hex: SerializedTransaction::from([0u8; 20].to_vec()),
+            hex: SerializedTransaction::from(
+                [0u8; zebra_chain::transaction::MIN_TRANSPARENT_TX_SIZE as usize].to_vec(),
+            ),
             height: i32::default(),
             confirmations: u32::default(),
         }

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1417,18 +1417,10 @@ impl AddressStrings {
 }
 
 /// The transparent balance of a set of addresses.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, serde::Serialize)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash, serde::Serialize)]
 pub struct AddressBalance {
     /// The total transparent balance.
     balance: u64,
-}
-
-impl Default for AddressBalance {
-    fn default() -> Self {
-        Self {
-            balance: u64::default(),
-        }
-    }
 }
 
 /// A hex-encoded [`ConsensusBranchId`] string.

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_mining_info.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_mining_info.rs
@@ -29,3 +29,14 @@ impl Response {
         }
     }
 }
+
+impl Default for Response {
+    fn default() -> Self {
+        Self {
+            networksolps: u64::default(),
+            networkhashps: u64::default(),
+            chain: String::default(),
+            testnet: bool::default(),
+        }
+    }
+}

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_mining_info.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_mining_info.rs
@@ -3,7 +3,7 @@
 use zebra_chain::parameters::Network;
 
 /// Response to a `getmininginfo` RPC request.
-#[derive(Debug, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Default, PartialEq, Eq, serde::Serialize)]
 pub struct Response {
     /// The estimated network solution rate in Sol/s.
     networksolps: u64,
@@ -26,17 +26,6 @@ impl Response {
             networkhashps: networksolps,
             chain: network.bip70_network_name(),
             testnet: network.is_a_test_network(),
-        }
-    }
-}
-
-impl Default for Response {
-    fn default() -> Self {
-        Self {
-            networksolps: u64::default(),
-            networkhashps: u64::default(),
-            chain: String::default(),
-            testnet: bool::default(),
         }
     }
 }

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/peer_info.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/peer_info.rs
@@ -16,3 +16,11 @@ impl From<MetaAddr> for PeerInfo {
         }
     }
 }
+
+impl Default for PeerInfo {
+    fn default() -> Self {
+        Self {
+            addr: PeerSocketAddr::unspecified(),
+        }
+    }
+}

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/submit_block.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/submit_block.rs
@@ -54,6 +54,12 @@ pub enum Response {
     Accepted,
 }
 
+impl Default for Response {
+    fn default() -> Self {
+        Self::ErrorResponse(ErrorResponse::Rejected)
+    }
+}
+
 impl From<ErrorResponse> for Response {
     fn from(error_response: ErrorResponse) -> Self {
         Self::ErrorResponse(error_response)

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/subsidy.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/subsidy.rs
@@ -28,6 +28,16 @@ pub struct BlockSubsidy {
     pub founders: Zec<NonNegative>,
 }
 
+impl Default for BlockSubsidy {
+    fn default() -> Self {
+        Self {
+            funding_streams: vec![],
+            miner: Zec::from_lossy_zec(0.0).unwrap(),
+            founders: Zec::from_lossy_zec(0.0).unwrap(),
+        }
+    }
+}
+
 /// A single funding stream's information in a  `getblocksubsidy` RPC request
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct FundingStream {

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/unified_address.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/unified_address.rs
@@ -13,6 +13,17 @@ pub struct Response {
     p2sh: String,
 }
 
+impl Default for Response {
+    fn default() -> Self {
+        Self {
+            orchard: "orchard address if any".to_string(),
+            sapling: "sapling address if any".to_string(),
+            p2pkh: "p2pkh address if any".to_string(),
+            p2sh: "p2sh address if any".to_string(),
+        }
+    }
+}
+
 impl Response {
     /// Create a new response for z_listunifiedreceivers given individual addresses.
     pub fn new(orchard: String, sapling: String, p2pkh: String, p2sh: String) -> Response {

--- a/zebra-rpc/src/methods/trees.rs
+++ b/zebra-rpc/src/methods/trees.rs
@@ -35,7 +35,7 @@ pub struct GetSubtrees {
 impl Default for GetSubtrees {
     fn default() -> Self {
         Self {
-            pool: String::default(),
+            pool: "sapling | orchard".to_string(),
             start_index: NoteCommitmentSubtreeIndex(u16::default()),
             subtrees: vec![],
         }

--- a/zebra-rpc/src/methods/trees.rs
+++ b/zebra-rpc/src/methods/trees.rs
@@ -32,6 +32,16 @@ pub struct GetSubtrees {
     pub subtrees: Vec<SubtreeRpcData>,
 }
 
+impl Default for GetSubtrees {
+    fn default() -> Self {
+        Self {
+            pool: String::default(),
+            start_index: NoteCommitmentSubtreeIndex(u16::default()),
+            subtrees: vec![],
+        }
+    }
+}
+
 /// Response to a `z_gettreestate` RPC request.
 ///
 /// Contains hex-encoded Sapling & Orchard note commitment trees and their corresponding

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -125,6 +125,7 @@ zcash_client_backend = { version = "0.12.1", optional = true }
 zcash_protocol = { version = "0.1.1" }
 
 # For the openapi generator
+rand = "0.8.5"
 syn = { version = "2.0.66", features = ["full"], optional = true }
 quote = { version = "1.0.36", optional = true }
 serde_yaml = { version = "0.9.34+deprecated", optional = true }

--- a/zebra-utils/src/bin/openapi-generator/main.rs
+++ b/zebra-utils/src/bin/openapi-generator/main.rs
@@ -611,6 +611,32 @@ fn get_default_properties(method_name: &str) -> Result<HashMap<String, Property>
             );
             props
         }
+        "validateaddress" => {
+            props.insert(
+                "result".to_string(),
+                Property {
+                    type_,
+                    items,
+                    default: serde_json::to_string(
+                        &get_block_template_rpcs::types::validate_address::Response::default(),
+                    )?,
+                },
+            );
+            props
+        }
+        "z_validateaddress" => {
+            props.insert(
+                "result".to_string(),
+                Property {
+                    type_,
+                    items,
+                    default: serde_json::to_string(
+                        &get_block_template_rpcs::types::z_validate_address::Response::default(),
+                    )?,
+                },
+            );
+            props
+        }
 
         _ => {
             props.insert(

--- a/zebra-utils/src/bin/openapi-generator/main.rs
+++ b/zebra-utils/src/bin/openapi-generator/main.rs
@@ -554,6 +554,19 @@ fn get_default_properties(method_name: &str) -> Result<HashMap<String, Property>
             );
             props
         }
+        "getmininginfo" => {
+            props.insert(
+                "result".to_string(),
+                Property {
+                    type_,
+                    items,
+                    default: serde_json::to_string(
+                        &get_block_template_rpcs::types::get_mining_info::Response::default(),
+                    )?,
+                },
+            );
+            props
+        }
 
         _ => {
             props.insert(

--- a/zebra-utils/src/bin/openapi-generator/main.rs
+++ b/zebra-utils/src/bin/openapi-generator/main.rs
@@ -659,6 +659,28 @@ fn get_default_properties(method_name: &str) -> Result<HashMap<String, Property>
             );
             props
         }
+        "sendrawtransaction" => {
+            props.insert(
+                "result".to_string(),
+                Property {
+                    type_,
+                    items,
+                    default: serde_json::to_string(&SentTransactionHash::default())?,
+                },
+            );
+            props
+        }
+        "getrawtransaction" => {
+            props.insert(
+                "result".to_string(),
+                Property {
+                    type_,
+                    items,
+                    default: serde_json::to_string(&GetRawTransaction::default())?,
+                },
+            );
+            props
+        }
 
         _ => {
             props.insert(

--- a/zebra-utils/src/bin/openapi-generator/main.rs
+++ b/zebra-utils/src/bin/openapi-generator/main.rs
@@ -637,6 +637,28 @@ fn get_default_properties(method_name: &str) -> Result<HashMap<String, Property>
             );
             props
         }
+        "getrawmempool" => {
+            props.insert(
+                "result".to_string(),
+                Property {
+                    type_,
+                    items,
+                    default: serde_json::to_string(&Vec::<String>::default())?,
+                },
+            );
+            props
+        }
+        "getdifficulty" => {
+            props.insert(
+                "result".to_string(),
+                Property {
+                    type_,
+                    items,
+                    default: serde_json::to_string(&f64::default())?,
+                },
+            );
+            props
+        }
 
         _ => {
             props.insert(

--- a/zebra-utils/src/bin/openapi-generator/main.rs
+++ b/zebra-utils/src/bin/openapi-generator/main.rs
@@ -567,6 +567,17 @@ fn get_default_properties(method_name: &str) -> Result<HashMap<String, Property>
             );
             props
         }
+        "getblockcount" => {
+            props.insert(
+                "result".to_string(),
+                Property {
+                    type_,
+                    items,
+                    default: serde_json::to_string(&u32::default())?,
+                },
+            );
+            props
+        }
 
         _ => {
             props.insert(

--- a/zebra-utils/src/bin/openapi-generator/main.rs
+++ b/zebra-utils/src/bin/openapi-generator/main.rs
@@ -681,6 +681,28 @@ fn get_default_properties(method_name: &str) -> Result<HashMap<String, Property>
             );
             props
         }
+        "getnetworksolps" => {
+            props.insert(
+                "result".to_string(),
+                Property {
+                    type_,
+                    items,
+                    default: serde_json::to_string(&u64::default())?,
+                },
+            );
+            props
+        }
+        "getnetworkhashps" => {
+            props.insert(
+                "result".to_string(),
+                Property {
+                    type_,
+                    items,
+                    default: serde_json::to_string(&u64::default())?,
+                },
+            );
+            props
+        }
 
         _ => {
             props.insert(

--- a/zebra-utils/src/bin/openapi-generator/main.rs
+++ b/zebra-utils/src/bin/openapi-generator/main.rs
@@ -578,6 +578,39 @@ fn get_default_properties(method_name: &str) -> Result<HashMap<String, Property>
             );
             props
         }
+        "getaddressbalance" => {
+            props.insert(
+                "result".to_string(),
+                Property {
+                    type_,
+                    items,
+                    default: serde_json::to_string(&AddressBalance::default())?,
+                },
+            );
+            props
+        }
+        "getaddressutxos" => {
+            props.insert(
+                "result".to_string(),
+                Property {
+                    type_,
+                    items,
+                    default: serde_json::to_string(&GetAddressUtxos::default())?,
+                },
+            );
+            props
+        }
+        "getaddresstxids" => {
+            props.insert(
+                "result".to_string(),
+                Property {
+                    type_,
+                    items,
+                    default: serde_json::to_string(&Vec::<String>::default())?,
+                },
+            );
+            props
+        }
 
         _ => {
             props.insert(

--- a/zebra-utils/src/bin/openapi-generator/main.rs
+++ b/zebra-utils/src/bin/openapi-generator/main.rs
@@ -703,6 +703,32 @@ fn get_default_properties(method_name: &str) -> Result<HashMap<String, Property>
             );
             props
         }
+        "submitblock" => {
+            props.insert(
+                "result".to_string(),
+                Property {
+                    type_,
+                    items,
+                    default: serde_json::to_string(
+                        &get_block_template_rpcs::types::submit_block::Response::default(),
+                    )?,
+                },
+            );
+            props
+        }
+        "z_listunifiedreceivers" => {
+            props.insert(
+                "result".to_string(),
+                Property {
+                    type_,
+                    items,
+                    default: serde_json::to_string(
+                        &get_block_template_rpcs::types::unified_address::Response::default(),
+                    )?,
+                },
+            );
+            props
+        }
 
         _ => {
             props.insert(

--- a/zebra-utils/src/bin/openapi-generator/main.rs
+++ b/zebra-utils/src/bin/openapi-generator/main.rs
@@ -472,6 +472,7 @@ fn default_property<T: serde::Serialize>(
 }
 
 // Get requests examples by using defaults from the Zebra RPC methods
+// TODO: Make this function more concise/readable (https://github.com/ZcashFoundation/zebra/pull/8616#discussion_r1643193949)
 fn get_default_properties(method_name: &str) -> Result<HashMap<String, Property>, Box<dyn Error>> {
     let type_ = "object";
     let items = None;

--- a/zebra-utils/src/bin/openapi-generator/main.rs
+++ b/zebra-utils/src/bin/openapi-generator/main.rs
@@ -453,294 +453,103 @@ fn add_params_to_description(description: &str, params_description: &str) -> Str
     new_description
 }
 
+fn default_property<T: serde::Serialize>(
+    type_: &str,
+    items: Option<ArrayItems>,
+    default_value: T,
+) -> Result<Property, Box<dyn Error>> {
+    Ok(Property {
+        type_: type_.to_string(),
+        items,
+        default: serde_json::to_string(&default_value)?,
+    })
+}
+
 // Get requests examples by using defaults from the Zebra RPC methods
 fn get_default_properties(method_name: &str) -> Result<HashMap<String, Property>, Box<dyn Error>> {
-    // TODO: Complete the list of methods
-
-    let type_ = "object".to_string();
+    let type_ = "object";
     let items = None;
     let mut props = HashMap::new();
 
-    let properties = match method_name {
-        "getinfo" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(&GetInfo::default())?,
-                },
-            );
-            props
-        }
-        "getbestblockhash" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(&GetBlockHash::default())?,
-                },
-            );
-            props
-        }
+    // TODO: An entry has to be added here manually for each new RPC method introduced, can we automate?
+    let default_result = match method_name {
+        // mining
+        // TODO: missing `getblocktemplate`. It's a complex method that requires a lot of parameters.
+        "getnetworkhashps" => default_property(type_, items.clone(), u64::default())?,
+        "getblocksubsidy" => default_property(
+            type_,
+            items.clone(),
+            get_block_template_rpcs::types::subsidy::BlockSubsidy::default(),
+        )?,
+        "getmininginfo" => default_property(
+            type_,
+            items.clone(),
+            get_block_template_rpcs::types::get_mining_info::Response::default(),
+        )?,
+        "getnetworksolps" => default_property(type_, items.clone(), u64::default())?,
+        "submitblock" => default_property(
+            type_,
+            items.clone(),
+            get_block_template_rpcs::types::submit_block::Response::default(),
+        )?,
+        // util
+        "validateaddress" => default_property(
+            type_,
+            items.clone(),
+            get_block_template_rpcs::types::validate_address::Response::default(),
+        )?,
+        "z_validateaddress" => default_property(
+            type_,
+            items.clone(),
+            get_block_template_rpcs::types::z_validate_address::Response::default(),
+        )?,
+        // address
+        "getaddressbalance" => default_property(type_, items.clone(), AddressBalance::default())?,
+        "getaddressutxos" => default_property(type_, items.clone(), GetAddressUtxos::default())?,
+        "getaddresstxids" => default_property(type_, items.clone(), Vec::<String>::default())?,
+        // network
+        "getpeerinfo" => default_property(
+            type_,
+            items.clone(),
+            get_block_template_rpcs::types::peer_info::PeerInfo::default(),
+        )?,
+        // blockchain
+        "getdifficulty" => default_property(type_, items.clone(), f64::default())?,
         "getblockchaininfo" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(&GetBlockChainInfo::default())?,
-                },
-            );
-            props
+            default_property(type_, items.clone(), GetBlockChainInfo::default())?
         }
-        "getblock" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(&GetBlock::default())?,
-                },
-            );
-            props
+        "getrawmempool" => default_property(type_, items.clone(), Vec::<String>::default())?,
+        "getblockhash" => default_property(type_, items.clone(), GetBlockHash::default())?,
+        "z_getsubtreesbyindex" => {
+            default_property(type_, items.clone(), trees::GetSubtrees::default())?
         }
-        "getblockhash" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(&GetBlockHash::default())?,
-                },
-            );
-            props
-        }
-        "z_gettreestate" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(&GetTreestate::default())?,
-                },
-            );
-            props
-        }
-        "getpeerinfo" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(
-                        &get_block_template_rpcs::types::peer_info::PeerInfo::default(),
-                    )?,
-                },
-            );
-            props
-        }
-        "getblocksubsidy" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(
-                        &get_block_template_rpcs::types::subsidy::BlockSubsidy::default(),
-                    )?,
-                },
-            );
-            props
-        }
-        "getmininginfo" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(
-                        &get_block_template_rpcs::types::get_mining_info::Response::default(),
-                    )?,
-                },
-            );
-            props
-        }
-        "getblockcount" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(&u32::default())?,
-                },
-            );
-            props
-        }
-        "getaddressbalance" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(&AddressBalance::default())?,
-                },
-            );
-            props
-        }
-        "getaddressutxos" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(&GetAddressUtxos::default())?,
-                },
-            );
-            props
-        }
-        "getaddresstxids" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(&Vec::<String>::default())?,
-                },
-            );
-            props
-        }
-        "validateaddress" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(
-                        &get_block_template_rpcs::types::validate_address::Response::default(),
-                    )?,
-                },
-            );
-            props
-        }
-        "z_validateaddress" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(
-                        &get_block_template_rpcs::types::z_validate_address::Response::default(),
-                    )?,
-                },
-            );
-            props
-        }
-        "getrawmempool" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(&Vec::<String>::default())?,
-                },
-            );
-            props
-        }
-        "getdifficulty" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(&f64::default())?,
-                },
-            );
-            props
-        }
+        "z_gettreestate" => default_property(type_, items.clone(), GetTreestate::default())?,
+        "getblockcount" => default_property(type_, items.clone(), u32::default())?,
+        "getbestblockhash" => default_property(type_, items.clone(), GetBlockHash::default())?,
+        "getblock" => default_property(type_, items.clone(), GetBlock::default())?,
+        // wallet
+        "z_listunifiedreceivers" => default_property(
+            type_,
+            items.clone(),
+            get_block_template_rpcs::types::unified_address::Response::default(),
+        )?,
+        // control
+        "getinfo" => default_property(type_, items.clone(), GetInfo::default())?,
+        // transaction
         "sendrawtransaction" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(&SentTransactionHash::default())?,
-                },
-            );
-            props
+            default_property(type_, items.clone(), SentTransactionHash::default())?
         }
         "getrawtransaction" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(&GetRawTransaction::default())?,
-                },
-            );
-            props
+            default_property(type_, items.clone(), GetRawTransaction::default())?
         }
-        "getnetworksolps" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(&u64::default())?,
-                },
-            );
-            props
-        }
-        "getnetworkhashps" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(&u64::default())?,
-                },
-            );
-            props
-        }
-        "submitblock" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(
-                        &get_block_template_rpcs::types::submit_block::Response::default(),
-                    )?,
-                },
-            );
-            props
-        }
-        "z_listunifiedreceivers" => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items,
-                    default: serde_json::to_string(
-                        &get_block_template_rpcs::types::unified_address::Response::default(),
-                    )?,
-                },
-            );
-            props
-        }
-
-        _ => {
-            props.insert(
-                "result".to_string(),
-                Property {
-                    type_,
-                    items: None,
-                    default: "{}".to_string(),
-                },
-            );
-            props
-        }
+        // default
+        _ => Property {
+            type_: type_.to_string(),
+            items: None,
+            default: "{}".to_string(),
+        },
     };
-    Ok(properties)
+
+    props.insert("result".to_string(), default_result);
+    Ok(props)
 }

--- a/zebra-utils/src/bin/openapi-generator/main.rs
+++ b/zebra-utils/src/bin/openapi-generator/main.rs
@@ -528,6 +528,33 @@ fn get_default_properties(method_name: &str) -> Result<HashMap<String, Property>
             );
             props
         }
+        "getpeerinfo" => {
+            props.insert(
+                "result".to_string(),
+                Property {
+                    type_,
+                    items,
+                    default: serde_json::to_string(
+                        &get_block_template_rpcs::types::peer_info::PeerInfo::default(),
+                    )?,
+                },
+            );
+            props
+        }
+        "getblocksubsidy" => {
+            props.insert(
+                "result".to_string(),
+                Property {
+                    type_,
+                    items,
+                    default: serde_json::to_string(
+                        &get_block_template_rpcs::types::subsidy::BlockSubsidy::default(),
+                    )?,
+                },
+            );
+            props
+        }
+
         _ => {
             props.insert(
                 "result".to_string(),

--- a/zebra-utils/src/bin/openapi-generator/main.rs
+++ b/zebra-utils/src/bin/openapi-generator/main.rs
@@ -365,7 +365,7 @@ fn create_request_body(method_name: &str, parameters_example: &str) -> RequestBo
         .map(char::from)
         .collect();
     let request_id_prop = Property {
-        type_: "number".to_string(),
+        type_: "string".to_string(),
         items: None,
         default: rand_string,
     };

--- a/zebra-utils/src/bin/openapi-generator/main.rs
+++ b/zebra-utils/src/bin/openapi-generator/main.rs
@@ -3,6 +3,7 @@
 use std::{collections::HashMap, error::Error, fs::File, io::Write};
 
 use quote::ToTokens;
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use serde::Serialize;
 use syn::LitStr;
 
@@ -357,11 +358,16 @@ fn create_request_body(method_name: &str, parameters_example: &str) -> RequestBo
         default: method_name.to_string(),
     };
 
-    // Add a hardcoded request_id to the request body
+    // Add random string is used to identify the requests done by the client
+    let rand_string: String = thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(10)
+        .map(char::from)
+        .collect();
     let request_id_prop = Property {
         type_: "number".to_string(),
         items: None,
-        default: "123".to_string(),
+        default: rand_string,
     };
 
     // Create the schema and add the first 2 properties


### PR DESCRIPTION
## Motivation

Several of the rpc methods need default implementations so a sample response can be created in the openapi spec.

## Solution

Add defaults where needed, complete hardcoded list of rpc methods in the openapi utility. Add a random string as the request ID. 

### Tests

Manually tested.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [ ] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

