### PR TITLE
chore: Release v1.8.0

### DIFF
--- a/.github/workflows/scripts/release-crates-dry-run.sh
+++ b/.github/workflows/scripts/release-crates-dry-run.sh
@@ -23,8 +23,8 @@ fi
 cargo release version --verbose --execute --no-confirm --allow-branch '*' --workspace --exclude zebrad --exclude zebra-scan --exclude zebra-grpc beta
 
 # Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
-cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebra-scan 0.1.0-alpha.7
-cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebra-grpc 0.1.0-alpha.5
+cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebra-scan 0.1.0-alpha.8
+cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebra-grpc 0.1.0-alpha.6
 
 # Update zebrad:
 cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebrad patch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Zebra 1.8.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.8.0) - 2024-07-02
 
+### Summary
 
-- Zebra now uses a default unpaid actions limit of 0, dropping transactions with any unpaid actions from the mempool and excluding them when selecting transactions from the mempool during block template construction.
+- Zebra now uses a default unpaid actions limit of 0, dropping transactions with
+  any unpaid actions from the mempool and excluding them when selecting
+  transactions from the mempool during block template construction.
 - The `zebrad` binary no longer contains the scanner of shielded transactions.
   This means `zebrad` no longer contains users' viewing keys.
 - Support for custom Testnets and Regtest is greatly enhanced.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,25 +5,56 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
-## Zebra 1.X.X - XXXX-XX-XX
+## [Zebra 1.8.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.8.0) - 2024-07-01
 
-### Changed
+### Summary
 
