### PR TITLE
add(ci): Check that dependencies have all been published to crates.io on release PRs

### DIFF
--- a/.github/workflows/sub-ci-unit-tests-docker.yml
+++ b/.github/workflows/sub-ci-unit-tests-docker.yml
@@ -197,3 +197,12 @@ jobs:
           # If there is already an open issue with this label, any failures become comments on that issue.
           always-create-new-issue: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  run-check-no-git-refs:
+    if: contains(github.event.pull_request.labels.*.name, 'A-release')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Run check_no_git_refs_in_cargo_lock
+      run: |
+        docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}
+        docker run --tty -e NETWORK -e RUN_CHECK_NO_GIT_REFS=1 ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -224,12 +224,12 @@ case "$1" in
       if [[ "${RUN_ALL_TESTS}" -eq "1" ]]; then
         # Run unit, basic acceptance tests, and ignored tests, only showing command output if the test fails.
         # If the lightwalletd environmental variables are set, we will also run those tests.
-        exec cargo test --locked --release --features "${ENTRYPOINT_FEATURES}" --workspace -- --nocapture --include-ignored --exclude check_no_git_refs_in_cargo_lock
+        exec cargo test --locked --release --features "${ENTRYPOINT_FEATURES}" --workspace -- --nocapture --include-ignored --skip check_no_git_refs_in_cargo_lock
 
       elif [[ "${RUN_ALL_EXPERIMENTAL_TESTS}" -eq "1" ]]; then
         # Run unit, basic acceptance tests, and ignored tests with experimental features.
         # If the lightwalletd environmental variables are set, we will also run those tests.
-        exec cargo test --locked --release --features "${ENTRYPOINT_FEATURES_EXPERIMENTAL}" --workspace -- --nocapture --include-ignored --exclude check_no_git_refs_in_cargo_lock
+        exec cargo test --locked --release --features "${ENTRYPOINT_FEATURES_EXPERIMENTAL}" --workspace -- --nocapture --include-ignored --skip check_no_git_refs_in_cargo_lock
 
       elif [[ "${RUN_CHECK_NO_GIT_REFS}" -eq "1" ]]; then
         # Run the check_no_git_refs_in_cargo_lock test.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -224,12 +224,16 @@ case "$1" in
       if [[ "${RUN_ALL_TESTS}" -eq "1" ]]; then
         # Run unit, basic acceptance tests, and ignored tests, only showing command output if the test fails.
         # If the lightwalletd environmental variables are set, we will also run those tests.
-        exec cargo test --locked --release --features "${ENTRYPOINT_FEATURES}" --workspace -- --nocapture --include-ignored
+        exec cargo test --locked --release --features "${ENTRYPOINT_FEATURES}" --workspace -- --nocapture --include-ignored --exclude check_no_git_refs_in_cargo_lock
 
       elif [[ "${RUN_ALL_EXPERIMENTAL_TESTS}" -eq "1" ]]; then
         # Run unit, basic acceptance tests, and ignored tests with experimental features.
         # If the lightwalletd environmental variables are set, we will also run those tests.
-        exec cargo test --locked --release --features "${ENTRYPOINT_FEATURES_EXPERIMENTAL}" --workspace -- --nocapture --include-ignored
+        exec cargo test --locked --release --features "${ENTRYPOINT_FEATURES_EXPERIMENTAL}" --workspace -- --nocapture --include-ignored --exclude check_no_git_refs_in_cargo_lock
+
+      elif [[ "${RUN_CHECK_NO_GIT_REFS}" -eq "1" ]]; then
+        # Run the check_no_git_refs_in_cargo_lock test.
+        exec cargo test --locked --release --features "${ENTRYPOINT_FEATURES}" --workspace -- --nocapture --include-ignored check_no_git_refs_in_cargo_lock
 
       elif [[ "${TEST_FAKE_ACTIVATION_HEIGHTS}" -eq "1" ]]; then
         # Run state tests with fake activation heights.

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -3538,3 +3538,15 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
 
     Ok(())
 }
+
+/// Check that Zebra does not depend on any crates from git sources.
+#[test]
+#[ignore]
+fn check_no_git_refs_in_cargo_lock() {
+    let cargo_lock_contents =
+        fs::read_to_string("../Cargo.lock").expect("should have Cargo.lock file in root dir");
+
+    if cargo_lock_contents.contains(r#"source = "git+"#) {
+        panic!("Cargo.lock includes git sources")
+    }
+}


### PR DESCRIPTION
## Motivation

We've mistakenly published a Github release that relies on crates from a git source thrice now, so we want to add a test that runs on release PRs to check that there are no git sources in the `Cargo.lock` file.

This is a draft PR because the test still needs to be added to CI and run for PRs that have the `A-release` label.

## Solution

- Adds a simple test that searches the `Cargo.toml` file for `"source = "git+"`.

TODO:
- Add a CI job for the test that runs on PRs with the `A-release` label

### Tests

This was tested with the `restore-internal-miner` branch to ensure that it panics when there are dependencies being pulled in from git sources.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [x] The solution is tested.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

