### PR TITLE
add(network-params): Allow configuring NU6 activation height on Regtest

### DIFF
--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -132,8 +132,14 @@ impl Network {
     }
 
     /// Creates a new [`Network::Testnet`] with `Regtest` parameters and the provided network upgrade activation heights.
-    pub fn new_regtest(nu5_activation_height: Option<u32>) -> Self {
-        Self::new_configured_testnet(testnet::Parameters::new_regtest(nu5_activation_height))
+    pub fn new_regtest(
+        nu5_activation_height: Option<u32>,
+        nu6_activation_height: Option<u32>,
+    ) -> Self {
+        Self::new_configured_testnet(testnet::Parameters::new_regtest(
+            nu5_activation_height,
+            nu6_activation_height,
+        ))
     }
 
     /// Returns true if the network is the default Testnet, or false otherwise.

--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -62,6 +62,7 @@ pub struct ConfiguredActivationHeights {
     #[serde(rename = "NU5")]
     pub nu5: Option<u32>,
     /// Activation height for `NU6` network upgrade.
+    #[serde(rename = "NU6")]
     pub nu6: Option<u32>,
 }
 
@@ -347,7 +348,10 @@ impl Parameters {
     /// Accepts a [`ConfiguredActivationHeights`].
     ///
     /// Creates an instance of [`Parameters`] with `Regtest` values.
-    pub fn new_regtest(nu5_activation_height: Option<u32>) -> Self {
+    pub fn new_regtest(
+        nu5_activation_height: Option<u32>,
+        nu6_activation_height: Option<u32>,
+    ) -> Self {
         #[cfg(any(test, feature = "proptest-impl"))]
         let nu5_activation_height = nu5_activation_height.or(Some(100));
 
@@ -365,6 +369,7 @@ impl Parameters {
                 .with_activation_heights(ConfiguredActivationHeights {
                     canopy: Some(1),
                     nu5: nu5_activation_height,
+                    nu6: nu6_activation_height,
                     ..Default::default()
                 })
                 .finish()
@@ -388,7 +393,7 @@ impl Parameters {
             slow_start_shift,
             target_difficulty_limit,
             disable_pow,
-        } = Self::new_regtest(None);
+        } = Self::new_regtest(None, None);
 
         self.network_name == network_name
             && self.network_magic == network_magic

--- a/zebra-chain/src/parameters/network/tests/vectors.rs
+++ b/zebra-chain/src/parameters/network/tests/vectors.rs
@@ -141,7 +141,7 @@ fn activates_network_upgrades_correctly() {
         (Network::Mainnet, MAINNET_ACTIVATION_HEIGHTS),
         (Network::new_default_testnet(), TESTNET_ACTIVATION_HEIGHTS),
         (
-            Network::new_regtest(None),
+            Network::new_regtest(None, None),
             expected_default_regtest_activation_heights,
         ),
     ] {
@@ -192,7 +192,7 @@ fn check_configured_network_name() {
         "Mainnet should be displayed as 'Mainnet'"
     );
     assert_eq!(
-        Network::new_regtest(None).to_string(),
+        Network::new_regtest(None, None).to_string(),
         "Regtest",
         "Regtest should be displayed as 'Regtest'"
     );

--- a/zebra-consensus/src/checkpoint/list/tests.rs
+++ b/zebra-consensus/src/checkpoint/list/tests.rs
@@ -237,7 +237,7 @@ fn checkpoint_list_load_hard_coded() -> Result<(), BoxError> {
 
     let _ = Mainnet.checkpoint_list();
     let _ = Network::new_default_testnet().checkpoint_list();
-    let _ = Network::new_regtest(None).checkpoint_list();
+    let _ = Network::new_regtest(None, None).checkpoint_list();
 
     Ok(())
 }

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -719,11 +719,12 @@ impl<'de> Deserialize<'de> for Config {
             (NetworkKind::Mainnet, _) => Network::Mainnet,
             (NetworkKind::Testnet, None) => Network::new_default_testnet(),
             (NetworkKind::Regtest, testnet_parameters) => {
-                let nu5_activation_height = testnet_parameters
+                let (nu5_activation_height, nu6_activation_height) = testnet_parameters
                     .and_then(|params| params.activation_heights)
-                    .and_then(|activation_height| activation_height.nu5);
+                    .map(|ConfiguredActivationHeights { nu5, nu6, .. }| (nu5, nu6))
+                    .unwrap_or_default();
 
-                Network::new_regtest(nu5_activation_height)
+                Network::new_regtest(nu5_activation_height, nu6_activation_height)
             }
             (
                 NetworkKind::Testnet,

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -399,7 +399,7 @@ lazy_static! {
 
         hash_map.insert(NetworkKind::Mainnet, Version::min_specified_for_upgrade(&Mainnet, Nu5));
         hash_map.insert(NetworkKind::Testnet, Version::min_specified_for_upgrade(&Network::new_default_testnet(), Nu5));
-        hash_map.insert(NetworkKind::Regtest, Version::min_specified_for_upgrade(&Network::new_regtest(None), Nu5));
+        hash_map.insert(NetworkKind::Regtest, Version::min_specified_for_upgrade(&Network::new_regtest(None, None), Nu5));
 
         hash_map
     };

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -2888,7 +2888,7 @@ async fn fully_synced_rpc_z_getsubtreesbyindex_snapshot_test() -> Result<()> {
 async fn validate_regtest_genesis_block() {
     let _init_guard = zebra_test::init();
 
-    let network = Network::new_regtest(None);
+    let network = Network::new_regtest(None, None);
     let state = zebra_state::init_test(&network);
     let (
         block_verifier_router,
@@ -2963,7 +2963,7 @@ async fn trusted_chain_sync_handles_forks_correctly() -> Result<()> {
     use zebra_state::{ReadResponse, Response};
 
     let _init_guard = zebra_test::init();
-    let mut config = os_assigned_rpc_port_config(false, &Network::new_regtest(None))?;
+    let mut config = os_assigned_rpc_port_config(false, &Network::new_regtest(None, None))?;
     config.state.ephemeral = false;
     let network = config.network.network.clone();
 

--- a/zebrad/tests/common/configs/v1.9.0.toml
+++ b/zebrad/tests/common/configs/v1.9.0.toml
@@ -1,0 +1,96 @@
+# Default configuration for zebrad.
+#
+# This file can be used as a skeleton for custom configs.
+#
+# Unspecified fields use default values. Optional fields are Some(field) if the
+# field is present and None if it is absent.
+#
+# This file is generated as an example using zebrad's current defaults.
+# You should set only the config options you want to keep, and delete the rest.
+# Only a subset of fields are present in the skeleton, since optional values
+# whose default is None are omitted.
+#
+# The config format (including a complete list of sections and fields) is
+# documented here:
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
+#
+# zebrad attempts to load configs in the following order:
+#
+# 1. The -c flag on the command line, e.g., `zebrad -c myconfig.toml start`;
+# 2. The file `zebrad.toml` in the users's preference directory (platform-dependent);
+# 3. The default config.
+#
+# The user's preference directory and the default path to the `zebrad` config are platform dependent,
+# based on `dirs::preference_dir`, see https://docs.rs/dirs/latest/dirs/fn.preference_dir.html :
+#
+# | Platform | Value                                 | Example                                        |
+# | -------- | ------------------------------------- | ---------------------------------------------- |
+# | Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/zebrad.toml`              |
+# | macOS    | `$HOME/Library/Preferences`           | `/Users/Alice/Library/Preferences/zebrad.toml` |
+# | Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Local\zebrad.toml`     |
+
+[consensus]
+checkpoint_sync = true
+
+[mempool]
+eviction_memory_time = "1h"
+tx_cost_limit = 80000000
+
+[metrics]
+
+[mining]
+debug_like_zcashd = true
+
+[network]
+cache_dir = true
+crawl_new_peer_interval = "1m 1s"
+initial_mainnet_peers = [
+    "dnsseed.z.cash:8233",
+    "dnsseed.str4d.xyz:8233",
+    "mainnet.seeder.zfnd.org:8233",
+    "mainnet.is.yolo.money:8233",
+]
+initial_testnet_peers = []
+listen_addr = "0.0.0.0:8233"
+max_connections_per_ip = 1
+network = "Testnet"
+peerset_initial_target_size = 25
+
+[network.testnet_parameters]
+network_name = "ConfiguredTestnet_1"
+network_magic = [0, 0, 0, 0]
+slow_start_interval = 0
+target_difficulty_limit = "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"
+disable_pow = true
+genesis_hash = "00040fe8ec8471911baa1db1266ea15dd06b4a8a5c453883c000b031973dce08"
+
+[network.testnet_parameters.activation_heights]
+BeforeOverwinter = 1
+Overwinter = 207_500
+Sapling = 280_000
+Blossom = 584_000
+Heartwood = 903_800
+Canopy = 1_028_500
+NU5 = 1_842_420
+NU6 = 2_000_000
+
+[rpc]
+debug_force_finished_sync = false
+parallel_cpu_threads = 0
+
+[state]
+cache_dir = "cache_dir"
+delete_old_database = true
+ephemeral = false
+
+[sync]
+checkpoint_verify_concurrency_limit = 1000
+download_concurrency_limit = 50
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+
+[tracing]
+buffer_limit = 128000
+force_use_color = false
+use_color = true
+use_journald = false

--- a/zebrad/tests/common/regtest.rs
+++ b/zebrad/tests/common/regtest.rs
@@ -43,7 +43,7 @@ pub(crate) async fn submit_blocks_test() -> Result<()> {
     let _init_guard = zebra_test::init();
     info!("starting regtest submit_blocks test");
 
-    let network = Network::new_regtest(None);
+    let network = Network::new_regtest(None, None);
     let mut config = os_assigned_rpc_port_config(false, &network)?;
     config.mempool.debug_enable_at_height = Some(0);
 


### PR DESCRIPTION
## Motivation

This is useful for testing changes related to NU6 deployment.

## Solution

Adds an argument to `Network::new_regtest()` and `testnet::Parameters::new_regtest()` for NU6 activation height.

### Tests

This will be tested in #8694.

### Follow-up Work

Update the Zebra book (blocked on #8694).

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [x] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

