### PR TITLE
feat(rpc): Add fields to `getblockchaininfo` RPC output

### DIFF
--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -576,9 +576,9 @@ where
                 Err(_) => ((Height::MIN, network.genesis_hash()), Default::default()),
             };
 
-            let difficulty = chain_tip_difficulty
-                .unwrap_or_else(|_| U256::from(network.target_difficulty_limit()).as_u128() as f64);
-
+            let difficulty = chain_tip_difficulty.unwrap_or_else(|_| {
+                (U256::from(network.target_difficulty_limit()) >> 128).as_u128() as f64
+            });
             (size_on_disk, tip, value_balance, difficulty)
         };
 

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -25,7 +25,6 @@ use zebra_chain::{
     transparent::{
         self, EXTRA_ZEBRA_COINBASE_DATA, MAX_COINBASE_DATA_LEN, MAX_COINBASE_HEIGHT_DATA_LEN,
     },
-    work::difficulty::{ParameterDifficulty as _, U256},
 };
 use zebra_consensus::{
     block_subsidy, funding_stream_address, funding_stream_values, miner_subsidy, RouterError,
@@ -36,7 +35,7 @@ use zebra_state::{ReadRequest, ReadResponse};
 
 use crate::{
     methods::{
-        best_chain_tip_height,
+        best_chain_tip_height, chain_tip_difficulty,
         get_block_template_rpcs::{
             constants::{
                 DEFAULT_SOLUTION_RATE_WINDOW_SIZE, GET_BLOCK_TEMPLATE_MEMPOOL_LONG_POLL_INTERVAL,
@@ -1261,67 +1260,7 @@ where
     }
 
     async fn get_difficulty(&self) -> Result<f64> {
-        let network = self.network.clone();
-        let mut state = self.state.clone();
-
-        let request = ReadRequest::ChainInfo;
-
-        // # TODO
-        // - add a separate request like BestChainNextMedianTimePast, but skipping the
-        //   consistency check, because any block's difficulty is ok for display
-        // - return 1.0 for a "not enough blocks in the state" error, like `zcashd`:
-        // <https://github.com/zcash/zcash/blob/7b28054e8b46eb46a9589d0bdc8e29f9fa1dc82d/src/rpc/blockchain.cpp#L40-L41>
-        let response = state
-            .ready()
-            .and_then(|service| service.call(request))
-            .await
-            .map_err(|error| ErrorObject::owned(0, error.to_string(), None::<()>))?;
-
-        let chain_info = match response {
-            ReadResponse::ChainInfo(info) => info,
-            _ => unreachable!("unmatched response to a chain info request"),
-        };
-
-        // This RPC is typically used for display purposes, so it is not consensus-critical.
-        // But it uses the difficulty consensus rules for its calculations.
-        //
-        // Consensus:
-        // https://zips.z.cash/protocol/protocol.pdf#nbits
-        //
-        // The zcashd implementation performs to_expanded() on f64,
-        // and then does an inverse division:
-        // https://github.com/zcash/zcash/blob/d6e2fada844373a8554ee085418e68de4b593a6c/src/rpc/blockchain.cpp#L46-L73
-        //
-        // But in Zebra we divide the high 128 bits of each expanded difficulty. This gives
-        // a similar result, because the lower 128 bits are insignificant after conversion
-        // to `f64` with a 53-bit mantissa.
-        //
-        // `pow_limit >> 128 / difficulty >> 128` is the same as the work calculation
-        // `(2^256 / pow_limit) / (2^256 / difficulty)`, but it's a bit more accurate.
-        //
-        // To simplify the calculation, we don't scale for leading zeroes. (Bitcoin's
-        // difficulty currently uses 68 bits, so even it would still have full precision
-        // using this calculation.)
-
-        // Get expanded difficulties (256 bits), these are the inverse of the work
-        let pow_limit: U256 = network.target_difficulty_limit().into();
-        let difficulty: U256 = chain_info
-            .expected_difficulty
-            .to_expanded()
-            .expect("valid blocks have valid difficulties")
-            .into();
-
-        // Shift out the lower 128 bits (256 bits, but the top 128 are all zeroes)
-        let pow_limit = pow_limit >> 128;
-        let difficulty = difficulty >> 128;
-
-        // Convert to u128 then f64.
-        // We could also convert U256 to String, then parse as f64, but that's slower.
-        let pow_limit = pow_limit.as_u128() as f64;
-        let difficulty = difficulty.as_u128() as f64;
-
-        // Invert the division to give approximately: `work(difficulty) / work(pow_limit)`
-        Ok(pow_limit / difficulty)
+        chain_tip_difficulty(self.network.clone(), self.state.clone()).await
     }
 
     async fn z_list_unified_receivers(&self, address: String) -> Result<unified_address::Response> {

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -25,7 +25,7 @@ use zebra_state::{BoxError, HashOrHeight};
 
 use zebra_test::mock_service::MockService;
 
-use crate::methods::{self, types::ValuePoolBalance};
+use crate::methods::{self, types::Balance};
 
 use super::super::{
     AddressBalance, AddressStrings, NetworkUpgradeStatus, RpcImpl, RpcServer, SentTransactionHash,
@@ -569,7 +569,7 @@ proptest! {
             prop_assert_eq!(response.best_block_hash, genesis_block.header.hash());
             prop_assert_eq!(response.chain, network.bip70_network_name());
             prop_assert_eq!(response.blocks, Height::MIN);
-            prop_assert_eq!(response.value_pools, ValuePoolBalance::from_value_balance(ValueBalance::zero()));
+            prop_assert_eq!(response.value_pools, Balance::value_pools(ValueBalance::zero()));
 
             let genesis_branch_id = NetworkUpgrade::current(&network, Height::MIN).branch_id().unwrap_or(ConsensusBranchId::RPC_MISSING_ID);
             let next_height = (Height::MIN + 1).expect("genesis height plus one is next height and valid");

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -12,7 +12,7 @@ use tower::buffer::Buffer;
 
 use zebra_chain::{
     amount::{Amount, NonNegative},
-    block::{self, Block, Height},
+    block::{Block, Height},
     chain_tip::{mock::MockChainTip, ChainTip, NoChainTip},
     parameters::{ConsensusBranchId, Network, NetworkUpgrade},
     serialization::{DateTime32, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize},

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -613,6 +613,12 @@ fn snapshot_rpc_getblockchaininfo(
                 // replace with:
                 "[Height]"
             }),
+            ".verificationprogress" => dynamic_redaction(|value, _path| {
+                // assert that the value looks like a valid verification progress here
+                assert!(value.as_f64().unwrap() < 1.0);
+                // replace with:
+                "[f64]"
+            }),
         })
     });
 }

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -615,7 +615,7 @@ fn snapshot_rpc_getblockchaininfo(
             }),
             ".verificationprogress" => dynamic_redaction(|value, _path| {
                 // assert that the value looks like a valid verification progress here
-                assert!(value.as_f64().unwrap() < 1.0);
+                assert!(value.as_f64().unwrap() <= 1.0);
                 // replace with:
                 "[f64]"
             }),

--- a/zebra-rpc/src/methods/tests/snapshots/get_blockchain_info@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_blockchain_info@mainnet_10.snap
@@ -5,33 +5,50 @@ expression: info
 {
   "chain": "main",
   "blocks": 10,
+  "headers": 10,
+  "difficulty": 1.0,
+  "verificationprogress": "[f64]",
+  "chainwork": 0,
+  "pruned": false,
+  "size_on_disk": 0,
+  "commitments": 0,
   "bestblockhash": "00074c46a4aa8172df8ae2ad1848a2e084e1b6989b7d9e6132adc938bf835b36",
   "estimatedheight": "[Height]",
+  "chainSupply": {
+    "chainValue": 0.034375,
+    "chainValueZat": 3437500,
+    "monitored": true
+  },
   "valuePools": [
     {
       "id": "transparent",
       "chainValue": 0.034375,
-      "chainValueZat": 3437500
+      "chainValueZat": 3437500,
+      "monitored": true
     },
     {
       "id": "sprout",
       "chainValue": 0.0,
-      "chainValueZat": 0
+      "chainValueZat": 0,
+      "monitored": false
     },
     {
       "id": "sapling",
       "chainValue": 0.0,
-      "chainValueZat": 0
+      "chainValueZat": 0,
+      "monitored": false
     },
     {
       "id": "orchard",
       "chainValue": 0.0,
-      "chainValueZat": 0
+      "chainValueZat": 0,
+      "monitored": false
     },
     {
       "id": "deferred",
       "chainValue": 0.0,
-      "chainValueZat": 0
+      "chainValueZat": 0,
+      "monitored": false
     }
   ],
   "upgrades": {

--- a/zebra-rpc/src/methods/tests/snapshots/get_blockchain_info@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_blockchain_info@testnet_10.snap
@@ -5,33 +5,50 @@ expression: info
 {
   "chain": "test",
   "blocks": 10,
+  "headers": 10,
+  "difficulty": 1.0,
+  "verificationprogress": "[f64]",
+  "chainwork": 0,
+  "pruned": false,
+  "size_on_disk": 0,
+  "commitments": 0,
   "bestblockhash": "079f4c752729be63e6341ee9bce42fbbe37236aba22e3deb82405f3c2805c112",
   "estimatedheight": "[Height]",
+  "chainSupply": {
+    "chainValue": 0.034375,
+    "chainValueZat": 3437500,
+    "monitored": true
+  },
   "valuePools": [
     {
       "id": "transparent",
       "chainValue": 0.034375,
-      "chainValueZat": 3437500
+      "chainValueZat": 3437500,
+      "monitored": true
     },
     {
       "id": "sprout",
       "chainValue": 0.0,
-      "chainValueZat": 0
+      "chainValueZat": 0,
+      "monitored": false
     },
     {
       "id": "sapling",
       "chainValue": 0.0,
-      "chainValueZat": 0
+      "chainValueZat": 0,
+      "monitored": false
     },
     {
       "id": "orchard",
       "chainValue": 0.0,
-      "chainValueZat": 0
+      "chainValueZat": 0,
+      "monitored": false
     },
     {
       "id": "deferred",
       "chainValue": 0.0,
-      "chainValueZat": 0
+      "chainValueZat": 0,
+      "monitored": false
     }
   ],
   "upgrades": {

--- a/zebra-rpc/src/methods/tests/snapshots/get_blockchain_info_future_nu6_height@nu6testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_blockchain_info_future_nu6_height@nu6testnet_10.snap
@@ -5,33 +5,50 @@ expression: info
 {
   "chain": "test",
   "blocks": 10,
+  "headers": 10,
+  "difficulty": 1.0,
+  "verificationprogress": "[f64]",
+  "chainwork": 0,
+  "pruned": false,
+  "size_on_disk": 0,
+  "commitments": 0,
   "bestblockhash": "079f4c752729be63e6341ee9bce42fbbe37236aba22e3deb82405f3c2805c112",
   "estimatedheight": "[Height]",
+  "chainSupply": {
+    "chainValue": 0.034375,
+    "chainValueZat": 3437500,
+    "monitored": true
+  },
   "valuePools": [
     {
       "id": "transparent",
       "chainValue": 0.034375,
-      "chainValueZat": 3437500
+      "chainValueZat": 3437500,
+      "monitored": true
     },
     {
       "id": "sprout",
       "chainValue": 0.0,
-      "chainValueZat": 0
+      "chainValueZat": 0,
+      "monitored": false
     },
     {
       "id": "sapling",
       "chainValue": 0.0,
-      "chainValueZat": 0
+      "chainValueZat": 0,
+      "monitored": false
     },
     {
       "id": "orchard",
       "chainValue": 0.0,
-      "chainValueZat": 0
+      "chainValueZat": 0,
+      "monitored": false
     },
     {
       "id": "deferred",
       "chainValue": 0.0,
-      "chainValueZat": 0
+      "chainValueZat": 0,
+      "monitored": false
     }
   ],
   "upgrades": {

--- a/zebra-rpc/src/methods/types.rs
+++ b/zebra-rpc/src/methods/types.rs
@@ -3,5 +3,5 @@
 mod get_blockchain_info;
 mod zec;
 
-pub use get_blockchain_info::ValuePoolBalance;
+pub use get_blockchain_info::Balance;
 pub use zec::Zec;

--- a/zebra-rpc/src/methods/types/get_blockchain_info.rs
+++ b/zebra-rpc/src/methods/types/get_blockchain_info.rs
@@ -23,12 +23,12 @@ pub struct Balance {
 }
 
 impl Balance {
-    /// Returns a list of [`ValuePoolBalance`]s converted from the default [`ValueBalance`].
+    /// Returns a list of [`Balance`]s converted from the default [`ValueBalance`].
     pub fn zero_pools() -> [Self; 5] {
         Self::value_pools(Default::default())
     }
 
-    /// Creates a new [`ValuePoolBalance`] from a pool name and its value balance.
+    /// Creates a new [`Balance`] from a pool name and its value balance.
     pub fn new(id: impl ToString, amount: Amount<NonNegative>) -> Self {
         Self {
             id: id.to_string(),
@@ -38,32 +38,32 @@ impl Balance {
         }
     }
 
-    /// Creates a [`ValuePoolBalance`] for the transparent pool.
+    /// Creates a [`Balance`] for the transparent pool.
     pub fn transparent(amount: Amount<NonNegative>) -> Self {
         Self::new("transparent", amount)
     }
 
-    /// Creates a [`ValuePoolBalance`] for the Sprout pool.
+    /// Creates a [`Balance`] for the Sprout pool.
     pub fn sprout(amount: Amount<NonNegative>) -> Self {
         Self::new("sprout", amount)
     }
 
-    /// Creates a [`ValuePoolBalance`] for the Sapling pool.
+    /// Creates a [`Balance`] for the Sapling pool.
     pub fn sapling(amount: Amount<NonNegative>) -> Self {
         Self::new("sapling", amount)
     }
 
-    /// Creates a [`ValuePoolBalance`] for the Orchard pool.
+    /// Creates a [`Balance`] for the Orchard pool.
     pub fn orchard(amount: Amount<NonNegative>) -> Self {
         Self::new("orchard", amount)
     }
 
-    /// Creates a [`ValuePoolBalance`] for the Deferred pool.
+    /// Creates a [`Balance`] for the Deferred pool.
     pub fn deferred(amount: Amount<NonNegative>) -> Self {
         Self::new("deferred", amount)
     }
 
-    /// Converts a [`ValueBalance`] to a list of [`ValuePoolBalance`]s.
+    /// Converts a [`ValueBalance`] to a list of [`Balance`]s.
     pub fn value_pools(value_balance: ValueBalance<NonNegative>) -> [Self; 5] {
         [
             Self::transparent(value_balance.transparent_amount()),

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -48,7 +48,7 @@ pub use request::{
 #[cfg(feature = "indexer")]
 pub use request::Spend;
 
-pub use response::{KnownBlock, MinedTx, ReadResponse, Response};
+pub use response::{GetBlockTemplateChainInfo, KnownBlock, MinedTx, ReadResponse, Response};
 pub use service::{
     chain_tip::{ChainTipBlock, ChainTipChange, ChainTipSender, LatestChainTip, TipAction},
     check, init, init_read_only,
@@ -72,9 +72,6 @@ pub use service::finalized_state::{
 };
 
 pub use service::{finalized_state::ZebraDb, ReadStateService};
-
-#[cfg(feature = "getblocktemplate-rpcs")]
-pub use response::GetBlockTemplateChainInfo;
 
 // Allow use in external tests
 #[cfg(any(test, feature = "proptest-impl"))]

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -1096,7 +1096,6 @@ pub enum ReadRequest {
     /// * [`ReadResponse::BlockHash(None)`](ReadResponse::BlockHash) otherwise.
     BestChainBlockHash(block::Height),
 
-    #[cfg(feature = "getblocktemplate-rpcs")]
     /// Get state information from the best block chain.
     ///
     /// Returns [`ReadResponse::ChainInfo(info)`](ReadResponse::ChainInfo) where `info` is a

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -1165,7 +1165,6 @@ impl ReadRequest {
             ReadRequest::BestChainBlockHash(_) => "best_chain_block_hash",
             #[cfg(feature = "indexer")]
             ReadRequest::SpendingTransactionId(_) => "spending_transaction_id",
-            #[cfg(feature = "getblocktemplate-rpcs")]
             ReadRequest::ChainInfo => "chain_info",
             #[cfg(feature = "getblocktemplate-rpcs")]
             ReadRequest::SolutionRate { .. } => "solution_rate",

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -866,6 +866,10 @@ impl Request {
 /// A read-only query about the chain state, via the
 /// [`ReadStateService`](crate::service::ReadStateService).
 pub enum ReadRequest {
+    /// Returns [`ReadResponse::UsageInfo(num_bytes: u64)`](ReadResponse::UsageInfo)
+    /// with the current disk space usage in bytes.
+    UsageInfo,
+
     /// Returns [`ReadResponse::Tip(Option<(Height, block::Hash)>)`](ReadResponse::Tip)
     /// with the current best chain tip.
     Tip,
@@ -1134,6 +1138,7 @@ pub enum ReadRequest {
 impl ReadRequest {
     fn variant_name(&self) -> &'static str {
         match self {
+            ReadRequest::UsageInfo => "usage_info",
             ReadRequest::Tip => "tip",
             ReadRequest::TipPoolValues => "tip_pool_values",
             ReadRequest::Depth(_) => "depth",

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -13,7 +13,6 @@ use zebra_chain::{
     value_balance::ValueBalance,
 };
 
-#[cfg(feature = "getblocktemplate-rpcs")]
 use zebra_chain::work::difficulty::CompactDifficulty;
 
 // Allow *only* these unused imports, so that rustdoc link resolution
@@ -262,7 +261,6 @@ pub enum ReadResponse {
 }
 
 /// A structure with the information needed from the state to build a `getblocktemplate` RPC response.
-#[cfg(feature = "getblocktemplate-rpcs")]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GetBlockTemplateChainInfo {
     // Data fetched directly from the state tip.

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -135,6 +135,9 @@ impl MinedTx {
 /// A response to a read-only
 /// [`ReadStateService`](crate::service::ReadStateService)'s [`ReadRequest`].
 pub enum ReadResponse {
+    /// Response to [`ReadRequest::UsageInfo`] with the current best chain tip.
+    UsageInfo(u64),
+
     /// Response to [`ReadRequest::Tip`] with the current best chain tip.
     Tip(Option<(block::Height, block::Hash)>),
 
@@ -336,7 +339,8 @@ impl TryFrom<ReadResponse> for Response {
 
             ReadResponse::ValidBestChainTipNullifiersAndAnchors => Ok(Response::ValidBestChainTipNullifiersAndAnchors),
 
-            ReadResponse::TipPoolValues { .. }
+            ReadResponse::UsageInfo(_)
+            | ReadResponse::TipPoolValues { .. }
             | ReadResponse::TransactionIdsForBlock(_)
             | ReadResponse::SaplingTree(_)
             | ReadResponse::OrchardTree(_)

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -241,7 +241,6 @@ pub enum ReadResponse {
     /// Response to [`ReadRequest::BestChainBlockHash`] with the specified block hash.
     BlockHash(Option<block::Hash>),
 
-    #[cfg(feature = "getblocktemplate-rpcs")]
     /// Response to [`ReadRequest::ChainInfo`] with the state
     /// information needed by the `getblocktemplate` RPC method.
     ChainInfo(GetBlockTemplateChainInfo),
@@ -345,7 +344,8 @@ impl TryFrom<ReadResponse> for Response {
             | ReadResponse::OrchardSubtrees(_)
             | ReadResponse::AddressBalance(_)
             | ReadResponse::AddressesTransactionIds(_)
-            | ReadResponse::AddressUtxos(_) => {
+            | ReadResponse::AddressUtxos(_)
+            | ReadResponse::ChainInfo(_) => {
                 Err("there is no corresponding Response for this ReadResponse")
             }
 
@@ -356,7 +356,7 @@ impl TryFrom<ReadResponse> for Response {
             ReadResponse::ValidBlockProposal => Ok(Response::ValidBlockProposal),
 
             #[cfg(feature = "getblocktemplate-rpcs")]
-            ReadResponse::ChainInfo(_) | ReadResponse::SolutionRate(_) | ReadResponse::TipBlockSize(_) => {
+            ReadResponse::SolutionRate(_) | ReadResponse::TipBlockSize(_) => {
                 Err("there is no corresponding Response for this ReadResponse")
             }
         }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1831,8 +1831,7 @@ impl Service<ReadRequest> for ReadStateService {
                 .wait_for_panics()
             }
 
-            // Used by get_block_template RPC.
-            #[cfg(feature = "getblocktemplate-rpcs")]
+            // Used by get_block_template and getblockchaininfo RPCs.
             ReadRequest::ChainInfo => {
                 let state = self.clone();
                 let latest_non_finalized_state = self.latest_non_finalized_state();

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1173,6 +1173,24 @@ impl Service<ReadRequest> for ReadStateService {
         let span = Span::current();
 
         match req {
+            // Used by the `getblockchaininfo` RPC.
+            ReadRequest::UsageInfo => {
+                let db = self.db.clone();
+
+                tokio::task::spawn_blocking(move || {
+                    span.in_scope(move || {
+                        // The work is done in the future.
+
+                        let db_size = db.size();
+
+                        timer.finish(module_path!(), line!(), "ReadRequest::UsageInfo");
+
+                        Ok(ReadResponse::UsageInfo(db_size))
+                    })
+                })
+                .wait_for_panics()
+            }
+
             // Used by the StateService.
             ReadRequest::Tip => {
                 let state = self.clone();

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -343,6 +343,11 @@ impl ZebraDb {
     pub fn print_db_metrics(&self) {
         self.db.print_db_metrics();
     }
+
+    /// Returns the estimated total disk space usage of the database.
+    pub fn size(&self) -> u64 {
+        self.db.size()
+    }
 }
 
 impl Drop for ZebraDb {

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -16,11 +16,9 @@ use crate::service;
 
 pub mod address;
 pub mod block;
+pub mod difficulty;
 pub mod find;
 pub mod tree;
-
-#[cfg(feature = "getblocktemplate-rpcs")]
-pub mod difficulty;
 
 #[cfg(test)]
 mod tests;

--- a/zebra-state/src/service/read/difficulty.rs
+++ b/zebra-state/src/service/read/difficulty.rs
@@ -82,6 +82,7 @@ pub fn get_block_template_chain_info(
 ///
 /// Returns the solution rate per second for the current best chain, or `None` if
 /// the `start_hash` and at least 1 block below it are not found in the chain.
+#[allow(unused)]
 pub fn solution_rate(
     non_finalized_state: &NonFinalizedState,
     db: &ZebraDb,

--- a/zebra-state/src/service/read/tree.rs
+++ b/zebra-state/src/service/read/tree.rs
@@ -197,7 +197,6 @@ where
     }
 }
 
-#[cfg(feature = "getblocktemplate-rpcs")]
 /// Get the history tree of the provided chain.
 pub fn history_tree<C>(
     chain: Option<C>,


### PR DESCRIPTION
## Motivation

This PR adds fields that are present on the zcashd `getblockchaininfo` RPC output which are likely required from Zebra's `getblockchaininfo` RPC too (except `chain_work` which should be added as part of https://github.com/ZcashFoundation/zebra/issues/7109).

Closes https://github.com/ZcashFoundation/zebra/issues/8449

## Solution

- Adds the missing fields to the response struct (except `softforks`)
- Adds a state request for querying the disk space usage
- Renames `ValuePoolBalance` to `Balance` and re-uses it for `chain_supply` by summing the amounts of all pools

Related:
- Runs `getblockchaininfo` state queries in parallel,
- Removes `BlockHeader` query, reads tip block time from latest chain tip channel instead, and
- Avoids returning an error when the state is empty (returns genesis/default values instead).

### Tests

- Updated snapshots
  - Ignores the `verificationprogress` field as it depends on the current time
- Updated existing prop tests
- Used shared logic covered by existing tests for the `difficulty` field

### Follow-up Work

- https://github.com/ZcashFoundation/zebra/issues/7109

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [ ] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

