### PR TITLE
change(mempool): Return verification result after attempting to insert transactions in the mempool

### DIFF
--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -584,17 +584,17 @@ where
                     )?;
 
                     if let Some(mut mempool) = mempool {
-                        if !transaction.transaction.transaction.outputs().is_empty() {
-                            tokio::spawn(async move {
-                                tokio::time::sleep(POLL_MEMPOOL_DELAY).await;
-                                let _ = mempool
-                                    .ready()
-                                    .await
-                                    .expect("mempool poll_ready() method should not return an error")
-                                    .call(mempool::Request::CheckForVerifiedTransactions)
-                                    .await;
-                            });
-                        }
+                        tokio::spawn(async move {
+                            // Best-effort poll of the mempool to provide a timely response to 
+                            // `sendrawtransaction` RPC calls or `AwaitOutput` mempool calls.
+                            tokio::time::sleep(POLL_MEMPOOL_DELAY).await;
+                            let _ = mempool
+                                .ready()
+                                .await
+                                .expect("mempool poll_ready() method should not return an error")
+                                .call(mempool::Request::CheckForVerifiedTransactions)
+                                .await;
+                        });
                     }
 
                     Response::Mempool { transaction, spent_mempool_outpoints }

--- a/zebra-node-services/src/mempool.rs
+++ b/zebra-node-services/src/mempool.rs
@@ -13,12 +13,9 @@ use zebra_chain::{
 use crate::BoxError;
 
 mod gossip;
-
 mod transaction_dependencies;
 
-pub use transaction_dependencies::TransactionDependencies;
-
-pub use self::gossip::Gossip;
+pub use self::{gossip::Gossip, transaction_dependencies::TransactionDependencies};
 
 /// A mempool service request.
 ///

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -626,12 +626,6 @@ impl Service<Request> for Mempool {
                         metrics::counter!("mempool.failed.verify.tasks.total", "reason" => error.to_string()).increment(1);
 
                         storage.reject_if_needed(tx_id, error);
-
-                        // Send the result to responder channel if one was provided.
-                        if let Some(rsp_tx) = rsp_tx {
-                            let _ =
-                                rsp_tx.send(Err("timeout waiting for verification result".into()));
-                        }
                     }
                     Err(elapsed) => {
                         // A timeout happens when the stream hangs waiting for another service,

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -978,21 +978,19 @@ async fn mempool_responds_to_await_output() -> Result<(), Report> {
     let result_rx = results.remove(0).expect("should pass initial checks");
     assert!(results.is_empty(), "should have 1 result for 1 queued tx");
 
-    tokio::time::timeout(Duration::from_secs(10), result_rx)
-        .await
-        .expect("should not time out")
-        .expect("mempool tx verification result channel should not be closed")
-        .expect("mocked verification should be successful");
-
-    // Wait for next steps in mempool's Downloads to finish
-    // TODO: Move this and the `ready().await` below above waiting for the mempool verification result above after
-    //       waiting to respond with a transaction's verification result until after it's been inserted into the mempool.
+    // Wait for post-verification steps in mempool's Downloads
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     mempool
         .ready()
         .await
         .expect("polling mempool should succeed");
+
+    tokio::time::timeout(Duration::from_secs(10), result_rx)
+        .await
+        .expect("should not time out")
+        .expect("mempool tx verification result channel should not be closed")
+        .expect("mocked verification should be successful");
 
     assert_eq!(
         mempool.storage().transaction_count(),

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -981,6 +981,8 @@ async fn mempool_responds_to_await_output() -> Result<(), Report> {
     // Wait for post-verification steps in mempool's Downloads
     tokio::time::sleep(Duration::from_secs(1)).await;
 
+    // Note: Buffered services shouldn't be polled without being called.
+    //       See `mempool::Request::CheckForVerifiedTransactions` for more details.
     mempool
         .ready()
         .await


### PR DESCRIPTION
## Motivation

We want to return a verification result from the mempool after a transaction has been inserted into its verified set (or has failed some final checks in the mempool).

## Solution

- Moves timeout from mempool to mempool's `Download` struct
- Sends the final result to the response channel after attempting to insert a transaction into the mempool storage instead of after a transaction is successfully verified

### Tests

Updates the `mempool_responds_to_await_output` test to expect the mempool storage to include a transaction immediately after receiving its verification result.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

