### PR TITLE
fix: typos correction docs

### DIFF
--- a/book/src/dev/continuous-delivery.md
+++ b/book/src/dev/continuous-delivery.md
@@ -1,6 +1,6 @@
 # Zebra Continuous Delivery
 
-Zebra has an extension of it's continuous integration since it automatically deploys all
+Zebra has an extension of its continuous integration since it automatically deploys all
 code changes to a testing and/or pre-production environment after each PR gets merged
 into the `main` branch, and on each Zebra `release`.
 

--- a/book/src/dev/rfcs/drafts/0005-treestate.md
+++ b/book/src/dev/rfcs/drafts/0005-treestate.md
@@ -96,7 +96,7 @@ parsed and the notes for each tree collected in their appropriate positions, the
 root of each tree is computed. While the trees are being built, the respective
 block nullifier sets are updated in memory as note nullifiers are revealed. If
 the rest of the block is validated according to consensus rules, that root is
-committed to its own datastructure via our state service (Sprout anchors,
+committed to its own data structure via our state service (Sprout anchors,
 Sapling anchors). Sapling block validation includes comparing the specified
 FinalSaplingRoot in its block header to the root of the Sapling `NoteCommitment`
 tree that we have just computed to make sure they match.

--- a/book/src/dev/rfcs/drafts/xxxx-block-subsidy.md
+++ b/book/src/dev/rfcs/drafts/xxxx-block-subsidy.md
@@ -70,7 +70,7 @@ In Zebra the consensus related code lives in the `zebra-consensus` crate. The bl
 Inside `zebra-consensus/src/block/subsidy/` the following submodules will be created:
 
 - `general.rs`: General block reward functions and utilities.
-- `founders_reward.rs`: Specific functions related to funders reward.
+- `founders_reward.rs`: Specific functions related to founders reward.
 - `funding_streams.rs`: Specific functions for funding streams.
 
 In addition to calculations the block subsidy requires constants defined in the protocol. The implementation will also create additional constants, all of them will live at:

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -177,6 +177,6 @@ Specific tests are defined in `docker/test.env` file and can be enabled by setti
 
 ## Registries
 
-The images built by the Zebra team are all publicly hosted. Old image versions meant to be used by our [CI pipeline](https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/ci-integration-tests-gcp.yml) (`zebrad-test`, `lighwalletd`) might be deleted on a scheduled basis.
+The images built by the Zebra team are all publicly hosted. Old image versions meant to be used by our [CI pipeline](https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/ci-integration-tests-gcp.yml) (`zebrad-test`, `lightwalletd`) might be deleted on a scheduled basis.
 
 We use [Docker Hub](https://hub.docker.com/r/zfnd/zebra) for end-user images and [Google Artifact Registry](https://console.cloud.google.com/artifacts/docker/zfnd-dev-zebra/us/zebra) to build external tools and test images.

--- a/book/src/user/shielded-scan.md
+++ b/book/src/user/shielded-scan.md
@@ -100,4 +100,4 @@ ldb --db="$HOME/.cache/zebra/private-scan/v1/mainnet" --secondary_path= --column
 
 Some of the output will be markers the scanner uses to keep track of progress, however, some of them will be transactions found.
 
-To lean more about how to filter the database please refer to [RocksDB Administration and Data Access Tool](https://github.com/facebook/rocksdb/wiki/Administration-and-Data-Access-Tool)
+To learn more about how to filter the database please refer to [RocksDB Administration and Data Access Tool](https://github.com/facebook/rocksdb/wiki/Administration-and-Data-Access-Tool)


### PR DESCRIPTION
## Motivation

- Correct typos and grammatical errors in various documentation files to improve clarity and professionalism.
- Enhance the accuracy of technical terms and links within the documentation.

## Specifications & References

- Changes made to the following files:
  - `book/src/dev/continuous-delivery.md`
  - `book/src/dev/rfcs/drafts/0005-treestate.md`
  - `book/src/dev/rfcs/drafts/xxxx-block-subsidy.md`
  - `book/src/user/docker.md`
  - `book/src/user/shielded-scan.md`

## Solution

- Fixed the incorrect use of "it's" to "its" in `continuous-delivery.md`.
- Changed "datastructure" to "data structure" in `0005-treestate.md`.
- Corrected "funders reward" to "founders reward" in `xxxx-block-subsidy.md`.
- Updated the typo `lighwalletd` to `lightwalletd` in `docker.md`.
- Corrected "To lean more about" to "To learn more about" in `shielded-scan.md`.

### Changes Overview

- **Additions:** 5
- **Deletions:** 5

### Related Issues

- None

## PR Author's Checklist

- [x] The PR name will make sense to users.
- [x] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

## PR Reviewer's Checklist

- [x] The PR Author's checklist is complete.
- [x] The PR resolves the issue.
