### PR TITLE
docs(openapi): Update the spec for RPC changes done for NU6

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,6 +11,677 @@ info:
 servers:
   - url: http://localhost:8232
 paths:
+  /getinfo:
+    post:
+      tags:
+      - control
+      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getinfo
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: string
+                  default: VcpiZMXHk6
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"build":"some build version","subversion":"some subversion"}'
+  /getblockhash:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns the hash of the block of a given height iff the index argument correspond
+
+        **Request body `params` arguments:**
+
+        - `index` - The block index.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[1]'
+                method:
+                  type: string
+                  default: getblockhash
+                id:
+                  type: string
+                  default: S1AqXuOHrh
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getbestblockheightandhash:
+    post:
+      tags:
+      - blockchain
+      description: Returns the height and hash of the current best blockchain tip block, as a [`GetBlockHeightAndHash`] JSON struct.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getbestblockheightandhash
+                id:
+                  type: string
+                  default: 1AwTlfVAWO
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getaddresstxids:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns the transaction ids made by the provided transparent addresses.
+
+        **Request body `params` arguments:**
+
+        - `request` - A struct with the following named fields:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  default: CLcDRLFUk0
+                method:
+                  type: string
+                  default: getaddresstxids
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
+      responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '[]'
+  /getnetworksolps:
+    post:
+      tags:
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getnetworksolps
+                id:
+                  type: string
+                  default: j3JjycZnU0
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
+  /getaddressutxos:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns all unspent outputs for a list of addresses.
+
+        **Request body `params` arguments:**
+
+        - `addresses` - The addresses to get outputs from.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getaddressutxos
+                id:
+                  type: string
+                  default: XQF0I05idD
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"address":"t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs","txid":"0000000000000000000000000000000000000000000000000000000000000000","outputIndex":0,"script":"00000000000000000000","satoshis":0,"height":0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getblockchaininfo:
+    post:
+      tags:
+      - blockchain
+      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblockchaininfo
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: string
+                  default: IyFwdvSO9j
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"valuePools":[{"id":"transparent","chainValue":0.0,"chainValueZat":0},{"id":"sprout","chainValue":0.0,"chainValueZat":0},{"id":"sapling","chainValue":0.0,"chainValueZat":0},{"id":"orchard","chainValue":0.0,"chainValueZat":0},{"id":"deferred","chainValue":0.0,"chainValueZat":0}],"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
+  /getbestblockhash:
+    post:
+      tags:
+      - blockchain
+      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getbestblockhash
+                id:
+                  type: string
+                  default: p3nOruYQuW
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+  /getpeerinfo:
+    post:
+      tags:
+      - network
+      description: Returns data about each connected network node.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getpeerinfo
+                id:
+                  type: string
+                  default: P9T9pzLdtc
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"addr":"0.0.0.0:0"}'
+  /validateaddress:
+    post:
+      tags:
+      - util
+      description: |-
+        Checks if a zcash address is valid.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash address to validate.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  default: tMj0CpPioh
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: validateaddress
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"isvalid":false}'
+  /getnetworkhashps:
+    post:
+      tags:
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  default: lepilwCF6U
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getnetworkhashps
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
+  /z_listunifiedreceivers:
+    post:
+      tags:
+      - wallet
+      description: |-
+        Returns the list of individual payment addresses given a unified address.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash unified address to get the list from.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: z_listunifiedreceivers
+                id:
+                  type: string
+                  default: Pl8cKIU3C7
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"orchard":"orchard address if any","sapling":"sapling address if any","p2pkh":"p2pkh address if any","p2sh":"p2sh address if any"}'
+  /getblocktemplate:
+    post:
+      tags:
+      - mining
+      description: |-
+        Returns a block template for mining new Zcash blocks.
+
+        **Request body `params` arguments:**
+
+        - `jsonrequestobject` - A JSON object containing arguments.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblocktemplate
+                id:
+                  type: string
+                  default: o8Br99rUmN
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /getmininginfo:
+    post:
+      tags:
+      - mining
+      description: Returns mining-related information.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  default: 6XNHWj7aB7
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: getmininginfo
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
+  /getblockcount:
+    post:
+      tags:
+      - blockchain
+      description: Returns the height of the most recent block in the best valid block chain (equivalently,
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  default: LlDAEBzezb
+                method:
+                  type: string
+                  default: getblockcount
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
+  /z_validateaddress:
+    post:
+      tags:
+      - util
+      description: |-
+        Checks if a zcash address is valid.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash address to validate.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: string
+                  default: 17jElx6yqZ
+                method:
+                  type: string
+                  default: z_validateaddress
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"isvalid":false}'
+  /submitblock:
+    post:
+      tags:
+      - mining
+      description: |-
+        Submits block to the node to be validated and committed.
+
+        **Request body `params` arguments:**
+
+        - `jsonparametersobject` - - currently ignored
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  default: BBwQ3RQ5a5
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                method:
+                  type: string
+                  default: submitblock
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"rejected"'
+  /z_getsubtreesbyindex:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns information about a range of Sapling or Orchard subtrees.
+
+        **Request body `params` arguments:**
+
+        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
+        - `start_index` - The index of the first 2^16-leaf subtree to return.
+        - `limit` - The maximum number of subtree values to return.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+                id:
+                  type: string
+                  default: o2ZAoa7n07
+                method:
+                  type: string
+                  default: z_getsubtreesbyindex
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"pool":"sapling | orchard","start_index":0,"subtrees":[]}'
   /getblock:
     post:
       tags:
