### PR TITLE
add(consensus): Check consensus branch ids in tx verifier

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -324,7 +324,17 @@ impl Transaction {
         }
     }
 
-    /// Return the version of this transaction.
+    /// Returns the version of this transaction.
+    ///
+    /// Note that the returned version is equal to `effectiveVersion`, described in [§ 7.1
+    /// Transaction Encoding and Consensus]:
+    ///
+    /// > `effectiveVersion` [...] is equal to `min(2, version)` when `fOverwintered = 0` and to
+    /// > `version` otherwise.
+    ///
+    /// Zebra handles the `fOverwintered` flag via the [`Self::is_overwintered`] method.
+    ///
+    /// [§ 7.1 Transaction Encoding and Consensus]: <https://zips.z.cash/protocol/protocol.pdf#txnencoding>
     pub fn version(&self) -> u32 {
         match self {
             Transaction::V1 { .. } => 1,
@@ -332,20 +342,6 @@ impl Transaction {
             Transaction::V3 { .. } => 3,
             Transaction::V4 { .. } => 4,
             Transaction::V5 { .. } => 5,
-        }
-    }
-
-    /// Returns `effectiveVersion` as described in [§ 7.1 Transaction Encoding and Consensus]:
-    ///
-    /// > `effectiveVersion` [...] is equal to `min(2, version)` when `fOverwintered = 0` and to
-    /// > `version` otherwise.
-    ///
-    /// [§ 7.1 Transaction Encoding and Consensus]: <https://zips.z.cash/protocol/protocol.pdf#txnencoding>
-    pub fn effective_version(&self) -> u32 {
-        if self.is_overwintered() {
-            self.version()
-        } else {
-            std::cmp::min(2, self.version())
         }
     }
 

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -335,6 +335,20 @@ impl Transaction {
         }
     }
 
