### PR TITLE
change(consensus): Skip coinbase spend must be shielded check on Regtest

### DIFF
--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -369,6 +369,7 @@ pub fn allow_all_transparent_coinbase_spends(
     _: transparent::OutPoint,
     _: transparent::CoinbaseSpendRestriction,
     _: &transparent::Utxo,
+    _: &Network,
 ) -> Result<(), ()> {
     Ok(())
 }
@@ -396,6 +397,7 @@ impl Block {
                 transparent::OutPoint,
                 transparent::CoinbaseSpendRestriction,
                 &transparent::Utxo,
+                &Network,
             ) -> Result<(), E>
             + Copy
             + 'static,
@@ -564,6 +566,7 @@ where
             transparent::OutPoint,
             transparent::CoinbaseSpendRestriction,
             &transparent::Utxo,
+            &Network,
         ) -> Result<(), E>
         + Copy
         + 'static,
@@ -645,6 +648,7 @@ where
             transparent::OutPoint,
             transparent::CoinbaseSpendRestriction,
             &transparent::Utxo,
+            &Network,
         ) -> Result<(), E>
         + Copy
         + 'static,
@@ -668,6 +672,7 @@ where
             *candidate_outpoint,
             *spend_restriction,
             candidate_utxo.as_ref(),
+            &Network::Mainnet,
         )
         .is_ok()
         {
@@ -677,6 +682,7 @@ where
                 *candidate_outpoint,
                 delete_transparent_outputs,
                 candidate_utxo.as_ref(),
+                &Network::Mainnet,
             )
             .is_ok()
         {

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -310,7 +310,7 @@ impl Transaction {
             // because of other consensus rules
             OnlyShieldedOutputs { spend_height }
         } else {
-            SomeTransparentOutputs
+            SomeTransparentOutputs { spend_height }
         }
     }
 

