### PR TITLE
fix(actions): do not require the `get-disk-name` job for forks

### DIFF
--- a/.github/workflows/cd-deploy-nodes-gcp.patch-external.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.patch-external.yml
@@ -43,3 +43,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'
+
+  get-disk-name:
+    name: Get disk name
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "Skipping job on fork"'

--- a/.github/workflows/cd-deploy-nodes-gcp.patch.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.patch.yml
@@ -52,3 +52,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
+
+  get-disk-name:
+    name: Get disk name
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'


### PR DESCRIPTION
## Motivation

Some PRs can't be merged as a new job was added which requires acccess to variables are not available from a fork repo, for example:
- #8964

## Solution

- Add this job to the `.patch-external.yml` workflow
- This job was also missing from the `.patch.yml` which could cause issue in other instances not related to forks

### Follow-up Work

Allow external PRs to be tested without avoiding to run these jobs

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [X] The PR name will make sense to users.
- [X] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [X] The documentation is up to date.
- [X] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

