### PR TITLE
fix(rpc): Refactor the cookie-based RPC authentication

### DIFF
--- a/zebra-rpc/src/server.rs
+++ b/zebra-rpc/src/server.rs
@@ -311,8 +311,12 @@ impl RpcServer {
         let wait_on_shutdown = move || {
             span.in_scope(|| {
                 if config.enable_cookie_auth {
-                    cookie::remove_from_disk(&config.cookie_dir)
-                        .expect("Zebra must be able to remove the auth cookie from the disk");
+                    if let Err(err) = cookie::remove_from_disk(&config.cookie_dir) {
+                        warn!(
+                            ?err,
+                            "unexpectedly could not remove the rpc auth cookie from the disk"
+                        )
+                    }
                 }
 
                 info!("Stopping RPC server");

--- a/zebra-rpc/src/server.rs
+++ b/zebra-rpc/src/server.rs
@@ -9,6 +9,8 @@
 
 use std::{fmt, panic, thread::available_parallelism};
 
+use cookie::Cookie;
+use http_request_compatibility::With;
 use jsonrpc_core::{Compatibility, MetaIoHandler};
 use jsonrpc_http_server::{CloseHandle, ServerBuilder};
 use tokio::task::JoinHandle;
@@ -25,7 +27,7 @@ use crate::{
     config::Config,
     methods::{Rpc, RpcImpl},
     server::{
-        http_request_compatibility::FixHttpRequestMiddleware,
+        http_request_compatibility::HttpRequestMiddleware,
         rpc_call_compatibility::FixRpcResponseMiddleware,
     },
 };
@@ -194,24 +196,28 @@ impl RpcServer {
                 parallel_cpu_threads = available_parallelism().map(usize::from).unwrap_or(1);
             }
 
-            // Generate a RPC authentication cookie
-            if config.enable_cookie_auth {
-                let _ = cookie::generate(config.cookie_dir.clone());
-            }
-
             // The server is a blocking task, which blocks on executor shutdown.
             // So we need to start it in a std::thread.
             // (Otherwise tokio panics on RPC port conflict, which shuts down the RPC server.)
             let span = Span::current();
             let start_server = move || {
                 span.in_scope(|| {
+                    let middleware = if config.enable_cookie_auth {
+                        let cookie = Cookie::default();
+                        cookie::write_to_disk(&cookie, &config.cookie_dir)
+                            .expect("Zebra must be able to write the auth cookie to the disk");
+                        HttpRequestMiddleware::default().with(cookie)
+                    } else {
+                        HttpRequestMiddleware::default()
+                    };
+
                     // Use a different tokio executor from the rest of Zebra,
                     // so that large RPCs and any task handling bugs don't impact Zebra.
                     let server_instance = ServerBuilder::new(io)
                         .threads(parallel_cpu_threads)
                         // TODO: disable this security check if we see errors from lightwalletd
                         //.allowed_hosts(DomainsValidation::Disabled)
-                        .request_middleware(FixHttpRequestMiddleware(config.clone()))
+                        .request_middleware(middleware)
                         .start_http(&listen_addr)
                         .expect("Unable to start RPC server");
 
@@ -280,32 +286,37 @@ impl RpcServer {
     /// This method can be called from within a tokio executor without panicking.
     /// But it is blocking, so `shutdown()` should be used instead.
     pub fn shutdown_blocking(&self) {
-        Self::shutdown_blocking_inner(self.close_handle.clone())
+        Self::shutdown_blocking_inner(self.close_handle.clone(), self.config.clone())
     }
 
     /// Shut down this RPC server asynchronously.
     /// Returns a task that completes when the server is shut down.
     pub fn shutdown(&self) -> JoinHandle<()> {
         let close_handle = self.close_handle.clone();
-
+        let config = self.config.clone();
         let span = Span::current();
+
         tokio::task::spawn_blocking(move || {
-            span.in_scope(|| Self::shutdown_blocking_inner(close_handle))
+            span.in_scope(|| Self::shutdown_blocking_inner(close_handle, config))
         })
     }
 
     /// Shuts down this RPC server using its `close_handle`.
     ///
     /// See `shutdown_blocking()` for details.
-    fn shutdown_blocking_inner(close_handle: CloseHandle) {
+    fn shutdown_blocking_inner(close_handle: CloseHandle, config: Config) {
         // The server is a blocking task, so it can't run inside a tokio thread.
         // See the note at wait_on_server.
         let span = Span::current();
         let wait_on_shutdown = move || {
             span.in_scope(|| {
+                if config.enable_cookie_auth {
+                    cookie::remove_from_disk(&config.cookie_dir)
+                        .expect("Zebra must be able to remove the auth cookie from the disk");
+                }
+
                 info!("Stopping RPC server");
                 close_handle.clone().close();
-                let _ = cookie::delete(); // delete the auth cookie if exists
                 debug!("Stopped RPC server");
             })
         };

--- a/zebra-rpc/src/server/cookie.rs
+++ b/zebra-rpc/src/server/cookie.rs
@@ -35,6 +35,8 @@ impl Default for Cookie {
 
 /// Writes the given cookie to the given dir.
 pub fn write_to_disk(cookie: &Cookie, dir: &Path) -> Result<()> {
+    // Create the directory if needed.
+    std::fs::create_dir_all(&dir)?;
     File::create(dir.join(FILE))?.write_all(format!("__cookie__:{}", cookie.0).as_bytes())?;
 
     tracing::info!("RPC auth cookie written to disk");

--- a/zebra-rpc/src/server/http_request_compatibility.rs
+++ b/zebra-rpc/src/server/http_request_compatibility.rs
@@ -47,10 +47,9 @@ pub struct HttpRequestMiddleware {
     cookie: Option<Cookie>,
 }
 
-/// A trait for applying a modification to an object, consuming it and returning the modified
-/// version.
+/// A trait for updating an object, consuming it and returning the updated version.
 pub trait With<T> {
-    /// Modifies `self` with an instance of type `T` and returns the modified version of `self`.
+    /// Updates `self` with an instance of type `T` and returns the updated version of `self`.
     fn with(self, _: T) -> Self;
 }
 

--- a/zebra-rpc/src/server/http_request_compatibility.rs
+++ b/zebra-rpc/src/server/http_request_compatibility.rs
@@ -9,26 +9,31 @@ use jsonrpc_http_server::{
     RequestMiddleware, RequestMiddlewareAction,
 };
 
-use crate::server::cookie;
+use super::cookie::Cookie;
 
 /// HTTP [`RequestMiddleware`] with compatibility workarounds.
 ///
 /// This middleware makes the following changes to HTTP requests:
 ///
-/// ## Remove `jsonrpc` field in JSON RPC 1.0
+/// ### Remove `jsonrpc` field in JSON RPC 1.0
 ///
 /// Removes "jsonrpc: 1.0" fields from requests,
 /// because the "jsonrpc" field was only added in JSON-RPC 2.0.
 ///
 /// <http://www.simple-is-better.org/rpc/#differences-between-1-0-and-2-0>
 ///
-/// ## Add missing `content-type` HTTP header
+/// ### Add missing `content-type` HTTP header
 ///
 /// Some RPC clients don't include a `content-type` HTTP header.
 /// But unlike web browsers, [`jsonrpc_http_server`] does not do content sniffing.
 ///
 /// If there is no `content-type` header, we assume the content is JSON,
 /// and let the parser error if we are incorrect.
+///
+/// ### Authenticate incoming requests
+///
+/// If the cookie-based RPC authentication is enabled, check that the incoming request contains the
+/// authentication cookie.
 ///
 /// This enables compatibility with `zcash-cli`.
 ///
@@ -37,10 +42,26 @@ use crate::server::cookie;
 /// Any user-specified data in RPC requests is hex or base58check encoded.
 /// We assume lightwalletd validates data encodings before sending it on to Zebra.
 /// So any fixes Zebra performs won't change user-specified data.
-#[derive(Clone, Debug)]
-pub struct FixHttpRequestMiddleware(pub crate::config::Config);
+#[derive(Clone, Debug, Default)]
+pub struct HttpRequestMiddleware {
+    cookie: Option<Cookie>,
+}
 
-impl RequestMiddleware for FixHttpRequestMiddleware {
+/// A trait for applying a modification to an object, consuming it and returning the modified
+/// version.
+pub trait With<T> {
+    /// Modifies `self` with an instance of type `T` and returns the modified version of `self`.
+    fn with(self, _: T) -> Self;
+}
+
+impl With<Cookie> for HttpRequestMiddleware {
+    fn with(mut self, cookie: Cookie) -> Self {
+        self.cookie = Some(cookie);
+        self
+    }
+}
+
+impl RequestMiddleware for HttpRequestMiddleware {
     fn on_request(&self, mut request: Request<Body>) -> RequestMiddlewareAction {
         tracing::trace!(?request, "original HTTP request");
 
@@ -62,7 +83,7 @@ impl RequestMiddleware for FixHttpRequestMiddleware {
         }
 
         // Fix the request headers if needed and we can do so.
-        FixHttpRequestMiddleware::insert_or_replace_content_type_header(request.headers_mut());
+        HttpRequestMiddleware::insert_or_replace_content_type_header(request.headers_mut());
 
         // Fix the request body
         let request = request.map(|body| {
@@ -100,7 +121,7 @@ impl RequestMiddleware for FixHttpRequestMiddleware {
     }
 }
 
-impl FixHttpRequestMiddleware {
+impl HttpRequestMiddleware {
     /// Remove any "jsonrpc: 1.0" fields in `data`, and return the resulting string.
     pub fn remove_json_1_fields(data: String) -> String {
         // Replace "jsonrpc = 1.0":
@@ -164,27 +185,15 @@ impl FixHttpRequestMiddleware {
 
     /// Check if the request is authenticated.
     pub fn check_credentials(&self, headers: &header::HeaderMap) -> bool {
-        if !self.0.enable_cookie_auth {
-            return true;
-        }
-        headers
-            .get(header::AUTHORIZATION)
-            .and_then(|auth_header| auth_header.to_str().ok())
-            .and_then(|auth| auth.split_whitespace().nth(1))
-            .and_then(|token| URL_SAFE.decode(token).ok())
-            .and_then(|decoded| String::from_utf8(decoded).ok())
-            .and_then(|decoded_str| {
-                decoded_str
-                    .split(':')
-                    .nth(1)
-                    .map(|password| password.to_string())
-            })
-            .map_or(false, |password| {
-                if let Ok(cookie_password) = cookie::get(self.0.cookie_dir.clone()) {
-                    cookie_password == password
-                } else {
-                    false
-                }
-            })
+        self.cookie.as_ref().map_or(true, |internal_cookie| {
+            headers
+                .get(header::AUTHORIZATION)
+                .and_then(|auth_header| auth_header.to_str().ok())
+                .and_then(|auth_header| auth_header.split_whitespace().nth(1))
+                .and_then(|encoded| URL_SAFE.decode(encoded).ok())
+                .and_then(|decoded| String::from_utf8(decoded).ok())
+                .and_then(|request_cookie| request_cookie.split(':').nth(1).map(String::from))
+                .map_or(false, |passwd| internal_cookie.authenticate(passwd))
+        })
     }
 }


### PR DESCRIPTION
## Motivation

Resolve https://github.com/ZcashFoundation/zebra/pull/8900#discussion_r1801089575 and https://github.com/ZcashFoundation/zebra/pull/8900#discussion_r1801090790.


## Solution

- Don't read the cookie from the disk at all.
- Use a path to the cookie file when removing it.
- Rename `FixHttpRequestMiddleware` to `HttpRequestMiddleware` since it doesn't contain only fixes anymore but also serves as an authentication layer.

### Tests

No new tests.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name is suitable for the change log.
- [ ] The solution is tested.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR resolves the issue.

