### PR TITLE
Add a Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 .zebra-state/
 # Nix configs
 shell.nix
+# Nix builds
+/result
 # Docker compose env files
 *.env
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,179 @@
+{
+  "nodes": {
+    "advisory-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1732819720,
+        "narHash": "sha256-6H7mKBKw3VErpGcCGEamBYJsopvqqdFmJhl8slfCtOQ=",
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "rev": "9dc4a0bb102451e3c71e1b639068aec5a3e1f5f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "locked": {
+        "lastModified": 1732990152,
+        "narHash": "sha256-brVP7vwtlMZCesoA5K+JWDH1MQlzGEp5PWs3DIhtWhY=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "a031189a409b41826c7b767a84f2cff60152e5b5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1732689334,
+        "narHash": "sha256-yKI1KiZ0+bvDvfPTQ1ZT3oP/nIu3jPYm4dnbRd6hYg4=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "a8a983027ca02b363dfc82fbe3f7d9548a8d3dce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": [
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1726989464,
+        "narHash": "sha256-Vl+WVTJwutXkimwGprnEtXc/s/s8sMuXzqXaspIGlwM=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "2f23fa308a7c067e52dfcc30a0758f47043ec176",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "release-24.05",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1732603785,
+        "narHash": "sha256-AEjWTJwOmSnVYsSJCojKgoguGfFfwel6z/6ud6UFMU8=",
+        "owner": "LnL7",
+        "repo": "nix-darwin",
+        "rev": "6ab87b7c84d4ee873e937108c4ff80c015a40c7a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "LnL7",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1732967653,
+        "narHash": "sha256-FFE2Ac749LNALTR9toJCflRBenkR6Cc5G165pqgwg/0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d634159c8bf583a28a7d963b9a3cb6729bb3b2f1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "advisory-db": "advisory-db",
+        "crane": "crane",
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "home-manager": "home-manager",
+        "nix-darwin": "nix-darwin",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1732633904,
+        "narHash": "sha256-7VKcoLug9nbAN2txqVksWHHJplqK9Ou8dXjIZAIYSGc=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "8d5e91c94f80c257ce6dbdfba7bd63a5e8a03fa6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,192 @@
+{
+  description = ''
+    Zebra: the Zcash Foundation's independent, consensus-compatible implementation of a Zcash node
+  '';
+
+  nixConfig = {
+    extra-experimental-features = ["no-url-literals"];
+    extra-substituters = [
+      "https://cache.garnix.io" # To benefit from the CI results
+      "https://nix-community.cachix.org" # Contains rust toolchains
+    ];
+    extra-trusted-public-keys = [
+      "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    ];
+    use-registries = false;
+    sandbox = "relaxed";
+  };
+
+  outputs = {
+    advisory-db,
+    crane,
+    fenix,
+    flake-utils,
+    home-manager,
+    nix-darwin,
+    nixpkgs,
+    self,
+    systems,
+  }: let
+    ## Since they currently line up, we just use `nix-systems/default`, but see
+    ## https://zebra.zfnd.org/user/supported-platforms.html for official support tiers.
+    ##
+    ## NixOS is not a supported OS, and this flake is not a supported distribution of Zebra, but
+    ## here’s an approximation of what you can expect from this flake:
+    ## - aarch64-darwin – tier 3
+    ## - aarch64-linux (on Debian 11) – tier 3
+    ## - x86_64-darwin – tier 2
+    ## - x86_64-linux
+    ##   - on Debian 11 – tier 1
+    ##   - on Ubuntu “latest” – tier 2
+    supportedSystems = import systems;
+
+    lib = import ./nix/lib {
+      inherit crane;
+      inherit (nixpkgs) lib;
+    };
+
+    src = nixpkgs.lib.cleanSourceWith {
+      src = ./.;
+      filter = path: type:
+        nixpkgs.lib.foldr
+        (e: acc: nixpkgs.lib.hasSuffix e path || acc)
+        true [".bin" ".proto" ".txt" ".utf8" ".vk"]
+        || lib.crane.filterCargoSources path type;
+    };
+
+    ## This sets up some common attributes that _should_ be set in the workspace Cargo.toml, but
+    ## aren’t.
+    workspace =
+      lib.crane.crateNameFromCargoToml {cargoToml = ./zebrad/Cargo.toml;} // {pname = "zebra";};
+
+    mkCraneLib = pkgs:
+      (crane.mkLib pkgs).overrideToolchain (import ./nix/rust-toolchain.nix {inherit fenix pkgs;});
+
+    localPackages = {
+      pkgs,
+      craneLib ? mkCraneLib pkgs,
+    }:
+      import ./nix/packages {
+        inherit craneLib src workspace;
+        inherit (pkgs) callPackage;
+      };
+  in
+    {
+      overlays.default = final: prev: localPackages {pkgs = final;};
+
+      darwinModules = {
+        default = self.darwinModules.zebra;
+        zebra = import ./nix/modules/zebra/darwin.nix;
+      };
+      homeModules = {
+        default = self.homeModules.zebra;
+        zebra = import ./nix/modules/zebra/home.nix;
+      };
+      nixosModules = {
+        default = self.nixosModules.zebra;
+        zebra = import ./nix/modules/zebra/nixos.nix;
+      };
+
+      ## For testing the `overlays` and  `darwinModules` as well as provide an example configuration
+      ## for users.
+      darwinConfigurations = builtins.listToAttrs (map (system: {
+          name = "${system}-example";
+          value = import ./nix/darwin-configuration.nix {
+            inherit nix-darwin nixpkgs system;
+            zebra = self;
+          };
+        })
+        (builtins.filter (nixpkgs.lib.hasSuffix "-darwin") supportedSystems));
+
+      ## For testing the `overlays` and  `homeModules` as well as provide an example configuration
+      ## for users.
+      homeConfigurations = builtins.listToAttrs (map (system: {
+          name = "${system}-example";
+          value = import ./nix/home-configuration.nix {
+            inherit home-manager nixpkgs system;
+            zebra = self;
+          };
+        })
+        supportedSystems);
+
+      ## For testing the `overlays` and  `nixosModules` as well as provide an example configuration
+      ## for users.
+      nixosConfigurations = builtins.listToAttrs (map (system: {
+          name = "${system}-example";
+          value = import ./nix/nixos-configuration.nix {
+            inherit nixpkgs system;
+            zebra = self;
+          };
+        })
+        (builtins.filter (nixpkgs.lib.hasSuffix "-linux") supportedSystems));
+    }
+    // flake-utils.lib.eachSystem supportedSystems (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+
+      craneLib = mkCraneLib pkgs;
+
+      packages = localPackages {inherit craneLib pkgs;};
+
+      cargoArtifacts = packages.zebra-deps;
+    in {
+      apps =
+        {default = self.apps.${system}.zebrad;}
+        // (import ./nix/apps.nix {
+          inherit flake-utils;
+          drv = self.packages.${system}.zebra;
+        });
+
+      packages =
+        {default = self.packages.${system}.zebra;}
+        // packages;
+
+      devShells.default = craneLib.devShell {
+        inherit cargoArtifacts;
+        checks = self.checks.${system};
+        inputsFrom = builtins.attrValues self.packages.${system};
+        packages = [pkgs.home-manager];
+        LIBCLANG_PATH = pkgs.libclang.lib + "/lib";
+      };
+
+      checks = import ./nix/checks.nix {
+        inherit advisory-db cargoArtifacts craneLib pkgs src workspace;
+        inherit (nixpkgs) lib;
+      };
+
+      formatter = pkgs.alejandra;
+    });
+
+  inputs = {
+    advisory-db = {
+      flake = false;
+      url = "github:rustsec/advisory-db";
+    };
+
+    crane.url = "github:ipetkov/crane";
+
+    fenix = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:nix-community/fenix";
+    };
+
+    flake-utils = {
+      inputs.systems.follows = "systems";
+      url = "github:numtide/flake-utils";
+    };
+
+    home-manager = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:nix-community/home-manager/release-24.05";
+    };
+
+    nix-darwin = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:LnL7/nix-darwin";
+    };
+
+    nixpkgs.url = "github:NixOS/nixpkgs/release-24.05";
+
+    systems.url = "github:nix-systems/default";
+  };
+}

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,0 +1,7 @@
+builds:
+  exclude:
+  # This system isn’t actually supported by garnix (see garnix-io/issues#94)
+  - "*.x86_64-darwin-example"
+  include:
+  - '*.*'
+  - '*.*.*'

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,94 @@
+# Zebra & Nix
+
+This exposes a `zebrad` package in various ways, but it’s recommended to lean on one of the higher-level modules to integrate Zebra with your system.
+
+## modules
+
+### Home Manager
+
+Zebra is generally intended to be run as a user service, so Home Manager tends to make the most sense for configuring it.
+
+Home Manager can manage keeping your zebrad instance up and running with either systemd (Linux) or launchd (MacOS).
+
+You first need to make this repository available to Home Manager. Here is a minimal flake for this purpose:
+
+```nix
+{
+  inputs = {
+    home-manager.url = "github:nix-community/home-manager/release-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-24.05";
+    zebra.url = "github:sellout/zebra/nix-flake";
+  };
+
+  outputs = {home-manager, nixpkgs, self, zebra}: {
+    homeConfigurations."<user>@<host>" = import ./home-configuration.nix {
+      inherit home-manager nixpkgs zebra;
+      system = "x86_64-linux";
+    };
+  };
+}
+```
+
+See [home-configuration.nix](./home-configuration.nix) for how to connect Zebra to your configuration and [our test configuration](./modules/home.nix) for an example of how to set up Zebra.
+
+### NixOS
+
+Similarly, this can be run as a NixOS user service.
+
+``` nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/release-24.05";
+    zebra.url = "github:sellout/zebra/nix-flake";
+  };
+
+  outputs = {home-manager, nixpkgs, self, zebra}: {
+    nixosConfigurations."<host>" = import ./nixos-configuration.nix {
+      inherit nixpkgs zebra;
+      system = "x86_64-linux";
+    };
+  };
+}
+```
+
+### nix-darwin
+
+Or as a nix-darwin user service.
+
+```nix
+{
+  inputs = {
+    nix-darwin.url = "github:LnL7/nix-darwin";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-24.05";
+    zebra.url = "github:sellout/zebra/nix-flake";
+  };
+
+  outputs = {nix-darwin, nixpkgs, self, zebra}: {
+    darwinConfigurations."<host>" = import ./darwin-configuration.nix {
+      inherit nix-darwin nixpkgs zebra;
+      system = "x86_64-linux";
+    };
+  };
+}
+```
+
+## overlay
+
+If you just want to access the applications directly, you can get them via the default overlay:
+
+```nix
+let
+  newPkgs = pkgs.appendOverlays [zebra.overlays.default];
+in [
+  newPkgs.zebra-scanner
+  newPkgs.zebrad
+]
+```
+
+## execution
+
+They can also be run directly, without installing anything.
+
+```bash
+nix run github:sellout/zebra/nix-flake#zebrad -- start
+```

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -1,0 +1,15 @@
+{
+  drv,
+  flake-utils,
+}: let
+  mkNamedApp = name: {
+    inherit name;
+    value = flake-utils.lib.mkApp {inherit drv name;};
+  };
+in
+  ## There are additional apps in the workspace, but they are only produced when particular
+  ## Cargo features are enabled.
+  builtins.listToAttrs (map mkNamedApp [
+    "zebra-scanner"
+    "zebrad"
+  ])

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -1,0 +1,47 @@
+{
+  advisory-db,
+  cargoArtifacts,
+  craneLib,
+  lib,
+  pkgs,
+  src,
+  workspace,
+}: {
+  audit = craneLib.cargoAudit {inherit advisory-db src;};
+
+  clippy = craneLib.cargoClippy (workspace
+    // {
+      inherit cargoArtifacts src;
+      buildInputs = lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+        pkgs.darwin.apple_sdk.frameworks.Security
+        pkgs.libiconv
+      ];
+      nativeBuildInputs = [pkgs.protobuf];
+      stdenv = pkgs.clangStdenv;
+      LIBCLANG_PATH = pkgs.libclang.lib + "/lib";
+      cargoClippyExtraArgs = "--all-targets"; # -- --deny warnings";
+    });
+
+  deny = craneLib.cargoDeny (workspace
+    // {
+      inherit src;
+      cargoDenyChecks = lib.concatStringsSep " " ["bans" "sources"];
+    });
+
+  doc = craneLib.cargoDoc (workspace
+    // {
+      inherit cargoArtifacts src;
+      buildInputs = lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+        pkgs.darwin.apple_sdk.frameworks.Security
+        pkgs.libiconv
+      ];
+      nativeBuildInputs = [pkgs.protobuf];
+      stdenv = pkgs.clangStdenv;
+      LIBCLANG_PATH = pkgs.libclang.lib + "/lib";
+    });
+
+  fmt = craneLib.cargoFmt (workspace // {inherit src;});
+
+  # toml-fmt =
+  #   craneLib.taploFmt (workspace // {src = lib.sources.sourceFilesBySuffices src [".toml"];});
+}

