### PR TITLE
change(network): Updates minimum protocol version for NU6 on Testnet and Mainnet

### DIFF
--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -82,9 +82,9 @@ impl Version {
             (_, Genesis) | (_, BeforeOverwinter) => 170_002,
             (Testnet(params), Overwinter) if params.is_default_testnet() => 170_003,
             (Mainnet, Overwinter) => 170_005,
-            // TODO: Use 170_006 for (Testnet(params), Sapling) if params.is_regtest() (`Regtest` in zcashd uses
-            //       version 170_006 for Sapling, and the same values as Testnet for other network upgrades.)
-            (_, Sapling) => 170_007,
+            (Testnet(params), Sapling) if params.is_default_testnet() => 170_007,
+            (Testnet(params), Sapling) if params.is_regtest() => 170_006,
+            (Mainnet, Sapling) => 170_007,
             (Testnet(params), Blossom) if params.is_default_testnet() => 170_008,
             (Mainnet, Blossom) => 170_009,
             (Testnet(params), Heartwood) if params.is_default_testnet() => 170_010,
@@ -93,11 +93,11 @@ impl Version {
             (Mainnet, Canopy) => 170_013,
             (Testnet(params), Nu5) if params.is_default_testnet() => 170_050,
             (Mainnet, Nu5) => 170_100,
-            (Testnet(params), Nu6) if params.is_default_testnet() => 170_050,
-            (Mainnet, Nu6) => 170_100,
+            (Testnet(params), Nu6) if params.is_default_testnet() => 170_110,
+            (Mainnet, Nu6) => 170_120,
 
             // It should be fine to reject peers with earlier network protocol versions on custom testnets for now.
-            (Testnet(_params), _) => CURRENT_NETWORK_PROTOCOL_VERSION.0,
+            (Testnet(_), _) => CURRENT_NETWORK_PROTOCOL_VERSION.0,
         })
     }
 }


### PR DESCRIPTION
## Motivation

Zebra should expect its peers to use the NU6 protocol version once NU6 is active.

The [relevant ZIP](https://github.com/zcash/zips/pull/878) is still in draft status, and the network protocol versions for Testnet and Mainnet may still change.

Part of #8689.

### Specifications & References

https://github.com/zcash/zips/pull/878

## Solution

- Updates the minimum protocol version for NU6 on Mainnet and Testnet

Related changes:
- Fixes the minimum protocol version for Sapling on custom Testnets and Regtest

### Tests

Updates the relevant vectors test.

### Follow-up Work

We likely want to update the [`CURRENT_NETWORK_PROTOCOL_VERSION`](https://github.com/ZcashFoundation/zebra/blob/main/zebra-network/src/constants.rs#L340) again before releasing a version of Zebra to deploy NU6 on Mainnet.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

