### PR TITLE
fix(actions): run `get-disk-name` on all workflow events

### DIFF
--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -204,7 +204,7 @@ jobs:
   get-disk-name:
     name: Get disk name
     uses: ./.github/workflows/sub-find-cached-disks.yml
-    if: ${{ !inputs.no_cached_disk && github.event_name == 'workflow_dispatch' }}
+    if: ${{ !inputs.no_cached_disk }}
     with:
       network: ${{ inputs.network || vars.ZCASH_NETWORK }}
       disk_prefix: zebrad-cache


### PR DESCRIPTION
## Motivation

While testing in https://github.com/ZcashFoundation/zebra/pull/8908, a testing condition was not removed and merged into the `main` branch, which skips a required job for the cached states images to be found and attached to the instances.

Identified here: https://github.com/ZcashFoundation/zebra/actions/runs/11385606467/job/31676320538

## Solution

- Remove the `github.event_name == 'workflow_dispatch'` condition that was used for testing in the PR

### Tests

- All tests should pass here


### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

