### PR TITLE
add(network): Check in proptest seeds for `zebra-network` tests

### DIFF
--- a/zebra-network/proptest-regressions/peer_set/set/tests/prop.txt
+++ b/zebra-network/proptest-regressions/peer_set/set/tests/prop.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 942cc3b893c2cc831afb9bf7079e1858a6f7e2dab8386c1f7c8304b439cd7b55 # shrinks to total_number_of_peers = 2


### PR DESCRIPTION
## Motivation

I started using `cargo fix` more regularly, and running it without any flags returns:

```log
error: the working directory of this package has uncommitted changes, and `cargo fix` can potentially perform destructive changes; if you'd like to suppress this error pass `--allow-dirty`, `--allow-staged`, or commit the changes to these files:

  * zebra-network/proptest-regressions/peer_set/set/ (dirty)
```

I've had the proptest file dangling among unstaged changes in git's workdir for a while. I assume it gets generated for others as well. Having it checked in is recommended in the file itself.

## Solution

- Track the file mentioned above in git.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.