### PR TITLE
chore: Fix `cargo check` annotations on Windows

### DIFF
--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -26,6 +26,8 @@ use tokio::{io::AsyncWriteExt, net::TcpStream, task::JoinHandle};
 use tower::{service_fn, Layer, Service, ServiceExt};
 
 use zebra_chain::{chain_tip::NoChainTip, parameters::Network, serialization::DateTime32};
+
+#[cfg(not(target_os = "windows"))]
 use zebra_test::net::random_known_port;
 
 use crate::{

--- a/zebra-scan/tests/scanner.rs
+++ b/zebra-scan/tests/scanner.rs
@@ -1,18 +1,25 @@
 //! `zebra-scanner` binary tests.
+
+use std::path::Path;
+
+#[cfg(not(target_os = "windows"))]
+use std::io::Write;
+
 use tempfile::TempDir;
 
-use zebra_grpc::scanner::{scanner_client::ScannerClient, Empty};
 use zebra_test::{
     args,
     command::{Arguments, TestDirExt},
     prelude::*,
 };
 
-use std::{io::Write, path::Path};
+#[cfg(not(target_os = "windows"))]
+use zebra_grpc::scanner::{scanner_client::ScannerClient, Empty};
 
 mod scan_task_commands;
 
 /// The extended Sapling viewing key of [ZECpages](https://zecpages.com/boardinfo)
+#[cfg(not(target_os = "windows"))]
 const ZECPAGES_SAPLING_VIEWING_KEY: &str = "zxviews1q0duytgcqqqqpqre26wkl45gvwwwd706xw608hucmvfalr759ejwf7qshjf5r9aa7323zulvz6plhttp5mltqcgs9t039cx2d09mgq05ts63n8u35hyv6h9nc9ctqqtue2u7cer2mqegunuulq2luhq3ywjcz35yyljewa4mgkgjzyfwh6fr6jd0dzd44ghk0nxdv2hnv4j5nxfwv24rwdmgllhe0p8568sgqt9ckt02v2kxf5ahtql6s0ltjpkckw8gtymxtxuu9gcr0swvz";
 
 /// Test the scanner binary with the `--help` flag.

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -7,7 +7,6 @@ use zebra_test::prelude::*;
 use zebra_chain::{
     amount::NonNegative,
     block::{self, arbitrary::allow_all_transparent_coinbase_spends, Block, Height},
-    fmt::DisplayToDebug,
     history_tree::{HistoryTree, NonEmptyHistoryTree},
     parameters::NetworkUpgrade::*,
     parameters::*,
@@ -18,12 +17,7 @@ use zebra_chain::{
 use crate::{
     arbitrary::Prepare,
     request::ContextuallyVerifiedBlock,
-    service::{
-        arbitrary::PreparedChain,
-        finalized_state::FinalizedState,
-        non_finalized_state::{Chain, NonFinalizedState},
-    },
-    Config,
+    service::{arbitrary::PreparedChain, non_finalized_state::Chain},
 };
 
 /// The default number of proptest cases for long partial chain tests.
@@ -453,6 +447,13 @@ fn finalized_equals_pushed_history_tree() -> Result<()> {
 #[test]
 #[cfg(not(target_os = "windows"))]
 fn rejection_restores_internal_state_genesis() -> Result<()> {
+    use zebra_chain::fmt::DisplayToDebug;
+
+    use crate::{
+        service::{finalized_state::FinalizedState, non_finalized_state::NonFinalizedState},
+        Config,
+    };
+
     let _init_guard = zebra_test::init();
 
     proptest!(ProptestConfig::with_cases(env::var("PROPTEST_CASES")

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -159,17 +159,21 @@ use zebra_chain::{
     parameters::Network::{self, *},
 };
 use zebra_consensus::ParameterCheckpoint;
-use zebra_network::constants::PORT_IN_USE_ERROR;
 use zebra_node_services::rpc_client::RpcRequestClient;
 use zebra_rpc::server::OPENED_RPC_ENDPOINT_MSG;
 use zebra_state::{constants::LOCK_FILE_ERROR, state_database_format_version_in_code};
 
+#[cfg(not(target_os = "windows"))]
+use zebra_network::constants::PORT_IN_USE_ERROR;
+
 use zebra_test::{
     args,
     command::{to_regex::CollectRegexSet, ContextFrom},
-    net::random_known_port,
     prelude::*,
 };
+
+#[cfg(not(target_os = "windows"))]
+use zebra_test::net::random_known_port;
 
 mod common;
 


### PR DESCRIPTION
## Motivation

The annotations about unused imports are adding noise to every PR.

## Solution

Skips unused imports on Windows

### Tests

This PR shouldn't have any annotations for unchanged code.

### PR Author's Checklist

- [x] The PR name will make sense to users.
- [x] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

