### PR TITLE
fix(codespell): Ignore some directories

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,4 @@
 [codespell]
-ignore-words-list=crate,Sur,inout,Groth,groth,re-use,
-exclude-file=book/mermaid.min.js
+ignore-words-list = crate,Sur,inout,Groth,groth,re-use,
+exclude-file = book/mermaid.min.js
+skip = ./zebra-rpc/qa/rpc-tests,./supply-chain


### PR DESCRIPTION
## Motivation

When `codespell` runs against the current main branch the following annotations will be displayed:

```
$ codespell --config .codespellrc 
./zebra-rpc/qa/rpc-tests/test_framework/script.py:20: bord ==> board, bored, border
./zebra-rpc/qa/rpc-tests/test_framework/script.py:24: bord ==> board, bored, border
./zebra-rpc/qa/rpc-tests/test_framework/script.py:709: bord ==> board, bored, border
./zebra-rpc/qa/rpc-tests/test_framework/script.py:725: bord ==> board, bored, border
./zebra-rpc/qa/rpc-tests/test_framework/script.py:732: bord ==> board, bored, border
./zebra-rpc/qa/rpc-tests/test_framework/script.py:732: bord ==> board, bored, border
./zebra-rpc/qa/rpc-tests/test_framework/script.py:739: bord ==> board, bored, border
./zebra-rpc/qa/rpc-tests/test_framework/script.py:739: bord ==> board, bored, border
./zebra-rpc/qa/rpc-tests/test_framework/script.py:739: bord ==> board, bored, border
./zebra-rpc/qa/rpc-tests/test_framework/script.py:739: bord ==> board, bored, border
./zebra-rpc/qa/rpc-tests/test_framework/zip244.py:280: nIn ==> inn, min, bin, nine
./zebra-rpc/qa/rpc-tests/test_framework/zip244.py:280: nIn ==> inn, min, bin, nine
./zebra-rpc/qa/rpc-tests/test_framework/zip244.py:282: nIn ==> inn, min, bin, nine
./zebra-rpc/qa/rpc-tests/test_framework/zip244.py:290: nIn ==> inn, min, bin, nine
./zebra-rpc/qa/rpc-tests/test_framework/zip244.py:293: nIn ==> inn, min, bin, nine
./supply-chain/imports.lock:645: ser ==> set
./supply-chain/imports.lock:654: ser ==> set
./supply-chain/imports.lock:656: ser ==> set
./supply-chain/imports.lock:713: neverthless ==> nevertheless
./supply-chain/imports.lock:1278: acces ==> access
./supply-chain/imports.lock:1584: soley ==> solely
``` 

## Solution

As RPC tests are imported code, we want to ignore codespell there. Also ignore it in the supply-chain directory which is an automatic thing.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

