### PR TITLE
fix(ci): fail cache disk creation if no db version is found

### DIFF
--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -503,18 +503,19 @@ jobs:
           )
 
           if [[ -z "$INITIAL_DISK_DB_VERSION" ]]; then
+          # Check for new database creation
+          if echo "$DOCKER_LOGS" | grep -q "creating.new.database"; then
+              INITIAL_DISK_DB_VERSION="new"
+          else
               echo "Checked logs:"
               echo ""
               echo "$DOCKER_LOGS"
               echo ""
-              echo "Missing initial disk database version in logs: $INITIAL_DISK_DB_VERSION"
+              echo "Missing initial disk database version in logs"
               # Fail the tests, because Zebra didn't log the initial disk database version,
               # or the regex in this step is wrong.
-              false
+              exit 1
           fi
-
-          if [[ "$INITIAL_DISK_DB_VERSION" = "creating.new.database" ]]; then
-              INITIAL_DISK_DB_VERSION="new"
           else
               INITIAL_DISK_DB_VERSION="v${INITIAL_DISK_DB_VERSION//./-}"
           fi
@@ -538,7 +539,7 @@ jobs:
               echo "Missing running database version in logs: $RUNNING_DB_VERSION"
               # Fail the tests, because Zebra didn't log the running database version,
               # or the regex in this step is wrong.
-              false
+              exit 1
           fi
 
           RUNNING_DB_VERSION="v${RUNNING_DB_VERSION//./-}"


### PR DESCRIPTION
In some cases Zebra logs might not output the database version, and thus we should avoid creating a disk without a version.

Before this change, a disk was created without a db version number, just indicating a `-v-`, that caused other tests to fail as an actual version was not found in their regexes.

## Motivation

<!--
- Describe the goals of the PR.
- If it closes any issues, list them here.
-->

### Specifications & References

The expected output in logs is:

```shell
Zcash network: Mainnet
running state version: 26.0.0
initial disk state version: creating.new.database
```

Like in this example: https://github.com/ZcashFoundation/zebra/actions/runs/11584155837/job/32255694034#step:11:614

Sometimes this is not the output as the **Diagnostic Metadata** is not shown: https://github.com/ZcashFoundation/zebra/actions/runs/11526479010/job/32091165009#step:11:632

## Solution

- If the version is not found, exit the `Get database versions from logs` step using an `exit 1`

### Follow-up Work

- We should confirm why the **Diagnostic Metadata** is not shown in some instances
- Manually fix the version numbers in the already created disks in GCP

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [X] The PR name will make sense to users.
- [X] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [X] The documentation is up to date.
- [X] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

