### PR TITLE
fix(mining): Advertise mined blocks

### DIFF
--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -469,7 +469,7 @@ where
         block_verifier_router: BlockVerifierRouter,
         sync_status: SyncStatus,
         address_book: AddressBook,
-        mined_block_sender: watch::Sender<(block::Hash, block::Height)>,
+        mined_block_sender: Option<watch::Sender<(block::Hash, block::Height)>>,
     ) -> Self {
         // Prevent loss of miner funds due to an unsupported or incorrect address type.
         if let Some(miner_address) = mining_config.miner_address.clone() {
@@ -532,7 +532,7 @@ where
             block_verifier_router,
             sync_status,
             address_book,
-            mined_block_sender,
+            mined_block_sender: mined_block_sender.unwrap_or_default(),
         }
     }
 }

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -532,7 +532,8 @@ where
             block_verifier_router,
             sync_status,
             address_book,
-            mined_block_sender: mined_block_sender.unwrap_or_default(),
+            mined_block_sender: mined_block_sender
+                .unwrap_or(submit_block::SubmitBlockChannel::default().sender()),
         }
     }
 }

--- a/zebra-rpc/src/methods/get_block_template_rpcs/get_block_template.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/get_block_template.rs
@@ -161,10 +161,7 @@ where
     Tip: ChainTip + Clone + Send + Sync + 'static,
     SyncStatus: ChainSyncStatus + Clone + Send + Sync + 'static,
 {
-    // TODO:
-    // - Add a `disable_peers` field to `Network` to check instead of `disable_pow()` (#8361)
-    // - Check the field in `sync_status` so it applies to the mempool as well.
-    if network.disable_pow() {
+    if network.is_a_test_network() {
         return Ok(());
     }
 

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/submit_block.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/submit_block.rs
@@ -94,3 +94,9 @@ impl SubmitBlockChannel {
         self.receiver.clone()
     }
 }
+
+impl Default for SubmitBlockChannel {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/submit_block.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/submit_block.rs
@@ -1,5 +1,9 @@
 //! Parameter and response types for the `submitblock` RPC.
 
+use tokio::sync::watch;
+
+use zebra_chain::{block, parameters::GENESIS_PREVIOUS_BLOCK_HASH};
+
 // Allow doc links to these imports.
 #[allow(unused_imports)]
 use crate::methods::get_block_template_rpcs::GetBlockTemplate;
@@ -62,5 +66,31 @@ impl Default for Response {
 impl From<ErrorResponse> for Response {
     fn from(error_response: ErrorResponse) -> Self {
         Self::ErrorResponse(error_response)
+    }
+}
+
+/// A submit block channel, used to inform the gossip task about mined blocks.
+pub struct SubmitBlockChannel {
+    /// The channel sender
+    sender: watch::Sender<(block::Hash, block::Height)>,
+    /// The channel receiver
+    receiver: watch::Receiver<(block::Hash, block::Height)>,
+}
+
+impl SubmitBlockChannel {
+    /// Create a new submit block channel
+    pub fn new() -> Self {
+        let (sender, receiver) = watch::channel((GENESIS_PREVIOUS_BLOCK_HASH, block::Height::MIN));
+        Self { sender, receiver }
+    }
+
+    /// Get the channel sender
+    pub fn sender(&self) -> watch::Sender<(block::Hash, block::Height)> {
+        self.sender.clone()
+    }
+
+    /// Get the channel receiver
+    pub fn receiver(&self) -> watch::Receiver<(block::Hash, block::Height)> {
+        self.receiver.clone()
     }
 }

--- a/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
@@ -151,7 +151,7 @@ pub async fn test_responses<State, ReadState>(
         block_verifier_router.clone(),
         mock_sync_status.clone(),
         mock_address_book,
-        submit_block::SubmitBlockChannel::default().sender(),
+        None,
     );
 
     if network.is_a_test_network() && !network.is_default_testnet() {
@@ -287,7 +287,7 @@ pub async fn test_responses<State, ReadState>(
         block_verifier_router,
         mock_sync_status.clone(),
         MockAddressBookPeers::default(),
-        submit_block::SubmitBlockChannel::default().sender(),
+        None,
     );
 
     // Basic variant (default mode and no extra features)
@@ -397,7 +397,7 @@ pub async fn test_responses<State, ReadState>(
         mock_block_verifier_router.clone(),
         mock_sync_status,
         MockAddressBookPeers::default(),
-        submit_block::SubmitBlockChannel::default().sender(),
+        None,
     );
 
     let get_block_template_fut = get_block_template_rpc_mock_state_verifier.get_block_template(

--- a/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
@@ -151,7 +151,7 @@ pub async fn test_responses<State, ReadState>(
         block_verifier_router.clone(),
         mock_sync_status.clone(),
         mock_address_book,
-        submit_block::SubmitBlockChannel::new().sender(),
+        submit_block::SubmitBlockChannel::default().sender(),
     );
 
     if network.is_a_test_network() && !network.is_default_testnet() {
@@ -287,7 +287,7 @@ pub async fn test_responses<State, ReadState>(
         block_verifier_router,
         mock_sync_status.clone(),
         MockAddressBookPeers::default(),
-        submit_block::SubmitBlockChannel::new().sender(),
+        submit_block::SubmitBlockChannel::default().sender(),
     );
 
     // Basic variant (default mode and no extra features)
@@ -397,7 +397,7 @@ pub async fn test_responses<State, ReadState>(
         mock_block_verifier_router.clone(),
         mock_sync_status,
         MockAddressBookPeers::default(),
-        submit_block::SubmitBlockChannel::new().sender(),
+        submit_block::SubmitBlockChannel::default().sender(),
     );
 
     let get_block_template_fut = get_block_template_rpc_mock_state_verifier.get_block_template(

--- a/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
@@ -151,6 +151,7 @@ pub async fn test_responses<State, ReadState>(
         block_verifier_router.clone(),
         mock_sync_status.clone(),
         mock_address_book,
+        submit_block::SubmitBlockChannel::new().sender(),
     );
 
     if network.is_a_test_network() && !network.is_default_testnet() {
@@ -286,6 +287,7 @@ pub async fn test_responses<State, ReadState>(
         block_verifier_router,
         mock_sync_status.clone(),
         MockAddressBookPeers::default(),
+        submit_block::SubmitBlockChannel::new().sender(),
     );
 
     // Basic variant (default mode and no extra features)
@@ -395,6 +397,7 @@ pub async fn test_responses<State, ReadState>(
         mock_block_verifier_router.clone(),
         mock_sync_status,
         MockAddressBookPeers::default(),
+        submit_block::SubmitBlockChannel::new().sender(),
     );
 
     let get_block_template_fut = get_block_template_rpc_mock_state_verifier.get_block_template(

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -6,19 +6,20 @@ use std::sync::Arc;
 use futures::FutureExt;
 use tower::buffer::Buffer;
 
-use zebra_chain::serialization::ZcashSerialize;
 use zebra_chain::{
     amount::Amount,
     block::Block,
     chain_tip::{mock::MockChainTip, NoChainTip},
     parameters::Network::*,
-    serialization::ZcashDeserializeInto,
+    serialization::{ZcashDeserializeInto, ZcashSerialize},
     transaction::UnminedTxId,
 };
 use zebra_node_services::BoxError;
 
 use zebra_state::{LatestChainTip, ReadStateService};
 use zebra_test::mock_service::MockService;
+
+use crate::methods::get_block_template_rpcs::types::submit_block::SubmitBlockChannel;
 
 use super::super::*;
 
@@ -1195,6 +1196,7 @@ async fn rpc_getblockcount() {
         block_verifier_router,
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
+        SubmitBlockChannel::new().sender(),
     );
 
     // Get the tip height using RPC method `get_block_count`
@@ -1244,6 +1246,7 @@ async fn rpc_getblockcount_empty_state() {
         block_verifier_router,
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
+        SubmitBlockChannel::new().sender(),
     );
 
     // Get the tip height using RPC method `get_block_count
@@ -1312,6 +1315,7 @@ async fn rpc_getpeerinfo() {
         block_verifier_router,
         MockSyncStatus::default(),
         mock_address_book,
+        SubmitBlockChannel::new().sender(),
     );
 
     // Call `get_peer_info`
@@ -1372,6 +1376,7 @@ async fn rpc_getblockhash() {
         tower::ServiceBuilder::new().service(block_verifier_router),
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
+        SubmitBlockChannel::new().sender(),
     );
 
     // Query the hashes using positive indexes
@@ -1428,6 +1433,7 @@ async fn rpc_getmininginfo() {
         MockService::build().for_unit_tests(),
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
+        SubmitBlockChannel::new().sender(),
     );
 
     get_block_template_rpc
@@ -1464,6 +1470,7 @@ async fn rpc_getnetworksolps() {
         MockService::build().for_unit_tests(),
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
+        SubmitBlockChannel::new().sender(),
     );
 
     let get_network_sol_ps_inputs = [
@@ -1595,6 +1602,7 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
         block_verifier_router,
         mock_sync_status.clone(),
         MockAddressBookPeers::default(),
+        SubmitBlockChannel::new().sender(),
     );
 
     // Fake the ChainInfo response
@@ -1870,6 +1878,7 @@ async fn rpc_submitblock_errors() {
         block_verifier_router,
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
+        SubmitBlockChannel::new().sender(),
     );
 
     // Try to submit pre-populated blocks and assert that it responds with duplicate.
@@ -1922,6 +1931,7 @@ async fn rpc_validateaddress() {
         MockService::build().for_unit_tests(),
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
+        SubmitBlockChannel::new().sender(),
     );
 
     let validate_address = get_block_template_rpc
@@ -1967,6 +1977,7 @@ async fn rpc_z_validateaddress() {
         MockService::build().for_unit_tests(),
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
+        SubmitBlockChannel::new().sender(),
     );
 
     let z_validate_address = get_block_template_rpc
@@ -2055,6 +2066,7 @@ async fn rpc_getdifficulty() {
         block_verifier_router,
         mock_sync_status.clone(),
         MockAddressBookPeers::default(),
+        SubmitBlockChannel::new().sender(),
     );
 
     // Fake the ChainInfo response: smallest numeric difficulty
@@ -2176,6 +2188,7 @@ async fn rpc_z_listunifiedreceivers() {
         MockService::build().for_unit_tests(),
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
+        SubmitBlockChannel::new().sender(),
     );
 
     // invalid address

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -19,8 +19,6 @@ use zebra_node_services::BoxError;
 use zebra_state::{LatestChainTip, ReadStateService};
 use zebra_test::mock_service::MockService;
 
-use crate::methods::get_block_template_rpcs::types::submit_block::SubmitBlockChannel;
-
 use super::super::*;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1196,7 +1194,7 @@ async fn rpc_getblockcount() {
         block_verifier_router,
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
-        SubmitBlockChannel::default().sender(),
+        None,
     );
 
     // Get the tip height using RPC method `get_block_count`
@@ -1246,7 +1244,7 @@ async fn rpc_getblockcount_empty_state() {
         block_verifier_router,
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
-        SubmitBlockChannel::default().sender(),
+        None,
     );
 
     // Get the tip height using RPC method `get_block_count
@@ -1315,7 +1313,7 @@ async fn rpc_getpeerinfo() {
         block_verifier_router,
         MockSyncStatus::default(),
         mock_address_book,
-        SubmitBlockChannel::default().sender(),
+        None,
     );
 
     // Call `get_peer_info`
@@ -1376,7 +1374,7 @@ async fn rpc_getblockhash() {
         tower::ServiceBuilder::new().service(block_verifier_router),
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
-        SubmitBlockChannel::default().sender(),
+        None,
     );
 
     // Query the hashes using positive indexes
@@ -1433,7 +1431,7 @@ async fn rpc_getmininginfo() {
         MockService::build().for_unit_tests(),
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
-        SubmitBlockChannel::default().sender(),
+        None,
     );
 
     get_block_template_rpc
@@ -1470,7 +1468,7 @@ async fn rpc_getnetworksolps() {
         MockService::build().for_unit_tests(),
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
-        SubmitBlockChannel::default().sender(),
+        None,
     );
 
     let get_network_sol_ps_inputs = [
@@ -1602,7 +1600,7 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
         block_verifier_router,
         mock_sync_status.clone(),
         MockAddressBookPeers::default(),
-        SubmitBlockChannel::default().sender(),
+        None,
     );
 
     // Fake the ChainInfo response
@@ -1878,7 +1876,7 @@ async fn rpc_submitblock_errors() {
         block_verifier_router,
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
-        SubmitBlockChannel::default().sender(),
+        None,
     );
 
     // Try to submit pre-populated blocks and assert that it responds with duplicate.
@@ -1931,7 +1929,7 @@ async fn rpc_validateaddress() {
         MockService::build().for_unit_tests(),
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
-        SubmitBlockChannel::default().sender(),
+        None,
     );
 
     let validate_address = get_block_template_rpc
@@ -1977,7 +1975,7 @@ async fn rpc_z_validateaddress() {
         MockService::build().for_unit_tests(),
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
-        SubmitBlockChannel::default().sender(),
+        None,
     );
 
     let z_validate_address = get_block_template_rpc
@@ -2066,7 +2064,7 @@ async fn rpc_getdifficulty() {
         block_verifier_router,
         mock_sync_status.clone(),
         MockAddressBookPeers::default(),
-        SubmitBlockChannel::default().sender(),
+        None,
     );
 
     // Fake the ChainInfo response: smallest numeric difficulty
@@ -2188,7 +2186,7 @@ async fn rpc_z_listunifiedreceivers() {
         MockService::build().for_unit_tests(),
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
-        SubmitBlockChannel::default().sender(),
+        None,
     );
 
     // invalid address

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -1196,7 +1196,7 @@ async fn rpc_getblockcount() {
         block_verifier_router,
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
-        SubmitBlockChannel::new().sender(),
+        SubmitBlockChannel::default().sender(),
     );
 
     // Get the tip height using RPC method `get_block_count`
@@ -1246,7 +1246,7 @@ async fn rpc_getblockcount_empty_state() {
         block_verifier_router,
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
-        SubmitBlockChannel::new().sender(),
+        SubmitBlockChannel::default().sender(),
     );
 
     // Get the tip height using RPC method `get_block_count
@@ -1315,7 +1315,7 @@ async fn rpc_getpeerinfo() {
         block_verifier_router,
         MockSyncStatus::default(),
         mock_address_book,
-        SubmitBlockChannel::new().sender(),
+        SubmitBlockChannel::default().sender(),
     );
 
     // Call `get_peer_info`
@@ -1376,7 +1376,7 @@ async fn rpc_getblockhash() {
         tower::ServiceBuilder::new().service(block_verifier_router),
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
-        SubmitBlockChannel::new().sender(),
+        SubmitBlockChannel::default().sender(),
     );
 
     // Query the hashes using positive indexes
@@ -1433,7 +1433,7 @@ async fn rpc_getmininginfo() {
         MockService::build().for_unit_tests(),
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
-        SubmitBlockChannel::new().sender(),
+        SubmitBlockChannel::default().sender(),
     );
 
     get_block_template_rpc
@@ -1470,7 +1470,7 @@ async fn rpc_getnetworksolps() {
         MockService::build().for_unit_tests(),
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
-        SubmitBlockChannel::new().sender(),
+        SubmitBlockChannel::default().sender(),
     );
 
     let get_network_sol_ps_inputs = [
@@ -1602,7 +1602,7 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
         block_verifier_router,
         mock_sync_status.clone(),
         MockAddressBookPeers::default(),
-        SubmitBlockChannel::new().sender(),
+        SubmitBlockChannel::default().sender(),
     );
 
     // Fake the ChainInfo response
@@ -1878,7 +1878,7 @@ async fn rpc_submitblock_errors() {
         block_verifier_router,
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
-        SubmitBlockChannel::new().sender(),
+        SubmitBlockChannel::default().sender(),
     );
 
     // Try to submit pre-populated blocks and assert that it responds with duplicate.
@@ -1931,7 +1931,7 @@ async fn rpc_validateaddress() {
         MockService::build().for_unit_tests(),
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
-        SubmitBlockChannel::new().sender(),
+        SubmitBlockChannel::default().sender(),
     );
 
     let validate_address = get_block_template_rpc
@@ -1977,7 +1977,7 @@ async fn rpc_z_validateaddress() {
         MockService::build().for_unit_tests(),
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
-        SubmitBlockChannel::new().sender(),
+        SubmitBlockChannel::default().sender(),
     );
 
     let z_validate_address = get_block_template_rpc
@@ -2066,7 +2066,7 @@ async fn rpc_getdifficulty() {
         block_verifier_router,
         mock_sync_status.clone(),
         MockAddressBookPeers::default(),
-        SubmitBlockChannel::new().sender(),
+        SubmitBlockChannel::default().sender(),
     );
 
     // Fake the ChainInfo response: smallest numeric difficulty
@@ -2188,7 +2188,7 @@ async fn rpc_z_listunifiedreceivers() {
         MockService::build().for_unit_tests(),
         MockSyncStatus::default(),
         MockAddressBookPeers::default(),
-        SubmitBlockChannel::new().sender(),
+        SubmitBlockChannel::default().sender(),
     );
 
     // invalid address

--- a/zebra-rpc/src/server.rs
+++ b/zebra-rpc/src/server.rs
@@ -116,6 +116,7 @@ impl RpcServer {
         address_book: AddressBook,
         latest_chain_tip: Tip,
         network: Network,
+        #[cfg_attr(not(feature = "getblocktemplate-rpcs"), allow(unused_variables))]
         mined_block_sender: watch::Sender<(block::Hash, block::Height)>,
     ) -> Result<(ServerTask, JoinHandle<()>), tower::BoxError>
     where

--- a/zebra-rpc/src/server.rs
+++ b/zebra-rpc/src/server.rs
@@ -117,7 +117,7 @@ impl RpcServer {
         latest_chain_tip: Tip,
         network: Network,
         #[cfg_attr(not(feature = "getblocktemplate-rpcs"), allow(unused_variables))]
-        mined_block_sender: watch::Sender<(block::Hash, block::Height)>,
+        mined_block_sender: Option<watch::Sender<(block::Hash, block::Height)>>,
     ) -> Result<(ServerTask, JoinHandle<()>), tower::BoxError>
     where
         VersionString: ToString + Clone + Send + 'static,

--- a/zebra-rpc/src/server.rs
+++ b/zebra-rpc/src/server.rs
@@ -12,7 +12,7 @@ use std::{fmt, panic};
 use cookie::Cookie;
 use jsonrpsee::server::middleware::rpc::RpcServiceBuilder;
 use jsonrpsee::server::{Server, ServerHandle};
-use tokio::task::JoinHandle;
+use tokio::{sync::watch, task::JoinHandle};
 use tower::Service;
 use tracing::*;
 
@@ -116,6 +116,7 @@ impl RpcServer {
         address_book: AddressBook,
         latest_chain_tip: Tip,
         network: Network,
+        mined_block_sender: watch::Sender<(block::Hash, block::Height)>,
     ) -> Result<(ServerTask, JoinHandle<()>), tower::BoxError>
     where
         VersionString: ToString + Clone + Send + 'static,
@@ -166,6 +167,7 @@ impl RpcServer {
             block_verifier_router,
             sync_status,
             address_book,
+            mined_block_sender,
         );
 
         // Initialize the rpc methods with the zebra version

--- a/zebra-rpc/src/server/error.rs
+++ b/zebra-rpc/src/server/error.rs
@@ -69,6 +69,14 @@ pub(crate) trait MapError<T>: Sized {
     /// Maps errors to [`jsonrpsee_types::ErrorObjectOwned`] with a specific error code.
     fn map_error(self, code: impl Into<ErrorCode>) -> std::result::Result<T, ErrorObjectOwned>;
 
+    /// Maps errors to [`jsonrpsee_types::ErrorObjectOwned`] with a prefixed message and a specific error code.
+    #[cfg(feature = "getblocktemplate-rpcs")]
+    fn map_error_with_prefix(
+        self,
+        code: impl Into<ErrorCode>,
+        msg_prefix: impl ToString,
+    ) -> Result<T, ErrorObjectOwned>;
+
     /// Maps errors to [`jsonrpsee_types::ErrorObjectOwned`] with a [`LegacyCode::Misc`] error code.
     fn map_misc_error(self) -> std::result::Result<T, ErrorObjectOwned> {
         self.map_error(LegacyCode::Misc)
@@ -97,6 +105,21 @@ where
 {
     fn map_error(self, code: impl Into<ErrorCode>) -> Result<T, ErrorObjectOwned> {
         self.map_err(|error| ErrorObject::owned(code.into().code(), error.to_string(), None::<()>))
+    }
+
+    #[cfg(feature = "getblocktemplate-rpcs")]
+    fn map_error_with_prefix(
+        self,
+        code: impl Into<ErrorCode>,
+        msg_prefix: impl ToString,
+    ) -> Result<T, ErrorObjectOwned> {
+        self.map_err(|error| {
+            ErrorObject::owned(
+                code.into().code(),
+                format!("{}: {}", msg_prefix.to_string(), error.to_string()),
+                None::<()>,
+            )
+        })
     }
 }
 

--- a/zebra-rpc/src/server/tests/vectors.rs
+++ b/zebra-rpc/src/server/tests/vectors.rs
@@ -15,6 +15,8 @@ use zebra_node_services::BoxError;
 
 use zebra_test::mock_service::MockService;
 
+use crate::methods::get_block_template_rpcs::types::submit_block::SubmitBlockChannel;
+
 use super::super::*;
 
 /// Test that the JSON-RPC server spawns.
@@ -56,6 +58,7 @@ async fn rpc_server_spawn() {
         MockAddressBookPeers::default(),
         NoChainTip,
         Mainnet,
+        SubmitBlockChannel::new().sender(),
     );
 
     info!("spawned RPC server, checking services...");
@@ -115,6 +118,7 @@ async fn rpc_spawn_unallocated_port(do_shutdown: bool) {
         MockAddressBookPeers::default(),
         NoChainTip,
         Mainnet,
+        SubmitBlockChannel::new().sender(),
     )
     .await
     .expect("");
@@ -170,6 +174,7 @@ async fn rpc_server_spawn_port_conflict() {
         MockAddressBookPeers::default(),
         NoChainTip,
         Mainnet,
+        SubmitBlockChannel::new().sender(),
     )
     .await;
 
@@ -189,6 +194,7 @@ async fn rpc_server_spawn_port_conflict() {
         MockAddressBookPeers::default(),
         NoChainTip,
         Mainnet,
+        SubmitBlockChannel::new().sender(),
     )
     .await;
 

--- a/zebra-rpc/src/server/tests/vectors.rs
+++ b/zebra-rpc/src/server/tests/vectors.rs
@@ -15,8 +15,6 @@ use zebra_node_services::BoxError;
 
 use zebra_test::mock_service::MockService;
 
-use crate::methods::get_block_template_rpcs::types::submit_block::SubmitBlockChannel;
-
 use super::super::*;
 
 /// Test that the JSON-RPC server spawns.
@@ -58,7 +56,7 @@ async fn rpc_server_spawn() {
         MockAddressBookPeers::default(),
         NoChainTip,
         Mainnet,
-        SubmitBlockChannel::default().sender(),
+        None,
     );
 
     info!("spawned RPC server, checking services...");
@@ -118,7 +116,7 @@ async fn rpc_spawn_unallocated_port(do_shutdown: bool) {
         MockAddressBookPeers::default(),
         NoChainTip,
         Mainnet,
-        SubmitBlockChannel::default().sender(),
+        None,
     )
     .await
     .expect("");
@@ -174,7 +172,7 @@ async fn rpc_server_spawn_port_conflict() {
         MockAddressBookPeers::default(),
         NoChainTip,
         Mainnet,
-        SubmitBlockChannel::default().sender(),
+        None,
     )
     .await;
 
@@ -194,7 +192,7 @@ async fn rpc_server_spawn_port_conflict() {
         MockAddressBookPeers::default(),
         NoChainTip,
         Mainnet,
-        SubmitBlockChannel::default().sender(),
+        None,
     )
     .await;
 

--- a/zebra-rpc/src/server/tests/vectors.rs
+++ b/zebra-rpc/src/server/tests/vectors.rs
@@ -58,7 +58,7 @@ async fn rpc_server_spawn() {
         MockAddressBookPeers::default(),
         NoChainTip,
         Mainnet,
-        SubmitBlockChannel::new().sender(),
+        SubmitBlockChannel::default().sender(),
     );
 
     info!("spawned RPC server, checking services...");
@@ -118,7 +118,7 @@ async fn rpc_spawn_unallocated_port(do_shutdown: bool) {
         MockAddressBookPeers::default(),
         NoChainTip,
         Mainnet,
-        SubmitBlockChannel::new().sender(),
+        SubmitBlockChannel::default().sender(),
     )
     .await
     .expect("");
@@ -174,7 +174,7 @@ async fn rpc_server_spawn_port_conflict() {
         MockAddressBookPeers::default(),
         NoChainTip,
         Mainnet,
-        SubmitBlockChannel::new().sender(),
+        SubmitBlockChannel::default().sender(),
     )
     .await;
 
@@ -194,7 +194,7 @@ async fn rpc_server_spawn_port_conflict() {
         MockAddressBookPeers::default(),
         NoChainTip,
         Mainnet,
-        SubmitBlockChannel::new().sender(),
+        SubmitBlockChannel::default().sender(),
     )
     .await;
 

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -308,7 +308,6 @@ impl StartCmd {
                 chain_tip_change.clone(),
                 peer_set.clone(),
                 submit_block_channel.receiver(),
-                config.network.network.clone(),
             )
             .in_current_span(),
         );

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -24,6 +24,7 @@ use zebra_network::{
     AddressBook, InventoryResponse, Request, Response,
 };
 use zebra_node_services::mempool;
+use zebra_rpc::methods::get_block_template_rpcs::types::submit_block::SubmitBlockChannel;
 use zebra_state::{ChainTipChange, Config as StateConfig, CHAIN_TIP_UPDATE_WAIT_LIMIT};
 use zebra_test::mock_service::{MockService, PanicAssertion};
 
@@ -974,10 +975,13 @@ async fn setup(
     // Pretend we're close to tip
     SyncStatus::sync_close_to_tip(&mut recent_syncs);
 
+    let submitblock_channel = SubmitBlockChannel::new();
     let sync_gossip_task_handle = tokio::spawn(sync::gossip_best_tip_block_hashes(
         sync_status.clone(),
         chain_tip_change.clone(),
         peer_set.clone(),
+        submitblock_channel.receiver(),
+        network.clone(),
     ));
 
     let tx_gossip_task_handle = tokio::spawn(gossip_mempool_transaction_id(

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -24,6 +24,7 @@ use zebra_network::{
     AddressBook, InventoryResponse, Request, Response,
 };
 use zebra_node_services::mempool;
+#[cfg(feature = "getblocktemplate-rpcs")]
 use zebra_rpc::methods::get_block_template_rpcs::types::submit_block::SubmitBlockChannel;
 use zebra_state::{ChainTipChange, Config as StateConfig, CHAIN_TIP_UPDATE_WAIT_LIMIT};
 use zebra_test::mock_service::{MockService, PanicAssertion};
@@ -975,12 +976,16 @@ async fn setup(
     // Pretend we're close to tip
     SyncStatus::sync_close_to_tip(&mut recent_syncs);
 
+    #[cfg(feature = "getblocktemplate-rpcs")]
     let submitblock_channel = SubmitBlockChannel::new();
     let sync_gossip_task_handle = tokio::spawn(sync::gossip_best_tip_block_hashes(
         sync_status.clone(),
         chain_tip_change.clone(),
         peer_set.clone(),
-        submitblock_channel.receiver(),
+        #[cfg(feature = "getblocktemplate-rpcs")]
+        Some(submitblock_channel.receiver()),
+        #[cfg(not(feature = "getblocktemplate-rpcs"))]
+        None,
     ));
 
     let tx_gossip_task_handle = tokio::spawn(gossip_mempool_transaction_id(

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -981,7 +981,6 @@ async fn setup(
         chain_tip_change.clone(),
         peer_set.clone(),
         submitblock_channel.receiver(),
-        network.clone(),
     ));
 
     let tx_gossip_task_handle = tokio::spawn(gossip_mempool_transaction_id(

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -796,7 +796,7 @@ async fn setup(
 mod submitblock_test {
     use std::io;
     use std::sync::{Arc, Mutex};
-    use tracing::Level;
+    use tracing::{Instrument, Level};
     use tracing_subscriber::fmt;
 
     use super::*;
@@ -872,12 +872,15 @@ mod submitblock_test {
 
         // Start the block gossip task with a SubmitBlockChannel
         let submitblock_channel = SubmitBlockChannel::new();
-        let gossip_task_handle = tokio::spawn(sync::gossip_best_tip_block_hashes(
-            sync_status.clone(),
-            chain_tip_change,
-            peer_set.clone(),
-            Some(submitblock_channel.receiver()),
-        ));
+        let gossip_task_handle = tokio::spawn(
+            sync::gossip_best_tip_block_hashes(
+                sync_status.clone(),
+                chain_tip_change,
+                peer_set.clone(),
+                Some(submitblock_channel.receiver()),
+            )
+            .in_current_span(),
+        );
 
         // Send a block top the channel
         submitblock_channel

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -21,6 +21,7 @@ use zebra_network::{
     Config as NetworkConfig, InventoryResponse, PeerError, Request, Response, SharedPeerError,
 };
 use zebra_node_services::mempool;
+#[cfg(feature = "getblocktemplate-rpcs")]
 use zebra_rpc::methods::get_block_template_rpcs::types::submit_block::SubmitBlockChannel;
 use zebra_state::Config as StateConfig;
 use zebra_test::mock_service::{MockService, PanicAssertion};
@@ -29,7 +30,7 @@ use crate::{
     components::{
         inbound::{downloads::MAX_INBOUND_CONCURRENCY, Inbound, InboundSetupData},
         mempool::{gossip_mempool_transaction_id, Config as MempoolConfig, Mempool},
-        sync::{self, BlockGossipError, SyncStatus, PEER_GOSSIP_DELAY},
+        sync::{self, BlockGossipError, SyncStatus},
     },
     BoxError,
 };
@@ -726,13 +727,17 @@ async fn setup(
     // We can't expect or unwrap because the returned Result does not implement Debug
     assert!(r.is_ok(), "unexpected setup channel send failure");
 
+    #[cfg(feature = "getblocktemplate-rpcs")]
     let submitblock_channel = SubmitBlockChannel::new();
 
     let block_gossip_task_handle = tokio::spawn(sync::gossip_best_tip_block_hashes(
         sync_status.clone(),
         chain_tip_change,
         peer_set.clone(),
-        submitblock_channel.receiver(),
+        #[cfg(feature = "getblocktemplate-rpcs")]
+        Some(submitblock_channel.receiver()),
+        #[cfg(not(feature = "getblocktemplate-rpcs"))]
+        None,
     ));
 
     let tx_gossip_task_handle = tokio::spawn(gossip_mempool_transaction_id(
@@ -787,104 +792,111 @@ async fn setup(
     )
 }
 
-use std::io;
-use std::sync::{Arc, Mutex};
-use tracing::Level;
-use tracing_subscriber::fmt;
+#[cfg(feature = "getblocktemplate-rpcs")]
+mod submitblock_test {
+    use std::io;
+    use std::sync::{Arc, Mutex};
+    use tracing::Level;
+    use tracing_subscriber::fmt;
 
-// Custom in-memory writer to capture logs
-struct TestWriter(Arc<Mutex<Vec<u8>>>);
+    use super::*;
 
-impl io::Write for TestWriter {
-    #[allow(clippy::unwrap_in_result)]
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let mut logs = self.0.lock().unwrap();
-        logs.extend_from_slice(buf);
-        Ok(buf.len())
+    use crate::components::sync::PEER_GOSSIP_DELAY;
+
+    // Custom in-memory writer to capture logs
+    struct TestWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for TestWriter {
+        #[allow(clippy::unwrap_in_result)]
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            let mut logs = self.0.lock().unwrap();
+            logs.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
     }
 
-    fn flush(&mut self) -> io::Result<()> {
+    #[tokio::test]
+    async fn submitblock_channel() -> Result<(), crate::BoxError> {
+        let logs = Arc::new(Mutex::new(Vec::new()));
+        let log_sink = logs.clone();
+
+        // Set up a tracing subscriber with a custom writer
+        let subscriber = fmt()
+            .with_max_level(Level::INFO)
+            .with_writer(move || TestWriter(log_sink.clone())) // Write logs to an in-memory buffer
+            .finish();
+
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let (sync_status, _recent_syncs) = SyncStatus::new();
+
+        // State
+        let state_config = StateConfig::ephemeral();
+        let (_state_service, _read_only_state_service, latest_chain_tip, chain_tip_change) =
+            zebra_state::init(state_config, &Network::Mainnet, Height::MAX, 0);
+
+        let config_listen_addr = "127.0.0.1:0".parse().unwrap();
+
+        // Network
+        let network_config = NetworkConfig {
+            network: Network::Mainnet,
+            listen_addr: config_listen_addr,
+
+            // Stop Zebra making outbound connections
+            initial_mainnet_peers: IndexSet::new(),
+            initial_testnet_peers: IndexSet::new(),
+            cache_dir: CacheDir::disabled(),
+
+            ..NetworkConfig::default()
+        };
+
+        // Inbound
+        let (_setup_tx, setup_rx) = oneshot::channel();
+        let inbound_service = Inbound::new(MAX_INBOUND_CONCURRENCY, setup_rx);
+        let inbound_service = ServiceBuilder::new()
+            .load_shed()
+            .buffer(10)
+            .service(BoxService::new(inbound_service));
+
+        let (peer_set, _address_book) = zebra_network::init(
+            network_config,
+            inbound_service.clone(),
+            latest_chain_tip.clone(),
+            "Zebra user agent".to_string(),
+        )
+        .await;
+
+        // Start the block gossip task with a SubmitBlockChannel
+        let submitblock_channel = SubmitBlockChannel::new();
+        let gossip_task_handle = tokio::spawn(sync::gossip_best_tip_block_hashes(
+            sync_status.clone(),
+            chain_tip_change,
+            peer_set.clone(),
+            Some(submitblock_channel.receiver()),
+        ));
+
+        // Send a block top the channel
+        submitblock_channel
+            .sender()
+            .send((block::Hash([1; 32]), block::Height(1)))
+            .unwrap();
+
+        // Wait for the block gossip task to process the block
+        tokio::time::sleep(PEER_GOSSIP_DELAY).await;
+
+        // Check that the block was processed as a mnined block by the gossip task
+        let captured_logs = logs.lock().unwrap();
+        let log_output = String::from_utf8(captured_logs.clone()).unwrap();
+
+        assert!(log_output.contains("initializing block gossip task"));
+        assert!(log_output.contains("sending mined block broadcast"));
+
+        std::mem::drop(gossip_task_handle);
+
         Ok(())
     }
-}
-
-#[tokio::test]
-async fn submitblock_channel() -> Result<(), crate::BoxError> {
-    let logs = Arc::new(Mutex::new(Vec::new()));
-    let log_sink = logs.clone();
-
-    // Set up a tracing subscriber with a custom writer
-    let subscriber = fmt()
-        .with_max_level(Level::INFO)
-        .with_writer(move || TestWriter(log_sink.clone())) // Write logs to an in-memory buffer
-        .finish();
-
-    let _guard = tracing::subscriber::set_default(subscriber);
-
-    let (sync_status, _recent_syncs) = SyncStatus::new();
-
-    // State
-    let state_config = StateConfig::ephemeral();
-    let (_state_service, _read_only_state_service, latest_chain_tip, chain_tip_change) =
-        zebra_state::init(state_config, &Network::Mainnet, Height::MAX, 0);
-
-    let config_listen_addr = "127.0.0.1:0".parse().unwrap();
-
-    // Network
-    let network_config = NetworkConfig {
-        network: Network::Mainnet,
-        listen_addr: config_listen_addr,
-
-        // Stop Zebra making outbound connections
-        initial_mainnet_peers: IndexSet::new(),
-        initial_testnet_peers: IndexSet::new(),
-        cache_dir: CacheDir::disabled(),
-
-        ..NetworkConfig::default()
-    };
-
-    // Inbound
-    let (_setup_tx, setup_rx) = oneshot::channel();
-    let inbound_service = Inbound::new(MAX_INBOUND_CONCURRENCY, setup_rx);
-    let inbound_service = ServiceBuilder::new()
-        .load_shed()
-        .buffer(10)
-        .service(BoxService::new(inbound_service));
-
-    let (peer_set, _address_book) = zebra_network::init(
-        network_config,
-        inbound_service.clone(),
-        latest_chain_tip.clone(),
-        "Zebra user agent".to_string(),
-    )
-    .await;
-
-    // Start the block gossip task with a SubmitBlockChannel
-    let submitblock_channel = SubmitBlockChannel::new();
-    let gossip_task_handle = tokio::spawn(sync::gossip_best_tip_block_hashes(
-        sync_status.clone(),
-        chain_tip_change,
-        peer_set.clone(),
-        submitblock_channel.receiver(),
-    ));
-
-    // Send a block top the channel
-    submitblock_channel
-        .sender()
-        .send((block::Hash([1; 32]), block::Height(1)))
-        .unwrap();
-
-    // Wait for the block gossip task to process the block
-    tokio::time::sleep(PEER_GOSSIP_DELAY).await;
-
-    // Check that the block was processed as a mnined block by the gossip task
-    let captured_logs = logs.lock().unwrap();
-    let log_output = String::from_utf8(captured_logs.clone()).unwrap();
-
-    assert!(log_output.contains("initializing block gossip task"));
-    assert!(log_output.contains("sending mined block broadcast"));
-
-    std::mem::drop(gossip_task_handle);
-
-    Ok(())
 }

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -29,7 +29,7 @@ use crate::{
     components::{
         inbound::{downloads::MAX_INBOUND_CONCURRENCY, Inbound, InboundSetupData},
         mempool::{gossip_mempool_transaction_id, Config as MempoolConfig, Mempool},
-        sync::{self, BlockGossipError, SyncStatus},
+        sync::{self, BlockGossipError, SyncStatus, PEER_GOSSIP_DELAY},
     },
     BoxError,
 };
@@ -733,7 +733,6 @@ async fn setup(
         chain_tip_change,
         peer_set.clone(),
         submitblock_channel.receiver(),
-        network.clone(),
     ));
 
     let tx_gossip_task_handle = tokio::spawn(gossip_mempool_transaction_id(
@@ -786,4 +785,103 @@ async fn setup(
         // real open socket addresses
         listen_addr,
     )
+}
+
+use std::io;
+use std::sync::{Arc, Mutex};
+use tracing::Level;
+use tracing_subscriber::fmt;
+
+// Custom in-memory writer to capture logs
+struct TestWriter(Arc<Mutex<Vec<u8>>>);
+
+impl io::Write for TestWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut logs = self.0.lock().unwrap();
+        logs.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn submitblock_channel() -> Result<(), crate::BoxError> {
+    let logs = Arc::new(Mutex::new(Vec::new()));
+    let log_sink = logs.clone();
+
+    // Set up a tracing subscriber with a custom writer
+    let subscriber = fmt()
+        .with_max_level(Level::INFO)
+        .with_writer(move || TestWriter(log_sink.clone())) // Write logs to an in-memory buffer
+        .finish();
+
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let (sync_status, _recent_syncs) = SyncStatus::new();
+
+    // State
+    let state_config = StateConfig::ephemeral();
+    let (_state_service, _read_only_state_service, latest_chain_tip, chain_tip_change) =
+        zebra_state::init(state_config, &Network::Mainnet, Height::MAX, 0);
+
+    let config_listen_addr = "127.0.0.1:0".parse().unwrap();
+
+    // Network
+    let network_config = NetworkConfig {
+        network: Network::Mainnet,
+        listen_addr: config_listen_addr,
+
+        // Stop Zebra making outbound connections
+        initial_mainnet_peers: IndexSet::new(),
+        initial_testnet_peers: IndexSet::new(),
+        cache_dir: CacheDir::disabled(),
+
+        ..NetworkConfig::default()
+    };
+
+    // Inbound
+    let (_setup_tx, setup_rx) = oneshot::channel();
+    let inbound_service = Inbound::new(MAX_INBOUND_CONCURRENCY, setup_rx);
+    let inbound_service = ServiceBuilder::new()
+        .load_shed()
+        .buffer(10)
+        .service(BoxService::new(inbound_service));
+
+    let (peer_set, _address_book) = zebra_network::init(
+        network_config,
+        inbound_service.clone(),
+        latest_chain_tip.clone(),
+        "Zebra user agent".to_string(),
+    )
+    .await;
+
+    // Start the block gossip task with a SubmitBlockChannel
+    let submitblock_channel = SubmitBlockChannel::new();
+    let _ = tokio::spawn(sync::gossip_best_tip_block_hashes(
+        sync_status.clone(),
+        chain_tip_change,
+        peer_set.clone(),
+        submitblock_channel.receiver(),
+    ));
+
+    // Send a block top the channel
+    submitblock_channel
+        .sender()
+        .send((block::Hash([1; 32]), block::Height(1)))
+        .unwrap();
+
+    // Wait for the block gossip task to process the block
+    tokio::time::sleep(PEER_GOSSIP_DELAY).await;
+
+    // Check that the block was processed as a mnined block by the gossip task
+    let captured_logs = logs.lock().unwrap();
+    let log_output = String::from_utf8(captured_logs.clone()).unwrap();
+
+    assert!(log_output.contains("initializing block gossip task"));
+    assert!(log_output.contains("sending mined block broadcast"));
+
+    Ok(())
 }

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -21,6 +21,7 @@ use zebra_network::{
     Config as NetworkConfig, InventoryResponse, PeerError, Request, Response, SharedPeerError,
 };
 use zebra_node_services::mempool;
+use zebra_rpc::methods::get_block_template_rpcs::types::submit_block::SubmitBlockChannel;
 use zebra_state::Config as StateConfig;
 use zebra_test::mock_service::{MockService, PanicAssertion};
 
@@ -725,10 +726,14 @@ async fn setup(
     // We can't expect or unwrap because the returned Result does not implement Debug
     assert!(r.is_ok(), "unexpected setup channel send failure");
 
+    let submitblock_channel = SubmitBlockChannel::new();
+
     let block_gossip_task_handle = tokio::spawn(sync::gossip_best_tip_block_hashes(
         sync_status.clone(),
         chain_tip_change,
         peer_set.clone(),
+        submitblock_channel.receiver(),
+        network.clone(),
     ));
 
     let tx_gossip_task_handle = tokio::spawn(gossip_mempool_transaction_id(

--- a/zebrad/src/components/sync/gossip.rs
+++ b/zebrad/src/components/sync/gossip.rs
@@ -2,11 +2,13 @@
 //!
 //! [`block::Hash`]: zebra_chain::block::Hash
 
+use futures::TryFutureExt;
 use thiserror::Error;
 use tokio::sync::watch;
 use tower::{timeout::Timeout, Service, ServiceExt};
+use tracing::Instrument;
 
-use zebra_chain::{block, chain_sync_status::ChainSyncStatus};
+use zebra_chain::block;
 use zebra_network as zn;
 use zebra_state::ChainTipChange;
 
@@ -44,10 +46,10 @@ pub enum BlockGossipError {
 ///
 /// [`block::Hash`]: zebra_chain::block::Hash
 pub async fn gossip_best_tip_block_hashes<ZN>(
-    mut sync_status: SyncStatus,
+    sync_status: SyncStatus,
     mut chain_state: ChainTipChange,
     broadcast_network: ZN,
-    mut receiver: Option<watch::Receiver<(block::Hash, block::Height)>>,
+    mut mined_block_receiver: Option<watch::Receiver<(block::Hash, block::Height)>>,
 ) -> Result<(), BlockGossipError>
 where
     ZN: Service<zn::Request, Response = zn::Response, Error = BoxError> + Send + Clone + 'static,
@@ -60,50 +62,56 @@ where
     let mut broadcast_network = Timeout::new(broadcast_network, TIPS_RESPONSE_TIMEOUT);
 
     loop {
-        // build a request if the sync status is close to the tip, or if we receive a block in the submitblock channel.
-        let request = if sync_status.is_close_to_tip() {
+        let mut sync_status = sync_status.clone();
+        let mut chain_tip = chain_state.clone();
+        let tip_change_close_to_network_tip_fut = async move {
             // wait for at least one tip change, to make sure we have a new block hash to broadcast
-            let tip_action = chain_state.wait_for_tip_change().await.map_err(TipChange)?;
+            let tip_action = chain_tip.wait_for_tip_change().await.map_err(TipChange)?;
 
             // wait until we're close to the tip, because broadcasts are only useful for nodes near the tip
-            // (if they're a long way from the tip, they use the syncer and block locators)
+            // (if they're a long way from the tip, they use the syncer and block locators), unless a mined block
+            // hash is received before `wait_until_close_to_tip()` is ready.
             sync_status
                 .wait_until_close_to_tip()
-                .await
-                .map_err(SyncStatus)?;
+                .map_err(SyncStatus)
+                .await?;
 
-            // get the latest tip change - it might be different to the change we awaited,
+            // get the latest tip change when close to tip - it might be different to the change we awaited,
             // because the syncer might take a long time to reach the tip
-            let tip_action = chain_state.last_tip_change().unwrap_or(tip_action);
+            let best_tip = chain_tip
+                .last_tip_change()
+                .unwrap_or(tip_action)
+                .best_tip_hash_and_height();
 
-            // block broadcasts inform other nodes about new blocks,
-            // so our internal Grow or Reset state doesn't matter to them
-            let request = zn::Request::AdvertiseBlock(tip_action.best_tip_hash());
+            Ok((best_tip, "sending committed block broadcast", chain_tip))
+        }
+        .in_current_span();
 
-            let height = tip_action.best_tip_height();
-            debug!(?height, ?request, "sending committed block broadcast");
-            request
-        } else if receiver.is_some()
-            && receiver
-                .clone()
-                .unwrap()
-                .has_changed()
-                .map_err(SyncStatus)?
+        let ((hash, height), log_msg, updated_chain_state) = if let Some(mined_block_receiver) =
+            mined_block_receiver.as_mut()
         {
-            // we have a new block to broadcast from the `submitblock `RPC method, get block data and release the channel.
-            let (hash, height) = *receiver.as_mut().unwrap().borrow_and_update();
+            tokio::select! {
+                tip_change_close_to_network_tip = tip_change_close_to_network_tip_fut => {
+                    mined_block_receiver.mark_unchanged();
+                    tip_change_close_to_network_tip?
+                },
 
-            // build a request with the obtained hash.
-            let request = zn::Request::AdvertiseBlock(hash);
-
-            info!(?height, ?request, "sending mined block broadcast");
-            request
+                Ok(_) = mined_block_receiver.changed() => {
+                    // we have a new block to broadcast from the `submitblock `RPC method, get block data and release the channel.
+                   (*mined_block_receiver.borrow_and_update(), "sending mined block broadcast", chain_state)
+                }
+            }
         } else {
-            // we don't have a new block to broadcast, so wait for a new one.
-            tokio::time::sleep(PEER_GOSSIP_DELAY).await;
-            continue;
+            tip_change_close_to_network_tip_fut.await?
         };
 
+        chain_state = updated_chain_state;
+
+        // block broadcasts inform other nodes about new blocks,
+        // so our internal Grow or Reset state doesn't matter to them
+        let request = zn::Request::AdvertiseBlock(hash);
+
+        info!(?height, ?request, log_msg);
         // broadcast requests don't return errors, and we'd just want to ignore them anyway
         let _ = broadcast_network
             .ready()

--- a/zebrad/src/components/sync/gossip.rs
+++ b/zebrad/src/components/sync/gossip.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 use tokio::sync::watch;
 use tower::{timeout::Timeout, Service, ServiceExt};
 
+use zebra_chain::{block, chain_sync_status::ChainSyncStatus, parameters::Network};
 use zebra_network as zn;
 use zebra_state::ChainTipChange;
 
@@ -43,9 +44,11 @@ pub enum BlockGossipError {
 ///
 /// [`block::Hash`]: zebra_chain::block::Hash
 pub async fn gossip_best_tip_block_hashes<ZN>(
-    mut sync_status: SyncStatus,
+    sync_status: SyncStatus,
     mut chain_state: ChainTipChange,
     broadcast_network: ZN,
+    mut receiver: watch::Receiver<(block::Hash, block::Height)>,
+    network: Network,
 ) -> Result<(), BlockGossipError>
 where
     ZN: Service<zn::Request, Response = zn::Response, Error = BoxError> + Send + Clone + 'static,
@@ -58,39 +61,48 @@ where
     let mut broadcast_network = Timeout::new(broadcast_network, TIPS_RESPONSE_TIMEOUT);
 
     loop {
-        // wait for at least one tip change, to make sure we have a new block hash to broadcast
-        let tip_action = chain_state.wait_for_tip_change().await.map_err(TipChange)?;
+        // get block hash and height to broadcast, if any.
+        let (hash, height) = if receiver.has_changed().map_err(SyncStatus)? {
+            // we have a new block to broadcast from the `submitblock `RPC method, get block data and release the channel.
+            receiver.borrow_and_update().clone()
+        } else if sync_status.is_close_to_tip() {
+            // wait for at least one tip change, to make sure we have a new block hash to broadcast
+            let tip_action = chain_state.wait_for_tip_change().await.map_err(TipChange)?;
 
-        // wait until we're close to the tip, because broadcasts are only useful for nodes near the tip
-        // (if they're a long way from the tip, they use the syncer and block locators)
-        sync_status
-            .wait_until_close_to_tip()
-            .await
-            .map_err(SyncStatus)?;
+            // get the latest tip change - it might be different to the change we awaited,
+            // because the syncer might take a long time to reach the tip
+            let tip_action = chain_state.last_tip_change().unwrap_or(tip_action);
 
-        // get the latest tip change - it might be different to the change we awaited,
-        // because the syncer might take a long time to reach the tip
-        let tip_action = chain_state.last_tip_change().unwrap_or(tip_action);
+            (tip_action.best_tip_hash(), tip_action.best_tip_height())
+        } else {
+            // wait for at least the network timeout between gossips
+            //
+            // in practice, we expect blocks to arrive approximately every 75 seconds,
+            // so waiting 6 seconds won't make much difference
+            tokio::time::sleep(PEER_GOSSIP_DELAY).await;
+            continue;
+        };
 
         // block broadcasts inform other nodes about new blocks,
         // so our internal Grow or Reset state doesn't matter to them
-        let request = zn::Request::AdvertiseBlock(tip_action.best_tip_hash());
+        let request = zn::Request::AdvertiseBlock(hash);
 
-        let height = tip_action.best_tip_height();
         debug!(?height, ?request, "sending committed block broadcast");
 
-        // broadcast requests don't return errors, and we'd just want to ignore them anyway
-        let _ = broadcast_network
-            .ready()
-            .await
-            .map_err(PeerSetReadiness)?
-            .call(request)
-            .await;
-
-        // wait for at least the network timeout between gossips
-        //
-        // in practice, we expect blocks to arrive approximately every 75 seconds,
-        // so waiting 6 seconds won't make much difference
-        tokio::time::sleep(PEER_GOSSIP_DELAY).await;
+        if network.is_regtest() {
+            warn!(
+                ?height,
+                ?request,
+                "we are in a regtest network, skipping broadcast"
+            );
+        } else {
+            // broadcast requests don't return errors, and we'd just want to ignore them anyway
+            let _ = broadcast_network
+                .ready()
+                .await
+                .map_err(PeerSetReadiness)?
+                .call(request)
+                .await;
+        }
     }
 }

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -156,8 +156,8 @@ use color_eyre::{
 };
 use semver::Version;
 use serde_json::Value;
-
 use tower::ServiceExt;
+
 use zebra_chain::{
     block::{self, genesis::regtest_genesis_block, Height},
     parameters::Network::{self, *},
@@ -3266,8 +3266,10 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
                 fetch_state_tip_and_local_time, generate_coinbase_and_roots,
                 proposal_block_from_template, GetBlockTemplate, GetBlockTemplateRequestMode,
             },
-            types::get_block_template,
-            types::submit_block,
+            types::{
+                get_block_template,
+                submit_block::{self, SubmitBlockChannel},
+            },
         },
         hex_data::HexData,
         GetBlockTemplateRpcImpl, GetBlockTemplateRpcServer,
@@ -3336,6 +3338,8 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
     let mut mock_sync_status = MockSyncStatus::default();
     mock_sync_status.set_is_close_to_tip(true);
 
+    let submitblock_channel = SubmitBlockChannel::new();
+
     let get_block_template_rpc_impl = GetBlockTemplateRpcImpl::new(
         &network,
         mining_config,
@@ -3345,6 +3349,7 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
         block_verifier_router,
         mock_sync_status,
         MockAddressBookPeers::default(),
+        submitblock_channel.sender(),
     );
 
     let make_mock_mempool_request_handler = || async move {
@@ -3400,6 +3405,17 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
         submit_block_response,
         submit_block::Response::Accepted,
         "valid block should be accepted"
+    );
+
+    // Check that the submitblock channel received the submitted block
+    let submit_block_channel_data = *submitblock_channel.receiver().borrow_and_update();
+    assert_eq!(
+        submit_block_channel_data,
+        (
+            proposal_block.hash(),
+            proposal_block.coinbase_height().unwrap()
+        ),
+        "submitblock channel should receive the submitted block"
     );
 
     // Use an invalid coinbase transaction (with an output value greater than the `block_subsidy + miner_fees - expected_lockbox_funding_stream`)

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -3349,7 +3349,7 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
         block_verifier_router,
         mock_sync_status,
         MockAddressBookPeers::default(),
-        submitblock_channel.sender(),
+        Some(submitblock_channel.sender()),
     );
 
     let make_mock_mempool_request_handler = || async move {


### PR DESCRIPTION
## Motivation

When blocks are mined and we are not close to the tip the mined block do not get advertised to the network.

Close https://github.com/ZcashFoundation/zebra/issues/8909

## Solution

Introduce a channel with a sender part used by the rpc method submit block to add a signal when a block is submitted and accepted. The receiver part of the channel is used by the block gossip task to advertise the block.

### Tests

- A `submitblock_channel` was added to check the gossip task can receive mined blocks.
- A check was added to existing test `nu6_funding_streams_and_coinbase_balance` to make sure the sender part of the channel is working.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

