### PR TITLE
deps(librustzcash): Upgrade zcash dependencies for NU6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,6 +443,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bip32"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa13fae8b6255872fd86f7faf4b41168661d7d78609f7bfe6771b85c6739a15b"
+dependencies = [
+ "bs58",
+ "hmac",
+ "rand_core 0.6.4",
+ "ripemd",
+ "secp256k1 0.27.0",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,6 +1329,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "equihash"
+version = "0.2.0"
+source = "git+https://github.com/zcash/librustzcash/?branch=main#5a4a3e06dcd2cf5bdf79a7cd48709b58693c65f0"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,6 +1368,14 @@ name = "f4jumble"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a83e8d7fd0c526af4aad893b7c9fe41e2699ed8a776a6c74aecdeafe05afc75"
+dependencies = [
+ "blake2b_simd",
+]
+
+[[package]]
+name = "f4jumble"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash/?branch=main#5a4a3e06dcd2cf5bdf79a7cd48709b58693c65f0"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1408,7 +1441,7 @@ dependencies = [
  "futures-sink",
  "nanorand",
  "pin-project",
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -1743,19 +1776,6 @@ dependencies = [
  "flate2",
  "nom",
  "num-traits",
-]
-
-[[package]]
-name = "hdwallet"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a03ba7d4c9ea41552cd4351965ff96883e629693ae85005c501bb4b9e1c48a7"
-dependencies = [
- "lazy_static",
- "rand_core 0.6.4",
- "ring 0.16.20",
- "secp256k1",
- "thiserror",
 ]
 
 [[package]]
@@ -2360,7 +2380,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -3661,21 +3681,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
@@ -3684,8 +3689,8 @@ dependencies = [
  "cfg-if 1.0.0",
  "getrandom 0.2.15",
  "libc",
- "spin 0.9.8",
- "untrusted 0.9.0",
+ "spin",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -3784,7 +3789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.8",
+ "ring",
  "rustls-webpki",
  "sct",
 ]
@@ -3804,8 +3809,8 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3885,8 +3890,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.8",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3897,6 +3902,15 @@ checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
 dependencies = [
  "secp256k1-sys",
  "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
+dependencies = [
+ "secp256k1-sys",
 ]
 
 [[package]]
@@ -4270,12 +4284,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -5117,12 +5125,6 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -5651,9 +5653,21 @@ checksum = "827c17a1f7e3a69f0d44e991ff610c7a842228afdc9dc2325ffdd1a67fee01e9"
 dependencies = [
  "bech32",
  "bs58",
- "f4jumble",
- "zcash_encoding",
- "zcash_protocol",
+ "f4jumble 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zcash_address"
+version = "0.3.2"
+source = "git+https://github.com/zcash/librustzcash/?branch=main#5a4a3e06dcd2cf5bdf79a7cd48709b58693c65f0"
+dependencies = [
+ "bech32",
+ "bs58",
+ "f4jumble 0.1.0 (git+https://github.com/zcash/librustzcash/?branch=main)",
+ "zcash_encoding 0.2.0 (git+https://github.com/zcash/librustzcash/?branch=main)",
+ "zcash_protocol 0.1.1 (git+https://github.com/zcash/librustzcash/?branch=main)",
 ]
 
 [[package]]
@@ -5686,12 +5700,12 @@ dependencies = [
  "tonic-build 0.10.2",
  "tracing",
  "which",
- "zcash_address",
- "zcash_encoding",
+ "zcash_address 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_keys",
  "zcash_note_encryption",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_primitives 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip32",
 ]
 
@@ -5700,6 +5714,15 @@ name = "zcash_encoding"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f03391b81727875efa6ac0661a20883022b6fba92365dc121c48fa9b00c5aac0"
+dependencies = [
+ "byteorder",
+ "nonempty",
+]
+
+[[package]]
+name = "zcash_encoding"
+version = "0.2.0"
+source = "git+https://github.com/zcash/librustzcash/?branch=main#5a4a3e06dcd2cf5bdf79a7cd48709b58693c65f0"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -5735,10 +5758,10 @@ dependencies = [
  "secrecy",
  "subtle",
  "tracing",
- "zcash_address",
- "zcash_encoding",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_address 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip32",
 ]
 
@@ -5766,11 +5789,46 @@ dependencies = [
  "blake2b_simd",
  "byteorder",
  "document-features",
- "equihash",
+ "equihash 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff",
  "fpe",
  "group",
- "hdwallet",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "memuse",
+ "nonempty",
+ "orchard",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "sha2",
+ "subtle",
+ "tracing",
+ "zcash_address 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_note_encryption",
+ "zcash_protocol 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_primitives"
+version = "0.15.1"
+source = "git+https://github.com/zcash/librustzcash/?branch=main#5a4a3e06dcd2cf5bdf79a7cd48709b58693c65f0"
+dependencies = [
+ "aes",
+ "bip32",
+ "blake2b_simd",
+ "bs58",
+ "byteorder",
+ "document-features",
+ "equihash 0.2.0 (git+https://github.com/zcash/librustzcash/?branch=main)",
+ "ff",
+ "fpe",
+ "group",
  "hex",
  "incrementalmerkletree",
  "jubjub",
@@ -5782,14 +5840,14 @@ dependencies = [
  "redjubjub",
  "ripemd",
  "sapling-crypto",
- "secp256k1",
+ "secp256k1 0.27.0",
  "sha2",
  "subtle",
  "tracing",
- "zcash_address",
- "zcash_encoding",
+ "zcash_address 0.3.2 (git+https://github.com/zcash/librustzcash/?branch=main)",
+ "zcash_encoding 0.2.0 (git+https://github.com/zcash/librustzcash/?branch=main)",
  "zcash_note_encryption",
- "zcash_protocol",
+ "zcash_protocol 0.1.1 (git+https://github.com/zcash/librustzcash/?branch=main)",
  "zcash_spec",
  "zip32",
 ]
@@ -5814,7 +5872,7 @@ dependencies = [
  "sapling-crypto",
  "tracing",
  "xdg",
- "zcash_primitives",
+ "zcash_primitives 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5822,6 +5880,15 @@ name = "zcash_protocol"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f8189d4a304e8aa3aef3b75e89f3874bb0dc84b1cd623316a84e79e06cddabc"
+dependencies = [
+ "document-features",
+ "memuse",
+]
+
+[[package]]
+name = "zcash_protocol"
+version = "0.1.1"
+source = "git+https://github.com/zcash/librustzcash/?branch=main#5a4a3e06dcd2cf5bdf79a7cd48709b58693c65f0"
 dependencies = [
  "document-features",
  "memuse",
@@ -5862,7 +5929,7 @@ dependencies = [
  "color-eyre",
  "criterion",
  "ed25519-zebra",
- "equihash",
+ "equihash 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "group",
  "halo2_proofs",
@@ -5885,7 +5952,7 @@ dependencies = [
  "redjubjub",
  "ripemd",
  "sapling-crypto",
- "secp256k1",
+ "secp256k1 0.26.0",
  "serde",
  "serde-big-array",
  "serde_json",
@@ -5899,13 +5966,13 @@ dependencies = [
  "tracing",
  "uint",
  "x25519-dalek",
- "zcash_address",
+ "zcash_address 0.3.2 (git+https://github.com/zcash/librustzcash/?branch=main)",
  "zcash_client_backend",
- "zcash_encoding",
+ "zcash_encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_history",
  "zcash_note_encryption",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_primitives 0.15.1 (git+https://github.com/zcash/librustzcash/?branch=main)",
+ "zcash_protocol 0.1.1 (git+https://github.com/zcash/librustzcash/?branch=main)",
  "zebra-test",
 ]
 
@@ -5970,7 +6037,7 @@ dependencies = [
  "tonic-build 0.12.1",
  "tonic-reflection",
  "tower",
- "zcash_primitives",
+ "zcash_primitives 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zebra-chain",
  "zebra-node-services",
  "zebra-state",
@@ -6056,8 +6123,8 @@ dependencies = [
  "tonic-reflection",
  "tower",
  "tracing",
- "zcash_address",
- "zcash_primitives",
+ "zcash_address 0.3.2 (git+https://github.com/zcash/librustzcash/?branch=main)",
+ "zcash_primitives 0.15.1 (git+https://github.com/zcash/librustzcash/?branch=main)",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",
@@ -6099,11 +6166,11 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
- "zcash_address",
+ "zcash_address 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_client_backend",
  "zcash_keys",
  "zcash_note_encryption",
- "zcash_primitives",
+ "zcash_primitives 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zebra-chain",
  "zebra-grpc",
  "zebra-node-services",
@@ -6221,8 +6288,8 @@ dependencies = [
  "tracing-error",
  "tracing-subscriber",
  "zcash_client_backend",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_primitives 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zebra-chain",
  "zebra-node-services",
  "zebra-rpc",

--- a/deny.toml
+++ b/deny.toml
@@ -109,6 +109,7 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
+    https://github.com/zcash/librustzcash.git
 ]
 
 [sources.allow-org]

--- a/deny.toml
+++ b/deny.toml
@@ -12,7 +12,7 @@
 multiple-versions = "deny"
 
 # Don't allow wildcard ("any version") dependencies
-# TODO: Change to `deny` after weupgrade to crates.io version of the ECC dependencies (#8746).
+# TODO: Change to `deny` after we upgrade to crates.io version of the ECC dependencies (#8749).
 wildcards = "allow"
 # Allow private and dev wildcard dependencies.
 # Switch this to `false` when #6924 is implemented.
@@ -94,7 +94,7 @@ skip-tree = [
     { name = "http-body", version = "=0.4.6" },
     { name = "hyper", version = "=0.14.30" },
 
-    # Remove this after we upgrade ECC dependencies to a crates.io version (#8746)
+    # Remove this after we upgrade ECC dependencies to a crates.io version (#8749)
     { name = "equihash", version = "=0.2.0" },
     { name = "f4jumble", version = "=0.1.0" },
     { name = "secp256k1", version = "=0.26.0" },

--- a/deny.toml
+++ b/deny.toml
@@ -94,7 +94,7 @@ skip-tree = [
     { name = "http-body", version = "=0.4.6" },
     { name = "hyper", version = "=0.14.30" },
 
-    # Remove this after we upgrade ECC dependencies to a crates.io version (#8749)
+    # TODO: Remove this after we upgrade ECC dependencies to a crates.io version (#8749)
     { name = "equihash", version = "=0.2.0" },
     { name = "f4jumble", version = "=0.1.0" },
     { name = "secp256k1", version = "=0.26.0" },

--- a/deny.toml
+++ b/deny.toml
@@ -12,7 +12,8 @@
 multiple-versions = "deny"
 
 # Don't allow wildcard ("any version") dependencies
-wildcards = "deny"
+# TODO: Change to `deny` after weupgrade to crates.io version of the ECC dependencies (#8746).
+wildcards = "allow"
 # Allow private and dev wildcard dependencies.
 # Switch this to `false` when #6924 is implemented.
 allow-wildcard-paths = true
@@ -92,6 +93,15 @@ skip-tree = [
     { name = "http", version = "=0.2.12" },
     { name = "http-body", version = "=0.4.6" },
     { name = "hyper", version = "=0.14.30" },
+
+    # Remove this after we upgrade ECC dependencies to a crates.io version (#8746)
+    { name = "equihash", version = "=0.2.0" },
+    { name = "f4jumble", version = "=0.1.0" },
+    { name = "secp256k1", version = "=0.26.0" },
+    { name = "zcash_address", version = "=0.3.2" },
+    { name = "zcash_encoding", version = "=0.2.0" },
+    { name = "zcash_primitives", version = "=0.15.1" },
+    { name = "zcash_protocol", version = "=0.1.1" },
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/deny.toml
+++ b/deny.toml
@@ -109,7 +109,7 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
-    https://github.com/zcash/librustzcash.git
+    "https://github.com/zcash/librustzcash.git"
 ]
 
 [sources.allow-org]

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -97,10 +97,13 @@ orchard = "0.8.0"
 zcash_encoding = "0.2.0"
 zcash_history = "0.4.0"
 zcash_note_encryption = "0.4.0"
-zcash_primitives = { version = "0.15.0", features = ["transparent-inputs"] }
+# TODO: Revert to a release once librustzcash is released.
+zcash_primitives = { git = "https://github.com/zcash/librustzcash/", branch = "main", features = ["transparent-inputs"] }
 sapling = { package = "sapling-crypto", version = "0.1" }
-zcash_protocol = { version = "0.1.1" }
-zcash_address = { version = "0.3.2" }
+# TODO: Revert to a release once librustzcash is released.
+zcash_protocol = { git = "https://github.com/zcash/librustzcash/", branch = "main"}
+# TODO: Revert to a release once librustzcash is released.
+zcash_address = { git = "https://github.com/zcash/librustzcash/", branch = "main"}
 
 # Time
 chrono = { version = "0.4.38", default-features = false, features = ["clock", "std", "serde"] }
@@ -176,7 +179,3 @@ required-features = ["bench"]
 [[bench]]
 name = "redpallas"
 harness = false
-
-[lints.rust]
-# TODO: Remove this once it's no longer needed for NU6.
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(zcash_unstable, values("nu6"))'] }

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -97,12 +97,12 @@ orchard = "0.8.0"
 zcash_encoding = "0.2.0"
 zcash_history = "0.4.0"
 zcash_note_encryption = "0.4.0"
-# TODO: Revert to a release once librustzcash is released.
+# TODO: Revert to a release once librustzcash is released (#8749).
 zcash_primitives = { git = "https://github.com/zcash/librustzcash/", branch = "main", features = ["transparent-inputs"] }
 sapling = { package = "sapling-crypto", version = "0.1" }
-# TODO: Revert to a release once librustzcash is released.
+# TODO: Revert to a release once librustzcash is released (#8749).
 zcash_protocol = { git = "https://github.com/zcash/librustzcash/", branch = "main"}
-# TODO: Revert to a release once librustzcash is released.
+# TODO: Revert to a release once librustzcash is released (#8749).
 zcash_address = { git = "https://github.com/zcash/librustzcash/", branch = "main"}
 
 # Time

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -531,7 +531,6 @@ impl From<zcash_protocol::consensus::NetworkUpgrade> for NetworkUpgrade {
             zcash_protocol::consensus::NetworkUpgrade::Heartwood => Self::Heartwood,
             zcash_protocol::consensus::NetworkUpgrade::Canopy => Self::Canopy,
             zcash_protocol::consensus::NetworkUpgrade::Nu5 => Self::Nu5,
-            #[cfg(zcash_unstable = "nu6")]
             zcash_protocol::consensus::NetworkUpgrade::Nu6 => Self::Nu6,
         }
     }

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -88,12 +88,14 @@ hex = { version = "0.4.3", features = ["serde"] }
 serde = { version = "1.0.204", features = ["serde_derive"] }
 
 
-zcash_primitives = { version = "0.15.0" }
+# TODO: Revert to a release once librustzcash is released.
+zcash_primitives = { git = "https://github.com/zcash/librustzcash/", branch = "main", features = ["transparent-inputs"] }
 
 # Experimental feature getblocktemplate-rpcs
 rand = { version = "0.8.5", optional = true }
 # ECC deps used by getblocktemplate-rpcs feature
-zcash_address = { version = "0.3.2", optional = true }
+# TODO: Revert to a release once librustzcash is released.
+zcash_address = { git = "https://github.com/zcash/librustzcash/", branch = "main",  optional = true}
 
 # Test-only feature proptest-impl
 proptest = { version = "1.4.0", optional = true }

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -88,13 +88,13 @@ hex = { version = "0.4.3", features = ["serde"] }
 serde = { version = "1.0.204", features = ["serde_derive"] }
 
 
-# TODO: Revert to a release once librustzcash is released.
+# TODO: Revert to a release once librustzcash is released (#8749).
 zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", branch = "main", features = ["transparent-inputs"] }
 
 # Experimental feature getblocktemplate-rpcs
 rand = { version = "0.8.5", optional = true }
 # ECC deps used by getblocktemplate-rpcs feature
-# TODO: Revert to a release once librustzcash is released.
+# TODO: Revert to a release once librustzcash is released (#8749).
 zcash_address = { git = "https://github.com/zcash/librustzcash.git", branch = "main",  optional = true}
 
 # Test-only feature proptest-impl

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -89,13 +89,13 @@ serde = { version = "1.0.204", features = ["serde_derive"] }
 
 
 # TODO: Revert to a release once librustzcash is released.
-zcash_primitives = { git = "https://github.com/zcash/librustzcash/", branch = "main", features = ["transparent-inputs"] }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", branch = "main", features = ["transparent-inputs"] }
 
 # Experimental feature getblocktemplate-rpcs
 rand = { version = "0.8.5", optional = true }
 # ECC deps used by getblocktemplate-rpcs feature
 # TODO: Revert to a release once librustzcash is released.
-zcash_address = { git = "https://github.com/zcash/librustzcash/", branch = "main",  optional = true}
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", branch = "main",  optional = true}
 
 # Test-only feature proptest-impl
 proptest = { version = "1.4.0", optional = true }

--- a/zebra-scan/src/bin/scanning-results-reader/main.rs
+++ b/zebra-scan/src/bin/scanning-results-reader/main.rs
@@ -40,6 +40,7 @@ use zebra_scan::{storage::Storage, Config};
 #[allow(clippy::print_stdout)]
 pub fn main() {
     let network = zebra_chain::parameters::Network::Mainnet;
+    let zp_network = zebra_scan::scan::zp_network(&network);
     let storage = Storage::new(&Config::default(), &network, true);
     // If the first memo is empty, it doesn't get printed. But we never print empty memos anyway.
     let mut prev_memo = "".to_owned();
@@ -57,11 +58,13 @@ pub fn main() {
                 let tx = Transaction::read(
                     &hex::decode(fetch_tx_via_rpc(txid.encode_hex()))
                         .expect("RPC response should be decodable from hex string to bytes")[..],
-                    BranchId::for_height(&network, height),
+                    BranchId::for_height(&zp_network, height),
                 )
                 .expect("TX fetched via RPC should be deserializable from raw bytes");
 
-                for output in decrypt_transaction(&network, height, &tx, &ufvks).sapling_outputs() {
+                for output in
+                    decrypt_transaction(&zp_network, height, &tx, &ufvks).sapling_outputs()
+                {
                     let memo = memo_bytes_to_string(output.memo().as_array());
 
                     if !memo.is_empty()

--- a/zebra-scan/src/service/scan_task/scan.rs
+++ b/zebra-scan/src/service/scan_task/scan.rs
@@ -556,7 +556,7 @@ pub fn dfvk_to_ufvk(dfvk: &DiversifiableFullViewingKey) -> Result<UnifiedFullVie
     .map_err(|e| eyre!(e))
 }
 
-/// Returns the `zcash_primitives::consensus::Network` for this network.
+/// Returns the [`zcash_primitives::consensus::Network`] for this network.
 pub fn zp_network(network: &Network) -> zcash_primitives::consensus::Network {
     match network {
         Network::Mainnet => zcash_primitives::consensus::Network::MainNetwork,

--- a/zebra-scan/src/service/scan_task/scan.rs
+++ b/zebra-scan/src/service/scan_task/scan.rs
@@ -377,7 +377,7 @@ pub fn scan_block(
     };
 
     zcash_client_backend::scanning::scan_block(
-        network,
+        &zp_network(network),
         block_to_compact(block, chain_metadata),
         scanning_key,
         // Ignore whether notes are change from a viewer's own spends for now.
@@ -554,4 +554,12 @@ pub fn dfvk_to_ufvk(dfvk: &DiversifiableFullViewingKey) -> Result<UnifiedFullVie
         &dfvk.to_bytes()[..],
     ))?])?)
     .map_err(|e| eyre!(e))
+}
+
+/// Returns the `zcash_primitives::consensus::Network` for this network.
+pub fn zp_network(network: &Network) -> zcash_primitives::consensus::Network {
+    match network {
+        Network::Mainnet => zcash_primitives::consensus::Network::MainNetwork,
+        Network::Testnet(_) => zcash_primitives::consensus::Network::TestNetwork,
+    }
 }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -299,5 +299,4 @@ zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.5" }
 zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.38" }
 
 [lints.rust]
-# TODO: Remove 'cfg(zcash_unstable, values("nu6"))' once it's no longer needed for NU6.
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)', 'cfg(zcash_unstable, values("nu6"))'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -3239,7 +3239,7 @@ async fn trusted_chain_sync_handles_forks_correctly() -> Result<()> {
 /// `cargo test --package zebrad --test acceptance --features getblocktemplate-rpcs -- nu6_funding_streams_and_coinbase_balance --exact --show-output`
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "getblocktemplate-rpcs")]
-async fn nu6_funding_streams() -> Result<()> {
+async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
     use zebra_chain::{
         chain_sync_status::MockSyncStatus,
         parameters::{

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -3236,9 +3236,9 @@ async fn trusted_chain_sync_handles_forks_correctly() -> Result<()> {
 /// Test successful block template submission as a block proposal or submission on a custom Testnet.
 ///
 /// This test can be run locally with:
-/// `RUSTFLAGS='--cfg zcash_unstable="nu6"' cargo test --package zebrad --test acceptance --features getblocktemplate-rpcs -- nu6_funding_streams --exact --show-output`
+/// `cargo test --package zebrad --test acceptance --features getblocktemplate-rpcs -- nu6_funding_streams --exact --show-output`
 #[tokio::test(flavor = "multi_thread")]
-#[cfg(all(feature = "getblocktemplate-rpcs", zcash_unstable = "nu6"))]
+#[cfg(feature = "getblocktemplate-rpcs")]
 async fn nu6_funding_streams() -> Result<()> {
     use zebra_chain::{
         chain_sync_status::MockSyncStatus,


### PR DESCRIPTION
## Motivation

We want to use the current main version of librustzcash so we can remove unstable features.

We will get back to depend on a release after librustzcash components are released.

Close https://github.com/ZcashFoundation/zebra/issues/8713

## Solution

Upgrade, fix problems.

Draft until CI pass as there might be issues for example in the deny.toml.

### Tests

No tests were added as our current suite should be enough coverage.

### Follow-up Work

<!--
- Describe or list what's missing from the solution.
- List any follow-up issues.
- If this PR blocks or is blocked by any other work, provide a description, or
  list the related issues.
-->

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [ ] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

