### PR TITLE
feat(actions): migrate Mergify to GitHub Merge Queue

### DIFF
--- a/.github/workflows/cd-deploy-nodes-gcp.patch-external.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.patch-external.yml
@@ -1,7 +1,7 @@
 # Workflow patches for skipping Google Cloud CD deployments on PRs from external repositories.
 name: Deploy Nodes to GCP
 
-# Run on PRs from external repositories, let them pass, and then Mergify will check them.
+# Run on PRs from external repositories, let them pass, and then GitHub's Merge Queue will check them.
 # GitHub doesn't support filtering workflows by source branch names, so we have to do it for each
 # job.
 on:
@@ -13,10 +13,16 @@ on:
 # `cd-deploy-nodes-gcp.patch-external.yml` must be kept in sync.
 jobs:
   # We don't patch the testnet job, because testnet isn't required to merge (it's too unstable)
+  get-disk-name:
+    name: Get disk name
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "Skipping job on fork"'
+
   build:
     name: Build CD Docker / Build images
     # Only run on PRs from external repositories, skipping ZF branches and tags.
-    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'
@@ -44,8 +50,3 @@ jobs:
     steps:
       - run: 'echo "Skipping job on fork"'
 
-  get-disk-name:
-    name: Get disk name
-    runs-on: ubuntu-latest
-    steps:
-      - run: 'echo "Skipping job on fork"'

--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -1,6 +1,6 @@
 # Google Cloud node deployments and tests that run when Rust code or dependencies are modified,
 # but only on PRs from the ZcashFoundation/zebra repository.
-# (External PRs are tested/deployed by mergify.) 
+# (External PRs are tested/deployed by GitHub's Merge Queue.) 
 #
 # 1. `versioning`: Extracts the major version from the release semver. Useful for segregating instances based on major versions.
 # 2. `build`: Builds a Docker image named `zebrad` with the necessary tags derived from Git.
@@ -27,6 +27,9 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
+  merge_group:
+    types: [ checks_requested ]
+
   workflow_dispatch:
     inputs:
       network:
@@ -141,15 +144,29 @@ jobs:
         id: set
         run: echo "major_version=${{ steps.get.outputs.result }}" >> "$GITHUB_OUTPUT"
 
+  # Finds a cached state disk for zebra
+  #
+  # Passes the disk name to subsequent jobs using `cached_disk_name` output
+  #
+  get-disk-name:
+    name: Get disk name
+    uses: ./.github/workflows/sub-find-cached-disks.yml
+    # Skip PRs from external repositories, let them pass, and then GitHub's Merge Queue will check them.
+    # This workflow also runs on release tags, the event name check will run it on releases.
+    if: ${{ (!startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork) && !inputs.no_cached_disk }}
+    with:
+      network: ${{ inputs.network || vars.ZCASH_NETWORK }}
+      disk_prefix: zebrad-cache
+      disk_suffix: ${{ inputs.cached_disk_type || 'tip' }}
+      prefer_main_cached_state: ${{ inputs.prefer_main_cached_state || (github.event_name == 'push' && github.ref_name == 'main' && true) || false }}
+
   # Each time this workflow is executed, a build will be triggered to create a new image
   # with the corresponding tags using information from Git
   #
   # The image will be commonly named `zebrad:<short-hash | github-ref | semver>`
   build:
     name: Build CD Docker
-    # Skip PRs from external repositories, let them pass, and then Mergify will check them.
-    # This workflow also runs on release tags, the event name check will run it on releases.
-    if: ${{ !startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork }}
+    needs: get-disk-name
     uses: ./.github/workflows/sub-build-docker-image.yml
     with:
       dockerfile_path: ./docker/Dockerfile
@@ -196,20 +213,6 @@ jobs:
       grep_patterns: '-e "loaded zebrad config.*config_path.*=.*v1.0.0-rc.2.toml"'
       test_variables: '-e NETWORK -e ZEBRA_CONF_PATH="zebrad/tests/common/configs/v1.0.0-rc.2.toml"'
       network: ${{ inputs.network || vars.ZCASH_NETWORK }}
-
-  # Finds a cached state disk for zebra
-  #
-  # Passes the disk name to subsequent jobs using `cached_disk_name` output
-  #
-  get-disk-name:
-    name: Get disk name
-    uses: ./.github/workflows/sub-find-cached-disks.yml
-    if: ${{ !inputs.no_cached_disk }}
-    with:
-      network: ${{ inputs.network || vars.ZCASH_NETWORK }}
-      disk_prefix: zebrad-cache
-      disk_suffix: ${{ inputs.cached_disk_type || 'tip' }}
-      prefer_main_cached_state: ${{ inputs.prefer_main_cached_state || (github.event_name == 'push' && github.ref_name == 'main' && true) || false }}
 
   # Deploy Managed Instance Groups (MiGs) for Mainnet and Testnet,
   # with one node in the configured GCP region.
