### PR TITLE
add(docs): Add minimal hardware requirements

### DIFF
--- a/book/src/user/requirements.md
+++ b/book/src/user/requirements.md
@@ -9,14 +9,14 @@ Zebra has the following hardware requirements.
 - 300 GB available disk space 
 - 100 Mbps network connection, with 300 GB of uploads and downloads per month
 
-## Minimal Requirements
+## Minimum Hardware Requirements
 
 - 2 CPU cores
 - 4 GB RAM
 - 300 GB available disk space 
 
-You can run Zebra fine on a computer such as Orange Pi Zero 2W with a 512 GB
-microSD card.
+[Zebra has successfully run on an Orange Pi Zero 2W with a 512 GB microSD card
+without any issues.](https://x.com/Zerodartz/status/1811460885996798159)
 
 ## Disk Requirements
 

--- a/book/src/user/requirements.md
+++ b/book/src/user/requirements.md
@@ -48,9 +48,6 @@ networks.
 - Ongoing updates: 10 MB - 10 GB upload and download per day, depending on
   user-created transaction size and peer requests.
 
-Zebra performs an initial sync every time its internal database version changes,
-so some version upgrades might require a full download of the whole chain.
-
 Zebra needs some peers which have a round-trip latency of 2 seconds or less. If
 this is a problem for you, please [open a
 ticket.](https://github.com/ZcashFoundation/zebra/issues/new/choose)

--- a/book/src/user/requirements.md
+++ b/book/src/user/requirements.md
@@ -1,16 +1,22 @@
 # System Requirements
 
-We recommend the following requirements for compiling and running `zebrad`:
+Zebra has the following hardware requirements.
+
+## Recommended Requirements
 
 - 4 CPU cores
 - 16 GB RAM
-- 300 GB available disk space for building binaries and storing cached chain
-  state
+- 300 GB available disk space 
 - 100 Mbps network connection, with 300 GB of uploads and downloads per month
 
-Zebra's tests can take over an hour, depending on your machine. Note that you
-might be able to build and run Zebra on slower systems — we haven't tested its
-exact limits yet.
+## Minimal Requirements
+
+- 2 CPU cores
+- 4 GB RAM
+- 300 GB available disk space 
+
+You can run Zebra fine on a computer such as Orange Pi Zero 2W with a 512 GB
+microSD card.
 
 ## Disk Requirements
 


### PR DESCRIPTION
A user reported that Zebra can run fine on much lower HW specs than what we had in the docs.

Source & credit: https://x.com/Zerodartz/status/1811460885996798159