### PR TITLE
fix(consensus): Avoid a concurrency bug when verifying transactions in blocks that are already present in the mempool

### DIFF
--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -699,7 +699,7 @@ where
                 .oneshot(zebra_state::Request::AwaitUtxo(*missing_outpoint));
             match query.await {
                 Ok(zebra_state::Response::Utxo(_)) => {}
-                Err(err) => return Some(Err(err.into())),
+                Err(_) => return Some(Err(TransactionError::TransparentInputNotFound)),
                 _ => unreachable!("AwaitUtxo always responds with Utxo"),
             };
         }
@@ -750,7 +750,10 @@ where
                         .clone()
                         .oneshot(zs::Request::UnspentBestChainUtxo(*outpoint));
 
-                    let zebra_state::Response::UnspentBestChainUtxo(utxo) = query.await? else {
+                    let zebra_state::Response::UnspentBestChainUtxo(utxo) = query
+                        .await
+                        .map_err(|_| TransactionError::TransparentInputNotFound)?
+                    else {
                         unreachable!("UnspentBestChainUtxo always responds with Option<Utxo>")
                     };
 

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -685,6 +685,10 @@ where
             .filter(|dependency_id| !known_outpoint_hashes.contains(dependency_id))
             .collect();
 
+        if missing_deps.is_empty() {
+            return Some(Ok(verified_tx));
+        }
+
         let missing_outpoints = tx.inputs().iter().filter_map(|input| {
             if let transparent::Input::PrevOut { outpoint, .. } = input {
                 missing_deps.contains(&outpoint.hash).then_some(outpoint)

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -402,7 +402,7 @@ where
         async move {
             tracing::trace!(?tx_id, ?req, "got tx verify request");
 
-            if let Some(result) = Self::try_find_verified_unmined_tx(&req, mempool.clone()).await {
+            if let Some(result) = Self::find_verified_unmined_tx(&req, mempool.clone(), state.clone()).await {
                 let verified_tx = result?;
 
                 return Ok(Response::Block {
@@ -645,15 +645,18 @@ where
     }
 
     /// Attempts to find a transaction in the mempool by its transaction hash and checks
-    /// that all of its dependencies are available in the block.
+    /// that all of its dependencies are available in the block or in the state.  Waits
+    /// for UTXOs being spent by the given transaction to arrive in the state if they're
+    /// not found elsewhere.
     ///
     /// Returns [`Some(Ok(VerifiedUnminedTx))`](VerifiedUnminedTx) if successful,
     /// None if the transaction id was not found in the mempool,
     /// or `Some(Err(TransparentInputNotFound))` if the transaction was found, but some of its
     /// dependencies are missing in the block.
-    async fn try_find_verified_unmined_tx(
+    async fn find_verified_unmined_tx(
         req: &Request,
         mempool: Option<Timeout<Mempool>>,
+        state: Timeout<ZS>,
     ) -> Option<Result<VerifiedUnminedTx, TransactionError>> {
         if req.is_mempool() || req.transaction().is_coinbase() {
             return None;
@@ -662,9 +665,10 @@ where
         let mempool = mempool?;
         let known_outpoint_hashes = req.known_outpoint_hashes();
         let tx_id = req.tx_mined_id();
+        let tx = req.transaction();
 
         let mempool::Response::TransactionWithDeps {
-            transaction,
+            transaction: verified_tx,
             dependencies,
         } = mempool
             .oneshot(mempool::Request::TransactionWithDepsByMinedId(tx_id))
@@ -676,17 +680,31 @@ where
 
         // Note: This does not verify that the spends are in order, the spend order
         //       should be verified during contextual validation in zebra-state.
-        let has_all_tx_deps = dependencies
+        let missing_deps: HashSet<_> = dependencies
             .into_iter()
-            .all(|dependency_id| known_outpoint_hashes.contains(&dependency_id));
+            .filter(|dependency_id| !known_outpoint_hashes.contains(dependency_id))
+            .collect();
 
-        let result = if has_all_tx_deps {
-            Ok(transaction)
-        } else {
-            Err(TransactionError::TransparentInputNotFound)
-        };
+        let missing_outpoints = tx.inputs().iter().filter_map(|input| {
+            if let transparent::Input::PrevOut { outpoint, .. } = input {
+                missing_deps.contains(&outpoint.hash).then_some(outpoint)
+            } else {
+                None
+            }
+        });
 
-        Some(result)
+        for missing_outpoint in missing_outpoints {
+            let query = state
+                .clone()
+                .oneshot(zebra_state::Request::AwaitUtxo(*missing_outpoint));
+            match query.await {
+                Ok(zebra_state::Response::Utxo(_)) => {}
+                Err(err) => return Some(Err(err.into())),
+                _ => unreachable!("AwaitUtxo always responds with Utxo"),
+            };
+        }
+
+        Some(Ok(verified_tx))
     }
 
     /// Wait for the UTXOs that are being spent by the given transaction.

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -652,20 +652,21 @@ where
     /// Returns [`Some(Ok(VerifiedUnminedTx))`](VerifiedUnminedTx) if successful,
     /// None if the transaction id was not found in the mempool,
     /// or `Some(Err(TransparentInputNotFound))` if the transaction was found, but some of its
-    /// dependencies are missing in the block.
+    /// dependencies were not found in the block or state after a timeout.
     async fn find_verified_unmined_tx(
         req: &Request,
         mempool: Option<Timeout<Mempool>>,
         state: Timeout<ZS>,
     ) -> Option<Result<VerifiedUnminedTx, TransactionError>> {
-        if req.is_mempool() || req.transaction().is_coinbase() {
+        let tx = req.transaction();
+
+        if req.is_mempool() || tx.is_coinbase() {
             return None;
         }
 
         let mempool = mempool?;
         let known_outpoint_hashes = req.known_outpoint_hashes();
         let tx_id = req.tx_mined_id();
-        let tx = req.transaction();
 
         let mempool::Response::TransactionWithDeps {
             transaction: verified_tx,

--- a/zebra-node-services/src/mempool/transaction_dependencies.rs
+++ b/zebra-node-services/src/mempool/transaction_dependencies.rs
@@ -11,6 +11,13 @@ pub struct TransactionDependencies {
     /// a mempool transaction. Used during block template construction
     /// to exclude transactions from block templates unless all of the
     /// transactions they depend on have been included.
+    ///
+    /// # Note
+    ///
+    /// Dependencies that have been mined into blocks are not removed here until those blocks have
+    /// been committed to the best chain. Dependencies that have been committed onto side chains, or
+    /// which are in the verification pipeline but have not yet been committed to the best chain,
+    /// are not removed here unless and until they arrive in the best chain, and the mempool is polled.
     dependencies: HashMap<transaction::Hash, HashSet<transaction::Hash>>,
 
     /// Lists of transaction ids in the mempool that spend UTXOs created

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -733,7 +733,8 @@ pub enum Request {
     ///
     /// This request is purely informational, and there are no guarantees about
     /// whether the UTXO remains unspent or is on the best chain, or any chain.
-    /// Its purpose is to allow asynchronous script verification.
+    /// Its purpose is to allow asynchronous script verification or to wait until
+    /// the UTXO arrives in the state before validating dependant transactions.
     ///
     /// # Correctness
     ///


### PR DESCRIPTION
## Motivation

This PR fixes a bug in `find_verified_unmined_tx()` where a `TransparentInputNotFound` is returned if a transaction's dependencies are missing from the block containing it. The mempool removes any transaction ids mined onto the best chain from its transaction dependencies, but it's possible for a transaction to depend on outputs that aren't in the same block or in the state, but elsewhere in the verification pipeline waiting to be contextually validated.

## Solution

Wait for the UTXOs to arrive in the state instead of returning an error when a transaction's dependencies in the mempool are unavailable in the block.

Related changes:
- Return `TransparentInputNotFound` errors from tx verifier instead of `InternalDowncastErrors` when `AwaitUtxo` requests timeout, and
- Rename `try_find_verified_unmined_tx` to `find_verified_unmined_tx`

### Tests

Updates the `skips_verification_of_block_transactions_in_mempool` test to check that the tx verifier falls back on waiting for UTXOs to arrive in the state service if a transaction's dependencies are missing from its block.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [ ] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