--- a/nix/darwin-configuration.nix
+++ b/nix/darwin-configuration.nix
@@ -1,0 +1,16 @@
+{
+  nix-darwin,
+  nixpkgs,
+  system,
+  zebra,
+}:
+nix-darwin.lib.darwinSystem {
+  pkgs = import nixpkgs {
+    inherit system;
+    overlays = [zebra.overlays.default]; # ← Makes `zebra` package available
+  };
+  modules = [
+    zebra.darwinModules.default #          ← Makes `services.zebra` options available
+    ./modules/darwin-configuration.nix #   ← This file contains your Zebra configuration
+  ];
+}

--- a/nix/home-configuration.nix
+++ b/nix/home-configuration.nix
@@ -1,0 +1,14 @@
+{
+  home-manager,
+  nixpkgs,
+  system,
+  zebra,
+}:
+home-manager.lib.homeManagerConfiguration {
+  modules = [
+    {nixpkgs.overlays = [zebra.overlays.default];} # ← Makes `zebra` package available
+    zebra.homeModules.default #                      ← Makes `services.zebra` options available
+    ./modules/home.nix #                             ← This file contains your Zebra configuration
+  ];
+  pkgs = nixpkgs.legacyPackages.${system};
+}

--- a/nix/lib/crane.nix
+++ b/nix/lib/crane.nix
@@ -1,0 +1,14 @@
+## TODO: This extracts various functions from the crane repo, bypassing `crane.mkLib`, since these
+##       don’t require `pkgs`. (See ipetkov/crane#699)
+{
+  crane,
+  lib,
+}: let
+  internalCrateNameFromCargoToml =
+    import "${crane}/lib/internalCrateNameFromCargoToml.nix" {inherit lib;};
+in {
+  crateNameFromCargoToml =
+    import "${crane}/lib/crateNameFromCargoToml.nix" {inherit internalCrateNameFromCargoToml lib;};
+
+  filterCargoSources = import "${crane}/lib/filterCargoSources.nix" {inherit lib;};
+}

