### PR TITLE
Add invalidate block method and invalidated_blocks field to NonFinalizedState

### DIFF
--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -1,9 +1,10 @@
 //! State [`tower::Service`] request types.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     ops::{Deref, DerefMut, RangeInclusive},
     sync::Arc,
+    time::SystemTime,
 };
 
 use zebra_chain::{
@@ -232,6 +233,18 @@ pub struct ContextuallyVerifiedBlock {
 
     /// The sum of the chain value pool changes of all transactions in this block.
     pub(crate) chain_value_pool_change: ValueBalance<NegativeAllowed>,
+}
+
+/// Data related to an invalidated block including the [`ContextuallyVerifiedBlock`] and
+/// descendants.
+#[derive(Clone, Debug)]
+pub struct InvalidatedBlockData {
+    /// The block that was invalidated.
+    pub block: ContextuallyVerifiedBlock,
+    /// All descendant blocks that were also removed in order by [`block::Height`].
+    pub descendants: BTreeMap<block::Height, ContextuallyVerifiedBlock>,
+    /// Timestamp in which the block was invalidated.
+    pub timestamp: SystemTime,
 }
 
 /// Wraps note commitment trees and the history tree together.

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -1,10 +1,9 @@
 //! State [`tower::Service`] request types.
 
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     ops::{Deref, DerefMut, RangeInclusive},
     sync::Arc,
-    time::SystemTime,
 };
 
 use zebra_chain::{
@@ -233,18 +232,6 @@ pub struct ContextuallyVerifiedBlock {
 
     /// The sum of the chain value pool changes of all transactions in this block.
     pub(crate) chain_value_pool_change: ValueBalance<NegativeAllowed>,
-}
-
-/// Data related to an invalidated block including the [`ContextuallyVerifiedBlock`] and
-/// descendants.
-#[derive(Clone, Debug)]
-pub struct InvalidatedBlockData {
-    /// The block that was invalidated.
-    pub block: ContextuallyVerifiedBlock,
-    /// All descendant blocks that were also removed in order by [`block::Height`].
-    pub descendants: BTreeMap<block::Height, ContextuallyVerifiedBlock>,
-    /// Timestamp in which the block was invalidated.
-    pub timestamp: SystemTime,
 }
 
 /// Wraps note commitment trees and the history tree together.

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -307,10 +307,10 @@ impl NonFinalizedState {
             self.insert_with(Arc::new(new_chain.clone()), |chain_set| {
                 chain_set.retain(|c| !c.contains_block_hash(block_hash))
             });
-
-            self.update_metrics_for_chains();
-            self.update_metrics_bars();
         }
+            
+        self.update_metrics_for_chains();
+        self.update_metrics_bars();
     }
 
     /// Commit block to the non-finalized state as a new chain where its parent

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -1565,7 +1565,7 @@ impl DerefMut for Chain {
 
 /// The revert position being performed on a chain.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-enum RevertPosition {
+pub(crate) enum RevertPosition {
     /// The chain root is being reverted via [`Chain::pop_root`], when a block
     /// is finalized.
     Root,
@@ -1584,7 +1584,7 @@ enum RevertPosition {
 /// and [`Chain::pop_tip`] functions, and fear that it would be easy to
 /// introduce bugs when updating them, unless the code was reorganized to keep
 /// related operations adjacent to each other.
-trait UpdateWith<T> {
+pub(crate) trait UpdateWith<T> {
     /// When `T` is added to the chain tip,
     /// update [`Chain`] cumulative data members to add data that are derived from `T`.
     fn update_chain_tip_with(&mut self, _: &T) -> Result<(), ValidateContextError>;

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -343,6 +343,20 @@ impl Chain {
         (block, treestate)
     }
 
+    pub fn invalidate_block_and_descendants(
+        &mut self,
+        height: &block::Height,
+    ) -> Vec<ContextuallyVerifiedBlock> {
+        // Split the new chain at the the `block_hash` and invalidate the block with the
+        // block_hash along with the block's descendants
+        let invalidated_blocks = self.blocks.split_off(height);
+        for (_, ctx_block) in invalidated_blocks.iter().rev() {
+            self.revert_chain_with(ctx_block, RevertPosition::Tip);
+        }
+
+        invalidated_blocks.into_values().collect()
+    }
+
     /// Returns the height of the chain root.
     pub fn non_finalized_root_height(&self) -> block::Height {
         self.blocks

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -272,18 +272,23 @@ fn invalidate_block_removes_block_and_descendants_from_chain_for_network(
         "invalidated blocks map should reference the hash of block2"
     );
 
-    let invalidated_blocks_state_descendants = &invalidated_blocks_state
-        .get(&block2.hash())
-        .unwrap()
-        .descendants;
+    let invalidated_blocks_state_descendants =
+        invalidated_blocks_state.get(&block2.hash()).unwrap();
+
     match network {
         Network::Mainnet => assert!(
-            invalidated_blocks_state_descendants.contains_key(&block::Height(653601)),
-            "invalidated blocks map should reference block3's height in descendants"
+            invalidated_blocks_state_descendants
+                .iter()
+                .find(|block| block.height == block::Height(653601))
+                .is_some(),
+            "invalidated descendants vec should contain block3"
         ),
         Network::Testnet(_parameters) => assert!(
-            invalidated_blocks_state_descendants.contains_key(&block::Height(584001)),
-            "invalidated blocks map should reference block3's height in descendants"
+            invalidated_blocks_state_descendants
+                .iter()
+                .find(|block| block.height == block::Height(584001))
+                .is_some(),
+            "invalidated descendants vec should contain block3"
         ),
     }
 

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use zebra_chain::{
     amount::NonNegative,
-    block::{Block, Height},
+    block::{self, Block, Height},
     history_tree::NonEmptyHistoryTree,
     parameters::{Network, NetworkUpgrade},
     serialization::ZcashDeserializeInto,
@@ -212,6 +212,91 @@ fn finalize_pops_from_best_chain_for_network(network: Network) -> Result<()> {
     assert_eq!(block2, finalized);
 
     assert!(state.best_chain().is_none());
+
+    Ok(())
+}
+
+fn invalidate_block_removes_block_and_descendants_from_chain_for_network(
+    network: Network,
+) -> Result<()> {
+    let block1: Arc<Block> = Arc::new(network.test_block(653599, 583999).unwrap());
+    let block2 = block1.make_fake_child().set_work(10);
+    let block3 = block2.make_fake_child().set_work(1);
+
+    let mut state = NonFinalizedState::new(&network);
+    let finalized_state = FinalizedState::new(
+        &Config::ephemeral(),
+        &network,
+        #[cfg(feature = "elasticsearch")]
+        false,
+    );
+
+    let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
+    finalized_state.set_finalized_value_pool(fake_value_pool);
+
+    state.commit_new_chain(block1.clone().prepare(), &finalized_state)?;
+    state.commit_block(block2.clone().prepare(), &finalized_state)?;
+    state.commit_block(block3.clone().prepare(), &finalized_state)?;
+
+    assert_eq!(
+        state
+            .best_chain()
+            .unwrap_or(&Arc::new(Chain::default()))
+            .blocks
+            .len(),
+        3
+    );
+
+    state.invalidate_block(block2.hash());
+
+    let post_invalidated_chain = state.best_chain().unwrap();
+
+    assert_eq!(post_invalidated_chain.blocks.len(), 1);
+    assert!(
+        post_invalidated_chain.contains_block_hash(block1.hash()),
+        "the new modified chain should contain block1"
+    );
+
+    assert!(
+        !post_invalidated_chain.contains_block_hash(block2.hash()),
+        "the new modified chain should not contain block2"
+    );
+    assert!(
+        !post_invalidated_chain.contains_block_hash(block3.hash()),
+        "the new modified chain should not contain block3"
+    );
+
+    let invalidated_blocks_state = &state.invalidated_blocks;
+    assert!(
+        invalidated_blocks_state.contains_key(&block2.hash()),
+        "invalidated blocks map should reference the hash of block2"
+    );
+
+    let invalidated_blocks_state_descendants = &invalidated_blocks_state
+        .get(&block2.hash())
+        .unwrap()
+        .descendants;
+    match network {
+        Network::Mainnet => assert!(
+            invalidated_blocks_state_descendants.contains_key(&block::Height(653601)),
+            "invalidated blocks map should reference block3's height in descendants"
+        ),
+        Network::Testnet(_parameters) => assert!(
+            invalidated_blocks_state_descendants.contains_key(&block::Height(584001)),
+            "invalidated blocks map should reference block3's height in descendants"
+        ),
+    }
+
+    Ok(())
+}
+
+#[test]
+fn invalidate_block_removes_block_and_descendants_from_chain() -> Result<()> {
+    let _init_guard = zebra_test::init();
+
+    for network in Network::iter() {
+        invalidate_block_removes_block_and_descendants_from_chain_for_network(network)?;
+    }
 
     Ok(())
 }

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -279,15 +279,13 @@ fn invalidate_block_removes_block_and_descendants_from_chain_for_network(
         Network::Mainnet => assert!(
             invalidated_blocks_state_descendants
                 .iter()
-                .find(|block| block.height == block::Height(653601))
-                .is_some(),
+                .any(|block| block.height == block::Height(653601)),
             "invalidated descendants vec should contain block3"
         ),
         Network::Testnet(_parameters) => assert!(
             invalidated_blocks_state_descendants
                 .iter()
-                .find(|block| block.height == block::Height(584001))
-                .is_some(),
+                .any(|block| block.height == block::Height(584001)),
             "invalidated descendants vec should contain block3"
         ),
     }


### PR DESCRIPTION
## Motivation

<!--
- Describe the goals of the PR.
- If it closes any issues, list them here.
-->

This PR implements a new method invalidate_block to invalidate a block based on the block::Hash along with the blocks descendants. This PR closes the following issue: #8840 , #8841 

### Specifications & References

<!--
- Provide references related to the PR.
-->
Reference: https://github.com/ZcashFoundation/zebra/issues/8634

## Solution

<!--
- Summarize or list the changes in the PR.
-->

- Adds invalidate_block method to NonFinalizedState
- Changes visibility to pub(crate) for UpdateWith / RevertPosition in chain.rs
- Adds test for invalidate_block in vectors.rs
- Adds new invalidated_blocks state to NonFinalizedState

### Tests

<!--
- Describe how the solution in this PR is tested:
  - Describe any manual or automated tests.
  - If the solution can't be tested, explain why.
-->

### Follow-up Work

<!--
- Describe or list what's missing from the solution.
- List any follow-up issues.
- If this PR blocks or is blocked by any other work, provide a description, or
  list the related issues.
-->

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [x] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [x] The PR Author's checklist is complete.
- [x] The PR resolves the issue.

