### PR TITLE
fix(openapi): Order of the generated openapi.yaml spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6272,6 +6272,7 @@ version = "1.0.0-beta.38"
 dependencies = [
  "color-eyre",
  "hex",
+ "indexmap 2.3.0",
  "itertools 0.13.0",
  "jsonrpc",
  "quote",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -26,13 +26,13 @@ paths:
                 method:
                   type: string
                   default: getinfo
+                id:
+                  type: string
+                  default: x2r3lRddGL
                 params:
                   type: array
                   items: {}
                   default: '[]'
-                id:
-                  type: string
-                  default: VcpiZMXHk6
       responses:
         '200':
           description: OK
@@ -44,216 +44,6 @@ paths:
                   result:
                     type: object
                     default: '{"build":"some build version","subversion":"some subversion"}'
-  /getblockhash:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns the hash of the block of a given height iff the index argument correspond
-
-        **Request body `params` arguments:**
-
-        - `index` - The block index.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[1]'
-                method:
-                  type: string
-                  default: getblockhash
-                id:
-                  type: string
-                  default: S1AqXuOHrh
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-  /getbestblockheightandhash:
-    post:
-      tags:
-      - blockchain
-      description: Returns the height and hash of the current best blockchain tip block, as a [`GetBlockHeightAndHash`] JSON struct.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getbestblockheightandhash
-                id:
-                  type: string
-                  default: 1AwTlfVAWO
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getaddresstxids:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns the transaction ids made by the provided transparent addresses.
-
-        **Request body `params` arguments:**
-
-        - `request` - A struct with the following named fields:
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: string
-                  default: CLcDRLFUk0
-                method:
-                  type: string
-                  default: getaddresstxids
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '[]'
-  /getnetworksolps:
-    post:
-      tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getnetworksolps
-                id:
-                  type: string
-                  default: j3JjycZnU0
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0'
-  /getaddressutxos:
-    post:
-      tags:
-      - address
-      description: |-
-        Returns all unspent outputs for a list of addresses.
-
-        **Request body `params` arguments:**
-
-        - `addresses` - The addresses to get outputs from.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getaddressutxos
-                id:
-                  type: string
-                  default: XQF0I05idD
-                params:
-                  type: array
-                  items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"address":"t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs","txid":"0000000000000000000000000000000000000000000000000000000000000000","outputIndex":0,"script":"00000000000000000000","satoshis":0,"height":0}'
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
   /getblockchaininfo:
     post:
       tags:
@@ -269,13 +59,13 @@ paths:
                 method:
                   type: string
                   default: getblockchaininfo
+                id:
+                  type: string
+                  default: w8Lb0nAvLd
                 params:
                   type: array
                   items: {}
                   default: '[]'
-                id:
-                  type: string
-                  default: IyFwdvSO9j
       responses:
         '200':
           description: OK
@@ -287,82 +77,16 @@ paths:
                   result:
                     type: object
                     default: '{"chain":"main","blocks":1,"bestblockhash":"0000000000000000000000000000000000000000000000000000000000000000","estimatedheight":1,"valuePools":[{"id":"transparent","chainValue":0.0,"chainValueZat":0},{"id":"sprout","chainValue":0.0,"chainValueZat":0},{"id":"sapling","chainValue":0.0,"chainValueZat":0},{"id":"orchard","chainValue":0.0,"chainValueZat":0},{"id":"deferred","chainValue":0.0,"chainValueZat":0}],"upgrades":{},"consensus":{"chaintip":"00000000","nextblock":"00000000"}}'
-  /getbestblockhash:
+  /getaddressbalance:
     post:
       tags:
-      - blockchain
-      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getbestblockhash
-                id:
-                  type: string
-                  default: p3nOruYQuW
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
-  /getpeerinfo:
-    post:
-      tags:
-      - network
-      description: Returns data about each connected network node.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getpeerinfo
-                id:
-                  type: string
-                  default: P9T9pzLdtc
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"addr":"0.0.0.0:0"}'
-  /validateaddress:
-    post:
-      tags:
-      - util
+      - address
       description: |-
-        Checks if a zcash address is valid.
+        Returns the total balance of a provided `addresses` in an [`AddressBalance`] instance.
 
         **Request body `params` arguments:**
 
-        - `address` - The zcash address to validate.
+        - `address_strings` - A JSON map with a single entry
       requestBody:
         required: true
         content:
@@ -370,16 +94,16 @@ paths:
             schema:
               type: object
               properties:
+                method:
+                  type: string
+                  default: getaddressbalance
                 id:
                   type: string
-                  default: tMj0CpPioh
+                  default: QbTztoTvRo
                 params:
                   type: array
                   items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: validateaddress
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
       responses:
         '200':
           description: OK
