### PR TITLE
Minor doc updates

### DIFF
--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -33,7 +33,7 @@ use crate::{
 /// See the [`TrustedChainSync::wait_for_chain_tip_change()`] method documentation for more information.
 const POLL_DELAY: Duration = Duration::from_millis(200);
 
-/// Syncs non-finalized blocks in the best chain from a trusted Zebra node's RPC methods.
+/// Syncs non-finalized blocks in the best chain from a trusted-for-block-validation Zebra node's RPC methods.
 #[derive(Debug)]
 struct TrustedChainSync {
     /// RPC client for calling Zebra's RPC methods.

--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -38,7 +38,7 @@ const POLL_DELAY: Duration = Duration::from_millis(200);
 struct TrustedChainSync {
     /// RPC client for calling Zebra's RPC methods.
     rpc_client: RpcRequestClient,
-    /// The read state service.
+    /// The recorded-state service.
     db: ZebraDb,
     /// The non-finalized state - currently only contains the best chain.
     non_finalized_state: NonFinalizedState,


### PR DESCRIPTION
## Motivation

<!--
Small readability improvements in doc-comments
-->


## Solution

<!--
  Specify what a zebra providing responses to a TrustChainSync is trusted *for*
  Use less ambiguous "recorded-state" in place of "read"
-->


### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

