### PR TITLE
fix(ci): do not silently fail integration tests

### DIFF
--- a/.github/workflows/sub-ci-integration-tests-gcp.yml
+++ b/.github/workflows/sub-ci-integration-tests-gcp.yml
@@ -589,7 +589,7 @@ jobs:
         lightwalletd-grpc-test,
         get-block-template-test,
         submit-block-test,
-        scan-start-where-left-test,
+        # scan-start-where-left-test,
         scan-task-commands-test,
       ]
     # Only open tickets for failed scheduled jobs, manual workflow runs, or `main` branch merges.


### PR DESCRIPTION
## Motivation

After #8594 some test might silently fail as a job dependency was removed for `failure-issue`, but it was still in the `needs` list.

## Solution

Comment the non existent dependency from `failure-issue` 

### Tests

- Integration tests should run here without issue

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [x] The PR Author's checklist is complete.
- [x] The PR resolves the issue.