@@ -38,7 +709,55 @@ paths:
                   default: getblock
                 id:
                   type: string
-                  default: ZIRjKWa3u3
+                  default: vERi9BqVGz
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getblocksubsidy:
+    post:
+      tags:
+      - mining
+      description: |-
+        Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
+
+        **Request body `params` arguments:**
+
+        - `height` - Can be any valid current or future height.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  default: rLmPnnIVhS
+                params:
+                  type: array
+                  items: {}
+                  default: '[1]'
+                method:
+                  type: string
+                  default: getblocksubsidy
       responses:
         '400':
           description: Bad request
@@ -59,12 +778,12 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
-  /getinfo:
+                    default: '{"miner":0.0,"founders":0.0,"fundingstreamstotal":0.0,"lockboxtotal":0.0,"totalblocksubsidy":0.0}'
+  /getdifficulty:
     post:
       tags:
-      - control
-      description: Returns software information from the RPC server, as a [`GetInfo`] JSON struct.
+      - blockchain
+      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
       requestBody:
         required: true
         content:
@@ -72,12 +791,12 @@ paths:
             schema:
               type: object
               properties:
-                method:
-                  type: string
-                  default: getinfo
                 id:
                   type: string
-                  default: bnMfmMTZg2
+                  default: ERvom5PVe3
+                method:
+                  type: string
+                  default: getdifficulty
                 params:
                   type: array
                   items: {}
@@ -92,17 +811,17 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{"build":"some build version","subversion":"some subversion"}'
-  /getaddresstxids:
+                    default: '0.0'
+  /sendrawtransaction:
     post:
       tags:
-      - address
+      - transaction
       description: |-
-        Returns the transaction ids made by the provided transparent addresses.
+        Sends the raw bytes of a signed transaction to the local node''s mempool, if the transaction is valid.
 
         **Request body `params` arguments:**
 
-        - `request` - A struct with the following named fields:
+        - `raw_transaction_hex` - The hex-encoded raw transaction bytes.
       requestBody:
         required: true
         content:
@@ -112,15 +831,25 @@ paths:
               properties:
                 method:
                   type: string
-                  default: getaddresstxids
+                  default: sendrawtransaction
                 id:
                   type: string
-                  default: B8VMAM4QVE
+                  default: 7Is5gKACas
                 params:
                   type: array
                   items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
+                  default: '["signedhex"]'
       responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
         '400':
           description: Bad request
           content:
@@ -131,16 +860,6 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '[]'
   /getaddressbalance:
     post:
       tags:
@@ -158,16 +877,16 @@ paths:
             schema:
               type: object
               properties:
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
                 method:
                   type: string
                   default: getaddressbalance
                 id:
                   type: string
