### PR TITLE
change: Refactor the deserialization of `ValueBalance`s

### DIFF
--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -348,7 +348,7 @@ impl ValueBalance<NonNegative> {
 
     /// From byte array
     #[allow(clippy::unwrap_in_result)]
-    pub fn from_bytes(bytes: [u8; 32]) -> Result<ValueBalance<NonNegative>, ValueBalanceError> {
+    pub fn from_bytes(bytes: &[u8]) -> Result<ValueBalance<NonNegative>, ValueBalanceError> {
         let transparent = Amount::from_bytes(
             bytes[0..8]
                 .try_into()

--- a/zebra-chain/src/value_balance/tests/prop.rs
+++ b/zebra-chain/src/value_balance/tests/prop.rs
@@ -109,8 +109,7 @@ proptest! {
     fn value_balance_serialization(value_balance in any::<ValueBalance<NonNegative>>()) {
         let _init_guard = zebra_test::init();
 
-        let bytes = value_balance.to_bytes();
-        let serialized_value_balance = ValueBalance::from_bytes(bytes)?;
+        let serialized_value_balance = ValueBalance::from_bytes(&value_balance.to_bytes())?;
 
         prop_assert_eq!(value_balance, serialized_value_balance);
     }
@@ -119,9 +118,8 @@ proptest! {
     fn value_balance_deserialization(bytes in any::<[u8; 32]>()) {
         let _init_guard = zebra_test::init();
 
-        if let Ok(deserialized) = ValueBalance::<NonNegative>::from_bytes(bytes) {
-            let bytes2 = deserialized.to_bytes();
-            prop_assert_eq!(bytes, bytes2);
+        if let Ok(deserialized) = ValueBalance::<NonNegative>::from_bytes(&bytes) {
+            prop_assert_eq!(bytes, deserialized.to_bytes());
         }
     }
 }

--- a/zebra-state/src/service/finalized_state/disk_format/chain.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/chain.rs
@@ -30,8 +30,7 @@ impl IntoDisk for ValueBalance<NonNegative> {
 
 impl FromDisk for ValueBalance<NonNegative> {
     fn from_bytes(bytes: impl AsRef<[u8]>) -> Self {
-        let array = bytes.as_ref().try_into().unwrap();
-        ValueBalance::from_bytes(array).unwrap()
+        ValueBalance::from_bytes(bytes.as_ref()).expect("ValueBalance should be parsable")
     }
 }
 


### PR DESCRIPTION
## Motivation

It looks like PR #8729 wrote 40-byte long `ValueBalance` to the cached state (instead of 32 bytes), and integration tests in other PRs are now failing.  

## Solution

- Don't expect fixed, 32-byte arrays when deserializing `ValueBalance`s.

### Tests

Current tests suffice.

### Follow-up Work

- #8729 will start using 40-byte serialization

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

