### PR TITLE
build(deps): make librustzcash crates workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,20 +429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bip0039"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef0f0152ec5cf17f49a5866afaa3439816207fd4f0a224c0211ffaf5e278426"
-dependencies = [
- "hmac",
- "pbkdf2",
- "rand 0.8.5",
- "sha2",
- "unicode-normalization",
- "zeroize",
-]
-
-[[package]]
 name = "bip32"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "bridgetree"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbfcb6c5a091e80cb3d3b0c1a7f126af4631cd5065b1f9929b139f1be8f3fb62"
+checksum = "f62227647af796dd9f1637da0392676a2e200973b817b082fc9be89bf93ddd74"
 dependencies = [
  "incrementalmerkletree",
 ]
@@ -901,8 +887,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86ed14aa9c9f927213c6e4f3ef75faaad3406134efe84ba2cb7983431d5f0931"
 dependencies = [
  "futures-core",
- "prost 0.13.1",
- "prost-types 0.13.1",
+ "prost",
+ "prost-types",
  "tonic",
  "tracing-core",
 ]
@@ -920,8 +906,8 @@ dependencies = [
  "hdrhistogram",
  "humantime",
  "hyper-util",
- "prost 0.13.1",
- "prost-types 0.13.1",
+ "prost",
+ "prost-types",
  "serde",
  "serde_json",
  "thread_local",
@@ -1331,7 +1317,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash/?branch=main#5a4a3e06dcd2cf5bdf79a7cd48709b58693c65f0"
+source = "git+https://github.com/zcash/librustzcash/?branch=main#40ca428c6081c61d5a2bf3f2053eb9e18219ca95"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -1366,16 +1352,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a83e8d7fd0c526af4aad893b7c9fe41e2699ed8a776a6c74aecdeafe05afc75"
-dependencies = [
- "blake2b_simd",
-]
-
-[[package]]
-name = "f4jumble"
-version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash/?branch=main#5a4a3e06dcd2cf5bdf79a7cd48709b58693c65f0"
+source = "git+https://github.com/zcash/librustzcash/?branch=main#40ca428c6081c61d5a2bf3f2053eb9e18219ca95"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2106,9 +2083,9 @@ dependencies = [
 
 [[package]]
 name = "incrementalmerkletree"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1872810fb725b06b8c153dde9e86f3ec26747b9b60096da7a869883b549cbe"
+checksum = "75346da3bd8e3d8891d02508245ed2df34447ca6637e343829f8d08986e9cde2"
 dependencies = [
  "either",
 ]
@@ -2785,9 +2762,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0462569fc8b0d1b158e4d640571867a4e4319225ebee2ab6647e60c70af19ae3"
+checksum = "4dc7bde644aeb980be296cd908c6650894dc8541deb56f9f5294c52ed7ca568f"
 dependencies = [
  "aes",
  "bitvec",
@@ -2808,6 +2785,7 @@ dependencies = [
  "serde",
  "subtle",
  "tracing",
+ "visibility",
  "zcash_note_encryption",
  "zcash_spec",
  "zip32",
@@ -2936,17 +2914,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d791538a6dcc1e7cb7fe6f6b58aca40e7f79403c45b2bc274008b5e647af1d8"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "pasta_curves"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2959,16 +2926,6 @@ dependencies = [
  "rand 0.8.5",
  "static_assertions",
  "subtle",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
-dependencies = [
- "digest",
- "password-hash",
 ]
 
 [[package]]
@@ -3242,43 +3199,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
-dependencies = [
- "bytes",
- "prost-derive 0.12.6",
-]
-
-[[package]]
-name = "prost"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13db3d3fde688c61e2446b4d843bc27a7e8af269a69440c0308021dc92333cc"
 dependencies = [
  "bytes",
- "prost-derive 0.13.1",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
-dependencies = [
- "bytes",
- "heck 0.5.0",
- "itertools 0.12.1",
- "log",
- "multimap",
- "once_cell",
- "petgraph",
- "prettyplease",
- "prost 0.12.6",
- "prost-types 0.12.6",
- "regex",
- "syn 2.0.72",
- "tempfile",
+ "prost-derive",
 ]
 
 [[package]]
@@ -3295,24 +3221,11 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.13.1",
- "prost-types 0.13.1",
+ "prost",
+ "prost-types",
  "regex",
  "syn 2.0.72",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
-dependencies = [
- "anyhow",
- "itertools 0.12.1",
- "proc-macro2",
- "quote",
- "syn 2.0.72",
 ]
 
 [[package]]
@@ -3330,20 +3243,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
-dependencies = [
- "prost 0.12.6",
-]
-
-[[package]]
-name = "prost-types"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cee5168b05f49d4b0ca581206eb14a7b22fafd963efe729ac48eb03266e25cc2"
 dependencies = [
- "prost 0.13.1",
+ "prost",
 ]
 
 [[package]]
@@ -3848,9 +3752,9 @@ dependencies = [
 
 [[package]]
 name = "sapling-crypto"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f4270033afcb0c74c5c7d59c73cfd1040367f67f224fe7ed9a919ae618f1b7"
+checksum = "15e379398fffad84e49f9a45a05635fc004f66086e65942dbf4eb95332c26d2a"
 dependencies = [
  "aes",
  "bellman",
@@ -4192,9 +4096,9 @@ dependencies = [
 
 [[package]]
 name = "shardtree"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cdd24424ce0b381646737fedddc33c4dcf7dcd2d545056b53f7982097bef5"
+checksum = "78222845cd8bbe5eb95687407648ff17693a35de5e8abaa39a4681fb21e033f9"
 dependencies = [
  "bitflags 2.6.0",
  "either",
@@ -4736,7 +4640,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.13.1",
+ "prost",
  "socket2",
  "tokio",
  "tokio-stream",
@@ -4748,26 +4652,13 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d021fc044c18582b9a2408cd0dd05b1596e3ecdb5c4df822bb0183545683889"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "prost-build 0.12.6",
- "quote",
- "syn 2.0.72",
-]
-
-[[package]]
-name = "tonic-build"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568392c5a2bd0020723e3f387891176aabafe36fd9fcd074ad309dfa0c8eb964"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build 0.13.1",
+ "prost-build",
  "quote",
  "syn 2.0.72",
 ]
@@ -4778,8 +4669,8 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b742c83ad673e9ab5b4ce0981f7b9e8932be9d60e8682cbf9120494764dbc173"
 dependencies = [
- "prost 0.13.1",
- "prost-types 0.13.1",
+ "prost",
+ "prost-types",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -5211,6 +5102,17 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
 
 [[package]]
 name = "void"
@@ -5648,34 +5550,20 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "zcash_address"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "827c17a1f7e3a69f0d44e991ff610c7a842228afdc9dc2325ffdd1a67fee01e9"
+version = "0.4.0"
+source = "git+https://github.com/zcash/librustzcash/?branch=main#40ca428c6081c61d5a2bf3f2053eb9e18219ca95"
 dependencies = [
  "bech32",
  "bs58",
- "f4jumble 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "zcash_address"
-version = "0.3.2"
-source = "git+https://github.com/zcash/librustzcash/?branch=main#5a4a3e06dcd2cf5bdf79a7cd48709b58693c65f0"
-dependencies = [
- "bech32",
- "bs58",
- "f4jumble 0.1.0 (git+https://github.com/zcash/librustzcash/?branch=main)",
- "zcash_encoding 0.2.0 (git+https://github.com/zcash/librustzcash/?branch=main)",
- "zcash_protocol 0.1.1 (git+https://github.com/zcash/librustzcash/?branch=main)",
+ "f4jumble",
+ "zcash_encoding",
+ "zcash_protocol",
 ]
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0364e69c446fcf96a1f73f342c6c3fa697ea65ae7eeeae7d76ca847b9c442e40"
+version = "0.13.0"
+source = "git+https://github.com/zcash/librustzcash/?branch=main#40ca428c6081c61d5a2bf3f2053eb9e18219ca95"
 dependencies = [
  "base64 0.21.7",
  "bech32",
@@ -5690,7 +5578,7 @@ dependencies = [
  "nom",
  "nonempty",
  "percent-encoding",
- "prost 0.12.6",
+ "prost",
  "rand_core 0.6.4",
  "rayon",
  "sapling-crypto",
@@ -5698,32 +5586,23 @@ dependencies = [
  "shardtree",
  "subtle",
  "time",
- "tonic-build 0.10.2",
+ "tonic-build",
  "tracing",
  "which",
- "zcash_address 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address",
+ "zcash_encoding",
  "zcash_keys",
  "zcash_note_encryption",
- "zcash_primitives 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives",
+ "zcash_protocol",
  "zip32",
+ "zip321",
 ]
 
 [[package]]
 name = "zcash_encoding"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03391b81727875efa6ac0661a20883022b6fba92365dc121c48fa9b00c5aac0"
-dependencies = [
- "byteorder",
- "nonempty",
-]
-
-[[package]]
-name = "zcash_encoding"
-version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash/?branch=main#5a4a3e06dcd2cf5bdf79a7cd48709b58693c65f0"
+version = "0.2.1"
+source = "git+https://github.com/zcash/librustzcash/?branch=main#40ca428c6081c61d5a2bf3f2053eb9e18219ca95"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -5732,8 +5611,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fde17bf53792f9c756b313730da14880257d7661b5bfc69d0571c3a7c11a76d"
+source = "git+https://github.com/zcash/librustzcash/?branch=main#40ca428c6081c61d5a2bf3f2053eb9e18219ca95"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -5742,9 +5620,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "663489ffb4e51bc4436ff8796832612a9ff3c6516f1c620b5a840cb5dcd7b866"
+version = "0.3.0"
+source = "git+https://github.com/zcash/librustzcash/?branch=main#40ca428c6081c61d5a2bf3f2053eb9e18219ca95"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -5759,10 +5636,10 @@ dependencies = [
  "secrecy",
  "subtle",
  "tracing",
- "zcash_address 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_primitives 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address",
+ "zcash_encoding",
+ "zcash_primitives",
+ "zcash_protocol",
  "zip32",
 ]
 
@@ -5781,44 +5658,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ccee58d0f9e8da312a999a4c0cd3d001ff3b37af6fb1318c89e6a3076f4da"
-dependencies = [
- "aes",
- "bip0039",
- "blake2b_simd",
- "byteorder",
- "document-features",
- "equihash 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ff",
- "fpe",
- "group",
- "hex",
- "incrementalmerkletree",
- "jubjub",
- "memuse",
- "nonempty",
- "orchard",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "redjubjub",
- "sapling-crypto",
- "sha2",
- "subtle",
- "tracing",
- "zcash_address 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_note_encryption",
- "zcash_protocol 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_spec",
- "zip32",
-]
-
-[[package]]
-name = "zcash_primitives"
-version = "0.15.1"
-source = "git+https://github.com/zcash/librustzcash/?branch=main#5a4a3e06dcd2cf5bdf79a7cd48709b58693c65f0"
+version = "0.16.0"
+source = "git+https://github.com/zcash/librustzcash/?branch=main#40ca428c6081c61d5a2bf3f2053eb9e18219ca95"
 dependencies = [
  "aes",
  "bip32",
@@ -5845,19 +5686,18 @@ dependencies = [
  "sha2",
  "subtle",
  "tracing",
- "zcash_address 0.3.2 (git+https://github.com/zcash/librustzcash/?branch=main)",
- "zcash_encoding 0.2.0 (git+https://github.com/zcash/librustzcash/?branch=main)",
+ "zcash_address",
+ "zcash_encoding",
  "zcash_note_encryption",
- "zcash_protocol 0.1.1 (git+https://github.com/zcash/librustzcash/?branch=main)",
+ "zcash_protocol",
  "zcash_spec",
  "zip32",
 ]
 
 [[package]]
 name = "zcash_proofs"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5163a1110f4265cc5f2fdf87ac4497fd1e014b6ce0760ca8d16d8e3853a5c0f7"
+version = "0.16.0"
+source = "git+https://github.com/zcash/librustzcash/?branch=main#40ca428c6081c61d5a2bf3f2053eb9e18219ca95"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5873,23 +5713,13 @@ dependencies = [
  "sapling-crypto",
  "tracing",
  "xdg",
- "zcash_primitives 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives",
 ]
 
 [[package]]
 name = "zcash_protocol"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f8189d4a304e8aa3aef3b75e89f3874bb0dc84b1cd623316a84e79e06cddabc"
-dependencies = [
- "document-features",
- "memuse",
-]
-
-[[package]]
-name = "zcash_protocol"
-version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash/?branch=main#5a4a3e06dcd2cf5bdf79a7cd48709b58693c65f0"
+version = "0.2.0"
+source = "git+https://github.com/zcash/librustzcash/?branch=main#40ca428c6081c61d5a2bf3f2053eb9e18219ca95"
 dependencies = [
  "document-features",
  "memuse",
@@ -5967,13 +5797,13 @@ dependencies = [
  "tracing",
  "uint",
  "x25519-dalek",
- "zcash_address 0.3.2 (git+https://github.com/zcash/librustzcash/?branch=main)",
+ "zcash_address",
  "zcash_client_backend",
- "zcash_encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding",
  "zcash_history",
  "zcash_note_encryption",
- "zcash_primitives 0.15.1 (git+https://github.com/zcash/librustzcash/?branch=main)",
- "zcash_protocol 0.1.1 (git+https://github.com/zcash/librustzcash/?branch=main)",
+ "zcash_primitives",
+ "zcash_protocol",
  "zebra-test",
 ]
 
@@ -6030,15 +5860,15 @@ dependencies = [
  "color-eyre",
  "futures-util",
  "insta",
- "prost 0.13.1",
+ "prost",
  "serde",
  "tokio",
  "tokio-stream",
  "tonic",
- "tonic-build 0.12.1",
+ "tonic-build",
  "tonic-reflection",
  "tower",
- "zcash_primitives 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives",
  "zebra-chain",
  "zebra-node-services",
  "zebra-state",
@@ -6112,7 +5942,7 @@ dependencies = [
  "jsonrpc-derive",
  "jsonrpc-http-server",
  "proptest",
- "prost 0.13.1",
+ "prost",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -6120,12 +5950,12 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
- "tonic-build 0.12.1",
+ "tonic-build",
  "tonic-reflection",
  "tower",
  "tracing",
- "zcash_address 0.3.2 (git+https://github.com/zcash/librustzcash/?branch=main)",
- "zcash_primitives 0.15.1 (git+https://github.com/zcash/librustzcash/?branch=main)",
+ "zcash_address",
+ "zcash_primitives",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",
@@ -6167,11 +5997,11 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
- "zcash_address 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address",
  "zcash_client_backend",
  "zcash_keys",
  "zcash_note_encryption",
- "zcash_primitives 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives",
  "zebra-chain",
  "zebra-grpc",
  "zebra-node-services",
@@ -6290,8 +6120,8 @@ dependencies = [
  "tracing-error",
  "tracing-subscriber",
  "zcash_client_backend",
- "zcash_primitives 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives",
+ "zcash_protocol",
  "zebra-chain",
  "zebra-node-services",
  "zebra-rpc",
@@ -6331,7 +6161,7 @@ dependencies = [
  "pin-project",
  "proptest",
  "proptest-derive",
- "prost 0.13.1",
+ "prost",
  "rand 0.8.5",
  "rayon",
  "regex",
@@ -6347,7 +6177,7 @@ dependencies = [
  "tokio-stream",
  "toml 0.8.19",
  "tonic",
- "tonic-build 0.12.1",
+ "tonic-build",
  "tower",
  "tracing",
  "tracing-appender",
@@ -6418,4 +6248,16 @@ dependencies = [
  "blake2b_simd",
  "memuse",
  "subtle",
+]
+
+[[package]]
+name = "zip321"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash/?branch=main#40ca428c6081c61d5a2bf3f2053eb9e18219ca95"
+dependencies = [
+ "base64 0.21.7",
+ "nom",
+ "percent-encoding",
+ "zcash_address",
+ "zcash_protocol",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,20 @@ resolver = "2"
 
 # `cargo release` settings
 
+[workspace.dependencies]
+incrementalmerkletree = "0.6.0"
+orchard = "0.9.0"
+sapling-crypto = "0.2.0"
+# TODO: Revert to a release once librustzcash is released (#8749).
+zcash_address = { git = "https://github.com/zcash/librustzcash/", branch = "main" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash/", branch = "main" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash/", branch = "main" }
+zcash_history = { git = "https://github.com/zcash/librustzcash/", branch = "main" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash/", branch = "main" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash/", branch = "main" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash/", branch = "main" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash/", branch = "main" }
+
 [workspace.metadata.release]
 
 # We always do releases from the main branch

--- a/deny.toml
+++ b/deny.toml
@@ -102,6 +102,12 @@ skip-tree = [
     { name = "zcash_encoding", version = "=0.2.0" },
     { name = "zcash_primitives", version = "=0.15.1" },
     { name = "zcash_protocol", version = "=0.1.1" },
+
+    # wait for structopt-derive to update heck
+    { name = "heck", version = "=0.3.3" },
+
+    # wait for librocksdb-sys to update bindgen to one that uses newer itertools
+    { name = "itertools", version = "=0.12.1" }
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -68,7 +68,7 @@ bitflags = "2.5.0"
 bitflags-serde-legacy = "0.1.1"
 blake2b_simd = "1.0.2"
 blake2s_simd = "1.0.2"
-bridgetree = "0.4.0"
+bridgetree = "0.5.0"
 bs58 = { version = "0.5.1", features = ["check"] }
 byteorder = "1.5.0"
 
@@ -78,7 +78,7 @@ byteorder = "1.5.0"
 equihash = "0.2.0"
 
 group = "0.13.0"
-incrementalmerkletree = "0.5.1"
+incrementalmerkletree.workspace = true
 jubjub = "0.10.0"
 lazy_static = "1.4.0"
 num-integer = "0.1.46"
@@ -93,17 +93,14 @@ x25519-dalek = { version = "2.0.1", features = ["serde"] }
 
 # ECC deps
 halo2 = { package = "halo2_proofs", version = "0.3.0" }
-orchard = "0.8.0"
-zcash_encoding = "0.2.0"
-zcash_history = "0.4.0"
+orchard.workspace = true
+zcash_encoding.workspace = true
+zcash_history.workspace = true
 zcash_note_encryption = "0.4.0"
-# TODO: Revert to a release once librustzcash is released (#8749).
-zcash_primitives = { git = "https://github.com/zcash/librustzcash/", branch = "main", features = ["transparent-inputs"] }
-sapling = { package = "sapling-crypto", version = "0.1" }
-# TODO: Revert to a release once librustzcash is released (#8749).
-zcash_protocol = { git = "https://github.com/zcash/librustzcash/", branch = "main"}
-# TODO: Revert to a release once librustzcash is released (#8749).
-zcash_address = { git = "https://github.com/zcash/librustzcash/", branch = "main"}
+zcash_primitives = { workspace = true, features = ["transparent-inputs"] }
+sapling-crypto.workspace = true
+zcash_protocol.workspace = true
+zcash_address.workspace = true
 
 # Time
 chrono = { version = "0.4.38", default-features = false, features = ["clock", "std", "serde"] }
@@ -137,7 +134,7 @@ serde_json = { version = "1.0.122", optional = true }
 tokio = { version = "1.39.2", optional = true }
 
 # Experimental feature shielded-scan
-zcash_client_backend = { version = "0.12.1", optional = true }
+zcash_client_backend = { workspace = true, optional = true }
 
 # Optional testing dependencies
 proptest = { version = "1.4.0", optional = true }

--- a/zebra-chain/src/primitives/address.rs
+++ b/zebra-chain/src/primitives/address.rs
@@ -17,7 +17,7 @@ pub enum Address {
         network: NetworkKind,
 
         /// Sapling address
-        address: sapling::PaymentAddress,
+        address: sapling_crypto::PaymentAddress,
     },
 
     /// Unified address
@@ -32,7 +32,7 @@ pub enum Address {
         orchard: Option<orchard::Address>,
 
         /// Sapling address
-        sapling: Option<sapling::PaymentAddress>,
+        sapling: Option<sapling_crypto::PaymentAddress>,
 
         /// Transparent address
         transparent: Option<transparent::Address>,
@@ -68,7 +68,7 @@ impl zcash_address::TryFromAddress for Address {
         data: [u8; 43],
     ) -> Result<Self, zcash_address::ConversionError<Self::Error>> {
         let network = network.into();
-        sapling::PaymentAddress::from_bytes(&data)
+        sapling_crypto::PaymentAddress::from_bytes(&data)
             .map(|address| Self::Sapling { address, network })
             .ok_or_else(|| BoxError::from("not a valid sapling address").into())
     }
@@ -97,7 +97,7 @@ impl zcash_address::TryFromAddress for Address {
                     }
                 }
                 unified::Receiver::Sapling(data) => {
-                    sapling = sapling::PaymentAddress::from_bytes(&data);
+                    sapling = sapling_crypto::PaymentAddress::from_bytes(&data);
                     // ZIP 316: Consumers MUST reject Unified Addresses/Viewing Keys in
                     // which any constituent Item does not meet the validation
                     // requirements of its encoding.

--- a/zebra-chain/src/primitives/viewing_key/sapling.rs
+++ b/zebra-chain/src/primitives/viewing_key/sapling.rs
@@ -1,6 +1,6 @@
 //! Defines types and implements methods for parsing Sapling viewing keys and converting them to `zebra-chain` types
 
-use sapling::keys::{FullViewingKey as SaplingFvk, SaplingIvk};
+use sapling_crypto::keys::{FullViewingKey as SaplingFvk, SaplingIvk};
 use zcash_client_backend::{
     encoding::decode_extended_full_viewing_key,
     keys::sapling::DiversifiableFullViewingKey as SaplingDfvk,

--- a/zebra-chain/src/primitives/zcash_note_encryption.rs
+++ b/zebra-chain/src/primitives/zcash_note_encryption.rs
@@ -25,19 +25,19 @@ pub fn decrypts_successfully(transaction: &Transaction, network: &Network, heigh
     )
     .expect("zcash_primitives and Zebra transaction formats must be compatible");
 
-    let null_sapling_ovk = sapling::keys::OutgoingViewingKey([0u8; 32]);
+    let null_sapling_ovk = sapling_crypto::keys::OutgoingViewingKey([0u8; 32]);
 
     // Note that, since this function is used to validate coinbase transactions, we can ignore
     // the "grace period" mentioned in ZIP-212.
     let zip_212_enforcement = if network_upgrade >= NetworkUpgrade::Canopy {
-        sapling::note_encryption::Zip212Enforcement::On
+        sapling_crypto::note_encryption::Zip212Enforcement::On
     } else {
-        sapling::note_encryption::Zip212Enforcement::Off
+        sapling_crypto::note_encryption::Zip212Enforcement::Off
     };
 
     if let Some(bundle) = alt_tx.sapling_bundle() {
         for output in bundle.shielded_outputs().iter() {
-            let recovery = sapling::note_encryption::try_sapling_output_recovery(
+            let recovery = sapling_crypto::note_encryption::try_sapling_output_recovery(
                 &null_sapling_ovk,
                 output,
                 zip_212_enforcement,

--- a/zebra-chain/src/primitives/zcash_primitives.rs
+++ b/zebra-chain/src/primitives/zcash_primitives.rs
@@ -84,31 +84,40 @@ impl<'a>
 
 struct IdentityMap;
 
-impl zp_tx::components::sapling::MapAuth<sapling::bundle::Authorized, sapling::bundle::Authorized>
-    for IdentityMap
+impl
+    zp_tx::components::sapling::MapAuth<
+        sapling_crypto::bundle::Authorized,
+        sapling_crypto::bundle::Authorized,
+    > for IdentityMap
 {
     fn map_spend_proof(
         &mut self,
-        p: <sapling::bundle::Authorized as sapling::bundle::Authorization>::SpendProof,
-    ) -> <sapling::bundle::Authorized as sapling::bundle::Authorization>::SpendProof {
+        p: <sapling_crypto::bundle::Authorized as sapling_crypto::bundle::Authorization>::SpendProof,
+    ) -> <sapling_crypto::bundle::Authorized as sapling_crypto::bundle::Authorization>::SpendProof
+    {
         p
     }
 
     fn map_output_proof(
         &mut self,
-        p: <sapling::bundle::Authorized as sapling::bundle::Authorization>::OutputProof,
-    ) -> <sapling::bundle::Authorized as sapling::bundle::Authorization>::OutputProof {
+        p: <sapling_crypto::bundle::Authorized as sapling_crypto::bundle::Authorization>::OutputProof,
+    ) -> <sapling_crypto::bundle::Authorized as sapling_crypto::bundle::Authorization>::OutputProof
+    {
         p
     }
 
     fn map_auth_sig(
         &mut self,
-        s: <sapling::bundle::Authorized as sapling::bundle::Authorization>::AuthSig,
-    ) -> <sapling::bundle::Authorized as sapling::bundle::Authorization>::AuthSig {
+        s: <sapling_crypto::bundle::Authorized as sapling_crypto::bundle::Authorization>::AuthSig,
+    ) -> <sapling_crypto::bundle::Authorized as sapling_crypto::bundle::Authorization>::AuthSig
+    {
         s
     }
 
-    fn map_authorization(&mut self, a: sapling::bundle::Authorized) -> sapling::bundle::Authorized {
+    fn map_authorization(
+        &mut self,
+        a: sapling_crypto::bundle::Authorized,
+    ) -> sapling_crypto::bundle::Authorized {
         a
     }
 }
@@ -135,7 +144,7 @@ struct PrecomputedAuth<'a> {
 
 impl<'a> zp_tx::Authorization for PrecomputedAuth<'a> {
     type TransparentAuth = TransparentAuth<'a>;
-    type SaplingAuth = sapling::bundle::Authorized;
+    type SaplingAuth = sapling_crypto::bundle::Authorized;
     type OrchardAuth = orchard::bundle::Authorized;
 }
 

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -57,10 +57,10 @@ tower = { version = "0.4.13", features = ["timeout", "util", "buffer"] }
 tracing = "0.1.39"
 tracing-futures = "0.2.5"
 
-sapling = { package = "sapling-crypto", version = "0.1" }
-orchard = "0.8.0"
+sapling-crypto.workspace = true
+orchard.workspace = true
 
-zcash_proofs = { version = "0.15.0", features = ["multicore" ] }
+zcash_proofs = { workspace = true, features = ["multicore" ] }
 wagyu-zcash-parameters = "0.2.0"
 
 tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.14" }

--- a/zebra-grpc/Cargo.toml
+++ b/zebra-grpc/Cargo.toml
@@ -26,7 +26,7 @@ tokio-stream = "0.1.15"
 tower = { version = "0.4.13", features = ["util", "buffer", "timeout"] }
 color-eyre = "0.6.3"
 
-zcash_primitives = { version = "0.15.0" }
+zcash_primitives.workspace = true
 
 zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.38", features = ["shielded-scan"] }
 zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.38" }

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -88,14 +88,12 @@ hex = { version = "0.4.3", features = ["serde"] }
 serde = { version = "1.0.204", features = ["serde_derive"] }
 
 
-# TODO: Revert to a release once librustzcash is released (#8749).
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", branch = "main", features = ["transparent-inputs"] }
+zcash_primitives = { workspace = true, features = ["transparent-inputs"] }
 
 # Experimental feature getblocktemplate-rpcs
 rand = { version = "0.8.5", optional = true }
 # ECC deps used by getblocktemplate-rpcs feature
-# TODO: Revert to a release once librustzcash is released (#8749).
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", branch = "main",  optional = true}
+zcash_address = { workspace = true, optional = true}
 
 # Test-only feature proptest-impl
 proptest = { version = "1.4.0", optional = true }

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -70,11 +70,11 @@ tower = "0.4.13"
 tracing = "0.1.39"
 futures = "0.3.30"
 
-zcash_client_backend = { version = "0.12.1" }
-zcash_keys = { version = "0.2.0", features = ["sapling"] }
-zcash_primitives = "0.15.0"
-zcash_address = "0.3.2"
-sapling = { package = "sapling-crypto", version = "0.1" }
+zcash_client_backend.workspace = true
+zcash_keys = { workspace = true, features = ["sapling"] }
+zcash_primitives.workspace = true
+zcash_address.workspace = true
+sapling-crypto.workspace = true
 
 zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38", features = ["shielded-scan"] }
 zebra-state = { path = "../zebra-state", version = "1.0.0-beta.38", features = ["shielded-scan"] }

--- a/zebra-scan/src/lib.rs
+++ b/zebra-scan/src/lib.rs
@@ -23,4 +23,4 @@ pub mod tests;
 pub use config::Config;
 pub use init::{init_with_server, spawn_init};
 
-pub use sapling::{zip32::DiversifiableFullViewingKey, SaplingIvk};
+pub use sapling_crypto::{zip32::DiversifiableFullViewingKey, SaplingIvk};

--- a/zebra-scan/src/service/scan_task/commands.rs
+++ b/zebra-scan/src/service/scan_task/commands.rs
@@ -8,7 +8,7 @@ use tokio::sync::{
     oneshot,
 };
 
-use sapling::zip32::DiversifiableFullViewingKey;
+use sapling_crypto::zip32::DiversifiableFullViewingKey;
 use zebra_chain::{block::Height, parameters::Network};
 use zebra_node_services::scan_service::response::ScanResult;
 use zebra_state::SaplingScanningKey;

--- a/zebra-scan/src/service/scan_task/scan.rs
+++ b/zebra-scan/src/service/scan_task/scan.rs
@@ -27,7 +27,7 @@ use zcash_client_backend::{
 };
 use zcash_primitives::zip32::{AccountId, Scope};
 
-use sapling::zip32::DiversifiableFullViewingKey;
+use sapling_crypto::zip32::DiversifiableFullViewingKey;
 
 use zebra_chain::{
     block::{Block, Height},

--- a/zebra-scan/src/service/scan_task/scan/scan_range.rs
+++ b/zebra-scan/src/service/scan_task/scan/scan_range.rs
@@ -7,7 +7,7 @@ use crate::{
     storage::Storage,
 };
 use color_eyre::eyre::Report;
-use sapling::zip32::DiversifiableFullViewingKey;
+use sapling_crypto::zip32::DiversifiableFullViewingKey;
 use tokio::{
     sync::{mpsc::Sender, watch},
     task::JoinHandle,

--- a/zebra-scan/src/tests.rs
+++ b/zebra-scan/src/tests.rs
@@ -1,4 +1,3 @@
-//! Test that we can scan the Zebra blockchain using the external `zcash_client_backend` crate
 //! scanning functionality.
 //!
 //! This tests belong to the proof of concept stage of the external wallet support functionality.
@@ -21,7 +20,7 @@ use zcash_client_backend::{
 use zcash_note_encryption::Domain;
 use zcash_primitives::{block::BlockHash, consensus::BlockHeight, memo::MemoBytes};
 
-use ::sapling::{
+use ::sapling_crypto::{
     constants::SPENDING_KEY_GENERATOR,
     note_encryption::{sapling_note_encryption, SaplingDomain},
     util::generate_random_rseed,
@@ -170,7 +169,10 @@ pub fn fake_compact_block(
 
     // Create a fake Note for the account
     let mut rng = OsRng;
-    let rseed = generate_random_rseed(::sapling::note_encryption::Zip212Enforcement::Off, &mut rng);
+    let rseed = generate_random_rseed(
+        ::sapling_crypto::note_encryption::Zip212Enforcement::Off,
+        &mut rng,
+    );
 
     let note = Note::from_parts(to, NoteValue::from_raw(value), rseed);
     let encryptor = sapling_note_encryption::<_>(

--- a/zebra-scan/src/tests/vectors.rs
+++ b/zebra-scan/src/tests/vectors.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use color_eyre::Result;
 
-use sapling::{
+use sapling_crypto::{
     zip32::{DiversifiableFullViewingKey, ExtendedSpendingKey},
     Nullifier,
 };

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -113,9 +113,9 @@ tokio = { version = "1.39.2", features = ["full"], optional = true }
 
 jsonrpc = { version = "0.18.0", optional = true }
 
-zcash_primitives = { version = "0.15.0", optional = true }
-zcash_client_backend = { version = "0.12.1", optional = true }
-zcash_protocol = { version = "0.1.1" }
+zcash_primitives = { workspace = true, optional = true }
+zcash_client_backend = { workspace = true, optional = true }
+zcash_protocol.workspace = true
 
 # For the openapi generator
 rand = "0.8.5"


### PR DESCRIPTION
## Motivation

Right now versions of some of the dependencies, particularly `librustzcash` crates and some ECC dependencies, are repeated in multiple `Cargo.toml` files which makes those versions difficult to manage.

Fixes #8791

## Solution

This PR introduces workspace dependencies to the workspace `Cargo.toml` file. Right now the `librustzcash` dependencies point to the `main` branch of the zcash/librustzcash repo as that was the newest version used.

This also removes all renames of `sapling-crypto` to `sapling` as package renames are not currently handled by workspace dependencies. In the code `use sapling::` was substituted with `use sapling_crypto::`.

### Tests

This PR passes all `cargo test` tests.

### PR Author's Checklist

- [x] The PR name will make sense to users.
- [x] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

- [x] The PR Author's checklist is complete.
- [x] The PR resolves the issue.

