### PR TITLE
Release v2.1.0

### DIFF
--- a/.github/workflows/scripts/release-crates-dry-run.sh
+++ b/.github/workflows/scripts/release-crates-dry-run.sh
@@ -20,11 +20,11 @@ fi
 # We use the same commands as the [release drafter](https://github.com/ZcashFoundation/zebra/blob/main/.github/PULL_REQUEST_TEMPLATE/release-checklist.md#update-crate-versions)
 # with an extra `--no-confirm` argument for non-interactive testing.
 # Update everything except for alpha crates and zebrad:
-cargo release version --verbose --execute --no-confirm --allow-branch '*' --workspace --exclude zebrad --exclude zebra-scan --exclude zebra-grpc patch
+cargo release version --verbose --execute --no-confirm --allow-branch '*' --workspace --exclude zebrad --exclude zebra-scan --exclude zebra-grpc beta
 
 # Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
-cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebra-scan 0.1.0-alpha.11
-cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebra-grpc 0.1.0-alpha.9
+cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebra-scan 0.1.0-alpha.13
+cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebra-grpc 0.1.0-alpha.11
 
 # Update zebrad:
 cargo release version --verbose --execute --no-confirm --allow-branch '*' --package zebrad patch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Zebra 2.1.0](https://github.com/ZcashFoundation/zebra/releases/tag/v2.1.0) - 2024-12-06
+
+This release adds a check to verify that V5 transactions in the mempool have the correct consensus branch id. It also bumps
+Zebra's initial minimum protocol version such that this release of Zebra will always reject connections with peers advertising
+a network protocol version below 170,120 on Mainnet and 170,110 on Testnet instead of accepting those connections until Zebra's
+chain state reaches the NU6 activation height.
+
+### Breaking Changes
+
+- Upgrade minimum protocol versions for all Zcash networks ([#9058](https://github.com/ZcashFoundation/zebra/pull/9058))
+
+### Added
+
+- `getblockheader` RPC method ([#8967](https://github.com/ZcashFoundation/zebra/pull/8967))
+- `rust-toolchain.toml` file ([#8985](https://github.com/ZcashFoundation/zebra/pull/8985))
+
+### Changed
+
+- Updated `getblock` RPC to more closely match zcashd ([#9006](https://github.com/ZcashFoundation/zebra/pull/9006))
+- Updated error messages to include inner error types (notably for the transaction verifier) ([#9066](https://github.com/ZcashFoundation/zebra/pull/9066))
+
+### Fixed
+
+- Validate consensus branch ids of mempool transactions ([#9063](https://github.com/ZcashFoundation/zebra/pull/9063))
+- Verify mempool transactions with unmined inputs if those inputs are in the mempool to support TEX transactions ([#8857](https://github.com/ZcashFoundation/zebra/pull/8857))
+- Wait until transactions have been added to the mempool before returning success response from `sendrawtransaction` RPC ([#9067](https://github.com/ZcashFoundation/zebra/pull/9067))
+
+### Contributors
+
+Thank you to everyone who contributed to this release, we couldn't make Zebra without you:
+@arya2, @conradoplg, @cypherpepe, @gustavovalverde, @idky137, @oxarbitrage, @pinglanlu and @upbqdn
+
 ## [Zebra 2.0.1](https://github.com/ZcashFoundation/zebra/releases/tag/v2.0.1) - 2024-10-30
 
 - Zebra now supports NU6 on Mainnet. This patch release updates dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Zebra 2.1.0](https://github.com/ZcashFoundation/zebra/releases/tag/v2.1.0) - 2024-12-06
 
-This release adds a check to verify that V5 transactions in the mempool have the correct consensus branch id. It also bumps
+This release adds a check to verify that V5 transactions in the mempool have the correct consensus branch ID; 
+Zebra would previously accept those and return a transaction ID (indicating success) even though they would
+be eventually rejected by the block consensus checks. Similarly, Zebra also now returns an error when trying
+to submit transactions that would eventually fail some consensus checks (e.g. double spends) but would also 
+return a transaction ID indicating success.  The release also bumps
 Zebra's initial minimum protocol version such that this release of Zebra will always reject connections with peers advertising
 a network protocol version below 170,120 on Mainnet and 170,110 on Testnet instead of accepting those connections until Zebra's
 chain state reaches the NU6 activation height.
+The `getblock` RPC method has been updated and now returns some additional information
+such as the block height (even if you provide a block hash) and other fields as supported
+by the `getblockheader` RPC call.
 
 ### Breaking Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "tower-batch-control"
-version = "0.2.41-beta.18"
+version = "0.2.41-beta.19"
 dependencies = [
  "color-eyre",
  "ed25519-zebra",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "tower-fallback"
-version = "0.2.41-beta.18"
+version = "0.2.41-beta.19"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -6039,7 +6039,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "1.0.0-beta.42"
+version = "1.0.0-beta.43"
 dependencies = [
  "bitflags 2.6.0",
  "bitflags-serde-legacy",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-consensus"
-version = "1.0.0-beta.42"
+version = "1.0.0-beta.43"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6150,7 +6150,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-grpc"
-version = "0.1.0-alpha.9"
+version = "0.1.0-alpha.10"
 dependencies = [
  "color-eyre",
  "futures-util",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-network"
-version = "1.0.0-beta.42"
+version = "1.0.0-beta.43"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
@@ -6213,7 +6213,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-node-services"
-version = "1.0.0-beta.42"
+version = "1.0.0-beta.43"
 dependencies = [
  "color-eyre",
  "jsonrpc-core",
@@ -6226,7 +6226,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "1.0.0-beta.42"
+version = "1.0.0-beta.43"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -6265,7 +6265,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-scan"
-version = "0.1.0-alpha.11"
+version = "0.1.0-alpha.12"
 dependencies = [
  "bls12_381",
  "chrono",
@@ -6311,7 +6311,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-script"
-version = "1.0.0-beta.42"
+version = "1.0.0-beta.43"
 dependencies = [
  "hex",
  "lazy_static",
@@ -6323,7 +6323,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "1.0.0-beta.42"
+version = "1.0.0-beta.43"
 dependencies = [
  "bincode",
  "chrono",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-test"
-version = "1.0.0-beta.42"
+version = "1.0.0-beta.43"
 dependencies = [
  "color-eyre",
  "futures",
@@ -6396,7 +6396,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-utils"
-version = "1.0.0-beta.42"
+version = "1.0.0-beta.43"
 dependencies = [
  "color-eyre",
  "hex",
@@ -6427,7 +6427,7 @@ dependencies = [
 
 [[package]]
 name = "zebrad"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "abscissa_core",
  "atty",

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -37,7 +37,7 @@ docker run -d --platform linux/amd64 \
 ### Build it locally
 
 ```shell
-git clone --depth 1 --branch v2.0.1 https://github.com/ZcashFoundation/zebra.git
+git clone --depth 1 --branch v2.1.0 https://github.com/ZcashFoundation/zebra.git
 docker build --file docker/Dockerfile --target runtime --tag zebra:local .
 docker run --detach zebra:local
 ```

--- a/book/src/user/install.md
+++ b/book/src/user/install.md
@@ -76,7 +76,7 @@ To compile Zebra directly from GitHub, or from a GitHub release source archive:
 ```sh
 git clone https://github.com/ZcashFoundation/zebra.git
 cd zebra
-git checkout v2.0.1
+git checkout v2.1.0
 ```
 
 3. Build and Run `zebrad`
@@ -89,7 +89,7 @@ target/release/zebrad start
 ### Compiling from git using cargo install
 
 ```sh
-cargo install --git https://github.com/ZcashFoundation/zebra --tag v2.0.1 zebrad
+cargo install --git https://github.com/ZcashFoundation/zebra --tag v2.1.0 zebrad
 ```
 
 ### Compiling on ARM

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-batch-control"
-version = "0.2.41-beta.18"
+version = "0.2.41-beta.19"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Tower middleware for batch request processing"
 # # Legal
@@ -43,10 +43,10 @@ rand = "0.8.5"
 
 tokio = { version = "1.41.0", features = ["full", "tracing", "test-util"] }
 tokio-test = "0.4.4"
-tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.18" }
+tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.19" }
 tower-test = "0.4.0"
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.42" }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.43" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-fallback"
-version = "0.2.41-beta.18"
+version = "0.2.41-beta.19"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Tower service combinator that sends requests to a first service, then retries processing on a second fallback service if the first service errors."
 license = "MIT OR Apache-2.0"
@@ -24,4 +24,4 @@ tracing = "0.1.39"
 [dev-dependencies]
 tokio = { version = "1.41.0", features = ["full", "tracing", "test-util"] }
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.42" }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.43" }

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-chain"
-version = "1.0.0-beta.42"
+version = "1.0.0-beta.43"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Core Zcash data structures"
 license = "MIT OR Apache-2.0"
@@ -145,7 +145,7 @@ proptest-derive = { version = "0.5.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 rand_chacha = { version = "0.3.1", optional = true }
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.42", optional = true }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.43", optional = true }
 
 [dev-dependencies]
 # Benchmarks
@@ -168,7 +168,7 @@ rand_chacha = "0.3.1"
 
 tokio = { version = "1.41.0", features = ["full", "tracing", "test-util"] }
 
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.42" }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.43" }
 
 [[bench]]
 name = "block"

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-consensus"
-version = "1.0.0-beta.42"
+version = "1.0.0-beta.43"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Implementation of Zcash consensus checks"
 license = "MIT OR Apache-2.0"
@@ -63,13 +63,13 @@ orchard.workspace = true
 zcash_proofs = { workspace = true, features = ["multicore" ] }
 wagyu-zcash-parameters = "0.2.0"
 
-tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.18" }
-tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41-beta.18" }
+tower-fallback = { path = "../tower-fallback/", version = "0.2.41-beta.19" }
+tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41-beta.19" }
 
-zebra-script = { path = "../zebra-script", version = "1.0.0-beta.42" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.42" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.42" }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.42" }
+zebra-script = { path = "../zebra-script", version = "1.0.0-beta.43" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.43" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.43" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.43" }
 
 # prod feature progress-bar
 howudoin = { version = "0.1.2", optional = true }
@@ -94,6 +94,6 @@ tokio = { version = "1.41.0", features = ["full", "tracing", "test-util"] }
 tracing-error = "0.2.0"
 tracing-subscriber = "0.3.18"
 
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.42", features = ["proptest-impl"] }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.42", features = ["proptest-impl"] }
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.42" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.43", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.43", features = ["proptest-impl"] }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.43" }

--- a/zebra-grpc/Cargo.toml
+++ b/zebra-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-grpc"
-version = "0.1.0-alpha.9"
+version = "0.1.0-alpha.10"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Zebra gRPC interface"
 license = "MIT OR Apache-2.0"
@@ -28,8 +28,8 @@ color-eyre = "0.6.3"
 
 zcash_primitives.workspace = true
 
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.42", features = ["shielded-scan"] }
-zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.42" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.43", features = ["shielded-scan"] }
+zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.43" }
 
 [build-dependencies]
 tonic-build = "0.12.3"

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-network"
-version = "1.0.0-beta.42"
+version = "1.0.0-beta.43"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Networking code for Zebra"
 # # Legal
@@ -83,7 +83,7 @@ howudoin = { version = "0.1.2", optional = true }
 proptest = { version = "1.4.0", optional = true }
 proptest-derive = { version = "0.5.0", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.42", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.43", features = ["async-error"] }
 
 [dev-dependencies]
 proptest = "1.4.0"

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-node-services"
-version = "1.0.0-beta.42"
+version = "1.0.0-beta.43"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The interfaces of some Zebra node services"
 license = "MIT OR Apache-2.0"
@@ -37,7 +37,7 @@ rpc-client = [
 shielded-scan = []
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.42" }
+zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.43" }
 
 # Optional dependencies
 

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-rpc"
-version = "1.0.0-beta.42"
+version = "1.0.0-beta.43"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Zebra JSON Remote Procedure Call (JSON-RPC) interface"
 license = "MIT OR Apache-2.0"
@@ -104,16 +104,16 @@ zcash_address = { workspace = true, optional = true}
 # Test-only feature proptest-impl
 proptest = { version = "1.4.0", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.42", features = [
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.43", features = [
     "json-conversion",
 ] }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.42" }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.42" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.42", features = [
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.43" }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.43" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.43", features = [
     "rpc-client",
 ] }
-zebra-script = { path = "../zebra-script", version = "1.0.0-beta.42" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.42" }
+zebra-script = { path = "../zebra-script", version = "1.0.0-beta.43" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.43" }
 
 [build-dependencies]
 tonic-build = { version = "0.12.3", optional = true }
@@ -126,17 +126,17 @@ proptest = "1.4.0"
 thiserror = "1.0.64"
 tokio = { version = "1.41.0", features = ["full", "tracing", "test-util"] }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.42", features = [
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.43", features = [
     "proptest-impl",
 ] }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.42", features = [
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.43", features = [
     "proptest-impl",
 ] }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.42", features = [
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.43", features = [
     "proptest-impl",
 ] }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.42", features = [
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.43", features = [
     "proptest-impl",
 ] }
 
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.42" }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.43" }

--- a/zebra-scan/Cargo.toml
+++ b/zebra-scan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-scan"
-version = "0.1.0-alpha.11"
+version = "0.1.0-alpha.12"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Shielded transaction scanner for the Zcash blockchain"
 license = "MIT OR Apache-2.0"
@@ -77,11 +77,11 @@ zcash_primitives.workspace = true
 zcash_address.workspace = true
 sapling-crypto.workspace = true
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.42", features = ["shielded-scan"] }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.42", features = ["shielded-scan"] }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.42", features = ["shielded-scan"] }
-zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.9" }
-zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.42" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.43", features = ["shielded-scan"] }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.43", features = ["shielded-scan"] }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.43", features = ["shielded-scan"] }
+zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.10" }
+zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.43" }
 
 chrono = { version = "0.4.38", default-features = false, features = ["clock", "std", "serde"] }
 
@@ -96,7 +96,7 @@ jubjub = { version = "0.10.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 zcash_note_encryption = { version = "0.4.0", optional = true }
 
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.42", optional = true }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.43", optional = true }
 
 # zebra-scanner binary dependencies
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
@@ -107,7 +107,7 @@ serde_json = "1.0.132"
 jsonrpc = { version = "0.18.0", optional = true }
 hex = { version = "0.4.3", optional = true }
 
-zebrad = { path = "../zebrad", version = "2.0.1" }
+zebrad = { path = "../zebrad", version = "2.1.0" }
 
 [dev-dependencies]
 insta = { version = "1.40.0", features = ["ron", "redactions"] }
@@ -125,6 +125,6 @@ zcash_note_encryption = "0.4.0"
 toml = "0.8.19"
 tonic = "0.12.3"
 
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.42", features = ["proptest-impl"] }
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.42" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.43", features = ["proptest-impl"] }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.43" }
 

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-script"
-version = "1.0.0-beta.42"
+version = "1.0.0-beta.43"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Zebra script verification wrapping zcashd's zcash_script library"
 license = "MIT OR Apache-2.0"
@@ -16,11 +16,11 @@ categories = ["api-bindings", "cryptography::cryptocurrencies"]
 
 [dependencies]
 zcash_script = "0.2.0"
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.42" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.43" }
 
 thiserror = "1.0.64"
 
 [dev-dependencies]
 hex = "0.4.3"
 lazy_static = "1.4.0"
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.42" }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.43" }

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-state"
-version = "1.0.0-beta.42"
+version = "1.0.0-beta.43"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "State contextual verification and storage code for Zebra"
 license = "MIT OR Apache-2.0"
@@ -77,13 +77,13 @@ tracing = "0.1.39"
 elasticsearch = { version = "8.5.0-alpha.1", default-features = false, features = ["rustls-tls"], optional = true }
 serde_json = { version = "1.0.132", package = "serde_json", optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.42", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.43", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { version = "0.1.2", optional = true }
 
 # test feature proptest-impl
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.42", optional = true }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.43", optional = true }
 proptest = { version = "1.4.0", optional = true }
 proptest-derive = { version = "0.5.0", optional = true }
 
@@ -108,5 +108,5 @@ jubjub = "0.10.0"
 
 tokio = { version = "1.41.0", features = ["full", "tracing", "test-util"] }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.42", features = ["proptest-impl"] }
-zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.42" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.43", features = ["proptest-impl"] }
+zebra-test = { path = "../zebra-test/", version = "1.0.0-beta.43" }

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-test"
-version = "1.0.0-beta.42"
+version = "1.0.0-beta.43"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Test harnesses and test vectors for Zebra"
 license = "MIT OR Apache-2.0"

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-utils"
-version = "1.0.0-beta.42"
+version = "1.0.0-beta.43"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Developer tools for Zebra maintenance and testing"
 license = "MIT OR Apache-2.0"
@@ -94,11 +94,11 @@ tracing-error = "0.2.0"
 tracing-subscriber = "0.3.18"
 thiserror = "1.0.64"
 
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.42" }
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.42" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.43" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.43" }
 
 # These crates are needed for the block-template-to-proposal binary
-zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.42", optional = true }
+zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.43", optional = true }
 
 # These crates are needed for the zebra-checkpoints binary
 itertools = { version = "0.13.0", optional = true }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate metadata
 name = "zebrad"
-version = "2.0.1"
+version = "2.1.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The Zcash Foundation's independent, consensus-compatible implementation of a Zcash node"
 license = "MIT OR Apache-2.0"
@@ -157,15 +157,15 @@ test_sync_past_mandatory_checkpoint_mainnet = []
 test_sync_past_mandatory_checkpoint_testnet = []
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.42" }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.42" }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.42" }
-zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.42", features = ["rpc-client"] }
-zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.42" }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.42" }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.43" }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.43" }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.43" }
+zebra-node-services = { path = "../zebra-node-services", version = "1.0.0-beta.43", features = ["rpc-client"] }
+zebra-rpc = { path = "../zebra-rpc", version = "1.0.0-beta.43" }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.43" }
 
 # Required for crates.io publishing, but it's only used in tests
-zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.42", optional = true }
+zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.43", optional = true }
 
 abscissa_core = "0.7.0"
 clap = { version = "4.5.20", features = ["cargo"] }
@@ -279,13 +279,13 @@ proptest-derive = "0.5.0"
 # enable span traces and track caller in tests
 color-eyre = { version = "0.6.3" }
 
-zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.42", features = ["proptest-impl"] }
-zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.42", features = ["proptest-impl"] }
-zebra-network = { path = "../zebra-network", version = "1.0.0-beta.42", features = ["proptest-impl"] }
-zebra-state = { path = "../zebra-state", version = "1.0.0-beta.42", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "1.0.0-beta.43", features = ["proptest-impl"] }
+zebra-consensus = { path = "../zebra-consensus", version = "1.0.0-beta.43", features = ["proptest-impl"] }
+zebra-network = { path = "../zebra-network", version = "1.0.0-beta.43", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", version = "1.0.0-beta.43", features = ["proptest-impl"] }
 
-zebra-test = { path = "../zebra-test", version = "1.0.0-beta.42" }
-zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.9" }
+zebra-test = { path = "../zebra-test", version = "1.0.0-beta.43" }
+zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.10" }
 
 # Used by the checkpoint generation tests via the zebra-checkpoints feature
 # (the binaries in this crate won't be built unless their features are enabled).
@@ -296,7 +296,7 @@ zebra-grpc = { path = "../zebra-grpc", version = "0.1.0-alpha.9" }
 # When `-Z bindeps` is stabilised, enable this binary dependency instead:
 # https://github.com/rust-lang/cargo/issues/9096
 # zebra-utils { path = "../zebra-utils", artifact = "bin:zebra-checkpoints" }
-zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.42" }
+zebra-utils = { path = "../zebra-utils", version = "1.0.0-beta.43" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_699_000;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_742_000;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.


### PR DESCRIPTION
Part of https://github.com/ZcashFoundation/zebra/issues/8997.

# Prepare for the Release

- [x] Make sure there has been [at least one successful full sync test in the main branch](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-tests.yml?query=branch%3Amain) since the last state change, or start a manual full sync.
- [x] Make sure the PRs with the new checkpoint hashes and missed dependencies are already merged.
      (See the release ticket checklist for details)

# Summarise Release Changes

These steps can be done a few days before the release, in the same PR:

## Change Log

**Important**: Any merge into `main` deletes any edits to the draft changelog.
Once you are ready to tag a release, copy the draft changelog into `CHANGELOG.md`.

We use [the Release Drafter workflow](https://github.com/marketplace/actions/release-drafter) to automatically create a [draft changelog](https://github.com/ZcashFoundation/zebra/releases). We follow the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.

To create the final change log:
- [x] Copy the **latest** draft changelog into `CHANGELOG.md` (there can be multiple draft releases)
- [x] Delete any trivial changes
    - [x] Put the list of deleted changelog entries in a PR comment to make reviewing easier
- [x] Combine duplicate changes
- [x] Edit change descriptions so they will make sense to Zebra users
- [x] Check the category for each change
  - Prefer the "Fix" category if you're not sure

## README

README updates can be skipped for urgent releases.

Update the README to:
- [x] Remove any "Known Issues" that have been fixed since the last release.
- [x] Update the "Build and Run Instructions" with any new dependencies.
      Check for changes in the `Dockerfile` since the last tag: `git diff <previous-release-tag> docker/Dockerfile`.
- [x] If Zebra has started using newer Rust language features or standard library APIs, update the known working Rust version in the README, book, and `Cargo.toml`s

You can use a command like:
```sh
fastmod --fixed-strings '1.58' '1.65'
```

## Create the Release PR

- [x] Push the updated changelog and README into a new branch
      for example: `bump-v1.0.0` - this needs to be different to the tag name
- [x] Create a release PR by adding `&template=release-checklist.md` to the comparing url ([Example](https://github.com/ZcashFoundation/zebra/compare/bump-v1.0.0?expand=1&template=release-checklist.md)).
- [x] Freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [x] Mark all the release PRs as `Critical` priority, so they go in the `urgent` Mergify queue.
- [x] Mark all non-release PRs with `do-not-merge`, because Mergify checks approved PRs against every commit, even when a queue is frozen.
- [x] Add the `A-release` tag to the release pull request in order for the `check_no_git_refs_in_cargo_lock` to run.

## Zebra git sources dependencies

- [x] Ensure the `check_no_git_refs_in_cargo_lock` check passes.

This check runs automatically on pull requests with the `A-release` label. It must pass for crates to be published to crates.io. If the check fails, you should either halt the release process or proceed with the understanding that the crates will not be published on crates.io.

# Update Versions and End of Support

## Update Zebra Version

### Choose a Release Level

Zebra follows [semantic versioning](https://semver.org). Semantic versions look like: MAJOR.MINOR.PATCH[-TAG.PRE-RELEASE]

Choose a release level for `zebrad`. Release levels are based on user-visible changes from the changelog:
- Mainnet Network Upgrades are `major` releases
- significant new features or behaviour changes; changes to RPCs, command-line, or configs; and deprecations or removals are `minor` releases
- otherwise, it is a `patch` release

Zebra's Rust API doesn't have any support or stability guarantees, so we keep all the `zebra-*` and `tower-*` crates on a beta `pre-release` version.

### Update Crate Versions

If you're publishing crates for the first time, [log in to crates.io](https://zebra.zfnd.org/dev/crate-owners.html#logging-in-to-cratesio),
and make sure you're a member of owners group.

Check that the release will work:
- [x] Update crate versions, commit the changes to the release branch, and do a release dry-run:

```sh
# Update everything except for alpha crates and zebrad:
cargo release version --verbose --execute --allow-branch '*' --workspace --exclude zebrad --exclude zebra-scan --exclude zebra-grpc beta
# Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
cargo release version --verbose --execute --allow-branch '*' --package zebra-scan 0.1.0-alpha.4
cargo release version --verbose --execute --allow-branch '*' --package zebra-grpc 0.1.0-alpha.2
# Update zebrad:
cargo release version --verbose --execute --allow-branch '*' --package zebrad patch # [ major | minor | patch ]
# Continue with the release process:
cargo release replace --verbose --execute --allow-branch '*' --package zebrad
cargo release commit --verbose --execute --allow-branch '*'
```

Crate publishing is [automatically checked in CI](https://github.com/ZcashFoundation/zebra/actions/workflows/release-crates-io.yml) using "dry run" mode, however due to a bug in `cargo-release` we need to pass exact versions to the alpha crates:

- [x] Update `zebra-scan` and `zebra-grpc` alpha crates in the [release-crates-dry-run workflow script](https://github.com/ZcashFoundation/zebra/blob/main/.github/workflows/scripts/release-crates-dry-run.sh)
- [x] Push the above version changes to the release branch.

## Update End of Support

The end of support height is calculated from the current blockchain height:
- [x] Find where the Zcash blockchain tip is now by using a [Zcash Block Explorer](https://mainnet.zcashexplorer.app/) or other tool.
- [x] Replace `ESTIMATED_RELEASE_HEIGHT` in [`end_of_support.rs`](https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/sync/end_of_support.rs) with the height you estimate the release will be tagged.

<details>

<summary>Optional: calculate the release tagging height</summary>

- Add `1152` blocks for each day until the release
- For example, if the release is in 3 days, add `1152 * 3` to the current Mainnet block height

</details>

## Update the Release PR

- [x] Push the version increments and the release constants to the release branch.

# Publish the Zebra Release

## Create the GitHub Pre-Release

- [x] Wait for all the release PRs to be merged
- [x] Create a new release using the draft release as a base, by clicking the Edit icon in the [draft release](https://github.com/ZcashFoundation/zebra/releases)
- [x] Set the tag name to the version tag,
      for example: `v1.0.0`
- [x] Set the release to target the `main` branch
- [x] Set the release title to `Zebra ` followed by the version tag,
      for example: `Zebra 1.0.0`
- [x] Replace the prepopulated draft changelog in the release description with the final changelog you created;
      starting just _after_ the title `## [Zebra ...` of the current version being released,
      and ending just _before_ the title of the previous release.
- [x] Mark the release as 'pre-release', until it has been built and tested
- [x] Publish the pre-release to GitHub using "Publish Release"
- [x] Delete all the [draft releases from the list of releases](https://github.com/ZcashFoundation/zebra/releases)

## Test the Pre-Release

- [x] Wait until the Docker binaries have been built on `main`, and the quick tests have passed:
    - [x] [ci-tests.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-tests.yml?query=branch%3Amain)
- [x] Wait until the [pre-release deployment machines have successfully launched](https://github.com/ZcashFoundation/zebra/actions/workflows/cd-deploy-nodes-gcp.yml?query=event%3Arelease)

## Publish Release

- [x] [Publish the release to GitHub](https://github.com/ZcashFoundation/zebra/releases) by disabling 'pre-release', then clicking "Set as the latest release"

## Publish Crates

- [x] [Run `cargo login`](https://zebra.zfnd.org/dev/crate-owners.html#logging-in-to-cratesio)
- [x] Run `cargo clean` in the zebra repo (optional)
- [x] Publish the crates to crates.io: `cargo release publish --verbose --workspace --execute`
- [x] Check that Zebra can be installed from `crates.io`:
      `cargo install --locked --force --version 1.minor.patch zebrad && ~/.cargo/bin/zebrad`
      and put the output in a comment on the PR.

## Publish Docker Images

- [x] Wait for the [the Docker images to be published successfully](https://github.com/ZcashFoundation/zebra/actions/workflows/release-binaries.yml?query=event%3Arelease).
- [x] Wait for the new tag in the [dockerhub zebra space](https://hub.docker.com/r/zfnd/zebra/tags)
- [x] Un-freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [x] Remove `do-not-merge` from the PRs you added it to

## Release Failures

If building or running fails after tagging:

<details>

<summary>Tag a new release, following these instructions...</summary>

1. Fix the bug that caused the failure
2. Start a new `patch` release
3. Skip the **Release Preparation**, and start at the **Release Changes** step
4. Update `CHANGELOG.md` with details about the fix
5. Follow the release checklist for the new Zebra version

</details>
