### PR TITLE
chore: Release v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,22 @@ from 16 weeks to 10 weeks so that it will panic before the expected activation h
 It also replaces the `shielded-scan` compilation feature with a new `zebra-scanner` binary, adds a `TrustedChainSync` module
 for replicating Zebra's best chain state, and a gRPC server in `zebra-rpc` as steps towards zcashd deprecation.
 
+Note: Zebra doesn't enforce an end-of-support height on Testnet, and previous versions of Zebra could mine or follow a chain fork that does not
+      activate NU6 on Testnet at height 2976000. Once a block from a fork is finalized in Zebra's state cache, updating to a version of Zebra that
+      does expect NU6 activation at that height will result in Zebra getting stuck, as it cannot rollback its finalized state. This can be resolved
+      by syncing Zebra from scratch, or by using the `copy-state` command to create a new state cache up to height 2975999. To use the `copy-state`
+      command, first make a copy Zebra's Testnet configuration with a different cache directory path, for example, if Zebra's configuration is at the
+      default path, by running `cp ~/.config/zebrad.toml ./zebrad-copy-target.toml`, then opening the new configuration file and editing the
+      `cache_dir` path in the `state` section. Once there's a copy of Zebra's configuration with the new state cache directory path, run:
+      `zebrad copy-state --target-config-path "./zebrad-copy-target.toml" --max-source-height "2975999"`, and then update the original 
+      Zebra configuration to use the new state cache directory.
+
 ### Added
 
 - A `zebra-scanner` binary replacing the `shielded-scan` compilation feature in `zebrad` ([#8608](https://github.com/ZcashFoundation/zebra/pull/8608))
 - Adds a `TrustedChainSync` module for keeping up with Zebra's non-finalized best chain from a separate process ([#8596](https://github.com/ZcashFoundation/zebra/pull/8596))
 - Add a tonic server in zebra-rpc with a `chain_tip_change()` method that notifies clients when Zebra's best chain tip changes ([#8674](https://github.com/ZcashFoundation/zebra/pull/8674))
-- NU6 network upgrade variant ([#8693](https://github.com/ZcashFoundation/zebra/pull/8693), [8733](https://github.com/ZcashFoundation/zebra/pull/8733))
+- NU6 network upgrade variant, minimum protocol version, and Testnet activation height ([#8693](https://github.com/ZcashFoundation/zebra/pull/8693), [8733](https://github.com/ZcashFoundation/zebra/pull/8733), [#8804](https://github.com/ZcashFoundation/zebra/pull/8804))
 - Configurable NU6 activation height on Regtest ([#8700](https://github.com/ZcashFoundation/zebra/pull/8700))
 - Configurable Testnet funding streams ([#8718](https://github.com/ZcashFoundation/zebra/pull/8718))
 - Post-NU6 funding streams, including a lockbox funding stream ([#8694](https://github.com/ZcashFoundation/zebra/pull/8694))
@@ -26,6 +36,7 @@ for replicating Zebra's best chain state, and a gRPC server in `zebra-rpc` as st
 ### Changed
 
 - Reduced the end-of-support halt time from 16 weeks to 10 weeks ([#8734](https://github.com/ZcashFoundation/zebra/pull/8734))
+- Bumps the current protocol version from 170100 to 170110 ([#8804](https://github.com/ZcashFoundation/zebra/pull/8804))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,17 @@ from 16 weeks to 10 weeks so that it will panic before the expected activation h
 It also replaces the `shielded-scan` compilation feature with a new `zebra-scanner` binary, adds a `TrustedChainSync` module
 for replicating Zebra's best chain state, and a gRPC server in `zebra-rpc` as steps towards zcashd deprecation.
 
-Note: Zebra doesn't enforce an end-of-support height on Testnet, and previous versions of Zebra could mine or follow a chain fork that does not
-      activate NU6 on Testnet at height 2976000. Once a block from a fork is finalized in Zebra's state cache, updating to a version of Zebra that
-      does expect NU6 activation at that height will result in Zebra getting stuck, as it cannot rollback its finalized state. This can be resolved
-      by syncing Zebra from scratch, or by using the `copy-state` command to create a new state cache up to height 2975999. To use the `copy-state`
-      command, first make a copy Zebra's Testnet configuration with a different cache directory path, for example, if Zebra's configuration is at the
-      default path, by running `cp ~/.config/zebrad.toml ./zebrad-copy-target.toml`, then opening the new configuration file and editing the
-      `cache_dir` path in the `state` section. Once there's a copy of Zebra's configuration with the new state cache directory path, run:
-      `zebrad copy-state --target-config-path "./zebrad-copy-target.toml" --max-source-height "2975999"`, and then update the original 
-      Zebra configuration to use the new state cache directory.
+#### Recovering after finalizing a block from a chain fork
+
+Zebra doesn't enforce an end-of-support height on Testnet, and previous versions of Zebra could mine or follow a chain fork that does not
+activate NU6 on Testnet at height 2976000. Once a block from a fork is finalized in Zebra's state cache, updating to a version of Zebra that
+does expect NU6 activation at that height will result in Zebra getting stuck, as it cannot rollback its finalized state. This can be resolved
+by syncing Zebra from scratch, or by using the `copy-state` command to create a new state cache up to height 2975999. To use the `copy-state`
+command, first make a copy Zebra's Testnet configuration with a different cache directory path, for example, if Zebra's configuration is at the
+default path, by running `cp ~/.config/zebrad.toml ./zebrad-copy-target.toml`, then opening the new configuration file and editing the
+`cache_dir` path in the `state` section. Once there's a copy of Zebra's configuration with the new state cache directory path, run:
+`zebrad copy-state --target-config-path "./zebrad-copy-target.toml" --max-source-height "2975999"`, and then update the original 
+Zebra configuration to use the new state cache directory.
 
 ### Added
 
@@ -32,17 +34,23 @@ Note: Zebra doesn't enforce an end-of-support height on Testnet, and previous ve
 - Configurable NU6 activation height on Regtest ([#8700](https://github.com/ZcashFoundation/zebra/pull/8700))
 - Configurable Testnet funding streams ([#8718](https://github.com/ZcashFoundation/zebra/pull/8718))
 - Post-NU6 funding streams, including a lockbox funding stream ([#8694](https://github.com/ZcashFoundation/zebra/pull/8694))
+- Add value pool balances to `getblockchaininfo` RPC method response ([#8769](https://github.com/ZcashFoundation/zebra/pull/8769))
+- Add NU6 lockbox funding stream information to `getblocksubsidy` RPC method response ([#8742](https://github.com/ZcashFoundation/zebra/pull/8742))
 
 ### Changed
 
-- Reduced the end-of-support halt time from 16 weeks to 10 weeks ([#8734](https://github.com/ZcashFoundation/zebra/pull/8734))
-- Bumps the current protocol version from 170100 to 170110 ([#8804](https://github.com/ZcashFoundation/zebra/pull/8804))
+- Reduce the end-of-support halt time from 16 weeks to 10 weeks ([#8734](https://github.com/ZcashFoundation/zebra/pull/8734))
+- Bump the current protocol version from 170100 to 170110 ([#8804](https://github.com/ZcashFoundation/zebra/pull/8804))
+- Track the balance of the deferred chain value pool ([#8732](https://github.com/ZcashFoundation/zebra/pull/8732), [#8729](https://github.com/ZcashFoundation/zebra/pull/8729))
+- Require that coinbase transactions balance exactly after NU6 activation ([#8727](https://github.com/ZcashFoundation/zebra/pull/8727))
+- Support in-place disk format upgrades for major database version bumps ([#8748](https://github.com/ZcashFoundation/zebra/pull/8748))
 
 ### Fixed
 
 - Return full network upgrade activation list in `getblockchaininfo` method ([#8699](https://github.com/ZcashFoundation/zebra/pull/8699))
 - Update documentation for the new `zebra-scanner` binary ([#8675](https://github.com/ZcashFoundation/zebra/pull/8675))
 - Update documentation for using Zebra with lightwalletd ([#8714](https://github.com/ZcashFoundation/zebra/pull/8714))
+- Reduce debug output for Network on Regtest and default Testnet ([#8760](https://github.com/ZcashFoundation/zebra/pull/8760))
 
 ### Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Zebra 1.9.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.9.0) - 2024-08-02
 
-TODO:
-- Add a summary of changes in this release
-- Add an entry for funding stream changes and protocol version bump
+This release includes deployment of NU6 on Testnet, configurable funding streams on custom Testnets, and updates Zebra's end-of-support (EoS)
+from 16 weeks to 14 weeks so that it will panic before the expected activation height of NU6 on Mainnet.
+
+It also replaces the `shielded-scan` compilation feature with a new `zebra-scanner` binary, adds a `TrustedChainSync` module
+for replicating Zebra's best chain state, and a gRPC server in `zebra-rpc` as steps towards zcashd deprecation.
 
 ### Added
 
-- Add a new `zebra-scanner` binary ([#8608](https://github.com/ZcashFoundation/zebra/pull/8608))
-- Allow configuring NU6 activation height on Regtest ([#8700](https://github.com/ZcashFoundation/zebra/pull/8700))
+- A `zebra-scanner` binary replacing the `shielded-scan` compilation feature in `zebrad` ([#8608](https://github.com/ZcashFoundation/zebra/pull/8608))
+- Adds a `TrustedChainSync` module for keeping up with Zebra's non-finalized best chain from a separate process ([#8596](https://github.com/ZcashFoundation/zebra/pull/8596))
+- Add a tonic server in zebra-rpc with a `chain_tip_change()` method that notifies clients when Zebra's best chain tip changes ([#8674](https://github.com/ZcashFoundation/zebra/pull/8674))
+- NU6 network upgrade variant ([#8693](https://github.com/ZcashFoundation/zebra/pull/8693), [8733](https://github.com/ZcashFoundation/zebra/pull/8733))
+- Configurable NU6 activation height on Regtest ([#8700](https://github.com/ZcashFoundation/zebra/pull/8700))
 - Configurable Testnet funding streams ([#8718](https://github.com/ZcashFoundation/zebra/pull/8718))
-- Adds a TrustedChainSync struct for keeping up with Zebra's non-finalized best chain from a separate process ([#8596](https://github.com/ZcashFoundation/zebra/pull/8596))
-- Add an NU6 network upgrade variant ([#8693](https://github.com/ZcashFoundation/zebra/pull/8693))
-- Add a tonic server in zebra-rpc ([#8674](https://github.com/ZcashFoundation/zebra/pull/8674))
+- Post-NU6 funding streams, including a lockbox funding stream ([#8694](https://github.com/ZcashFoundation/zebra/pull/8694))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Zebra 1.9.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.9.0) - 2024-08-02
+
+TODO:
+- Add a summary of changes in this release
+- Add an entry for funding stream changes and protocol version bump
+
+### Added
+
+- Add a new `zebra-scanner` binary ([#8608](https://github.com/ZcashFoundation/zebra/pull/8608))
+- Allow configuring NU6 activation height on Regtest ([#8700](https://github.com/ZcashFoundation/zebra/pull/8700))
+- Configurable Testnet funding streams ([#8718](https://github.com/ZcashFoundation/zebra/pull/8718))
+- Adds a TrustedChainSync struct for keeping up with Zebra's non-finalized best chain from a separate process ([#8596](https://github.com/ZcashFoundation/zebra/pull/8596))
+- Add an NU6 network upgrade variant ([#8693](https://github.com/ZcashFoundation/zebra/pull/8693))
+- Add a tonic server in zebra-rpc ([#8674](https://github.com/ZcashFoundation/zebra/pull/8674))
+
+### Fixed
+
+- Return full network upgrade activation list in `getblockchaininfo` method ([#8699](https://github.com/ZcashFoundation/zebra/pull/8699))
+- Update documentation for the new `zebra-scanner` binary ([#8675](https://github.com/ZcashFoundation/zebra/pull/8675))
+- Update documentation for using Zebra with lightwalletd ([#8714](https://github.com/ZcashFoundation/zebra/pull/8714))
+
+### Contributors
+
+Thank you to everyone who contributed to this release, we couldn't make Zebra without you:
+@arya2, @conradoplg, @dependabot[bot], @oxarbitrage, @therealyingtong and @upbqdn
+
+
 ## [Zebra 1.8.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.8.0) - 2024-07-02
 
 - Zebra now uses a default unpaid actions limit of 0, dropping transactions with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ## [Zebra 1.9.0](https://github.com/ZcashFoundation/zebra/releases/tag/v1.9.0) - 2024-08-02
 
 This release includes deployment of NU6 on Testnet, configurable funding streams on custom Testnets, and updates Zebra's end-of-support (EoS)
-from 16 weeks to 14 weeks so that it will panic before the expected activation height of NU6 on Mainnet.
+from 16 weeks to 10 weeks so that it will panic before the expected activation height of NU6 on Mainnet.
 
 It also replaces the `shielded-scan` compilation feature with a new `zebra-scanner` binary, adds a `TrustedChainSync` module
 for replicating Zebra's best chain state, and a gRPC server in `zebra-rpc` as steps towards zcashd deprecation.
@@ -22,6 +22,10 @@ for replicating Zebra's best chain state, and a gRPC server in `zebra-rpc` as st
 - Configurable NU6 activation height on Regtest ([#8700](https://github.com/ZcashFoundation/zebra/pull/8700))
 - Configurable Testnet funding streams ([#8718](https://github.com/ZcashFoundation/zebra/pull/8718))
 - Post-NU6 funding streams, including a lockbox funding stream ([#8694](https://github.com/ZcashFoundation/zebra/pull/8694))
+
+### Changed
+
+- Reduced the end-of-support halt time from 16 weeks to 10 weeks ([#8734](https://github.com/ZcashFoundation/zebra/pull/8734))
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4699,7 +4699,7 @@ dependencies = [
 
 [[package]]
 name = "tower-batch-control"
-version = "0.2.41-beta.14"
+version = "0.2.41-beta.15"
 dependencies = [
  "color-eyre",
  "ed25519-zebra",
@@ -4722,7 +4722,7 @@ dependencies = [
 
 [[package]]
 name = "tower-fallback"
-version = "0.2.41-beta.14"
+version = "0.2.41-beta.15"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "1.0.0-beta.38"
+version = "1.0.0-beta.39"
 dependencies = [
  "bitflags 2.6.0",
  "bitflags-serde-legacy",
@@ -5809,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-consensus"
-version = "1.0.0-beta.38"
+version = "1.0.0-beta.39"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-grpc"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 dependencies = [
  "color-eyre",
  "futures-util",
@@ -5877,7 +5877,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-network"
-version = "1.0.0-beta.38"
+version = "1.0.0-beta.39"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
@@ -5918,7 +5918,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-node-services"
-version = "1.0.0-beta.38"
+version = "1.0.0-beta.39"
 dependencies = [
  "color-eyre",
  "jsonrpc-core",
@@ -5931,7 +5931,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "1.0.0-beta.38"
+version = "1.0.0-beta.39"
 dependencies = [
  "chrono",
  "futures",
@@ -5967,7 +5967,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-scan"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 dependencies = [
  "bls12_381",
  "chrono",
@@ -6013,7 +6013,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-script"
-version = "1.0.0-beta.38"
+version = "1.0.0-beta.39"
 dependencies = [
  "hex",
  "lazy_static",
@@ -6025,7 +6025,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "1.0.0-beta.38"
+version = "1.0.0-beta.39"
 dependencies = [
  "bincode",
  "chrono",
@@ -6070,7 +6070,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-test"
-version = "1.0.0-beta.38"
+version = "1.0.0-beta.39"
 dependencies = [
  "color-eyre",
  "futures",
@@ -6098,7 +6098,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-utils"
-version = "1.0.0-beta.38"
+version = "1.0.0-beta.39"
 dependencies = [
  "color-eyre",
  "hex",
@@ -6129,7 +6129,7 @@ dependencies = [
 
 [[package]]
 name = "zebrad"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "abscissa_core",
  "atty",

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -37,7 +37,7 @@ docker run -d --platform linux/amd64 \
 ### Build it locally
 
 ```shell
-git clone --depth 1 --branch v1.8.1 https://github.com/ZcashFoundation/zebra.git
+git clone --depth 1 --branch v1.9.0 https://github.com/ZcashFoundation/zebra.git
 docker build --file docker/Dockerfile --target runtime --tag zebra:local .
 docker run --detach zebra:local
 ```

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -37,7 +37,7 @@ docker run -d --platform linux/amd64 \
 ### Build it locally
 
 ```shell
-git clone --depth 1 --branch v1.8.0 https://github.com/ZcashFoundation/zebra.git
+git clone --depth 1 --branch v1.8.1 https://github.com/ZcashFoundation/zebra.git
 docker build --file docker/Dockerfile --target runtime --tag zebra:local .
 docker run --detach zebra:local
 ```

--- a/book/src/user/install.md
+++ b/book/src/user/install.md
@@ -76,7 +76,7 @@ To compile Zebra directly from GitHub, or from a GitHub release source archive:
 ```sh
 git clone https://github.com/ZcashFoundation/zebra.git
 cd zebra
-git checkout v1.8.1
+git checkout v1.9.0
 ```
 
 3. Build and Run `zebrad`
@@ -89,7 +89,7 @@ target/release/zebrad start
 ### Compiling from git using cargo install
 
 ```sh
-cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.8.1 zebrad
+cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.9.0 zebrad
 ```
 
 ### Compiling on ARM

--- a/book/src/user/install.md
+++ b/book/src/user/install.md
@@ -76,7 +76,7 @@ To compile Zebra directly from GitHub, or from a GitHub release source archive:
 ```sh
 git clone https://github.com/ZcashFoundation/zebra.git
 cd zebra
-git checkout v1.8.0
+git checkout v1.8.1
 ```
 
 3. Build and Run `zebrad`
@@ -89,7 +89,7 @@ target/release/zebrad start
 ### Compiling from git using cargo install
 
 ```sh
-cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.8.0 zebrad
+cargo install --git https://github.com/ZcashFoundation/zebra --tag v1.8.1 zebrad
 ```
 
 ### Compiling on ARM

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-batch-control"
-version = "0.2.41-beta.14"
+version = "0.2.41-beta.15"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Tower middleware for batch request processing"
 # # Legal
@@ -43,10 +43,10 @@ rand = "0.8.5"
 
 tokio = { version = "1.39.2", features = ["full", "tracing", "test-util"] }
 tokio-test = "0.4.4"
-tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.14" }
+tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.15" }
 tower-test = "0.4.0"
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.38" }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.39" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-fallback"
-version = "0.2.41-beta.14"
+version = "0.2.41-beta.15"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Tower service combinator that sends requests to a first service, then retries processing on a second fallback service if the first service errors."
 license = "MIT OR Apache-2.0"
@@ -24,4 +24,4 @@ tracing = "0.1.39"
 [dev-dependencies]
 tokio = { version = "1.39.2", features = ["full", "tracing", "test-util"] }
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.38" }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.39" }

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-chain"
-version = "1.0.0-beta.38"
+version = "1.0.0-beta.39"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Core Zcash data structures"
 license = "MIT OR Apache-2.0"
@@ -143,7 +143,7 @@ proptest-derive = { version = "0.5.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 rand_chacha = { version = "0.3.1", optional = true }
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.38", optional = true }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.39", optional = true }
 
 [dev-dependencies]
 # Benchmarks
@@ -166,7 +166,7 @@ rand_chacha = "0.3.1"
 
 tokio = { version = "1.39.2", features = ["full", "tracing", "test-util"] }
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.38" }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.39" }
 
 [[bench]]
 name = "block"

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-consensus"
-version = "1.0.0-beta.38"
+version = "1.0.0-beta.39"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Implementation of Zcash consensus checks"
 license = "MIT OR Apache-2.0"
@@ -63,13 +63,13 @@ orchard.workspace = true
 zcash_proofs = { workspace = true, features = ["multicore" ] }
 wagyu-zcash-parameters = "0.2.0"
 
-tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.14" }
-tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41-beta.14" }
+tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.15" }
+tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41-beta.15" }
 
-zebra-script = { path = "../zebra-script", version = "1.0.0-beta.38" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.38" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.38" }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38" }
+zebra-script = { path = "../zebra-script", version = "1.0.0-beta.39" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.39" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.39" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.39" }
 
 # prod feature progress-bar
 howudoin = { version = "0.1.2", optional = true }
@@ -94,6 +94,6 @@ tokio = { version = "1.39.2", features = ["full", "tracing", "test-util"] }
 tracing-error = "0.2.0"
 tracing-subscriber = "0.3.18"
 
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.38", features = ["proptest-impl"] }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38", features = ["proptest-impl"] }
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.38" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.39", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.39", features = ["proptest-impl"] }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.39" }

--- a/zebra-grpc/Cargo.toml
+++ b/zebra-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-grpc"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.6"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Zebra gRPC interface"
 license = "MIT OR Apache-2.0"
@@ -28,8 +28,8 @@ color-eyre = "0.6.3"
 
 zcash_primitives.workspace = true
 
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.38", features = ["shielded-scan"] }
-zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.38" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.39", features = ["shielded-scan"] }
+zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.39" }
 
 [build-dependencies]
 tonic-build = "0.12.1"

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-network"
-version = "1.0.0-beta.38"
+version = "1.0.0-beta.39"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Networking code for Zebra"
 # # Legal
@@ -83,7 +83,7 @@ howudoin = { version = "0.1.2", optional = true }
 proptest = { version = "1.4.0", optional = true }
 proptest-derive = { version = "0.5.0", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.39", features = ["async-error"] }
 
 [dev-dependencies]
 proptest = "1.4.0"

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-node-services"
-version = "1.0.0-beta.38"
+version = "1.0.0-beta.39"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The interfaces of some Zebra node services"
 license = "MIT OR Apache-2.0"
@@ -37,7 +37,7 @@ rpc-client = [
 shielded-scan = ["tokio"]
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.38" }
+zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.39" }
 
 # Optional dependencies
 

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-rpc"
-version = "1.0.0-beta.38"
+version = "1.0.0-beta.39"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Zebra JSON Remote Procedure Call (JSON-RPC) interface"
 license = "MIT OR Apache-2.0"
@@ -98,16 +98,16 @@ zcash_address = { workspace = true, optional = true}
 # Test-only feature proptest-impl
 proptest = { version = "1.4.0", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38", features = [
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.39", features = [
     "json-conversion",
 ] }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.38" }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.38" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.38", features = [
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.39" }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.39" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.39", features = [
     "rpc-client",
 ] }
-zebra-script = { path = "../zebra-script", version = "1.0.0-beta.38" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.38" }
+zebra-script = { path = "../zebra-script", version = "1.0.0-beta.39" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.39" }
 
 [build-dependencies]
 tonic-build = { version = "0.12.1", optional = true }
@@ -120,17 +120,17 @@ proptest = "1.4.0"
 thiserror = "1.0.63"
 tokio = { version = "1.39.2", features = ["full", "tracing", "test-util"] }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38", features = [
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.39", features = [
     "proptest-impl",
 ] }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.38", features = [
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.39", features = [
     "proptest-impl",
 ] }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.38", features = [
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.39", features = [
     "proptest-impl",
 ] }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.38", features = [
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.39", features = [
     "proptest-impl",
 ] }
 
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.38" }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.39" }

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-scan"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Shielded transaction scanner for the Zcash blockchain"
 license = "MIT OR Apache-2.0"
@@ -76,11 +76,11 @@ zcash_primitives.workspace = true
 zcash_address.workspace = true
 sapling-crypto.workspace = true
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38", features = ["shielded-scan"] }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.38", features = ["shielded-scan"] }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.38", features = ["shielded-scan"] }
-zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.5" }
-zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.38" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.39", features = ["shielded-scan"] }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.39", features = ["shielded-scan"] }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.39", features = ["shielded-scan"] }
+zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.6" }
+zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.39" }
 
 chrono = { version = "0.4.38", default-features = false, features = ["clock", "std", "serde"] }
 
@@ -95,7 +95,7 @@ jubjub = { version = "0.10.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 zcash_note_encryption = { version = "0.4.0", optional = true }
 
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.38", optional = true }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.39", optional = true }
 
 # zebra-scanner binary dependencies
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
@@ -106,7 +106,7 @@ serde_json = "1.0.122"
 jsonrpc = { version = "0.18.0", optional = true }
 hex = { version = "0.4.3", optional = true }
 
-zebrad = { path = "../zebrad", version = "1.8.0" }
+zebrad = { path = "../zebrad", version = "1.8.1" }
 
 [dev-dependencies]
 insta = { version = "1.39.0", features = ["ron", "redactions"] }
@@ -124,6 +124,6 @@ zcash_note_encryption = "0.4.0"
 toml = "0.8.19"
 tonic = "0.12.1"
 
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.38", features = ["proptest-impl"] }
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.38" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.39", features = ["proptest-impl"] }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.39" }
 

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-script"
-version = "1.0.0-beta.38"
+version = "1.0.0-beta.39"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Zebra script verification wrapping zcashd's zcash_script library"
 license = "MIT OR Apache-2.0"
@@ -16,11 +16,11 @@ categories = ["api-bindings", "cryptography::cryptocurrencies"]
 
 [dependencies]
 zcash_script = "0.2.0"
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.39" }
 
 thiserror = "1.0.63"
 
 [dev-dependencies]
 hex = "0.4.3"
 lazy_static = "1.4.0"
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.38" }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.39" }

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-state"
-version = "1.0.0-beta.38"
+version = "1.0.0-beta.39"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "State contextual verification and storage code for Zebra"
 license = "MIT OR Apache-2.0"
@@ -77,13 +77,13 @@ tracing = "0.1.39"
 elasticsearch = { version = "8.5.0-alpha.1", default-features = false, features = ["rustls-tls"], optional = true }
 serde_json = { version = "1.0.122", package = "serde_json", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.39", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { version = "0.1.2", optional = true }
 
 # test feature proptest-impl
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.38", optional = true }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.39", optional = true }
 proptest = { version = "1.4.0", optional = true }
 proptest-derive = { version = "0.5.0", optional = true }
 
@@ -108,5 +108,5 @@ jubjub = "0.10.0"
 
 tokio = { version = "1.39.2", features = ["full", "tracing", "test-util"] }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38", features = ["proptest-impl"] }
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.38" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.39", features = ["proptest-impl"] }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.39" }

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-test"
-version = "1.0.0-beta.38"
+version = "1.0.0-beta.39"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Test harnesses and test vectors for Zebra"
 license = "MIT OR Apache-2.0"

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-utils"
-version = "1.0.0-beta.38"
+version = "1.0.0-beta.39"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Developer tools for Zebra maintenance and testing"
 license = "MIT OR Apache-2.0"
@@ -94,11 +94,11 @@ tracing-error = "0.2.0"
 tracing-subscriber = "0.3.18"
 thiserror = "1.0.63"
 
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.38" }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.39" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.39" }
 
 # These crates are needed for the block-template-to-proposal binary
-zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.38", optional = true }
+zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.39", optional = true }
 
 # These crates are needed for the zebra-checkpoints binary
 itertools = { version = "0.13.0", optional = true }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate metadata
 name = "zebrad"
-version = "1.8.0"
+version = "1.9.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The Zcash Foundation's independent, consensus-compatible implementation of a Zcash node"
 license = "MIT OR Apache-2.0"
@@ -157,15 +157,15 @@ test_sync_past_mandatory_checkpoint_mainnet = []
 test_sync_past_mandatory_checkpoint_testnet = []
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38" }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.38" }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.38" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.38", features = ["rpc-client"] }
-zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.38" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.38" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.39" }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.39" }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.39" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.39", features = ["rpc-client"] }
+zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.39" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.39" }
 
 # Required for crates.io publishing, but it's only used in tests
-zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.38", optional = true }
+zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.39", optional = true }
 
 abscissa_core = "0.7.0"
 clap = { version = "4.5.13", features = ["cargo"] }
@@ -279,13 +279,13 @@ proptest-derive = "0.5.0"
 # enable span traces and track caller in tests
 color-eyre = { version = "0.6.3" }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38", features = ["proptest-impl"] }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.38", features = ["proptest-impl"] }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.38", features = ["proptest-impl"] }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.38", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.39", features = ["proptest-impl"] }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.39", features = ["proptest-impl"] }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.39", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.39", features = ["proptest-impl"] }
 
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.38" }
-zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.5" }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.39" }
+zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.6" }
 
 # Used by the checkpoint generation tests via the zebra-checkpoints feature
 # (the binaries in this crate won't be built unless their features are enabled).
@@ -296,7 +296,7 @@ zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.5" }
 # When `-Z bindeps` is stabilised, enable this binary dependency instead:
 # https://github.com/rust-lang/cargo/issues/9096
 # zebra-utils { path = "../zebra-utils", artifact = "bin:zebra-checkpoints" }
-zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.38" }
+zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.39" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_562_000;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_598_000;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.
@@ -22,8 +22,8 @@ pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_562_000;
 ///
 /// - Zebra will exit with a panic if the current tip height is bigger than the `ESTIMATED_RELEASE_HEIGHT`
 ///   plus this number of days.
-/// - Currently set to 16 weeks.
-pub const EOS_PANIC_AFTER: u32 = 112;
+/// - Currently set to 14 weeks.
+pub const EOS_PANIC_AFTER: u32 = 98;
 
 /// The number of days before the end of support where Zebra will display warnings.
 pub const EOS_WARN_AFTER: u32 = EOS_PANIC_AFTER - 14;

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -23,7 +23,7 @@ pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_598_000;
 /// - Zebra will exit with a panic if the current tip height is bigger than the `ESTIMATED_RELEASE_HEIGHT`
 ///   plus this number of days.
 /// - Currently set to 14 weeks.
-pub const EOS_PANIC_AFTER: u32 = 98;
+pub const EOS_PANIC_AFTER: u32 = 70;
 
 /// The number of days before the end of support where Zebra will display warnings.
 pub const EOS_WARN_AFTER: u32 = EOS_PANIC_AFTER - 14;

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_626_000;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_626_500;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_598_000;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_626_000;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.


### PR DESCRIPTION
Part of #8543.
Will close #8709.

This PR still needs to set an NU6 activation height for Testnet and to update the NU6 funding streams start height. It's also blocked on updating Zebra's librustzcash dependencies.

# Prepare for the Release

- [x] Make sure there has been [at least one successful full sync test](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-integration-tests-gcp.yml?query=event%3Aschedule) since the last state change, or start a manual full sync.
- [x] Make sure the PRs with the new checkpoint hashes and missed dependencies are already merged.
      (See the release ticket checklist for details)


# Summarise Release Changes

These steps can be done a few days before the release, in the same PR:

## Change Log

**Important**: Any merge into `main` deletes any edits to the draft changelog.
Once you are ready to tag a release, copy the draft changelog into `CHANGELOG.md`.

We use [the Release Drafter workflow](https://github.com/marketplace/actions/release-drafter) to automatically create a [draft changelog](https://github.com/ZcashFoundation/zebra/releases). We follow the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.

To create the final change log:
- [x] Copy the **latest** draft changelog into `CHANGELOG.md` (there can be multiple draft releases)
- [x] Delete any trivial changes
    - [x] Put the list of deleted changelog entries in a PR comment to make reviewing easier
- [x] Combine duplicate changes
- [x] Edit change descriptions so they will make sense to Zebra users
- [x] Check the category for each change
  - Prefer the "Fix" category if you're not sure

## README

README updates can be skipped for urgent releases.

Update the README to:
- [x] Remove any "Known Issues" that have been fixed since the last release.
- [x] Update the "Build and Run Instructions" with any new dependencies.
      Check for changes in the `Dockerfile` since the last tag: `git diff <previous-release-tag> docker/Dockerfile`.
- [x] If Zebra has started using newer Rust language features or standard library APIs, update the known working Rust version in the README, book, and `Cargo.toml`s

You can use a command like:
```sh
fastmod --fixed-strings '1.58' '1.65'
```

## Create the Release PR

- [x] Push the updated changelog and README into a new branch
      for example: `bump-v1.0.0` - this needs to be different to the tag name
- [x] Create a release PR by adding `&template=release-checklist.md` to the comparing url ([Example](https://github.com/ZcashFoundation/zebra/compare/bump-v1.0.0?expand=1&template=release-checklist.md)).
- [x] Freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [x] Mark all the release PRs as `Critical` priority, so they go in the `urgent` Mergify queue.
- [x] Mark all non-release PRs with `do-not-merge`, because Mergify checks approved PRs against every commit, even when a queue is frozen.


# Update Versions and End of Support

## Update Zebra Version

### Choose a Release Level

Zebra follows [semantic versioning](https://semver.org). Semantic versions look like: MAJOR.MINOR.PATCH[-TAG.PRE-RELEASE]

Choose a release level for `zebrad`. Release levels are based on user-visible changes from the changelog:
- Mainnet Network Upgrades are `major` releases
- significant new features or behaviour changes; changes to RPCs, command-line, or configs; and deprecations or removals are `minor` releases
- otherwise, it is a `patch` release

Zebra's Rust API doesn't have any support or stability guarantees, so we keep all the `zebra-*` and `tower-*` crates on a beta `pre-release` version.

### Update Crate Versions

If you're publishing crates for the first time, [log in to crates.io](https://github.com/ZcashFoundation/zebra/blob/doc-crate-own/book/src/dev/crate-owners.md#logging-in-to-cratesio),
and make sure you're a member of owners group.

Check that the release will work:
- [x] Update crate versions, commit the changes to the release branch, and do a release dry-run:

```sh
# Update everything except for alpha crates and zebrad:
cargo release version --verbose --execute --allow-branch '*' --workspace --exclude zebrad --exclude zebra-scan --exclude zebra-grpc beta
# Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
cargo release version --verbose --execute --allow-branch '*' --package zebra-scan 0.1.0-alpha.4
cargo release version --verbose --execute --allow-branch '*' --package zebra-grpc 0.1.0-alpha.2
# Update zebrad:
cargo release version --verbose --execute --allow-branch '*' --package zebrad patch # [ major | minor | patch ]
# Continue with the release process:
cargo release replace --verbose --execute --allow-branch '*' --package zebrad
cargo release commit --verbose --execute --allow-branch '*'
```

Crate publishing is [automatically checked in CI](https://github.com/ZcashFoundation/zebra/actions/workflows/release-crates-io.yml) using "dry run" mode, however due to a bug in `cargo-release` we need to pass exact versions to the alpha crates:

- [x] Update `zebra-scan` and `zebra-grpc` alpha crates in the [release-crates-dry-run workflow script](https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/scripts/release-crates-dry-run.sh)
- [x] Push the above version changes to the release branch.

## Update End of Support

The end of support height is calculated from the current blockchain height:
- [x] Find where the Zcash blockchain tip is now by using a [Zcash explorer](https://zcashblockexplorer.com/blocks) or other tool.
- [x] Replace `ESTIMATED_RELEASE_HEIGHT` in [`end_of_support.rs`](https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/sync/end_of_support.rs) with the height you estimate the release will be tagged.

<details>

<summary>Optional: calculate the release tagging height</summary>

- Add `1152` blocks for each day until the release
- For example, if the release is in 3 days, add `1152 * 3` to the current Mainnet block height

</details>

## Update the Release PR

- [x] Push the version increments and the release constants to the release branch.


# Publish the Zebra Release

## Create the GitHub Pre-Release

- [x] Wait for all the release PRs to be merged
- [x] Create a new release using the draft release as a base, by clicking the Edit icon in the [draft release](https://github.com/ZcashFoundation/zebra/releases)
- [x] Set the tag name to the version tag,
      for example: `v1.0.0`
- [x] Set the release to target the `main` branch
- [x] Set the release title to `Zebra ` followed by the version tag,
      for example: `Zebra 1.0.0`
- [x] Replace the prepopulated draft changelog in the release description with the final changelog you created;
      starting just _after_ the title `## [Zebra ...` of the current version being released,
      and ending just _before_ the title of the previous release.
- [x] Mark the release as 'pre-release', until it has been built and tested
- [x] Publish the pre-release to GitHub using "Publish Release"
- [x] Delete all the [draft releases from the list of releases](https://github.com/ZcashFoundation/zebra/releases)

## Test the Pre-Release

- [x] Wait until the Docker binaries have been built on `main`, and the quick tests have passed:
    - [x] [ci-unit-tests-docker.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-unit-tests-docker.yml?query=branch%3Amain)
    - [x] [ci-integration-tests-gcp.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-integration-tests-gcp.yml?query=branch%3Amain)
- [x] Wait until the [pre-release deployment machines have successfully launched](https://github.com/ZcashFoundation/zebra/actions/workflows/cd-deploy-nodes-gcp.yml?query=event%3Arelease)

## Publish Release

- [x] [Publish the release to GitHub](https://github.com/ZcashFoundation/zebra/releases) by disabling 'pre-release', then clicking "Set as the latest release"

## Publish Crates

- [x] [Run `cargo login`](https://github.com/ZcashFoundation/zebra/blob/doc-crate-own/book/src/dev/crate-owners.md#logging-in-to-cratesio)
- [x] Run `cargo clean` in the zebra repo (optional)
- [x] Publish the crates to crates.io: `cargo release publish --verbose --workspace --execute`
- [x] Check that Zebra can be installed from `crates.io`:
      `cargo install --locked --force --version 1.minor.patch zebrad && ~/.cargo/bin/zebrad`
      and put the output in a comment on the PR.

## Publish Docker Images
- [x] Wait for the [the Docker images to be published successfully](https://github.com/ZcashFoundation/zebra/actions/workflows/release-binaries.yml?query=event%3Arelease).
- [x] Un-freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [x] Remove `do-not-merge` from the PRs you added it to

## Release Failures

If building or running fails after tagging:

<details>

<summary>Tag a new release, following these instructions...</summary>

1. Fix the bug that caused the failure
2. Start a new `patch` release
3. Skip the **Release Preparation**, and start at the **Release Changes** step
4. Update `CHANGELOG.md` with details about the fix
5. Follow the release checklist for the new Zebra version

</details>
