### PR TITLE
fix(ci): remove `scan-start-where-left-test` from CI

### DIFF
--- a/.github/workflows/sub-ci-integration-tests-gcp.yml
+++ b/.github/workflows/sub-ci-integration-tests-gcp.yml
@@ -480,29 +480,6 @@ jobs:
       saves_to_disk: false
     secrets: inherit
 
-  # Test that the scanner can continue scanning where it was left when zebrad restarts.
-  #
-  # Runs:
-  # - after every PR is merged to `main`
-  # - on every PR update
-  #
-  # If the state version has changed, waits for the new cached states to be created.
-  # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
-  scan-start-where-left-test:
-    name: Scan starts where left
-    needs: [test-full-sync, get-available-disks]
-    uses: ./.github/workflows/sub-deploy-integration-tests-gcp.yml
-    if: ${{ !cancelled() && !failure() && (fromJSON(needs.get-available-disks.outputs.zebra_tip_disk) || needs.test-full-sync.result == 'success') && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
-    with:
-      app_name: zebra-scan
-      test_id: scan-start-where-left
-      test_description: Test that the scanner can continue scanning where it was left when zebrad restarts.
-      test_variables: "-e NETWORK=${{ inputs.network || vars.ZCASH_NETWORK }} -e TEST_SCAN_START_WHERE_LEFT=1 -e ZEBRA_FORCE_USE_COLOR=1 -e ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache"
-      needs_zebra_state: true
-      needs_lwd_state: false
-      saves_to_disk: true
-    secrets: inherit
-
   # Test that the scan task registers keys, deletes keys, and subscribes to results for keys while running.
   #
   # Runs:
@@ -546,7 +523,6 @@ jobs:
         lightwalletd-grpc-test,
         get-block-template-test,
         submit-block-test,
-        scan-start-where-left-test,
         scan-task-commands-test,
       ]
     # Only open tickets for failed scheduled jobs, manual workflow runs, or `main` branch merges.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -74,7 +74,6 @@ fi
 : "${TEST_LWD_TRANSACTIONS:=}"
 : "${TEST_GET_BLOCK_TEMPLATE:=}"
 : "${TEST_SUBMIT_BLOCK:=}"
-: "${TEST_SCAN_START_WHERE_LEFT:=}"
 : "${ENTRYPOINT_FEATURES:=}"
 : "${TEST_SCAN_TASK_COMMANDS:=}"
 
@@ -339,11 +338,6 @@ case "$1" in
         # Starting with a cached Zebra tip, test sending a block to Zebra's RPC port.
         check_directory_files "${ZEBRA_CACHED_STATE_DIR}"
         run_cargo_test "${ENTRYPOINT_FEATURES}" "submit_block"
-
-      elif [[ "${TEST_SCAN_START_WHERE_LEFT}" -eq "1" ]]; then
-        # Test that the scanner can continue scanning where it was left when zebra-scanner restarts.
-        check_directory_files "${ZEBRA_CACHED_STATE_DIR}"
-        exec cargo test --locked --release --features "zebra-test" --package zebra-scan -- --nocapture --include-ignored scan_start_where_left
 
       elif [[ "${TEST_SCAN_TASK_COMMANDS}" -eq "1" ]]; then
         # Test that the scan task commands are working.


### PR DESCRIPTION
## Motivation

The `scan_start_where_left` test is failing our CI apparently for [this reason](https://github.com/ZcashFoundation/zebra/pull/8987#issuecomment-2455438148).

## Solution

- Instead of fixing it we want to disable the `scan_start_where_left` test from the workflow keeping the rust test available for local runs.

### Tests

CI should not fail in this test as it will not be there anymore.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [ ] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

