### PR TITLE
fix(rpc): Return verification errors from `sendrawtransaction` RPC method

### DIFF
--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -34,7 +34,7 @@ rpc-client = [
     "serde_json",
 ]
 
-shielded-scan = ["tokio"]
+shielded-scan = []
 
 [dependencies]
 zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.39" }
@@ -48,7 +48,7 @@ jsonrpc-core = { version = "18.0.0", optional = true }
 reqwest = { version = "0.11.26", default-features = false, features = ["rustls-tls"], optional = true }
 serde = { version = "1.0.204", optional = true }
 serde_json = { version = "1.0.122", optional = true }
-tokio = { version = "1.39.2", features = ["time"], optional = true }
+tokio = { version = "1.39.2", features = ["time", "sync"] }
 
 [dev-dependencies]
 

--- a/zebra-node-services/src/mempool.rs
+++ b/zebra-node-services/src/mempool.rs
@@ -4,6 +4,7 @@
 
 use std::collections::HashSet;
 
+use tokio::sync::oneshot;
 use zebra_chain::transaction::{self, UnminedTx, UnminedTxId};
 
 #[cfg(feature = "getblocktemplate-rpcs")]
@@ -114,13 +115,11 @@ pub enum Response {
     /// Returns matching cached rejected [`UnminedTxId`]s from the mempool,
     RejectedTransactionIds(HashSet<UnminedTxId>),
 
-    /// Returns a list of queue results.
-    ///
-    /// These are the results of the initial queue checks.
-    /// The transaction may also fail download or verification later.
+    /// Returns a list of initial queue checks results and a oneshot receiver
+    /// for awaiting download and/or verification results.
     ///
     /// Each result matches the request at the corresponding vector index.
-    Queued(Vec<Result<(), BoxError>>),
+    Queued(Vec<Result<oneshot::Receiver<Result<(), BoxError>>, BoxError>>),
 
     /// Confirms that the mempool has checked for recently verified transactions.
     CheckedForVerifiedTransactions,

--- a/zebra-node-services/src/mempool.rs
+++ b/zebra-node-services/src/mempool.rs
@@ -58,11 +58,6 @@ pub enum Request {
     /// The transaction downloader checks for duplicates across IDs and transactions.
     Queue(Vec<Gossip>),
 
-    /// Queue a list of unmined transactions submitted via the `sendrawtransaction` RPC method,
-    /// and wait for them to be verified, rejected, or for their verification task to be cancelled if
-    /// the transaction id is mined into the best chain.
-    QueueRpc(Vec<UnminedTx>),
-
     /// Check for newly verified transactions.
     ///
     /// The transaction downloader does not push transactions into the mempool.

--- a/zebra-node-services/src/mempool.rs
+++ b/zebra-node-services/src/mempool.rs
@@ -58,6 +58,11 @@ pub enum Request {
     /// The transaction downloader checks for duplicates across IDs and transactions.
     Queue(Vec<Gossip>),
 
+    /// Queue a list of unmined transactions submitted via the `sendrawtransaction` RPC method,
+    /// and wait for them to be verified, rejected, or for their verification task to be cancelled if
+    /// the transaction id is mined into the best chain.
+    QueueRpc(Vec<UnminedTx>),
+
     /// Check for newly verified transactions.
     ///
     /// The transaction downloader does not push transactions into the mempool.

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -685,6 +685,7 @@ where
             tracing::debug!("sent transaction to mempool: {:?}", &queue_result);
 
             queue_result
+                .map_server_error()?
                 .map(|_| SentTransactionHash(transaction_hash))
                 .map_server_error()
         }

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -664,7 +664,7 @@ where
 
             let response = mempool.oneshot(request).await.map_server_error()?;
 
-            let queue_results = match response {
+            let mut queue_results = match response {
                 mempool::Response::Queued(results) => results,
                 _ => unreachable!("incorrect response variant from mempool service"),
             };
@@ -675,10 +675,16 @@ where
                 "mempool service returned more results than expected"
             );
 
-            tracing::debug!("sent transaction to mempool: {:?}", &queue_results[0]);
+            let queue_result = queue_results
+                .pop()
+                .expect("there should be exactly one item in Vec")
+                .inspect_err(|err| tracing::debug!("sent transaction to mempool: {:?}", &err))
+                .map_server_error()?
+                .await;
 
-            queue_results[0]
-                .as_ref()
+            tracing::debug!("sent transaction to mempool: {:?}", &queue_result);
+
+            queue_result
                 .map(|_| SentTransactionHash(transaction_hash))
                 .map_server_error()
         }

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -656,7 +656,7 @@ where
             let transaction_hash = raw_transaction.hash();
 
             // send transaction to the rpc queue, ignore any error.
-            let unmined_transaction = UnminedTx::from(raw_transaction.clone());
+            let unmined_transaction = UnminedTx::from(raw_transaction);
             let _ = queue_sender.send(unmined_transaction.clone());
 
             let request = mempool::Request::QueueRpc(vec![unmined_transaction]);

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -657,10 +657,9 @@ where
 
             // send transaction to the rpc queue, ignore any error.
             let unmined_transaction = UnminedTx::from(raw_transaction.clone());
-            let _ = queue_sender.send(unmined_transaction);
+            let _ = queue_sender.send(unmined_transaction.clone());
 
-            let transaction_parameter = mempool::Gossip::Tx(raw_transaction.into());
-            let request = mempool::Request::Queue(vec![transaction_parameter]);
+            let request = mempool::Request::QueueRpc(vec![unmined_transaction]);
 
             let response = mempool.oneshot(request).await.map_server_error()?;
 

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -656,10 +656,11 @@ where
             let transaction_hash = raw_transaction.hash();
 
             // send transaction to the rpc queue, ignore any error.
-            let unmined_transaction = UnminedTx::from(raw_transaction);
-            let _ = queue_sender.send(unmined_transaction.clone());
+            let unmined_transaction = UnminedTx::from(raw_transaction.clone());
+            let _ = queue_sender.send(unmined_transaction);
 
-            let request = mempool::Request::QueueRpc(vec![unmined_transaction]);
+            let transaction_parameter = mempool::Gossip::Tx(raw_transaction.into());
+            let request = mempool::Request::Queue(vec![transaction_parameter]);
 
             let response = mempool.oneshot(request).await.map_server_error()?;
 

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -60,7 +60,7 @@ proptest! {
             let send_task = tokio::spawn(rpc.send_raw_transaction(transaction_hex));
 
             let unmined_transaction = UnminedTx::from(transaction);
-            let expected_request = mempool::Request::QueueRpc(vec![unmined_transaction.into()]);
+            let expected_request = mempool::Request::QueueRpc(vec![unmined_transaction]);
             let response = mempool::Response::Queued(vec![Ok(())]);
 
             mempool
@@ -114,7 +114,7 @@ proptest! {
             let send_task = tokio::spawn(rpc.send_raw_transaction(transaction_hex));
 
             let unmined_transaction = UnminedTx::from(transaction);
-            let expected_request = mempool::Request::QueueRpc(vec![unmined_transaction.into()]);
+            let expected_request = mempool::Request::QueueRpc(vec![unmined_transaction]);
 
             mempool
                 .expect_request(expected_request)
@@ -174,7 +174,7 @@ proptest! {
             let send_task = tokio::spawn(rpc.send_raw_transaction(transaction_hex));
 
             let unmined_transaction = UnminedTx::from(transaction);
-            let expected_request = mempool::Request::QueueRpc(vec![unmined_transaction.into()]);
+            let expected_request = mempool::Request::QueueRpc(vec![unmined_transaction]);
             let response = mempool::Response::Queued(vec![Err(DummyError.into())]);
 
             mempool
@@ -857,7 +857,7 @@ proptest! {
             let send_task = tokio::spawn(rpc.send_raw_transaction(tx_hex));
 
             let tx_unmined = UnminedTx::from(tx);
-            let expected_request = mempool::Request::QueueRpc(vec![tx_unmined.clone().into()]);
+            let expected_request = mempool::Request::QueueRpc(vec![tx_unmined.clone()]);
 
             // fail the mempool insertion
             mempool
@@ -949,7 +949,7 @@ proptest! {
                 let send_task = tokio::spawn(rpc.send_raw_transaction(tx_hex));
 
                 let tx_unmined = UnminedTx::from(tx.clone());
-                let expected_request = mempool::Request::QueueRpc(vec![tx_unmined.clone().into()]);
+                let expected_request = mempool::Request::QueueRpc(vec![tx_unmined.clone()]);
 
                 // insert to hs we will use later
                 transactions_hash_set.insert(tx_unmined.id);

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -60,7 +60,7 @@ proptest! {
             let send_task = tokio::spawn(rpc.send_raw_transaction(transaction_hex));
 
             let unmined_transaction = UnminedTx::from(transaction);
-            let expected_request = mempool::Request::Queue(vec![unmined_transaction.into()]);
+            let expected_request = mempool::Request::QueueRpc(vec![unmined_transaction.into()]);
             let response = mempool::Response::Queued(vec![Ok(())]);
 
             mempool
@@ -114,7 +114,7 @@ proptest! {
             let send_task = tokio::spawn(rpc.send_raw_transaction(transaction_hex));
 
             let unmined_transaction = UnminedTx::from(transaction);
-            let expected_request = mempool::Request::Queue(vec![unmined_transaction.into()]);
+            let expected_request = mempool::Request::QueueRpc(vec![unmined_transaction.into()]);
 
             mempool
                 .expect_request(expected_request)
@@ -174,7 +174,7 @@ proptest! {
             let send_task = tokio::spawn(rpc.send_raw_transaction(transaction_hex));
 
             let unmined_transaction = UnminedTx::from(transaction);
-            let expected_request = mempool::Request::Queue(vec![unmined_transaction.into()]);
+            let expected_request = mempool::Request::QueueRpc(vec![unmined_transaction.into()]);
             let response = mempool::Response::Queued(vec![Err(DummyError.into())]);
 
             mempool
@@ -857,7 +857,7 @@ proptest! {
             let send_task = tokio::spawn(rpc.send_raw_transaction(tx_hex));
 
             let tx_unmined = UnminedTx::from(tx);
-            let expected_request = mempool::Request::Queue(vec![tx_unmined.clone().into()]);
+            let expected_request = mempool::Request::QueueRpc(vec![tx_unmined.clone().into()]);
 
             // fail the mempool insertion
             mempool
@@ -949,7 +949,7 @@ proptest! {
                 let send_task = tokio::spawn(rpc.send_raw_transaction(tx_hex));
 
                 let tx_unmined = UnminedTx::from(tx.clone());
-                let expected_request = mempool::Request::Queue(vec![tx_unmined.clone().into()]);
+                let expected_request = mempool::Request::QueueRpc(vec![tx_unmined.clone().into()]);
 
                 // insert to hs we will use later
                 transactions_hash_set.insert(tx_unmined.id);

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -7,6 +7,7 @@ use hex::ToHex;
 use jsonrpc_core::{Error, ErrorCode};
 use proptest::{collection::vec, prelude::*};
 use thiserror::Error;
+use tokio::sync::oneshot;
 use tower::buffer::Buffer;
 
 use zebra_chain::{
@@ -61,7 +62,9 @@ proptest! {
 
             let unmined_transaction = UnminedTx::from(transaction);
             let expected_request = mempool::Request::Queue(vec![unmined_transaction.into()]);
-            let response = mempool::Response::Queued(vec![Ok(())]);
+            let (rsp_tx, rsp_rx) = oneshot::channel();
+            let _ = rsp_tx.send(Ok(()));
+            let response = mempool::Response::Queued(vec![Ok(rsp_rx)]);
 
             mempool
                 .expect_request(expected_request)
@@ -897,7 +900,9 @@ proptest! {
             // now a retry will be sent to the mempool
             let expected_request =
                 mempool::Request::Queue(vec![mempool::Gossip::Tx(tx_unmined.clone())]);
-            let response = mempool::Response::Queued(vec![Ok(())]);
+            let (rsp_tx, rsp_rx) = oneshot::channel();
+            let _ = rsp_tx.send(Ok(()));
+            let response = mempool::Response::Queued(vec![Ok(rsp_rx)]);
 
             mempool
                 .expect_request(expected_request)
@@ -997,7 +1002,9 @@ proptest! {
             for tx in txs.clone() {
                 let expected_request =
                     mempool::Request::Queue(vec![mempool::Gossip::Tx(UnminedTx::from(tx))]);
-                let response = mempool::Response::Queued(vec![Ok(())]);
+                let (rsp_tx, rsp_rx) = oneshot::channel();
+                let _ = rsp_tx.send(Ok(()));
+                let response = mempool::Response::Queued(vec![Ok(rsp_rx)]);
 
                 mempool
                     .expect_request(expected_request)

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -60,7 +60,7 @@ proptest! {
             let send_task = tokio::spawn(rpc.send_raw_transaction(transaction_hex));
 
             let unmined_transaction = UnminedTx::from(transaction);
-            let expected_request = mempool::Request::QueueRpc(vec![unmined_transaction]);
+            let expected_request = mempool::Request::Queue(vec![unmined_transaction.into()]);
             let response = mempool::Response::Queued(vec![Ok(())]);
 
             mempool
@@ -114,7 +114,7 @@ proptest! {
             let send_task = tokio::spawn(rpc.send_raw_transaction(transaction_hex));
 
             let unmined_transaction = UnminedTx::from(transaction);
-            let expected_request = mempool::Request::QueueRpc(vec![unmined_transaction]);
+            let expected_request = mempool::Request::Queue(vec![unmined_transaction.into()]);
 
             mempool
                 .expect_request(expected_request)
@@ -174,7 +174,7 @@ proptest! {
             let send_task = tokio::spawn(rpc.send_raw_transaction(transaction_hex));
 
             let unmined_transaction = UnminedTx::from(transaction);
-            let expected_request = mempool::Request::QueueRpc(vec![unmined_transaction]);
+            let expected_request = mempool::Request::Queue(vec![unmined_transaction.into()]);
             let response = mempool::Response::Queued(vec![Err(DummyError.into())]);
 
             mempool
@@ -857,7 +857,7 @@ proptest! {
             let send_task = tokio::spawn(rpc.send_raw_transaction(tx_hex));
 
             let tx_unmined = UnminedTx::from(tx);
-            let expected_request = mempool::Request::QueueRpc(vec![tx_unmined.clone()]);
+            let expected_request = mempool::Request::Queue(vec![tx_unmined.clone().into()]);
 
             // fail the mempool insertion
             mempool
@@ -949,7 +949,7 @@ proptest! {
                 let send_task = tokio::spawn(rpc.send_raw_transaction(tx_hex));
 
                 let tx_unmined = UnminedTx::from(tx.clone());
-                let expected_request = mempool::Request::QueueRpc(vec![tx_unmined.clone()]);
+                let expected_request = mempool::Request::Queue(vec![tx_unmined.clone().into()]);
 
                 // insert to hs we will use later
                 transactions_hash_set.insert(tx_unmined.id);

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -758,7 +758,7 @@ impl Service<Request> for Mempool {
                 Request::Queue(gossiped_txs) => {
                     trace!(req_count = ?gossiped_txs.len(), "got mempool Queue request");
 
-                    let results: Vec<Result<oneshot::Receiver<Result<(), BoxError>>, BoxError>> =
+                    let rsp: Vec<Result<oneshot::Receiver<Result<(), BoxError>>, BoxError>> =
                         gossiped_txs
                             .into_iter()
                             .map(
@@ -780,19 +780,7 @@ impl Service<Request> for Mempool {
                     // We've added transactions to the queue
                     self.update_metrics();
 
-                    async move {
-                        let mut rsp = vec![];
-
-                        for result in results {
-                            rsp.push(match result {
-                                Ok(rsp_rx) => rsp_rx.await?,
-                                Err(err) => Err(err),
-                            })
-                        }
-
-                        Ok(Response::Queued(rsp))
-                    }
-                    .boxed()
+                    async move { Ok(Response::Queued(rsp)) }.boxed()
                 }
 
                 // Store successfully downloaded and verified transactions in the mempool

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -51,7 +51,7 @@ use zebra_chain::{
 use zebra_consensus::transaction as tx;
 use zebra_network as zn;
 use zebra_node_services::mempool::Gossip;
-use zebra_state as zs;
+use zebra_state::{self as zs, CloneError};
 
 use crate::components::sync::{BLOCK_DOWNLOAD_TIMEOUT, BLOCK_VERIFY_TIMEOUT};
 
@@ -105,17 +105,17 @@ pub const MAX_INBOUND_CONCURRENCY: usize = 25;
 struct CancelDownloadAndVerify;
 
 /// Errors that can occur while downloading and verifying a transaction.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 #[allow(dead_code)]
 pub enum TransactionDownloadVerifyError {
     #[error("transaction is already in state")]
     InState,
 
     #[error("error in state service")]
-    StateError(#[source] BoxError),
+    StateError(#[source] CloneError),
 
     #[error("error downloading transaction")]
-    DownloadFailed(#[source] BoxError),
+    DownloadFailed(#[source] CloneError),
 
     #[error("transaction download / verification was cancelled")]
     Cancelled,
@@ -243,6 +243,7 @@ where
     pub fn download_if_needed_and_verify(
         &mut self,
         gossiped_tx: Gossip,
+        rsp_tx: Option<oneshot::Sender<Result<(), BoxError>>>,
     ) -> Result<(), MempoolError> {
         let txid = gossiped_tx.id();
 
@@ -295,7 +296,7 @@ where
                     Ok((Some(height), next_height))
                 }
                 Ok(_) => unreachable!("wrong response"),
-                Err(e) => Err(TransactionDownloadVerifyError::StateError(e)),
+                Err(e) => Err(TransactionDownloadVerifyError::StateError(e.into())),
             }?;
 
             trace!(?txid, ?next_height, "got next height");
@@ -307,11 +308,12 @@ where
                     let tx = match network
                         .oneshot(req)
                         .await
+                        .map_err(CloneError::from)
                         .map_err(TransactionDownloadVerifyError::DownloadFailed)?
                     {
                         zn::Response::Transactions(mut txs) => txs.pop().ok_or_else(|| {
                             TransactionDownloadVerifyError::DownloadFailed(
-                                "no transactions returned".into(),
+                                BoxError::from("no transactions returned").into(),
                             )
                         })?,
                         _ => unreachable!("wrong response to transaction request"),
@@ -373,7 +375,7 @@ where
 
         let task = tokio::spawn(async move {
             // Prefer the cancel handle if both are ready.
-            tokio::select! {
+            let result = tokio::select! {
                 biased;
                 _ = &mut cancel_rx => {
                     trace!("task cancelled prior to completion");
@@ -381,7 +383,17 @@ where
                     Err((TransactionDownloadVerifyError::Cancelled, txid))
                 }
                 verification = fut => verification,
+            };
+
+            // Send the result to responder channel if one was provided.
+            if let Some(rsp_tx) = rsp_tx {
+                let _ =
+                    rsp_tx.send(result.as_ref().map(|_| ()).map_err(|(err, id)| {
+                        format!("failed to verify tx {id}, err: {err}").into()
+                    }));
             }
+
+            result
         });
 
         self.pending.push(task);
@@ -458,6 +470,7 @@ where
         match state
             .ready()
             .await
+            .map_err(CloneError::from)
             .map_err(TransactionDownloadVerifyError::StateError)?
             .call(zs::Request::Transaction(txid.mined_id()))
             .await
@@ -465,7 +478,7 @@ where
             Ok(zs::Response::Transaction(None)) => Ok(()),
             Ok(zs::Response::Transaction(Some(_))) => Err(TransactionDownloadVerifyError::InState),
             Ok(_) => unreachable!("wrong response"),
-            Err(e) => Err(TransactionDownloadVerifyError::StateError(e)),
+            Err(e) => Err(TransactionDownloadVerifyError::StateError(e.into())),
         }?;
 
         Ok(())

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -387,10 +387,12 @@ where
 
             // Send the result to responder channel if one was provided.
             if let Some(rsp_tx) = rsp_tx {
-                let _ =
-                    rsp_tx.send(result.as_ref().map(|_| ()).map_err(|(err, id)| {
-                        format!("failed to verify tx {id}, err: {err}").into()
-                    }));
+                let _ = rsp_tx.send(
+                    result
+                        .as_ref()
+                        .map(|_| ())
+                        .map_err(|(err, _)| err.clone().into()),
+                );
             }
 
             result


### PR DESCRIPTION
## Motivation

We want to return an error from the `sendrawtransaction` RPC method if a transaction cannot be verified and added to the mempool.

Closes #8778.

## Solution

Adds a `QueueRpc` mempool request to wait for a transaction verification result and return an error message to the client if the transaction was not verified and added to Zebra's mempool.

### Tests

This PR still needs tests.

### Follow-up Work

- @hhanh00 reported that Zebra was failing to add transactions to its mempool or return an error describing why transactions weren't added to the mempool, we want to return a specific error so we can fix the issue.
- We likely need an update to lightwalletd to handle these errors correctly.
- Handle verification errors in inbound service by incrementing peer connection "bad score" when tracking misbehaving nodes

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

