### PR TITLE
fix(workflows): update patch jobs conditions and naming

### DIFF
--- a/.github/workflows/cd-deploy-nodes-gcp.patch-external.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.patch-external.yml
@@ -7,15 +7,15 @@ name: Deploy Nodes to GCP
 on:
   pull_request:
 
-# IMPORTANT
-#
-# The job names in `cd-deploy-nodes-gcp.yml`, `cd-deploy-nodes-gcp.patch.yml` and
-# `cd-deploy-nodes-gcp.patch-external.yml` must be kept in sync.
+#! IMPORTANT
+#!
+#! The job names in `cd-deploy-nodes-gcp.yml`, `cd-deploy-nodes-gcp.patch.yml` and
+#! `cd-deploy-nodes-gcp.patch-external.yml` must be kept in sync.
 jobs:
   # We don't patch the testnet job, because testnet isn't required to merge (it's too unstable)
   get-disk-name:
-    name: Get disk name
-    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
+    name: Get disk name / Get Mainnet cached disk
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'
@@ -24,6 +24,7 @@ jobs:
     name: Build CD Docker / Build images
     # Only run on PRs from external repositories, skipping ZF branches and tags.
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
 
@@ -33,13 +34,15 @@ jobs:
     # change.
     needs: build
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
 
   test-configuration-file-testnet:
-    name: Test CD testnet Docker config file / Test default-conf in Docker
+    name: Test CD testnet Docker config file / Test testnet-conf in Docker
     needs: build
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
 
@@ -47,6 +50,6 @@ jobs:
     name: Test CD custom Docker config file / Test custom-conf in Docker
     needs: build
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
-

--- a/.github/workflows/cd-deploy-nodes-gcp.patch.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.patch.yml
@@ -22,39 +22,43 @@ on:
      - '.github/workflows/cd-deploy-nodes-gcp.yml'
      - '.github/workflows/sub-build-docker-image.yml'
 
-# IMPORTANT
-#
-# The job names in `cd-deploy-nodes-gcp.yml`, `cd-deploy-nodes-gcp.patch.yml` and
-# `cd-deploy-nodes-gcp.patch-external.yml` must be kept in sync.
+#! IMPORTANT
+#!
+#! The job names in `cd-deploy-nodes-gcp.yml`, `cd-deploy-nodes-gcp.patch.yml` and
+#! `cd-deploy-nodes-gcp.patch-external.yml` must be kept in sync.
 jobs:
   # We don't patch the testnet job, because testnet isn't required to merge (it's too unstable)
+  get-disk-name:
+    name: Get disk name / Get Mainnet cached disk
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+    steps:
+      - run: 'echo "No build required"'
+
   build:
     name: Build CD Docker / Build images
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'
 
   test-configuration-file:
     name: Test CD default Docker config file / Test default-conf in Docker
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'
 
   test-configuration-file-testnet:
-    name: Test CD testnet Docker config file / Test default-conf in Docker
+    name: Test CD testnet Docker config file / Test testnet-conf in Docker
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'
-
 
   test-zebra-conf-path:
     name: Test CD custom Docker config file / Test custom-conf in Docker
     runs-on: ubuntu-latest
-    steps:
-      - run: 'echo "No build required"'
-
-  get-disk-name:
-    name: Get disk name
-    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/ci-tests.patch-external.yml
+++ b/.github/workflows/ci-tests.patch-external.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     name: Build CI Docker / Build images
     # Only run on PRs from external repositories.
-    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Skipping job on fork"'
@@ -24,116 +24,134 @@ jobs:
   ## The following jobs are related to sub-ci-unit-tests-docker.yml
   ###
   test-all:
-    name: Test all
+    name: Unit tests / Test all
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
 
   test-fake-activation-heights:
-    name: Test with fake activation heights
+    name: Unit tests / Test with fake activation heights
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
 
   test-empty-sync:
-    name: Test checkpoint sync from empty state
+    name: Unit tests / Test checkpoint sync from empty state
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
 
   test-lightwalletd-integration:
-    name: Test integration with lightwalletd
+    name: Unit tests / Test integration with lightwalletd
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
 
   test-configuration-file:
-    name: Test CI default Docker config file / Test default-conf in Docker
+    name: Unit tests / Test CI default Docker config file / Test default-conf in Docker
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
 
   test-configuration-file-testnet:
-    name: Test CI testnet Docker config file / Test default-conf in Docker
+    name: Unit tests / Test CI testnet Docker config file / Test testnet-conf in Docker
     needs: build
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
 
   test-zebra-conf-path:
