### PR TITLE
refactor(workflows): avoid using cached states for release instances

### DIFF
--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -53,9 +53,9 @@ on:
         description: 'Prefer cached state from the main branch'
         required: false
         type: boolean
-      no_cached_disk:
-        default: false
-        description: 'Do not use a cached state disk'
+      need_cached_disk:
+        default: true
+        description: 'Use a cached state disk'
         required: false
         type: boolean
       no_cache:
@@ -153,7 +153,7 @@ jobs:
     uses: ./.github/workflows/sub-find-cached-disks.yml
     # Skip PRs from external repositories, let them pass, and then GitHub's Merge Queue will check them.
     # This workflow also runs on release tags, the event name check will run it on releases.
-    if: ${{ (!startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork) && !inputs.no_cached_disk }}
+    if: ${{ inputs.need_cached_disk && github.event_name != 'release' && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
     with:
       network: ${{ inputs.network || vars.ZCASH_NETWORK }}
       disk_prefix: zebrad-cache
@@ -279,11 +279,15 @@ jobs:
 
       - name: Create instance template for ${{ matrix.network }}
         run: |
-          DISK_NAME="zebrad-cache-${{ env.GITHUB_HEAD_REF_SLUG_URL || env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-${NETWORK}"
+          if [ "${{ github.event_name }}" == "release" ]; then
+            DISK_NAME="zebrad-cache-${NETWORK}"
+          else
+            DISK_NAME="zebrad-cache-${{ env.GITHUB_HEAD_REF_SLUG_URL || env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-${NETWORK}"
+          fi
           DISK_PARAMS="name=${DISK_NAME},device-name=${DISK_NAME},size=400GB,type=pd-balanced"
           if [ -n "${{ env.CACHED_DISK_NAME }}" ]; then
             DISK_PARAMS+=",image=${{ env.CACHED_DISK_NAME }}"
-          elif [ ${{ inputs.no_cached_disk && github.event_name == 'workflow_dispatch' }} ]; then
+          elif [ ${{ !inputs.need_cached_disk && github.event_name == 'workflow_dispatch' }} ]; then
            echo "No cached disk required"
           else
             echo "No cached disk found for ${{ matrix.network }} in main branch"
@@ -395,7 +399,7 @@ jobs:
           DISK_PARAMS="name=${DISK_NAME},device-name=${DISK_NAME},size=400GB,type=pd-balanced"
           if [ -n "${{ env.CACHED_DISK_NAME }}" ]; then
             DISK_PARAMS+=",image=${{ env.CACHED_DISK_NAME }}"
-          elif [ ${{ inputs.no_cached_disk && github.event_name == 'workflow_dispatch' }} ]; then
+          elif [ ${{ !inputs.need_cached_disk && github.event_name == 'workflow_dispatch' }} ]; then
            echo "No cached disk required"
           else
             echo "No cached disk found for ${{ matrix.network }} in main branch"

--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -384,11 +384,6 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    # We want to create main branch images for both dev and prod environments
-    strategy:
-      matrix:
-        environment: ${{ github.ref_name == 'main' && fromJSON('["dev", "prod"]') }}
-    environment: ${{ matrix.environment }}
     steps:
       - uses: actions/checkout@v4.2.2
         with:


### PR DESCRIPTION
## Motivation

We don't need the complexity of cached states in our long-lived instances, as we'll be using the same state across releases (this will also test the upgrades will work as expected).

This will also fix an regression in our main branch, caused by #9003

## Solution

- Renamed `no_cached_disk` input to `need_cached_disk` in `cd-deploy-nodes-gcp.yml` to clarify its purpose.
- Adjusted conditional logic for cached disk usage based on event types (release vs. non-release) in `cd-deploy-nodes-gcp.yml`.
- Removed the environment strategy matrix from `sub-deploy-integration-tests-gcp.yml` to avoid creating cached states in another environments
### Follow-up Work

- Do frequent backups to our release nodes states (bi-daily, weekly, etc) as decided.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [X] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [X] The documentation is up to date.
- [X] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

