### PR TITLE
fix(actions):  do not require a cached state for disk regeneration

### DIFF
--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -113,6 +113,7 @@ jobs:
   get-disk-name:
     name: Get disk name
     uses: ./.github/workflows/sub-find-cached-disks.yml
+    if: ${{ inputs.needs_zebra_state || inputs.needs_lwd_state }}
     with:
       network: ${{ inputs.network || vars.ZCASH_NETWORK }}
       disk_prefix: ${{ inputs.needs_lwd_state && 'lwd-cache' || inputs.needs_zebra_state && 'zebrad-cache' }}


### PR DESCRIPTION
## Motivation

Some tests, but mainly the one that create a cached state from scratch (or regenerate one), do not required an existing disk image to exists in GCP.

This also makes our weekly scheduled full sync to fail: https://github.com/ZcashFoundation/zebra/actions/runs/11179660535

## Solution

- Skip the job that search for the cached disk images, as this one fails if no disk is found

### Tests

- This manually triggered workflow should run the test. The test finalization is not required: https://github.com/ZcashFoundation/zebra/actions/runs/11180441616

### Follow-up Work

- https://github.com/ZcashFoundation/zebra/pull/8908

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [x] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

