### PR TITLE
fix(test): Renames `regtest_submit_blocks` test to avoid an RPC port conflict

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -2957,7 +2957,7 @@ fn external_address() -> Result<()> {
 // TODO: Test this with an NU5 activation height too once config can be serialized.
 #[tokio::test]
 #[cfg(feature = "getblocktemplate-rpcs")]
-async fn regtest_submit_blocks() -> Result<()> {
+async fn regtest_block_templates_are_valid_block_submissions() -> Result<()> {
     common::regtest::submit_blocks_test().await?;
     Ok(())
 }


### PR DESCRIPTION
## Motivation

The `submit_block` test [failed here](https://github.com/ZcashFoundation/zebra/actions/runs/10379987688/job/28739428347#step:16:758), it happened [before the timeout](https://github.com/ZcashFoundation/zebra/actions/runs/10379987688/job/28739428347#step:16:342), so it must've panicked. The last log was the RPC listen address, and the test passed when it was run again, so it was likely due to a port conflict.

The `regtest_submit_blocks` test shouldn't be running there, and it could occasionally cause a port conflict since long-running tests like `submit_block` that use `TestType::zebrad_config()` are still using an unbound RPC port.

## Solution

Renames the `regtest_submit_blocks` test so it doesn't contain `"submit_block"`. 

### Tests

Only the `submit_block` test should run in that CI job in this PR.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [x] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

