### PR TITLE
feat(network): Track misbehaving peer connections and ban them past a threshold

### DIFF
--- a/zebra-chain/src/tests/vectors.rs
+++ b/zebra-chain/src/tests/vectors.rs
@@ -37,6 +37,15 @@ impl Network {
         }
     }
 
+    /// Returns iterator over deserialized blocks.
+    pub fn block_parsed_iter(&self) -> impl Iterator<Item = Block> {
+        self.block_iter().map(|(_, block_bytes)| {
+            block_bytes
+                .zcash_deserialize_into::<Block>()
+                .expect("block is structurally valid")
+        })
+    }
+
     /// Returns iterator over verified unmined transactions in the provided block height range.
     pub fn unmined_transactions_in_blocks(
         &self,

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -100,6 +100,17 @@ impl VerifyBlockError {
             _ => false,
         }
     }
+
+    /// Returns a suggested misbehaviour score increment for a certain error.
+    pub fn misbehavior_score(&self) -> u32 {
+        // TODO: Adjust these values based on zcashd.
+        use VerifyBlockError::*;
+        match self {
+            Block { source } => source.misbehavior_score(),
+            Equihash { .. } => 100,
+            _other => 0,
+        }
+    }
 }
 
 /// The maximum allowed number of legacy signature check operations in a block.

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -103,7 +103,7 @@ impl VerifyBlockError {
 
     /// Returns a suggested misbehaviour score increment for a certain error.
     pub fn misbehavior_score(&self) -> u32 {
-        // TODO: Adjust these values based on zcashd.
+        // TODO: Adjust these values based on zcashd (#9258).
         use VerifyBlockError::*;
         match self {
             Block { source } => source.misbehavior_score(),

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -1037,6 +1037,21 @@ impl VerifyCheckpointError {
             _ => false,
         }
     }
+
+    /// Returns a suggested misbehaviour score increment for a certain error.
+    pub fn misbehavior_score(&self) -> u32 {
+        // TODO: Adjust these values based on zcashd.
+        match self {
+            VerifyCheckpointError::VerifyBlock(verify_block_error) => {
+                verify_block_error.misbehavior_score()
+            }
+            VerifyCheckpointError::SubsidyError(_)
+            | VerifyCheckpointError::CoinbaseHeight { .. }
+            | VerifyCheckpointError::DuplicateTransaction
+            | VerifyCheckpointError::AmountError(_) => 100,
+            _other => 0,
+        }
+    }
 }
 
 /// The CheckpointVerifier service implementation.

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -1040,7 +1040,7 @@ impl VerifyCheckpointError {
 
     /// Returns a suggested misbehaviour score increment for a certain error.
     pub fn misbehavior_score(&self) -> u32 {
-        // TODO: Adjust these values based on zcashd.
+        // TODO: Adjust these values based on zcashd (#9258).
         match self {
             VerifyCheckpointError::VerifyBlock(verify_block_error) => {
                 verify_block_error.misbehavior_score()

--- a/zebra-consensus/src/checkpoint/list.rs
+++ b/zebra-consensus/src/checkpoint/list.rs
@@ -67,7 +67,7 @@ impl ParameterCheckpoint for Network {
         let (checkpoints_for_network, should_fallback_to_genesis_hash_as_checkpoint) = match self {
             Network::Mainnet => (MAINNET_CHECKPOINTS, false),
             Network::Testnet(params) if params.is_default_testnet() => (TESTNET_CHECKPOINTS, false),
-            Network::Testnet(_params) => (TESTNET_CHECKPOINTS, true),
+            Network::Testnet(_params) => ("", true),
         };
 
         // Check that the list starts with the correct genesis block and parses checkpoint list.

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -304,11 +304,9 @@ impl TransactionError {
             | CoinbaseInMempool
             | NonCoinbaseHasCoinbaseInput
             | CoinbaseExpiryBlockHeight { .. }
-            | MaximumExpiryHeight { .. }
             | IncorrectFee
             | Subsidy(_)
             | WrongVersion
-            | UnsupportedByNetworkUpgrade(_, _)
             | NoInputs
             | NoOutputs
             | BadBalance

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -290,7 +290,7 @@ impl TransactionError {
     pub fn mempool_misbehavior_score(&self) -> u32 {
         use TransactionError::*;
 
-        // TODO: Adjust these values based on zcashd.
+        // TODO: Adjust these values based on zcashd (#9258).
         match self {
             ImmatureTransparentCoinbaseSpend { .. }
             | UnshieldedTransparentCoinbaseSpend { .. }

--- a/zebra-consensus/src/router.rs
+++ b/zebra-consensus/src/router.rs
@@ -139,6 +139,15 @@ impl RouterError {
             RouterError::Block { source, .. } => source.is_duplicate_request(),
         }
     }
+
+    /// Returns a suggested misbehaviour score increment for a certain error.
+    pub fn misbehavior_score(&self) -> u32 {
+        // TODO: Adjust these values based on zcashd.
+        match self {
+            RouterError::Checkpoint { source } => source.misbehavior_score(),
+            RouterError::Block { source } => source.misbehavior_score(),
+        }
+    }
 }
 
 impl<S, V> Service<Request> for BlockVerifierRouter<S, V>

--- a/zebra-consensus/src/router.rs
+++ b/zebra-consensus/src/router.rs
@@ -142,7 +142,7 @@ impl RouterError {
 
     /// Returns a suggested misbehaviour score increment for a certain error.
     pub fn misbehavior_score(&self) -> u32 {
-        // TODO: Adjust these values based on zcashd.
+        // TODO: Adjust these values based on zcashd (#9258).
         match self {
             RouterError::Checkpoint { source } => source.misbehavior_score(),
             RouterError::Block { source } => source.misbehavior_score(),

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -10,10 +10,12 @@ use std::{
 };
 
 // TODO:
-//
-// - Add a sender to the peer conn discover channel as a field on address book,
-// - Report failures from mempool/sync to the address book?
-// - Send `Change::Remove` messages from the address book once a peer's bad score is excessive.
+// - Search for "bad score" in zcashd and replicate its behaviour and weights in Zebra
+// - Cache ban list on disk
+// - Cache misbehaviour scores on disk?
+// - Add an acceptance test to check that two zebrad testchild instances on different and
+//   incompatible custom Testnets initially connect to each other, but then disconnect (this may rely on reliably gossiping mined blocks).
+//   Note: It disconnects from entire IPs, but this is fine as it'll be tested with only one other local peer node.
 
 use chrono::Utc;
 use indexmap::IndexMap;

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -16,6 +16,7 @@ use std::{
 // - Send `Change::Remove` messages from the address book once a peer's bad score is excessive.
 
 use chrono::Utc;
+use indexmap::IndexMap;
 use ordered_map::OrderedMap;
 use tokio::sync::watch;
 use tracing::Span;
@@ -85,6 +86,9 @@ pub struct AddressBook {
     /// currently only supports a `max_connections_per_ip` of 1, and must be `None` when used with a greater `max_connections_per_ip`.
     // TODO: Replace with `by_ip: HashMap<IpAddr, BTreeMap<DateTime32, MetaAddr>>` to support configured `max_connections_per_ip` greater than 1
     most_recent_by_ip: Option<HashMap<IpAddr, MetaAddr>>,
+
+    /// A list of banned addresses, with the time they were banned.
+    bans_by_ip: Arc<IndexMap<IpAddr, Instant>>,
 
     /// The local listener address.
     local_listener: SocketAddr,
@@ -168,6 +172,7 @@ impl AddressBook {
             address_metrics_tx,
             last_address_log: None,
             most_recent_by_ip: should_limit_outbound_conns_per_ip.then(HashMap::new),
+            bans_by_ip: Default::default(),
         };
 
         new_book.update_metrics(instant_now, chrono_now);
@@ -434,6 +439,44 @@ impl AddressBook {
         );
 
         if let Some(updated) = updated {
+            if updated.misbehavior() > constants::MAX_PEER_MISBEHAVIOR_SCORE {
+                // Ban and skip outbound connections with excessively misbehaving peers.
+                let banned_ip = updated.addr.ip();
+                let bans_by_ip = Arc::make_mut(&mut self.bans_by_ip);
+
+                bans_by_ip.insert(banned_ip, Instant::now());
+                if bans_by_ip.len() > constants::MAX_BANNED_IPS {
+                    // Remove the oldest banned IP from the address book.
+                    bans_by_ip.shift_remove_index(0);
+                }
+
+                self.most_recent_by_ip
+                    .as_mut()
+                    .expect("should be some when should_remove_most_recent_by_ip is true")
+                    .remove(&banned_ip);
+
+                let banned_addrs: Vec<_> = self
+                    .by_addr
+                    .descending_keys()
+                    .skip_while(|addr| addr.ip() != banned_ip)
+                    .take_while(|addr| addr.ip() == banned_ip)
+                    .cloned()
+                    .collect();
+
+                for addr in banned_addrs {
+                    self.by_addr.remove(&addr);
+                }
+
+                warn!(
+                    ?updated,
+                    total_peers = self.by_addr.len(),
+                    recent_peers = self.recently_live_peers(chrono_now).len(),
+                    "banned ip and removed banned peer addresses from address book",
+                );
+
+                return None;
+            }
+
             // Ignore invalid outbound addresses.
             // (Inbound connections can be monitored via Zebra's metrics.)
             if !updated.address_is_valid_for_outbound(&self.network) {
@@ -640,6 +683,11 @@ impl AddressBook {
             .cloned()
     }
 
+    /// Returns banned IP addresses.
+    pub fn bans(&self) -> Arc<IndexMap<IpAddr, Instant>> {
+        self.bans_by_ip.clone()
+    }
+
     /// Returns the number of entries in this address book.
     pub fn len(&self) -> usize {
         self.by_addr.len()
@@ -811,6 +859,7 @@ impl Clone for AddressBook {
             address_metrics_tx,
             last_address_log: None,
             most_recent_by_ip: self.most_recent_by_ip.clone(),
+            bans_by_ip: self.bans_by_ip.clone(),
         }
     }
 }

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -9,6 +9,12 @@ use std::{
     time::Instant,
 };
 
+// TODO:
+//
+// - Add a sender to the peer conn discover channel as a field on address book,
+// - Report failures from mempool/sync to the address book?
+// - Send `Change::Remove` messages from the address book once a peer's bad score is excessive.
+
 use chrono::Utc;
 use ordered_map::OrderedMap;
 use tokio::sync::watch;

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -9,14 +9,6 @@ use std::{
     time::Instant,
 };
 
-// TODO:
-// - Search for "bad score" in zcashd and replicate its behaviour and weights in Zebra
-// - Cache ban list on disk
-// - Cache misbehaviour scores on disk?
-// - Add an acceptance test to check that two zebrad testchild instances on different and
-//   incompatible custom Testnets initially connect to each other, but then disconnect (this may rely on reliably gossiping mined blocks).
-//   Note: It disconnects from entire IPs, but this is fine as it'll be tested with only one other local peer node.
-
 use chrono::Utc;
 use indexmap::IndexMap;
 use ordered_map::OrderedMap;

--- a/zebra-network/src/config/cache_dir.rs
+++ b/zebra-network/src/config/cache_dir.rs
@@ -20,6 +20,18 @@ pub enum CacheDir {
     CustomPath(PathBuf),
 }
 
+impl From<bool> for CacheDir {
+    fn from(value: bool) -> Self {
+        CacheDir::IsEnabled(value)
+    }
+}
+
+impl From<PathBuf> for CacheDir {
+    fn from(value: PathBuf) -> Self {
+        CacheDir::CustomPath(value)
+    }
+}
+
 impl CacheDir {
     /// Returns a `CacheDir` enabled with the default path.
     pub fn default_path() -> Self {

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -383,6 +383,13 @@ pub const MAX_OVERLOAD_DROP_PROBABILITY: f32 = 0.5;
 /// The minimum interval between logging peer set status updates.
 pub const MIN_PEER_SET_LOG_INTERVAL: Duration = Duration::from_secs(60);
 
+/// The maximum number of peer misbehavior incidents before a peer is
+/// disconnected and banned.
+pub const MAX_PEER_MISBEHAVIOR_SCORE: u32 = 100;
+
+/// The maximum number of banned IP addresses to be stored in-memory at any time.
+pub const MAX_BANNED_IPS: usize = 20_000;
+
 lazy_static! {
     /// The minimum network protocol version accepted by this crate for each network,
     /// represented as a network upgrade.

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -973,10 +973,11 @@ impl MetaAddrChange {
 
         let previous_has_been_attempted = !previous.last_connection_state.is_never_attempted();
         let change_to_never_attempted = self.peer_addr_state().is_never_attempted();
+        let is_misbehavior_update = self.misbehavior_score() != 0;
 
         // Invalid changes
 
-        if change_to_never_attempted && previous_has_been_attempted {
+        if change_to_never_attempted && previous_has_been_attempted && !is_misbehavior_update {
             // Existing entry has been attempted, change is NeverAttempted
             // - ignore the change
             //
@@ -987,7 +988,7 @@ impl MetaAddrChange {
             return None;
         }
 
-        if change_is_out_of_order && !change_is_concurrent {
+        if change_is_out_of_order && !change_is_concurrent && !is_misbehavior_update {
             // Change is significantly out of order: ignore it.
             //
             // # Security
@@ -997,7 +998,7 @@ impl MetaAddrChange {
             return None;
         }
 
-        if change_is_concurrent && !connection_has_more_progress {
+        if change_is_concurrent && !connection_has_more_progress && !is_misbehavior_update {
             // Change is close together in time, and it would revert the connection to an earlier
             // state.
             //

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -200,6 +200,7 @@ pub struct MetaAddr {
     last_failure: Option<Instant>,
 
     /// The misbehavior score for this peer.
+    #[cfg_attr(any(test, feature = "proptest-impl"), proptest(value = 0))]
     misbehavior_score: u32,
 
     /// The outcome of our most recent communication attempt with this peer.

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -835,7 +835,6 @@ impl MetaAddrChange {
             // local listeners get sanitized, so the state doesn't matter here
             NewLocal { .. } => NeverAttemptedGossiped,
             UpdateAttempt { .. } => AttemptPending,
-            // TODO: Review whether this will have unintended consequences
             UpdateConnected { .. } | UpdateResponded { .. } | UpdateMisbehavior { .. } => Responded,
             UpdateFailed { .. } => Failed,
         }

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -662,7 +662,7 @@ impl MetaAddr {
         }
 
         // Avoid responding to GetAddr requests with addresses of misbehaving peers.
-        if self.misbehavior_score != 0 {
+        if self.misbehavior_score != 0 || self.is_inbound {
             return None;
         }
 
@@ -675,16 +675,8 @@ impl MetaAddr {
             .checked_sub(remainder.into())
             .expect("unexpected underflow: rem_euclid is strictly less than timestamp");
 
-        let addr = if self.is_inbound {
-            let mut addr = self.addr;
-            addr.set_port(network.default_port());
-            addr
-        } else {
-            self.addr
-        };
-
         Some(MetaAddr {
-            addr: canonical_peer_addr(addr),
+            addr: canonical_peer_addr(self.addr),
             // initial peers are sanitized assuming they are `NODE_NETWORK`
             // TODO: split untrusted and direct services
             //       consider sanitizing untrusted services to NODE_NETWORK (#2324)

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -286,11 +286,8 @@ pub enum MetaAddrChange {
 
     /// Updates an existing `MetaAddr` when a peer misbehaves such as by advertising
     /// semantically invalid blocks or transactions.
+    #[proptest(skip)]
     UpdateMisbehavior {
-        #[cfg_attr(
-            any(test, feature = "proptest-impl"),
-            proptest(strategy = "canonical_peer_addr_strategy()")
-        )]
         addr: PeerSocketAddr,
         score_increment: u32,
     },

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -445,6 +445,11 @@ impl MetaAddr {
         self.last_response.or(self.untrusted_last_seen)
     }
 
+    /// Returns whether the address is from an inbound peer connection
+    pub fn is_inbound(&self) -> bool {
+        self.is_inbound
+    }
+
     /// Returns the unverified "last seen time" gossiped by the remote peer that
     /// sent us this address.
     ///

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -287,7 +287,7 @@ pub enum MetaAddrChange {
 
     /// Updates an existing `MetaAddr` when a peer misbehaves such as by advertising
     /// semantically invalid blocks or transactions.
-    #[proptest(skip)]
+    #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
     UpdateMisbehavior {
         addr: PeerSocketAddr,
         score_increment: u32,

--- a/zebra-network/src/meta_addr/tests/prop.rs
+++ b/zebra-network/src/meta_addr/tests/prop.rs
@@ -48,6 +48,8 @@ proptest! {
             // also check the address, port, and services individually
             prop_assert!(!addr.addr.ip().is_unspecified());
             prop_assert_ne!(addr.addr.port(), 0);
+            prop_assert_eq!(addr.misbehavior(), 0);
+            prop_assert!(!addr.is_inbound());
 
             if let Some(services) = addr.services {
                 prop_assert!(services.contains(PeerServices::NODE_NETWORK));

--- a/zebra-network/src/meta_addr/tests/vectors.rs
+++ b/zebra-network/src/meta_addr/tests/vectors.rs
@@ -36,6 +36,7 @@ fn sanitize_extremes() {
         last_attempt: None,
         last_failure: None,
         last_connection_state: Default::default(),
+        misbehavior_score: Default::default(),
     };
 
     let max_time_entry = MetaAddr {
@@ -46,6 +47,7 @@ fn sanitize_extremes() {
         last_attempt: None,
         last_failure: None,
         last_connection_state: Default::default(),
+        misbehavior_score: Default::default(),
     };
 
     if let Some(min_sanitized) = min_time_entry.sanitize(&Mainnet) {

--- a/zebra-network/src/meta_addr/tests/vectors.rs
+++ b/zebra-network/src/meta_addr/tests/vectors.rs
@@ -37,6 +37,7 @@ fn sanitize_extremes() {
         last_failure: None,
         last_connection_state: Default::default(),
         misbehavior_score: Default::default(),
+        is_inbound: false,
     };
 
     let max_time_entry = MetaAddr {
@@ -48,6 +49,7 @@ fn sanitize_extremes() {
         last_failure: None,
         last_connection_state: Default::default(),
         misbehavior_score: Default::default(),
+        is_inbound: false,
     };
 
     if let Some(min_sanitized) = min_time_entry.sanitize(&Mainnet) {

--- a/zebra-network/src/peer/connection/tests/prop.rs
+++ b/zebra-network/src/peer/connection/tests/prop.rs
@@ -113,7 +113,7 @@ proptest! {
             );
             let response = response_result.unwrap();
 
-            prop_assert_eq!(response, Response::Blocks(vec![Available(second_block.0)]));
+            prop_assert_eq!(response, Response::Blocks(vec![Available((second_block.0, None))]));
 
             // Check the state after the response
             let error = shared_error_slot.try_get_error();

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -221,6 +221,7 @@ where
         demand_tx.clone(),
         handle_rx,
         inv_receiver,
+        bans_receiver.clone(),
         address_metrics,
         MinimumPeerVersion::new(latest_chain_tip, &config.network),
         None,

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -145,7 +145,7 @@ where
                     _ = flush_timer.next() => {
                         for (addr, score_increment) in misbehaviors.drain() {
                             let _ = misbehaviour_updater
-                                .send(MetaAddrChange::UpdateMisbehavior{
+                                .send(MetaAddrChange::UpdateMisbehavior {
                                     addr,
                                     score_increment
                                 })

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -1444,7 +1444,7 @@ async fn local_listener_port_with(listen_addr: SocketAddr, network: Network) {
     let inbound_service =
         service_fn(|_| async { unreachable!("inbound service should never be called") });
 
-    let (_peer_service, address_book) = init(
+    let (_peer_service, address_book, _) = init(
         config,
         inbound_service,
         NoChainTip,
@@ -1510,7 +1510,7 @@ where
         ..default_config
     };
 
-    let (_peer_service, address_book) = init(
+    let (_peer_service, address_book, _) = init(
         config,
         inbound_service,
         NoChainTip,

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -1547,8 +1547,13 @@ where
         config.peerset_initial_target_size = peerset_initial_target_size;
     }
 
-    let (address_book, address_book_updater, _address_metrics, _address_book_updater_guard) =
-        AddressBookUpdater::spawn(&config, config.listen_addr);
+    let (
+        address_book,
+        _bans_receiver,
+        address_book_updater,
+        _address_metrics,
+        _address_book_updater_guard,
+    ) = AddressBookUpdater::spawn(&config, config.listen_addr);
 
     // Add enough fake peers to go over the limit, even if the limit is zero.
     let over_limit_peers = config.peerset_outbound_connection_limit() * 2 + 1;
@@ -1678,6 +1683,8 @@ where
     let over_limit_connections = config.peerset_inbound_connection_limit() * 2 + 1;
     let (peerset_tx, peerset_rx) = mpsc::channel::<DiscoveredPeer>(over_limit_connections);
 
+    let (_bans_tx, bans_rx) = tokio::sync::watch::channel(Default::default());
+
     // Start listening for connections.
     let listen_fut = accept_inbound_connections(
         config.clone(),
@@ -1685,6 +1692,7 @@ where
         MIN_INBOUND_PEER_CONNECTION_INTERVAL_FOR_TESTS,
         listen_handshaker,
         peerset_tx.clone(),
+        bans_rx,
     );
     let listen_task_handle = tokio::spawn(listen_fut);
 
@@ -1789,8 +1797,13 @@ where
 
     let (peerset_tx, peerset_rx) = mpsc::channel::<DiscoveredPeer>(peer_count + 1);
 
-    let (_address_book, address_book_updater, _address_metrics, address_book_updater_guard) =
-        AddressBookUpdater::spawn(&config, unused_v4);
+    let (
+        _address_book,
+        _bans_receiver,
+        address_book_updater,
+        _address_metrics,
+        address_book_updater_guard,
+    ) = AddressBookUpdater::spawn(&config, unused_v4);
 
     let add_fut = add_initial_peers(config, outbound_connector, peerset_tx, address_book_updater);
     let add_task_handle = tokio::spawn(add_fut);

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -100,6 +100,7 @@ use std::{
     marker::PhantomData,
     net::IpAddr,
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
     time::Instant,
 };
@@ -111,6 +112,7 @@ use futures::{
     stream::FuturesUnordered,
     task::noop_waker,
 };
+use indexmap::IndexMap;
 use itertools::Itertools;
 use num_integer::div_ceil;
 use tokio::{
@@ -182,6 +184,9 @@ where
 
     /// A channel that asks the peer crawler task to connect to more peers.
     demand_signal: mpsc::Sender<MorePeers>,
+
+    /// A watch channel receiver with a copy of banned IP addresses.
+    bans_receiver: watch::Receiver<Arc<IndexMap<IpAddr, std::time::Instant>>>,
 
     // Peer Tracking: Ready Peers
     //
@@ -280,6 +285,7 @@ where
     ///                and shuts down all the tasks as soon as one task exits;
     /// - `inv_stream`: receives inventory changes from peers,
     ///                 allowing the peer set to direct inventory requests;
+    /// - `bans_receiver`: receives a map of banned IP addresses that should be dropped;
     /// - `address_book`: when peer set is busy, it logs address book diagnostics.
     /// - `minimum_peer_version`: endpoint to see the minimum peer protocol version in real time.
     /// - `max_conns_per_ip`: configured maximum number of peers that can be in the
@@ -291,6 +297,7 @@ where
         demand_signal: mpsc::Sender<MorePeers>,
         handle_rx: tokio::sync::oneshot::Receiver<Vec<JoinHandle<Result<(), BoxError>>>>,
         inv_stream: broadcast::Receiver<InventoryChange>,
+        bans_receiver: watch::Receiver<Arc<IndexMap<IpAddr, std::time::Instant>>>,
         address_metrics: watch::Receiver<AddressMetrics>,
         minimum_peer_version: MinimumPeerVersion<C>,
         max_conns_per_ip: Option<usize>,
@@ -299,6 +306,8 @@ where
             // New peers
             discover,
             demand_signal,
+            // Banned peers
+            bans_receiver,
 
             // Ready peers
             ready_services: HashMap::new(),
@@ -475,6 +484,12 @@ where
                 Some(Ok((key, svc))) => {
                     trace!(?key, "service became ready");
 
+                    if self.bans_receiver.borrow().contains_key(&key.ip()) {
+                        debug!(?key, "service is banned, dropping service");
+                        std::mem::drop(svc);
+                        continue;
+                    }
+
                     self.push_ready(true, key, svc);
 
                     // Return Ok if at least one peer became ready.
@@ -544,7 +559,15 @@ where
 
             match peer_readiness {
                 // Still ready, add it back to the list.
-                Ok(()) => self.push_ready(false, key, svc),
+                Ok(()) => {
+                    if self.bans_receiver.borrow().contains_key(&key.ip()) {
+                        debug!(?key, "service ip is banned, dropping service");
+                        std::mem::drop(svc);
+                        continue;
+                    }
+
+                    self.push_ready(false, key, svc)
+                }
 
                 // Ready -> Errored
                 Err(error) => {

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -485,7 +485,7 @@ where
                     trace!(?key, "service became ready");
 
                     if self.bans_receiver.borrow().contains_key(&key.ip()) {
-                        debug!(?key, "service is banned, dropping service");
+                        warn!(?key, "service is banned, dropping service");
                         std::mem::drop(svc);
                         continue;
                     }

--- a/zebra-network/src/peer_set/set/tests.rs
+++ b/zebra-network/src/peer_set/set/tests.rs
@@ -211,6 +211,7 @@ where
             .unwrap_or_else(|| guard.create_inventory_receiver());
 
         let address_metrics = guard.prepare_address_book(self.address_book);
+        let (_bans_sender, bans_receiver) = tokio::sync::watch::channel(Default::default());
 
         let peer_set = PeerSet::new(
             &config,
@@ -218,6 +219,7 @@ where
             demand_signal,
             handle_rx,
             inv_stream,
+            bans_receiver,
             address_metrics,
             minimum_peer_version,
             max_conns_per_ip,

--- a/zebra-network/src/protocol/internal/response.rs
+++ b/zebra-network/src/protocol/internal/response.rs
@@ -7,7 +7,7 @@ use zebra_chain::{
     transaction::{UnminedTx, UnminedTxId},
 };
 
-use crate::{meta_addr::MetaAddr, protocol::internal::InventoryResponse};
+use crate::{meta_addr::MetaAddr, protocol::internal::InventoryResponse, PeerSocketAddr};
 
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
@@ -67,14 +67,14 @@ pub enum Response {
     /// `zcashd` sometimes sends no response, and sometimes sends `notfound`.
     //
     // TODO: make this into a HashMap<block::Hash, InventoryResponse<Arc<Block>, ()>> - a unique list (#2244)
-    Blocks(Vec<InventoryResponse<Arc<Block>, block::Hash>>),
+    Blocks(Vec<InventoryResponse<(Arc<Block>, Option<PeerSocketAddr>), block::Hash>>),
 
     /// A list of found unmined transactions, and missing unmined transaction IDs.
     ///
     /// Each list contains zero or more entries.
     //
     // TODO: make this into a HashMap<UnminedTxId, InventoryResponse<UnminedTx, ()>> - a unique list (#2244)
-    Transactions(Vec<InventoryResponse<UnminedTx, UnminedTxId>>),
+    Transactions(Vec<InventoryResponse<(UnminedTx, Option<PeerSocketAddr>), UnminedTxId>>),
 }
 
 impl fmt::Display for Response {
@@ -94,7 +94,7 @@ impl fmt::Display for Response {
             // Display heights for single-block responses (which Zebra requests and expects)
             Response::Blocks(blocks) if blocks.len() == 1 => {
                 match blocks.first().expect("len is 1") {
-                    Available(block) => format!(
+                    Available((block, _)) => format!(
                         "Block {{ height: {}, hash: {} }}",
                         block
                             .coinbase_height()

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -1319,10 +1319,10 @@ where
         > = self.clone();
         let network = self.network.clone();
 
-        if !network.is_regtest() {
+        if !network.disable_pow() {
             return Err(ErrorObject::borrowed(
                 0,
-                "generate is only supported on regtest",
+                "generate is only supported on networks where PoW is disabled",
                 None,
             ));
         }

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -200,6 +200,7 @@ impl StartCmd {
             block_verifier_router.clone(),
             state.clone(),
             latest_chain_tip.clone(),
+            misbehavior_sender.clone(),
         );
 
         info!("initializing mempool");

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -173,7 +173,7 @@ impl StartCmd {
                 setup_rx,
             ));
 
-        let (peer_set, address_book) = zebra_network::init(
+        let (peer_set, address_book, _misbehavior_sender) = zebra_network::init(
             config.network.clone(),
             inbound,
             latest_chain_tip.clone(),

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -173,7 +173,7 @@ impl StartCmd {
                 setup_rx,
             ));
 
-        let (peer_set, address_book, _misbehavior_sender) = zebra_network::init(
+        let (peer_set, address_book, misbehavior_sender) = zebra_network::init(
             config.network.clone(),
             inbound,
             latest_chain_tip.clone(),
@@ -211,6 +211,7 @@ impl StartCmd {
             sync_status.clone(),
             latest_chain_tip.clone(),
             chain_tip_change.clone(),
+            misbehavior_sender.clone(),
         );
         let mempool = BoxService::new(mempool);
         let mempool = ServiceBuilder::new()
@@ -230,6 +231,7 @@ impl StartCmd {
             mempool: mempool.clone(),
             state: state.clone(),
             latest_chain_tip: latest_chain_tip.clone(),
+            misbehavior_sender,
         };
         setup_tx
             .send(setup_data)

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -338,7 +338,10 @@ impl Service<zn::Request> for Inbound {
                         continue;
                     };
 
-                    let _ = misbehavior_sender.try_send((advertiser_addr, err.misbehavior_score()));
+                    if err.misbehavior_score() != 0 {
+                        let _ =
+                            misbehavior_sender.try_send((advertiser_addr, err.misbehavior_score()));
+                    }
                 }
 
                 result = Ok(());

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -21,15 +21,15 @@ use futures::{
 use tokio::sync::oneshot::{self, error::TryRecvError};
 use tower::{buffer::Buffer, timeout::Timeout, util::BoxService, Service, ServiceExt};
 
-use zebra_network as zn;
-use zebra_state as zs;
+use zebra_network::{self as zn, PeerSocketAddr};
+use zebra_state::{self as zs};
 
 use zebra_chain::{
     block::{self, Block},
     serialization::ZcashSerialize,
     transaction::UnminedTxId,
 };
-use zebra_consensus::router::RouterError;
+use zebra_consensus::{router::RouterError, VerifyBlockError};
 use zebra_network::{AddressBook, InventoryResponse};
 use zebra_node_services::mempool;
 
@@ -107,6 +107,9 @@ pub struct InboundSetupData {
 
     /// Allows efficient access to the best tip of the blockchain.
     pub latest_chain_tip: zs::LatestChainTip,
+
+    /// A channel to send misbehavior reports to the [`AddressBook`].
+    pub misbehavior_sender: tokio::sync::mpsc::Sender<(PeerSocketAddr, u32)>,
 }
 
 /// Tracks the internal state of the [`Inbound`] service during setup.
@@ -148,6 +151,9 @@ pub enum Setup {
 
         /// A service that manages cached blockchain state.
         state: State,
+
+        /// A channel to send misbehavior reports to the [`AddressBook`].
+        misbehavior_sender: tokio::sync::mpsc::Sender<(PeerSocketAddr, u32)>,
     },
 
     /// Temporary state used in the inbound service's internal initialization code.
@@ -261,6 +267,7 @@ impl Service<zn::Request> for Inbound {
                         mempool,
                         state,
                         latest_chain_tip,
+                        misbehavior_sender,
                     } = setup_data;
 
                     let cached_peer_addr_response = CachedPeerAddrResponse::new(address_book);
@@ -279,6 +286,7 @@ impl Service<zn::Request> for Inbound {
                         block_downloads,
                         mempool,
                         state,
+                        misbehavior_sender,
                     }
                 }
                 Err(TryRecvError::Empty) => {
@@ -314,13 +322,24 @@ impl Service<zn::Request> for Inbound {
                 mut block_downloads,
                 mempool,
                 state,
+                misbehavior_sender,
             } => {
                 // # Correctness
                 //
                 // Clear the stream but ignore the final Pending return value.
                 // If we returned Pending here, and there were no waiting block downloads,
                 // then inbound requests would wait for the next block download, and hang forever.
-                while let Poll::Ready(Some(_)) = block_downloads.as_mut().poll_next(cx) {}
+                while let Poll::Ready(Some(result)) = block_downloads.as_mut().poll_next(cx) {
+                    let Err((err, Some(advertiser_addr))) = result else {
+                        continue;
+                    };
+
+                    let Ok(err) = err.downcast::<VerifyBlockError>() else {
+                        continue;
+                    };
+
+                    let _ = misbehavior_sender.try_send((advertiser_addr, err.misbehavior_score()));
+                }
 
                 result = Ok(());
 
@@ -329,6 +348,7 @@ impl Service<zn::Request> for Inbound {
                     block_downloads,
                     mempool,
                     state,
+                    misbehavior_sender,
                 }
             }
         };
@@ -362,6 +382,7 @@ impl Service<zn::Request> for Inbound {
                 block_downloads,
                 mempool,
                 state,
+                misbehavior_sender: _,
             } => (cached_peer_addr_response, block_downloads, mempool, state),
             _ => {
                 debug!("ignoring request from remote peer during setup");
@@ -398,7 +419,7 @@ impl Service<zn::Request> for Inbound {
                 let state = state.clone();
 
                 async move {
-                    let mut blocks: Vec<InventoryResponse<Arc<Block>, block::Hash>> = Vec::new();
+                    let mut blocks: Vec<InventoryResponse<(Arc<Block>, Option<PeerSocketAddr>), block::Hash>> = Vec::new();
                     let mut total_size = 0;
 
                     // Ignore any block hashes past the response limit.
@@ -422,7 +443,7 @@ impl Service<zn::Request> for Inbound {
                                 // return the size from the state using a wrapper type.
                                 total_size += block.zcash_serialized_size();
 
-                                blocks.push(Available(block))
+                                blocks.push(Available((block, None)))
                             },
                             // We don't need to limit the size of the missing block IDs list,
                             // because it is already limited to the size of the getdata request
@@ -473,7 +494,7 @@ impl Service<zn::Request> for Inbound {
                         total_size += tx.size;
 
                         within_limit
-                    }).map(Available);
+                    }).map(|tx| Available((tx, None)));
 
                     // The network layer handles splitting this response into multiple `tx`
                     // messages, and a `notfound` message if needed.

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -106,7 +106,7 @@ async fn mempool_requests_for_transactions() {
                 response,
                 added_transactions
                     .into_iter()
-                    .map(Available)
+                    .map(|tx| Available((tx, None)))
                     .collect::<Vec<_>>(),
             )
         }
@@ -259,7 +259,10 @@ async fn mempool_advertise_transaction_ids() -> Result<(), crate::BoxError> {
             .expect_request(Request::TransactionsById(txs))
             .map(|responder| {
                 let unmined_transaction = UnminedTx::from(test_transaction.clone());
-                responder.respond(Response::Transactions(vec![Available(unmined_transaction)]))
+                responder.respond(Response::Transactions(vec![Available((
+                    unmined_transaction,
+                    None,
+                ))]))
             });
     // Simulate a successful transaction verification
     let verification = tx_verifier.expect_request_that(|_| true).map(|responder| {
@@ -676,7 +679,7 @@ async fn inbound_block_height_lookahead_limit() -> Result<(), crate::BoxError> {
     peer_set
         .expect_request(Request::BlocksByHash(iter::once(block_hash).collect()))
         .await
-        .respond(Response::Blocks(vec![Available(block)]));
+        .respond(Response::Blocks(vec![Available((block, None))]));
 
     // Wait for the chain tip update
     if let Err(timeout_error) = timeout(
@@ -712,7 +715,7 @@ async fn inbound_block_height_lookahead_limit() -> Result<(), crate::BoxError> {
     peer_set
         .expect_request(Request::BlocksByHash(iter::once(block_hash).collect()))
         .await
-        .respond(Response::Blocks(vec![Available(block)]));
+        .respond(Response::Blocks(vec![Available((block, None))]));
 
     let response = state_service
         .clone()
@@ -808,6 +811,7 @@ async fn caches_getaddr_response() {
             .service(Inbound::new(MAX_INBOUND_CONCURRENCY, setup_rx));
         let inbound_service = BoxService::new(inbound_service);
         let inbound_service = ServiceBuilder::new().buffer(1).service(inbound_service);
+        let (misbehavior_sender, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
 
         let setup_data = InboundSetupData {
             address_book: address_book.clone(),
@@ -816,6 +820,7 @@ async fn caches_getaddr_response() {
             mempool: buffered_mempool_service.clone(),
             state: state_service.clone(),
             latest_chain_tip,
+            misbehavior_sender,
         };
         let r = setup_tx.send(setup_data);
         // We can't expect or unwrap because the returned Result does not implement Debug
@@ -963,6 +968,7 @@ async fn setup(
     // Don't wait for the chain tip update here, we wait for expect_request(AdvertiseBlock) below,
     // which is called by the gossip_best_tip_block_hashes task once the chain tip changes.
 
+    let (misbehavior_tx, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
     let (mut mempool_service, transaction_receiver) = Mempool::new(
         &MempoolConfig::default(),
         buffered_peer_set.clone(),
@@ -971,6 +977,7 @@ async fn setup(
         sync_status.clone(),
         latest_chain_tip.clone(),
         chain_tip_change.clone(),
+        misbehavior_tx,
     );
 
     // Pretend we're close to tip
@@ -1031,6 +1038,7 @@ async fn setup(
     let inbound_service = BoxService::new(inbound_service);
     let inbound_service = ServiceBuilder::new().buffer(1).service(inbound_service);
 
+    let (misbehavior_sender, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
     let setup_data = InboundSetupData {
         address_book,
         block_download_peer_set: buffered_peer_set,
@@ -1038,6 +1046,7 @@ async fn setup(
         mempool: mempool_service.clone(),
         state: state_service.clone(),
         latest_chain_tip,
+        misbehavior_sender,
     };
     let r = setup_tx.send(setup_data);
     // We can't expect or unwrap because the returned Result does not implement Debug

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -658,7 +658,7 @@ async fn setup(
 
         ..NetworkConfig::default()
     };
-    let (mut peer_set, address_book) = zebra_network::init(
+    let (mut peer_set, address_book, _) = zebra_network::init(
         network_config,
         inbound_service.clone(),
         latest_chain_tip.clone(),

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -868,7 +868,7 @@ mod submitblock_test {
             .buffer(10)
             .service(BoxService::new(inbound_service));
 
-        let (peer_set, _address_book) = zebra_network::init(
+        let (peer_set, _address_book, _misbehavior_tx) = zebra_network::init(
             network_config,
             inbound_service.clone(),
             latest_chain_tip.clone(),

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -340,7 +340,8 @@ async fn outbound_tx_unrelated_response_notfound() -> Result<(), crate::BoxError
     // We respond with an unrelated transaction, so the peer gives up on the request.
     let unrelated_response: Transaction =
         zebra_test::vectors::DUMMY_TX1.zcash_deserialize_into()?;
-    let unrelated_response = Response::Transactions(vec![Available(unrelated_response.into())]);
+    let unrelated_response =
+        Response::Transactions(vec![Available((unrelated_response.into(), None))]);
 
     let (
         // real services
@@ -487,8 +488,8 @@ async fn outbound_tx_partial_response_notfound() -> Result<(), crate::BoxError> 
     let repeated_tx: Transaction = zebra_test::vectors::DUMMY_TX1.zcash_deserialize_into()?;
     let repeated_tx: UnminedTx = repeated_tx.into();
     let repeated_response = Response::Transactions(vec![
-        Available(repeated_tx.clone()),
-        Available(repeated_tx.clone()),
+        Available((repeated_tx.clone(), None)),
+        Available((repeated_tx.clone(), None)),
     ]);
 
     let (
@@ -523,6 +524,7 @@ async fn outbound_tx_partial_response_notfound() -> Result<(), crate::BoxError> 
         let available: Vec<UnminedTx> = tx_response
             .iter()
             .filter_map(InventoryResponse::available)
+            .map(|(tx, _)| tx)
             .collect();
         let missing: Vec<UnminedTxId> = tx_response
             .iter()
@@ -694,6 +696,7 @@ async fn setup(
         .service(BoxService::new(mock_tx_verifier.clone()));
 
     // Mempool
+    let (misbehavior_tx, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
     let mempool_config = MempoolConfig::default();
     let (mut mempool_service, transaction_receiver) = Mempool::new(
         &mempool_config,
@@ -703,6 +706,7 @@ async fn setup(
         sync_status.clone(),
         latest_chain_tip.clone(),
         chain_tip_change.clone(),
+        misbehavior_tx,
     );
 
     // Enable the mempool
@@ -715,6 +719,7 @@ async fn setup(
         .service(mempool_service);
 
     // Initialize the inbound service
+    let (misbehavior_sender, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
     let setup_data = InboundSetupData {
         address_book,
         block_download_peer_set: peer_set.clone(),
@@ -722,6 +727,7 @@ async fn setup(
         mempool: mempool_service.clone(),
         state: state_service.clone(),
         latest_chain_tip,
+        misbehavior_sender,
     };
     let r = setup_tx.send(setup_data);
     // We can't expect or unwrap because the returned Result does not implement Debug

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -27,7 +27,7 @@ use std::{
 };
 
 use futures::{future::FutureExt, stream::Stream};
-use tokio::sync::{broadcast, oneshot};
+use tokio::sync::{broadcast, mpsc, oneshot};
 use tower::{buffer::Buffer, timeout::Timeout, util::BoxService, Service};
 
 use zebra_chain::{
@@ -37,7 +37,7 @@ use zebra_chain::{
     transaction::UnminedTxId,
 };
 use zebra_consensus::{error::TransactionError, transaction};
-use zebra_network as zn;
+use zebra_network::{self as zn, PeerSocketAddr};
 use zebra_node_services::mempool::{Gossip, Request, Response};
 use zebra_state as zs;
 use zebra_state::{ChainTipChange, TipAction};
@@ -71,7 +71,8 @@ pub use storage::{
 pub use self::tests::UnboxMempoolError;
 
 use downloads::{
-    Downloads as TxDownloads, TRANSACTION_DOWNLOAD_TIMEOUT, TRANSACTION_VERIFY_TIMEOUT,
+    Downloads as TxDownloads, TransactionDownloadVerifyError, TRANSACTION_DOWNLOAD_TIMEOUT,
+    TRANSACTION_VERIFY_TIMEOUT,
 };
 
 type Outbound = Buffer<BoxService<zn::Request, zn::Response, zn::BoxError>, zn::Request>;
@@ -239,6 +240,9 @@ pub struct Mempool {
     /// Used to broadcast transaction ids to peers.
     transaction_sender: broadcast::Sender<HashSet<UnminedTxId>>,
 
+    /// Sender for reporting peer addresses that advertised unexpectedly invalid transactions.
+    misbehavior_sender: mpsc::Sender<(PeerSocketAddr, u32)>,
+
     // Diagnostics
     //
     /// Queued transactions pending download or verification transmitter.
@@ -263,6 +267,7 @@ pub struct Mempool {
 }
 
 impl Mempool {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         config: &Config,
         outbound: Outbound,
@@ -271,6 +276,7 @@ impl Mempool {
         sync_status: SyncStatus,
         latest_chain_tip: zs::LatestChainTip,
         chain_tip_change: ChainTipChange,
+        misbehavior_sender: mpsc::Sender<(PeerSocketAddr, u32)>,
     ) -> (Self, broadcast::Receiver<HashSet<UnminedTxId>>) {
         let (transaction_sender, transaction_receiver) =
             tokio::sync::broadcast::channel(gossip::MAX_CHANGES_BEFORE_SEND * 2);
@@ -286,6 +292,7 @@ impl Mempool {
             state,
             tx_verifier,
             transaction_sender,
+            misbehavior_sender,
             #[cfg(feature = "progress-bar")]
             queued_count_bar: None,
             #[cfg(feature = "progress-bar")]
@@ -621,6 +628,16 @@ impl Service<Request> for Mempool {
                         }
                     }
                     Ok(Err((tx_id, error))) => {
+                        if let TransactionDownloadVerifyError::Invalid {
+                            error,
+                            advertiser_addr: Some(advertiser_addr),
+                        } = &error
+                        {
+                            let _ = self
+                                .misbehavior_sender
+                                .try_send((*advertiser_addr, error.mempool_misbehavior_score()));
+                        };
+
                         tracing::debug!(?tx_id, ?error, "mempool transaction failed to verify");
 
                         metrics::counter!("mempool.failed.verify.tasks.total", "reason" => error.to_string()).increment(1);

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -633,9 +633,12 @@ impl Service<Request> for Mempool {
                             advertiser_addr: Some(advertiser_addr),
                         } = &error
                         {
-                            let _ = self
-                                .misbehavior_sender
-                                .try_send((*advertiser_addr, error.mempool_misbehavior_score()));
+                            if error.mempool_misbehavior_score() != 0 {
+                                let _ = self.misbehavior_sender.try_send((
+                                    *advertiser_addr,
+                                    error.mempool_misbehavior_score(),
+                                ));
+                            }
                         };
 
                         tracing::debug!(?tx_id, ?error, "mempool transaction failed to verify");

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -643,8 +643,8 @@ impl Storage {
 
             // Consensus verification failed. Reject transaction to avoid
             // having to download and verify it again just for it to fail again.
-            TransactionDownloadVerifyError::Invalid(e) => {
-                self.reject(tx_id, ExactTipRejectionError::FailedVerification(e).into())
+            TransactionDownloadVerifyError::Invalid { error, .. }  => {
+                self.reject(tx_id, ExactTipRejectionError::FailedVerification(error).into())
             }
         }
     }

--- a/zebrad/src/components/mempool/tests/prop.rs
+++ b/zebrad/src/components/mempool/tests/prop.rs
@@ -271,6 +271,7 @@ fn setup(
     let (mut chain_tip_sender, latest_chain_tip, chain_tip_change) =
         ChainTipSender::new(None, network);
 
+    let (misbehavior_tx, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
     let (mempool, _transaction_receiver) = Mempool::new(
         &Config {
             tx_cost_limit: 160_000_000,
@@ -282,6 +283,7 @@ fn setup(
         sync_status,
         latest_chain_tip,
         chain_tip_change,
+        misbehavior_tx,
     );
 
     // sends a fake chain tip so that the mempool can be enabled

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -9,7 +9,7 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
 use tokio::{
-    sync::watch,
+    sync::{mpsc, watch},
     task::JoinError,
     time::{sleep, timeout},
 };
@@ -23,7 +23,7 @@ use zebra_chain::{
     chain_tip::ChainTip,
 };
 use zebra_consensus::ParameterCheckpoint as _;
-use zebra_network as zn;
+use zebra_network::{self as zn, PeerSocketAddr};
 use zebra_state as zs;
 
 use crate::{
@@ -380,6 +380,9 @@ where
     /// Receiver that is `true` when the downloader is past the lookahead limit.
     /// This is based on the downloaded block height and the state tip height.
     past_lookahead_limit_receiver: zs::WatchReceiver<bool>,
+
+    /// Sender for reporting peer addresses that advertised unexpectedly invalid transactions.
+    misbehavior_sender: mpsc::Sender<(PeerSocketAddr, u32)>,
 }
 
 /// Polls the network to determine whether further blocks are available and
@@ -425,6 +428,7 @@ where
         verifier: ZV,
         state: ZS,
         latest_chain_tip: ZSTip,
+        misbehavior_sender: mpsc::Sender<(PeerSocketAddr, u32)>,
     ) -> (Self, SyncStatus) {
         let mut download_concurrency_limit = config.sync.download_concurrency_limit;
         let mut checkpoint_verify_concurrency_limit =
@@ -513,6 +517,7 @@ where
             prospective_tips: HashSet::new(),
             recent_syncs,
             past_lookahead_limit_receiver,
+            misbehavior_sender,
         };
 
         (new_syncer, sync_status)
@@ -1094,10 +1099,23 @@ where
             Ok((height, hash)) => {
                 trace!(?height, ?hash, "verified and committed block to state");
 
-                Ok(())
+                return Ok(());
             }
-            Err(_) => Self::handle_response(response),
-        }
+
+            Err(BlockDownloadVerifyError::Invalid {
+                ref error,
+                advertiser_addr: Some(advertiser_addr),
+                ..
+            }) if error.misbehavior_score() != 0 => {
+                let _ = self
+                    .misbehavior_sender
+                    .try_send((advertiser_addr, error.misbehavior_score()));
+            }
+
+            Err(_) => {}
+        };
+
+        Self::handle_response(response)
     }
 
     /// Handles a response to block hash submission, passing through any extra hashes.

--- a/zebrad/src/components/sync/tests/timing.rs
+++ b/zebrad/src/components/sync/tests/timing.rs
@@ -158,6 +158,7 @@ fn request_genesis_is_rate_limited() {
         );
 
     // start the sync
+    let (misbehavior_tx, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
     let (mut chain_sync, _) = ChainSync::new(
         &ZebradConfig::default(),
         Height(0),
@@ -165,6 +166,7 @@ fn request_genesis_is_rate_limited() {
         verifier_service,
         state_service,
         latest_chain_tip,
+        misbehavior_tx,
     );
 
     // run `request_genesis()` with a timeout of 13 seconds

--- a/zebrad/src/components/sync/tests/vectors.rs
+++ b/zebrad/src/components/sync/tests/vectors.rs
@@ -1024,6 +1024,7 @@ fn setup() -> (
 
     let (mock_chain_tip, mock_chain_tip_sender) = MockChainTip::new();
 
+    let (misbehavior_tx, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
     let (chain_sync, sync_status) = ChainSync::new(
         &config,
         Height(0),
@@ -1031,6 +1032,7 @@ fn setup() -> (
         block_verifier_router.clone(),
         state_service.clone(),
         mock_chain_tip,
+        misbehavior_tx,
     );
 
     let chain_sync_future = chain_sync.sync();

--- a/zebrad/src/components/sync/tests/vectors.rs
+++ b/zebrad/src/components/sync/tests/vectors.rs
@@ -86,7 +86,10 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
     peer_set
         .expect_request(zn::Request::BlocksByHash(iter::once(block0_hash).collect()))
         .await
-        .respond(zn::Response::Blocks(vec![Available(block0.clone())]));
+        .respond(zn::Response::Blocks(vec![Available((
+            block0.clone(),
+            None,
+        ))]));
 
     block_verifier_router
         .expect_request(zebra_consensus::Request::Commit(block0))
@@ -160,11 +163,17 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
     peer_set
         .expect_request(zn::Request::BlocksByHash(iter::once(block1_hash).collect()))
         .await
-        .respond(zn::Response::Blocks(vec![Available(block1.clone())]));
+        .respond(zn::Response::Blocks(vec![Available((
+            block1.clone(),
+            None,
+        ))]));
     peer_set
         .expect_request(zn::Request::BlocksByHash(iter::once(block2_hash).collect()))
         .await
-        .respond(zn::Response::Blocks(vec![Available(block2.clone())]));
+        .respond(zn::Response::Blocks(vec![Available((
+            block2.clone(),
+            None,
+        ))]));
 
     // We can't guarantee the verification request order
     let mut remaining_blocks: HashMap<block::Hash, Arc<Block>> =
@@ -224,11 +233,17 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
     peer_set
         .expect_request(zn::Request::BlocksByHash(iter::once(block3_hash).collect()))
         .await
-        .respond(zn::Response::Blocks(vec![Available(block3.clone())]));
+        .respond(zn::Response::Blocks(vec![Available((
+            block3.clone(),
+            None,
+        ))]));
     peer_set
         .expect_request(zn::Request::BlocksByHash(iter::once(block4_hash).collect()))
         .await
-        .respond(zn::Response::Blocks(vec![Available(block4.clone())]));
+        .respond(zn::Response::Blocks(vec![Available((
+            block4.clone(),
+            None,
+        ))]));
 
     // We can't guarantee the verification request order
     let mut remaining_blocks: HashMap<block::Hash, Arc<Block>> =
@@ -313,7 +328,10 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
     peer_set
         .expect_request(zn::Request::BlocksByHash(iter::once(block0_hash).collect()))
         .await
-        .respond(zn::Response::Blocks(vec![Available(block0.clone())]));
+        .respond(zn::Response::Blocks(vec![Available((
+            block0.clone(),
+            None,
+        ))]));
 
     block_verifier_router
         .expect_request(zebra_consensus::Request::Commit(block0))
@@ -389,11 +407,17 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
     peer_set
         .expect_request(zn::Request::BlocksByHash(iter::once(block1_hash).collect()))
         .await
-        .respond(zn::Response::Blocks(vec![Available(block1.clone())]));
+        .respond(zn::Response::Blocks(vec![Available((
+            block1.clone(),
+            None,
+        ))]));
     peer_set
         .expect_request(zn::Request::BlocksByHash(iter::once(block2_hash).collect()))
         .await
-        .respond(zn::Response::Blocks(vec![Available(block2.clone())]));
+        .respond(zn::Response::Blocks(vec![Available((
+            block2.clone(),
+            None,
+        ))]));
 
     // We can't guarantee the verification request order
     let mut remaining_blocks: HashMap<block::Hash, Arc<Block>> =
@@ -455,11 +479,17 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
     peer_set
         .expect_request(zn::Request::BlocksByHash(iter::once(block3_hash).collect()))
         .await
-        .respond(zn::Response::Blocks(vec![Available(block3.clone())]));
+        .respond(zn::Response::Blocks(vec![Available((
+            block3.clone(),
+            None,
+        ))]));
     peer_set
         .expect_request(zn::Request::BlocksByHash(iter::once(block4_hash).collect()))
         .await
-        .respond(zn::Response::Blocks(vec![Available(block4.clone())]));
+        .respond(zn::Response::Blocks(vec![Available((
+            block4.clone(),
+            None,
+        ))]));
 
     // We can't guarantee the verification request order
     let mut remaining_blocks: HashMap<block::Hash, Arc<Block>> =
@@ -530,7 +560,10 @@ async fn sync_block_lookahead_drop() -> Result<(), crate::BoxError> {
     peer_set
         .expect_request(zn::Request::BlocksByHash(iter::once(block0_hash).collect()))
         .await
-        .respond(zn::Response::Blocks(vec![Available(block982k.clone())]));
+        .respond(zn::Response::Blocks(vec![Available((
+            block982k.clone(),
+            None,
+        ))]));
 
     // Block is dropped because it is too far ahead of the tip.
     // We expect more requests to the state service, because the syncer keeps on running.
@@ -595,7 +628,10 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
     peer_set
         .expect_request(zn::Request::BlocksByHash(iter::once(block0_hash).collect()))
         .await
-        .respond(zn::Response::Blocks(vec![Available(block0.clone())]));
+        .respond(zn::Response::Blocks(vec![Available((
+            block0.clone(),
+            None,
+        ))]));
 
     block_verifier_router
         .expect_request(zebra_consensus::Request::Commit(block0))
@@ -677,15 +713,24 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
             iter::once(block982k_hash).collect(),
         ))
         .await
-        .respond(zn::Response::Blocks(vec![Available(block982k.clone())]));
+        .respond(zn::Response::Blocks(vec![Available((
+            block982k.clone(),
+            None,
+        ))]));
     peer_set
         .expect_request(zn::Request::BlocksByHash(iter::once(block1_hash).collect()))
         .await
-        .respond(zn::Response::Blocks(vec![Available(block1.clone())]));
+        .respond(zn::Response::Blocks(vec![Available((
+            block1.clone(),
+            None,
+        ))]));
     peer_set
         .expect_request(zn::Request::BlocksByHash(iter::once(block2_hash).collect()))
         .await
-        .respond(zn::Response::Blocks(vec![Available(block2.clone())]));
+        .respond(zn::Response::Blocks(vec![Available((
+            block2.clone(),
+            None,
+        ))]));
 
     // At this point, the following tasks race:
     // - The valid chain verifier requests
@@ -756,7 +801,10 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
     peer_set
         .expect_request(zn::Request::BlocksByHash(iter::once(block0_hash).collect()))
         .await
-        .respond(zn::Response::Blocks(vec![Available(block0.clone())]));
+        .respond(zn::Response::Blocks(vec![Available((
+            block0.clone(),
+            None,
+        ))]));
 
     block_verifier_router
         .expect_request(zebra_consensus::Request::Commit(block0))
@@ -830,11 +878,17 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
     peer_set
         .expect_request(zn::Request::BlocksByHash(iter::once(block1_hash).collect()))
         .await
-        .respond(zn::Response::Blocks(vec![Available(block1.clone())]));
+        .respond(zn::Response::Blocks(vec![Available((
+            block1.clone(),
+            None,
+        ))]));
     peer_set
         .expect_request(zn::Request::BlocksByHash(iter::once(block2_hash).collect()))
         .await
-        .respond(zn::Response::Blocks(vec![Available(block2.clone())]));
+        .respond(zn::Response::Blocks(vec![Available((
+            block2.clone(),
+            None,
+        ))]));
 
     // We can't guarantee the verification request order
     let mut remaining_blocks: HashMap<block::Hash, Arc<Block>> =
@@ -896,17 +950,26 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
     peer_set
         .expect_request(zn::Request::BlocksByHash(iter::once(block3_hash).collect()))
         .await
-        .respond(zn::Response::Blocks(vec![Available(block3.clone())]));
+        .respond(zn::Response::Blocks(vec![Available((
+            block3.clone(),
+            None,
+        ))]));
     peer_set
         .expect_request(zn::Request::BlocksByHash(iter::once(block4_hash).collect()))
         .await
-        .respond(zn::Response::Blocks(vec![Available(block4.clone())]));
+        .respond(zn::Response::Blocks(vec![Available((
+            block4.clone(),
+            None,
+        ))]));
     peer_set
         .expect_request(zn::Request::BlocksByHash(
             iter::once(block982k_hash).collect(),
         ))
         .await
-        .respond(zn::Response::Blocks(vec![Available(block982k.clone())]));
+        .respond(zn::Response::Blocks(vec![Available((
+            block982k.clone(),
+            None,
+        ))]));
 
     // At this point, the following tasks race:
     // - The valid chain verifier requests

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -3715,3 +3715,9 @@ fn check_no_git_refs_in_cargo_lock() {
         panic!("Cargo.lock includes git sources")
     }
 }
+
+// TODO: Add an acceptance test to check that two zebrad testchild instances on different and
+//       incompatible custom Testnets initially connect to each other, but then disconnect.
+//       (this may depend on reliably gossiping mined blocks)
+//
+// Note: It disconnects from entire IPs, but this is fine as it'll be tested with only one other local peer node.

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -3718,7 +3718,7 @@ fn check_no_git_refs_in_cargo_lock() {
 
 /// Check that Zebra will disconnect from misbehaving peers.
 #[tokio::test]
-#[cfg(feature = "getblocktemplate-rpcs")]
+#[cfg(all(feature = "getblocktemplate-rpcs", not(target_os = "windows")))]
 async fn disconnects_from_misbehaving_peers() -> Result<()> {
     use std::sync::{atomic::AtomicBool, Arc};
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -3718,19 +3718,33 @@ fn check_no_git_refs_in_cargo_lock() {
 
 /// Check that Zebra will disconnect from misbehaving peers.
 #[tokio::test]
+#[cfg(feature = "getblocktemplate-rpcs")]
 async fn disconnects_from_misbehaving_peers() -> Result<()> {
-    use zebra_chain::parameters::testnet;
-    use zebra_rpc::methods::{get_block_template_rpcs::types::peer_info::PeerInfo, GetBlockHash};
+    use std::sync::{atomic::AtomicBool, Arc};
+
+    use common::regtest::MiningRpcMethods;
+    use zebra_chain::parameters::testnet::{self, ConfiguredActivationHeights};
+    use zebra_rpc::methods::get_block_template_rpcs::types::peer_info::PeerInfo;
 
     let _init_guard = zebra_test::init();
     let network = testnet::Parameters::build()
+        .with_activation_heights(ConfiguredActivationHeights {
+            canopy: Some(1),
+            nu5: Some(2),
+            nu6: Some(3),
+            ..Default::default()
+        })
+        .with_slow_start_interval(Height::MIN)
         .with_disable_pow(true)
         .to_network();
 
-    let test_type = UpdateZebraCachedStateWithRpc;
+    let test_type = LaunchWithEmptyState {
+        launches_lightwalletd: false,
+    };
     let test_name = "disconnects_from_misbehaving_peers_test";
 
     if !common::launch::can_spawn_zebrad_for_test_type(test_name, test_type, false) {
+        tracing::warn!("skipping disconnects_from_misbehaving_peers test");
         return Ok(());
     }
 
@@ -3738,62 +3752,139 @@ async fn disconnects_from_misbehaving_peers() -> Result<()> {
     let mut config = test_type
         .zebrad_config(test_name, false, None, &network)
         .expect("already checked config")?;
+
+    config.network.cache_dir = false.into();
     config.network.listen_addr = format!("127.0.0.1:{}", random_known_port()).parse()?;
 
-    let rpc_client1 = RpcRequestClient::new(config.rpc.listen_addr.unwrap());
+    let rpc_listen_addr = config.rpc.listen_addr.unwrap();
+    let rpc_client_1 = RpcRequestClient::new(rpc_listen_addr);
 
-    let (zebrad_failure_messages, zebrad_ignore_messages) = test_type.zebrad_failure_messages();
+    tracing::info!(
+        ?rpc_listen_addr,
+        network_listen_addr = ?config.network.listen_addr,
+        "starting a zebrad child on incompatible custom Testnet"
+    );
 
-    let mut _zebrad_child_1 = testdir()?
-        .with_exact_config(&config)?
-        .spawn_child(args!["start"])?
-        .bypass_test_capture(true)
-        .with_timeout(test_type.zebrad_timeout())
-        .with_failure_regex_iter(
-            zebrad_failure_messages.clone(),
-            zebrad_ignore_messages.clone(),
-        );
+    let is_finished = Arc::new(AtomicBool::new(false));
+
+    {
+        let is_finished = Arc::clone(&is_finished);
+        let config = config.clone();
+        let (zebrad_failure_messages, zebrad_ignore_messages) = test_type.zebrad_failure_messages();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut zebrad_child = testdir()?
+                .with_exact_config(&config)?
+                .spawn_child(args!["start"])?
+                .bypass_test_capture(true)
+                .with_timeout(test_type.zebrad_timeout())
+                .with_failure_regex_iter(zebrad_failure_messages, zebrad_ignore_messages);
+
+            while !is_finished.load(std::sync::atomic::Ordering::SeqCst) {
+                zebrad_child.wait_for_stdout_line(Some("zebraA1".to_string()));
+            }
+
+            Ok(())
+        });
+    }
 
     config.network.initial_testnet_peers = [config.network.listen_addr.to_string()].into();
     config.network.network = Network::new_default_testnet();
+    config.network.listen_addr = "127.0.0.1:0".parse()?;
     config.rpc.listen_addr = Some(format!("127.0.0.1:{}", random_known_port()).parse()?);
 
-    let rpc_client2 = RpcRequestClient::new(config.rpc.listen_addr.unwrap());
+    let rpc_listen_addr = config.rpc.listen_addr.unwrap();
+    let rpc_client_2 = RpcRequestClient::new(rpc_listen_addr);
 
-    let mut _zebrad_child_2 = testdir()?
-        .with_exact_config(&config)?
-        .spawn_child(args!["start"])?
-        .bypass_test_capture(true)
-        .with_timeout(test_type.zebrad_timeout())
-        .with_failure_regex_iter(zebrad_failure_messages, zebrad_ignore_messages);
+    tracing::info!(
+        ?rpc_listen_addr,
+        network_listen_addr = ?config.network.listen_addr,
+        "starting a zebrad child on the default Testnet"
+    );
+
+    {
+        let is_finished = Arc::clone(&is_finished);
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let (zebrad_failure_messages, zebrad_ignore_messages) =
+                test_type.zebrad_failure_messages();
+            let mut zebrad_child = testdir()?
+                .with_exact_config(&config)?
+                .spawn_child(args!["start"])?
+                .bypass_test_capture(true)
+                .with_timeout(test_type.zebrad_timeout())
+                .with_failure_regex_iter(zebrad_failure_messages, zebrad_ignore_messages);
+
+            while !is_finished.load(std::sync::atomic::Ordering::SeqCst) {
+                zebrad_child.wait_for_stdout_line(Some("zebraB2".to_string()));
+            }
+
+            Ok(())
+        });
+    }
+
+    tracing::info!("waiting for zebrad nodes to connect");
 
     // Wait a few seconds for Zebra to start up and make outbound peer connections
     tokio::time::sleep(LAUNCH_DELAY).await;
 
+    tracing::info!("checking for peers");
+
     // Call `getpeerinfo` to check that the zebrad instances have connected
-    let peer_info: Vec<PeerInfo> = rpc_client2
+    let peer_info: Vec<PeerInfo> = rpc_client_2
         .json_result_from_call("getpeerinfo", "[]")
         .await
         .map_err(|err| eyre!(err))?;
 
     assert!(!peer_info.is_empty(), "should have outbound peer");
 
-    // Call the `generate` method to mine blocks in the zebrad instance where PoW is disabled
-    let _: Vec<GetBlockHash> = rpc_client1
-        .json_result_from_call("generate", "[10]")
-        .await
-        .map_err(|err| eyre!(err))?;
+    tracing::info!(
+        ?peer_info,
+        "found peer connection, committing genesis block"
+    );
 
-    // Wait a few seconds for Zebra to drop the peer connection
-    tokio::time::sleep(Duration::from_secs(5)).await;
+    let genesis_block = network.block_parsed_iter().next().unwrap();
+    rpc_client_1.submit_block(genesis_block.clone()).await?;
+    rpc_client_2.submit_block(genesis_block).await?;
+
+    // Call the `generate` method to mine blocks in the zebrad instance where PoW is disabled
+    tracing::info!("committed genesis block, mining blocks with invalid PoW");
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    rpc_client_1.call("generate", "[500]").await?;
+
+    tracing::info!("wait for misbehavior messages to flush into address updater channel");
+
+    tokio::time::sleep(Duration::from_secs(30)).await;
+
+    tracing::info!("calling getpeerinfo to confirm Zebra has dropped the peer connection");
 
     // Call `getpeerinfo` to check that the zebrad instances have disconnected
-    let peer_info: Vec<PeerInfo> = rpc_client2
+    for i in 0..600 {
+        let peer_info: Vec<PeerInfo> = rpc_client_2
+            .json_result_from_call("getpeerinfo", "[]")
+            .await
+            .map_err(|err| eyre!(err))?;
+
+        if peer_info.is_empty() {
+            break;
+        } else if i % 10 == 0 {
+            tracing::info!(?peer_info, "has not yet disconnected from misbehaving peer");
+        }
+
+        rpc_client_1.call("generate", "[1]").await?;
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+
+    let peer_info: Vec<PeerInfo> = rpc_client_2
         .json_result_from_call("getpeerinfo", "[]")
         .await
         .map_err(|err| eyre!(err))?;
 
+    tracing::info!(?peer_info, "called getpeerinfo");
+
     assert!(peer_info.is_empty(), "should have no peers");
+
+    is_finished.store(true, std::sync::atomic::Ordering::SeqCst);
 
     Ok(())
 }

--- a/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
+++ b/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
@@ -162,7 +162,7 @@ pub(crate) async fn run() -> Result<()> {
 /// or `ProposalResponse` in 'proposal' mode.
 async fn try_validate_block_template(client: &RpcRequestClient) -> Result<()> {
     let mut response_json_result: GetBlockTemplate = client
-        .json_result_from_call("getblocktemplate", "[]".to_string())
+        .json_result_from_call("getblocktemplate", "[]")
         .await
         .expect("response should be success output with a serialized `GetBlockTemplate`");
 

--- a/zebrad/tests/common/get_block_template_rpcs/get_peer_info.rs
+++ b/zebrad/tests/common/get_block_template_rpcs/get_peer_info.rs
@@ -40,7 +40,7 @@ pub(crate) async fn run() -> Result<()> {
 
     // call `getpeerinfo` RPC method
     let peer_info_result: Vec<PeerInfo> = RpcRequestClient::new(rpc_address)
-        .json_result_from_call("getpeerinfo", "[]".to_string())
+        .json_result_from_call("getpeerinfo", "[]")
         .await
         .map_err(|err| eyre!(err))?;
 


### PR DESCRIPTION
## Motivation

Zebra should drop connections to and avoid reconnecting with peers which advertise blocks or mempool transactions that fail some semantic validation checks.

Closes #9111.
Depends-On: #9224.

## Solution

Channels:
- Adds a new mpsc channel for the mempool, inbound svc, and syncer to report misbehaviour to the address book,
- Adds a watch channel for the address book to broadcast the latest bans to the peer set and inbound connector
- Adds a task for batching updates to addresses' misbehavior scores

Type Updates:
- Adds a `misbehavior_score` field on `MetaAddr`, a `bans_by_ip` field to `AddressBook`, and a `UpdateMisbehavior` variant to `MetaAddrChange`
- Updates `MetaAddrChange.apply_to_meta_addr()` to apply `UpdateMisbehavior` changes
- Adds the `PeerSocketAddr` of the peer that provided a block or transaction to the `Transaction` and `Block` variants of the peer set's response type
- Updates error types for mempool, inbound service, and syncer `Downloads` components to include the peer address from which the block or transaction originated
- Passes the new channel for reporting misbehaviour to the mempool, inbound service, and syncer

Method Updates:
- Updates `AddressBook.update()` to remove any addresses that exceed a misbehavior score threshold and add them to `bans_by_ip`
  - Removes oldest banned IPs if `bans_by_ip` exceeds its maximum size
  - Removing the addresses from the `by_addr` field avoids attempting outbound connections to them as candidates,
- Updates `sanitized()` method to avoid providing addresses with a non-zero misbehavior score in responses to `GetAddr` requests
- Adds `misbehavior_score()` and `mempool_misbehavior_score()` methods on `TransactionError`, `VerifyBlockError`, and `BlockError`
- Updates mempool, inbound service, and syncer to send `UpdateMisbehavior` messages to the address book updater when blocks or transactions fail some checks during semantic validation
- Updates peer set's `poll_ready()` method to drop connections to banned IPs

### Tests

Adds an acceptance test which spawns an instance of zebrad on a Testnet where PoW is disabled, and one on the default Testnet. Checks that they've connected, mines blocks via the `generate()` RPC, and checks that they've disconnected.


## Follow Up Work

Increment the misbehaviour score for more errors and adjust the amounts based on zcashd (though at a glance, it looks similar already).

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

