### PR TITLE
fix(bug): Reduces `Debug` output for `Network` on Regtest and default Testnet

### DIFF
--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -41,7 +41,7 @@ impl From<Network> for NetworkKind {
 }
 
 /// An enum describing the possible network choices.
-#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+#[derive(Clone, Default, Eq, PartialEq, Serialize)]
 #[serde(into = "NetworkKind")]
 pub enum Network {
     /// The production mainnet.
@@ -118,6 +118,22 @@ impl<'a> From<&'a Network> for &'a str {
 impl fmt::Display for Network {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.into())
+    }
+}
+
+impl std::fmt::Debug for Network {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Mainnet => write!(f, "{self}"),
+            Self::Testnet(params) if params.is_regtest() => f
+                .debug_struct("Regtest")
+                .field("activation_heights", params.activation_heights())
+                .finish(),
+            Self::Testnet(params) if params.is_default_testnet() => {
+                write!(f, "{self}")
+            }
+            Self::Testnet(params) => f.debug_tuple("ConfiguredTestnet").field(params).finish(),
+        }
     }
 }
 


### PR DESCRIPTION
## Motivation

This has likely been part of what was causing our full Testnet sync to fail in CI as the test [expects a comma after the network name](https://github.com/ZcashFoundation/zebra/blob/fix-network-debug-impl/zebrad/tests/common/sync.rs#L387).

## Solution

- Reduces `Debug` output on the default Testnet to just the network name

Related changes:
- Reduces `Debug` output on Regtest to just the network name and activation heights (since the other fields are not currently configurable)

### Tests

The `full_sync_testnet` test should pass on this PR, running one here: https://github.com/ZcashFoundation/zebra/actions/runs/10381498189.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

