### PR TITLE
fix(state): Avoids panicking during contextual validation when a parent block is missing

### DIFF
--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -67,9 +67,16 @@ where
         .take(POW_ADJUSTMENT_BLOCK_SPAN)
         .collect();
 
-    let parent_block = relevant_chain
-        .first()
-        .expect("state must contain parent block to do contextual validation");
+    let Some(parent_block) = relevant_chain.first() else {
+        warn!(
+            ?semantically_verified,
+            ?finalized_tip_height,
+            "state must contain parent block to do contextual validation"
+        );
+
+        return Err(ValidateContextError::NotReadyToBeCommitted);
+    };
+
     let parent_block = parent_block.borrow();
     let parent_height = parent_block
         .coinbase_height()


### PR DESCRIPTION
## Motivation

We want to avoid panicking when Zebra can't find a parent in its state during contextual validation of a candidate block.

Fixes #8881 (although without fully diagnosing how it was possible).

## Solution

Returns a `NotReadyToBeCommitted` error instead of panicking when the relevant chain is empty

### Follow-up Work

I'm not completely sure why this was happening in the first place, it may be plausible that because `non_finalized_block_write_sent_hashes()` isn't pruned until after the call to `can_fork_chain_at()`, the missing parent blocks on a side chain were dropped when the block height was finalized. We may want to take another look at it.

`block_is_valid_for_recent_chain()` definitely needs an update, there's a condition `relevant_chain.is_empty()` that can never be reached and another test-only condition that is outdated since Zebra can calculate difficulty thresholds with fewer than `POW_ADJUSTMENT_BLOCK_SPAN` blocks.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [ ] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