-                  default: NA7pOvDSEt
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
+                  default: RLL3gIFkfb
       responses:
         '200':
           description: OK
@@ -189,6 +908,39 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
+  /getrawmempool:
+    post:
+      tags:
+      - blockchain
+      description: Returns all transaction ids in the memory pool, as a JSON array.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getrawmempool
+                id:
+                  type: string
+                  default: ZZsLmMamA3
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '[]'
   /z_gettreestate:
     post:
       tags:
@@ -206,27 +958,17 @@ paths:
             schema:
               type: object
               properties:
+                id:
+                  type: string
+                  default: OC5K0jGgMR
+                method:
+                  type: string
+                  default: z_gettreestate
                 params:
                   type: array
                   items: {}
                   default: '["00000000febc373a1da2bd9f887b105ad79ddc26ac26c2b28652d64e5207c5b5"]'
-                method:
-                  type: string
-                  default: z_gettreestate
-                id:
-                  type: string
-                  default: 7fsifMJFvD
       responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
         '200':
           description: OK
           content:
@@ -237,77 +979,16 @@ paths:
                   result:
                     type: object
                     default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","height":0,"time":0}'
-  /getblocktemplate:
-    post:
-      tags:
-      - mining
-      description: |-
-        Returns a block template for mining new Zcash blocks.
-
-        **Request body `params` arguments:**
-
-        - `jsonrequestobject` - A JSON object containing arguments.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: string
-                  default: 434jrn4jzN
-                method:
-                  type: string
-                  default: getblocktemplate
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
+        '400':
+          description: Bad request
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getblockcount:
-    post:
-      tags:
-      - blockchain
-      description: Returns the height of the most recent block in the best valid block chain (equivalently,
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: string
-                  default: OAVHYYvbys
-                method:
-                  type: string
-                  default: getblockcount
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0'
+                  error:
+                    type: string
+                    default: Invalid parameters
   /getrawtransaction:
     post:
       tags:
@@ -326,17 +1007,27 @@ paths:
             schema:
               type: object
               properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '["mytxid", 1]'
                 method:
                   type: string
                   default: getrawtransaction
                 id:
                   type: string
-                  default: oFXx0njb3Q
+                  default: uKvbHUWnFK
+                params:
+                  type: array
+                  items: {}
+                  default: '["mytxid", 1]'
       responses:
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
         '200':
           description: OK
           content:
@@ -347,661 +1038,3 @@ paths:
                   result:
                     type: object
                     default: '{"hex":"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","height":0,"confirmations":0}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getmininginfo:
-    post:
-      tags:
-      - mining
-      description: Returns mining-related information.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: string
-                  default: 6JMrKCulfK
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getmininginfo
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
-  /getnetworksolps:
-    post:
-      tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getnetworksolps
-                id:
-                  type: string
-                  default: njhGtG4nug
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0'
-  /getblocksubsidy:
-    post:
-      tags:
-      - mining
-      description: |-
-        Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
-
-        **Request body `params` arguments:**
-
-        - `height` - Can be any valid current or future height.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[1]'
-                id:
-                  type: string
-                  default: o9on8TUcxC
-                method:
-                  type: string
-                  default: getblocksubsidy
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"fundingstreams":[],"miner":0.0,"founders":0.0}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getdifficulty:
-    post:
-      tags:
-      - blockchain
-      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: string
-                  default: mZ3lenrWTl
-                method:
-                  type: string
-                  default: getdifficulty
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0.0'
-  /z_listunifiedreceivers:
-    post:
-      tags:
-      - wallet
-      description: |-
-        Returns the list of individual payment addresses given a unified address.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash unified address to get the list from.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: string
-                  default: lv1vEXiEVB
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: z_listunifiedreceivers
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"orchard":"orchard address if any","sapling":"sapling address if any","p2pkh":"p2pkh address if any","p2sh":"p2sh address if any"}'
-  /validateaddress:
-    post:
-      tags:
-      - util
-      description: |-
-        Checks if a zcash address is valid.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash address to validate.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: validateaddress
-                id:
-                  type: string
-                  default: v8H0x69zSY
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"isvalid":false}'
-  /getblockchaininfo:
-    post:
-      tags:
-      - blockchain
-      description: Returns blockchain state information, as a [`GetBlockChainInfo`] JSON struct.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getblockchaininfo
-                id:
-                  type: string
-                  default: zRjGZZwAnV
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
-  /sendrawtransaction:
-    post:
-      tags:
-      - transaction
-      description: |-
-        Sends the raw bytes of a signed transaction to the local node''s mempool, if the transaction is valid.
-
-        **Request body `params` arguments:**
-
-        - `raw_transaction_hex` - The hex-encoded raw transaction bytes.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: string
-                  default: Jfjekl0y9o
-                method:
-                  type: string
-                  default: sendrawtransaction
-                params:
-                  type: array
-                  items: {}
-                  default: '["signedhex"]'
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-  /getaddressutxos:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns all unspent outputs for a list of addresses.
-
-        **Request body `params` arguments:**
-
-        - `addresses` - The addresses to get outputs from.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: string
-                  default: z9RH4BT3dD
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
-                method:
-                  type: string
-                  default: getaddressutxos
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"address":"t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs","txid":"0000000000000000000000000000000000000000000000000000000000000000","outputIndex":0,"script":"00000000000000000000","satoshis":0,"height":0}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getnetworkhashps:
-    post:
-      tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: string
-                  default: 5DEifPkJXG
-                method:
-                  type: string
-                  default: getnetworkhashps
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0'
-  /getblockhash:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns the hash of the block of a given height iff the index argument correspond
-
-        **Request body `params` arguments:**
-
-        - `index` - The block index.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[1]'
-                id:
-                  type: string
-                  default: FEsc1mYWNA
-                method:
-                  type: string
-                  default: getblockhash
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /submitblock:
-    post:
-      tags:
-      - mining
-      description: |-
-        Submits block to the node to be validated and committed.
-
-        **Request body `params` arguments:**
-
-        - `jsonparametersobject` - - currently ignored
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: submitblock
-                id:
-                  type: string
-                  default: YSNgpz5kOl
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"rejected"'
-  /z_validateaddress:
-    post:
-      tags:
-      - util
-      description: |-
-        Checks if a zcash address is valid.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash address to validate.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: z_validateaddress
-                id:
-                  type: string
-                  default: 0m8Q1ZRXFa
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"isvalid":false}'
-  /z_getsubtreesbyindex:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns information about a range of Sapling or Orchard subtrees.
-
-        **Request body `params` arguments:**
-
-        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
-        - `start_index` - The index of the first 2^16-leaf subtree to return.
-        - `limit` - The maximum number of subtree values to return.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: string
-                  default: TCjABbbF6x
-                method:
-                  type: string
-                  default: z_getsubtreesbyindex
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"pool":"sapling | orchard","start_index":0,"subtrees":[]}'
-  /getrawmempool:
-    post:
-      tags:
-      - blockchain
-      description: Returns all transaction ids in the memory pool, as a JSON array.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getrawmempool
-                id:
-                  type: string
-                  default: 3KcsXMidC9
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '[]'
-  /getpeerinfo:
-    post:
-      tags:
-      - network
-      description: Returns data about each connected network node.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getpeerinfo
-                id:
-                  type: string
-                  default: dPCf95i0af
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"addr":"0.0.0.0:0"}'
-  /getbestblockhash:
-    post:
-      tags:
-      - blockchain
-      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getbestblockhash
-                id:
-                  type: string
-                  default: iqmITz3oTr
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'


### PR DESCRIPTION
## Motivation

We made some changes to the RPC methods for the NU6. By this the openapi.yaml spec is out of date. 

No code changes are needed but just re run the utility to buid the spec with the command described [here](https://github.com/ZcashFoundation/zebra/tree/main/zebra-utils#openapi-generator).

## Solution

Run the openapi utility tool. Push the results.

### Tests

Manually, looks good, default responses of the modified RPC methods(getblocksubsidy, getblockchaininfo) were upgraded as expected.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [ ] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

