### PR TITLE
rpc(getblock): Add value pools output

### DIFF
--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@mainnet_10.snap
@@ -9,5 +9,32 @@ expression: block
   "tx": [
     "851bf6fbf7a976327817c738c489d7fa657752445430922d94c983c0b9ed4609"
   ],
-  "trees": {}
+  "trees": {},
+  "valuePools": [
+    {
+      "id": "lockbox",
+      "valueDelta": 0.0,
+      "valueDeltaZat": 0
+    },
+    {
+      "id": "orchard",
+      "valueDelta": 0.0,
+      "valueDeltaZat": 0
+    },
+    {
+      "id": "sapling",
+      "valueDelta": 0.0,
+      "valueDeltaZat": 0
+    },
+    {
+      "id": "sprout",
+      "valueDelta": 0.0,
+      "valueDeltaZat": 0
+    },
+    {
+      "id": "transparent",
+      "valueDelta": 0.000625,
+      "valueDeltaZat": 62500
+    }
+  ]
 }

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@testnet_10.snap
@@ -9,5 +9,32 @@ expression: block
   "tx": [
     "f37e9f691fffb635de0999491d906ee85ba40cd36dae9f6e5911a8277d7c5f75"
   ],
-  "trees": {}
+  "trees": {},
+  "valuePools": [
+    {
+      "id": "lockbox",
+      "valueDelta": 0.0,
+      "valueDeltaZat": 0
+    },
+    {
+      "id": "orchard",
+      "valueDelta": 0.0,
+      "valueDeltaZat": 0
+    },
+    {
+      "id": "sapling",
+      "valueDelta": 0.0,
+      "valueDeltaZat": 0
+    },
+    {
+      "id": "sprout",
+      "valueDelta": 0.0,
+      "valueDeltaZat": 0
+    },
+    {
+      "id": "transparent",
+      "valueDelta": 0.000625,
+      "valueDeltaZat": 62500
+    }
+  ]
 }

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@mainnet_10.snap
@@ -10,5 +10,32 @@ expression: block
   "tx": [
     "851bf6fbf7a976327817c738c489d7fa657752445430922d94c983c0b9ed4609"
   ],
-  "trees": {}
+  "trees": {},
+  "valuePools": [
+    {
+      "id": "lockbox",
+      "valueDelta": 0.0,
+      "valueDeltaZat": 0
+    },
+    {
+      "id": "orchard",
+      "valueDelta": 0.0,
+      "valueDeltaZat": 0
+    },
+    {
+      "id": "sapling",
+      "valueDelta": 0.0,
+      "valueDeltaZat": 0
+    },
+    {
+      "id": "sprout",
+      "valueDelta": 0.0,
+      "valueDeltaZat": 0
+    },
+    {
+      "id": "transparent",
+      "valueDelta": 0.000625,
+      "valueDeltaZat": 62500
+    }
+  ]
 }

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@testnet_10.snap
@@ -10,5 +10,32 @@ expression: block
   "tx": [
     "f37e9f691fffb635de0999491d906ee85ba40cd36dae9f6e5911a8277d7c5f75"
   ],
-  "trees": {}
+  "trees": {},
+  "valuePools": [
+    {
+      "id": "lockbox",
+      "valueDelta": 0.0,
+      "valueDeltaZat": 0
+    },
+    {
+      "id": "orchard",
+      "valueDelta": 0.0,
+      "valueDeltaZat": 0
+    },
+    {
+      "id": "sapling",
+      "valueDelta": 0.0,
+      "valueDeltaZat": 0
+    },
+    {
+      "id": "sprout",
+      "valueDelta": 0.0,
+      "valueDeltaZat": 0
+    },
+    {
+      "id": "transparent",
+      "valueDelta": 0.000625,
+      "valueDeltaZat": 62500
+    }
+  ]
 }

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -145,6 +145,7 @@ async fn rpc_getblock() {
                     .map(|tx| tx.hash().encode_hex())
                     .collect(),
                 trees,
+                value_pools: vec![],
             }
         );
     }
@@ -169,6 +170,7 @@ async fn rpc_getblock() {
                     .map(|tx| tx.hash().encode_hex())
                     .collect(),
                 trees,
+                value_pools: vec![],
             }
         );
     }
