### PR TITLE
ref: adjust GCP instances resources to better fit requirements

### DIFF
--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -276,7 +276,7 @@ jobs:
       - name: Create instance template for ${{ matrix.network }}
         run: |
           DISK_NAME="zebrad-cache-${{ env.GITHUB_HEAD_REF_SLUG_URL || env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-${NETWORK}"
-          DISK_PARAMS="name=${DISK_NAME},device-name=${DISK_NAME},size=400GB,type=pd-ssd"
+          DISK_PARAMS="name=${DISK_NAME},device-name=${DISK_NAME},size=400GB,type=pd-balanced"
           if [ -n "${{ env.CACHED_DISK_NAME }}" ]; then
             DISK_PARAMS+=",image=${{ env.CACHED_DISK_NAME }}"
           elif [ ${{ inputs.no_cached_disk && github.event_name == 'workflow_dispatch' }} ]; then
@@ -287,8 +287,8 @@ jobs:
           fi
           gcloud compute instance-templates create-with-container zebrad-${{ needs.versioning.outputs.major_version || env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-${NETWORK} \
           --machine-type ${{ vars.GCP_SMALL_MACHINE }} \
-          --boot-disk-size 50GB \
-          --boot-disk-type=pd-ssd \
+          --boot-disk-size=10GB \
+          --boot-disk-type=pd-standard \
           --image-project=cos-cloud \
           --image-family=cos-stable \
           --network-interface=subnet=${{ vars.GCP_SUBNETWORK }} \
@@ -388,7 +388,7 @@ jobs:
       - name: Manual deploy of a single ${{ inputs.network }} instance running zebrad
         run: |
           DISK_NAME="zebrad-cache-${{ env.GITHUB_HEAD_REF_SLUG_URL || env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-${NETWORK}"
-          DISK_PARAMS="name=${DISK_NAME},device-name=${DISK_NAME},size=400GB,type=pd-ssd"
+          DISK_PARAMS="name=${DISK_NAME},device-name=${DISK_NAME},size=400GB,type=pd-balanced"
           if [ -n "${{ env.CACHED_DISK_NAME }}" ]; then
             DISK_PARAMS+=",image=${{ env.CACHED_DISK_NAME }}"
           elif [ ${{ inputs.no_cached_disk && github.event_name == 'workflow_dispatch' }} ]; then
@@ -399,8 +399,8 @@ jobs:
           fi
           gcloud compute instances create-with-container "zebrad-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-${NETWORK}" \
           --machine-type ${{ vars.GCP_SMALL_MACHINE }} \
-          --boot-disk-size 50GB \
-          --boot-disk-type=pd-ssd \
+          --boot-disk-size=10GB \
+          --boot-disk-type=pd-standard \
           --image-project=cos-cloud \
           --image-family=cos-stable \
           --network-interface=subnet=${{ vars.GCP_SUBNETWORK }} \

--- a/.github/workflows/manual-zcashd-deploy.yml
+++ b/.github/workflows/manual-zcashd-deploy.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Create instance template
         run: |
           gcloud compute instance-templates create-with-container zcashd-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
-          --boot-disk-size 10GB \
-          --boot-disk-type=pd-ssd \
+          --boot-disk-size=10GB \
+          --boot-disk-type=pd-standard \
           --image-project=cos-cloud \
           --image-family=cos-stable \
           --container-stdin \

--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -188,18 +188,18 @@ jobs:
         shell: /usr/bin/bash -x {0}
         run: |
           NAME="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}"
-          DISK_PARAMS="size=400GB,type=pd-ssd,name=${NAME},device-name=${NAME}"
+          DISK_PARAMS="size=400GB,type=pd-balanced,name=${NAME},device-name=${NAME}"
           if [ -n "${{ env.CACHED_DISK_NAME }}" ]; then
             DISK_PARAMS+=",image=${{ env.CACHED_DISK_NAME }}"
           fi
           gcloud compute instances create-with-container "${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}" \
-          --boot-disk-size 50GB \
-          --boot-disk-type pd-ssd \
+          --boot-disk-size=50GB \
+          --boot-disk-type=pd-ssd \
           --image-project=cos-cloud \
           --image-family=cos-stable \
           --create-disk="${DISK_PARAMS}" \
           --container-image=gcr.io/google-containers/busybox \
-          --machine-type ${{ vars.GCP_LARGE_MACHINE }} \
+          --machine-type ${{ inputs.is_long_test && vars.GCP_LARGE_MACHINE || vars.GCP_SMALL_MACHINE }} \
           --network-interface=subnet=${{ vars.GCP_SUBNETWORK }} \
           --scopes cloud-platform \
           --metadata=google-monitoring-enabled=TRUE,google-logging-enabled=TRUE \


### PR DESCRIPTION
## Motivation

Previously, most of our deployed instances needed to sync the whole blockchain from genesis, but after implementing the mounting of cached states for the release instances, this is no longer required, thus the amount of resources can be reduced to adapt to these new scenarios.

As a side effect this should also reduce our GCP billing.

### Specifications & References

- https://cloud.google.com/compute/docs/disks

## Solution

Main changes:
- Reduce the boot disk size for CD images to 10GB (in CI Zebra might need to rebuild based on test flags, requiring more disk space)
- Use `pd-standard` instead of `pd-ssd` for the boot disk
- Use `pd-balanced` instead of `pd-ssd` for the mounted disk (where most of the reads and writes happens)
- Change our `GCP_SMALL_MACHINE` from `c2-standard-4` (vCPUs: 4, RAM: 16 GiB) to `c2d-standard-2` (vCPUs: 2, RAM: 8 GiB)
- Keep long running tests `is_long_test` with `GCP_LARGE_MACHINE` (`c2d-standard-16`) and other with the new `GCP_SMALL_MACHINE`  configuration (`c2d-standard-2`)

### Tests

- Test should run as normal, but we should check if the time it takes for tests increases considerably with these changes, or if the time increase is acceptable.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [X] The PR name will make sense to users.
- [X] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [X] The documentation is up to date.
- [X] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

