### PR TITLE
docs(fix): `reject_and_remove_same_effects` docs is wrong

### DIFF
--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -294,8 +294,8 @@ impl Storage {
     /// - Removes from the 'verified' set, if present.
     ///   Maintains the order in which the other unmined transactions have been inserted into the mempool.
     ///
-    /// Reject and remove transactions from the mempool that contain any outpoints or nullifiers in
-    /// the `spent_outpoints` or `nullifiers` collections that are obtained from the passed in transaction.
+    /// Reject and remove transactions from the mempool that contain any spent outpoints or revealed
+    /// nullifiers from the passed in `transactions`.
     ///
     /// Returns the number of transactions that were removed.
     pub fn reject_and_remove_same_effects(

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -295,7 +295,7 @@ impl Storage {
     ///   Maintains the order in which the other unmined transactions have been inserted into the mempool.
     ///
     /// Reject and remove transactions from the mempool that contain any outpoints or nullifiers in
-    /// the `spent_outpoints` or `nullifiers` collections that are passed in.
+    /// the `spent_outpoints` or `nullifiers` collections that are obtained from the passed in transaction.
     ///
     /// Returns the number of transactions that were removed.
     pub fn reject_and_remove_same_effects(


### PR DESCRIPTION
## Motivation

Pointed by @daira in discord.

https://discordapp.com/channels/809218587167293450/809251029673312267/1275432591360790578

> minor doc issue for that function:
> /// Reject and remove transactions from the mempool that contain any outpoints or nullifiers in
> /// the spent_outpoints or nullifiers collections that are passed in.
> There are no spent_outpoints or nullifiers parameters. The spent outpoints and nullifiers are obtained from the transactions argument.

## Solution

Fix the doc comment.

