### PR TITLE
fix(docker): do not run the Zebra nodes with the root user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -182,14 +182,30 @@ RUN chmod u+x /entrypoint.sh
 # To save space, this step starts from scratch using debian, and only adds the resulting
 # binary from the `release` stage
 FROM debian:bookworm-slim AS runtime
-COPY --from=release /opt/zebrad/target/release/zebrad /usr/local/bin
-COPY --from=release /entrypoint.sh /
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     rocksdb-tools
+
+# Create a non-privileged user that the app will run under.
+# Running as root inside the container is running as root in the Docker host
+# If an attacker manages to break out of the container, they will have root access to the host
+# See https://docs.docker.com/go/dockerfile-user-best-practices/
+ARG USER=zebra
+ARG UID=10001
+ARG GID=10001
+
+RUN addgroup --system --gid ${GID} ${USER} \
+    && adduser \
+    --no-log-init \
+    --system \
+    --disabled-login \
+    --shell /bin/bash \
+    --uid "${UID}" \
+    --gid "{GID}" \
+    ${USER}
 
 # Config settings for zebrad
 ARG FEATURES
@@ -198,6 +214,11 @@ ENV FEATURES=${FEATURES}
 # Path and name of the config file
 ENV ZEBRA_CONF_DIR=${ZEBRA_CONF_DIR:-/etc/zebrad}
 ENV ZEBRA_CONF_FILE=${ZEBRA_CONF_FILE:-zebrad.toml}
+
+COPY --from=release /opt/zebrad/target/release/zebrad /usr/local/bin
+COPY --from=release /entrypoint.sh /
+
+USER ${USER}
 
 # Expose configured ports
 EXPOSE 8233 18233


### PR DESCRIPTION
## Motivation

We should not run our nodes with a privileged user inside the container. If an attacker manages to break out of the container, they will have root access to the host.

### Specifications & References

- https://docs.docker.com/build/building/best-practices/#user
- https://www.docker.com/blog/understanding-the-docker-user-instruction/

## Solution

- Create an user to run `zebrad`

### Tests

- CI and CD tests should pass

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [x] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

