### PR TITLE
fix(test): Increase expected height in sync-past-checkpoint test

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1267,7 +1267,7 @@ fn create_cached_database(network: Network) -> Result<()> {
 
 #[tracing::instrument]
 fn sync_past_mandatory_checkpoint(network: Network) -> Result<()> {
-    let height = network.mandatory_checkpoint_height() + 1200;
+    let height = network.mandatory_checkpoint_height() + (32_257 + 1200);
     let full_validation_stop_regex =
         format!("{STOP_AT_HEIGHT_REGEX}.*commit contextually-verified request");
 


### PR DESCRIPTION
## Motivation

This may help the `sync-past-checkpoint` test pass in CI. This test stopped working when we lowered the mandatory checkpoint height by the ZIP-212 grace period because the tip height in our cached state is now above the new mandatory checkpoint height.

## Solution

Increases the expected height in the affected checkpoint sync test back to where it was before the mandatory checkpoint height was lowered.

### Follow-up Work

Revert this change after updating the cached state to lower its tip height in CI?

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [x] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

