### PR TITLE
fix(ci): pin release-drafter to v6.0.0 to prevent duplicate drafts

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@v6.0.0
         with:
           config-name: release-drafter.yml
           commitish: main


### PR DESCRIPTION
## Motivation

Release Drafter v6.1.0 introduced a regression that causes it to create multiple duplicate draft releases instead of updating existing ones. This was causing ~160 duplicate draft releases to be created for Zebra 2.2.0.

Fixes #9187

## Solution

Pin to v6.0.0 which correctly finds and updates existing draft releases. This is a known issue tracked in release-drafter/release-drafter#1425.
