### PR TITLE
fix: Cache Sprout tree roots in tests

### DIFF
--- a/zebra-state/src/service/finalized_state/zebra_db/arbitrary.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/arbitrary.rs
@@ -49,14 +49,15 @@ impl ZebraDb {
         let sapling_anchors = self.db().cf_handle("sapling_anchors").unwrap();
         let orchard_anchors = self.db().cf_handle("orchard_anchors").unwrap();
 
+        let sprout_tree = sprout::tree::NoteCommitmentTree::default();
+        // Calculate the root so we pass the tree with a cached root to the database. We need to do
+        // that because the database checks if the tree has a cached root.
+        sprout_tree.root();
+
         for transaction in block.transactions.iter() {
             // Sprout
             for joinsplit in transaction.sprout_groth16_joinsplits() {
-                batch.zs_insert(
-                    &sprout_anchors,
-                    joinsplit.anchor,
-                    sprout::tree::NoteCommitmentTree::default(),
-                );
+                batch.zs_insert(&sprout_anchors, joinsplit.anchor, sprout_tree.clone());
             }
 
             // Sapling


### PR DESCRIPTION
## Motivation

Close #8739.

## Solution

- Cache the roots of Sprout trees before storing the trees in the state in tests.

### Tests

Tests in #8729 should pass after rebasing it atop this PR.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

