### PR TITLE
fix(deps): Replace `serde_yaml` by `serde_yml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,6 +2435,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4071,16 +4081,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yml"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
 dependencies = [
  "indexmap 2.3.0",
  "itoa",
+ "libyml",
+ "memchr",
  "ryu",
  "serde",
- "unsafe-libyaml",
+ "version_check",
 ]
 
 [[package]]
@@ -5019,12 +5031,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5108,9 +5114,9 @@ dependencies = [
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "visibility"
@@ -6318,7 +6324,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yml",
  "structopt",
  "syn 2.0.72",
  "thiserror",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -28,7 +28,7 @@ paths:
                   default: getinfo
                 id:
                   type: string
-                  default: x2r3lRddGL
+                  default: VuJXrxLSw8
                 params:
                   type: array
                   items: {}
@@ -61,7 +61,7 @@ paths:
                   default: getblockchaininfo
                 id:
                   type: string
-                  default: w8Lb0nAvLd
+                  default: HDVqYXM9m6
                 params:
                   type: array
                   items: {}
@@ -99,7 +99,7 @@ paths:
                   default: getaddressbalance
                 id:
                   type: string
-                  default: QbTztoTvRo
+                  default: Xw5TDBKXGl
                 params:
                   type: array
                   items: {}
@@ -147,7 +147,7 @@ paths:
                   default: sendrawtransaction
                 id:
                   type: string
-                  default: aDK5RQWj16
+                  default: QaJv2bXyZu
                 params:
                   type: array
                   items: {}
@@ -196,7 +196,7 @@ paths:
                   default: getblock
                 id:
                   type: string
-                  default: xxCP1d61X0
+                  default: k0DACJrgZs
                 params:
                   type: array
                   items: {}
@@ -239,7 +239,7 @@ paths:
                   default: getbestblockhash
                 id:
                   type: string
-                  default: DoZgd1j7xW
+                  default: rIFaLhZwHF
                 params:
                   type: array
                   items: {}
@@ -272,7 +272,7 @@ paths:
                   default: getbestblockheightandhash
                 id:
                   type: string
-                  default: 0iUFHsOjk3
+                  default: oxrhh1swvh
                 params:
                   type: array
                   items: {}
@@ -305,7 +305,7 @@ paths:
                   default: getrawmempool
                 id:
                   type: string
-                  default: WXG2c6FcCK
+                  default: E7oUD34jk2
                 params:
                   type: array
                   items: {}
@@ -343,7 +343,7 @@ paths:
                   default: z_gettreestate
                 id:
                   type: string
-                  default: 38P0xXV0do
+                  default: Hp22XK728i
                 params:
                   type: array
                   items: {}
@@ -393,7 +393,7 @@ paths:
                   default: z_getsubtreesbyindex
                 id:
                   type: string
-                  default: 662iR8VZGT
+                  default: Cs69hg68pl
                 params:
                   type: array
                   items: {}
@@ -432,7 +432,7 @@ paths:
                   default: getrawtransaction
                 id:
                   type: string
-                  default: UuvVrzSzqC
+                  default: iu395PEErc
                 params:
                   type: array
                   items: {}
@@ -480,7 +480,7 @@ paths:
                   default: getaddresstxids
                 id:
                   type: string
-                  default: KMss2wDMwH
+                  default: z3lOKfsQdp
                 params:
                   type: array
                   items: {}
@@ -528,7 +528,7 @@ paths:
                   default: getaddressutxos
                 id:
                   type: string
-                  default: 4Y6BAhe6Lf
+                  default: '7U4Q4dSxej'
                 params:
                   type: array
                   items: {}
@@ -571,7 +571,7 @@ paths:
                   default: getblockcount
                 id:
                   type: string
-                  default: nzPm5W3X1G
+                  default: '8yw3EX7Cwi'
                 params:
                   type: array
                   items: {}
@@ -609,7 +609,7 @@ paths:
                   default: getblockhash
                 id:
                   type: string
-                  default: KLKosq2Z8E
+                  default: ndDYksCl9E
                 params:
                   type: array
                   items: {}
@@ -657,7 +657,7 @@ paths:
                   default: getblocktemplate
                 id:
                   type: string
-                  default: spj7gKe2AA
+                  default: lJi2hfxty1
                 params:
                   type: array
                   items: {}
@@ -695,7 +695,7 @@ paths:
                   default: submitblock
                 id:
                   type: string
-                  default: QOQsC3nA7z
+                  default: '9fEFOdTQle'
                 params:
                   type: array
                   items: {}
@@ -728,7 +728,7 @@ paths:
                   default: getmininginfo
                 id:
                   type: string
-                  default: Si3Sdb9ICT
+                  default: Dytpq4f3lF
                 params:
                   type: array
                   items: {}
@@ -761,7 +761,7 @@ paths:
                   default: getnetworksolps
                 id:
                   type: string
-                  default: jWvKPdOxDa
+                  default: yX3woRnOaN
                 params:
                   type: array
                   items: {}
@@ -794,7 +794,7 @@ paths:
                   default: getnetworkhashps
                 id:
                   type: string
-                  default: wnFwBVFrN0
+                  default: AyAZMtbezv
                 params:
                   type: array
                   items: {}
@@ -827,7 +827,7 @@ paths:
                   default: getpeerinfo
                 id:
                   type: string
-                  default: NpKiq59CE8
+                  default: nNcrsu3ZAR
                 params:
                   type: array
                   items: {}
@@ -865,7 +865,7 @@ paths:
                   default: validateaddress
                 id:
                   type: string
-                  default: PDjTChWgFW
+                  default: LGyfO7zTjW
                 params:
                   type: array
                   items: {}
@@ -903,7 +903,7 @@ paths:
                   default: z_validateaddress
                 id:
                   type: string
-                  default: aCeb6xbIuo
+                  default: '2Q09a2Nh4N'
                 params:
                   type: array
                   items: {}
@@ -941,7 +941,7 @@ paths:
                   default: getblocksubsidy
                 id:
                   type: string
-                  default: EeBvVXCJon
+                  default: nv6lOWCRso
                 params:
                   type: array
                   items: {}
@@ -984,7 +984,7 @@ paths:
                   default: getdifficulty
                 id:
                   type: string
-                  default: jg2K8N0ZG4
+                  default: '2O3A0PF1SS'
                 params:
                   type: array
                   items: {}
@@ -1022,7 +1022,7 @@ paths:
                   default: z_listunifiedreceivers
                 id:
                   type: string
-                  default: Y3gscsg8yT
+                  default: XYgGcDIx2X
                 params:
                   type: array
                   items: {}

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1,4 +1,3 @@
-
 # cargo-vet config file
 
 [cargo-vet]
@@ -1412,10 +1411,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.serde_with_macros]]
 version = "3.8.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.serde_yaml]]
-version = "0.9.34+deprecated"
 criteria = "safe-to-deploy"
 
 [[exemptions.sha2]]

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -77,7 +77,7 @@ openapi-generator = [
     "zebra-rpc",
     "syn",
     "quote",
-    "serde_yaml",
+    "serde_yml",
     "serde"
 ]
 
@@ -121,7 +121,7 @@ zcash_protocol.workspace = true
 rand = "0.8.5"
 syn = { version = "2.0.72", features = ["full"], optional = true }
 quote = { version = "1.0.36", optional = true }
-serde_yaml = { version = "0.9.34+deprecated", optional = true }
+serde_yml = { version = "0.0.12", optional = true }
 serde = { version = "1.0.204", features = ["serde_derive"], optional = true }
 indexmap = "2.3.0"
 

--- a/zebra-utils/src/bin/openapi-generator/main.rs
+++ b/zebra-utils/src/bin/openapi-generator/main.rs
@@ -174,9 +174,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let all_methods = Methods { paths: methods };
 
     // Add openapi header and write to file
-    let yaml_string = serde_yaml::to_string(&all_methods)?;
+    let yml_string = serde_yml::to_string(&all_methods)?;
     let mut w = File::create("openapi.yaml")?;
-    w.write_all(format!("{}{}", create_yaml(), yaml_string).as_bytes())?;
+    w.write_all(format!("{}{}", create_yaml(), yml_string).as_bytes())?;
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

Close #8455.

## Solution

- Use `serde_yml` instead of `serde_yaml`.
- Regenerate `openapi.yaml`.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.