+    /// Returns `effectiveVersion` as described in [§ 7.1 Transaction Encoding and Consensus]:
+    ///
+    /// > `effectiveVersion` [...] is equal to `min(2, version)` when `fOverwintered = 0` and to
+    /// > `version` otherwise.
+    ///
+    /// [§ 7.1 Transaction Encoding and Consensus]: <https://zips.z.cash/protocol/protocol.pdf#txnencoding>
+    pub fn effective_version(&self) -> u32 {
+        if self.is_overwintered() {
+            self.version()
+        } else {
+            std::cmp::min(2, self.version())
+        }
+    }
+
     /// Get this transaction's lock time.
     pub fn lock_time(&self) -> Option<LockTime> {
         let lock_time = match self {

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -471,6 +471,29 @@ impl Transaction {
         }
     }
 
+    /// Updates the [`NetworkUpgrade`] for this transaction.
+    ///
+    /// ## Notes
+    ///
+    /// - Updating the network upgrade for V1, V2, V3 and V4 transactions is not possible.
+    pub fn update_network_upgrade(&mut self, nu: NetworkUpgrade) -> Result<(), &str> {
+        match self {
+            Transaction::V1 { .. }
+            | Transaction::V2 { .. }
+            | Transaction::V3 { .. }
+            | Transaction::V4 { .. } => Err(
+                "Updating the network upgrade for V1, V2, V3 and V4 transactions is not possible.",
+            ),
+            Transaction::V5 {
+                ref mut network_upgrade,
+                ..
+            } => {
+                *network_upgrade = nu;
+                Ok(())
+            }
+        }
+    }
+
     // transparent
 
     /// Access the transparent inputs of this transaction, regardless of version.

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -242,6 +242,9 @@ pub enum TransactionError {
 
     #[error("the transaction uses an incorrect consensus branch id")]
     WrongConsensusBranchId,
+
+    #[error("wrong tx format: tx version is ≥ 5, but `nConsensusBranchId` is missing")]
+    MissingConsensusBranchId,
 }
 
 impl From<ValidateContextError> for TransactionError {

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -240,7 +240,7 @@ pub enum TransactionError {
     #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
     Zip317(#[from] zebra_chain::transaction::zip317::Error),
 
-    #[error("the transaction uses an incorrect consensus branch id")]
+    #[error("transaction uses an incorrect consensus branch id")]
     WrongConsensusBranchId,
 
     #[error("wrong tx format: tx version is ≥ 5, but `nConsensusBranchId` is missing")]

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -239,6 +239,9 @@ pub enum TransactionError {
     #[error("failed to verify ZIP-317 transaction rules, transaction was not inserted to mempool")]
     #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
     Zip317(#[from] zebra_chain::transaction::zip317::Error),
+
+    #[error("the transaction uses an incorrect consensus branch id")]
+    WrongConsensusBranchId,
 }
 
 impl From<ValidateContextError> for TransactionError {

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -380,6 +380,7 @@ where
             // Do quick checks first
             check::has_inputs_and_outputs(&tx)?;
             check::has_enough_orchard_flags(&tx)?;
+            check::consensus_branch_id(&tx, req.height(), &network)?;
 
             // Validate the coinbase input consensus rules
             if req.is_mempool() && tx.is_coinbase() {

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -510,6 +510,9 @@ pub fn tx_transparent_coinbase_spends_maturity(
 /// - When deserializing transactions, Zebra converts the `nConsensusBranchId` into
 ///   [`NetworkUpgrade`].
 ///
+/// - The values returned by [`Transaction::version`] match `effectiveVersion` so we use them in
+///   place of `effectiveVersion`. More details in [`Transaction::version`].
+///
 /// [ZIP-244]: <https://zips.z.cash/zip-0244>
 /// [7.1.2 Transaction Consensus Rules]: <https://zips.z.cash/protocol/protocol.pdf#txnconsensus>
 pub fn consensus_branch_id(
@@ -519,7 +522,7 @@ pub fn consensus_branch_id(
 ) -> Result<(), TransactionError> {
     let current_nu = NetworkUpgrade::current(network, height);
 
-    if current_nu < NetworkUpgrade::Nu5 || tx.effective_version() < 5 {
+    if current_nu < NetworkUpgrade::Nu5 || tx.version() < 5 {
         return Ok(());
     }
 

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -525,9 +525,6 @@ pub fn consensus_branch_id(
 ) -> Result<(), TransactionError> {
     if let Some(tx_nu) = tx.network_upgrade() {
         if tx_nu != NetworkUpgrade::current(network, height) {
-            let nu = NetworkUpgrade::current(network, height);
-            println!("tx_nu: {tx_nu}");
-            println!("cu_nu: {nu}");
             return Err(TransactionError::WrongConsensusBranchId);
         }
     }

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -498,25 +498,32 @@ pub fn tx_transparent_coinbase_spends_maturity(
 
 /// Checks the `nConsensusBranchId` field.
 ///
-/// ## Consensus Rules
+/// # Consensus
 ///
-/// ### [4.10 SIGHASH Transaction Hashing]
+/// ## [7.1.2 Transaction Consensus Rules]
+///
+/// > [N​U​5 onward] If effectiveVersion ≥ 5, the nConsensusBranchId field MUST match the consensus branch ID
+///    used for SIGHASH transaction hashes, as specified in [ZIP-244].
+///
+/// ## [4.10 SIGHASH Transaction Hashing]
 ///
 /// > 1. [**NU5** only, pre-**NU6**] All transactions **MUST** use the **NU5** consensus branch ID
 /// >    `0xF919A198` as defined in [ZIP-252].
 /// > 2. [**NU6** only] All transactions **MUST** use the **NU6** consensus branch ID `0xC8E71055`
 /// >    as defined in [ZIP-253].
 ///
-/// #### Notes
+/// ### Notes
 ///
 /// 1. At the time of writing this check, the `nConsensusBranchId` field is present only in
 ///    [`Transaction::V5`].
 /// 2. When deserializing a transaction, Zebra converts the `nConsensusBranchId` into
 ///    [`NetworkUpgrade`] and stores it in [`Transaction::V5::network_upgrade`].
 ///
+/// [ZIP-244]: <https://zips.z.cash/zip-0244>
 /// [ZIP-252]: <https://zips.z.cash/zip-0252>
 /// [ZIP-253]: <https://zips.z.cash/zip-0253>
 /// [4.10 SIGHASH Transaction Hashing]: <https://zips.z.cash/protocol/protocol.pdf#sighash>
+/// [7.1.2 Transaction Consensus Rules]: <https://zips.z.cash/protocol/protocol.pdf#txnconsensus>
 pub fn consensus_branch_id(
     tx: &Transaction,
     height: Height,

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -504,7 +504,6 @@ pub fn tx_transparent_coinbase_spends_maturity(
 ///
 /// > 1. [**NU5** only, pre-**NU6**] All transactions **MUST** use the **NU5** consensus branch ID
 /// >    `0xF919A198` as defined in [ZIP-252].
-/// >
 /// > 2. [**NU6** only] All transactions **MUST** use the **NU6** consensus branch ID `0xC8E71055`
 /// >    as defined in [ZIP-253].
 ///

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -1006,45 +1006,43 @@ async fn v5_transaction_is_rejected_before_nu5_activation() {
 fn v5_transaction_is_accepted_after_nu5_activation() {
     let _init_guard = zebra_test::init();
 
-    for network in [Network::Mainnet, Network::new_default_testnet()] {
-        zebra_test::MULTI_THREADED_RUNTIME.block_on(test(network));
-    }
+    for network in Network::iter() {
+        zebra_test::MULTI_THREADED_RUNTIME.block_on(async {
+            let nu5_activation_height = NetworkUpgrade::Nu5
+                .activation_height(&network)
+                .expect("NU5 activation height is specified");
 
-    async fn test(network: Network) {
-        let nu5_activation_height = NetworkUpgrade::Nu5
-            .activation_height(&network)
-            .expect("NU5 activation height is specified");
+            let state = service_fn(|_| async { unreachable!("Service should not be called") });
 
-        let state = service_fn(|_| async { unreachable!("Service should not be called") });
+            let mut tx = fake_v5_transactions_for_network(&network, network.block_iter())
+                .next_back()
+                .expect("At least one fake V5 transaction in the test vectors");
 
-        let mut tx = fake_v5_transactions_for_network(&network, network.block_iter())
-            .next_back()
-            .expect("At least one fake V5 transaction in the test vectors");
+            if tx.expiry_height().expect("V5 must have expiry_height") < nu5_activation_height {
+                *tx.expiry_height_mut() = nu5_activation_height;
+                tx.update_network_upgrade(NetworkUpgrade::Nu5)
+                    .expect("updating the network upgrade for a V5 tx should succeed");
+            }
 
-        if tx.expiry_height().expect("V5 must have expiry_height") < nu5_activation_height {
-            *tx.expiry_height_mut() = nu5_activation_height;
-            tx.update_network_upgrade(NetworkUpgrade::Nu5)
-                .expect("updating the network upgrade for a V5 tx should succeed");
-        }
+            let expected_hash = tx.unmined_id();
+            let expiry_height = tx.expiry_height().expect("V5 must have expiry_height");
 
-        let expected_hash = tx.unmined_id();
-        let expiry_height = tx.expiry_height().expect("V5 must have expiry_height");
+            let verification_result = Verifier::new_for_tests(&network, state)
+                .oneshot(Request::Block {
+                    transaction: Arc::new(tx),
+                    known_utxos: Arc::new(HashMap::new()),
+                    height: expiry_height,
+                    time: DateTime::<Utc>::MAX_UTC,
+                })
+                .await;
 
-        let verification_result = Verifier::new_for_tests(&network, state)
-            .oneshot(Request::Block {
-                transaction: Arc::new(tx),
-                known_utxos: Arc::new(HashMap::new()),
-                height: expiry_height,
-                time: DateTime::<Utc>::MAX_UTC,
-            })
-            .await;
-
-        assert_eq!(
-            verification_result
-                .expect("successful verification")
-                .tx_id(),
-            expected_hash
-        );
+            assert_eq!(
+                verification_result
+                    .expect("successful verification")
+                    .tx_id(),
+                expected_hash
+            );
+        });
     }
 }
 
@@ -2103,11 +2101,7 @@ async fn v5_transaction_with_transparent_transfer_is_rejected_by_the_script() {
 /// Test if V5 transaction with an internal double spend of transparent funds is rejected.
 #[tokio::test]
 async fn v5_transaction_with_conflicting_transparent_spend_is_rejected() {
-    for network in [Network::Mainnet, Network::new_default_testnet()] {
-        test(network).await;
-    }
-
-    async fn test(network: Network) {
+    for network in Network::iter() {
         let canopy_activation_height = NetworkUpgrade::Canopy
             .activation_height(&network)
             .expect("Canopy activation height is specified");

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -6,7 +6,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use chrono::{DateTime, TimeZone, Utc};
 use color_eyre::eyre::Report;
-use futures::TryFutureExt;
+use futures::{FutureExt, TryFutureExt};
 use halo2::pasta::{group::ff::PrimeField, pallas};
 use tower::{buffer::Buffer, service_fn, ServiceExt};
 
@@ -2566,75 +2566,153 @@ fn v5_with_duplicate_orchard_action() {
 /// Checks that the tx verifier handles consensus branch ids in V5 txs correctly.
 #[tokio::test]
 async fn v5_consensus_branch_ids() {
-    let state = service_fn(|_| async { unreachable!("state service should not be called") });
+    let mut state = MockService::build().for_unit_tests();
+
+    let (input, output, known_utxos) = mock_transparent_transfer(
+        Height(1),
+        true,
+        0,
+        Amount::try_from(10001).expect("valid amount"),
+    );
+
+    let known_utxos = Arc::new(known_utxos);
+
+    // NU5 is the first network upgrade that supports V5 txs.
+    let mut network_upgrade = NetworkUpgrade::Nu5;
+
+    let mut tx = Transaction::V5 {
+        inputs: vec![input],
+        outputs: vec![output],
+        lock_time: LockTime::unlocked(),
+        expiry_height: Height::MAX_EXPIRY_HEIGHT,
+        sapling_shielded_data: None,
+        orchard_shielded_data: None,
+        network_upgrade,
+    };
+
+    let outpoint = match tx.inputs()[0] {
+        transparent::Input::PrevOut { outpoint, .. } => outpoint,
+        transparent::Input::Coinbase { .. } => panic!("requires a non-coinbase transaction"),
+    };
 
     for network in Network::iter() {
-        let verifier = Buffer::new(Verifier::new_for_tests(&network, state), 10);
-
-        let (input, output, known_utxos) = mock_transparent_transfer(
-            Height(1),
-            true,
-            0,
-            Amount::try_from(1).expect("valid amount"),
-        );
-
-        let known_utxos = Arc::new(known_utxos);
-
-        let verify = |tx, nu: NetworkUpgrade| {
-            verifier
-                .clone()
-                .oneshot(Request::Block {
-                    transaction: Arc::new(tx),
-                    known_utxos: known_utxos.clone(),
-                    height: nu
-                        .activation_height(&network)
-                        .expect("network upgrade activation height"),
-                    time: DateTime::<Utc>::MAX_UTC,
-                })
-                .map_err(|err| {
-                    *err.downcast()
-                        .expect("error type should be `TransactionError`")
-                })
-        };
-
-        // NU5 is the first network upgrade that supports V5 txs.
-        let mut network_upgrade = NetworkUpgrade::Nu5;
-
-        let mut tx = Transaction::V5 {
-            inputs: vec![input],
-            outputs: vec![output],
-            lock_time: LockTime::unlocked(),
-            expiry_height: Height::MAX_EXPIRY_HEIGHT,
-            sapling_shielded_data: None,
-            orchard_shielded_data: None,
-            network_upgrade,
-        };
+        let verifier = Buffer::new(Verifier::new_for_tests(&network, state.clone()), 10);
 
         while let Some(next_nu) = network_upgrade.next_upgrade() {
             // Check an outdated network upgrade.
-            assert_eq!(
-                verify(tx.clone(), next_nu).await,
-                Err(TransactionError::WrongConsensusBranchId)
-            );
+            let height = next_nu.activation_height(&network).expect("height");
+
+            let block_req = verifier
+                .clone()
+                .oneshot(Request::Block {
+                    transaction: Arc::new(tx.clone()),
+                    known_utxos: known_utxos.clone(),
+                    // The consensus branch ID of the tx is outdated for this height.
+                    height,
+                    time: DateTime::<Utc>::MAX_UTC,
+                })
+                .map_err(|err| *err.downcast().expect("`TransactionError` type"));
+
+            let mempool_req = verifier
+                .clone()
+                .oneshot(Request::Mempool {
+                    transaction: tx.clone().into(),
+                    // The consensus branch ID of the tx is outdated for this height.
+                    height,
+                })
+                .map_err(|err| *err.downcast().expect("`TransactionError` type"));
+
+            let (block_rsp, mempool_rsp) = futures::join!(block_req, mempool_req);
+
+            assert_eq!(block_rsp, Err(TransactionError::WrongConsensusBranchId));
+            assert_eq!(mempool_rsp, Err(TransactionError::WrongConsensusBranchId));
 
             // Check the currently supported network upgrade.
-            assert_eq!(
-                verify(tx.clone(), network_upgrade)
-                    .await
-                    .expect("successful verification")
-                    .tx_id(),
-                tx.unmined_id()
-            );
+            let height = network_upgrade.activation_height(&network).expect("height");
+
+            let block_req = verifier
+                .clone()
+                .oneshot(Request::Block {
+                    transaction: Arc::new(tx.clone()),
+                    known_utxos: known_utxos.clone(),
+                    // The consensus branch ID of the tx is supported by this height.
+                    height,
+                    time: DateTime::<Utc>::MAX_UTC,
+                })
+                .map_ok(|rsp| rsp.tx_id())
+                .map_err(|e| format!("{e}"));
+
+            let mempool_req = verifier
+                .clone()
+                .oneshot(Request::Mempool {
+                    transaction: tx.clone().into(),
+                    // The consensus branch ID of the tx is supported by this height.
+                    height,
+                })
+                .map_ok(|rsp| rsp.tx_id())
+                .map_err(|e| format!("{e}"));
+
+            let state_req = async {
+                state
+                    .expect_request(zebra_state::Request::UnspentBestChainUtxo(outpoint))
+                    .map(|r| {
+                        r.respond(zebra_state::Response::UnspentBestChainUtxo(
+                            known_utxos.get(&outpoint).map(|utxo| utxo.utxo.clone()),
+                        ))
+                    })
+                    .await;
+
+                state
+                    .expect_request_that(|req| {
+                        matches!(
+                            req,
+                            zebra_state::Request::CheckBestChainTipNullifiersAndAnchors(_)
+                        )
+                    })
+                    .map(|r| {
+                        r.respond(zebra_state::Response::ValidBestChainTipNullifiersAndAnchors)
+                    })
+                    .await;
+            };
+
+            let (block_rsp, mempool_rsp, _) = futures::join!(block_req, mempool_req, state_req);
+            let txid = tx.unmined_id();
+
+            assert_eq!(block_rsp, Ok(txid));
+            assert_eq!(mempool_rsp, Ok(txid));
 
             // Check a network upgrade that Zebra doesn't support yet.
             tx.update_network_upgrade(next_nu)
                 .expect("V5 txs support updating NUs");
 
-            assert_eq!(
-                verify(tx.clone(), network_upgrade).await,
-                Err(TransactionError::WrongConsensusBranchId)
-            );
+            let height = network_upgrade.activation_height(&network).expect("height");
 
+            let block_req = verifier
+                .clone()
+                .oneshot(Request::Block {
+                    transaction: Arc::new(tx.clone()),
+                    known_utxos: known_utxos.clone(),
+                    // The consensus branch ID of the tx is not supported by this height.
+                    height,
+                    time: DateTime::<Utc>::MAX_UTC,
+                })
+                .map_err(|err| *err.downcast().expect("`TransactionError` type"));
+
+            let mempool_req = verifier
+                .clone()
+                .oneshot(Request::Mempool {
+                    transaction: tx.clone().into(),
+                    // The consensus branch ID of the tx is not supported by this height.
+                    height,
+                })
+                .map_err(|err| *err.downcast().expect("`TransactionError` type"));
+
+            let (block_rsp, mempool_rsp) = futures::join!(block_req, mempool_req);
+
+            assert_eq!(block_rsp, Err(TransactionError::WrongConsensusBranchId));
+            assert_eq!(mempool_rsp, Err(TransactionError::WrongConsensusBranchId));
+
+            // Shift the network upgrade for the next loop iteration.
             network_upgrade = next_nu;
         }
     }


### PR DESCRIPTION
## Motivation

Close #9064.

### Context

The tx verifier is not checking if the `nConsensusBranchId` field in V5 txs conforms to the following consensus rule:

> [**NU5** onward] If `effectiveVersion` ≥ 5, the `nConsensusBranchId` field **MUST** match the consensus branch ID used for SIGHASH transaction hashes, as specified in [ZIP-244](https://zips.z.cash/zip-0244). 

We have this check in the block verifier. However, since the mempool uses only the tx verifier, it can currently accept txs with an incorrect `nConsenusBranchId`.

### Specifications & References

- The consensus rules in [§ 7.1.2 Transaction Consensus Rules](https://zips.z.cash/protocol/protocol.pdf#txnconsensus).

## Solution

- Add the check mentioned above to the tx verifier.
- Clean-ups:
  - [Move test-only tx methods out of the default impl](https://github.com/ZcashFoundation/zebra/pull/9063/commits/fad17b6587daaf0359e5e13833b5063c88cb7749)

### Tests

- Add unit tests.
- Adjust existing unit tests.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