@@ -390,337 +114,7 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{"isvalid":false}'
-  /getnetworkhashps:
-    post:
-      tags:
-      - mining
-      description: Returns the estimated network solutions per second based on the last `num_blocks` before
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: string
-                  default: lepilwCF6U
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getnetworkhashps
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0'
-  /z_listunifiedreceivers:
-    post:
-      tags:
-      - wallet
-      description: |-
-        Returns the list of individual payment addresses given a unified address.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash unified address to get the list from.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: z_listunifiedreceivers
-                id:
-                  type: string
-                  default: Pl8cKIU3C7
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"orchard":"orchard address if any","sapling":"sapling address if any","p2pkh":"p2pkh address if any","p2sh":"p2sh address if any"}'
-  /getblocktemplate:
-    post:
-      tags:
-      - mining
-      description: |-
-        Returns a block template for mining new Zcash blocks.
-
-        **Request body `params` arguments:**
-
-        - `jsonrequestobject` - A JSON object containing arguments.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                method:
-                  type: string
-                  default: getblocktemplate
-                id:
-                  type: string
-                  default: o8Br99rUmN
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{}'
-  /getmininginfo:
-    post:
-      tags:
-      - mining
-      description: Returns mining-related information.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: string
-                  default: 6XNHWj7aB7
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: getmininginfo
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
-  /getblockcount:
-    post:
-      tags:
-      - blockchain
-      description: Returns the height of the most recent block in the best valid block chain (equivalently,
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: string
-                  default: LlDAEBzezb
-                method:
-                  type: string
-                  default: getblockcount
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0'
-  /z_validateaddress:
-    post:
-      tags:
-      - util
-      description: |-
-        Checks if a zcash address is valid.
-
-        **Request body `params` arguments:**
-
-        - `address` - The zcash address to validate.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: string
-                  default: 17jElx6yqZ
-                method:
-                  type: string
-                  default: z_validateaddress
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"isvalid":false}'
-  /submitblock:
-    post:
-      tags:
-      - mining
-      description: |-
-        Submits block to the node to be validated and committed.
-
-        **Request body `params` arguments:**
-
-        - `jsonparametersobject` - - currently ignored
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: string
-                  default: BBwQ3RQ5a5
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                method:
-                  type: string
-                  default: submitblock
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '"rejected"'
-  /z_getsubtreesbyindex:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns information about a range of Sapling or Orchard subtrees.
-
-        **Request body `params` arguments:**
-
-        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
-        - `start_index` - The index of the first 2^16-leaf subtree to return.
-        - `limit` - The maximum number of subtree values to return.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-                id:
-                  type: string
-                  default: o2ZAoa7n07
-                method:
-                  type: string
-                  default: z_getsubtreesbyindex
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"pool":"sapling | orchard","start_index":0,"subtrees":[]}'
-  /getblock:
-    post:
-      tags:
-      - blockchain
-      description: |-
-        Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
-
-        **Request body `params` arguments:**
-
-        - `hash_or_height` - The hash or height for the block to be returned.
-        - `verbosity` - 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                params:
-                  type: array
-                  items: {}
-                  default: '["1", 1]'
-                method:
-                  type: string
-                  default: getblock
-                id:
-                  type: string
-                  default: vERi9BqVGz
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
+                    default: '{"balance":0}'
         '400':
           description: Bad request
           content:
@@ -731,87 +125,6 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getblocksubsidy:
-    post:
-      tags:
-      - mining
-      description: |-
-        Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
-
-        **Request body `params` arguments:**
-
-        - `height` - Can be any valid current or future height.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: string
-                  default: rLmPnnIVhS
-                params:
-                  type: array
-                  items: {}
-                  default: '[1]'
-                method:
-                  type: string
-                  default: getblocksubsidy
-      responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '{"miner":0.0,"founders":0.0,"fundingstreamstotal":0.0,"lockboxtotal":0.0,"totalblocksubsidy":0.0}'
-  /getdifficulty:
-    post:
-      tags:
-      - blockchain
-      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: string
-                  default: ERvom5PVe3
-                method:
-                  type: string
-                  default: getdifficulty
-                params:
-                  type: array
-                  items: {}
-                  default: '[]'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  result:
-                    type: object
-                    default: '0.0'
   /sendrawtransaction:
     post:
       tags:
@@ -834,7 +147,7 @@ paths:
                   default: sendrawtransaction
                 id:
                   type: string
-                  default: 7Is5gKACas
+                  default: aDK5RQWj16
                 params:
                   type: array
                   items: {}
@@ -860,16 +173,17 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
-  /getaddressbalance:
+  /getblock:
     post:
       tags:
-      - address
+      - blockchain
       description: |-
-        Returns the total balance of a provided `addresses` in an [`AddressBalance`] instance.
+        Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
 
         **Request body `params` arguments:**
 
-        - `address_strings` - A JSON map with a single entry
+        - `hash_or_height` - The hash or height for the block to be returned.
+        - `verbosity` - 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data.
       requestBody:
         required: true
         content:
@@ -877,16 +191,16 @@ paths:
             schema:
               type: object
               properties:
+                method:
+                  type: string
+                  default: getblock
+                id:
+                  type: string
+                  default: xxCP1d61X0
                 params:
                   type: array
                   items: {}
-                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
-                method:
-                  type: string
-                  default: getaddressbalance
-                id:
-                  type: string
-                  default: RLL3gIFkfb
+                  default: '["1", 1]'
       responses:
         '200':
           description: OK
@@ -897,7 +211,7 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{"balance":0}'
+                    default: '{"hash":"0000000000000000000000000000000000000000000000000000000000000000","confirmations":0,"tx":[],"trees":{}}'
         '400':
           description: Bad request
           content:
@@ -908,6 +222,72 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
+  /getbestblockhash:
+    post:
+      tags:
+      - blockchain
+      description: Returns the hash of the current best blockchain tip block, as a [`GetBlockHash`] JSON string.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getbestblockhash
+                id:
+                  type: string
+                  default: DoZgd1j7xW
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+  /getbestblockheightandhash:
+    post:
+      tags:
+      - blockchain
+      description: Returns the height and hash of the current best blockchain tip block, as a [`GetBlockHeightAndHash`] JSON struct.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getbestblockheightandhash
+                id:
+                  type: string
+                  default: 0iUFHsOjk3
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
   /getrawmempool:
     post:
       tags:
@@ -925,7 +305,7 @@ paths:
                   default: getrawmempool
                 id:
                   type: string
-                  default: ZZsLmMamA3
+                  default: WXG2c6FcCK
                 params:
                   type: array
                   items: {}
@@ -958,12 +338,12 @@ paths:
             schema:
               type: object
               properties:
-                id:
-                  type: string
-                  default: OC5K0jGgMR
                 method:
                   type: string
                   default: z_gettreestate
+                id:
+                  type: string
+                  default: 38P0xXV0do
                 params:
                   type: array
                   items: {}
@@ -989,6 +369,46 @@ paths:
                   error:
                     type: string
                     default: Invalid parameters
+  /z_getsubtreesbyindex:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns information about a range of Sapling or Orchard subtrees.
+
+        **Request body `params` arguments:**
+
+        - `pool` - The pool from which subtrees should be returned. Either \"sapling\" or \"orchard\".
+        - `start_index` - The index of the first 2^16-leaf subtree to return.
+        - `limit` - The maximum number of subtree values to return.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: z_getsubtreesbyindex
+                id:
+                  type: string
+                  default: 662iR8VZGT
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"pool":"sapling | orchard","start_index":0,"subtrees":[]}'
   /getrawtransaction:
     post:
       tags:
@@ -1012,22 +432,12 @@ paths:
                   default: getrawtransaction
                 id:
                   type: string
-                  default: uKvbHUWnFK
+                  default: UuvVrzSzqC
                 params:
                   type: array
                   items: {}
                   default: '["mytxid", 1]'
       responses:
-        '400':
-          description: Bad request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    default: Invalid parameters
         '200':
           description: OK
           content:
@@ -1038,3 +448,593 @@ paths:
                   result:
                     type: object
                     default: '{"hex":"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","height":0,"confirmations":0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getaddresstxids:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns the transaction ids made by the provided transparent addresses.