--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -1,0 +1,24 @@
+{
+  crane,
+  lib,
+}: {
+  crane = import ./crane.nix {inherit crane lib;};
+
+  ## Accepts separate configurations for nix-darwin, Home Manager, and NixOS, returning the correct
+  ## one for whichever configuration is being built (guessing based on the attributes defined by
+  ## `options`).
+  ##
+  ## This is useful for writing modules that work across multiple types of configuration.
+  multiConfig = options: {
+    darwin ? {},
+    home ? {},
+    nixos ? {},
+  }: {
+    config =
+      if options ? homebrew
+      then darwin
+      else if options ? home
+      then home
+      else nixos;
+  };
+}

--- a/nix/modules/configuration.nix
+++ b/nix/modules/configuration.nix
@@ -1,0 +1,25 @@
+{
+  services.zebra = {
+    ## If this is false, Zebra will not run, no matter what else is set in this section.
+    enable = true;
+    ## This exactly matches the structure of zebrad.toml, just using Nix syntax instead of TOML.
+    config = {
+      network.network = "Testnet";
+      state.cache_dir = "/var/cache/zebrad";
+      tracing = {
+        ## This automatically enables the flamegraph support in Zebra.
+        flamegraph = "/var/lib/zebrad/flamegraph";
+        use_color = true;
+      };
+    };
+    ## Other features to enable in the Zebra package. There is no need to list things that are
+    ## required by entries in `services.zebra.config`, as those get enabled as needed (although
+    ## adding them can improve Nix cache hits, since different configs on different machines won’t
+    ## require different builds).
+    extraFeatures = ["elasticsearch"];
+  };
+
+  boot.loader.grub.devices = ["/dev/sda1"];
+  fileSystems."/".device = "/dev/sda1";
+  system.stateVersion = "24.05";
+}

