### PR TITLE
fix(mergify): remove deprecated `speculative_checks` option

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -3,6 +3,10 @@
 # This file can be edited and validated using:
 # https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/config-editor
 
+# Set the maximum number of PRs that can be checked in parallel in a queue
+merge_queue:
+  max_parallel_checks: 5
+
 # Provides a means to set configuration values that act as fallbacks
 # for queue_rules and pull_request_rules
 defaults:
@@ -15,7 +19,6 @@ defaults:
     # Allow to update/rebase the original pull request if possible to check its mergeability,
     # and it does not create a draft PR if not needed
     allow_inplace_checks: True
-    speculative_checks: 1
     batch_size: 20
     # Wait for about 10% of the time it takes Rust PRs to run CI (~1h)
     batch_max_wait_time: "10 minutes"


### PR DESCRIPTION
## Motivation

While using Mergify's configuration checker, this issue was not raised, but it's now showing in some PR's summaries, as in https://github.com/ZcashFoundation/zebra/pull/9026/checks?check_run_id=33066692861

### Specifications & References

- https://docs.mergify.com/merge-queue/parallel-checks/

## Solution

- Use the new root level option `max_parallel_checks` 
### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [X] The PR name will make sense to users.
- [X] The PR provides a CHANGELOG summary.
- [X] The solution is tested.
- [X] The documentation is up to date.
- [X] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

