### PR TITLE
fix(tests): Address port conflict issues and enable related Windows tests

### DIFF
--- a/zebra-grpc/src/tests/snapshot.rs
+++ b/zebra-grpc/src/tests/snapshot.rs
@@ -59,7 +59,7 @@ async fn test_mocked_rpc_response_data_for_network(network: Network) {
     sleep(Duration::from_secs(1));
 
     // connect to the gRPC server
-    let client = ScannerClient::connect(listen_addr.to_string())
+    let client = ScannerClient::connect(format!("http://{listen_addr}"))
         .await
         .expect("server should receive connection");
 

--- a/zebra-rpc/src/server.rs
+++ b/zebra-rpc/src/server.rs
@@ -70,6 +70,9 @@ impl fmt::Debug for RpcServer {
     }
 }
 
+/// The message to log when logging the RPC server's listen address
+pub const OPENED_RPC_ENDPOINT_MSG: &str = "Opened RPC endpoint at ";
+
 impl RpcServer {
     /// Start a new RPC server endpoint using the supplied configs and services.
     ///
@@ -206,7 +209,7 @@ impl RpcServer {
                         .start_http(&listen_addr)
                         .expect("Unable to start RPC server");
 
-                    info!("Opened RPC endpoint at {}", server_instance.address());
+                    info!("{OPENED_RPC_ENDPOINT_MSG}{}", server_instance.address());
 
                     let close_handle = server_instance.close_handle();
 

--- a/zebra-rpc/src/server/tests/vectors.rs
+++ b/zebra-rpc/src/server/tests/vectors.rs
@@ -23,7 +23,6 @@ use super::super::*;
 
 /// Test that the JSON-RPC server spawns when configured with a single thread.
 #[test]
-#[cfg(not(target_os = "windows"))]
 fn rpc_server_spawn_single_thread() {
     rpc_server_spawn(false)
 }
@@ -42,9 +41,8 @@ fn rpc_server_spawn_parallel_threads() {
 fn rpc_server_spawn(parallel_cpu_threads: bool) {
     let _init_guard = zebra_test::init();
 
-    let port = zebra_test::net::random_known_port();
     let config = Config {
-        listen_addr: Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port).into()),
+        listen_addr: Some(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0).into()),
         parallel_cpu_threads: if parallel_cpu_threads { 2 } else { 1 },
         debug_force_finished_sync: false,
     };

--- a/zebra-scan/src/init.rs
+++ b/zebra-scan/src/init.rs
@@ -35,7 +35,8 @@ pub async fn init_with_server(
     info!(?listen_addr, "starting scan gRPC server");
 
     // Start the gRPC server.
-    zebra_grpc::server::init(listen_addr, scan_service).await?;
+    let (server_task, _listen_addr) = zebra_grpc::server::init(listen_addr, scan_service).await?;
+    server_task.await??;
 
     Ok(())
 }

--- a/zebrad/tests/common/config.rs
+++ b/zebrad/tests/common/config.rs
@@ -16,7 +16,6 @@ use color_eyre::eyre::Result;
 use tempfile::TempDir;
 
 use zebra_chain::parameters::Network;
-use zebra_rpc::server::OPENED_RPC_ENDPOINT_MSG;
 use zebra_test::{command::TestChild, net::random_known_port};
 use zebrad::{
     components::{mempool, sync, tracing},
@@ -193,12 +192,13 @@ pub fn rpc_port_config(
 }
 
 /// Reads Zebra's RPC server listen address from a testchild's logs
-pub fn read_rpc_port_from_logs(child: &mut TestChild<TempDir>) -> Result<SocketAddr> {
-    let line = child.expect_stdout_line_matches(OPENED_RPC_ENDPOINT_MSG)?;
-    let rpc_addr_position = line
-        .find(OPENED_RPC_ENDPOINT_MSG)
-        .expect("already checked for match")
-        + OPENED_RPC_ENDPOINT_MSG.len();
+pub fn read_listen_addr_from_logs(
+    child: &mut TestChild<TempDir>,
+    expected_msg: &str,
+) -> Result<SocketAddr> {
+    let line = child.expect_stdout_line_matches(expected_msg)?;
+    let rpc_addr_position =
+        line.find(expected_msg).expect("already checked for match") + expected_msg.len();
     let rpc_addr = line[rpc_addr_position..].trim().to_string();
     Ok(rpc_addr.parse()?)
 }

--- a/zebrad/tests/common/config.rs
+++ b/zebrad/tests/common/config.rs
@@ -16,7 +16,8 @@ use color_eyre::eyre::Result;
 use tempfile::TempDir;
 
 use zebra_chain::parameters::Network;
-use zebra_test::net::random_known_port;
+use zebra_rpc::server::OPENED_RPC_ENDPOINT_MSG;
+use zebra_test::{command::TestChild, net::random_known_port};
 use zebrad::{
     components::{mempool, sync, tracing},
     config::ZebradConfig,
@@ -152,6 +153,27 @@ pub fn random_known_rpc_port_config(
 ) -> Result<ZebradConfig> {
     // [Note on port conflict](#Note on port conflict)
     let listen_port = random_known_port();
+    rpc_port_config(listen_port, parallel_cpu_threads, network)
+}
+
+/// Returns a `zebrad` config with an OS-assigned RPC port.
+///
+/// Set `parallel_cpu_threads` to true to auto-configure based on the number of CPU cores.
+pub fn os_assigned_rpc_port_config(
+    parallel_cpu_threads: bool,
+    network: &Network,
+) -> Result<ZebradConfig> {
+    rpc_port_config(0, parallel_cpu_threads, network)
+}
+
+/// Returns a `zebrad` config with the provided RPC port.
+///
+/// Set `parallel_cpu_threads` to true to auto-configure based on the number of CPU cores.
+pub fn rpc_port_config(
+    listen_port: u16,
+    parallel_cpu_threads: bool,
+    network: &Network,
+) -> Result<ZebradConfig> {
     let listen_ip = "127.0.0.1".parse().expect("hard-coded IP is valid");
     let zebra_rpc_listener = SocketAddr::new(listen_ip, listen_port);
 
@@ -168,4 +190,15 @@ pub fn random_known_rpc_port_config(
     }
 
     Ok(config)
+}
+
+/// Reads Zebra's RPC server listen address from a testchild's logs
+pub fn read_rpc_port_from_logs(child: &mut TestChild<TempDir>) -> Result<SocketAddr> {
+    let line = child.expect_stdout_line_matches(OPENED_RPC_ENDPOINT_MSG)?;
+    let rpc_addr_position = line
+        .find(OPENED_RPC_ENDPOINT_MSG)
+        .expect("already checked for match")
+        + OPENED_RPC_ENDPOINT_MSG.len();
+    let rpc_addr = line[rpc_addr_position..].trim().to_string();
+    Ok(rpc_addr.parse()?)
 }


### PR DESCRIPTION
## Motivation

We want to re-enable these tests on Windows while avoiding spurious panics due to port conflicts.

Closes #8553.

## Solution

- Bind a `TcpListener` in zebra-grpc, return the address by spawning a tokio task and returning the value from the init function
- Replace the call to `Router.serve()` with `serve_with_incoming()`
- Use port 0 for the RPC `listen_addr` in RPC endpoint acceptance tests and read the RPC socket address from Zebra's logs when spawning `TestChild`s instead of using the configured listen address

Omitted:
- Returning the listen address from `open_listener()` in the peer set `init()` function and use it instead of the random known port
  - It's already possible to get the peer set's listen address from the address book returned by `open_listener()`
  - The affected tests are deliberately checking fixed ports, there are already versions of them using OS-assigned ports
- Returning the local listen address from the `Server` instance in zebra-rpc 
  - The affected tests don't need to know the listen address, it's fine to use an unknown OS-assigned port to check that the RPC server spawns successfully

### PR Author's Checklist

- [x] The PR name will make sense to users.
- [x] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

