### PR TITLE
build(deps): Upgrade ECC crates  for Zebra `v2.0.0-rc.0` release candidate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,7 +543,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cef977c7f8e75aa81fc589064c121ab8d32448b7939d34d58df479aa93e65ea5"
 dependencies = [
- "incrementalmerkletree",
+ "incrementalmerkletree 0.7.0",
 ]
 
 [[package]]
@@ -1321,6 +1321,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "equihash"
+version = "0.2.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1410f1449100a417bfbc4f6c7167aa9808e38792#1410f1449100a417bfbc4f6c7167aa9808e38792"
+dependencies = [
+ "blake2b_simd",
+ "byteorder",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,6 +1360,14 @@ name = "f4jumble"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a83e8d7fd0c526af4aad893b7c9fe41e2699ed8a776a6c74aecdeafe05afc75"
+dependencies = [
+ "blake2b_simd",
+]
+
+[[package]]
+name = "f4jumble"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1410f1449100a417bfbc4f6c7167aa9808e38792#1410f1449100a417bfbc4f6c7167aa9808e38792"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2080,9 +2097,17 @@ dependencies = [
 
 [[package]]
 name = "incrementalmerkletree"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45063fbc4b0a37837f6bfe0445f269d13d730ad0aa3b5a7f74aa7bf27a0f4df"
+checksum = "75346da3bd8e3d8891d02508245ed2df34447ca6637e343829f8d08986e9cde2"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "incrementalmerkletree"
+version = "0.7.0"
+source = "git+https://github.com/zcash/incrementalmerkletree?rev=ffe4234788fd22662b937ba7c6ea01535fcc1293#ffe4234788fd22662b937ba7c6ea01535fcc1293"
 dependencies = [
  "either",
 ]
@@ -2781,9 +2806,8 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f18e997fa121de5c73e95cdc7e8512ae43b7de38904aeea5e5713cc48f3c0ba"
+version = "0.9.1"
+source = "git+https://github.com/zcash/orchard?rev=55fb089a335bbbc1cda186c706bc037073df8eb7#55fb089a335bbbc1cda186c706bc037073df8eb7"
 dependencies = [
  "aes",
  "bitvec",
@@ -2794,7 +2818,7 @@ dependencies = [
  "halo2_gadgets",
  "halo2_proofs",
  "hex",
- "incrementalmerkletree",
+ "incrementalmerkletree 0.7.0",
  "lazy_static",
  "memuse",
  "nonempty",
@@ -3771,9 +3795,8 @@ dependencies = [
 
 [[package]]
 name = "sapling-crypto"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfff8cfce16aeb38da50b8e2ed33c9018f30552beff2210c266662a021b17f38"
+version = "0.2.0"
+source = "git+https://github.com/zcash/sapling-crypto?rev=b1ad3694ee13a2fc5d291ad04721a6252da0993c#b1ad3694ee13a2fc5d291ad04721a6252da0993c"
 dependencies = [
  "aes",
  "bellman",
@@ -3787,7 +3810,7 @@ dependencies = [
  "fpe",
  "group",
  "hex",
- "incrementalmerkletree",
+ "incrementalmerkletree 0.7.0",
  "jubjub",
  "lazy_static",
  "memuse",
@@ -4108,13 +4131,13 @@ dependencies = [
 
 [[package]]
 name = "shardtree"
-version = "0.5.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5f2390975ebfe8838f9e861f7a588123d49a7a7a0a08568ea831d8ad53fc9b4"
+checksum = "78222845cd8bbe5eb95687407648ff17693a35de5e8abaa39a4681fb21e033f9"
 dependencies = [
  "bitflags 2.6.0",
  "either",
- "incrementalmerkletree",
+ "incrementalmerkletree 0.6.0",
  "tracing",
 ]
 
@@ -5578,22 +5601,33 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "zcash_address"
-version = "0.6.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ff95eac82f71286a79c750e674550d64fb2b7aadaef7b89286b2917f645457d"
+checksum = "a6d26f21381dc220836dd8d2a9a10dbe85928a26232b011bc6a42b611789b743"
 dependencies = [
  "bech32",
  "bs58",
- "f4jumble",
+ "f4jumble 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_encoding",
- "zcash_protocol",
+ "zcash_protocol 0.2.0",
+]
+
+[[package]]
+name = "zcash_address"
+version = "0.5.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1410f1449100a417bfbc4f6c7167aa9808e38792#1410f1449100a417bfbc4f6c7167aa9808e38792"
+dependencies = [
+ "bech32",
+ "bs58",
+ "f4jumble 0.1.0 (git+https://github.com/zcash/librustzcash.git?rev=1410f1449100a417bfbc4f6c7167aa9808e38792)",
+ "zcash_encoding",
+ "zcash_protocol 0.3.0",
 ]
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbeeede366fdb642710d3c59fc2090489affd075f66db53ed11bb7138d2d0258"
+version = "0.13.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1410f1449100a417bfbc4f6c7167aa9808e38792#1410f1449100a417bfbc4f6c7167aa9808e38792"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -5603,7 +5637,7 @@ dependencies = [
  "document-features",
  "group",
  "hex",
- "incrementalmerkletree",
+ "incrementalmerkletree 0.7.0",
  "memuse",
  "nom",
  "nonempty",
@@ -5619,12 +5653,12 @@ dependencies = [
  "tonic-build",
  "tracing",
  "which",
- "zcash_address",
+ "zcash_address 0.5.0",
  "zcash_encoding",
- "zcash_keys",
+ "zcash_keys 0.3.0 (git+https://github.com/zcash/librustzcash.git?rev=1410f1449100a417bfbc4f6c7167aa9808e38792)",
  "zcash_note_encryption",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_primitives 0.17.0",
+ "zcash_protocol 0.3.0",
  "zip32",
  "zip321",
 ]
@@ -5632,8 +5666,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052d8230202f0a018cd9b5d1b56b94cd25e18eccc2d8665073bcea8261ab87fc"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1410f1449100a417bfbc4f6c7167aa9808e38792#1410f1449100a417bfbc4f6c7167aa9808e38792"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -5642,8 +5675,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fde17bf53792f9c756b313730da14880257d7661b5bfc69d0571c3a7c11a76d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1410f1449100a417bfbc4f6c7167aa9808e38792#1410f1449100a417bfbc4f6c7167aa9808e38792"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -5652,9 +5684,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.4.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8162c94957f1e379b8e2fb30f97b95cfa93ac9c6bc02895946ca6392d1abb81"
+checksum = "712faf4070107ab0b2828d0eda6aeaf4c3cb02564109832d95b97ad3467c95a5"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -5669,10 +5701,35 @@ dependencies = [
  "secrecy",
  "subtle",
  "tracing",
- "zcash_address",
+ "zcash_address 0.4.0",
  "zcash_encoding",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_primitives 0.16.0",
+ "zcash_protocol 0.2.0",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_keys"
+version = "0.3.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1410f1449100a417bfbc4f6c7167aa9808e38792#1410f1449100a417bfbc4f6c7167aa9808e38792"
+dependencies = [
+ "bech32",
+ "blake2b_simd",
+ "bls12_381",
+ "bs58",
+ "document-features",
+ "group",
+ "memuse",
+ "nonempty",
+ "rand_core 0.6.4",
+ "sapling-crypto",
+ "secrecy",
+ "subtle",
+ "tracing",
+ "zcash_address 0.5.0",
+ "zcash_encoding",
+ "zcash_primitives 0.17.0",
+ "zcash_protocol 0.3.0",
  "zip32",
 ]
 
@@ -5691,9 +5748,44 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.19.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab47d526d7fd6f88b3a2854ad81b54757a80c2aeadd1d8b06f690556af9743c"
+checksum = "5f044bc9cf2887ec408196fbafb44749e5581f57cc18d8da7aabaeb60cc40c64"
+dependencies = [
+ "aes",
+ "blake2b_simd",
+ "bs58",
+ "byteorder",
+ "document-features",
+ "equihash 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ff",
+ "fpe",
+ "group",
+ "hex",
+ "incrementalmerkletree 0.6.0",
+ "jubjub",
+ "memuse",
+ "nonempty",
+ "orchard",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "sha2",
+ "subtle",
+ "tracing",
+ "zcash_address 0.4.0",
+ "zcash_encoding",
+ "zcash_note_encryption",
+ "zcash_protocol 0.2.0",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
+name = "zcash_primitives"
+version = "0.17.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1410f1449100a417bfbc4f6c7167aa9808e38792#1410f1449100a417bfbc4f6c7167aa9808e38792"
 dependencies = [
  "aes",
  "bip32",
@@ -5701,12 +5793,12 @@ dependencies = [
  "bs58",
  "byteorder",
  "document-features",
- "equihash",
+ "equihash 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=1410f1449100a417bfbc4f6c7167aa9808e38792)",
  "ff",
  "fpe",
  "group",
  "hex",
- "incrementalmerkletree",
+ "incrementalmerkletree 0.7.0",
  "jubjub",
  "memuse",
  "nonempty",
@@ -5720,19 +5812,18 @@ dependencies = [
  "sha2",
  "subtle",
  "tracing",
- "zcash_address",
+ "zcash_address 0.5.0",
  "zcash_encoding",
  "zcash_note_encryption",
- "zcash_protocol",
+ "zcash_protocol 0.3.0",
  "zcash_spec",
  "zip32",
 ]
 
 [[package]]
 name = "zcash_proofs"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daba607872e60d91a09248d8e1ea3d6801c819fb80d67016d9de02d81323c10d"
+version = "0.17.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1410f1449100a417bfbc4f6c7167aa9808e38792#1410f1449100a417bfbc4f6c7167aa9808e38792"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5748,14 +5839,23 @@ dependencies = [
  "sapling-crypto",
  "tracing",
  "xdg",
- "zcash_primitives",
+ "zcash_primitives 0.17.0",
 ]
 
 [[package]]
 name = "zcash_protocol"
-version = "0.4.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bc22b9155b2c7eb20105cd06de170d188c1bc86489b92aa3fda7b8da8d96acf"
+checksum = "f35eac659fdbba614333d119217c5963c0d7cea43aee33176c4f2f95e5460d8d"
+dependencies = [
+ "document-features",
+ "memuse",
+]
+
+[[package]]
+name = "zcash_protocol"
+version = "0.3.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1410f1449100a417bfbc4f6c7167aa9808e38792#1410f1449100a417bfbc4f6c7167aa9808e38792"
 dependencies = [
  "document-features",
  "memuse",
@@ -5797,13 +5897,13 @@ dependencies = [
  "criterion",
  "dirs",
  "ed25519-zebra",
- "equihash",
+ "equihash 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "group",
  "halo2_proofs",
  "hex",
  "humantime",
- "incrementalmerkletree",
+ "incrementalmerkletree 0.7.0",
  "itertools 0.13.0",
  "jubjub",
  "lazy_static",
@@ -5835,13 +5935,13 @@ dependencies = [
  "tracing",
  "uint 0.10.0",
  "x25519-dalek",
- "zcash_address",
+ "zcash_address 0.5.0",
  "zcash_client_backend",
  "zcash_encoding",
  "zcash_history",
  "zcash_note_encryption",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_primitives 0.17.0",
+ "zcash_protocol 0.3.0",
  "zebra-test",
 ]
 
@@ -5906,7 +6006,7 @@ dependencies = [
  "tonic-build",
  "tonic-reflection",
  "tower",
- "zcash_primitives",
+ "zcash_primitives 0.17.0",
  "zebra-chain",
  "zebra-node-services",
  "zebra-state",
@@ -5993,8 +6093,8 @@ dependencies = [
  "tonic-reflection",
  "tower",
  "tracing",
- "zcash_address",
- "zcash_primitives",
+ "zcash_address 0.5.0",
+ "zcash_primitives 0.17.0",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",
@@ -6036,11 +6136,11 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
- "zcash_address",
+ "zcash_address 0.5.0",
  "zcash_client_backend",
- "zcash_keys",
+ "zcash_keys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_note_encryption",
- "zcash_primitives",
+ "zcash_primitives 0.17.0",
  "zebra-chain",
  "zebra-grpc",
  "zebra-node-services",
@@ -6159,8 +6259,8 @@ dependencies = [
  "tracing-error",
  "tracing-subscriber",
  "zcash_client_backend",
- "zcash_primitives",
- "zcash_protocol",
+ "zcash_primitives 0.17.0",
+ "zcash_protocol 0.3.0",
  "zebra-chain",
  "zebra-node-services",
  "zebra-rpc",
@@ -6291,13 +6391,12 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3e613defb0940acef1f54774b51c7f48f2fa705613dd800870dc69f35cd2ea"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1410f1449100a417bfbc4f6c7167aa9808e38792#1410f1449100a417bfbc4f6c7167aa9808e38792"
 dependencies = [
  "base64 0.22.1",
  "nom",
  "percent-encoding",
- "zcash_address",
- "zcash_protocol",
+ "zcash_address 0.5.0",
+ "zcash_protocol 0.3.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6399,8 +6399,3 @@ dependencies = [
  "zcash_address 0.5.0",
  "zcash_protocol 0.3.0",
 ]
-
-[[patch.unused]]
-name = "incrementalmerkletree-testing"
-version = "0.1.0"
-source = "git+https://github.com/zcash/incrementalmerkletree?rev=ffe4234788fd22662b937ba7c6ea01535fcc1293#ffe4234788fd22662b937ba7c6ea01535fcc1293"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "bridgetree"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f62227647af796dd9f1637da0392676a2e200973b817b082fc9be89bf93ddd74"
+checksum = "cef977c7f8e75aa81fc589064c121ab8d32448b7939d34d58df479aa93e65ea5"
 dependencies = [
  "incrementalmerkletree",
 ]
@@ -1321,15 +1321,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "equihash"
-version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash/#a1047adf0b6f324dad415db34762dc26f8367ce4"
-dependencies = [
- "blake2b_simd",
- "byteorder",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,14 +1351,6 @@ name = "f4jumble"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a83e8d7fd0c526af4aad893b7c9fe41e2699ed8a776a6c74aecdeafe05afc75"
-dependencies = [
- "blake2b_simd",
-]
-
-[[package]]
-name = "f4jumble"
-version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash/#a1047adf0b6f324dad415db34762dc26f8367ce4"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2097,9 +2080,9 @@ dependencies = [
 
 [[package]]
 name = "incrementalmerkletree"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75346da3bd8e3d8891d02508245ed2df34447ca6637e343829f8d08986e9cde2"
+checksum = "d45063fbc4b0a37837f6bfe0445f269d13d730ad0aa3b5a7f74aa7bf27a0f4df"
 dependencies = [
  "either",
 ]
@@ -2798,9 +2781,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc7bde644aeb980be296cd908c6650894dc8541deb56f9f5294c52ed7ca568f"
+checksum = "4f18e997fa121de5c73e95cdc7e8512ae43b7de38904aeea5e5713cc48f3c0ba"
 dependencies = [
  "aes",
  "bitvec",
@@ -3788,9 +3771,9 @@ dependencies = [
 
 [[package]]
 name = "sapling-crypto"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e379398fffad84e49f9a45a05635fc004f66086e65942dbf4eb95332c26d2a"
+checksum = "cfff8cfce16aeb38da50b8e2ed33c9018f30552beff2210c266662a021b17f38"
 dependencies = [
  "aes",
  "bellman",
@@ -4134,9 +4117,9 @@ dependencies = [
 
 [[package]]
 name = "shardtree"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78222845cd8bbe5eb95687407648ff17693a35de5e8abaa39a4681fb21e033f9"
+checksum = "b5f2390975ebfe8838f9e861f7a588123d49a7a7a0a08568ea831d8ad53fc9b4"
 dependencies = [
  "bitflags 2.6.0",
  "either",
@@ -5604,49 +5587,24 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "zcash_address"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d26f21381dc220836dd8d2a9a10dbe85928a26232b011bc6a42b611789b743"
+checksum = "4ff95eac82f71286a79c750e674550d64fb2b7aadaef7b89286b2917f645457d"
 dependencies = [
  "bech32",
  "bs58",
- "f4jumble 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.2.0",
-]
-
-[[package]]
-name = "zcash_address"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14bccd6cefb76f87b6d15a9e7b02b6c0515648c6de8e806c4e2d6f0f6ae640c5"
-dependencies = [
- "bech32",
- "bs58",
- "f4jumble 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "zcash_address"
-version = "0.5.0"
-source = "git+https://github.com/zcash/librustzcash/#a1047adf0b6f324dad415db34762dc26f8367ce4"
-dependencies = [
- "bech32",
- "bs58",
- "f4jumble 0.1.0 (git+https://github.com/zcash/librustzcash/)",
- "zcash_encoding 0.2.1 (git+https://github.com/zcash/librustzcash/)",
- "zcash_protocol 0.3.0 (git+https://github.com/zcash/librustzcash/)",
+ "f4jumble",
+ "zcash_encoding",
+ "zcash_protocol",
 ]
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e3a0f3e5d7f299d8b7ef3237697630989c31ab1b162824c99c1cd8bc83715e"
+checksum = "cbeeede366fdb642710d3c59fc2090489affd075f66db53ed11bb7138d2d0258"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bech32",
  "bls12_381",
  "bs58",
@@ -5670,53 +5628,14 @@ dependencies = [
  "tonic-build",
  "tracing",
  "which",
- "zcash_address 0.4.0",
- "zcash_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_keys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address",
+ "zcash_encoding",
+ "zcash_keys",
  "zcash_note_encryption",
- "zcash_primitives 0.16.0",
- "zcash_protocol 0.2.0",
+ "zcash_primitives",
+ "zcash_protocol",
  "zip32",
- "zip321 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "zcash_client_backend"
-version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash/#a1047adf0b6f324dad415db34762dc26f8367ce4"
-dependencies = [
- "base64 0.21.7",
- "bech32",
- "bls12_381",
- "bs58",
- "crossbeam-channel",
- "document-features",
- "group",
- "hex",
- "incrementalmerkletree",
- "memuse",
- "nom",
- "nonempty",
- "percent-encoding",
- "prost",
- "rand_core 0.6.4",
- "rayon",
- "sapling-crypto",
- "secrecy",
- "shardtree",
- "subtle",
- "time",
- "tonic-build",
- "tracing",
- "which",
- "zcash_address 0.5.0 (git+https://github.com/zcash/librustzcash/)",
- "zcash_encoding 0.2.1 (git+https://github.com/zcash/librustzcash/)",
- "zcash_keys 0.3.0 (git+https://github.com/zcash/librustzcash/)",
- "zcash_note_encryption",
- "zcash_primitives 0.17.0 (git+https://github.com/zcash/librustzcash/)",
- "zcash_protocol 0.3.0 (git+https://github.com/zcash/librustzcash/)",
- "zip32",
- "zip321 0.1.0 (git+https://github.com/zcash/librustzcash/)",
+ "zip321",
 ]
 
 [[package]]
@@ -5724,15 +5643,6 @@ name = "zcash_encoding"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052d8230202f0a018cd9b5d1b56b94cd25e18eccc2d8665073bcea8261ab87fc"
-dependencies = [
- "byteorder",
- "nonempty",
-]
-
-[[package]]
-name = "zcash_encoding"
-version = "0.2.1"
-source = "git+https://github.com/zcash/librustzcash/#a1047adf0b6f324dad415db34762dc26f8367ce4"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -5751,9 +5661,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712faf4070107ab0b2828d0eda6aeaf4c3cb02564109832d95b97ad3467c95a5"
+checksum = "e8162c94957f1e379b8e2fb30f97b95cfa93ac9c6bc02895946ca6392d1abb81"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -5768,35 +5678,10 @@ dependencies = [
  "secrecy",
  "subtle",
  "tracing",
- "zcash_address 0.4.0",
- "zcash_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_primitives 0.16.0",
- "zcash_protocol 0.2.0",
- "zip32",
-]
-
-[[package]]
-name = "zcash_keys"
-version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash/#a1047adf0b6f324dad415db34762dc26f8367ce4"
-dependencies = [
- "bech32",
- "blake2b_simd",
- "bls12_381",
- "bs58",
- "document-features",
- "group",
- "memuse",
- "nonempty",
- "rand_core 0.6.4",
- "sapling-crypto",
- "secrecy",
- "subtle",
- "tracing",
- "zcash_address 0.5.0 (git+https://github.com/zcash/librustzcash/)",
- "zcash_encoding 0.2.1 (git+https://github.com/zcash/librustzcash/)",
- "zcash_primitives 0.17.0 (git+https://github.com/zcash/librustzcash/)",
- "zcash_protocol 0.3.0 (git+https://github.com/zcash/librustzcash/)",
+ "zcash_address",
+ "zcash_encoding",
+ "zcash_primitives",
+ "zcash_protocol",
  "zip32",
 ]
 
@@ -5815,45 +5700,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.16.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f044bc9cf2887ec408196fbafb44749e5581f57cc18d8da7aabaeb60cc40c64"
-dependencies = [
- "aes",
- "blake2b_simd",
- "bs58",
- "byteorder",
- "document-features",
- "equihash 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ff",
- "fpe",
- "group",
- "hex",
- "incrementalmerkletree",
- "jubjub",
- "memuse",
- "nonempty",
- "orchard",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "redjubjub",
- "sapling-crypto",
- "sha2",
- "subtle",
- "tracing",
- "zcash_address 0.4.0",
- "zcash_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_note_encryption",
- "zcash_protocol 0.2.0",
- "zcash_spec",
- "zip32",
-]
-
-[[package]]
-name = "zcash_primitives"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d87ab6a55591a8cf1866749fdc739ae1bbd06e6cec07ab0bbe5d57ee3390eb2"
+checksum = "6ab47d526d7fd6f88b3a2854ad81b54757a80c2aeadd1d8b06f690556af9743c"
 dependencies = [
  "aes",
  "bip32",
@@ -5861,7 +5710,7 @@ dependencies = [
  "bs58",
  "byteorder",
  "document-features",
- "equihash 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "equihash",
  "ff",
  "fpe",
  "group",
@@ -5880,54 +5729,19 @@ dependencies = [
  "sha2",
  "subtle",
  "tracing",
- "zcash_address 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address",
+ "zcash_encoding",
  "zcash_note_encryption",
- "zcash_protocol 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_spec",
- "zip32",
-]
-
-[[package]]
-name = "zcash_primitives"
-version = "0.17.0"
-source = "git+https://github.com/zcash/librustzcash/#a1047adf0b6f324dad415db34762dc26f8367ce4"
-dependencies = [
- "aes",
- "blake2b_simd",
- "bs58",
- "byteorder",
- "document-features",
- "equihash 0.2.0 (git+https://github.com/zcash/librustzcash/)",
- "ff",
- "fpe",
- "group",
- "hex",
- "incrementalmerkletree",
- "jubjub",
- "memuse",
- "nonempty",
- "orchard",
- "rand 0.8.5",
- "rand_core 0.6.4",
- "redjubjub",
- "sapling-crypto",
- "sha2",
- "subtle",
- "tracing",
- "zcash_address 0.5.0 (git+https://github.com/zcash/librustzcash/)",
- "zcash_encoding 0.2.1 (git+https://github.com/zcash/librustzcash/)",
- "zcash_note_encryption",
- "zcash_protocol 0.3.0 (git+https://github.com/zcash/librustzcash/)",
+ "zcash_protocol",
  "zcash_spec",
  "zip32",
 ]
 
 [[package]]
 name = "zcash_proofs"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9fc0032b3d90f000f50dba7a996ad6556b7dba5b5145f93ab67b6eb74d3a48"
+checksum = "daba607872e60d91a09248d8e1ea3d6801c819fb80d67016d9de02d81323c10d"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -5943,33 +5757,14 @@ dependencies = [
  "sapling-crypto",
  "tracing",
  "xdg",
- "zcash_primitives 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives",
 ]
 
 [[package]]
 name = "zcash_protocol"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f35eac659fdbba614333d119217c5963c0d7cea43aee33176c4f2f95e5460d8d"
-dependencies = [
- "document-features",
- "memuse",
-]
-
-[[package]]
-name = "zcash_protocol"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1ff002bd41ba76b42d42a02ee11de06790b7fdbc904bdea4486b9a93b2a5e4"
-dependencies = [
- "document-features",
- "memuse",
-]
-
-[[package]]
-name = "zcash_protocol"
-version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash/#a1047adf0b6f324dad415db34762dc26f8367ce4"
+checksum = "6bc22b9155b2c7eb20105cd06de170d188c1bc86489b92aa3fda7b8da8d96acf"
 dependencies = [
  "document-features",
  "memuse",
@@ -6011,7 +5806,7 @@ dependencies = [
  "criterion",
  "dirs",
  "ed25519-zebra",
- "equihash 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "equihash",
  "futures",
  "group",
  "halo2_proofs",
@@ -6049,13 +5844,13 @@ dependencies = [
  "tracing",
  "uint 0.10.0",
  "x25519-dalek",
- "zcash_address 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_client_backend 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_encoding 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address",
+ "zcash_client_backend",
+ "zcash_encoding",
  "zcash_history",
  "zcash_note_encryption",
- "zcash_primitives 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives",
+ "zcash_protocol",
  "zebra-test",
 ]
 
@@ -6120,7 +5915,7 @@ dependencies = [
  "tonic-build",
  "tonic-reflection",
  "tower",
- "zcash_primitives 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_primitives",
  "zebra-chain",
  "zebra-node-services",
  "zebra-state",
@@ -6207,8 +6002,8 @@ dependencies = [
  "tonic-reflection",
  "tower",
  "tracing",
- "zcash_address 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_primitives 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address",
+ "zcash_primitives",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",
@@ -6250,11 +6045,11 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
- "zcash_address 0.5.0 (git+https://github.com/zcash/librustzcash/)",
- "zcash_client_backend 0.13.0 (git+https://github.com/zcash/librustzcash/)",
- "zcash_keys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_address",
+ "zcash_client_backend",
+ "zcash_keys",
  "zcash_note_encryption",
- "zcash_primitives 0.17.0 (git+https://github.com/zcash/librustzcash/)",
+ "zcash_primitives",
  "zebra-chain",
  "zebra-grpc",
  "zebra-node-services",
@@ -6372,9 +6167,9 @@ dependencies = [
  "tokio",
  "tracing-error",
  "tracing-subscriber",
- "zcash_client_backend 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_primitives 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zcash_protocol 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_client_backend",
+ "zcash_primitives",
+ "zcash_protocol",
  "zebra-chain",
  "zebra-node-services",
  "zebra-rpc",
@@ -6505,25 +6300,13 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc85f862f7be64fb0d46f9eb5b82ad54e58cde314fa979d5bae591bc0143693"
+checksum = "1f3e613defb0940acef1f54774b51c7f48f2fa705613dd800870dc69f35cd2ea"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "nom",
  "percent-encoding",
- "zcash_address 0.4.0",
- "zcash_protocol 0.2.0",
-]
-
-[[package]]
-name = "zip321"
-version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash/#a1047adf0b6f324dad415db34762dc26f8367ce4"
-dependencies = [
- "base64 0.21.7",
- "nom",
- "percent-encoding",
- "zcash_address 0.5.0 (git+https://github.com/zcash/librustzcash/)",
- "zcash_protocol 0.3.0 (git+https://github.com/zcash/librustzcash/)",
+ "zcash_address",
+ "zcash_protocol",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4132,12 +4132,11 @@ dependencies = [
 [[package]]
 name = "shardtree"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78222845cd8bbe5eb95687407648ff17693a35de5e8abaa39a4681fb21e033f9"
+source = "git+https://github.com/zcash/incrementalmerkletree?rev=ffe4234788fd22662b937ba7c6ea01535fcc1293#ffe4234788fd22662b937ba7c6ea01535fcc1293"
 dependencies = [
  "bitflags 2.6.0",
  "either",
- "incrementalmerkletree 0.6.0",
+ "incrementalmerkletree 0.7.0",
  "tracing",
 ]
 
@@ -6400,3 +6399,8 @@ dependencies = [
  "zcash_address 0.5.0",
  "zcash_protocol 0.3.0",
 ]
+
+[[patch.unused]]
+name = "incrementalmerkletree-testing"
+version = "0.1.0"
+source = "git+https://github.com/zcash/incrementalmerkletree?rev=ffe4234788fd22662b937ba7c6ea01535fcc1293#ffe4234788fd22662b937ba7c6ea01535fcc1293"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,7 +438,7 @@ dependencies = [
  "hmac",
  "rand_core 0.6.4",
  "ripemd",
- "secp256k1 0.27.0",
+ "secp256k1",
  "sha2",
  "subtle",
  "zeroize",
@@ -3819,21 +3819,12 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
-dependencies = [
- "secp256k1-sys",
- "serde",
-]
-
-[[package]]
-name = "secp256k1"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
  "secp256k1-sys",
+ "serde",
 ]
 
 [[package]]
@@ -5725,7 +5716,7 @@ dependencies = [
  "redjubjub",
  "ripemd",
  "sapling-crypto",
- "secp256k1 0.27.0",
+ "secp256k1",
  "sha2",
  "subtle",
  "tracing",
@@ -5829,7 +5820,7 @@ dependencies = [
  "redjubjub",
  "ripemd",
  "sapling-crypto",
- "secp256k1 0.26.0",
+ "secp256k1",
  "serde",
  "serde-big-array",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,5 +116,4 @@ zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "141
 sapling-crypto = { git = "https://github.com/zcash/sapling-crypto", rev = "b1ad3694ee13a2fc5d291ad04721a6252da0993c" }
 orchard = { git = "https://github.com/zcash/orchard", rev = "55fb089a335bbbc1cda186c706bc037073df8eb7" }
 incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "ffe4234788fd22662b937ba7c6ea01535fcc1293" }
-incrementalmerkletree-testing = { git = "https://github.com/zcash/incrementalmerkletree", rev = "ffe4234788fd22662b937ba7c6ea01535fcc1293" }
 shardtree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "ffe4234788fd22662b937ba7c6ea01535fcc1293" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,16 @@ resolver = "2"
 
 [workspace.dependencies]
 incrementalmerkletree = "0.7.0"
-orchard = "0.10.0"
-sapling-crypto = "0.3.0"
-zcash_address = "0.6.0"
-zcash_client_backend = "0.14.0"
+orchard = "0.9.0"
+sapling-crypto = "0.2.0"
+zcash_address = "0.5.0"
+zcash_client_backend = "0.13.0"
 zcash_encoding = "0.2.1"
 zcash_history = "0.4.0"
-zcash_keys = "0.4.0"
-zcash_primitives = "0.19.0"
-zcash_proofs = "0.19.0"
-zcash_protocol = "0.4.0"
+zcash_keys = "0.3.0"
+zcash_primitives = "0.17.0"
+zcash_proofs = "0.17.0"
+zcash_protocol = "0.3.0"
 
 [workspace.metadata.release]
 
@@ -102,3 +102,15 @@ panic = "abort"
 #     - add "-flto=thin" to all C/C++ code builds
 #     - see https://doc.rust-lang.org/rustc/linker-plugin-lto.html#cc-code-as-a-dependency-in-rust
 lto = "thin"
+
+[patch.crates-io]
+incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "ffe4234788fd22662b937ba7c6ea01535fcc1293" }
+orchard = { git = "https://github.com/zcash/orchard", rev = "55fb089a335bbbc1cda186c706bc037073df8eb7" }
+sapling-crypto = { git = "https://github.com/zcash/sapling-crypto", rev = "b1ad3694ee13a2fc5d291ad04721a6252da0993c" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "1410f1449100a417bfbc4f6c7167aa9808e38792" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "1410f1449100a417bfbc4f6c7167aa9808e38792" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "1410f1449100a417bfbc4f6c7167aa9808e38792" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "1410f1449100a417bfbc4f6c7167aa9808e38792" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "1410f1449100a417bfbc4f6c7167aa9808e38792" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "1410f1449100a417bfbc4f6c7167aa9808e38792" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "1410f1449100a417bfbc4f6c7167aa9808e38792" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,10 +103,9 @@ panic = "abort"
 #     - see https://doc.rust-lang.org/rustc/linker-plugin-lto.html#cc-code-as-a-dependency-in-rust
 lto = "thin"
 
+# We can remove this patches after we get out of 2.0 release candidate and upgrade the ECC dpeendencies above.
+# This revisions are at the commit just before setting mainnet activation heights.
 [patch.crates-io]
-incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "ffe4234788fd22662b937ba7c6ea01535fcc1293" }
-orchard = { git = "https://github.com/zcash/orchard", rev = "55fb089a335bbbc1cda186c706bc037073df8eb7" }
-sapling-crypto = { git = "https://github.com/zcash/sapling-crypto", rev = "b1ad3694ee13a2fc5d291ad04721a6252da0993c" }
 zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "1410f1449100a417bfbc4f6c7167aa9808e38792" }
 zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "1410f1449100a417bfbc4f6c7167aa9808e38792" }
 zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "1410f1449100a417bfbc4f6c7167aa9808e38792" }
@@ -114,3 +113,8 @@ zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "1410
 zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "1410f1449100a417bfbc4f6c7167aa9808e38792" }
 zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "1410f1449100a417bfbc4f6c7167aa9808e38792" }
 zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "1410f1449100a417bfbc4f6c7167aa9808e38792" }
+sapling-crypto = { git = "https://github.com/zcash/sapling-crypto", rev = "b1ad3694ee13a2fc5d291ad04721a6252da0993c" }
+orchard = { git = "https://github.com/zcash/orchard", rev = "55fb089a335bbbc1cda186c706bc037073df8eb7" }
+incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "ffe4234788fd22662b937ba7c6ea01535fcc1293" }
+incrementalmerkletree-testing = { git = "https://github.com/zcash/incrementalmerkletree", rev = "ffe4234788fd22662b937ba7c6ea01535fcc1293" }
+shardtree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "ffe4234788fd22662b937ba7c6ea01535fcc1293" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,17 +22,17 @@ resolver = "2"
 # `cargo release` settings
 
 [workspace.dependencies]
-incrementalmerkletree = "0.6.0"
-orchard = "0.9.0"
-sapling-crypto = "0.2.0"
-zcash_address = "0.5.0"
-zcash_client_backend = "0.13.0"
+incrementalmerkletree = "0.7.0"
+orchard = "0.10.0"
+sapling-crypto = "0.3.0"
+zcash_address = "0.6.0"
+zcash_client_backend = "0.14.0"
 zcash_encoding = "0.2.1"
 zcash_history = "0.4.0"
-zcash_keys = "0.3.0"
-zcash_primitives = "0.17.0"
-zcash_proofs = "0.17.0"
-zcash_protocol = "0.3.0"
+zcash_keys = "0.4.0"
+zcash_primitives = "0.19.0"
+zcash_proofs = "0.19.0"
+zcash_protocol = "0.4.0"
 
 [workspace.metadata.release]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ panic = "abort"
 #     - see https://doc.rust-lang.org/rustc/linker-plugin-lto.html#cc-code-as-a-dependency-in-rust
 lto = "thin"
 
-# We can remove this patches after we get out of 2.0 release candidate and upgrade the ECC dpeendencies above.
+# We can remove this patches after we get out of 2.0 release candidate and upgrade the ECC dependencies above.
 # This revisions are at the commit just before setting mainnet activation heights.
 [patch.crates-io]
 zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "1410f1449100a417bfbc4f6c7167aa9808e38792" }

--- a/deny.toml
+++ b/deny.toml
@@ -124,8 +124,7 @@ allow-git = [
     "https://github.com/zcash/librustzcash.git",
     "https://github.com/zcash/incrementalmerkletree",
     "https://github.com/zcash/orchard",
-    "https://github.com/zcash/sapling-crypto",
-    "https://github.com/zcash/incrementalmerkletree"
+    "https://github.com/zcash/sapling-crypto"
 ]
 
 [sources.allow-org]

--- a/deny.toml
+++ b/deny.toml
@@ -94,7 +94,16 @@ skip-tree = [
     { name = "uint", version = "=0.9.5" },
 
     # wait for dirs-sys to update windows-sys
-    { name = "windows-sys", version = "=0.48.0" }
+    { name = "windows-sys", version = "=0.48.0" },
+
+    # Remove after release candicate period is over and the ECC crates are not patched anymore
+    { name = "equihash", version = "=0.2.0" },
+    { name = "f4jumble", version = "=0.1.0" },
+    { name = "incrementalmerkletree", version = "=0.6.0" },
+    { name = "zcash_address", version = "=0.4.0" },
+    { name = "zcash_keys", version = "=0.3.0" },
+    { name = "zcash_primitives", version = "=0.16.0" },
+    { name = "zcash_protocol", version = "=0.2.0" }
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/deny.toml
+++ b/deny.toml
@@ -71,9 +71,6 @@ skip-tree = [
     # also wait for ron to update insta, and wait for tonic update.
     { name = "base64", version = "=0.13.1" },
 
-    # wait for elasticsearch to update base64, darling, rustc_version, serde_with
-    { name = "elasticsearch", version = "=8.5.0-alpha.1" },
-
     # wait for reqwest to update base64
     { name = "base64", version = "=0.21.7" },
     { name = "sync_wrapper", version = "0.1.2" },

--- a/deny.toml
+++ b/deny.toml
@@ -121,7 +121,11 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
-    "https://github.com/zcash/librustzcash.git"
+    "https://github.com/zcash/librustzcash.git",
+    "https://github.com/zcash/incrementalmerkletree",
+    "https://github.com/zcash/orchard",
+    "https://github.com/zcash/sapling-crypto",
+    "https://github.com/zcash/incrementalmerkletree"
 ]
 
 [sources.allow-org]

--- a/deny.toml
+++ b/deny.toml
@@ -97,6 +97,12 @@ skip-tree = [
 
     # wait for librocksdb-sys to update bindgen to one that uses newer itertools
     { name = "itertools", version = "=0.12.1" }
+
+    # wait for halo2_gadgets and primitive-types to update uint
+    { name = "uint", version = "=0.9.5" }
+
+    # wait for dirs-sys to update windows-sys
+    { name = "windows-sys", version = "=0.48.0" }
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/deny.toml
+++ b/deny.toml
@@ -86,7 +86,7 @@ skip-tree = [
 
     # wait for structopt-derive to update heck
     { name = "heck", version = "=0.3.3" },
-,
+
     # wait for librocksdb-sys to update bindgen to one that uses newer itertools
     { name = "itertools", version = "=0.12.1" },
 

--- a/deny.toml
+++ b/deny.toml
@@ -84,22 +84,14 @@ skip-tree = [
     { name = "http-body", version = "=0.4.6" },
     { name = "hyper", version = "=0.14.30" },
 
-    # TODO: Remove this after we upgrade ECC dependencies to a crates.io version (#8749)
-    { name = "equihash", version = "=0.2.0" },
-    { name = "f4jumble", version = "=0.1.0" },
-    { name = "secp256k1", version = "=0.26.0" },
-    { name = "zcash_address", version = "=0.5.0" },
-    { name = "zcash_client_backend", version = "=0.13.0" },
-
-
     # wait for structopt-derive to update heck
     { name = "heck", version = "=0.3.3" },
-
+,
     # wait for librocksdb-sys to update bindgen to one that uses newer itertools
-    { name = "itertools", version = "=0.12.1" }
+    { name = "itertools", version = "=0.12.1" },
 
     # wait for halo2_gadgets and primitive-types to update uint
-    { name = "uint", version = "=0.9.5" }
+    { name = "uint", version = "=0.9.5" },
 
     # wait for dirs-sys to update windows-sys
     { name = "windows-sys", version = "=0.48.0" }

--- a/deny.toml
+++ b/deny.toml
@@ -71,6 +71,9 @@ skip-tree = [
     # also wait for ron to update insta, and wait for tonic update.
     { name = "base64", version = "=0.13.1" },
 
+    # wait for elasticsearch to update base64, darling, rustc_version, serde_with
+    { name = "elasticsearch", version = "=8.5.0-alpha.1" },
+
     # wait for reqwest to update base64
     { name = "base64", version = "=0.21.7" },
     { name = "sync_wrapper", version = "0.1.2" },

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,6 +1,11 @@
 
 # cargo-vet audits file
 
+[audits]
+equihash = []
+f4jumble = []
+zcash_encoding = []
+
 [[audits.anstyle]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
@@ -25,6 +30,11 @@ delta = "0.5.1 -> 0.5.2"
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.4.0 -> 0.5.0"
+
+[[audits.bridgetree]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.5.0 -> 0.6.0"
 
 [[audits.bytemuck]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
@@ -91,18 +101,6 @@ who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.3.0 -> 0.4.0"
 
-[[audits.equihash]]
-who = "Alfredo Garcia <oxarbitrage@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "0.2.0 -> 0.2.0@git:a1047adf0b6f324dad415db34762dc26f8367ce4"
-importable = false
-
-[[audits.f4jumble]]
-who = "Alfredo Garcia <oxarbitrage@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "0.1.0 -> 0.1.0@git:a1047adf0b6f324dad415db34762dc26f8367ce4"
-importable = false
-
 [[audits.git2]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
@@ -127,6 +125,11 @@ delta = "0.1.6 -> 0.1.9"
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.5.1 -> 0.6.0"
+
+[[audits.incrementalmerkletree]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.6.0 -> 0.7.0"
 
 [[audits.indexmap]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
@@ -208,6 +211,11 @@ who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.8.0 -> 0.9.0"
 
+[[audits.orchard]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.0 -> 0.10.0"
+
 [[audits.owo-colors]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
@@ -283,6 +291,11 @@ who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.1.3 -> 0.2.0"
 
+[[audits.sapling-crypto]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.3.0"
+
 [[audits.serde_spanned]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
@@ -317,6 +330,11 @@ version = "0.0.12"
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.3.1 -> 0.4.0"
+
+[[audits.shardtree]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.5.0"
 
 [[audits.tempfile]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
@@ -541,8 +559,7 @@ delta = "0.4.0 -> 0.5.0"
 [[audits.zcash_address]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
-delta = "0.5.0 -> 0.5.0@git:a1047adf0b6f324dad415db34762dc26f8367ce4"
-importable = false
+delta = "0.5.0 -> 0.6.0"
 
 [[audits.zcash_client_backend]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
@@ -552,20 +569,12 @@ delta = "0.12.1 -> 0.13.0"
 [[audits.zcash_client_backend]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
-delta = "0.13.0 -> 0.13.0@git:a1047adf0b6f324dad415db34762dc26f8367ce4"
-importable = false
-
-[[audits.zcash_encoding]]
-who = "Alfredo Garcia <oxarbitrage@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "0.2.1 -> 0.2.1@git:a1047adf0b6f324dad415db34762dc26f8367ce4"
-importable = false
+delta = "0.13.0 -> 0.14.0"
 
 [[audits.zcash_keys]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
-delta = "0.3.0 -> 0.3.0@git:a1047adf0b6f324dad415db34762dc26f8367ce4"
-importable = false
+delta = "0.3.0 -> 0.4.0"
 
 [[audits.zcash_primitives]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
@@ -575,13 +584,17 @@ delta = "0.16.0 -> 0.17.0"
 [[audits.zcash_primitives]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
-delta = "0.17.0 -> 0.17.0@git:a1047adf0b6f324dad415db34762dc26f8367ce4"
-importable = false
+delta = "0.17.0 -> 0.19.0"
 
 [[audits.zcash_proofs]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.16.0 -> 0.17.0"
+
+[[audits.zcash_proofs]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.17.0 -> 0.19.0"
 
 [[audits.zcash_protocol]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
@@ -596,8 +609,7 @@ delta = "0.1.1 -> 0.3.0"
 [[audits.zcash_protocol]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
-delta = "0.3.0 -> 0.3.0@git:a1047adf0b6f324dad415db34762dc26f8367ce4"
-importable = false
+delta = "0.3.0 -> 0.4.0"
 
 [[audits.zebra-chain]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
@@ -662,8 +674,7 @@ version = "0.1.0"
 [[audits.zip321]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
-delta = "0.1.0 -> 0.1.0@git:a1047adf0b6f324dad415db34762dc26f8367ce4"
-importable = false
+delta = "0.1.0 -> 0.2.0"
 
 [[trusted.clap]]
 criteria = "safe-to-deploy"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1,11 +1,6 @@
 
 # cargo-vet audits file
 
-[audits]
-equihash = []
-f4jumble = []
-zcash_encoding = []
-
 [[audits.anstyle]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
@@ -101,6 +96,18 @@ who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.3.0 -> 0.4.0"
 
+[[audits.equihash]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.2.0@git:1410f1449100a417bfbc4f6c7167aa9808e38792"
+importable = false
+
+[[audits.f4jumble]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.1.0@git:1410f1449100a417bfbc4f6c7167aa9808e38792"
+importable = false
+
 [[audits.git2]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
@@ -130,6 +137,12 @@ delta = "0.5.1 -> 0.6.0"
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.6.0 -> 0.7.0"
+
+[[audits.incrementalmerkletree]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.0 -> 0.7.0@git:ffe4234788fd22662b937ba7c6ea01535fcc1293"
+importable = false
 
 [[audits.indexmap]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
@@ -216,6 +229,12 @@ who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.9.0 -> 0.10.0"
 
+[[audits.orchard]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.10.0 -> 0.9.1@git:55fb089a335bbbc1cda186c706bc037073df8eb7"
+importable = false
+
 [[audits.owo-colors]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
@@ -296,6 +315,12 @@ who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.2.0 -> 0.3.0"
 
+[[audits.sapling-crypto]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.0 -> 0.2.0@git:b1ad3694ee13a2fc5d291ad04721a6252da0993c"
+importable = false
+
 [[audits.serde_spanned]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
@@ -335,6 +360,12 @@ delta = "0.3.1 -> 0.4.0"
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.4.0 -> 0.5.0"
+
+[[audits.shardtree]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.5.0 -> 0.4.0@git:ffe4234788fd22662b937ba7c6ea01535fcc1293"
+importable = false
 
 [[audits.tempfile]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
@@ -559,6 +590,12 @@ delta = "0.4.0 -> 0.5.0"
 [[audits.zcash_address]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
+delta = "0.5.0 -> 0.5.0@git:1410f1449100a417bfbc4f6c7167aa9808e38792"
+importable = false
+
+[[audits.zcash_address]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
 delta = "0.5.0 -> 0.6.0"
 
 [[audits.zcash_client_backend]]
@@ -571,15 +608,45 @@ who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.13.0 -> 0.14.0"
 
+[[audits.zcash_client_backend]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.14.0 -> 0.13.0@git:1410f1449100a417bfbc4f6c7167aa9808e38792"
+importable = false
+
+[[audits.zcash_encoding]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.1 -> 0.2.1@git:1410f1449100a417bfbc4f6c7167aa9808e38792"
+importable = false
+
+[[audits.zcash_history]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.4.0@git:1410f1449100a417bfbc4f6c7167aa9808e38792"
+importable = false
+
 [[audits.zcash_keys]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.3.0 -> 0.4.0"
 
+[[audits.zcash_keys]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.3.0@git:1410f1449100a417bfbc4f6c7167aa9808e38792"
+importable = false
+
 [[audits.zcash_primitives]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.16.0 -> 0.17.0"
+
+[[audits.zcash_primitives]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.17.0 -> 0.17.0@git:1410f1449100a417bfbc4f6c7167aa9808e38792"
+importable = false
 
 [[audits.zcash_primitives]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
@@ -590,6 +657,12 @@ delta = "0.17.0 -> 0.19.0"
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.16.0 -> 0.17.0"
+
+[[audits.zcash_proofs]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.17.0 -> 0.17.0@git:1410f1449100a417bfbc4f6c7167aa9808e38792"
+importable = false
 
 [[audits.zcash_proofs]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
@@ -610,6 +683,12 @@ delta = "0.1.1 -> 0.3.0"
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.3.0 -> 0.4.0"
+
+[[audits.zcash_protocol]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.3.0@git:1410f1449100a417bfbc4f6c7167aa9808e38792"
+importable = false
 
 [[audits.zebra-chain]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
@@ -675,6 +754,12 @@ version = "0.1.0"
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.1.0 -> 0.2.0"
+
+[[audits.zip321]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.1.0@git:1410f1449100a417bfbc4f6c7167aa9808e38792"
+importable = false
 
 [[trusted.clap]]
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -16,10 +16,66 @@ url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/
 [imports.zcashd]
 url = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
+[policy."equihash:0.2.0"]
+
+[policy."equihash:0.2.0@git:1410f1449100a417bfbc4f6c7167aa9808e38792"]
+audit-as-crates-io = true
+
+[policy."f4jumble:0.1.0"]
+
+[policy."f4jumble:0.1.0@git:1410f1449100a417bfbc4f6c7167aa9808e38792"]
+audit-as-crates-io = true
+
+[policy."incrementalmerkletree:0.6.0"]
+
+[policy."incrementalmerkletree:0.7.0@git:ffe4234788fd22662b937ba7c6ea01535fcc1293"]
+audit-as-crates-io = true
+
+[policy.orchard]
+audit-as-crates-io = true
+
+[policy.sapling-crypto]
+audit-as-crates-io = true
+
+[policy.shardtree]
+audit-as-crates-io = true
+
 [policy.tower-batch-control]
 audit-as-crates-io = true
 
 [policy.tower-fallback]
+audit-as-crates-io = true
+
+[policy."zcash_address:0.4.0"]
+
+[policy."zcash_address:0.5.0@git:1410f1449100a417bfbc4f6c7167aa9808e38792"]
+audit-as-crates-io = true
+
+[policy.zcash_client_backend]
+audit-as-crates-io = true
+
+[policy.zcash_encoding]
+audit-as-crates-io = true
+
+[policy.zcash_history]
+audit-as-crates-io = true
+
+[policy."zcash_keys:0.3.0"]
+
+[policy."zcash_keys:0.3.0@git:1410f1449100a417bfbc4f6c7167aa9808e38792"]
+audit-as-crates-io = true
+
+[policy."zcash_primitives:0.16.0"]
+
+[policy."zcash_primitives:0.17.0@git:1410f1449100a417bfbc4f6c7167aa9808e38792"]
+audit-as-crates-io = true
+
+[policy.zcash_proofs]
+audit-as-crates-io = true
+
+[policy."zcash_protocol:0.2.0"]
+
+[policy."zcash_protocol:0.3.0@git:1410f1449100a417bfbc4f6c7167aa9808e38792"]
 audit-as-crates-io = true
 
 [policy.zebra-chain]
@@ -56,6 +112,9 @@ audit-as-crates-io = true
 audit-as-crates-io = true
 
 [policy.zebrad]
+audit-as-crates-io = true
+
+[policy.zip321]
 audit-as-crates-io = true
 
 [[exemptions.abscissa_core]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -16,34 +16,10 @@ url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/
 [imports.zcashd]
 url = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
-[policy.equihash]
-audit-as-crates-io = true
-
-[policy.f4jumble]
-audit-as-crates-io = true
-
 [policy.tower-batch-control]
 audit-as-crates-io = true
 
 [policy.tower-fallback]
-audit-as-crates-io = true
-
-[policy.zcash_address]
-audit-as-crates-io = true
-
-[policy.zcash_client_backend]
-audit-as-crates-io = true
-
-[policy.zcash_encoding]
-audit-as-crates-io = true
-
-[policy.zcash_keys]
-audit-as-crates-io = true
-
-[policy.zcash_primitives]
-audit-as-crates-io = true
-
-[policy.zcash_protocol]
 audit-as-crates-io = true
 
 [policy.zebra-chain]
@@ -80,9 +56,6 @@ audit-as-crates-io = true
 audit-as-crates-io = true
 
 [policy.zebrad]
-audit-as-crates-io = true
-
-[policy.zip321]
 audit-as-crates-io = true
 
 [[exemptions.abscissa_core]]

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -88,7 +88,7 @@ primitive-types = "0.12.2"
 rand_core = "0.6.4"
 ripemd = "0.1.3"
 # Matches version used by hdwallet
-secp256k1 = { version = "0.26.0", features = ["serde"] }
+secp256k1 = { version = "0.27.0", features = ["serde"] }
 sha2 = { version = "0.10.7", features = ["compress"] }
 uint = "0.10.0"
 x25519-dalek = { version = "2.0.1", features = ["serde"] }

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -68,7 +68,7 @@ bitflags = "2.5.0"
 bitflags-serde-legacy = "0.1.1"
 blake2b_simd = "1.0.2"
 blake2s_simd = "1.0.2"
-bridgetree = "0.5.0"
+bridgetree = "0.6.0"
 bs58 = { version = "0.5.1", features = ["check"] }
 byteorder = "1.5.0"
 

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -71,11 +71,10 @@ tracing = "0.1.39"
 futures = "0.3.30"
 
 # ECC dependencies.
-# TODO: we can't use the workspace version for all ECC dependencies in this crate yet (#8809)
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash/", commit = "40ca428c6081c61d5a2bf3f2053eb9e18219ca95" }
+zcash_client_backend.workspace = true
 zcash_keys = { workspace = true, features = ["sapling"] }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash/", commit = "40ca428c6081c61d5a2bf3f2053eb9e18219ca95" }
-zcash_address = { git = "https://github.com/zcash/librustzcash/", commit = "40ca428c6081c61d5a2bf3f2053eb9e18219ca95" }
+zcash_primitives.workspace = true
+zcash_address.workspace = true
 sapling-crypto.workspace = true
 
 zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.39", features = ["shielded-scan"] }


### PR DESCRIPTION
## Motivation

We need to upgrade the ECC dependencies for the next release.

This PR will also close https://github.com/ZcashFoundation/zebra/issues/8809 

## Solution

- Upgrade the dependencies to match zcashd 6.0.0 release candidate - https://github.com/zcash/zcash/blob/v6.0.0-rc1/Cargo.toml
- Additional patches are also needed: https://github.com/zcash/librustzcash/blob/1410f1449100a417bfbc4f6c7167aa9808e38792/Cargo.toml#L165-L170
- Upgrade `secp256k1` now that we can and do some deny.toml cleanup.

### Tests

All CI tests should pass.

### PR Author's Checklist

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

