### PR TITLE
feat(rpc): Add more fields to `getmininginfo` call

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -28,7 +28,7 @@ paths:
                   default: getinfo
                 id:
                   type: string
-                  default: QWlDS9bxlK
+                  default: tocbYJJbOV
                 params:
                   type: array
                   items: {}
@@ -61,7 +61,7 @@ paths:
                   default: getblockchaininfo
                 id:
                   type: string
-                  default: XSg3wvZykA
+                  default: aLNdjqbO2F
                 params:
                   type: array
                   items: {}
@@ -99,7 +99,7 @@ paths:
                   default: getaddressbalance
                 id:
                   type: string
-                  default: GEd1QJWprH
+                  default: SP8ltCyyTB
                 params:
                   type: array
                   items: {}
@@ -147,7 +147,7 @@ paths:
                   default: sendrawtransaction
                 id:
                   type: string
-                  default: nhQi7D6Oru
+                  default: obz2x3FUtb
                 params:
                   type: array
                   items: {}
@@ -196,7 +196,7 @@ paths:
                   default: getblock
                 id:
                   type: string
-                  default: qIEYMzgbJZ
+                  default: '7nMgD38TFh'
                 params:
                   type: array
                   items: {}
@@ -239,7 +239,7 @@ paths:
                   default: getbestblockhash
                 id:
                   type: string
-                  default: P9UBS8IXXU
+                  default: '9iZPlvcq4k'
                 params:
                   type: array
                   items: {}
@@ -272,7 +272,7 @@ paths:
                   default: getbestblockheightandhash
                 id:
                   type: string
-                  default: gQNhsomx7N
+                  default: '3kahZUB47G'
                 params:
                   type: array
                   items: {}
@@ -305,7 +305,7 @@ paths:
                   default: getrawmempool
                 id:
                   type: string
-                  default: c2ScL31PtX
+                  default: '775E7dCkJY'
                 params:
                   type: array
                   items: {}
@@ -343,7 +343,7 @@ paths:
                   default: z_gettreestate
                 id:
                   type: string
-                  default: JQ0mENKbdm
+                  default: X5dnRwM06D
                 params:
                   type: array
                   items: {}
@@ -393,7 +393,7 @@ paths:
                   default: z_getsubtreesbyindex
                 id:
                   type: string
-                  default: bZUCv4t0f4
+                  default: '76Z2kJzcEK'
                 params:
                   type: array
                   items: {}
@@ -432,7 +432,7 @@ paths:
                   default: getrawtransaction
                 id:
                   type: string
-                  default: I0FAejAi4r
+                  default: RuJIBJPzSH
                 params:
                   type: array
                   items: {}
@@ -480,7 +480,7 @@ paths:
                   default: getaddresstxids
                 id:
                   type: string
-                  default: '3fMzDHOglf'
+                  default: GM0FBOoRXg
                 params:
                   type: array
                   items: {}
@@ -528,7 +528,7 @@ paths:
                   default: getaddressutxos
                 id:
                   type: string
-                  default: LE2AR8Tr6X
+                  default: BU4pYqDqWW
                 params:
                   type: array
                   items: {}
@@ -571,7 +571,7 @@ paths:
                   default: stop
                 id:
                   type: string
-                  default: PbxxqB0ZpF
+                  default: Ia6PiwVt9b
                 params:
                   type: array
                   items: {}
@@ -604,7 +604,7 @@ paths:
                   default: getblockcount
                 id:
                   type: string
-                  default: WO6BAIKSCg
+                  default: dYt6KL8y9k
                 params:
                   type: array
                   items: {}
@@ -642,7 +642,7 @@ paths:
                   default: getblockhash
                 id:
                   type: string
-                  default: vHpKNIQRLF
+                  default: vCyKThLa1P
                 params:
                   type: array
                   items: {}
@@ -690,7 +690,7 @@ paths:
                   default: getblocktemplate
                 id:
                   type: string
-                  default: L04jp5F2QW
+                  default: '3QGZTfysCT'
                 params:
                   type: array
                   items: {}
@@ -728,7 +728,7 @@ paths:
                   default: submitblock
                 id:
                   type: string
-                  default: Izn7vhiMaA
+                  default: WQonyZVAdv
                 params:
                   type: array
                   items: {}
@@ -761,7 +761,7 @@ paths:
                   default: getmininginfo
                 id:
                   type: string
