### PR TITLE
fix(rpc): Use `jsonrpsee` in `zebra-node-services`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5896,6 +5896,7 @@ version = "1.0.0-beta.44"
 dependencies = [
  "color-eyre",
  "jsonrpc-core",
+ "jsonrpsee-types",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,21 +2150,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpc-core"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
-dependencies = [
- "futures",
- "futures-executor",
- "futures-util",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
 name = "jsonrpsee"
 version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5895,7 +5880,6 @@ name = "zebra-node-services"
 version = "1.0.0-beta.44"
 dependencies = [
  "color-eyre",
- "jsonrpc-core",
  "jsonrpsee-types",
  "reqwest",
  "serde",

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -56,3 +56,4 @@ color-eyre = "0.6.3"
 reqwest = { version = "0.12.9", default-features = false, features = ["rustls-tls"] }
 serde = "1.0.215"
 serde_json = "1.0.133"
+jsonrpsee-types = "0.24.7"

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -28,7 +28,7 @@ getblocktemplate-rpcs = [
 
 rpc-client = [
     "color-eyre",
-    "jsonrpc-core",
+    "jsonrpsee-types",
     "reqwest",
     "serde",
     "serde_json",
@@ -43,7 +43,7 @@ zebra-chain = { path = "../zebra-chain" , version = "1.0.0-beta.44" }
 
 # Tool and test feature rpc-client
 color-eyre = { version = "0.6.3", optional = true }
-jsonrpc-core = { version = "18.0.0", optional = true }
+jsonrpsee-types = { version = "0.24.7", optional = true }
 # Security: avoid default dependency on openssl
 reqwest = { version = "0.12.9", default-features = false, features = ["rustls-tls"], optional = true }
 serde = { version = "1.0.215", optional = true }

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -53,7 +53,6 @@ tokio = { version = "1.42.0", features = ["time", "sync"] }
 [dev-dependencies]
 
 color-eyre = "0.6.3"
-jsonrpc-core = "18.0.0"
 reqwest = { version = "0.12.9", default-features = false, features = ["rustls-tls"] }
 serde = "1.0.215"
 serde_json = "1.0.133"

--- a/zebra-node-services/src/rpc_client.rs
+++ b/zebra-node-services/src/rpc_client.rs
@@ -108,12 +108,13 @@ impl RpcRequestClient {
     fn json_result_from_response_text<T: serde::de::DeserializeOwned>(
         response_text: &str,
     ) -> std::result::Result<T, BoxError> {
-        use jsonrpc_core::Output;
-
-        let output: Output = serde_json::from_str(response_text)?;
-        match output {
-            Output::Success(success) => Ok(serde_json::from_value(success.result)?),
-            Output::Failure(failure) => Err(failure.error.into()),
+        let output: jsonrpsee_types::Response<serde_json::Value> =
+            serde_json::from_str(response_text)?;
+        match output.payload {
+            jsonrpsee_types::ResponsePayload::Success(success) => {
+                Ok(serde_json::from_value(success.into_owned())?)
+            }
+            jsonrpsee_types::ResponsePayload::Error(failure) => Err(failure.to_string().into()),
         }
     }
 }

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -64,9 +64,7 @@ jsonrpsee-types = "0.24.7"
 jsonrpsee-proc-macros = "0.24.7"
 hyper = "1.5.0"
 http-body-util = "0.1.2"
-
-# zebra-rpc needs the preserve_order feature in serde_json, which is a dependency of jsonrpc-core
-serde_json = { version = "1.0.133", features = ["preserve_order"] }
+serde_json = "1.0.133"
 indexmap = { version = "2.7.0", features = ["serde"] }
 
 # RPC endpoint basic auth


### PR DESCRIPTION
## Motivation

In https://github.com/ZcashFoundation/zebra/pull/9059 we replaced `jsonrpc-*` crates in the `zebra-rpc` module. However there is still a small use case of the deprecated library in the `zebra-node-services` crate that we will want to upgrade too.

## Solution

- Upgrade `zebra-nodes-services` to use `jsonrpsee-types` instead.
- Make other small cleanps.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [ ] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

