### PR TITLE
fix(build): Update Zebra's MSRV and use the latest Rust Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ ARG TEST_FEATURES="lightwalletd-grpc-tests zebra-checkpoints"
 ARG EXPERIMENTAL_FEATURES=""
 
 ARG APP_HOME="/opt/zebrad"
-ARG RUST_VERSION=1.79.0
+ARG RUST_VERSION=1.82.0
 # In this stage we download all system requirements to build the project
 #
 # It also captures all the build arguments to be used as environment variables.

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2021"
 
 # Zebra is only supported on the latest stable Rust version. See the README for details.
 # Any Zebra release can break compatibility with older Rust versions.
-rust-version = "1.76"
+rust-version = "1.81.0"
 
 # Settings that impact runtime behaviour
 


### PR DESCRIPTION
## Motivation

This [test failed](https://github.com/ZcashFoundation/zebra/actions/runs/11440468788/job/31826372026#step:10:846) on main due to a missing `PanicHookInfo` struct in the standard library that wasn't added until [Rust v1.81.0](https://doc.rust-lang.org/stable/releases.html#stabilized-apis-1).

We want to keep Zebra's minimum Rust version up-to-date and use the latest version of Rust in our docker builds.

## Solution

Updates `RUST_VERSION` in Dockerfile and the `rust-version` field in `zebrad/Cargo.toml`

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