-                  default: SgyuBQbMik
+                  default: WUDNNpqVW4
                 params:
                   type: array
                   items: {}
@@ -776,7 +776,7 @@ paths:
                 properties:
                   result:
                     type: object
-                    default: '{"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
+                    default: '{"blocks":0,"networksolps":0,"networkhashps":0,"chain":"","testnet":false}'
   /getnetworksolps:
     post:
       tags:
@@ -794,7 +794,7 @@ paths:
                   default: getnetworksolps
                 id:
                   type: string
-                  default: FXg2iH3eaX
+                  default: PMF5rR6HYt
                 params:
                   type: array
                   items: {}
@@ -827,7 +827,7 @@ paths:
                   default: getnetworkhashps
                 id:
                   type: string
-                  default: '2PWjf8QqfI'
+                  default: C8JXbf9dgl
                 params:
                   type: array
                   items: {}
@@ -860,7 +860,7 @@ paths:
                   default: getpeerinfo
                 id:
                   type: string
-                  default: OE9s5wkP0w
+                  default: saWf9ns3k4
                 params:
                   type: array
                   items: {}
@@ -898,7 +898,7 @@ paths:
                   default: validateaddress
                 id:
                   type: string
-                  default: '6FS4iGA4Ht'
+                  default: qQup8squeY
                 params:
                   type: array
                   items: {}
@@ -936,7 +936,7 @@ paths:
                   default: z_validateaddress
                 id:
                   type: string
-                  default: utp8tN61yU
+                  default: '0G6JfZ0iEM'
                 params:
                   type: array
                   items: {}
@@ -974,7 +974,7 @@ paths:
                   default: getblocksubsidy
                 id:
                   type: string
-                  default: dgNZGo7lNa
+                  default: hn0z6RuWtv
                 params:
                   type: array
                   items: {}
@@ -1017,7 +1017,7 @@ paths:
                   default: getdifficulty
                 id:
                   type: string
-                  default: KEJv30D2MI
+                  default: eOXG5K3QIN
                 params:
                   type: array
                   items: {}
@@ -1055,7 +1055,7 @@ paths:
                   default: z_listunifiedreceivers
                 id:
                   type: string
-                  default: lfBqvYghGm
+                  default: xrepQvDofT
                 params:
                   type: array
                   items: {}

