### PR TITLE
add(build): Add a `rust-toolchain.toml` file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
## Motivation

Cargo should automatically use the right version of `rustc` when a `rust-toolchain.toml` file is present.

### Specifications & References

https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file

## Solution

Adds a `rust-toolchain.toml` that sets the channel to the latest stable release.

### Tests

This was used for convenience in an early version of zebra-launcher that relied on the nightly release for artifact dependencies and worked as expected.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [x] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

