### PR TITLE
chore(docker): remove debugging output by default

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,8 +10,6 @@
 # 4. Node Startup: Starts the node, allowing it to begin its operations.
 #
 
-# Show the commands we are executing
-set -x
 # Exit if a command fails
 set -e
 # Exit if any command in a pipeline fails


### PR DESCRIPTION
## Motivation

When initiating a Zebra node using Docker, there's way too much output at the beginning, making it hard to identify information that we're specifically showing in the interface.

## Solution

- Remove the `-x` option from the entrypoing

### Tests

Not extra testing required


### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [x] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