--- a/nix/modules/darwin-configuration.nix
+++ b/nix/modules/darwin-configuration.nix
@@ -1,0 +1,23 @@
+{
+  services.zebra = {
+    ## If this is false, Zebra will not run, no matter what else is set in this section.
+    enable = true;
+    ## This exactly matches the structure of zebrad.toml, just using Nix syntax instead of TOML.
+    config = {
+      network.network = "Testnet";
+      state.cache_dir = "/var/cache/zebrad";
+      tracing = {
+        ## This automatically enables the flamegraph support in Zebra.
+        flamegraph = "/var/lib/zebrad/flamegraph";
+        use_color = true;
+      };
+    };
+    ## Other features to enable in the Zebra package. There is no need to list things that are
+    ## required by entries in `services.zebra.config`, as those get enabled as needed (although
+    ## adding them can improve Nix cache hits, since different configs on different machines won’t
+    ## require different builds).
+    extraFeatures = ["elasticsearch"];
+  };
+
+  system.stateVersion = 5;
+}

--- a/nix/modules/home.nix
+++ b/nix/modules/home.nix
@@ -1,0 +1,28 @@
+{config, ...}: {
+  services.zebra = {
+    ## If this is false, Zebra will not run, no matter what else is set in this section.
+    enable = true;
+    ## This exactly matches the structure of zebrad.toml, just using Nix syntax instead of TOML.
+    config = {
+      network.network = "Testnet";
+      state.cache_dir = "${config.xdg.cacheHome}/zebrad";
+      tracing = {
+        ## This automatically enables the flamegraph Cargo feature in Zebra.
+        flamegraph = "${config.xdg.stateHome}/zebrad/flamegraph";
+        use_color = true;
+      };
+    };
+    ## Other Cargo features to enable in the Zebra package. There is no need to list things that are
+    ## required by entries in `services.zebra.config`, as those get enabled as needed (although
+    ## adding them can improve Nix cache hits, since different configs on different machines won’t
+    ## require different builds).
+    extraFeatures = ["elasticsearch"];
+  };
+
+  ## These attributes are simply required by Home Manager.
+  home = {
+    homeDirectory = /tmp/example;
+    stateVersion = "24.05";
+    username = "example-user";
+  };
+}

--- a/nix/modules/zebra/darwin.nix
+++ b/nix/modules/zebra/darwin.nix
@@ -1,0 +1,27 @@
+{
+  config,
+  lib,
+  options,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.zebra;
+in {
+  imports = [./generic.nix];
+
+  config = lib.mkIf cfg.enable (let
+    toml = pkgs.formats.toml {};
+
+    configFile = toml.generate "zebrad.toml" cfg.config;
+  in {
+    environment = {
+      etc."zebrad/zebrad.toml".source = configFile;
+      systemPackages = [cfg.package];
+    };
+
+    launchd.agents.zebrad.serviceConfig = import ./launchd.nix {
+      inherit configFile lib;
+      inherit (cfg) package;
+    };
+  });
+}

--- a/nix/modules/zebra/generic.nix
+++ b/nix/modules/zebra/generic.nix
@@ -1,0 +1,65 @@
+{
+  config,
+  lib,
+  options,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.zebra;
+in {
+  options.services.zebra = {
+    enable = lib.mkEnableOption "Zebra";
+
+    basePackage = lib.mkPackageOption pkgs "Zebra" {default = ["zebra"];};
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      readOnly = true;
+      description = ''
+        The _actual_ package, built from the base package with `extraFeatures` applied.
+      '';
+    };
+
+    config = lib.mkOption {
+      type = lib.types.attrs;
+      default = {
+        tracing.use_journald = pkgs.stdenv.hostPlatform.isLinux;
+      };
+      defaultText = lib.literalExpression ''
+        {
+          tracing.use_journald = pkgs.stdenv.hostPlatform.isLinux;
+        }
+      '';
+      description = "A Nix attribute set of the values to put in zebrad.toml";
+      example = {
+        tracing.progress_bar = "summary";
+      };
+    };
+
+    extraFeatures = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      description = ''
+        A list of optional features to enable in the package. See
+        https://docs.rs/zebrad/latest/zebrad/index.html#zebra-feature-flags
+        for the avaliable values.
+
+        __NB__: Some features are enabled automatically if config options that require them are set.
+                For example, `services.zebra.config.tracing.use_journald = true` will cause
+               `"journald"` to be enabled and
+               `services.zebra.config.tracing.flamegraph = "some/path"` will cause `"flamegraph"` to
+                be enabled.
+      '';
+      example = ["elasticsearch" "journald" "prometheus"];
+    };
+  };
+
+  config = lib.mkIf cfg.enable (let
+    combinedFeatures =
+      cfg.extraFeatures
+      ++ lib.optional (cfg.config.tracing.flamegraph or null != null) "flamegraph"
+      ++ lib.optional (cfg.config.tracing.use_journald or false) "journald";
+  in {
+    services.zebra.package = cfg.basePackage.override {extraFeatures = combinedFeatures;};
+  });
+}

