### PR TITLE
change(consensus): Optimize checks for coinbase transactions

### DIFF
--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -83,6 +83,9 @@ pub enum TransactionError {
     #[error("non-coinbase transactions MUST NOT have coinbase inputs")]
     NonCoinbaseHasCoinbaseInput,
 
+    #[error("the tx is not coinbase, but it should be")]
+    NotCoinbase,
+
     #[error("transaction is locked until after block height {}", _0.0)]
     LockedUntilAfterBlockHeight(block::Height),
 

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -309,7 +309,7 @@ where
 /// # Consensus
 ///
 /// > [Heartwood onward] All Sapling and Orchard outputs in coinbase transactions MUST decrypt to a note
-/// > plaintext, i.e. the procedure in § 4.19.3 ‘Decryption using a Full Viewing Key ( Sapling and Orchard )’ on p. 67
+/// > plaintext, i.e. the procedure in § 4.20.3 ‘Decryption using a Full Viewing Key (Sapling and Orchard)’
 /// > does not return ⊥, using a sequence of 32 zero bytes as the outgoing viewing key. (This implies that before
 /// > Canopy activation, Sapling outputs of a coinbase transaction MUST have note plaintext lead byte equal to
 /// > 0x01.)


### PR DESCRIPTION
## Motivation

The original motivation was to address https://github.com/ZcashFoundation/zebra/pull/9098#discussion_r1911778505 and https://github.com/ZcashFoundation/zebra/pull/9098#discussion_r1913455598. Then I noticed that the [`coinbase_outputs_are_decryptable`](https://github.com/zcashfoundation/zebra/blob/050cdc39e89ae9ccf25bbf6f0598f386cb7307a7/zebra-consensus/src/transaction/check.rs#L328) fn currently [converts](https://github.com/zcashfoundation/zebra/blob/050cdc39e89ae9ccf25bbf6f0598f386cb7307a7/zebra-chain/src/primitives/zcash_primitives.rs#L181) each post-Heartwood coinbase tx to check if its shielded outputs are decryptable, even if the tx has no shielded outputs. This conversion involves a serialization and deserialization cycle. We can skip this conversion for txs with no shielded outputs.

## Solution

- Return early if the tx has no shielded outputs.
- Return a new `Transaction::NotCoinbase` error if the tx is not coinbase but should be.
- Update docs.

### Tests

- Improve tests so they check more scenarios.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.