@@ -422,7 +425,7 @@ jobs:
     # When a new job is added to this workflow, add it to this list.
     needs: [ versioning, build, deploy-nodes, deploy-instance ]
     # Only open tickets for failed or cancelled jobs that are not coming from PRs.
-    # (PR statuses are already reported in the PR jobs list, and checked by Mergify.)
+    # (PR statuses are already reported in the PR jobs list, and checked by GitHub's Merge Queue.)
     if: (failure() && github.event.pull_request == null) || (cancelled() && github.event.pull_request == null)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-build-crates.yml
+++ b/.github/workflows/ci-build-crates.yml
@@ -169,7 +169,7 @@ jobs:
     # When a new job is added to this workflow, add it to this list.
     needs: [ matrix, build ]
     # Only open tickets for failed or cancelled jobs that are not coming from PRs.
-    # (PR statuses are already reported in the PR jobs list, and checked by Mergify.)
+    # (PR statuses are already reported in the PR jobs list, and checked by GitHub's Merge Queue.)
     if: (failure() && github.event.pull_request == null) || (cancelled() && github.event.pull_request == null)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-tests.patch-external.yml
+++ b/.github/workflows/ci-tests.patch-external.yml
@@ -1,7 +1,7 @@
 # Workflow patches for skipping CI tests on PRs from external repositories
 name: Run tests
 
-# Run on PRs from external repositories, let them pass, and then Mergify will check them.
+# Run on PRs from external repositories, let them pass, and then GitHub's Merge Queue will check them.
 # GitHub doesn't support filtering workflows by source branch names, so we have to do it for each
 # job.
 on:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -10,6 +10,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  merge_group:
+    types: [checks_requested]
+
   schedule:
     # Run this job every Friday at mid-day UTC
     # This is limited to the Zebra and lightwalletd Full Sync jobs
@@ -119,7 +122,7 @@ jobs:
   # testnet when running the image.
   build:
     name: Build images
-    # Skip PRs from external repositories, let them pass, and then Mergify will check them
+    # Skip PRs from external repositories, let them pass, and then GitHub's Merge Queue will check them
     if: ${{ !startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork }}
     uses: ./.github/workflows/sub-build-docker-image.yml
     with:

--- a/.github/workflows/ci-unit-tests-os.yml
+++ b/.github/workflows/ci-unit-tests-os.yml
@@ -14,6 +14,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  merge_group:
+    types: [checks_requested]
+
   workflow_dispatch:
 
   pull_request:
@@ -305,7 +308,7 @@ jobs:
     # When a new job is added to this workflow, add it to this list.
     needs: [ test,  install-from-lockfile-no-cache, check-cargo-lock, cargo-deny, unused-deps ]
     # Only open tickets for failed or cancelled jobs that are not coming from PRs.
-    # (PR statuses are already reported in the PR jobs list, and checked by Mergify.)
+    # (PR statuses are already reported in the PR jobs list, and checked by GitHub's Merge Queue.)
     if: (failure() && github.event.pull_request == null) || (cancelled() && github.event.pull_request == null)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docs-deploy-firebase.patch-external.yml
+++ b/.github/workflows/docs-deploy-firebase.patch-external.yml
@@ -1,7 +1,7 @@
 # Workflow patches for skipping Google Cloud docs updates on PRs from external repositories.
 name: Docs
 
-# Run on PRs from external repositories, let them pass, and then Mergify will check them.
+# Run on PRs from external repositories, let them pass, and then GitHub's Merge Queue will check them.
 # GitHub doesn't support filtering workflows by source branch names, so we have to do it for each
 # job.
 on:

--- a/.github/workflows/docs-deploy-firebase.yml
+++ b/.github/workflows/docs-deploy-firebase.yml
@@ -1,5 +1,5 @@
 # Google Cloud docs updates that run when docs, Rust code, or dependencies are modified,
-# but only on PRs from the ZcashFoundation/zebra repository. (External PRs are deployed by mergify.)
+# but only on PRs from the ZcashFoundation/zebra repository. (External PRs are deployed by GitHub's Merge Queue.)
 
 # - Builds and deploys Zebra Book Docs using mdBook, setting up necessary tools and deploying to Firebase.
 # - Compiles and deploys external documentation, setting up Rust with the beta toolchain and default profile, building the docs, and deploying them to Firebase.
@@ -74,7 +74,7 @@ env:
 jobs:
   build-docs-book:
     name: Build and Deploy Zebra Book Docs
-    # Skip PRs from external repositories, let them pass, and then Mergify will check them
+    # Skip PRs from external repositories, let them pass, and then GitHub's Merge Queue will check them
     if: ${{ !startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork }}
     timeout-minutes: 5
     runs-on: ubuntu-latest

--- a/.github/workflows/release-crates-io.yml
+++ b/.github/workflows/release-crates-io.yml
@@ -112,7 +112,7 @@ jobs:
     # When a new job is added to this workflow, add it to this list.
     needs: [ check-release ]
     # Only open tickets for failed or cancelled jobs that are not coming from PRs.