+
+        **Request body `params` arguments:**
+
+        - `request` - A struct with the following named fields:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getaddresstxids
+                id:
+                  type: string
+                  default: KMss2wDMwH
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"], "start": 1000, "end": 2000}]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '[]'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getaddressutxos:
+    post:
+      tags:
+      - address
+      description: |-
+        Returns all unspent outputs for a list of addresses.
+
+        **Request body `params` arguments:**
+
+        - `addresses` - The addresses to get outputs from.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getaddressutxos
+                id:
+                  type: string
+                  default: 4Y6BAhe6Lf
+                params:
+                  type: array
+                  items: {}
+                  default: '[{"addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"]}]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"address":"t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs","txid":"0000000000000000000000000000000000000000000000000000000000000000","outputIndex":0,"script":"00000000000000000000","satoshis":0,"height":0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getblockcount:
+    post:
+      tags:
+      - blockchain
+      description: Returns the height of the most recent block in the best valid block chain (equivalently,
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblockcount
+                id:
+                  type: string
+                  default: nzPm5W3X1G
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
+  /getblockhash:
+    post:
+      tags:
+      - blockchain
+      description: |-
+        Returns the hash of the block of a given height iff the index argument correspond
+
+        **Request body `params` arguments:**
+
+        - `index` - The block index.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblockhash
+                id:
+                  type: string
+                  default: KLKosq2Z8E
+                params:
+                  type: array
+                  items: {}
+                  default: '[1]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"0000000000000000000000000000000000000000000000000000000000000000"'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getblocktemplate:
+    post:
+      tags:
+      - mining
+      description: |-
+        Returns a block template for mining new Zcash blocks.
+
+        **Request body `params` arguments:**
+
+        - `jsonrequestobject` - A JSON object containing arguments.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblocktemplate
+                id:
+                  type: string
+                  default: spj7gKe2AA
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{}'
+  /submitblock:
+    post:
+      tags:
+      - mining
+      description: |-
+        Submits block to the node to be validated and committed.
+
+        **Request body `params` arguments:**
+
+        - `jsonparametersobject` - - currently ignored
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: submitblock
+                id:
+                  type: string
+                  default: QOQsC3nA7z
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '"rejected"'
+  /getmininginfo:
+    post:
+      tags:
+      - mining
+      description: Returns mining-related information.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getmininginfo
+                id:
+                  type: string
+                  default: Si3Sdb9ICT
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
+  /getnetworksolps:
+    post:
+      tags:
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getnetworksolps
+                id:
+                  type: string
+                  default: jWvKPdOxDa
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
+  /getnetworkhashps:
+    post:
+      tags:
+      - mining
+      description: Returns the estimated network solutions per second based on the last `num_blocks` before
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getnetworkhashps
+                id:
+                  type: string
+                  default: wnFwBVFrN0
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0'
+  /getpeerinfo:
+    post:
+      tags:
+      - network
+      description: Returns data about each connected network node.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getpeerinfo
+                id:
+                  type: string
+                  default: NpKiq59CE8
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"addr":"0.0.0.0:0"}'
+  /validateaddress:
+    post:
+      tags:
+      - util
+      description: |-
+        Checks if a zcash address is valid.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash address to validate.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: validateaddress
+                id:
+                  type: string
+                  default: PDjTChWgFW
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"isvalid":false}'
+  /z_validateaddress:
+    post:
+      tags:
+      - util
+      description: |-
+        Checks if a zcash address is valid.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash address to validate.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: z_validateaddress
+                id:
+                  type: string
+                  default: aCeb6xbIuo
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"isvalid":false}'
+  /getblocksubsidy:
+    post:
+      tags:
+      - mining
+      description: |-
+        Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
+
+        **Request body `params` arguments:**
+
+        - `height` - Can be any valid current or future height.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getblocksubsidy
+                id:
+                  type: string
+                  default: EeBvVXCJon
+                params:
+                  type: array
+                  items: {}
+                  default: '[1]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"miner":0.0,"founders":0.0,"fundingstreamstotal":0.0,"lockboxtotal":0.0,"totalblocksubsidy":0.0}'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    default: Invalid parameters
+  /getdifficulty:
+    post:
+      tags:
+      - blockchain
+      description: Returns the proof-of-work difficulty as a multiple of the minimum difficulty.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: getdifficulty
+                id:
+                  type: string
+                  default: jg2K8N0ZG4
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '0.0'
+  /z_listunifiedreceivers:
+    post:
+      tags:
+      - wallet
+      description: |-
+        Returns the list of individual payment addresses given a unified address.
+
+        **Request body `params` arguments:**
+
+        - `address` - The zcash unified address to get the list from.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                method:
+                  type: string
+                  default: z_listunifiedreceivers
+                id:
+                  type: string
+                  default: Y3gscsg8yT
+                params:
+                  type: array
+                  items: {}
+                  default: '[]'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: object
+                    default: '{"orchard":"orchard address if any","sapling":"sapling address if any","p2pkh":"p2pkh address if any","p2sh":"p2sh address if any"}'

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -123,3 +123,5 @@ syn = { version = "2.0.72", features = ["full"], optional = true }
 quote = { version = "1.0.36", optional = true }
 serde_yaml = { version = "0.9.34+deprecated", optional = true }
 serde = { version = "1.0.204", features = ["serde_derive"], optional = true }
+indexmap = "2.3.0"
+


### PR DESCRIPTION
## Motivation

Each time the tool runs, it may select a different order making changes the openapi.yaml spec huge for a simple update.

Close https://github.com/ZcashFoundation/zebra/issues/8775

## Solution

Change all hashmaps of the tool to indexmap, they preserve insertion order. This should make future upgrades don't differ that much.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [ ] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

