### PR TITLE
change(tests): Adds timeouts tonic clients in tests

### DIFF
--- a/zebra-grpc/src/tests/vectors.rs
+++ b/zebra-grpc/src/tests/vectors.rs
@@ -232,7 +232,9 @@ async fn start_server_and_get_client() -> (
     MockService<ScanRequest, ScanResponse, PanicAssertion>,
 ) {
     // get a mocked scan service
-    let mock_scan_service = MockService::build().for_unit_tests();
+    let mock_scan_service = MockService::build()
+        .with_max_request_delay(Duration::from_secs(2))
+        .for_unit_tests();
 
     // start the gRPC server
     let listen_addr: std::net::SocketAddr = "127.0.0.1:0"
@@ -246,8 +248,12 @@ async fn start_server_and_get_client() -> (
     // wait for the server to start
     sleep(Duration::from_secs(1));
 
+    let endpoint = tonic::transport::channel::Endpoint::new(format!("http://{listen_addr}"))
+        .unwrap()
+        .timeout(Duration::from_secs(2));
+
     // connect to the gRPC server
-    let client = ScannerClient::connect(format!("http://{listen_addr}"))
+    let client = ScannerClient::connect(endpoint)
         .await
         .expect("server should receive connection");
 


### PR DESCRIPTION
## Motivation

The `test_grpc_methods_mocked` seemed to hang in CI here: https://github.com/ZcashFoundation/zebra/actions/runs/10101606903/job/27935542667?pr=8694#step:12:2915

Tonic doesn't add any timeout by default on the server or the client, the test isn't checking for panics in the spawned tokio tasks for handling mock service responses, and the mock service isn't wrapped in a `Timeout` tower layer.

## Solution

- Adds a 2s timeout to the tonic client endpoints in the affected tests
- Increases the timeout of the relevant mock services from the 300ms default to 2s

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [ ] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

