### PR TITLE
Suggestion for "change(rpc): Update getblock RPC to more closely match zcashd"

### DIFF
--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -664,6 +664,7 @@ async fn rpc_getblockheader() {
             version: 4,
             merkle_root: block.header.merkle_root,
             final_sapling_root: expected_final_sapling_root,
+            sapling_tree_size: sapling_tree.count(),
             time: block.header.time.timestamp(),
             nonce: expected_nonce,
             solution: block.header.solution,


### PR DESCRIPTION
This is a suggestion PR for @conradoplg with:
- some minor cleanups,
- setting a value for the `orchardfinalroot` field, and
- removing handling of verbosity = 3 in the `getblock` method.

