### PR TITLE
Respond to getblockchaininfo with genesis block when empty state

### DIFF
--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -22,17 +22,10 @@ use tracing::Instrument;
 
 use zcash_primitives::consensus::Parameters;
 use zebra_chain::{
-    block::{self, Height, SerializedBlock},
-    chain_tip::{ChainTip, NetworkChainTipHeightEstimator},
-    parameters::{ConsensusBranchId, Network, NetworkUpgrade},
-    serialization::{ZcashDeserialize, ZcashSerialize},
-    subtree::NoteCommitmentSubtreeIndex,
-    transaction::{self, SerializedTransaction, Transaction, UnminedTx},
-    transparent::{self, Address},
-    work::{
+    block::{self, Height, SerializedBlock}, chain_tip::{ChainTip, NetworkChainTipHeightEstimator}, parameters::{ConsensusBranchId, Network, NetworkUpgrade}, serialization::{ZcashDeserialize, ZcashSerialize}, subtree::NoteCommitmentSubtreeIndex, transaction::{self, SerializedTransaction, Transaction, UnminedTx}, transparent::{self, Address}, value_balance::ValueBalance, work::{
         difficulty::{CompactDifficulty, ExpandedDifficulty},
         equihash::Solution,
-    },
+    }
 };
 use zebra_node_services::mempool;
 use zebra_state::{HashOrHeight, OutputIndex, OutputLocation, TransactionLocation};
@@ -546,38 +539,40 @@ where
         let network = self.network.clone();
         let debug_force_finished_sync = self.debug_force_finished_sync;
         let mut state = self.state.clone();
-
+        
         // `chain` field
         let chain = network.bip70_network_name();
 
-        let request = zebra_state::ReadRequest::TipPoolValues;
-        let response: zebra_state::ReadResponse = state
-            .ready()
-            .and_then(|service| service.call(request))
-            .await
-            .map_misc_error()?;
-
-        let zebra_state::ReadResponse::TipPoolValues {
-            tip_height,
-            tip_hash,
-            value_balance,
-        } = response
-        else {
-            unreachable!("unmatched response to a TipPoolValues request")
+        let (tip_height, tip_hash, tip_block_time, value_balance) = match state.ready().and_then(|service| service.call(zebra_state::ReadRequest::TipPoolValues)).await {
+            Ok(zebra_state::ReadResponse::TipPoolValues { tip_height, tip_hash, value_balance }) => {
+                let request = zebra_state::ReadRequest::BlockHeader(tip_hash.into());
+                let response: zebra_state::ReadResponse = state
+                    .ready()
+                    .and_then(|service| service.call(request))
+                    .await
+                    .map_misc_error()?;
+                
+                if let zebra_state::ReadResponse::BlockHeader { header, .. } = response {
+                   (tip_height, tip_hash, header.time, value_balance)
+                } else {
+                    unreachable!("unmatched response to a BlockHeader request")
+                }
+            }
+            _ => {
+                let request = zebra_state::ReadRequest::BlockHeader(HashOrHeight::Height(block::Height(0)));
+                let response: zebra_state::ReadResponse = state
+                    .ready()
+                    .and_then(|service| service.call(request))
+                    .await
+                    .map_misc_error()?;
+                
+                if let zebra_state::ReadResponse::BlockHeader { header, hash, height, .. } = response {
+                   (height, hash, header.time, ValueBalance::zero())
+                } else {
+                    unreachable!("unmatched response to a BlockHeader request")
+                }
+            }
         };
-
-        let request = zebra_state::ReadRequest::BlockHeader(tip_hash.into());
-        let response: zebra_state::ReadResponse = state
-            .ready()
-            .and_then(|service| service.call(request))
-            .await
-            .map_misc_error()?;
-
-        let zebra_state::ReadResponse::BlockHeader { header, .. } = response else {
-            unreachable!("unmatched response to a BlockHeader request")
-        };
-
-        let tip_block_time = header.time;
 
         let now = Utc::now();
         let zebra_estimated_height =

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -18,7 +18,8 @@ use zebra_chain::{
     serialization::{DateTime32, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize},
     transaction::{self, Transaction, UnminedTx, VerifiedUnminedTx},
     transparent,
-    value_balance::ValueBalance, work::equihash::Solution,
+    value_balance::ValueBalance,
+    work::equihash::Solution,
 };
 use zebra_node_services::mempool;
 use zebra_state::{BoxError, HashOrHeight};
@@ -590,7 +591,7 @@ proptest! {
 
             mempool.expect_no_requests().await?;
             state.expect_no_requests().await?;
-            
+
             // The queue task should continue without errors or panics
             prop_assert!(mempool_tx_queue.now_or_never().is_none());
 

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -12,14 +12,13 @@ use tower::buffer::Buffer;
 
 use zebra_chain::{
     amount::{Amount, NonNegative},
-    block::{self, Block, Header, Height},
+    block::{self, Block, Height},
     chain_tip::{mock::MockChainTip, ChainTip, NoChainTip},
     parameters::{ConsensusBranchId, Network, NetworkUpgrade},
-    serialization::{DateTime32, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize},
+    serialization::{ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize},
     transaction::{self, Transaction, UnminedTx, VerifiedUnminedTx},
     transparent,
     value_balance::ValueBalance,
-    work::equihash::Solution,
 };
 use zebra_node_services::mempool;
 use zebra_state::{BoxError, HashOrHeight};
@@ -503,22 +502,21 @@ proptest! {
         let _guard = runtime.enter();
         let (mut mempool, mut state, rpc, mempool_tx_queue) = mock_services(network.clone(), NoChainTip);
 
+        // CORRECTNESS: Nothing in this test depends on real time, so we can speed it up.
+        tokio::time::pause();
 
         let genesis_block = match network {
             Network::Mainnet => {
-                let block_bytes = zebra_test::vectors::CONTINUOUS_MAINNET_BLOCKS[&0];
+                let block_bytes = &zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES;
                 let block: Arc<Block> = block_bytes.zcash_deserialize_into().expect("block is valid");
                 block
             },
             Network::Testnet(_) => {
-                let block_bytes = zebra_test::vectors::CONTINUOUS_TESTNET_BLOCKS[&0];
+                let block_bytes = &zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES;
                 let block: Arc<Block> = block_bytes.zcash_deserialize_into().expect("block is valid");
                 block
             },
         };
-
-        // CORRECTNESS: Nothing in this test depends on real time, so we can speed it up.
-        tokio::time::pause();
 
         // Genesis block fields
         let block_time = genesis_block.header.time;


### PR DESCRIPTION
## Motivation

<!--
- Describe the goals of the PR.
- If it closes any issues, list them here.
-->
A lightwalletd test fails for getblockchaininfo when the state is empty. This PR refactors the rpc request to return the genesis block.

### Specifications & References

<!--
- Provide references related to the PR.
-->

## Solution

<!--
- Summarize or list the changes in the PR.
-->
Adds a test for returning the genesis state in prop.rs. Refactors getblockchaininfo rpc to return the genesis block if TipPoolValues request fails.

### Tests

<!--
- Describe how the solution in this PR is tested:
  - Describe any manual or automated tests.
  - If the solution can't be tested, explain why.
-->


### Follow-up Work

<!--
- Describe or list what's missing from the solution.
- List any follow-up issues.
- If this PR blocks or is blocked by any other work, provide a description, or
  list the related issues.
-->

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [X] The PR name will make sense to users.
- [X] The PR provides a CHANGELOG summary.
- [X] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

