### PR TITLE
fix(docker): add `gosu` and remove unsupported flag in `adduser`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -187,15 +187,21 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
-    rocksdb-tools
+    rocksdb-tools \
+    gosu \
+    && \
+    rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Create a non-privileged user that the app will run under.
 # Running as root inside the container is running as root in the Docker host
 # If an attacker manages to break out of the container, they will have root access to the host
 # See https://docs.docker.com/go/dockerfile-user-best-practices/
 ARG USER=zebra
+ENV USER=${USER}
 ARG UID=10001
+ENV UID=${UID}
 ARG GID=10001
+ENV GID=${GID}
 
 RUN addgroup --system --gid ${GID} ${USER} \
     && adduser \
@@ -216,8 +222,6 @@ ENV ZEBRA_CONF_FILE=${ZEBRA_CONF_FILE:-zebrad.toml}
 
 COPY --from=release /opt/zebrad/target/release/zebrad /usr/local/bin
 COPY --from=release /entrypoint.sh /
-
-USER ${USER}
 
 # Expose configured ports
 EXPOSE 8233 18233

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -199,12 +199,11 @@ ARG GID=10001
 
 RUN addgroup --system --gid ${GID} ${USER} \
     && adduser \
-    --no-log-init \
     --system \
     --disabled-login \
     --shell /bin/bash \
     --uid "${UID}" \
-    --gid "{GID}" \
+    --gid "${GID}" \
     ${USER}
 
 # Config settings for zebrad

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -357,11 +357,11 @@ case "$1" in
         exec cargo test --locked --release --features "zebra-test" --package zebra-scan -- --nocapture --include-ignored scan_task_commands
 
       else
-          exec "$@"
+          exec gosu "$USER" "$@"
       fi
     fi
     ;;
   *)
-    exec "$@"
+    exec gosu "$USER" "$@"
     ;;
 esac


### PR DESCRIPTION
## Motivation

PR https://github.com/ZcashFoundation/zebra/pull/8803 had a failing test, but it was allowed to get merge. 

## Solution

- Fix typo and non-allowed option in `adduser` for Debian
- Add `gosu` to avoid running Zebra with root, but allowing our `entrypoint.sh` to create directories and files

### Tests

- Verify that all tests are passing

### PR Author's Checklist

- [x] The PR name will make sense to users.
- [x] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