-    # (PR statuses are already reported in the PR jobs list, and checked by Mergify.)
+    # (PR statuses are already reported in the PR jobs list, and checked by GitHub's Merge Queue.)
     if: (failure() && github.event.pull_request == null) || (cancelled() && github.event.pull_request == null)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sub-ci-integration-tests-gcp.yml
+++ b/.github/workflows/sub-ci-integration-tests-gcp.yml
@@ -1,5 +1,5 @@
 # Google Cloud integration tests that run when Rust code or dependencies are modified,
-# but only on PRs from the ZcashFoundation/zebra repository. (External PRs are tested by mergify.)
+# but only on PRs from the ZcashFoundation/zebra repository. (External PRs are tested by GitHub's Merge Queue.)
 #
 # Specific conditions and dependencies are set for each job to ensure they are executed in the correct sequence and under the right circumstances.
 # Each test has a description of the conditions under which it runs.
@@ -36,10 +36,6 @@ on:
 #! `sub-deploy-integration-tests-gcp.yml` workflow file as inputs. If modified in this file, they must
 #! also be updated in the `sub-deploy-integration-tests-gcp.yml` file.
 jobs:
-  # to also run a job on Mergify head branches,
-  # add `|| (github.event_name == 'push' && startsWith(github.head_ref, 'mergify/merge-queue/'))`:
-  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-based-on-the-head-or-base-branch-of-a-pull-request-1
-
   # Check if the cached state disks used by the tests are available for the default network.
   #
   # The default network is mainnet unless a manually triggered workflow or repository variable
@@ -48,7 +44,7 @@ jobs:
   # The outputs for this job have the same names as the workflow outputs in sub-find-cached-disks.yml
   get-available-disks:
     name: Check if cached state disks exist for ${{ inputs.network || vars.ZCASH_NETWORK }}
-    # Skip PRs from external repositories, let them pass, and then Mergify will check them
+    # Skip PRs from external repositories, let them pass, and then GitHub's Merge Queue will check them
     if: ${{ !startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork }}
     uses: ./.github/workflows/sub-find-cached-disks.yml
     with:
@@ -554,7 +550,7 @@ jobs:
         scan-task-commands-test,
       ]
     # Only open tickets for failed scheduled jobs, manual workflow runs, or `main` branch merges.
-    # (PR statuses are already reported in the PR jobs list, and checked by Mergify.)
+    # (PR statuses are already reported in the PR jobs list, and checked by GitHub's Merge Queue.)
     if: (failure() && github.event.pull_request == null) || (cancelled() && github.event.pull_request == null)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sub-ci-unit-tests-docker.yml
+++ b/.github/workflows/sub-ci-unit-tests-docker.yml
@@ -1,5 +1,5 @@
 # Google Cloud unit tests that run when Rust code or dependencies are modified,
-# but only on PRs from the ZcashFoundation/zebra repository. (External PRs are tested by mergify.)
+# but only on PRs from the ZcashFoundation/zebra repository. (External PRs are tested by GitHub's Merge Queue.)
 #
 # This workflow is designed for running various unit tests within Docker containers.
 # Jobs:
@@ -183,7 +183,7 @@ jobs:
     # Testnet jobs are not in this list, because we expect testnet to fail occasionally.
     needs: [ test-all, test-fake-activation-heights, test-empty-sync, test-lightwalletd-integration, test-configuration-file, test-zebra-conf-path ]
     # Only open tickets for failed scheduled jobs, manual workflow runs, or `main` branch merges.
-    # (PR statuses are already reported in the PR jobs list, and checked by Mergify.)
+    # (PR statuses are already reported in the PR jobs list, and checked by GitHub's Merge Queue.)
     # TODO: if a job times out, we want to create a ticket. Does failure() do that? Or do we need cancelled()?
     if: failure() && github.event.pull_request == null
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

We previously migrated to [GitHub Rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) as the new and preferred way to handle branch protection rules, but Mergify hasn't been updated to use rulesets, and we're also dealing with some deprecations around our actual Mergify configurations.

As GitHub Merge queue has matured enough to comply with most of our use cases, and it's already included in our actual GitHub Plan, we decided to start this migration path.

> This is an initial step before completely removing Mergify, to keep the duality between the two to avoid downtime with queue management

### Specifications & References

- https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
- https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#merge_group

## Solution

- Additionally to the tests that are triggered in a PR, we'll additionally re-run the Integration tests and CD Tests as these are the most relevant tests that must be confirmed when multiple PRs are being merged at the same time.

### Tests

- After merging this PR we should disable Mergify and activate GitHub Merge Queue, to confirm the behavior, as this only gets evaluated once the `merge_group` is available in the default branch.

### Follow-up Work

- Disable Mergify and turn on GitHub Merge Queue
- We should evaluate this new behavior, the time it takes for Merge PRs to get fully evaluated, etc.
- The Merge queue configurations should be as similar as the ones we have in the `mergify.yml` file
- Documentation should be updated in the following PR, once everything has been confirmed and the removal of Mergify is finalized.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [X] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [X] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

