### PR TITLE
fix(ci): Avoid caching state in `lwd-update-sync` job

### DIFF
--- a/.github/workflows/ci-tests.patch-external.yml
+++ b/.github/workflows/ci-tests.patch-external.yml
@@ -25,36 +25,42 @@ jobs:
   ###
   test-all:
     name: Test all
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'
 
   test-fake-activation-heights:
     name: Test with fake activation heights
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'
 
   test-empty-sync:
     name: Test checkpoint sync from empty state
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'
 
   test-lightwalletd-integration:
     name: Test integration with lightwalletd
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'
 
   test-configuration-file:
     name: Test CI default Docker config file / Test default-conf in Docker
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'
 
   test-configuration-file-testnet:
     name: Test CI testnet Docker config file / Test default-conf in Docker
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -62,6 +68,7 @@ jobs:
 
   test-zebra-conf-path:
     name: Test CI custom Docker config file / Test custom-conf in Docker
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'
@@ -74,66 +81,77 @@ jobs:
   # We don't patch the testnet job, because testnet isn't required to merge (it's too unstable)
   get-available-disks:
     name: Check if cached state disks exist for Mainnet / Check if cached state disks exist
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'
 
   test-stateful-sync:
     name: Zebra checkpoint update / Run sync-past-checkpoint test
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'
 
   test-update-sync:
     name: Zebra tip update / Run update-to-tip test
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'
 
   checkpoints-mainnet:
     name: Generate checkpoints mainnet / Run checkpoints-mainnet test
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'
 
   lightwalletd-rpc-test:
     name: Zebra tip JSON-RPC / Run fully-synced-rpc test
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'
 
   lightwalletd-transactions-test:
     name: lightwalletd tip send / Run lwd-send-transactions test
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'
 
   get-block-template-test:
     name: get block template / Run get-block-template test
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'
 
   submit-block-test:
     name: submit block / Run submit-block test
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'
 
   lightwalletd-full-sync:
     name: lightwalletd tip / Run lwd-full-sync test
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'
 
   lightwalletd-update-sync:
     name: lightwalletd tip update / Run lwd-update-sync test
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'
 
   lightwalletd-grpc-test:
     name: lightwalletd GRPC tests / Run lwd-grpc-wallet test
+    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'

--- a/.github/workflows/sub-ci-integration-tests-gcp.yml
+++ b/.github/workflows/sub-ci-integration-tests-gcp.yml
@@ -344,7 +344,6 @@ jobs:
   # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
   lightwalletd-update-sync:
     name: lightwalletd tip update
-    needs: [lightwalletd-full-sync, get-available-disks]
     uses: ./.github/workflows/sub-deploy-integration-tests-gcp.yml
     if: ${{ !cancelled() && !failure() && (inputs.network || vars.ZCASH_NETWORK) == 'Mainnet' && (fromJSON(needs.get-available-disks.outputs.lwd_tip_disk) || needs.lightwalletd-full-sync.result == 'success') && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
     with:

--- a/.github/workflows/sub-ci-integration-tests-gcp.yml
+++ b/.github/workflows/sub-ci-integration-tests-gcp.yml
@@ -352,10 +352,10 @@ jobs:
       test_id: lwd-update-sync
       test_description: Test lightwalletd update sync with both states
       test_variables: "-e NETWORK=${{ inputs.network || vars.ZCASH_NETWORK }} -e TEST_LWD_UPDATE_SYNC=1 -e ZEBRA_TEST_LIGHTWALLETD=1 -e ZEBRA_FORCE_USE_COLOR=1 -e ZEBRA_CACHED_STATE_DIR=/var/cache/zebrad-cache -e LIGHTWALLETD_DATA_DIR=/var/cache/lwd-cache"
-      needs_zebra_state: true
-      needs_lwd_state: true
-      saves_to_disk: true
-      force_save_to_disk: ${{ inputs.force_save_to_disk || false }}
+      needs_zebra_state: false
+      needs_lwd_state: false
+      saves_to_disk: false
+      force_save_to_disk: false
       disk_prefix: lwd-cache
       height_grep_text: "Waiting for block: "
     secrets: inherit


### PR DESCRIPTION
## Motivation

This test is failing in CI since https://github.com/ZcashFoundation/zebra/pull/9004, it's not clear why it was passing before then as the expected log was missing before #9004 as well.

The [test documentation](https://github.com/ZcashFoundation/zebra/blob/disable-lwd-update-sync-save-to-disk/zebrad/tests/acceptance.rs#L1776-L1780) says it's meant to be run with an empty Zebra and lightwalletd test (and it is consistent with the test code). The test should not be producing an updated cache state, it should never be saved to a cached disk for other tests to use.

Depends-On: #9026.

## Solution

Sets the `needs_zebra_state`, `needs_lwd_state`, `save_to_disk`, and `force_save_to_disk` Github action inputs as false for the `lightwalletd-update-sync` job.

Related changes:
- Checks if a branch is from a fork before all of the external patch jobs

### Tests

The test should pass in CI for this PR.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

