### PR TITLE
Fix Typos in Continuous Integration and Release Process Documentation

### DIFF
--- a/book/src/dev/continuous-integration.md
+++ b/book/src/dev/continuous-integration.md
@@ -16,7 +16,7 @@ Some of our builds and tests are repeated on the `main` branch, due to:
 - our cached state sharing rules, or
 - generating base coverage for PR coverage reports.
 
-Currently, each Zebra and lightwalletd full and update sync will updates cached state images,
+Currently, each Zebra and lightwalletd full and update sync will update cached state images,
 which are shared by all tests. Tests prefer the latest image generated from the same commit.
 But if a state from the same commit is not available, tests will use the latest image from
 any branch and commit, as long as the state version is the same.

--- a/book/src/dev/release-process.md
+++ b/book/src/dev/release-process.md
@@ -65,7 +65,7 @@ We let you preview what's coming by providing Release Candidate \(`rc`\) pre-rel
 
 ### Distribution tags
 
-Zebras's tagging relates directly to versions published on Docker. We will reference these [Docker Hub distribution tags](https://hub.docker.com/r/zfnd/zebra/tags) throughout:
+Zebra's tagging relates directly to versions published on Docker. We will reference these [Docker Hub distribution tags](https://hub.docker.com/r/zfnd/zebra/tags) throughout:
 
 | Tag    | Description |
 |:---    |:---         |


### PR DESCRIPTION
## Description

This pull request fixes a couple of typos in our documentation:

### 1. Continuous Integration Documentation (`book/src/dev/continuous-integration.md`)

- **Change:** Corrects the verb tense from "will updates" to "will update"  
- **Result:** The sentence now reads:  
  > "Currently, each Zebra and lightwalletd full and update sync will update cached state images, which are shared by all tests. Tests prefer the latest image generated from the same commit. But if a state from the same commit is not available, tests will use the latest image from any branch and commit, as long as the state version is the same."

### 2. Release Process Documentation (`book/src/dev/release-process.md`)

- **Change:** Adjusts the description of the distribution tags for clarity and consistency  
- **Result:** The updated text now reads:  
  > "Zebra's tagging relates directly to versions published on Docker. We will reference these [Docker Hub distribution tags](https://hub.docker.com/r/zfnd/zebra/tags) throughout:"  
- **Purpose:** Ensures the description accurately reflects the connection between our tags and the published Docker images.

## Additional Context

- **Commits:**
  - `typo continuous-integration.md` (authored by podZzzzz)
  - `typorelease-process.md` (authored by podZzzzz)

- **Files Changed:**
  - `book/src/dev/continuous-integration.md` (1 addition, 1 deletion)
  - `book/src/dev/release-process.md` (1 addition, 1 deletion)

- **Impact:** These changes improve the clarity and correctness of our documentation without affecting functionality.

---

Feel free to review and merge if everything looks good. Let me know if you need any further changes!
