### PR TITLE
fix(network): Respond to getheaders requests with a maximum of 160 block headers

### DIFF
--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -107,20 +107,7 @@ pub const MAX_NON_FINALIZED_CHAIN_FORKS: usize = 10;
 pub const MAX_FIND_BLOCK_HASHES_RESULTS: u32 = 500;
 
 /// The maximum number of block headers allowed in `getheaders` responses in the Zcash network protocol.
-const MAX_FIND_BLOCK_HEADERS_RESULTS_FOR_PROTOCOL: u32 = 160;
-
-/// The maximum number of block headers sent by Zebra in `getheaders` responses.
-///
-/// Older versions of Zcashd will blindly request more block headers as long as it
-/// got 160 block headers in response to a previous query,
-/// _even if those headers are already known_.
-///
-/// To avoid this behavior, return slightly fewer than the maximum,
-/// so `zcashd` thinks it has reached our chain tip.
-///
-/// <https://github.com/bitcoin/bitcoin/pull/4468/files#r17026905>
-pub const MAX_FIND_BLOCK_HEADERS_RESULTS_FOR_ZEBRA: u32 =
-    MAX_FIND_BLOCK_HEADERS_RESULTS_FOR_PROTOCOL - 2;
+pub const MAX_FIND_BLOCK_HEADERS_RESULTS: u32 = 160;
 
 /// These database versions can be recreated from their directly preceding versions.
 pub const RESTORABLE_DB_VERSIONS: [u64; 1] = [26];

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -25,7 +25,7 @@ use zebra_chain::{
 /// will work with inline links.
 #[allow(unused_imports)]
 use crate::{
-    constants::{MAX_FIND_BLOCK_HASHES_RESULTS, MAX_FIND_BLOCK_HEADERS_RESULTS_FOR_ZEBRA},
+    constants::{MAX_FIND_BLOCK_HASHES_RESULTS, MAX_FIND_BLOCK_HEADERS_RESULTS},
     ReadResponse, Response,
 };
 
@@ -721,7 +721,7 @@ pub enum Request {
     /// Stops the list of headers after:
     ///   * adding the best tip,
     ///   * adding the header matching the `stop` hash to the list, if it is in the best chain, or
-    ///   * adding [`MAX_FIND_BLOCK_HEADERS_RESULTS_FOR_ZEBRA`] headers to the list.
+    ///   * adding [`MAX_FIND_BLOCK_HEADERS_RESULTS`] headers to the list.
     ///
     /// Returns an empty list if the state is empty.
     ///
@@ -925,7 +925,7 @@ pub enum ReadRequest {
     /// Stops the list of headers after:
     ///   * adding the best tip,
     ///   * adding the header matching the `stop` hash to the list, if it is in the best chain, or
-    ///   * adding [`MAX_FIND_BLOCK_HEADERS_RESULTS_FOR_ZEBRA`] headers to the list.
+    ///   * adding [`MAX_FIND_BLOCK_HEADERS_RESULTS`] headers to the list.
     ///
     /// Returns an empty list if the state is empty.
     ///

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -44,8 +44,7 @@ use zebra_chain::{block::Height, serialization::ZcashSerialize};
 
 use crate::{
     constants::{
-        MAX_FIND_BLOCK_HASHES_RESULTS, MAX_FIND_BLOCK_HEADERS_RESULTS_FOR_ZEBRA,
-        MAX_LEGACY_CHAIN_BLOCKS,
+        MAX_FIND_BLOCK_HASHES_RESULTS, MAX_FIND_BLOCK_HEADERS_RESULTS, MAX_LEGACY_CHAIN_BLOCKS,
     },
     service::{
         block_iter::any_ancestor_blocks,
@@ -1476,7 +1475,7 @@ impl Service<ReadRequest> for ReadStateService {
                                     &state.db,
                                     known_blocks,
                                     stop,
-                                    MAX_FIND_BLOCK_HEADERS_RESULTS_FOR_ZEBRA,
+                                    MAX_FIND_BLOCK_HEADERS_RESULTS,
                                 )
                             },
                         );


### PR DESCRIPTION
## Motivation

This PR fixes a bug in Zebra's network protocol implementation where Zebra will return fewer than the expected maximum number of block headers in response to getheaders requests which has been falsely indicating to peers that they have reached the tip of Zebra's chain.

This doesn't strictly block the release if we want to also ignore getheaders requests during Zebra's initial sync.

Closes #8907.

## Solution

- Returns a maximum of 160 block headers in response to getheaders requests instead of 158

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [ ] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

