### PR TITLE
Suggestion for "feat(regtest): Add regtest halving interval and port test"

### DIFF
--- a/zebra-consensus/src/block/subsidy/general.rs
+++ b/zebra-consensus/src/block/subsidy/general.rs
@@ -42,7 +42,7 @@ pub fn num_halvings(height: Height, network: &Network) -> u32 {
         0
     } else if height < blossom_height {
         let pre_blossom_height = height - slow_start_shift;
-        pre_blossom_height / PRE_BLOSSOM_HALVING_INTERVAL
+        pre_blossom_height / network.pre_blossom_halving_interval()
     } else {
         let pre_blossom_height = blossom_height - slow_start_shift;
         let scaled_pre_blossom_height =
@@ -50,7 +50,7 @@ pub fn num_halvings(height: Height, network: &Network) -> u32 {
 
         let post_blossom_height = height - blossom_height;
 
-        (scaled_pre_blossom_height + post_blossom_height) / POST_BLOSSOM_HALVING_INTERVAL
+        (scaled_pre_blossom_height + post_blossom_height) / network.post_blossom_halving_interval()
     };
 
     halving_index

--- a/zebra-consensus/src/block/subsidy/general.rs
+++ b/zebra-consensus/src/block/subsidy/general.rs
@@ -39,7 +39,7 @@ pub fn num_halvings(height: Height, network: &Network) -> u32 {
         .expect("blossom activation height should be available");
 
     let halving_index = if height < slow_start_shift {
-        panic!("unsupported block height {height:?}: checkpoints should handle blocks below {slow_start_shift:?}")
+        0
     } else if height < blossom_height {
         let pre_blossom_height = height - slow_start_shift;
         pre_blossom_height / PRE_BLOSSOM_HALVING_INTERVAL


### PR DESCRIPTION
This is a suggestion PR for #8888 that:
- Adds a `height_for_halving_index()` function to be used for calculating the height for first index on custom Testnets and Regtest (though it's not needed on Regtest as the relevant parameters are not configurable and a hard-coded value is fine).
- Factors calculating of the number of halvings out of `halving_divisor()` into `num_halvings()` for use in tests

@oxarbitrage can review and optionally merge it into their PR.