### PR TITLE
fix(ci): allow to run all lighwalletd tests in Docker

### DIFF
--- a/.github/workflows/sub-ci-unit-tests-docker.yml
+++ b/.github/workflows/sub-ci-unit-tests-docker.yml
@@ -138,7 +138,7 @@ jobs:
           NETWORK: ${{ inputs.network || vars.ZCASH_NETWORK }}
         run: |
           docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}
-          docker run --tty -e NETWORK -e ZEBRA_TEST_LIGHTWALLETD=1 ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}
+          docker run --tty -e NETWORK -e ZEBRA_TEST_LIGHTWALLETD=1 -e TEST_LWD_INTEGRATION=1 ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}
 
   # Test that Zebra works using the default config with the latest Zebra version.
   test-configuration-file:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -59,7 +59,7 @@ fi
 : "${RUN_ALL_EXPERIMENTAL_TESTS:=}"
 : "${TEST_FAKE_ACTIVATION_HEIGHTS:=}"
 : "${TEST_ZEBRA_EMPTY_SYNC:=}"
-: "${ZEBRA_TEST_LIGHTWALLETD:=}"
+: "${TEST_LWD_INTEGRATION:=}"
 : "${FULL_SYNC_MAINNET_TIMEOUT_MINUTES:=}"
 : "${FULL_SYNC_TESTNET_TIMEOUT_MINUTES:=}"
 : "${TEST_DISK_REBUILD:=}"
@@ -240,10 +240,6 @@ case "$1" in
         # Test that Zebra syncs and checkpoints a few thousand blocks from an empty state.
         run_cargo_test "${ENTRYPOINT_FEATURES}" "sync_large_checkpoints_"
 
-      elif [[ "${ZEBRA_TEST_LIGHTWALLETD}" -eq "1" ]]; then
-        # Test launching lightwalletd with an empty lightwalletd and Zebra state.
-        run_cargo_test "${ENTRYPOINT_FEATURES}" "lightwalletd_integration"
-
       elif [[ -n "${FULL_SYNC_MAINNET_TIMEOUT_MINUTES}" ]]; then
         # Run a Zebra full sync test on mainnet.
         run_cargo_test "${ENTRYPOINT_FEATURES}" "full_sync_mainnet"
@@ -303,6 +299,10 @@ case "$1" in
         # Run both the fully synced RPC test and the subtree snapshot test, one test at a time.
         # Since these tests use the same cached state, a state problem in the first test can fail the second test.
         run_cargo_test "${ENTRYPOINT_FEATURES}" "--test-threads" "1" "fully_synced_rpc_"
+
+      elif [[ "${TEST_LWD_INTEGRATION}" -eq "1" ]]; then
+        # Test launching lightwalletd with an empty lightwalletd and Zebra state.
+        run_cargo_test "${ENTRYPOINT_FEATURES}" "lightwalletd_integration"
 
       elif [[ "${TEST_LWD_FULL_SYNC}" -eq "1" ]]; then
         # Starting at a cached Zebra tip, run a lightwalletd sync to tip.


### PR DESCRIPTION
## Motivation

A LWD test was expecting the `ZEBRA_TEST_LIGHTWALLETD` to be set, but this variable is needed for all LWD tests and not specifically for `lightwalletd_integration`.

We had to rename this variable on a buggy `elif` statement in our Docker entrypoint.

This was avoiding most LWD tests to run correctly.

## Solution

- Use `$TEST_LWD_INTEGRATION` to run `lightwalletd_integration` in our entrypoint and in CI
- Remove `$ZEBRA_TEST_LIGHTWALLETD` as this was an incorrect logic

### Tests

- We must validate this tests are running correctly, by **checking the logs directly** in this PR

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [X] The PR name will make sense to users.
- [X] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [X] The documentation is up to date.
- [X] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

