### PR TITLE
add(support): Include Windows as a tier2 supported platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - We're no longer using general conditional compilation attributes for `tor`,
   but only feature flags instead.
 - Fixed a bug with trailing characters in the openapi spec method descriptions ([#8597](https://github.com/ZcashFoundation/zebra/pull/8597))
-- Added default constructions for several RPC method responses([#8616](https://github.com/ZcashFoundation/zebra/pull/8616))
+- Added default constructions for several RPC method responses ([#8616](https://github.com/ZcashFoundation/zebra/pull/8616))
+- Added Windows to the list of supported platforms in Tier 2 ([#8637](https://github.com/ZcashFoundation/zebra/pull/8637))
 
 ## [Zebra 1.7.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.7.0) - 2024-05-07
 

--- a/book/src/user/supported-platforms.md
+++ b/book/src/user/supported-platforms.md
@@ -35,6 +35,7 @@ For the full requirements, see [Tier 2 platform policy](platform-tier-policy.md#
 | `x86_64-unknown-linux-gnu` | [GitHub ubuntu-latest](https://github.com/actions/virtual-environments#available-environments) | 64-bit | [latest stable release](https://github.com/rust-lang/rust/releases) | N/A
 | `x86_64-unknown-linux-gnu` | [GitHub ubuntu-latest](https://github.com/actions/virtual-environments#available-environments) | 64-bit | [latest beta release](https://github.com/rust-lang/rust/blob/beta/src/version) | N/A
 | `x86_64-apple-darwin` | [GitHub macos-latest](https://github.com/actions/virtual-environments#available-environments) | 64-bit | [latest stable release](https://github.com/rust-lang/rust/releases) | N/A
+| `x86_64-pc-windows-msvc` | [GitHub windows-latest](https://github.com/actions/virtual-environments#available-environments) | 64-bit | [latest stable release](https://github.com/rust-lang/rust/releases) | N/A
 
 ## Tier 3
 


### PR DESCRIPTION
## Motivation

Now that our Windows builds had been fixed and stabilized and our tests are working, we want to add Windows as a Tier2 platform.

Close https://github.com/ZcashFoundation/zebra/issues/8517

## Solution

Add windows to the supported platforms windows in the Tier2 section.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [ ] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

