### PR TITLE
build(deps): Upgrade ECC dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,7 +1317,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash/?branch=main#40ca428c6081c61d5a2bf3f2053eb9e18219ca95"
+source = "git+https://github.com/zcash/librustzcash/#a1047adf0b6f324dad415db34762dc26f8367ce4"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -1352,7 +1352,16 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash/?branch=main#40ca428c6081c61d5a2bf3f2053eb9e18219ca95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a83e8d7fd0c526af4aad893b7c9fe41e2699ed8a776a6c74aecdeafe05afc75"
+dependencies = [
+ "blake2b_simd",
+]
+
+[[package]]
+name = "f4jumble"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash/#a1047adf0b6f324dad415db34762dc26f8367ce4"
 dependencies = [
  "blake2b_simd",
 ]
@@ -5551,19 +5560,46 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 [[package]]
 name = "zcash_address"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash/?branch=main#40ca428c6081c61d5a2bf3f2053eb9e18219ca95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6d26f21381dc220836dd8d2a9a10dbe85928a26232b011bc6a42b611789b743"
 dependencies = [
  "bech32",
  "bs58",
- "f4jumble",
- "zcash_encoding",
- "zcash_protocol",
+ "f4jumble 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.2.0",
+]
+
+[[package]]
+name = "zcash_address"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14bccd6cefb76f87b6d15a9e7b02b6c0515648c6de8e806c4e2d6f0f6ae640c5"
+dependencies = [
+ "bech32",
+ "bs58",
+ "f4jumble 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zcash_address"
+version = "0.5.0"
+source = "git+https://github.com/zcash/librustzcash/#a1047adf0b6f324dad415db34762dc26f8367ce4"
+dependencies = [
+ "bech32",
+ "bs58",
+ "f4jumble 0.1.0 (git+https://github.com/zcash/librustzcash/)",
+ "zcash_encoding 0.2.1 (git+https://github.com/zcash/librustzcash/)",
+ "zcash_protocol 0.3.0 (git+https://github.com/zcash/librustzcash/)",
 ]
 
 [[package]]
 name = "zcash_client_backend"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash/?branch=main#40ca428c6081c61d5a2bf3f2053eb9e18219ca95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e3a0f3e5d7f299d8b7ef3237697630989c31ab1b162824c99c1cd8bc83715e"
 dependencies = [
  "base64 0.21.7",
  "bech32",
@@ -5589,20 +5625,69 @@ dependencies = [
  "tonic-build",
  "tracing",
  "which",
- "zcash_address",
- "zcash_encoding",
- "zcash_keys",
+ "zcash_address 0.4.0",
+ "zcash_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_keys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_note_encryption",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_primitives 0.16.0",
+ "zcash_protocol 0.2.0",
  "zip32",
- "zip321",
+ "zip321 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zcash_client_backend"
+version = "0.13.0"
+source = "git+https://github.com/zcash/librustzcash/#a1047adf0b6f324dad415db34762dc26f8367ce4"
+dependencies = [
+ "base64 0.21.7",
+ "bech32",
+ "bls12_381",
+ "bs58",
+ "crossbeam-channel",
+ "document-features",
+ "group",
+ "hex",
+ "incrementalmerkletree",
+ "memuse",
+ "nom",
+ "nonempty",
+ "percent-encoding",
+ "prost",
+ "rand_core 0.6.4",
+ "rayon",
+ "sapling-crypto",
+ "secrecy",
+ "shardtree",
+ "subtle",
+ "time",
+ "tonic-build",
+ "tracing",
+ "which",
+ "zcash_address 0.5.0 (git+https://github.com/zcash/librustzcash/)",
+ "zcash_encoding 0.2.1 (git+https://github.com/zcash/librustzcash/)",
+ "zcash_keys 0.3.0 (git+https://github.com/zcash/librustzcash/)",
+ "zcash_note_encryption",
+ "zcash_primitives 0.17.0 (git+https://github.com/zcash/librustzcash/)",
+ "zcash_protocol 0.3.0 (git+https://github.com/zcash/librustzcash/)",
+ "zip32",
+ "zip321 0.1.0 (git+https://github.com/zcash/librustzcash/)",
 ]
 
 [[package]]
 name = "zcash_encoding"
 version = "0.2.1"
-source = "git+https://github.com/zcash/librustzcash/?branch=main#40ca428c6081c61d5a2bf3f2053eb9e18219ca95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052d8230202f0a018cd9b5d1b56b94cd25e18eccc2d8665073bcea8261ab87fc"
+dependencies = [
+ "byteorder",
+ "nonempty",
+]
+
+[[package]]
+name = "zcash_encoding"
+version = "0.2.1"
+source = "git+https://github.com/zcash/librustzcash/#a1047adf0b6f324dad415db34762dc26f8367ce4"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -5611,7 +5696,8 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash/?branch=main#40ca428c6081c61d5a2bf3f2053eb9e18219ca95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fde17bf53792f9c756b313730da14880257d7661b5bfc69d0571c3a7c11a76d"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -5621,7 +5707,8 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash/?branch=main#40ca428c6081c61d5a2bf3f2053eb9e18219ca95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712faf4070107ab0b2828d0eda6aeaf4c3cb02564109832d95b97ad3467c95a5"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -5636,10 +5723,35 @@ dependencies = [
  "secrecy",
  "subtle",
  "tracing",
- "zcash_address",
- "zcash_encoding",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_address 0.4.0",
+ "zcash_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.16.0",
+ "zcash_protocol 0.2.0",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_keys"
+version = "0.3.0"
+source = "git+https://github.com/zcash/librustzcash/#a1047adf0b6f324dad415db34762dc26f8367ce4"
+dependencies = [
+ "bech32",
+ "blake2b_simd",
+ "bls12_381",
+ "bs58",
+ "document-features",
+ "group",
+ "memuse",
+ "nonempty",
+ "rand_core 0.6.4",
+ "sapling-crypto",
+ "secrecy",
+ "subtle",
+ "tracing",
+ "zcash_address 0.5.0 (git+https://github.com/zcash/librustzcash/)",
+ "zcash_encoding 0.2.1 (git+https://github.com/zcash/librustzcash/)",
+ "zcash_primitives 0.17.0 (git+https://github.com/zcash/librustzcash/)",
+ "zcash_protocol 0.3.0 (git+https://github.com/zcash/librustzcash/)",
  "zip32",
 ]
 
@@ -5659,7 +5771,44 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.16.0"
-source = "git+https://github.com/zcash/librustzcash/?branch=main#40ca428c6081c61d5a2bf3f2053eb9e18219ca95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f044bc9cf2887ec408196fbafb44749e5581f57cc18d8da7aabaeb60cc40c64"
+dependencies = [
+ "aes",
+ "blake2b_simd",
+ "bs58",
+ "byteorder",
+ "document-features",
+ "equihash 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ff",
+ "fpe",
+ "group",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "memuse",
+ "nonempty",
+ "orchard",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "sha2",
+ "subtle",
+ "tracing",
+ "zcash_address 0.4.0",
+ "zcash_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_note_encryption",
+ "zcash_protocol 0.2.0",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_primitives"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d87ab6a55591a8cf1866749fdc739ae1bbd06e6cec07ab0bbe5d57ee3390eb2"
 dependencies = [
  "aes",
  "bip32",
@@ -5667,7 +5816,7 @@ dependencies = [
  "bs58",
  "byteorder",
  "document-features",
- "equihash 0.2.0 (git+https://github.com/zcash/librustzcash/?branch=main)",
+ "equihash 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ff",
  "fpe",
  "group",
@@ -5686,18 +5835,54 @@ dependencies = [
  "sha2",
  "subtle",
  "tracing",
- "zcash_address",
- "zcash_encoding",
+ "zcash_address 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_note_encryption",
- "zcash_protocol",
+ "zcash_protocol 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_primitives"
+version = "0.17.0"
+source = "git+https://github.com/zcash/librustzcash/#a1047adf0b6f324dad415db34762dc26f8367ce4"
+dependencies = [
+ "aes",
+ "blake2b_simd",
+ "bs58",
+ "byteorder",
+ "document-features",
+ "equihash 0.2.0 (git+https://github.com/zcash/librustzcash/)",
+ "ff",
+ "fpe",
+ "group",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "memuse",
+ "nonempty",
+ "orchard",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "sha2",
+ "subtle",
+ "tracing",
+ "zcash_address 0.5.0 (git+https://github.com/zcash/librustzcash/)",
+ "zcash_encoding 0.2.1 (git+https://github.com/zcash/librustzcash/)",
+ "zcash_note_encryption",
+ "zcash_protocol 0.3.0 (git+https://github.com/zcash/librustzcash/)",
  "zcash_spec",
  "zip32",
 ]
 
 [[package]]
 name = "zcash_proofs"
-version = "0.16.0"
-source = "git+https://github.com/zcash/librustzcash/?branch=main#40ca428c6081c61d5a2bf3f2053eb9e18219ca95"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b9fc0032b3d90f000f50dba7a996ad6556b7dba5b5145f93ab67b6eb74d3a48"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5713,13 +5898,33 @@ dependencies = [
  "sapling-crypto",
  "tracing",
  "xdg",
- "zcash_primitives",
+ "zcash_primitives 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zcash_protocol"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash/?branch=main#40ca428c6081c61d5a2bf3f2053eb9e18219ca95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f35eac659fdbba614333d119217c5963c0d7cea43aee33176c4f2f95e5460d8d"
+dependencies = [
+ "document-features",
+ "memuse",
+]
+
+[[package]]
+name = "zcash_protocol"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1ff002bd41ba76b42d42a02ee11de06790b7fdbc904bdea4486b9a93b2a5e4"
+dependencies = [
+ "document-features",
+ "memuse",
+]
+
+[[package]]
+name = "zcash_protocol"
+version = "0.3.0"
+source = "git+https://github.com/zcash/librustzcash/#a1047adf0b6f324dad415db34762dc26f8367ce4"
 dependencies = [
  "document-features",
  "memuse",
@@ -5797,13 +6002,13 @@ dependencies = [
  "tracing",
  "uint",
  "x25519-dalek",
- "zcash_address",
- "zcash_client_backend",
- "zcash_encoding",
+ "zcash_address 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_client_backend 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_history",
  "zcash_note_encryption",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_primitives 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zebra-test",
 ]
 
@@ -5868,7 +6073,7 @@ dependencies = [
  "tonic-build",
  "tonic-reflection",
  "tower",
- "zcash_primitives",
+ "zcash_primitives 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zebra-chain",
  "zebra-node-services",
  "zebra-state",
@@ -5954,8 +6159,8 @@ dependencies = [
  "tonic-reflection",
  "tower",
  "tracing",
- "zcash_address",
- "zcash_primitives",
+ "zcash_address 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",
@@ -5997,11 +6202,11 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
- "zcash_address",
- "zcash_client_backend",
- "zcash_keys",
+ "zcash_address 0.5.0 (git+https://github.com/zcash/librustzcash/)",
+ "zcash_client_backend 0.13.0 (git+https://github.com/zcash/librustzcash/)",
+ "zcash_keys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_note_encryption",
- "zcash_primitives",
+ "zcash_primitives 0.17.0 (git+https://github.com/zcash/librustzcash/)",
  "zebra-chain",
  "zebra-grpc",
  "zebra-node-services",
@@ -6119,9 +6324,9 @@ dependencies = [
  "tokio",
  "tracing-error",
  "tracing-subscriber",
- "zcash_client_backend",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_client_backend 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zebra-chain",
  "zebra-node-services",
  "zebra-rpc",
@@ -6253,11 +6458,24 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash/?branch=main#40ca428c6081c61d5a2bf3f2053eb9e18219ca95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc85f862f7be64fb0d46f9eb5b82ad54e58cde314fa979d5bae591bc0143693"
 dependencies = [
  "base64 0.21.7",
  "nom",
  "percent-encoding",
- "zcash_address",
- "zcash_protocol",
+ "zcash_address 0.4.0",
+ "zcash_protocol 0.2.0",
+]
+
+[[package]]
+name = "zip321"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash/#a1047adf0b6f324dad415db34762dc26f8367ce4"
+dependencies = [
+ "base64 0.21.7",
+ "nom",
+ "percent-encoding",
+ "zcash_address 0.5.0 (git+https://github.com/zcash/librustzcash/)",
+ "zcash_protocol 0.3.0 (git+https://github.com/zcash/librustzcash/)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,15 +25,14 @@ resolver = "2"
 incrementalmerkletree = "0.6.0"
 orchard = "0.9.0"
 sapling-crypto = "0.2.0"
-# TODO: Revert to a release once librustzcash is released (#8749).
-zcash_address = { git = "https://github.com/zcash/librustzcash/", branch = "main" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash/", branch = "main" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash/", branch = "main" }
-zcash_history = { git = "https://github.com/zcash/librustzcash/", branch = "main" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash/", branch = "main" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash/", branch = "main" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash/", branch = "main" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash/", branch = "main" }
+zcash_address = "0.5.0"
+zcash_client_backend = "0.13.0"
+zcash_encoding = "0.2.1"
+zcash_history = "0.4.0"
+zcash_keys = "0.3.0"
+zcash_primitives = "0.17.0"
+zcash_proofs = "0.17.0"
+zcash_protocol = "0.3.0"
 
 [workspace.metadata.release]
 

--- a/deny.toml
+++ b/deny.toml
@@ -58,9 +58,6 @@ skip-tree = [
     # wait for `color-eyre` to upgrade
     { name = "owo-colors", version = "=3.5.0" },
 
-    # wait for hdwallet to upgrade
-    { name = "ring", version = "=0.16.20" },
-
     # wait for structopt upgrade (or upgrade to clap 4)
     { name = "clap", version = "=2.34.0" },
 
@@ -73,13 +70,6 @@ skip-tree = [
     # wait for console-subscriber and tower to update hdrhistogram.
     # also wait for ron to update insta, and wait for tonic update.
     { name = "base64", version = "=0.13.1" },
-
-    # wait for console-subscriber to update tonic.
-    { name = "tonic", version = "=0.11.0" },
-    { name = "tonic-build", version = "=0.10.2" },
-    { name = "axum", version = "=0.6.20" },
-    { name = "axum-core", version = "=0.3.4" },
-    { name = "hyper-timeout", version = "=0.4.1" },
 
     # wait for elasticsearch to update base64, darling, rustc_version, serde_with
     { name = "elasticsearch", version = "=8.5.0-alpha.1" },
@@ -98,10 +88,9 @@ skip-tree = [
     { name = "equihash", version = "=0.2.0" },
     { name = "f4jumble", version = "=0.1.0" },
     { name = "secp256k1", version = "=0.26.0" },
-    { name = "zcash_address", version = "=0.3.2" },
-    { name = "zcash_encoding", version = "=0.2.0" },
-    { name = "zcash_primitives", version = "=0.15.1" },
-    { name = "zcash_protocol", version = "=0.1.1" },
+    { name = "zcash_address", version = "=0.5.0" },
+    { name = "zcash_client_backend", version = "=0.13.0" },
+
 
     # wait for structopt-derive to update heck
     { name = "heck", version = "=0.3.3" },

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -70,10 +70,12 @@ tower = "0.4.13"
 tracing = "0.1.39"
 futures = "0.3.30"
 
-zcash_client_backend.workspace = true
+# ECC dependencies.
+# TODO: we can't use the workspace version for all ECC dependencies in this crate yet (#8809)
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash/", commit = "40ca428c6081c61d5a2bf3f2053eb9e18219ca95" }
 zcash_keys = { workspace = true, features = ["sapling"] }
-zcash_primitives.workspace = true
-zcash_address.workspace = true
+zcash_primitives = { git = "https://github.com/zcash/librustzcash/", commit = "40ca428c6081c61d5a2bf3f2053eb9e18219ca95" }
+zcash_address = { git = "https://github.com/zcash/librustzcash/", commit = "40ca428c6081c61d5a2bf3f2053eb9e18219ca95" }
 sapling-crypto.workspace = true
 
 zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.38", features = ["shielded-scan"] }


### PR DESCRIPTION
## Motivation

We need to upgrade the ECC dependencies for NU6.

Close https://github.com/ZcashFoundation/zebra/issues/8749
Close https://github.com/ZcashFoundation/zebra/pull/8799

## Solution

We can upgrade the root Cargo.toml which makes this a lot easier (thank you @tomekpiotrowski !).

However, we need to remain in older versions for some of the ECC crates in the `zebra-scan` crate for now.

### Tests

CI should take care of this.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [ ] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

