### PR TITLE
fix(docs): sample configurations in the custom testnet book page

### DIFF
--- a/book/src/user/custom-testnets.md
+++ b/book/src/user/custom-testnets.md
@@ -29,7 +29,10 @@ miner_address = 't27eWDgjFYJGVXmzrXeVjnb5J3uXDM9xH9v'
 [network]
 network = "Testnet"
 
-[network.testnet_parameters.activation_heights]
+# No peers
+initial_testnet_peers = []
+
+[network.testnet_parameters]
 network_name = "ConfiguredTestnet_1"
 # The Testnet network magic is not reserved, but it's not recommended
 # for use with incompatible Testnet parameters like those in this config.
@@ -69,7 +72,10 @@ miner_address = 't27eWDgjFYJGVXmzrXeVjnb5J3uXDM9xH9v'
 [network]
 network = "Testnet"
 
-[network.testnet_parameters.activation_heights]
+# No peers
+initial_testnet_peers = []
+
+[network.testnet_parameters]
 # The Mainnet, Testnet, and Regtest network names are reserved.
 network_name = "ConfiguredTestnet_2"
 


### PR DESCRIPTION
## Motivation

I tried to launch some custom testnets and i found a few small issues in the docs, with the sample configurations provided. 

## Solution

Small modifications so the provided configs can be just pasted into a file and used to launch zebra. Initial peers field was added, with an empty list or:

```
error: zebrad fatal error: parse error: cannot use default initials peers with incompatible testnet for key `network` at line 44 column 1
```
### Tests

Manual, both configurations now are valid and start zebrad.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [x] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [x] The PR Author's checklist is complete.
- [x] The PR resolves the issue.