--- a/nix/modules/zebra/home.nix
+++ b/nix/modules/zebra/home.nix
@@ -1,0 +1,35 @@
+{
+  config,
+  lib,
+  options,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.zebra;
+in {
+  imports = [./generic.nix];
+
+  config = lib.mkIf cfg.enable (let
+    toml = pkgs.formats.toml {};
+
+    configFile = toml.generate "zebrad.toml" cfg.config;
+  in {
+    home.packages = [cfg.package];
+
+    launchd.agents.zebra = {
+      enable = true;
+      config = import ./launchd.nix {
+        inherit configFile lib;
+        inherit (cfg) package;
+      };
+    };
+
+    systemd.user.services.zebrad = import ./systemd.nix {
+      inherit configFile lib;
+      inherit (cfg) package;
+    };
+
+    ## TODO: Maybe need to put this somewhere else on darwin.
+    xdg.configFile."zebrad.toml".source = configFile;
+  });
+}

--- a/nix/modules/zebra/launchd.nix
+++ b/nix/modules/zebra/launchd.nix
@@ -1,0 +1,11 @@
+{
+  configFile,
+  lib,
+  package,
+}: {
+  Program = lib.getExe package;
+  ProgramArguments = ["--config" (toString configFile) "start"];
+  ProcessType = "Background";
+  KeepAlive = true;
+  RunAtLoad = true;
+}

--- a/nix/modules/zebra/nixos.nix
+++ b/nix/modules/zebra/nixos.nix
@@ -1,0 +1,33 @@
+{
+  config,
+  lib,
+  options,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.zebra;
+in {
+  imports = [./generic.nix];
+
+  config = lib.mkIf cfg.enable (let
+    toml = pkgs.formats.toml {};
+
+    configFile = toml.generate "zebrad.toml" cfg.config;
+  in {
+    environment = {
+      etc."zebrad/zebrad.toml".source = configFile;
+      systemPackages = [cfg.package];
+    };
+
+    systemd.services.zebrad = let
+      config = import ./systemd.nix {
+        inherit configFile lib;
+        inherit (cfg) package;
+      };
+    in {
+      unitConfig = config.Unit;
+      serviceConfig = config.Service;
+      wantedBy = config.Install.WantedBy;
+    };
+  });
+}

--- a/nix/modules/zebra/systemd.nix
+++ b/nix/modules/zebra/systemd.nix
@@ -1,0 +1,22 @@
+## TODO: This should instead read zebrad/systemd/zebrad.service, and modify the
+##       few things that need to be.
+{
+  configFile,
+  lib,
+  package,
+}: let
+  programPath = lib.getExe package;
+in {
+  Unit.AssertPathExists = programPath;
+
+  Service = {
+    ExecStart = "${programPath} --config ${lib.escapeShellArg configFile} start";
+    Restart = "always";
+    PrivateTmp = true;
+    NoNewPrivileges = true;
+    StandardOutput = "journal";
+    StandardError = "journal";
+  };
+
+  Install.WantedBy = ["default.target"];
+}

--- a/nix/nixos-configuration.nix
+++ b/nix/nixos-configuration.nix
@@ -1,0 +1,13 @@
+{
+  nixpkgs,
+  system,
+  zebra,
+}:
+nixpkgs.lib.nixosSystem {
+  inherit system;
+  modules = [
+    {nixpkgs.overlays = [zebra.overlays.default];} # ← Makes `zebra` package available
+    zebra.nixosModules.default #                     ← Makes `services.zebra` options available
+    ./modules/configuration.nix #                    ← This file contains your Zebra configuration
+  ];
+}

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -1,0 +1,14 @@
+{
+  callPackage,
+  craneLib,
+  src,
+  workspace,
+}: let
+  zebra-deps = callPackage ./zebra-deps.nix {inherit craneLib src workspace;};
+in {
+  inherit zebra-deps;
+  zebra = callPackage ./zebra {
+    inherit craneLib src workspace;
+    cargoArtifacts = zebra-deps;
+  };
+}

--- a/nix/packages/zebra-deps.nix
+++ b/nix/packages/zebra-deps.nix
@@ -1,0 +1,22 @@
+{
+  clangStdenv,
+  craneLib,
+  lib,
+  libclang,
+  libiconv,
+  src,
+  stdenv,
+  workspace,
+}:
+craneLib.buildDepsOnly (
+  workspace
+  // {
+    inherit src;
+
+    buildInputs = lib.optional stdenv.hostPlatform.isDarwin libiconv;
+
+    stdenv = clangStdenv;
+
+    LIBCLANG_PATH = libclang.lib + "/lib";
+  }
+)

--- a/nix/packages/zebra/default.nix
+++ b/nix/packages/zebra/default.nix
@@ -1,0 +1,61 @@
+{
+  cargoArtifacts,
+  clangStdenv,
+  craneLib,
+  darwin,
+  lib,
+  libclang,
+  libiconv,
+  protobuf,
+  src,
+  stdenv,
+  workspace,
+  ## Any additional features to compile zebrad with. See
+  ## https://docs.rs/zebrad/latest/zebrad/index.html#zebra-feature-flags for available features.
+  extraFeatures ? [],
+  ## Whether to use exactly the dependency versions specified in the Cargo.lock file.
+  locked ? true,
+}:
+craneLib.buildPackage (
+  workspace
+  // {
+    inherit cargoArtifacts src;
+
+    strictDeps = true;
+
+    buildInputs =
+      if stdenv.hostPlatform.isDarwin
+      then [
+        darwin.apple_sdk.frameworks.Security
+        darwin.apple_sdk.frameworks.SystemConfiguration
+        libiconv
+      ]
+      else [];
+
+    nativeBuildInputs = [protobuf];
+
+    stdenv = clangStdenv;
+
+    LIBCLANG_PATH = libclang.lib + "/lib";
+
+    cargoExtraArgs = lib.escapeShellArgs (
+      ["--features" (lib.concatStringsSep "," extraFeatures)]
+      ++ lib.optional locked "--locked"
+    );
+
+    ## TODO: Use the fixed-output derivation trick to allow network access during tests, so this can
+    ##       be removed.
+    ZEBRA_SKIP_NETWORK_TESTS = true;
+
+    ## Tests against localhost aren’t disabled by `ZEBRA_SKIP_NETWORK_TESTS`, so this allows them to
+    ## pass on darwin.
+    __darwinAllowLocalNetworking = true;
+
+    cargoTestExtraArgs =
+      lib.escapeShellArgs
+      (["--"]
+        ++ lib.concatMap (test: ["--skip" test]) (import ./failing-tests.nix {inherit lib stdenv;}));
+
+    meta.mainProgram = "zebrad";
+  }
+)