@@ -193,6 +195,11 @@ async fn rpc_getblock() {
                     .map(|tx| tx.hash().encode_hex())
                     .collect(),
                 trees,
+                value_pools: create_value_pools(
+                    block
+                        .chain_value_pool_change(&std::collections::HashMap::new(), None)
+                        .unwrap()
+                ),
             }
         );
     }
@@ -217,6 +224,11 @@ async fn rpc_getblock() {
                     .map(|tx| tx.hash().encode_hex())
                     .collect(),
                 trees,
+                value_pools: create_value_pools(
+                    block
+                        .chain_value_pool_change(&std::collections::HashMap::new(), None)
+                        .unwrap()
+                ),
             }
         );
     }
@@ -241,6 +253,7 @@ async fn rpc_getblock() {
                     .map(|tx| tx.hash().encode_hex())
                     .collect(),
                 trees,
+                value_pools: vec![],
             }
         );
     }
@@ -265,6 +278,7 @@ async fn rpc_getblock() {
                     .map(|tx| tx.hash().encode_hex())
                     .collect(),
                 trees,
+                value_pools: vec![],
             }
         );
     }

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -1059,6 +1059,9 @@ pub enum ReadRequest {
     /// Returns [`ReadResponse::ValidBlockProposal`] when successful, or an error if
     /// the block fails contextual validation.
     CheckBlockProposalValidity(SemanticallyVerifiedBlock),
+
+    /// Get the value pools for a given block.
+    ValuePools(HashOrHeight),
 }
 
 impl ReadRequest {
@@ -1093,6 +1096,7 @@ impl ReadRequest {
             ReadRequest::SolutionRate { .. } => "solution_rate",
             #[cfg(feature = "getblocktemplate-rpcs")]
             ReadRequest::CheckBlockProposalValidity(_) => "check_block_proposal_validity",
+            ReadRequest::ValuePools(_) => "value_pools",
         }
     }
 

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -3,13 +3,14 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use zebra_chain::{
-    amount::{Amount, NonNegative},
+    amount::{Amount, NegativeAllowed, NonNegative},
     block::{self, Block},
     orchard, sapling,
     serialization::DateTime32,
     subtree::{NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex},
     transaction::{self, Transaction},
     transparent,
+    value_balance::ValueBalance,
 };
 
 #[cfg(feature = "getblocktemplate-rpcs")]
@@ -217,6 +218,9 @@ pub enum ReadResponse {
     #[cfg(feature = "getblocktemplate-rpcs")]
     /// Response to [`ReadRequest::CheckBlockProposalValidity`]
     ValidBlockProposal,
+
+    /// Response to [`ReadRequest::ValuePools`]
+    ValuePools(ValueBalance<NegativeAllowed>),
 }
 
 /// A structure with the information needed from the state to build a `getblocktemplate` RPC response.
@@ -294,7 +298,8 @@ impl TryFrom<ReadResponse> for Response {
             | ReadResponse::OrchardSubtrees(_)
             | ReadResponse::AddressBalance(_)
             | ReadResponse::AddressesTransactionIds(_)
-            | ReadResponse::AddressUtxos(_) => {
+            | ReadResponse::AddressUtxos(_)
+            | ReadResponse::ValuePools(_) => {
                 Err("there is no corresponding Response for this ReadResponse")
             }
 


### PR DESCRIPTION
## Motivation

We want the lockbox value pool information in the `getblock` output for a given block

The lockbox information was added in zcashd at https://github.com/zcash/zcash/pull/6912,  It is part of a list of pools that this PR adds to Zebra.

https://github.com/ZcashFoundation/zebra/issues/8730

### Specifications & References

https://github.com/zcash/zcash/pull/6912

## Solution

The solution implements the `valuePools` object and some of the fields. In zcashd this is like:

```
...
  "valuePools": [
    {
      "id": "transparent",
      "monitored": true,
      "chainValue": 0.03437500,
      "chainValueZat": 3437500,
      "valueDelta": 0.00625000,
      "valueDeltaZat": 625000
    },
 ...
 ```

Where `valueDelta` is the value pool for the requested block but `chainValue` is the value pool up to the requested blocks. Zebra do not keep track of value pools at specific heights for the finalized chain so i think we can't have that value. I am open to suggestions here. 

Solution implements `id`, `valueDelta` and `valueDeltaZat` for each pool including the lockbox

### Tests

Snapshot tests added by now.

### Follow-up Work

Need zcashd diff tests.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [ ] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