-- We realized that a longer than `zcashd` end of support could be problematic in
-  some cases so we reverted back from 20 to 16 weeks
-  ([#8530](https://github.com/ZcashFoundation/zebra/pull/8530))
+- Zebra now drops transactions with unpaid actions in block templates and from
+  the mempool.
 - The `zebrad` binary no longer contains the scanner of shielded transactions.
   This means `zebrad` no longer contains users' viewing keys.
-- We're no longer using general conditional compilation attributes for `tor`,
-  but only feature flags instead.
-- Fixed a bug with trailing characters in the openapi spec method descriptions ([#8597](https://github.com/ZcashFoundation/zebra/pull/8597))
-- Added default constructions for several RPC method responses ([#8616](https://github.com/ZcashFoundation/zebra/pull/8616))
-- Added Windows to the list of supported platforms in Tier 2 ([#8637](https://github.com/ZcashFoundation/zebra/pull/8637))
-- Zebra now drops transactions with unpaid actions in block templates and from the mempool.
+- Support for custom Testnets and Regtest is greatly enhanced.
+- Windows is now back in the second tier of supported platforms.
+- The end-of-support time interval is set to match `zcashd`'s 16 weeks.
+- The RPC serialization of empty treestates matches `zcashd`. 
 
 ### Added
 
-- Added a page to the Zebra book describing custom Testnets ([#8636](https://github.com/ZcashFoundation/zebra/pull/8636))
+- Add an init function for a standalone `ReadStateService` ([#8595](https://github.com/ZcashFoundation/zebra/pull/8595))
+- Add new parameters for custom Testnets ([#8477](https://github.com/ZcashFoundation/zebra/pull/8477), [#8518](https://github.com/ZcashFoundation/zebra/pull/8518), [#8524](https://github.com/ZcashFoundation/zebra/pull/8524))
+- Add default constructions for several RPC method responses ([#8616](https://github.com/ZcashFoundation/zebra/pull/8616))
+- Allow custom Testnets to make peer connections and configure more parameters ([#8528](https://github.com/ZcashFoundation/zebra/pull/8528))
+- Allow configurable NU5 activation height on Regtest ([#8505](https://github.com/ZcashFoundation/zebra/pull/8505))
+
+#### Docs
+
+- Add a section on Regtest usage to the Zebra book ([#8526](https://github.com/ZcashFoundation/zebra/pull/8526))
+- Describe custom Testnets in the Zebra book ([#8636](https://github.com/ZcashFoundation/zebra/pull/8636))
+
+### Changed
+
+- Drop transactions with unpaid actions ([#8638](https://github.com/ZcashFoundation/zebra/pull/8638))
+- Lower the mandatory checkpoint height ([#8629](https://github.com/ZcashFoundation/zebra/pull/8629))
+- Use the new `zcash_script` callback API ([#8566](https://github.com/ZcashFoundation/zebra/pull/8566))
+- Put Windows in Tier 2 of supported platforms ([#8637](https://github.com/ZcashFoundation/zebra/pull/8637))
+- Remove support for starting the scanner at `zebrad` startup ([#8594](https://github.com/ZcashFoundation/zebra/pull/8594))
+- Reduce the end of support time from 20 weeks to 16 weeks ([#8530](https://github.com/ZcashFoundation/zebra/pull/8530))
+- Restore parts of the internal-miner feature for use on Regtest ([#8506](https://github.com/ZcashFoundation/zebra/pull/8506))
+
+### Fixed
+
+- Allow square brackets in network config listen addr and external addr ([#8504](https://github.com/ZcashFoundation/zebra/pull/8504))
+- Fix general conditional compilation attributes ([#8602](https://github.com/ZcashFoundation/zebra/pull/8602))
+- Update `median_timespan()` method to align with zcashd implementation ([#8491](https://github.com/ZcashFoundation/zebra/pull/8491))
+- Refactor the serialization of empty treestates ([#8533](https://github.com/ZcashFoundation/zebra/pull/8533))
+- Address port conflict issues and enable related Windows tests ([#8624](https://github.com/ZcashFoundation/zebra/pull/8624))
+- Fix a bug with trailing characters in the openapi spec method descriptions ([#8597](https://github.com/ZcashFoundation/zebra/pull/8597))
+- Stop using `displaydoc` ([#8614](https://github.com/ZcashFoundation/zebra/pull/8614))
+
+### Contributors
+
+Thank you to everyone who contributed to this release, we couldn't make Zebra without you:
+@arya2, @conradoplg, @gustavovalverde, @oxarbitrage and @upbqdn
 
 ## [Zebra 1.7.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.7.0) - 2024-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Zebra 1.8.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.8.0) - 2024-07-02
 
-### Summary
-
 - Zebra now uses a default unpaid actions limit of 0, dropping transactions with
   any unpaid actions from the mempool and excluding them when selecting
   transactions from the mempool during block template construction.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,10 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Zebra 1.8.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.8.0) - 2024-07-01
+## [Zebra 1.8.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.8.0) - 2024-07-02
 
-### Summary
 
-- Zebra now drops transactions with unpaid actions in block templates and from
-  the mempool.
+- Zebra now uses a default unpaid actions limit of 0, dropping transactions with any unpaid actions from the mempool and excluding them when selecting transactions from the mempool during block template construction.
 - The `zebrad` binary no longer contains the scanner of shielded transactions.
   This means `zebrad` no longer contains users' viewing keys.
 - Support for custom Testnets and Regtest is greatly enhanced.
@@ -21,35 +19,33 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Added
 
 - Add an init function for a standalone `ReadStateService` ([#8595](https://github.com/ZcashFoundation/zebra/pull/8595))
-- Add new parameters for custom Testnets ([#8477](https://github.com/ZcashFoundation/zebra/pull/8477), [#8518](https://github.com/ZcashFoundation/zebra/pull/8518), [#8524](https://github.com/ZcashFoundation/zebra/pull/8524))
-- Add default constructions for several RPC method responses ([#8616](https://github.com/ZcashFoundation/zebra/pull/8616))
-- Allow custom Testnets to make peer connections and configure more parameters ([#8528](https://github.com/ZcashFoundation/zebra/pull/8528))
-- Allow configurable NU5 activation height on Regtest ([#8505](https://github.com/ZcashFoundation/zebra/pull/8505))
+- Allow configuring more parameters on custom Testnets and an NU5 activation height on Regtest ([#8477](https://github.com/ZcashFoundation/zebra/pull/8477), [#8518](https://github.com/ZcashFoundation/zebra/pull/8518), [#8524](https://github.com/ZcashFoundation/zebra/pull/8524), [#8528](https://github.com/ZcashFoundation/zebra/pull/8528), [#8636](https://github.com/ZcashFoundation/zebra/pull/8636))
+- Add default constructions for several RPC method responses ([#8616](https://github.com/ZcashFoundation/zebra/pull/8616), [#8505](https://github.com/ZcashFoundation/zebra/pull/8505))
+- Support constructing Canopy proposal blocks from block templates ([#8505](https://github.com/ZcashFoundation/zebra/pull/8505))
 
 #### Docs
 
-- Add a section on Regtest usage to the Zebra book ([#8526](https://github.com/ZcashFoundation/zebra/pull/8526))
-- Describe custom Testnets in the Zebra book ([#8636](https://github.com/ZcashFoundation/zebra/pull/8636))
+- Document custom Testnets, Regtest and how they compare to Mainnet and the default Testnet in the Zebra book ([#8526](https://github.com/ZcashFoundation/zebra/pull/8526), [#8636](https://github.com/ZcashFoundation/zebra/pull/8636))
 
 ### Changed
 
-- Drop transactions with unpaid actions ([#8638](https://github.com/ZcashFoundation/zebra/pull/8638))
-- Lower the mandatory checkpoint height ([#8629](https://github.com/ZcashFoundation/zebra/pull/8629))
-- Use the new `zcash_script` callback API ([#8566](https://github.com/ZcashFoundation/zebra/pull/8566))
+- Use a default unpaid action limit of 0 so that transactions with unpaid actions are excluded from the mempool and block templates by default ([#8638](https://github.com/ZcashFoundation/zebra/pull/8638))
+- Lower the mandatory checkpoint height from immediately above the ZIP-212 grace period to immediately below Canopy activation ([#8629](https://github.com/ZcashFoundation/zebra/pull/8629))
+- Use the new `zcash_script` callback API in `zebra-script`, allowing Zebra's ECC dependencies to be upgraded independently of `zcash_script` and `zcashd` ([#8566](https://github.com/ZcashFoundation/zebra/pull/8566))
 - Put Windows in Tier 2 of supported platforms ([#8637](https://github.com/ZcashFoundation/zebra/pull/8637))
-- Remove support for starting the scanner at `zebrad` startup ([#8594](https://github.com/ZcashFoundation/zebra/pull/8594))
+- Remove experimental support for starting the `zebra-scan` in the `zebrad` process as a step towards moving the scanner to its own process ([#8594](https://github.com/ZcashFoundation/zebra/pull/8594))
 - Reduce the end of support time from 20 weeks to 16 weeks ([#8530](https://github.com/ZcashFoundation/zebra/pull/8530))
-- Restore parts of the internal-miner feature for use on Regtest ([#8506](https://github.com/ZcashFoundation/zebra/pull/8506))
+- Restore parts of the experimental `internal-miner` feature for use on Regtest ([#8506](https://github.com/ZcashFoundation/zebra/pull/8506))
 
 ### Fixed
 
-- Allow square brackets in network config listen addr and external addr ([#8504](https://github.com/ZcashFoundation/zebra/pull/8504))
+- Allow square brackets in network config listen addr and external addr without explicitly configuring a port in the listen addr ([#8504](https://github.com/ZcashFoundation/zebra/pull/8504))
 - Fix general conditional compilation attributes ([#8602](https://github.com/ZcashFoundation/zebra/pull/8602))
 - Update `median_timespan()` method to align with zcashd implementation ([#8491](https://github.com/ZcashFoundation/zebra/pull/8491))
-- Refactor the serialization of empty treestates ([#8533](https://github.com/ZcashFoundation/zebra/pull/8533))
-- Address port conflict issues and enable related Windows tests ([#8624](https://github.com/ZcashFoundation/zebra/pull/8624))
-- Fix a bug with trailing characters in the openapi spec method descriptions ([#8597](https://github.com/ZcashFoundation/zebra/pull/8597))
-- Stop using `displaydoc` ([#8614](https://github.com/ZcashFoundation/zebra/pull/8614))
+- Allow custom Testnets to make peer connections ([#8528](https://github.com/ZcashFoundation/zebra/pull/8528))
+- Refactor and simplify the serialization of empty treestates to fix an incorrect serialization of empty note commitment trees for RPCs ([#8533](https://github.com/ZcashFoundation/zebra/pull/8533))
+- Fix port conflict issue in some tests and re-enable those tests on Windows where those issues were especially problematic ([#8624](https://github.com/ZcashFoundation/zebra/pull/8624))
+- Fix a bug with trailing characters in the OpenAPI spec method descriptions ([#8597](https://github.com/ZcashFoundation/zebra/pull/8597))
 
 ### Contributors
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4768,7 +4768,7 @@ dependencies = [
 
 [[package]]
 name = "tower-batch-control"
-version = "0.2.41-beta.13"
+version = "0.2.41-beta.14"
 dependencies = [
  "color-eyre",
  "ed25519-zebra",
@@ -4791,7 +4791,7 @@ dependencies = [
 
 [[package]]
 name = "tower-fallback"
-version = "0.2.41-beta.13"
+version = "0.2.41-beta.14"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "1.0.0-beta.37"
+version = "1.0.0-beta.38"
 dependencies = [
  "bitflags 2.6.0",
  "bitflags-serde-legacy",
@@ -5880,7 +5880,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-consensus"
-version = "1.0.0-beta.37"
+version = "1.0.0-beta.38"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5926,7 +5926,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-grpc"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 dependencies = [
  "color-eyre",
  "futures-util",
@@ -5948,7 +5948,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-network"
-version = "1.0.0-beta.37"
+version = "1.0.0-beta.38"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
@@ -5989,7 +5989,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-node-services"
-version = "1.0.0-beta.37"
+version = "1.0.0-beta.38"
 dependencies = [
  "color-eyre",
  "jsonrpc-core",
@@ -6002,7 +6002,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "1.0.0-beta.37"
+version = "1.0.0-beta.38"
 dependencies = [
  "chrono",
  "futures",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-scan"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 dependencies = [
  "bls12_381",
  "chrono",
@@ -6069,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-script"
-version = "1.0.0-beta.37"
+version = "1.0.0-beta.38"
 dependencies = [
  "hex",
  "lazy_static",
@@ -6081,7 +6081,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "1.0.0-beta.37"
+version = "1.0.0-beta.38"
 dependencies = [
  "bincode",
  "chrono",
@@ -6126,7 +6126,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-test"
-version = "1.0.0-beta.37"
+version = "1.0.0-beta.38"
 dependencies = [
  "color-eyre",
  "futures",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-utils"
-version = "1.0.0-beta.37"
+version = "1.0.0-beta.38"
 dependencies = [
  "color-eyre",
  "hex",
@@ -6185,7 +6185,7 @@ dependencies = [
 
 [[package]]
 name = "zebrad"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "abscissa_core",
  "atty",

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -37,7 +37,7 @@ docker run -d --platform linux/amd64 \
 ### Build it locally
 
 ```shell
-git clone --depth 1 --branch v1.7.0 https://github.com/ZcashFoundation/zebra.git
+git clone --depth 1 --branch v1.8.0 https://github.com/ZcashFoundation/zebra.git
 docker build --file docker/Dockerfile --target runtime --tag zebra:local .
 docker run --detach zebra:local
 ```

--- a/book/src/user/install.md
+++ b/book/src/user/install.md
@@ -19,7 +19,7 @@ To compile Zebra directly from GitHub, or from a GitHub release source archive:
 ```sh
 git clone https://github.com/ZcashFoundation/zebra.git
 cd zebra
-git checkout v1.7.0
+git checkout v1.8.0
 ```
 
 3. Build and Run `zebrad`
@@ -32,7 +32,7 @@ target/release/zebrad start
 ### Compiling from git using cargo install
 
 ```sh
-cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.7.0 zebrad
+cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.8.0 zebrad
 ```
 
 ### Compiling on ARM

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-batch-control"
-version = "0.2.41-beta.13"
+version = "0.2.41-beta.14"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Tower middleware for batch request processing"
 # # Legal
@@ -43,10 +43,10 @@ rand = "0.8.5"
 
 tokio = { version = "1.37.0", features = ["full", "tracing", "test-util"] }
 tokio-test = "0.4.4"
-tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.13" }
+tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.14" }
 tower-test = "0.4.0"
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.37" }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.38" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-fallback"
-version = "0.2.41-beta.13"
+version = "0.2.41-beta.14"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Tower service combinator that sends requests to a first service, then retries processing on a second fallback service if the first service errors."
 license = "MIT OR Apache-2.0"
@@ -24,4 +24,4 @@ tracing = "0.1.39"
 [dev-dependencies]
 tokio = { version = "1.37.0", features = ["full", "tracing", "test-util"] }
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.37" }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.38" }

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-chain"
-version = "1.0.0-beta.37"
+version = "1.0.0-beta.38"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Core Zcash data structures"
 license = "MIT OR Apache-2.0"
@@ -143,7 +143,7 @@ proptest-derive = { version = "0.4.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 rand_chacha = { version = "0.3.1", optional = true }
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.37", optional = true }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.38", optional = true }
 
 [dev-dependencies]
 # Benchmarks
@@ -166,7 +166,7 @@ rand_chacha = "0.3.1"
 
 tokio = { version = "1.37.0", features = ["full", "tracing", "test-util"] }
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.37" }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.38" }
 
 [[bench]]
 name = "block"

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-consensus"
-version = "1.0.0-beta.37"
+version = "1.0.0-beta.38"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Implementation of Zcash consensus checks"
 license = "MIT OR Apache-2.0"
@@ -63,13 +63,13 @@ orchard = "0.8.0"
 zcash_proofs = { version = "0.15.0", features = ["multicore" ] }
 wagyu-zcash-parameters = "0.2.0"
 
-tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.13" }
-tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41-beta.13" }
+tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.14" }
+tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41-beta.14" }
 
-zebra-script = { path = "../zebra-script", version = "1.0.0-beta.37" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.37" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.37" }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37" }
+zebra-script = { path = "../zebra-script", version = "1.0.0-beta.38" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.38" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.38" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38" }
 
 # prod feature progress-bar
 howudoin = { version = "0.1.2", optional = true }
@@ -94,6 +94,6 @@ tokio = { version = "1.37.0", features = ["full", "tracing", "test-util"] }
 tracing-error = "0.2.0"
 tracing-subscriber = "0.3.18"
 
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.37", features = ["proptest-impl"] }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37", features = ["proptest-impl"] }
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.37" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.38", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38", features = ["proptest-impl"] }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.38" }

--- a/zebra-grpc/Cargo.toml
+++ b/zebra-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-grpc"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Zebra gRPC interface"
 license = "MIT OR Apache-2.0"
@@ -28,8 +28,8 @@ color-eyre = "0.6.3"
 
 zcash_primitives = { version = "0.15.0" }
 
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.37", features = ["shielded-scan"] }
-zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.37" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.38", features = ["shielded-scan"] }
+zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.38" }
 
 [build-dependencies]
 tonic-build = "0.11.0"

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-network"
-version = "1.0.0-beta.37"
+version = "1.0.0-beta.38"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Networking code for Zebra"
 # # Legal
@@ -83,7 +83,7 @@ howudoin = { version = "0.1.2", optional = true }
 proptest = { version = "1.4.0", optional = true }
 proptest-derive = { version = "0.4.0", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38", features = ["async-error"] }
 
 [dev-dependencies]
 proptest = "1.4.0"

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-node-services"
-version = "1.0.0-beta.37"
+version = "1.0.0-beta.38"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The interfaces of some Zebra node services"
 license = "MIT OR Apache-2.0"
@@ -37,7 +37,7 @@ rpc-client = [
 shielded-scan = ["tokio"]
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.37" }
+zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.38" }
 
 # Optional dependencies
 

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-rpc"
-version = "1.0.0-beta.37"
+version = "1.0.0-beta.38"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Zebra JSON Remote Procedure Call (JSON-RPC) interface"
 license = "MIT OR Apache-2.0"
@@ -74,12 +74,12 @@ zcash_address = { version = "0.3.2", optional = true }
 # Test-only feature proptest-impl
 proptest = { version = "1.4.0", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37", features = ["json-conversion"] }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.37" }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.37" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.37" }
-zebra-script = { path = "../zebra-script", version = "1.0.0-beta.37" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.37" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38", features = ["json-conversion"] }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.38" }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.38" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.38" }
+zebra-script = { path = "../zebra-script", version = "1.0.0-beta.38" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.38" }
 
 [dev-dependencies]
 insta = { version = "1.39.0", features = ["redactions", "json", "ron"] }
@@ -89,9 +89,9 @@ proptest = "1.4.0"
 thiserror = "1.0.61"
 tokio = { version = "1.37.0", features = ["full", "tracing", "test-util"] }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37", features = ["proptest-impl"] }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.37", features = ["proptest-impl"] }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.37", features = ["proptest-impl"] }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.37", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38", features = ["proptest-impl"] }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.38", features = ["proptest-impl"] }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.38", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.38", features = ["proptest-impl"] }
 
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.37" }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.38" }

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-scan"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Shielded transaction scanner for the Zcash blockchain"
 license = "MIT OR Apache-2.0"
@@ -57,10 +57,10 @@ zcash_primitives = "0.15.0"
 zcash_address = "0.3.2"
 sapling = { package = "sapling-crypto", version = "0.1" }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37", features = ["shielded-scan"] }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.37", features = ["shielded-scan"] }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.37", features = ["shielded-scan"] }
-zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.4" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38", features = ["shielded-scan"] }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.38", features = ["shielded-scan"] }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.38", features = ["shielded-scan"] }
+zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.5" }
 
 chrono = { version = "0.4.38", default-features = false, features = ["clock", "std", "serde"] }
 
@@ -75,7 +75,7 @@ jubjub = { version = "0.10.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 zcash_note_encryption = { version = "0.4.0", optional = true }
 
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.37", optional = true }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.38", optional = true }
 
 [dev-dependencies]
 insta = { version = "1.39.0", features = ["ron", "redactions"] }
@@ -90,5 +90,5 @@ jubjub = "0.10.0"
 rand = "0.8.5"
 zcash_note_encryption = "0.4.0"
 
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.37", features = ["proptest-impl"] }
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.37" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.38", features = ["proptest-impl"] }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.38" }

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-script"
-version = "1.0.0-beta.37"
+version = "1.0.0-beta.38"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Zebra script verification wrapping zcashd's zcash_script library"
 license = "MIT OR Apache-2.0"
@@ -16,11 +16,11 @@ categories = ["api-bindings", "cryptography::cryptocurrencies"]
 
 [dependencies]
 zcash_script = "0.2.0"
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38" }
 
 thiserror = "1.0.61"
 
 [dev-dependencies]
 hex = "0.4.3"
 lazy_static = "1.4.0"
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.37" }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.38" }

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-state"
-version = "1.0.0-beta.37"
+version = "1.0.0-beta.38"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "State contextual verification and storage code for Zebra"
 license = "MIT OR Apache-2.0"
@@ -77,13 +77,13 @@ tracing = "0.1.39"
 elasticsearch = { version = "8.5.0-alpha.1", default-features = false, features = ["rustls-tls"], optional = true }
 serde_json = { version = "1.0.117", package = "serde_json", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { version = "0.1.2", optional = true }
 
 # test feature proptest-impl
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.37", optional = true }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.38", optional = true }
 proptest = { version = "1.4.0", optional = true }
 proptest-derive = { version = "0.4.0", optional = true }
 
@@ -108,5 +108,5 @@ jubjub = "0.10.0"
 
 tokio = { version = "1.37.0", features = ["full", "tracing", "test-util"] }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37", features = ["proptest-impl"] }
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.37" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38", features = ["proptest-impl"] }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.38" }

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-test"
-version = "1.0.0-beta.37"
+version = "1.0.0-beta.38"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Test harnesses and test vectors for Zebra"
 license = "MIT OR Apache-2.0"

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-utils"
-version = "1.0.0-beta.37"
+version = "1.0.0-beta.38"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Developer tools for Zebra maintenance and testing"
 license = "MIT OR Apache-2.0"
@@ -100,12 +100,12 @@ tracing-error = "0.2.0"
 tracing-subscriber = "0.3.18"
 thiserror = "1.0.61"
 
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.37" }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37" }
-zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.6", optional = true }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.38" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38" }
+zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.7", optional = true }
 
 # These crates are needed for the block-template-to-proposal binary
-zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.37", optional = true }
+zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.38", optional = true }
 
 # These crates are needed for the zebra-checkpoints binary
 itertools = { version = "0.13.0", optional = true }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate metadata
 name = "zebrad"
-version = "1.7.0"
+version = "1.8.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The Zcash Foundation's independent, consensus-compatible implementation of a Zcash node"
 license = "MIT OR Apache-2.0"
@@ -158,18 +158,18 @@ test_sync_past_mandatory_checkpoint_mainnet = []
 test_sync_past_mandatory_checkpoint_testnet = []
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37" }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.37" }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.37" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.37" }
-zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.37" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.37" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38" }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.38" }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.38" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.38" }
+zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.38" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.38" }
 
 # Experimental shielded-scan feature
-zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.6", optional = true }
+zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.7", optional = true }
 
 # Required for crates.io publishing, but it's only used in tests
-zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.37", optional = true }
+zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.38", optional = true }
 
 abscissa_core = "0.7.0"
 clap = { version = "4.5.4", features = ["cargo"] }
@@ -280,16 +280,16 @@ proptest-derive = "0.4.0"
 # enable span traces and track caller in tests
 color-eyre = { version = "0.6.3" }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.37", features = ["proptest-impl"] }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.37", features = ["proptest-impl"] }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.37", features = ["proptest-impl"] }
-zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.6", features = ["proptest-impl"] }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.37", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38", features = ["proptest-impl"] }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.38", features = ["proptest-impl"] }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.38", features = ["proptest-impl"] }
+zebra-scan = { path = "../zebra-scan", version = "0.1.0-alpha.7", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.38", features = ["proptest-impl"] }
 
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.37", features = ["rpc-client"] }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.38", features = ["rpc-client"] }
 
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.37" }
-zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.4" }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.38" }
+zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.5" }
 
 # Used by the checkpoint generation tests via the zebra-checkpoints feature
 # (the binaries in this crate won't be built unless their features are enabled).
@@ -300,7 +300,7 @@ zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.4" }
 # When `-Z bindeps` is stabilised, enable this binary dependency instead:
 # https://github.com/rust-lang/cargo/issues/9096
 # zebra-utils { path = "../zebra-utils", artifact = "bin:zebra-checkpoints" }
-zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.37" }
+zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.38" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_496_122;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_561_000;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_561_000;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_562_000;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.


### PR DESCRIPTION
---
name: 'Release Checklist Template'
about: 'Checklist to create and publish a Zebra release'
title: 'Release Zebra (version)'
labels: 'A-release, C-trivial, P-Critical :ambulance:'
assignees: ''

---

# Prepare for the Release

- [x] Make sure there has been [at least one successful full sync test](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-integration-tests-gcp.yml?query=event%3Aschedule) since the last state change, or start a manual full sync.
- [x] Make sure the PRs with the new checkpoint hashes and missed dependencies are already merged.
      (See the release ticket checklist for details)
 
# Summarise Release Changes

These steps can be done a few days before the release, in the same PR:

## Change Log

**Important**: Any merge into `main` deletes any edits to the draft changelog.
Once you are ready to tag a release, copy the draft changelog into `CHANGELOG.md`.

We use [the Release Drafter workflow](https://github.com/marketplace/actions/release-drafter) to automatically create a [draft changelog](https://github.com/ZcashFoundation/zebra/releases). We follow the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.

To create the final change log:
- [x] Copy the **latest** draft changelog into `CHANGELOG.md` (there can be multiple draft releases)
- [x] Delete any trivial changes
    - [x] Put the list of deleted changelog entries in a PR comment to make reviewing easier
- [x] Combine duplicate changes
- [x] Edit change descriptions so they will make sense to Zebra users
- [x] Check the category for each change
  - Prefer the "Fix" category if you're not sure

## README

README updates can be skipped for urgent releases.

Update the README to:
- [x] Remove any "Known Issues" that have been fixed since the last release.
- [x] Update the "Build and Run Instructions" with any new dependencies.
      Check for changes in the `Dockerfile` since the last tag: `git diff <previous-release-tag> docker/Dockerfile`.
- [x] If Zebra has started using newer Rust language features or standard library APIs, update the known working Rust version in the README, book, and `Cargo.toml`s

You can use a command like:
```sh
fastmod --fixed-strings '1.58' '1.65'
```

## Create the Release PR

- [x] Push the updated changelog and README into a new branch
      for example: `bump-v1.0.0` - this needs to be different to the tag name
- [x] Create a release PR by adding `&template=release-checklist.md` to the comparing url ([Example](https://github.com/ZcashFoundation/zebra/compare/bump-v1.0.0?expand=1&template=release-checklist.md)).
- [x] Freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [x] Mark all the release PRs as `Critical` priority, so they go in the `urgent` Mergify queue.
- [x] Mark all non-release PRs with `do-not-merge`, because Mergify checks approved PRs against every commit, even when a queue is frozen.


# Update Versions and End of Support

## Update Zebra Version

### Choose a Release Level

Zebra follows [semantic versioning](https://semver.org). Semantic versions look like: MAJOR.MINOR.PATCH[-TAG.PRE-RELEASE]

Choose a release level for `zebrad`. Release levels are based on user-visible changes from the changelog:
- Mainnet Network Upgrades are `major` releases
- significant new features or behaviour changes; changes to RPCs, command-line, or configs; and deprecations or removals are `minor` releases
- otherwise, it is a `patch` release

Zebra's Rust API doesn't have any support or stability guarantees, so we keep all the `zebra-*` and `tower-*` crates on a beta `pre-release` version.

### Update Crate Versions

If you're publishing crates for the first time, [log in to crates.io](https://github.com/ZcashFoundation/zebra/blob/doc-crate-own/book/src/dev/crate-owners.md#logging-in-to-cratesio),
and make sure you're a member of owners group.

Check that the release will work:
- [x] Update crate versions, commit the changes to the release branch, and do a release dry-run:

```sh
# Update everything except for alpha crates and zebrad:
cargo release version --verbose --execute --allow-branch '*' --workspace --exclude zebrad --exclude zebra-scan --exclude zebra-grpc beta
# Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
cargo release version --verbose --execute --allow-branch '*' --package zebra-scan 0.1.0-alpha.4
cargo release version --verbose --execute --allow-branch '*' --package zebra-grpc 0.1.0-alpha.2
# Update zebrad:
cargo release version --verbose --execute --allow-branch '*' --package zebrad patch # [ major | minor | patch ]
# Continue with the release process:
cargo release replace --verbose --execute --allow-branch '*' --package zebrad
cargo release commit --verbose --execute --allow-branch '*'
```

Crate publishing is [automatically checked in CI](https://github.com/ZcashFoundation/zebra/actions/workflows/release-crates-io.yml) using "dry run" mode, however due to a bug in `cargo-release` we need to pass exact versions to the alpha crates:

- [x] Update `zebra-scan` and `zebra-grpc` alpha crates in the [release-crates-dry-run workflow script](https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/scripts/release-crates-dry-run.sh)
- [x] Push the above version changes to the release branch.

## Update End of Support

The end of support height is calculated from the current blockchain height:
- [x] Find where the Zcash blockchain tip is now by using a [Zcash explorer](https://zcashblockexplorer.com/blocks) or other tool.
- [x] Replace `ESTIMATED_RELEASE_HEIGHT` in [`end_of_support.rs`](https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/sync/end_of_support.rs) with the height you estimate the release will be tagged.

<details>

<summary>Optional: calculate the release tagging height</summary>

- Add `1152` blocks for each day until the release
- For example, if the release is in 3 days, add `1152 * 3` to the current Mainnet block height

</details>

## Update the Release PR

- [x] Push the version increments and the release constants to the release branch.


# Publish the Zebra Release

## Create the GitHub Pre-Release

- [x] Wait for all the release PRs to be merged
- [x] Create a new release using the draft release as a base, by clicking the Edit icon in the [draft release](https://github.com/ZcashFoundation/zebra/releases)
- [x] Set the tag name to the version tag,
      for example: `v1.0.0`
- [x] Set the release to target the `main` branch
- [x] Set the release title to `Zebra ` followed by the version tag,
      for example: `Zebra 1.0.0`
- [x] Replace the prepopulated draft changelog in the release description with the final changelog you created;
      starting just _after_ the title `## [Zebra ...` of the current version being released,
      and ending just _before_ the title of the previous release.
- [x] Mark the release as 'pre-release', until it has been built and tested
- [x] Publish the pre-release to GitHub using "Publish Release"
- [x] Delete all the [draft releases from the list of releases](https://github.com/ZcashFoundation/zebra/releases)

## Test the Pre-Release

- [x] Wait until the Docker binaries have been built on `main`, and the quick tests have passed:
    - [x] [ci-unit-tests-docker.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-unit-tests-docker.yml?query=branch%3Amain)
    - [x] [ci-integration-tests-gcp.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-integration-tests-gcp.yml?query=branch%3Amain)
- [x] Wait until the [pre-release deployment machines have successfully launched](https://github.com/ZcashFoundation/zebra/actions/workflows/cd-deploy-nodes-gcp.yml?query=event%3Arelease)

## Publish Release

- [x] [Publish the release to GitHub](https://github.com/ZcashFoundation/zebra/releases) by disabling 'pre-release', then clicking "Set as the latest release"

## Publish Crates

- [x] [Run `cargo login`](https://github.com/ZcashFoundation/zebra/blob/doc-crate-own/book/src/dev/crate-owners.md#logging-in-to-cratesio)
- [x] Run `cargo clean` in the zebra repo (optional)
- [x] Publish the crates to crates.io: `cargo release publish --verbose --workspace --execute`
- [x] Check that Zebra can be installed from `crates.io`:
      `cargo install --locked --force --version 1.minor.patch zebrad && ~/.cargo/bin/zebrad`
      and put the output in a comment on the PR.

## Publish Docker Images
- [x] Wait for the [the Docker images to be published successfully](https://github.com/ZcashFoundation/zebra/actions/workflows/release-binaries.yml?query=event%3Arelease).
- [x] Un-freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [x] Remove `do-not-merge` from the PRs you added it to

## Release Failures

If building or running fails after tagging:

<details>

<summary>Tag a new release, following these instructions...</summary>

1. Fix the bug that caused the failure
2. Start a new `patch` release
3. Skip the **Release Preparation**, and start at the **Release Changes** step
4. Update `CHANGELOG.md` with details about the fix
5. Follow the release checklist for the new Zebra version

</details>