--- a/nix/packages/zebra/default.nix
+++ b/nix/packages/zebra/default.nix
@@ -47,10 +47,10 @@ craneLib.buildPackage (
     ##       be removed.
     ZEBRA_SKIP_NETWORK_TESTS = true;
 
-    cargoTestExtraArgs =
-      lib.escapeShellArgs
-      (["--"]
-        ++ lib.concatMap (test: ["--skip" test]) (import ./failing-tests.nix {inherit lib stdenv;}));
+    cargoTestExtraArgs = let
+      failingTests = import ./failing-tests.nix {inherit extraFeatures lib stdenv;};
+    in
+      lib.escapeShellArgs (["--"] ++ lib.concatMap (test: ["--skip" test]) failingTests);
 
     meta.mainProgram = "zebrad";
   }

--- a/nix/packages/zebra/default.nix
+++ b/nix/packages/zebra/default.nix
@@ -47,10 +47,6 @@ craneLib.buildPackage (
     ##       be removed.
     ZEBRA_SKIP_NETWORK_TESTS = true;
 
-    ## Tests against localhost aren’t disabled by `ZEBRA_SKIP_NETWORK_TESTS`, so this allows them to
-    ## pass on darwin.
-    __darwinAllowLocalNetworking = true;
-
     cargoTestExtraArgs =
       lib.escapeShellArgs
       (["--"]

--- a/nix/packages/zebra/failing-tests.nix
+++ b/nix/packages/zebra/failing-tests.nix
@@ -3,18 +3,11 @@
   lib,
   stdenv,
 }:
+## NB: On Darwin, `__darwinAllowLocalNetworking` would allow many of these tests to pass, but only
+##     in a non-sandboxed environment.
 [
   ## zebra-scan
   "scan_binary_starts"
-  ## zebrad – acceptance
-  "config_tests"
-  "trusted_chain_sync_handles_forks_correctly"
-]
-++ lib.optionals stdenv.hostPlatform.isDarwin [
-  ## zebrad – acceptance
-  "regtest_block_templates_are_valid_block_submissions"
-]
-++ lib.optionals stdenv.hostPlatform.isLinux [
   ## zebrad – acceptance
   "config_tests"
   "end_of_support_is_checked_at_start"
@@ -23,6 +16,50 @@
   "external_address"
   "misconfigured_ephemeral_existing_directory"
   "misconfigured_ephemeral_missing_directory"
-  "non_blocking_logger"
   "persistent_mode"
+  "trusted_chain_sync_handles_forks_correctly"
+]
+++ lib.optionals stdenv.hostPlatform.isDarwin [
+  ## zebra-consensus
+  "checkpoint::tests::block_higher_than_max_checkpoint_fail_test"
+  "checkpoint::tests::checkpoint_drop_cancel_test"
+  "checkpoint::tests::continuous_blockchain_no_restart"
+  "checkpoint::tests::continuous_blockchain_restart"
+  "checkpoint::tests::hard_coded_mainnet_test"
+  "checkpoint::tests::multi_item_checkpoint_list_test"
+  "checkpoint::tests::single_item_checkpoint_list_test"
+  "checkpoint::tests::wrong_checkpoint_hash_fail_test"
+  "router::tests::round_trip_checkpoint_test"
+  "router::tests::verify_checkpoint_test"
+  "router::tests::verify_fail_add_block_checkpoint_test"
+  "router::tests::verify_fail_no_coinbase_test"
+  ## zebra-grpc
+  "tests::snapshot::test_grpc_response_data"
+  "tests::vectors::test_grpc_methods_mocked"
+  ## zebra-rpc
+  "server::tests::vectors::rpc_server_spawn_parallel_threads"
+  "server::tests::vectors::rpc_server_spawn_single_thread"
+  "server::tests::vectors::rpc_server_spawn_unallocated_port_single_thread"
+  "server::tests::vectors::rpc_server_spawn_unallocated_port_single_thread_shutdown"
+  "server::tests::vectors::rpc_sever_spawn_unallocated_port_parallel_threads"
+  "server::tests::vectors::rpc_sever_spawn_unallocated_port_parallel_threads_shutdown"
+  ## zebrad
+  "components::inbound::tests::real_peer_set::inbound_block_empty_state_notfound"
+  "components::inbound::tests::real_peer_set::inbound_peers_empty_address_book"
+  "components::inbound::tests::real_peer_set::inbound_tx_empty_state_notfound"
+  "components::inbound::tests::real_peer_set::outbound_tx_partial_response_notfound"
+  "components::inbound::tests::real_peer_set::outbound_tx_unrelated_response_notfound"
+  ## zebrad – acceptance
+  "downgrade_state_format"
+  "new_state_format"
+  "regtest_block_templates_are_valid_block_submissions"
+  "start_args"
+  "start_no_args"
+  "update_state_format"
+  "zebra_state_conflict"
+  "zebra_zcash_listener_conflict"
+]
+++ lib.optionals stdenv.hostPlatform.isLinux [
+  ## zebrad – acceptance
+  "non_blocking_logger"
 ]

--- a/nix/packages/zebra/failing-tests.nix
+++ b/nix/packages/zebra/failing-tests.nix
@@ -1,5 +1,6 @@
 ### Tests that fail on Nix, but aren’t skipped by `ZEBRA_SKIP_NETWORK_TESTS`.
 {
+  extraFeatures,
   lib,
   stdenv,
 }:
@@ -62,4 +63,56 @@
 ++ lib.optionals stdenv.hostPlatform.isLinux [
   ## zebrad – acceptance
   "non_blocking_logger"
+]
+## These tests seem to only fail when the `elasticsearch` feature is enabled on MacOS.
+++ lib.optionals (stdenv.hostPlatform.isDarwin && lib.elem "elasticsearch" extraFeatures) [
+  ## zebra-rpc
+  "methods::tests::snapshot::test_rpc_response_data"
+  "methods::tests::snapshot::test_z_get_treestate"
+  "methods::tests::vectors::rpc_getaddresstxids_invalid_arguments"
+  "methods::tests::vectors::rpc_getaddresstxids_response"
+  "methods::tests::vectors::rpc_getaddressutxos_response"
+  "methods::tests::vectors::rpc_getbestblockhash"
+  "methods::tests::vectors::rpc_getblock"
+  "methods::tests::vectors::rpc_getblockcount"
+  "methods::tests::vectors::rpc_getblockcount_empty_state"
+  "methods::tests::vectors::rpc_getblockhash"
+  "methods::tests::vectors::rpc_getmininginfo"
+  "methods::tests::vectors::rpc_getnetworksolps"
+  "methods::tests::vectors::rpc_getpeerinfo"
+  "methods::tests::vectors::rpc_getrawtransaction"
+  "methods::tests::vectors::rpc_submitblock_errors"
+  ## zebra-scan
+  "service::tests::scan_service_registers_keys_correctly"
+  "tests::vectors::scanning_zecpages_from_populated_zebra_state"
+  ## zebra-state
+  "service::read::tests::vectors::empty_read_state_still_responds_to_requests"
+  "service::read::tests::vectors::populated_read_state_responds_correctly"
+  "service::tests::chain_tip_sender_is_updated"
+  "service::tests::empty_state_still_responds_to_requests"
+  "service::tests::state_behaves_when_blocks_are_committed_in_order"
+  "service::tests::state_behaves_when_blocks_are_committed_out_of_order"
+  "service::tests::value_pool_is_updated"
+  ## zebra-state – basic
+  "check_transcripts_mainnet"
+  "check_transcripts_testnet"
+  ## zebrad
+  "components::inbound::tests::fake_peer_set::caches_getaddr_response"
+  "components::inbound::tests::fake_peer_set::inbound_block_height_lookahead_limit"
+  "components::inbound::tests::fake_peer_set::mempool_advertise_transaction_ids"
+  "components::inbound::tests::fake_peer_set::mempool_push_transaction"
+  "components::inbound::tests::fake_peer_set::mempool_requests_for_transactions"
+  "components::inbound::tests::fake_peer_set::mempool_transaction_expiration"
+  "components::mempool::tests::vector::mempool_cancel_downloads_after_network_upgrade"
+  "components::mempool::tests::vector::mempool_cancel_mined"
+  "components::mempool::tests::vector::mempool_failed_download_is_not_rejected"
+  "components::mempool::tests::vector::mempool_failed_verification_is_rejected"
+  "components::mempool::tests::vector::mempool_queue"
+  "components::mempool::tests::vector::mempool_reverifies_after_tip_change"
+  "components::mempool::tests::vector::mempool_service_basic"
+  "components::mempool::tests::vector::mempool_service_disabled"
+  ## zebrad – acceptance
+  "db_init_outside_future_executor"
+  "nu6_funding_streams_and_coinbase_balance"
+  "validate_regtest_genesis_block"
 ]

--- a/nix/packages/zebra/failing-tests.nix
+++ b/nix/packages/zebra/failing-tests.nix
@@ -1,0 +1,28 @@
+### Tests that fail on Nix, but aren’t skipped by `ZEBRA_SKIP_NETWORK_TESTS`.
+{
+  lib,
+  stdenv,
+}:
+[
+  ## zebra-scan
+  "scan_binary_starts"
+  ## zebrad – acceptance
+  "config_tests"
+  "trusted_chain_sync_handles_forks_correctly"
+]
+++ lib.optionals stdenv.hostPlatform.isDarwin [
+  ## zebrad – acceptance
+  "regtest_block_templates_are_valid_block_submissions"
+]
+++ lib.optionals stdenv.hostPlatform.isLinux [
+  ## zebrad – acceptance
+  "config_tests"
+  "end_of_support_is_checked_at_start"
+  "ephemeral_existing_directory"
+  "ephemeral_missing_directory"
+  "external_address"
+  "misconfigured_ephemeral_existing_directory"
+  "misconfigured_ephemeral_missing_directory"
+  "non_blocking_logger"
+  "persistent_mode"
+]

--- a/nix/rust-toolchain.nix
+++ b/nix/rust-toolchain.nix
@@ -1,0 +1,27 @@
+{
+  fenix,
+  pkgs,
+}:
+## TODO: This conditional is a workaround for nix-community/fenix#178. Use the `else`
+##       unconditionally once that is fixed.
+if pkgs.stdenv.isDarwin
+then let
+  fnx = fenix.packages.${pkgs.system};
+in
+  fnx.combine [
+    (fnx.stable.cargo.overrideAttrs (old: {
+      postBuild = ''
+        install_name_tool \
+          -change "/usr/lib/libcurl.4.dylib" "${pkgs.curl.out}/lib/libcurl.4.dylib" \
+          ./cargo/bin/cargo
+      '';
+    }))
+    fnx.stable.clippy
+    fnx.stable.rustc
+    fnx.stable.rustfmt
+  ]
+else
+  fenix.packages.${pkgs.system}.fromToolchainFile {
+    file = ../rust-toolchain.toml;
+    sha256 = "s1RPtyvDGJaX/BisLT+ifVfuhDT1nZkZ1NcK8sbwELM=";
+  }

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -990,7 +990,7 @@ impl DiskDb {
             //
             // We don't attempt to guard against malicious symlinks created by attackers
             // (TOCTOU attacks). Zebra should not be run with elevated privileges.
-            if !old_path.starts_with(&cache_path) {
+            if !old_path.starts_with(cache_path) {
                 info!("skipped reusing previous state cache: state is outside cache directory");
                 return;
             }

--- a/zebrad/systemd/zebrad.service
+++ b/zebrad/systemd/zebrad.service
@@ -6,7 +6,7 @@
 # sudo cp target/release/zebrad /usr/bin
 # 3- Replace AssertPathExists and ExecStart with the location of your binary if needed.
 # 4- Place this file in systemd system folder, with the other systemd files:
-# cp zebrad/systemd/zebrad.service /lib/systemd/system/ 
+# cp zebrad/systemd/zebrad.service /lib/systemd/system/
 # 5- Start zebrad from systemd for the first time:
 # systemctl start zebrad.service
 # 6- Check status:
@@ -26,5 +26,4 @@ StandardOutput=journal
 StandardError=journal
 
 [Install]
-Alias=zebrad
 WantedBy=default.target


### PR DESCRIPTION
## Motivation

I manage all of my systems with Nix, so this grew out of me doing various work around Zebra the past few months. I currently merge this branch into whatever I’m working on (which is easy, because this basically only adds new files[^1], so no conflicts).

[^1]: There are three minor changes to existing files:
    1. ignored the Nix build result in .gitignore,
    2. fixed a clippy complaint in disk_db.rs, and
    3. removed an invalid `Alias` from systemd/zebrad.service.

I also saw @teor2345 had previously put up a Nix derivation in #1479, which roughly corresponds to [nix/packages/zebra](./nix/packages/zebra/default.nix) in this PR.

## Solution

Here is a summary of what’s added. `${system}` can be replaced with any of `aarch64-darwin`, `aarch64-linux`, `x86_64-darwin`, `x86_64-linux`.

```
├───apps
│   └───${system}
│       ├───default: app
│       ├───zebra-scanner: app
│       └───zebrad: app
├───checks
│   └───${system}
│       ├───audit: derivation 'crate-audit-0.0.0'
│       ├───clippy: derivation 'zebra-clippy-2.0.1'
│       ├───deny: derivation 'zebra-deny-2.0.1'
│       ├───doc: derivation 'zebra-doc-2.0.1'
│       └───fmt: derivation 'zebra-fmt-2.0.1'
├───darwinConfigurations
│   ├───aarch64-darwin-example: nix-darwin configuration
│   └───x86_64-darwin-example: nix-darwin configuration
├───darwinModules
│   ├───default: nix-darwin module
│   └───zebra: nix-darwin module
├───devShells
│   └───${system}
│       └───default: development environment 'nix-shell'
├───formatter
│   └───${system}: package 'alejandra-3.0.0'
├───homeConfigurations: unknown
│   └───${system}-example: Home Manager configuration
├───homeModules
│   ├───default: Home Manager module
│   └───zebra: Home Manager module
├───nixosConfigurations
│   ├───aarch64-linux-example: NixOS configuration
│   └───x86_64-linux-example: NixOS configuration
├───nixosModules
│   ├───default: NixOS module
│   └───zebra: NixOS module
├───overlays
│   └───default: Nixpkgs overlay
└───packages
    └───${system}
        ├───default: package 'zebra-2.0.1'
        ├───zebra: package 'zebra-2.0.1'
        └───zebra-deps: package 'zebra-deps-2.0.1'
```

- `packages` are builds of the main content of this repo
- `checks` are various tests (other than `cargo test`, which is covered by `packages`)
- `*Modules` allow you to configure zebrad like [this]( ./nix/modules/home.nix)
- `*Configurations` are examples of those configurations that are built as tests of much of the flake
- `devShells` provide a sandboxed development environment with `rustc`, `cargo`, etc.

### Tests

Everything is built on aarch64-darwin, aarch64-linux, and x86_64-linux at [garnix](https://garnix.io/repo/sellout/zebra), which also runs the various checks (clippy, fmt, etc.), and it builds the example configurations which implicitly tests the overlays, modules, etc.

For these CI builds to run on not-my-fork, the ZcashFoundation org would need to [get a garnix account](https://garnix.io/), or would need to add some Nix-based GitHub workflow (ideally with some caching solution, which garnix handles automatically).

### Follow-up Work

The current solution has everything in there, but I think the Nix/Rust tooling could be improved wrt cache-friendliness. It currently uses [crane](https://crane.dev/), which condenses everything into only two packages (“zebra”, containing all the crates in this repo, and “zebra-deps”, containing all the dependency crates _not_ in this repo), so if any part of Zebra changes, all of Zebra gets rebuilt, and if a dependency changes, all of Zebra and all deps get rebuilt. Having a separate package for each crate would minimize rebuilds, so a solution like cargo2nix or crate2nix is probably the way to go longer-term[^2].

[^2]: They’re not being used yet because of a bug in Nix (NixOS/nix#4119) that prevents packages with a lot of dependencies from building in a sandbox on MacOS (which would cause failures on garnix CI, as it requires everything to be sandboxed).

The derivation is built with `ZEBRA_SKIP_NETWORK_TESTS`, because of Nix sandboxing[^3]. But even so, there are a number of [failing tests](./nix/packages/zebra/failing-tests.nix) that I’ve explicitly skipped. That file conditionalizes them so you can see in which contexts they fail. One thing I didn’t conditionally enable is tests that pass outside of a sandbox, because I think that makes the dev / CI divide confusing. E.g., a number of disabled tests can pass if `__darwinAllowLocalNetworking` is enabled, but that can only be done outside of a sandbox. Also interesting is that there are a number of tests that only fail when the `elasticsearch` feature is enabled (and only on MacOS).

[^3]: There are ways to enable network access in a sandbox, so that might allow all (or at least more) tests to be enabled.

This PR doesn’t provide a default.nix or shell.nix (#1479 did, just under a different name), because I do everything with flakes, but it’s easy enough to expose them with [flake-compat](https://github.com/edolstra/flake-compat) if that’s desired.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [ ] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.