--- a/zebra-chain/src/transparent/utxo.rs
+++ b/zebra-chain/src/transparent/utxo.rs
@@ -126,7 +126,10 @@ impl OrderedUtxo {
 )]
 pub enum CoinbaseSpendRestriction {
     /// The UTXO is spent in a transaction with one or more transparent outputs
-    SomeTransparentOutputs,
+    SomeTransparentOutputs {
+        /// The height at which the UTXO is spent
+        spend_height: block::Height,
+    },
 
     /// The UTXO is spent in a transaction which only has shielded outputs
     OnlyShieldedOutputs {

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -376,7 +376,7 @@ where
             // WONTFIX: Return an error for Request::Block as well to replace this check in
             //       the state once #2336 has been implemented?
             if req.is_mempool() {
-                Self::check_maturity_height(&req, &spent_utxos)?;
+                Self::check_maturity_height(&req, &spent_utxos, &network)?;
             }
 
             let cached_ffi_transaction =
@@ -586,12 +586,14 @@ where
     pub fn check_maturity_height(
         request: &Request,
         spent_utxos: &HashMap<transparent::OutPoint, transparent::Utxo>,
+        network: &Network,
     ) -> Result<(), TransactionError> {
         check::tx_transparent_coinbase_spends_maturity(
             request.transaction(),
             request.height(),
             request.known_utxos(),
             spent_utxos,
+            network,
         )
     }
 

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -480,6 +480,7 @@ pub fn tx_transparent_coinbase_spends_maturity(
     height: Height,
     block_new_outputs: Arc<HashMap<transparent::OutPoint, transparent::OrderedUtxo>>,
     spent_utxos: &HashMap<transparent::OutPoint, transparent::Utxo>,
+    network: &Network,
 ) -> Result<(), TransactionError> {
     for spend in tx.spent_outpoints() {
         let utxo = block_new_outputs
@@ -490,7 +491,7 @@ pub fn tx_transparent_coinbase_spends_maturity(
 
         let spend_restriction = tx.coinbase_spend_restriction(height);
 
-        zebra_state::check::transparent_coinbase_spend(spend, spend_restriction, &utxo)?;
+        zebra_state::check::transparent_coinbase_spend(spend, spend_restriction, &utxo, network)?;
     }
 
     Ok(())

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -634,11 +634,15 @@ async fn mempool_request_with_immature_spend_is_rejected() {
         })
         .expect("known_utxos should contain the outpoint");
 
-    let expected_error =
-        zebra_state::check::transparent_coinbase_spend(input_outpoint, spend_restriction, &utxo)
-            .map_err(Box::new)
-            .map_err(TransactionError::ValidateContextError)
-            .expect_err("check should fail");
+    let expected_error = zebra_state::check::transparent_coinbase_spend(
+        input_outpoint,
+        spend_restriction,
+        &utxo,
+        &Network::Mainnet,
+    )
+    .map_err(Box::new)
+    .map_err(TransactionError::ValidateContextError)
+    .expect_err("check should fail");
 
     let mock_state_responses = || {
         let mut state = state.clone();

--- a/zebra-state/src/service/check/tests/utxo.rs
+++ b/zebra-state/src/service/check/tests/utxo.rs
@@ -8,6 +8,7 @@ use zebra_chain::{
     amount::Amount,
     block::{Block, Height},
     fmt::TypeNameToDebug,
+    parameters::Network,
     serialization::ZcashDeserializeInto,
     transaction::{self, LockTime, Transaction},
     transparent,
@@ -52,8 +53,12 @@ fn accept_shielded_mature_coinbase_utxo_spend() {
         spend_height: min_spend_height,
     };
 
-    let result =
-        check::utxo::transparent_coinbase_spend(outpoint, spend_restriction, ordered_utxo.as_ref());
+    let result = check::utxo::transparent_coinbase_spend(
+        outpoint,
+        spend_restriction,
+        ordered_utxo.as_ref(),
+        &Network::Mainnet,
+    );
 
     assert_eq!(
         result,
@@ -80,8 +85,12 @@ fn reject_unshielded_coinbase_utxo_spend() {
 
     let spend_restriction = transparent::CoinbaseSpendRestriction::SomeTransparentOutputs;
 
-    let result =
-        check::utxo::transparent_coinbase_spend(outpoint, spend_restriction, ordered_utxo.as_ref());
+    let result = check::utxo::transparent_coinbase_spend(
+        outpoint,
+        spend_restriction,
+        ordered_utxo.as_ref(),
+        &Network::Mainnet,
+    );
     assert_eq!(result, Err(UnshieldedTransparentCoinbaseSpend { outpoint }));
 }
 
@@ -106,8 +115,12 @@ fn reject_immature_coinbase_utxo_spend() {
     let spend_restriction =
         transparent::CoinbaseSpendRestriction::OnlyShieldedOutputs { spend_height };
 
-    let result =
-        check::utxo::transparent_coinbase_spend(outpoint, spend_restriction, ordered_utxo.as_ref());
+    let result = check::utxo::transparent_coinbase_spend(
+        outpoint,
+        spend_restriction,
+        ordered_utxo.as_ref(),
+        &Network::Mainnet,
+    );
     assert_eq!(
         result,
         Err(ImmatureTransparentCoinbaseSpend {
@@ -122,7 +135,7 @@ fn reject_immature_coinbase_utxo_spend() {
         outpoint,
         spend_restriction,
         ordered_utxo.as_ref(),
-        &Network::new_regtest(),
+        &Network::new_regtest(None, None),
     )
     .expect("should pass check on Regtest");
 }

--- a/zebra-state/src/service/check/tests/utxo.rs
+++ b/zebra-state/src/service/check/tests/utxo.rs
@@ -83,7 +83,10 @@ fn reject_unshielded_coinbase_utxo_spend() {
     };
     let ordered_utxo = transparent::OrderedUtxo::new(output, created_height, 0);
 
-    let spend_restriction = transparent::CoinbaseSpendRestriction::SomeTransparentOutputs;
+    let spend_restriction = transparent::CoinbaseSpendRestriction::SomeTransparentOutputs {
+        // Use some fake height, this is only used on Regtest
+        spend_height: Height::MIN,
+    };
 
     let result = check::utxo::transparent_coinbase_spend(
         outpoint,

--- a/zebra-state/src/service/check/tests/utxo.rs
+++ b/zebra-state/src/service/check/tests/utxo.rs
@@ -85,7 +85,7 @@ fn reject_unshielded_coinbase_utxo_spend() {
     assert_eq!(result, Err(UnshieldedTransparentCoinbaseSpend { outpoint }));
 }
 
-/// Check that early spends of coinbase transparent outputs fail.
+/// Check that early spends of coinbase transparent outputs fail, except on Regtest.
 #[test]
 fn reject_immature_coinbase_utxo_spend() {
     let _init_guard = zebra_test::init();
@@ -117,6 +117,14 @@ fn reject_immature_coinbase_utxo_spend() {
             created_height
         })
     );
+
+    check::utxo::transparent_coinbase_spend(
+        outpoint,
+        spend_restriction,
+        ordered_utxo.as_ref(),
+        &Network::new_regtest(),
+    )
+    .expect("should pass check on Regtest");
 }
 
 // These tests use the `Arbitrary` trait to easily generate complex types,


### PR DESCRIPTION
## Motivation

This PR is not yet ready for review.

Coinbase outputs must be shielded when first spent on Mainnet and Testnet in zcashd, but not on Regtest when configured with a flag, we want to do the same in Zebra.

Closes #8478.

## Solution

- Skips coinbase output maturity check on Regtest

### Tests

Updates existing tests for immature coinbase output spends failing validation in the transaction verifier and state utxo check.

## Follow Up Work

Add a field to `testnet::Parameters` for configuring whether the coinbase maturity rule should be checked or ignored on Regtest.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

