### PR TITLE
chore(actions): remove warnings related to gcp and docker steps

### DIFF
--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -230,7 +230,6 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2.1.3
         with:
-          retries: '3'
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_DEPLOYMENTS_SA }}'
 
@@ -332,7 +331,6 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2.1.3
         with:
-          retries: '3'
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_DEPLOYMENTS_SA }}'
 

--- a/.github/workflows/chore-delete-gcp-resources.yml
+++ b/.github/workflows/chore-delete-gcp-resources.yml
@@ -48,7 +48,6 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2.1.3
         with:
-          retries: '3'
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_DEPLOYMENTS_SA }}'
 
@@ -116,7 +115,6 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2.1.3
         with:
-          retries: '3'
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_DEPLOYMENTS_SA }}'
           token_format: 'access_token'

--- a/.github/workflows/docs-deploy-firebase.yml
+++ b/.github/workflows/docs-deploy-firebase.yml
@@ -108,7 +108,6 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2.1.3
         with:
-          retries: '3'
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_FIREBASE_SA }}'
 
@@ -167,7 +166,6 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2.1.3
         with:
-          retries: '3'
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_FIREBASE_SA }}'
 

--- a/.github/workflows/manual-zcashd-deploy.yml
+++ b/.github/workflows/manual-zcashd-deploy.yml
@@ -54,7 +54,6 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2.1.3
         with:
-          retries: '3'
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_DEPLOYMENTS_SA }}'
 

--- a/.github/workflows/sub-build-docker-image.yml
+++ b/.github/workflows/sub-build-docker-image.yml
@@ -75,6 +75,8 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
+    env:
+      DOCKER_BUILD_SUMMARY: ${{ vars.DOCKER_BUILD_SUMMARY }}
     steps:
       - uses: actions/checkout@v4.1.7
         with:
@@ -124,7 +126,6 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2.1.3
         with:
-          retries: '3'
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_ARTIFACTS_SA }}'
           token_format: 'access_token'

--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -152,7 +152,6 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2.1.3
         with:
-          retries: '3'
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_DEPLOYMENTS_SA }}'
 

--- a/.github/workflows/sub-find-cached-disks.yml
+++ b/.github/workflows/sub-find-cached-disks.yml
@@ -47,7 +47,6 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2.1.3
         with:
-          retries: '3'
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_DEPLOYMENTS_SA }}'
 


### PR DESCRIPTION
## Motivation

Having warnings that are not helpful in our workflows summaries, makes warning that we should care about less relevant or harder to find.

![image](https://github.com/user-attachments/assets/336b9bde-4845-4bf3-bed0-4ad9a7931011)


## Solution

- Remove deprecated arguments
- Deactivate Docker summary (not supported by Docker Build Cloud, yet)
  - Use a variable `DOCKER_BUILD_SUMMARY ` and set it to false, as this feature might be available in the future

### Follow-up Work

I also tried solving this warning:
- `Unable to extend GITHUB_TOKEN expiration time due to: GITHUB_TOKEN has expired.`

But it seems we won't be able to do it, based on this discussion: 
- https://github.com/orgs/community/discussions/50472

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [X] The PR name will make sense to users.
- [X] The PR provides a CHANGELOG summary.
- [X] The solution is tested.
- [X] The documentation is up to date.
- [X] The PR has a priority label.
