### PR TITLE
fix(test): Updates ignored failure messages in `lightwalletd_integration` test

### DIFF
--- a/zebra-rpc/src/methods/get_block_template_rpcs/get_block_template.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/get_block_template.rs
@@ -25,9 +25,12 @@ use zebra_consensus::{
 use zebra_node_services::mempool;
 use zebra_state::GetBlockTemplateChainInfo;
 
-use crate::methods::get_block_template_rpcs::{
-    constants::{MAX_ESTIMATED_DISTANCE_TO_NETWORK_CHAIN_TIP, NOT_SYNCED_ERROR_CODE},
-    types::{default_roots::DefaultRoots, transaction::TransactionTemplate},
+use crate::methods::{
+    errors::OkOrServerError,
+    get_block_template_rpcs::{
+        constants::{MAX_ESTIMATED_DISTANCE_TO_NETWORK_CHAIN_TIP, NOT_SYNCED_ERROR_CODE},
+        types::{default_roots::DefaultRoots, transaction::TransactionTemplate},
+    },
 };
 
 pub use crate::methods::get_block_template_rpcs::types::get_block_template::*;
@@ -178,11 +181,7 @@ where
     // but this is ok for an estimate
     let (estimated_distance_to_chain_tip, local_tip_height) = latest_chain_tip
         .estimate_distance_to_network_chain_tip(network)
-        .ok_or_else(|| Error {
-            code: ErrorCode::ServerError(0),
-            message: "No Chain tip available yet".to_string(),
-            data: None,
-        })?;
+        .ok_or_server_error("no chain tip available yet")?;
 
     if !sync_status.is_close_to_tip()
         || estimated_distance_to_chain_tip > MAX_ESTIMATED_DISTANCE_TO_NETWORK_CHAIN_TIP

--- a/zebrad/tests/common/failure_messages.rs
+++ b/zebrad/tests/common/failure_messages.rs
@@ -121,7 +121,7 @@ pub const LIGHTWALLETD_EMPTY_ZEBRA_STATE_IGNORE_MESSAGES: &[&str] = &[
     //
     // This log matches the "error with" RPC error message,
     // but we expect Zebra to start with an empty state.
-    r#"No Chain tip available yet","level":"warning","msg":"error with getblockchaininfo rpc, retrying"#,
+    r#"no chain tip available yet","level":"warning","msg":"error with getblockchaininfo rpc, retrying"#,
 ];
 
 /// Failure log messages from `zebra-checkpoints`.

--- a/zebrad/tests/common/test_type.rs
+++ b/zebrad/tests/common/test_type.rs
@@ -330,7 +330,7 @@ impl TestType {
         // Zebra state failures
         if self.needs_zebra_cached_state() {
             // Fail if we need a cached Zebra state, but it's empty
-            lightwalletd_failure_messages.push("No Chain tip available yet".to_string());
+            lightwalletd_failure_messages.push("no chain tip available yet".to_string());
         }
 
         // lightwalletd state failures


### PR DESCRIPTION
## Motivation

The error returned by the `getblockchaininfo` RPC method was updated in #8769 for consistency, but now the `lightwalletd_integration` test frequently fails because the expected failure message isn't ignored.

## Solution

- Updates the ignored failure message.

Related changes:
- Updates an error conversion to use the `.ok_or_server_error()` method

### Tests

The `lightwalletd_integration` test should pass for this PR. (https://github.com/ZcashFoundation/zebra/actions/runs/10478114195/job/29021273807?pr=8784)

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [x] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

