### PR TITLE
fix(docs): Update documents for cookie auth where needed

### DIFF
--- a/book/src/user/lightwalletd.md
+++ b/book/src/user/lightwalletd.md
@@ -46,6 +46,8 @@ for Zebra is:
 - `8232` for Mainnet, and
 - `18232` for Testnet.
 
+Starting with Zebra v2.0.0, a cookie authentication method like the one used by the `zcashd` node is enabled by default. However, lightwalletd currently [does not support cookie authentication](https://github.com/zcash/lightwalletd/blob/master/docs/docker-compose-setup.md#edit-the-two-zcashconf-files), so we need to disable this authentication method to use Zebra as a backend for lightwalletd.
+
 For example, to use Zebra as a `lightwalletd` backend on Mainnet, give it this
 `~/.config/zebrad.toml`:
 
@@ -56,6 +58,9 @@ listen_addr = '127.0.0.1:8232'
 
 # automatically use multiple CPU threads
 parallel_cpu_threads = 0
+
+# diable cookie auth
+enable_cookie_auth = false
 ```
 
 **WARNING:** This config allows multiple Zebra instances to share the same RPC port.

--- a/book/src/user/lightwalletd.md
+++ b/book/src/user/lightwalletd.md
@@ -46,7 +46,7 @@ for Zebra is:
 - `8232` for Mainnet, and
 - `18232` for Testnet.
 
-Starting with Zebra v2.0.0, a cookie authentication method like the one used by the `zcashd` node is enabled by default. However, lightwalletd currently [does not support cookie authentication](https://github.com/zcash/lightwalletd/blob/master/docs/docker-compose-setup.md#edit-the-two-zcashconf-files), so we need to disable this authentication method to use Zebra as a backend for lightwalletd.
+Starting with Zebra v2.0.0, a cookie authentication method like the one used by the `zcashd` node is enabled by default for the RPC server. However, lightwalletd currently [does not support cookie authentication](https://github.com/zcash/lightwalletd/blob/master/docs/docker-compose-setup.md#edit-the-two-zcashconf-files), so we need to disable this authentication method to use Zebra as a backend for lightwalletd.
 
 For example, to use Zebra as a `lightwalletd` backend on Mainnet, give it this
 `~/.config/zebrad.toml`:

--- a/book/src/user/lightwalletd.md
+++ b/book/src/user/lightwalletd.md
@@ -59,7 +59,7 @@ listen_addr = '127.0.0.1:8232'
 # automatically use multiple CPU threads
 parallel_cpu_threads = 0
 
-# diable cookie auth
+# disable cookie auth
 enable_cookie_auth = false
 ```
 

--- a/book/src/user/mining-testnet-s-nomp.md
+++ b/book/src/user/mining-testnet-s-nomp.md
@@ -13,6 +13,7 @@ These fixes disable mining pool operator payments and miner payments: they just 
     - change the `network.network` config to `Testnet`
     - add your testnet transparent address in `mining.miner_address`, or you can use the ZF testnet address `t27eWDgjFYJGVXmzrXeVjnb5J3uXDM9xH9v`
     - ensure that there is an `rpc.listen_addr` in the config to enable the RPC server
+    - disable the cookie auth system by changing `rpc.enable_cookie_auth` to `false`
 
     Example config:
     <details>
@@ -48,6 +49,7 @@ These fixes disable mining pool operator payments and miner payments: they just 
     debug_force_finished_sync = false
     parallel_cpu_threads = 1
     listen_addr = '127.0.0.1:18232'
+    enable_cookie_auth = false
 
     [state]
     cache_dir = '/home/ar/.cache/zebra'

--- a/book/src/user/mining.md
+++ b/book/src/user/mining.md
@@ -80,8 +80,16 @@ Wait until zebra is in sync, you will see the sync at 100% when this happens:
 
 The easiest way to check your setup is to call the `getblocktemplate` RPC method and check the result.
 
+Starting with Zebra v2.0.0, a cookie authentication method similar to the one used by the `zcashd` node is enabled by default. The cookie is stored in the default cache directory when the RPC endpoint starts and is deleted at shutdown. By default, the cookie is located in the cache directory; for example, on Linux, it may be found at `/home/user/.cache/zebra/.cookie`. You can change the cookie's location using the `rpc.cookie_dir` option in the configuration, or disable cookie authentication altogether by setting `rpc.enable_cookie_auth` to false. The contents of the cookie file look like this:
+
+```
+__cookie__:YwDDua GzvtEmWG6KWnhgd9gilo5mKdi6m38v__we3Ko=
+```
+
+The password is an encoded, randomly generated string. You can use it in your call as follows:
+
 ```console
-$ curl --silent --data-binary '{"jsonrpc": "1.0", "id":"curltest", "method": "getblocktemplate", "params": [] }' -H 'Content-type: application/json' http://127.0.0.1:8232/ | jq
+$ curl --silent --data-binary '{"jsonrpc": "1.0", "id":"curltest", "method": "getblocktemplate", "params": [] }' -H 'Content-type: application/json' http://__cookie__:YwDDuaGzvtEmWG6KWnhgd9gilo5mKdi6m38v__we3Ko=@127.0.0.1:8232/ | jq
 ```
 
 If you can see something similar to the following then you are good to go.


### PR DESCRIPTION
## Motivation

We added the cookie auth method to our RPC endpoint in https://github.com/ZcashFoundation/zebra/pull/8900

We want to update the zebra book documentation to enable/disable/use it where needed.

## Solution

- Update ligthwalletd and mining docs.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