--- a/zebra-chain/src/chain_tip/mock.rs
+++ b/zebra-chain/src/chain_tip/mock.rs
@@ -106,7 +106,7 @@ impl ChainTip for MockChainTip {
     }
 
     fn best_tip_mined_transaction_ids(&self) -> Arc<[transaction::Hash]> {
-        unreachable!("Method not used in tests");
+        Arc::new([])
     }
 
     fn estimate_distance_to_network_chain_tip(

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -994,9 +994,32 @@ where
 
     fn get_mining_info(&self) -> BoxFuture<Result<get_mining_info::Response>> {
         let network = self.network.clone();
+        let mut state = self.state.clone();
+
+        let chain_tip = self.latest_chain_tip.clone();
+        let tip_height = chain_tip.best_tip_height().unwrap_or(Height(0)).0;
+
+        let mined_tx_ids = chain_tip.best_tip_mined_transaction_ids();
+        let current_block_tx = (!mined_tx_ids.is_empty()).then(|| mined_tx_ids.len());
+
         let solution_rate_fut = self.get_network_sol_ps(None, None);
         async move {
+            // Get the current block size.
+            let request = zebra_state::ReadRequest::TipBlockSize;
+            let response: zebra_state::ReadResponse = state
+                .ready()
+                .and_then(|service| service.call(request))
+                .await
+                .map_server_error()?;
+            let current_block_size = match response {
+                zebra_state::ReadResponse::TipBlockSize(Some(block_size)) => Some(block_size),
+                _ => None,
+            };
+
             Ok(get_mining_info::Response::new(
+                tip_height,
+                current_block_size,
+                current_block_tx,
                 network,
                 solution_rate_fut.await?,
             ))

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -1017,22 +1017,29 @@ where
         let chain_tip = self.latest_chain_tip.clone();
         let tip_height = chain_tip.best_tip_height().unwrap_or(Height(0)).0;
 
-        let mined_tx_ids = chain_tip.best_tip_mined_transaction_ids();
-        let current_block_tx = (!mined_tx_ids.is_empty()).then(|| mined_tx_ids.len());
+        let mut current_block_tx = None;
+        if tip_height > 0 {
+            let mined_tx_ids = chain_tip.best_tip_mined_transaction_ids();
+            current_block_tx =
+                (!mined_tx_ids.is_empty()).then(|| mined_tx_ids.len().saturating_sub(1));
+        }
 
         let solution_rate_fut = self.get_network_sol_ps(None, None);
         async move {
             // Get the current block size.
-            let request = zebra_state::ReadRequest::TipBlockSize;
-            let response: zebra_state::ReadResponse = state
-                .ready()
-                .and_then(|service| service.call(request))
-                .await
-                .map_server_error()?;
-            let current_block_size = match response {
-                zebra_state::ReadResponse::TipBlockSize(Some(block_size)) => Some(block_size),
-                _ => None,
-            };
+            let mut current_block_size = None;
+            if tip_height > 0 {
+                let request = zebra_state::ReadRequest::TipBlockSize;
+                let response: zebra_state::ReadResponse = state
+                    .ready()
+                    .and_then(|service| service.call(request))
+                    .await
+                    .map_server_error()?;
+                current_block_size = match response {
+                    zebra_state::ReadResponse::TipBlockSize(Some(block_size)) => Some(block_size),
+                    _ => None,
+                };
+            }
 
             Ok(get_mining_info::Response::new(
                 tip_height,

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_mining_info.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_mining_info.rs
@@ -5,6 +5,18 @@ use zebra_chain::parameters::Network;
 /// Response to a `getmininginfo` RPC request.
 #[derive(Debug, Default, PartialEq, Eq, serde::Serialize)]
 pub struct Response {
+    /// The current tip height.
+    #[serde(rename = "blocks")]
+    tip_height: u32,
+
+    /// The size of the last mined block if any.
+    #[serde(rename = "currentblocksize", skip_serializing_if = "Option::is_none")]
+    current_block_size: Option<usize>,
+
+    /// The number of transactions in the last mined block if any.
+    #[serde(rename = "currentblocktx", skip_serializing_if = "Option::is_none")]
+    current_block_tx: Option<usize>,
+
     /// The estimated network solution rate in Sol/s.
     networksolps: u64,
 
@@ -20,8 +32,17 @@ pub struct Response {
 
 impl Response {
     /// Creates a new `getmininginfo` response
-    pub fn new(network: Network, networksolps: u64) -> Self {
+    pub fn new(
+        tip_height: u32,
+        current_block_size: Option<usize>,
+        current_block_tx: Option<usize>,
+        network: Network,
+        networksolps: u64,
+    ) -> Self {
         Self {
+            tip_height,
+            current_block_size,
+            current_block_tx,
             networksolps,
             networkhashps: networksolps,
             chain: network.bip70_network_name(),

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_mining_info@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_mining_info@mainnet_10.snap
@@ -3,6 +3,8 @@ source: zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
 expression: get_mining_info
 ---
 {
+  "blocks": 1687104,
+  "currentblocksize": 1617,
   "networksolps": 2,
   "networkhashps": 2,
   "chain": "main",

--- a/zebra-rpc/src/methods/tests/snapshot/snapshots/get_mining_info@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshot/snapshots/get_mining_info@testnet_10.snap
@@ -3,6 +3,8 @@ source: zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
 expression: get_mining_info
 ---
 {
+  "blocks": 1842420,
+  "currentblocksize": 1618,
   "networksolps": 0,
   "networkhashps": 0,
   "chain": "test",

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -1063,6 +1063,11 @@ pub enum ReadRequest {
     /// Returns [`ReadResponse::ValidBlockProposal`] when successful, or an error if
     /// the block fails contextual validation.
     CheckBlockProposalValidity(SemanticallyVerifiedBlock),
+
+    #[cfg(feature = "getblocktemplate-rpcs")]
+    /// Returns [`ReadResponse::TipBlockSize(usize)`](ReadResponse::TipBlockSize)
+    /// with the current best chain tip block size in bytes.
+    TipBlockSize,
 }
 
 impl ReadRequest {
@@ -1098,6 +1103,8 @@ impl ReadRequest {
             ReadRequest::SolutionRate { .. } => "solution_rate",
             #[cfg(feature = "getblocktemplate-rpcs")]
             ReadRequest::CheckBlockProposalValidity(_) => "check_block_proposal_validity",
+            #[cfg(feature = "getblocktemplate-rpcs")]
+            ReadRequest::TipBlockSize => "tip_block_size",
         }
     }
 

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -229,6 +229,10 @@ pub enum ReadResponse {
     #[cfg(feature = "getblocktemplate-rpcs")]
     /// Response to [`ReadRequest::CheckBlockProposalValidity`]
     ValidBlockProposal,
+
+    #[cfg(feature = "getblocktemplate-rpcs")]
+    /// Response to [`ReadRequest::TipBlockSize`]
+    TipBlockSize(Option<usize>),
 }
 
 /// A structure with the information needed from the state to build a `getblocktemplate` RPC response.
@@ -315,7 +319,7 @@ impl TryFrom<ReadResponse> for Response {
             ReadResponse::ValidBlockProposal => Ok(Response::ValidBlockProposal),
 
             #[cfg(feature = "getblocktemplate-rpcs")]
-            ReadResponse::ChainInfo(_) | ReadResponse::SolutionRate(_) => {
+            ReadResponse::ChainInfo(_) | ReadResponse::SolutionRate(_) | ReadResponse::TipBlockSize(_) => {
                 Err("there is no corresponding Response for this ReadResponse")
             }
         }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -33,12 +33,14 @@ use tracing::{instrument, Instrument, Span};
 use tower::buffer::Buffer;
 
 use zebra_chain::{
-    block::{self, CountedHeader, Height, HeightDiff},
+    block::{self, CountedHeader, HeightDiff},
     diagnostic::{task::WaitForPanics, CodeTimer},
     parameters::{Network, NetworkUpgrade},
-    serialization::ZcashSerialize,
     subtree::NoteCommitmentSubtreeIndex,
 };
+
+#[cfg(feature = "getblocktemplate-rpcs")]
+use zebra_chain::{block::Height, serialization::ZcashSerialize};
 
 use crate::{
     constants::{
@@ -1907,6 +1909,7 @@ impl Service<ReadRequest> for ReadStateService {
                 .wait_for_panics()
             }
 
+            #[cfg(feature = "getblocktemplate-rpcs")]
             ReadRequest::TipBlockSize => {
                 let state = self.clone();
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -33,9 +33,10 @@ use tracing::{instrument, Instrument, Span};
 use tower::buffer::Buffer;
 
 use zebra_chain::{
-    block::{self, CountedHeader, HeightDiff},
+    block::{self, CountedHeader, Height, HeightDiff},
     diagnostic::{task::WaitForPanics, CodeTimer},
     parameters::{Network, NetworkUpgrade},
+    serialization::ZcashSerialize,
     subtree::NoteCommitmentSubtreeIndex,
 };
 
@@ -1901,6 +1902,45 @@ impl Service<ReadRequest> for ReadStateService {
                         );
 
                         Ok(ReadResponse::ValidBlockProposal)
+                    })
+                })
+                .wait_for_panics()
+            }
+
+            ReadRequest::TipBlockSize => {
+                let state = self.clone();
+
+                tokio::task::spawn_blocking(move || {
+                    span.in_scope(move || {
+                        // Get the best chain tip height.
+                        let tip_height = state
+                            .non_finalized_state_receiver
+                            .with_watch_data(|non_finalized_state| {
+                                read::tip_height(non_finalized_state.best_chain(), &state.db)
+                            })
+                            .unwrap_or(Height(0));
+
+                        // Get the block at the best chain tip height.
+                        let block = state.non_finalized_state_receiver.with_watch_data(
+                            |non_finalized_state| {
+                                read::block(
+                                    non_finalized_state.best_chain(),
+                                    &state.db,
+                                    tip_height.into(),
+                                )
+                            },
+                        );
+
+                        // The work is done in the future.
+                        timer.finish(module_path!(), line!(), "ReadRequest::TipBlockSize");
+
+                        // Respond with the length of the obtained block if any.
+                        match block {
+                            Some(b) => Ok(ReadResponse::TipBlockSize(Some(
+                                b.zcash_serialize_to_vec()?.len(),
+                            ))),
+                            None => Ok(ReadResponse::TipBlockSize(None)),
+                        }
                     })
                 })
                 .wait_for_panics()


### PR DESCRIPTION
## Motivation

We want to add some more fields to the `getmininginfo` RPC method.

Close https://github.com/ZcashFoundation/zebra/issues/8858

## Solution

A new `ReadState::TipBlockSize` was added. The rest is pretty straightforward.

### Tests

Snapshot tests were updated.

### PR Author's Checklist

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

