### PR TITLE
fix(state): Updates `total_size_on_disk` metric to be the total sst file size

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -537,7 +537,7 @@ impl DiskDb {
             let total_sst_files_size = db
                 .property_int_value_cf(cf_handle, "rocksdb.total-sst-files-size")
                 .unwrap_or(Some(0));
-            let cf_disk_size = live_data_size.unwrap_or(0) + total_sst_files_size.unwrap_or(0);
+            let cf_disk_size = total_sst_files_size.unwrap_or(0);
             total_size_on_disk += cf_disk_size;
             total_live_size_on_disk += live_data_size.unwrap_or(0);
             let mem_table_size = db


### PR DESCRIPTION
## Motivation

The db metrics printed by Zebra when it starts up seem too high, it looks like the total sst size in RocksDB includes the live database size.

## Solution

- Avoid adding the live database size to the total db size when printing db metrics

### Tests

Manually tested that the output matches the cache directory size reported by `du -hs`

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