-    name: Test CI custom Docker config file / Test custom-conf in Docker
+    name: Unit tests / Test CI custom Docker config file / Test custom-conf in Docker
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
 
-
+  ####
   ####
   ## The following jobs are related to sub-ci-integration-tests-gcp.yml
   ###
 
   # We don't patch the testnet job, because testnet isn't required to merge (it's too unstable)
   get-available-disks:
-    name: Check if cached state disks exist for Mainnet / Check if cached state disks exist
+    name: Integration tests / Check if cached state disks exist for Mainnet / Get Mainnet cached disk
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
 
   test-stateful-sync:
-    name: Zebra checkpoint update / Run sync-past-checkpoint test
+    name: Integration tests / Zebra checkpoint update / Run sync-past-checkpoint test
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
 
   test-update-sync:
-    name: Zebra tip update / Run update-to-tip test
+    name: Integration tests / Zebra tip update / Run update-to-tip test
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
 
   checkpoints-mainnet:
-    name: Generate checkpoints mainnet / Run checkpoints-mainnet test
+    name: Integration tests / Generate checkpoints mainnet / Run checkpoints-mainnet test
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
 
   lightwalletd-rpc-test:
-    name: Zebra tip JSON-RPC / Run fully-synced-rpc test
+    name: Integration tests / Zebra tip JSON-RPC / Run fully-synced-rpc test
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
 
   lightwalletd-transactions-test:
-    name: lightwalletd tip send / Run lwd-send-transactions test
+    name: Integration tests / lightwalletd tip send / Run lwd-send-transactions test
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
 
   get-block-template-test:
-    name: get block template / Run get-block-template test
+    name: Integration tests / get block template / Run get-block-template test
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
 
   submit-block-test:
-    name: submit block / Run submit-block test
+    name: Integration tests / submit block / Run submit-block test
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
 
   lightwalletd-full-sync:
-    name: lightwalletd tip / Run lwd-full-sync test
+    name: Integration tests / lightwalletd tip / Run lwd-full-sync test
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
 
   lightwalletd-update-sync:
-    name: lightwalletd tip update / Run lwd-update-sync test
+    name: Integration tests / lightwalletd tip update / Run lwd-update-sync test
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
 
   lightwalletd-grpc-test:
-    name: lightwalletd GRPC tests / Run lwd-grpc-wallet test
+    name: Integration tests / lightwalletd GRPC tests / Run lwd-grpc-wallet test
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'

--- a/.github/workflows/ci-tests.patch.yml
+++ b/.github/workflows/ci-tests.patch.yml
@@ -43,45 +43,52 @@ jobs:
   ## The following jobs are related to sub-ci-unit-tests-docker.yml
   ###
   test-all:
-    name: Test all
+    name: Unit tests / Test all
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'
 
   test-fake-activation-heights:
-    name: Test with fake activation heights
+    name: Unit tests / Test with fake activation heights
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'
 
   test-empty-sync:
-    name: Test checkpoint sync from empty state
+    name: Unit tests / Test checkpoint sync from empty state
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'
 
   test-lightwalletd-integration:
-    name: Test integration with lightwalletd
+    name: Unit tests / Test integration with lightwalletd
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'
 
   test-configuration-file:
-    name: Test CI default Docker config file / Test default-conf in Docker
+    name: Unit tests / Test CI default Docker config file / Test default-conf in Docker
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'
 
-  test-configuration-file-testnet:
-    name: Test CI testnet Docker config file / Test default-conf in Docker
+  test-configuration-file-testnet:  
+    name: Unit tests / Test CI testnet Docker config file / Test testnet-conf in Docker
     needs: build
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'
 
   test-zebra-conf-path:
-    name: Test CI custom Docker config file / Test custom-conf in Docker
+    name: Unit tests / Test CI custom Docker config file / Test custom-conf in Docker
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'
 
@@ -92,67 +99,78 @@ jobs:
 
   # We don't patch the testnet job, because testnet isn't required to merge (it's too unstable)
   get-available-disks:
-    name: Check if cached state disks exist for Mainnet / Check if cached state disks exist
+    name: Integration tests / Check if cached state disks exist for Mainnet / Get Mainnet cached disk
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'
 
   test-stateful-sync:
-    name: Zebra checkpoint update / Run sync-past-checkpoint test
+    name: Integration tests / Zebra checkpoint update / Run sync-past-checkpoint test
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'
 
   test-update-sync:
-    name: Zebra tip update / Run update-to-tip test
+    name: Integration tests / Zebra tip update / Run update-to-tip test
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'
 
   checkpoints-mainnet:
-    name: Generate checkpoints mainnet / Run checkpoints-mainnet test
+    name: Integration tests / Generate checkpoints mainnet / Run checkpoints-mainnet test
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'
 
   lightwalletd-rpc-test:
-    name: Zebra tip JSON-RPC / Run fully-synced-rpc test
+    name: Integration tests / Zebra tip JSON-RPC / Run fully-synced-rpc test
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'
 
   lightwalletd-transactions-test:
-    name: lightwalletd tip send / Run lwd-send-transactions test
+    name: Integration tests / lightwalletd tip send / Run lwd-send-transactions test
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'
 
   get-block-template-test:
-    name: get block template / Run get-block-template test
+    name: Integration tests / get block template / Run get-block-template test
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'
 
   submit-block-test:
-    name: submit block / Run submit-block test
+    name:  Integration tests / submit block / Run submit-block test
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'
 
   lightwalletd-full-sync:
-    name: lightwalletd tip / Run lwd-full-sync test
+    name: Integration tests / lightwalletd tip / Run lwd-full-sync test
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'
 
   lightwalletd-update-sync:
-    name: lightwalletd tip update / Run lwd-update-sync test
+    name: Integration tests / lightwalletd tip update / Run lwd-update-sync test
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'
 
   lightwalletd-grpc-test:
-    name: lightwalletd GRPC tests / Run lwd-grpc-wallet test
+    name: Integration tests / lightwalletd GRPC tests / Run lwd-grpc-wallet test
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'

--- a/.github/workflows/docs-deploy-firebase.patch-external.yml
+++ b/.github/workflows/docs-deploy-firebase.patch-external.yml
@@ -7,16 +7,15 @@ name: Docs
 on:
   pull_request:
 
-# IMPORTANT
-#
-# The job names in `docs-deploy-firebase.yml`, `docs-deploy-firebase.patch.yml` and
-# `docs-deploy-firebase.patch-external.yml` must be kept in sync.
+#! IMPORTANT
+#!
+#! The job names in `docs-deploy-firebase.yml`, `docs-deploy-firebase.patch.yml` and
+#! `docs-deploy-firebase.patch-external.yml` must be kept in sync.
 jobs:
   build-docs-book:
     name: Build and Deploy Zebra Book Docs
-    # Only run on PRs from external repositories.
-    if: ${{ startsWith(github.event_name, 'pull') && github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
 
@@ -26,5 +25,6 @@ jobs:
     # change.
     needs: build-docs-book
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'

--- a/.github/workflows/docs-deploy-firebase.patch.yml
+++ b/.github/workflows/docs-deploy-firebase.patch.yml
@@ -21,19 +21,21 @@ on:
       # workflow definitions
       - '.github/workflows/docs-deploy-firebase.yml'
 
-# IMPORTANT
-#
-# The job names in `docs-deploy-firebase.yml`, `docs-deploy-firebase.patch.yml` and
-# `docs-deploy-firebase.patch-external.yml` must be kept in sync.
+#! IMPORTANT
+#!
+#! The job names in `docs-deploy-firebase.yml`, `docs-deploy-firebase.patch.yml` and
+#! `docs-deploy-firebase.patch-external.yml` must be kept in sync.
 jobs:
   build-docs-book:
     name: Build and Deploy Zebra Book Docs
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'
 
   build-docs-internal:
     name: Build and Deploy Zebra Internal Docs
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'


### PR DESCRIPTION
## Motivation

Some PRs get stuck as we had to update our required workflows configuration after refactoring mergify. GitHub rulesets now recommends using the whole workflow name path, for example: `Unit tests / Test CI default Docker config file / Test default-conf in Docker` based on the names of the jobs chain generated by the reusable workflows.

Fixes #9108

### Specifications & References

- Rulesets: https://github.com/ZcashFoundation/zebra/settings/rules/746379

## Solution

- Modified job conditions in multiple workflow files to ensure they only run for pull requests from external repositories.
- Updated job names for clarity and consistency across `cd-deploy-nodes-gcp`, `ci-tests`, and `docs-deploy-firebase` workflows, and to sync them with our rulesets
- Enhanced comments to emphasize the importance of synchronizing job names across related workflow files.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [X] The PR name will make sense to users.
- [X] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [X] The documentation is up to date.
- [X] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

