### PR TITLE
fix(rpc): Return full network upgrade activation list in `getblockchaininfo` method

### DIFF
--- a/zebra-chain/src/parameters/network/tests/vectors.rs
+++ b/zebra-chain/src/parameters/network/tests/vectors.rs
@@ -270,3 +270,28 @@ fn check_network_name() {
         "network must be displayed as configured network name"
     );
 }
+
+#[test]
+fn check_full_activation_list() {
+    let network = testnet::Parameters::build()
+        .with_activation_heights(ConfiguredActivationHeights {
+            nu5: Some(1),
+            ..Default::default()
+        })
+        .to_network();
+
+    // We expect the first 8 network upgrades to be included, up to NU5
+    let expected_network_upgrades = &NETWORK_UPGRADES_IN_ORDER[..8];
+    let full_activation_list_network_upgrades: Vec<_> = network
+        .full_activation_list()
+        .into_iter()
+        .map(|(_, nu)| nu)
+        .collect();
+
+    for expected_network_upgrade in expected_network_upgrades {
+        assert!(
+            full_activation_list_network_upgrades.contains(expected_network_upgrade),
+            "full activation list should contain expected network upgrade"
+        );
+    }
+}

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -252,6 +252,9 @@ impl Network {
     /// When the environment variable TEST_FAKE_ACTIVATION_HEIGHTS is set
     /// and it's a test build, this returns a list of fake activation heights
     /// used by some tests.
+    ///
+    /// Note: This skips implicit network upgrade activations, use [`Network::full_activation_list`]
+    ///       to get an explicit list of all network upgrade activations.
     pub fn activation_list(&self) -> BTreeMap<block::Height, NetworkUpgrade> {
         match self {
             // To prevent accidentally setting this somehow, only check the env var
@@ -276,6 +279,15 @@ impl Network {
             Mainnet => MAINNET_ACTIVATION_HEIGHTS.iter().cloned().collect(),
             Testnet(params) => params.activation_heights().clone(),
         }
+    }
+
+    /// Returns a vector of all implicit and explicit network upgrades for `network`,
+    /// in ascending height order.
+    pub fn full_activation_list(&self) -> Vec<(block::Height, NetworkUpgrade)> {
+        NETWORK_UPGRADES_IN_ORDER
+            .into_iter()
+            .map_while(|nu| Some((NetworkUpgrade::activation_height(&nu, self)?, nu)))
+            .collect()
     }
 }
 

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -541,7 +541,7 @@ where
         //
         // Get the network upgrades in height order, like `zcashd`.
         let mut upgrades = IndexMap::new();
-        for (activation_height, network_upgrade) in network.activation_list() {
+        for (activation_height, network_upgrade) in network.full_activation_list() {
             // Zebra defines network upgrades based on incompatible consensus rule changes,
             // but zcashd defines them based on ZIPs.
             //


### PR DESCRIPTION
## Motivation

Lightwalletd relies on the Sapling activation height from the `getblockchaininfo` response to skip syncing pre-Sapling blocks.

## Solution

- Adds a `full_activation_list()` method on `Network`
- Replaces the call to `activation_list()` in the `get_block_chain_info` RPC method with a call to `full_activation_list()`
- Updates docs

### Tests

Adds a vector test to check that `full_activation_list()` returns all implicit network upgrade activations 

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

