### PR TITLE
Network Sustainability Mechanism - ZIP 233 implementation

### DIFF
--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -234,8 +234,9 @@ pub(crate) const CONSENSUS_BRANCH_IDS: &[(NetworkUpgrade, ConsensusBranchId)] = 
     (Nu5, ConsensusBranchId(0xc2d6d0b4)),
     (Nu6, ConsensusBranchId(0xc8e71055)),
     (Nu6_1, ConsensusBranchId(0x4dec4df0)),
+    // TODO: set below to (Nu7, ConsensusBranchId(0x77190ad8)), once the same value is set in librustzcash
     #[cfg(any(test, feature = "zebra-test"))]
-    (Nu7, ConsensusBranchId(0x77190ad8)),
+    (Nu7, ConsensusBranchId(0xffffffff)),
     #[cfg(zcash_unstable = "zfuture")]
     (ZFuture, ConsensusBranchId(0xffffffff)),
 ];

--- a/zebra-chain/src/transaction/builder.rs
+++ b/zebra-chain/src/transaction/builder.rs
@@ -9,6 +9,101 @@ use crate::{
 };
 
 impl Transaction {
+    /// Returns a new version 6 coinbase transaction for `network` and `height`,
+    /// which contains the specified `outputs`.
+    #[cfg(feature = "tx_v6")]
+    pub fn new_v6_coinbase(
+        network: &Network,
+        height: Height,
+        outputs: impl IntoIterator<Item = (Amount<NonNegative>, transparent::Script)>,
+        miner_data: Vec<u8>,
+        zip233_amount: Option<Amount<NonNegative>>,
+    ) -> Transaction {
+        // # Consensus
+        //
+        // These consensus rules apply to v5 coinbase transactions after NU5 activation:
+        //
+        // > If effectiveVersion ≥ 5 then this condition MUST hold:
+        // > tx_in_count > 0 or nSpendsSapling > 0 or
+        // > (nActionsOrchard > 0 and enableSpendsOrchard = 1).
+        //
+        // > A coinbase transaction for a block at block height greater than 0 MUST have
+        // > a script that, as its first item, encodes the block height as follows. ...
+        // > let heightBytes be the signed little-endian representation of height,
+        // > using the minimum nonzero number of bytes such that the most significant byte
+        // > is < 0x80. The length of heightBytes MUST be in the range {1 .. 5}.
+        // > Then the encoding is the length of heightBytes encoded as one byte,
+        // > followed by heightBytes itself. This matches the encoding used by Bitcoin
+        // > in the implementation of [BIP-34]
+        // > (but the description here is to be considered normative).
+        //
+        // > A coinbase transaction script MUST have length in {2 .. 100} bytes.
+        //
+        // Zebra adds extra coinbase data if configured to do so.
+        //
+        // Since we're not using a lock time, any sequence number is valid here.
+        // See `Transaction::lock_time()` for the relevant consensus rules.
+        //
+        // <https://zips.z.cash/protocol/protocol.pdf#txnconsensus>
+        let inputs = vec![transparent::Input::new_coinbase(height, miner_data, None)];
+
+        // > The block subsidy is composed of a miner subsidy and a series of funding streams.
+        //
+        // <https://zips.z.cash/protocol/protocol.pdf#subsidyconcepts>
+        //
+        // > The total value in zatoshi of transparent outputs from a coinbase transaction,
+        // > minus vbalanceSapling, minus vbalanceOrchard, MUST NOT be greater than
+        // > the value in zatoshi of block subsidy plus the transaction fees
+        // > paid by transactions in this block.
+        //
+        // > If effectiveVersion ≥ 5 then this condition MUST hold:
+        // > tx_out_count > 0 or nOutputsSapling > 0 or
+        // > (nActionsOrchard > 0 and enableOutputsOrchard = 1).
+        //
+        // <https://zips.z.cash/protocol/protocol.pdf#txnconsensus>
+        let outputs: Vec<_> = outputs
+            .into_iter()
+            .map(|(amount, lock_script)| transparent::Output::new_coinbase(amount, lock_script))
+            .collect();
+        assert!(
+            !outputs.is_empty(),
+            "invalid coinbase transaction: must have at least one output"
+        );
+
+        Transaction::V6 {
+            // > The transaction version number MUST be 4 or 5. ...
+            // > If the transaction version number is 5 then the version group ID
+            // > MUST be 0x26A7270A.
+            // > If effectiveVersion ≥ 5, the nConsensusBranchId field MUST match the consensus
+            // > branch ID used for SIGHASH transaction hashes, as specified in [ZIP-244].
+            network_upgrade: NetworkUpgrade::current(network, height),
+
+            // There is no documented consensus rule for the lock time field in coinbase
+            // transactions, so we just leave it unlocked. (We could also set it to `height`.)
+            lock_time: LockTime::unlocked(),
+
+            // > The nExpiryHeight field of a coinbase transaction MUST be equal to its
+            // > block height.
+            expiry_height: height,
+
+            // > The NSM zip233_amount field [ZIP-233] must be set. It must be >= 0.
+            zip233_amount: zip233_amount.unwrap_or(Amount::zero()),
+
+            inputs,
+            outputs,
+
+            // Zebra does not support shielded coinbase yet.
+            //
+            // > In a version 5 coinbase transaction, the enableSpendsOrchard flag MUST be 0.
+            // > In a version 5 transaction, the reserved bits 2 .. 7 of the flagsOrchard field
+            // > MUST be zero.
+            //
+            // See the Zcash spec for additional shielded coinbase consensus rules.
+            sapling_shielded_data: None,
+            orchard_shielded_data: None,
+        }
+    }
+
     /// Returns a new version 5 coinbase transaction for `network` and `height`,
     /// which contains the specified `outputs`.
     pub fn new_v5_coinbase(

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -122,9 +122,15 @@ pub fn lock_time_has_passed(
 ///
 /// This check counts both `Coinbase` and `PrevOut` transparent inputs.
 pub fn has_inputs_and_outputs(tx: &Transaction) -> Result<(), TransactionError> {
+    #[cfg(feature = "tx_v6")]
+    let has_other_circulation_effects = tx.has_zip233_amount();
+
+    #[cfg(not(feature = "tx_v6"))]
+    let has_other_circulation_effects = false;
+
     if !tx.has_transparent_or_shielded_inputs() {
         Err(TransactionError::NoInputs)
-    } else if !tx.has_transparent_or_shielded_outputs() {
+    } else if !tx.has_transparent_or_shielded_outputs() && !has_other_circulation_effects {
         Err(TransactionError::NoOutputs)
     } else {
         Ok(())

--- a/zebra-consensus/src/transaction/tests/prop.rs
+++ b/zebra-consensus/src/transaction/tests/prop.rs
@@ -303,6 +303,9 @@ fn mock_transparent_transaction(
     // Create the mock transaction
     let expiry_height = block_height;
 
+    #[cfg(feature = "tx_v6")]
+    let zip233_amount = Amount::zero();
+
     let transaction = match transaction_version {
         4 => Transaction::V4 {
             inputs,
@@ -317,6 +320,17 @@ fn mock_transparent_transaction(
             outputs,
             lock_time,
             expiry_height,
+            sapling_shielded_data: None,
+            orchard_shielded_data: None,
+            network_upgrade,
+        },
+        #[cfg(feature = "tx_v6")]
+        6 => Transaction::V6 {
+            inputs,
+            outputs,
+            lock_time,
+            expiry_height,
+            zip233_amount,
             sapling_shielded_data: None,
             orchard_shielded_data: None,
             network_upgrade,

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -23,6 +23,7 @@ categories = [
 exclude = ["*.proto"]
 
 [features]
+tx_v6 = ["zebra-chain/tx_v6", "zebra-state/tx_v6", "zebra-consensus/tx_v6"]
 
 # Production features that activate extra dependencies, or extra features in
 # dependencies
@@ -38,6 +39,7 @@ proptest-impl = [
     "zebra-network/proptest-impl",
     "zebra-chain/proptest-impl",
 ]
+
 
 [dependencies]
 chrono = { workspace = true, features = ["clock", "std"] }

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -2500,6 +2500,8 @@ where
             mempool_txs,
             mempool_tx_deps,
             extra_coinbase_data.clone(),
+            #[cfg(feature = "tx_v6")]
+            None,
         );
 
         tracing::debug!(
@@ -2520,6 +2522,8 @@ where
             mempool_txs,
             submit_old,
             extra_coinbase_data,
+            #[cfg(feature = "tx_v6")]
+            None,
         );
 
         Ok(response.into())

--- a/zebra-rpc/src/methods/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/types/get_block_template.rs
@@ -273,6 +273,7 @@ impl BlockTemplateResponse {
         #[cfg(test)] mempool_txs: Vec<(InBlockTxDependenciesDepth, VerifiedUnminedTx)>,
         submit_old: Option<bool>,
         extra_coinbase_data: Vec<u8>,
+        #[cfg(feature = "tx_v6")] zip233_amount: Option<Amount<NonNegative>>,
     ) -> Self {
         // Calculate the next block height.
         let next_block_height =
@@ -324,6 +325,8 @@ impl BlockTemplateResponse {
             &mempool_txs,
             chain_tip_and_local_time.chain_history_root,
             extra_coinbase_data,
+            #[cfg(feature = "tx_v6")]
+            zip233_amount,
         )
         .expect("coinbase should be valid under the given parameters");
 
@@ -785,6 +788,7 @@ where
 // - Response processing
 
 /// Generates and returns the coinbase transaction and default roots.
+#[allow(clippy::too_many_arguments)]
 pub fn generate_coinbase_and_roots(
     network: &Network,
     height: Height,
@@ -792,14 +796,21 @@ pub fn generate_coinbase_and_roots(
     mempool_txs: &[VerifiedUnminedTx],
     chain_history_root: Option<ChainHistoryMmrRootHash>,
     miner_data: Vec<u8>,
+    #[cfg(feature = "tx_v6")] zip233_amount: Option<Amount<NonNegative>>,
 ) -> Result<(TransactionTemplate<NegativeOrZero>, DefaultRoots), &'static str> {
     let miner_fee = calculate_miner_fee(mempool_txs);
     let outputs = standard_coinbase_outputs(network, height, miner_address, miner_fee);
 
     let tx = match NetworkUpgrade::current(network, height) {
         NetworkUpgrade::Canopy => Transaction::new_v4_coinbase(height, outputs, miner_data),
-        NetworkUpgrade::Nu5 | NetworkUpgrade::Nu6 | NetworkUpgrade::Nu6_1 | NetworkUpgrade::Nu7 => {
+        NetworkUpgrade::Nu5 | NetworkUpgrade::Nu6 | NetworkUpgrade::Nu6_1 => {
             Transaction::new_v5_coinbase(network, height, outputs, miner_data)
+        }
+        #[cfg(not(feature = "tx_v6"))]
+        NetworkUpgrade::Nu7 => Transaction::new_v5_coinbase(network, height, outputs, miner_data),
+        #[cfg(feature = "tx_v6")]
+        NetworkUpgrade::Nu7 => {
+            Transaction::new_v6_coinbase(network, height, outputs, miner_data, zip233_amount)
         }
         _ => Err("Zebra does not support generating pre-Canopy coinbase transactions")?,
     }

--- a/zebra-rpc/src/methods/types/get_block_template/zip317.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/zip317.rs
@@ -26,6 +26,12 @@ use zebra_node_services::mempool::TransactionDependencies;
 
 use crate::methods::types::transaction::TransactionTemplate;
 
+#[cfg(feature = "tx_v6")]
+use crate::methods::{Amount, NonNegative};
+
+#[cfg(feature = "tx_v6")]
+use zebra_chain::parameters::NetworkUpgrade;
+
 #[cfg(test)]
 mod tests;
 
@@ -52,6 +58,7 @@ type SelectedMempoolTx = VerifiedUnminedTx;
 /// Returns selected transactions from `mempool_txs`.
 ///
 /// [ZIP-317]: https://zips.z.cash/zip-0317#block-production
+#[allow(clippy::too_many_arguments)]
 pub fn select_mempool_transactions(
     network: &Network,
     next_block_height: Height,
@@ -59,6 +66,7 @@ pub fn select_mempool_transactions(
     mempool_txs: Vec<VerifiedUnminedTx>,
     mempool_tx_deps: TransactionDependencies,
     extra_coinbase_data: Vec<u8>,
+    #[cfg(feature = "tx_v6")] zip233_amount: Option<Amount<NonNegative>>,
 ) -> Vec<SelectedMempoolTx> {
     // Use a fake coinbase transaction to break the dependency between transaction
     // selection, the miner fee, and the fee payment in the coinbase transaction.
@@ -67,6 +75,8 @@ pub fn select_mempool_transactions(
         next_block_height,
         miner_address,
         extra_coinbase_data,
+        #[cfg(feature = "tx_v6")]
+        zip233_amount,
     );
 
     let tx_dependencies = mempool_tx_deps.dependencies();
@@ -142,6 +152,7 @@ pub fn fake_coinbase_transaction(
     height: Height,
     miner_address: &Address,
     extra_coinbase_data: Vec<u8>,
+    #[cfg(feature = "tx_v6")] zip233_amount: Option<Amount<NonNegative>>,
 ) -> TransactionTemplate<NegativeOrZero> {
     // Block heights are encoded as variable-length (script) and `u32` (lock time, expiry height).
     // They can also change the `u32` consensus branch id.
@@ -154,7 +165,20 @@ pub fn fake_coinbase_transaction(
     // https://developer.bitcoin.org/reference/transactions.html#txout-a-transaction-output
     let miner_fee = 1.try_into().expect("amount is valid and non-negative");
     let outputs = standard_coinbase_outputs(net, height, miner_address, miner_fee);
+
+    #[cfg(not(feature = "tx_v6"))]
     let coinbase = Transaction::new_v5_coinbase(net, height, outputs, extra_coinbase_data).into();
+
+    #[cfg(feature = "tx_v6")]
+    let coinbase = {
+        let network_upgrade = NetworkUpgrade::current(net, height);
+        if network_upgrade < NetworkUpgrade::Nu7 {
+            Transaction::new_v5_coinbase(net, height, outputs, extra_coinbase_data).into()
+        } else {
+            Transaction::new_v6_coinbase(net, height, outputs, extra_coinbase_data, zip233_amount)
+                .into()
+        }
+    };
 
     TransactionTemplate::from_coinbase(&coinbase, miner_fee)
 }

--- a/zebra-rpc/src/methods/types/get_block_template/zip317/tests.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/zip317/tests.rs
@@ -34,6 +34,8 @@ fn excludes_tx_with_unselected_dependencies() {
             vec![unmined_tx],
             mempool_tx_deps,
             extra_coinbase_data,
+            #[cfg(feature = "tx_v6")]
+            None,
         ),
         vec![],
         "should not select any transactions when dependencies are unavailable"
@@ -78,6 +80,8 @@ fn includes_tx_with_selected_dependencies() {
         unmined_txs.clone(),
         mempool_tx_deps.clone(),
         extra_coinbase_data,
+        #[cfg(feature = "tx_v6")]
+        None,
     );
 
     assert_eq!(

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -43,5 +43,8 @@ tracing = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 
+[features]
+tx_v6 = []
+
 [lints]
 workspace = true

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -145,7 +145,7 @@ lightwalletd-grpc-tests = ["tonic-prost-build"]
 # https://github.com/tokio-rs/console/blob/main/console-subscriber/README.md#enabling-tokio-instrumentation
 tokio-console = ["console-subscriber"]
 
-tx_v6 = ["zebra-chain/tx_v6", "zebra-state/tx_v6", "zebra-consensus/tx_v6"]
+tx_v6 = ["zebra-chain/tx_v6", "zebra-state/tx_v6", "zebra-consensus/tx_v6", "zebra-rpc/tx_v6"]
 
 # Enable the C++/Rust comparison interpreter. See zebra-script/Cargo.toml for
 # details. This should be only used for testing.

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -3517,6 +3517,8 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
         &[],
         chain_history_root,
         vec![],
+        #[cfg(feature = "tx_v6")]
+        None,
     )
     .expect("coinbase transaction should be valid under the given parameters");
 
@@ -3575,6 +3577,8 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
         &[],
         chain_history_root,
         vec![],
+        #[cfg(feature = "tx_v6")]
+        None,
     )
     .expect("coinbase transaction should be valid under the given parameters");
 
@@ -3621,6 +3625,164 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
     let proposal_block =
         proposal_block_from_template(&valid_original_block_template, None, &network)?;
 
+    let submit_block_response = rpc
+        .submit_block(HexData(proposal_block.zcash_serialize_to_vec()?), None)
+        .await?;
+
+    assert_eq!(
+        submit_block_response,
+        SubmitBlockResponse::Accepted,
+        "valid block should be accepted"
+    );
+
+    Ok(())
+}
+
+/// Test successful block template submission as a block proposal.
+///
+/// This test can be run locally with:
+/// `cargo test --package zebrad --test acceptance --features tx_v6 -- nu7_nsm_transactions --exact --show-output`
+#[tokio::test(flavor = "multi_thread")]
+#[cfg(feature = "tx_v6")]
+async fn nu7_nsm_transactions() -> Result<()> {
+    use zebra_chain::{
+        chain_sync_status::MockSyncStatus,
+        parameters::testnet::{self, ConfiguredActivationHeights, ConfiguredFundingStreams},
+        serialization::ZcashSerialize,
+        work::difficulty::U256,
+    };
+    use zebra_network::address_book_peers::MockAddressBookPeers;
+    use zebra_node_services::mempool;
+    use zebra_rpc::client::HexData;
+    use zebra_test::mock_service::MockService;
+    let _init_guard = zebra_test::init();
+
+    tracing::info!("running nu7_nsm_transactions test");
+
+    let base_network_params = testnet::Parameters::build()
+        // Regtest genesis hash
+        .with_genesis_hash("029f11d80ef9765602235e1bc9727e3eb6ba20839319f761fee920d63401e327")
+        .with_checkpoints(false)
+        .with_target_difficulty_limit(U256::from_big_endian(&[0x0f; 32]))
+        .with_disable_pow(true)
+        .with_slow_start_interval(Height::MIN)
+        .with_lockbox_disbursements(vec![])
+        .with_activation_heights(ConfiguredActivationHeights {
+            nu7: Some(1),
+            ..Default::default()
+        });
+
+    let network = base_network_params
+        .clone()
+        .with_funding_streams(vec![ConfiguredFundingStreams {
+            // Start checking funding streams from block height 1
+            height_range: Some(Height(1)..Height(100)),
+            // Use default post-NU6 recipients
+            recipients: None,
+        }])
+        .to_network();
+
+    tracing::info!("built configured Testnet, starting state service and block verifier");
+
+    let default_test_config = default_test_config(&network)?;
+    let mining_config = default_test_config.mining;
+
+    let (state, read_state, latest_chain_tip, _chain_tip_change) =
+        zebra_state::init_test_services(&network).await;
+
+    let (
+        block_verifier_router,
+        _transaction_verifier,
+        _parameter_download_task_handle,
+        _max_checkpoint_height,
+    ) = zebra_consensus::router::init_test(
+        zebra_consensus::Config::default(),
+        &network,
+        state.clone(),
+    )
+    .await;
+
+    tracing::info!("started state service and block verifier, committing Regtest genesis block");
+
+    let genesis_hash = block_verifier_router
+        .clone()
+        .oneshot(zebra_consensus::Request::Commit(regtest_genesis_block()))
+        .await
+        .expect("should validate Regtest genesis block");
+
+    let mut mempool = MockService::build()
+        .with_max_request_delay(Duration::from_secs(5))
+        .for_unit_tests();
+    let mut mock_sync_status = MockSyncStatus::default();
+    mock_sync_status.set_is_close_to_tip(true);
+
+    let submitblock_channel = SubmitBlockChannel::new();
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+
+    let (rpc, _) = RpcImpl::new(
+        network.clone(),
+        mining_config,
+        false,
+        "0.0.1",
+        "Zebra tests",
+        mempool.clone(),
+        state.clone(),
+        read_state.clone(),
+        block_verifier_router,
+        mock_sync_status,
+        latest_chain_tip,
+        MockAddressBookPeers::default(),
+        rx,
+        Some(submitblock_channel.sender()),
+    );
+
+    let make_mock_mempool_request_handler = || async move {
+        mempool
+            .expect_request(mempool::Request::FullTransactions)
+            .await
+            .respond(mempool::Response::FullTransactions {
+                transactions: vec![],
+                transaction_dependencies: Default::default(),
+                // tip hash needs to match chain info for long poll requests
+                last_seen_tip_hash: genesis_hash,
+            });
+    };
+
+    let block_template_fut = rpc.get_block_template(None);
+    let mock_mempool_request_handler = make_mock_mempool_request_handler.clone()();
+    let (block_template, _) = tokio::join!(block_template_fut, mock_mempool_request_handler);
+    let GetBlockTemplateResponse::TemplateMode(block_template) =
+        block_template.expect("unexpected error in getblocktemplate RPC call")
+    else {
+        panic!("this getblocktemplate call without parameters should return the `TemplateMode` variant of the response")
+    };
+
+    let proposal_block = proposal_block_from_template(&block_template, None, &network)?;
+    let hex_proposal_block = HexData(proposal_block.zcash_serialize_to_vec()?);
+
+    // Check that the block template is a valid block proposal
+    let GetBlockTemplateResponse::ProposalMode(block_proposal_result) = rpc
+        .get_block_template(Some(GetBlockTemplateParameters::new(
+            GetBlockTemplateRequestMode::Proposal,
+            Some(hex_proposal_block),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+        )))
+        .await?
+    else {
+        panic!(
+            "this getblocktemplate call should return the `ProposalMode` variant of the response"
+        )
+    };
+
+    assert!(
+        block_proposal_result.is_valid(),
+        "block proposal should succeed"
+    );
+
+    // Submit the same block
     let submit_block_response = rpc
         .submit_block(HexData(proposal_block.zcash_serialize_to_vec()?), None)
         .await?;


### PR DESCRIPTION
## Motivation

This PR implements the ZIP-233, described [here](https://github.com/zcash/zips/pull/913).

### Specifications & References

[ZIP-233](https://github.com/zcash/zips/pull/913)

## Solution

A new field, `zip233_amount,` is added to the v6 transaction version according to the specification in ZIP-233. 

This implementation uses the `nsm` branch of the librustzcash library.

### Tests

For testing purposes, a local testnet network was set up. It contained two nodes—a zebra and a zcashd one (with the ZIP-233 implemented, too, PR [here](https://github.com/zcash/zcash/pull/6969)). A transaction in a new format containing the `zip233_amount` field was created and added to the block by zcashd. The zebra node synced with zcashd without any errors and accepted the block.

### Follow-up Work

The next PR will contain an implementation of zips [ZIP-234](https://github.com/zcash/zips/pull/914) and [ZIP-235](https://github.com/zcash/zips/pull/915).

### PR Author's Checklist

- [x] The PR name will make sense to users.
- [x] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [ ] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

