### PR TITLE
Point zcash_script dependency at master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5957,10 +5957,10 @@ dependencies = [
 [[package]]
 name = "zcash_script"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2122a042c77d529d3c60b899e74705eda39ae96a8a992460caeb06afa76990a2"
+source = "git+https://github.com/ZcashFoundation/zcash_script.git?rev=9d16e79#9d16e79c72ea469642ae991f064c30de424bba99"
 dependencies = [
  "bindgen",
+ "bitflags 2.6.0",
  "cc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
         "zebra-test",
         "zebra-utils",
         "zebra-scan",
-	"zebra-grpc",
+        "zebra-grpc",
         "tower-batch-control",
         "tower-fallback",
 ]
@@ -33,6 +33,9 @@ zcash_keys = "0.3.0"
 zcash_primitives = "0.17.0"
 zcash_proofs = "0.17.0"
 zcash_protocol = "0.3.0"
+
+[patch.crates-io]
+zcash_script = { git = 'https://github.com/ZcashFoundation/zcash_script.git', rev = "9d16e79" }
 
 [workspace.metadata.release]
 


### PR DESCRIPTION
## Motivation

Show that the existing Zebra main branch would work with a new zcash_script release.

This should not be merged.