### PR TITLE
fix(rpc): modify shutdown used in `stop()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,6 +693,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chacha20"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2648,6 +2654,18 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if 1.0.0",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -6154,6 +6172,7 @@ dependencies = [
  "jsonrpc-core",
  "jsonrpc-derive",
  "jsonrpc-http-server",
+ "nix",
  "proptest",
  "prost",
  "rand 0.8.5",

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -87,6 +87,8 @@ tracing = "0.1.39"
 hex = { version = "0.4.3", features = ["serde"] }
 serde = { version = "1.0.204", features = ["serde_derive"] }
 
+# For the `stop` RPC method.
+nix = { version = "0.29.0", features = ["signal"] }
 
 zcash_primitives = { workspace = true, features = ["transparent-inputs"] }
 

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -302,6 +302,7 @@ pub trait Rpc {
         address_strings: AddressStrings,
     ) -> BoxFuture<Result<Vec<GetAddressUtxos>>>;
 
+    #[cfg(not(target_os = "windows"))]
     #[rpc(name = "stop")]
     /// Stop the running zebrad process.
     ///
@@ -1357,8 +1358,9 @@ where
         .boxed()
     }
 
+    #[cfg(not(target_os = "windows"))]
     fn stop(&self) -> Result<String> {
-        if self.network.is_regtest() && cfg!(not(target_os = "windows")) {
+        if self.network.is_regtest() {
             match nix::sys::signal::raise(nix::sys::signal::SIGINT) {
                 Ok(_) => Ok("Zebra server stopping".to_string()),
                 Err(error) => Err(Error {
@@ -1370,8 +1372,7 @@ where
         } else {
             Err(Error {
                 code: ErrorCode::MethodNotFound,
-                message: "stop is only available on *nix platforms and regtest networks"
-                    .to_string(),
+                message: "stop is only available on regtest networks".to_string(),
                 data: None,
             })
         }

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -308,7 +308,8 @@ pub trait Rpc {
     ///
     /// # Notes
     ///
-    /// Only works if the network of the running zebrad process is `Regtest`.
+    /// - Available for non windows targets only.
+    /// - Only works if the network of the running zebrad process is `Regtest`.
     ///
     /// zcashd reference: [`stop`](https://zcash.github.io/rpc/stop.html)
     /// method: post

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -302,18 +302,17 @@ pub trait Rpc {
         address_strings: AddressStrings,
     ) -> BoxFuture<Result<Vec<GetAddressUtxos>>>;
 
-    #[cfg(not(target_os = "windows"))]
-    #[rpc(name = "stop")]
     /// Stop the running zebrad process.
     ///
     /// # Notes
     ///
-    /// - Available for non windows targets only.
-    /// - Only works if the network of the running zebrad process is `Regtest`.
+    /// - Works for non windows targets only.
+    /// - Works only if the network of the running zebrad process is `Regtest`.
     ///
     /// zcashd reference: [`stop`](https://zcash.github.io/rpc/stop.html)
     /// method: post
     /// tags: control
+    #[rpc(name = "stop")]
     fn stop(&self) -> Result<String>;
 }
 
@@ -1359,8 +1358,8 @@ where
         .boxed()
     }
 
-    #[cfg(not(target_os = "windows"))]
     fn stop(&self) -> Result<String> {
+        #[cfg(not(target_os = "windows"))]
         if self.network.is_regtest() {
             match nix::sys::signal::raise(nix::sys::signal::SIGINT) {
                 Ok(_) => Ok("Zebra server stopping".to_string()),
@@ -1377,6 +1376,12 @@ where
                 data: None,
             })
         }
+        #[cfg(target_os = "windows")]
+        Err(Error {
+            code: ErrorCode::MethodNotFound,
+            message: "stop is not available in windows targets".to_string(),
+            data: None,
+        })
     }
 }
 


### PR DESCRIPTION
## Motivation

The `std::process::exit` I introduced for the `stop` RPC method is not a good idea for the rpc testing because (among other issues) it terminates immediately and the tests require for the method to return before actually finishing with the current process.

Additionally this is a more graceful shutdown and will close https://github.com/ZcashFoundation/zebra/issues/8850

## Solution

Terminate the process by sending a `SIGINT` signal.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

