### PR TITLE
change(rpc): Accept an unused second param in `sendrawtransaction` RPC

### DIFF
--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -131,6 +131,7 @@ pub trait Rpc {
     /// # Parameters
     ///
     /// - `raw_transaction_hex`: (string, required, example="signedhex") The hex-encoded raw transaction bytes.
+    /// - `allow_high_fees`: (bool, optional) A legacy parameter accepted by zcashd but ignored by Zebra.
     ///
     /// # Notes
     ///
@@ -140,6 +141,7 @@ pub trait Rpc {
     async fn send_raw_transaction(
         &self,
         raw_transaction_hex: String,
+        _allow_high_fees: Option<bool>,
     ) -> Result<SentTransactionHash>;
 
     /// Returns the requested block by hash or height, as a [`GetBlock`] JSON string.
@@ -688,6 +690,7 @@ where
     async fn send_raw_transaction(
         &self,
         raw_transaction_hex: String,
+        _allow_high_fees: Option<bool>,
     ) -> Result<SentTransactionHash> {
         let mempool = self.mempool.clone();
         let queue_sender = self.queue_sender.clone();

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -49,7 +49,7 @@ proptest! {
 
             let transaction_hex = hex::encode(&transaction_bytes);
 
-            let send_task = tokio::spawn(async move { rpc.send_raw_transaction(transaction_hex).await });
+            let send_task = tokio::spawn(async move { rpc.send_raw_transaction(transaction_hex, None).await });
 
             let unmined_transaction = UnminedTx::from(transaction);
             let expected_request = mempool::Request::Queue(vec![unmined_transaction.into()]);
@@ -93,7 +93,7 @@ proptest! {
 
             let _rpc = rpc.clone();
             let _transaction_hex = transaction_hex.clone();
-            let send_task = tokio::spawn(async move { _rpc.send_raw_transaction(_transaction_hex).await });
+            let send_task = tokio::spawn(async move { _rpc.send_raw_transaction(_transaction_hex, None).await });
 
             let unmined_transaction = UnminedTx::from(transaction);
             let expected_request = mempool::Request::Queue(vec![unmined_transaction.clone().into()]);
@@ -109,7 +109,7 @@ proptest! {
 
             check_err_code(result, ErrorCode::ServerError(-1))?;
 
-            let send_task = tokio::spawn(async move { rpc.send_raw_transaction(transaction_hex.clone()).await });
+            let send_task = tokio::spawn(async move { rpc.send_raw_transaction(transaction_hex.clone(), None).await });
 
             let expected_request = mempool::Request::Queue(vec![unmined_transaction.clone().into()]);
 
@@ -147,7 +147,7 @@ proptest! {
             let rsp = mempool::Response::Queued(vec![Err(DummyError.into())]);
             let mempool_query = mempool.expect_request(req).map_ok(|r| r.respond(rsp));
 
-            let (rpc_rsp, _) = tokio::join!(rpc.send_raw_transaction(tx), mempool_query);
+            let (rpc_rsp, _) = tokio::join!(rpc.send_raw_transaction(tx, None), mempool_query);
 
             check_err_code(rpc_rsp, ErrorCode::ServerError(-1))?;
 
@@ -175,7 +175,7 @@ proptest! {
         tokio::time::pause();
 
         runtime.block_on(async move {
-            let send_task = rpc.send_raw_transaction(non_hex_string);
+            let send_task = rpc.send_raw_transaction(non_hex_string, None);
 
             // Check that there are no further requests.
             mempool.expect_no_requests().await?;
@@ -206,7 +206,7 @@ proptest! {
         prop_assume!(Transaction::zcash_deserialize(&*random_bytes).is_err());
 
         runtime.block_on(async move {
-            let send_task = rpc.send_raw_transaction(hex::encode(random_bytes));
+            let send_task = rpc.send_raw_transaction(hex::encode(random_bytes), None);
 
             mempool.expect_no_requests().await?;
             state.expect_no_requests().await?;
@@ -711,7 +711,7 @@ proptest! {
             let tx_hex = hex::encode(&tx_bytes);
             let send_task = {
                 let rpc = rpc.clone();
-                tokio::task::spawn(async move { rpc.send_raw_transaction(tx_hex).await })
+                tokio::task::spawn(async move { rpc.send_raw_transaction(tx_hex, None).await })
             };
             let tx_unmined = UnminedTx::from(tx);
             let expected_request = mempool::Request::Queue(vec![tx_unmined.clone().into()]);
@@ -790,7 +790,7 @@ proptest! {
                 // send a transaction
                 let tx_bytes = tx.zcash_serialize_to_vec()?;
                 let tx_hex = hex::encode(&tx_bytes);
-                let send_task = tokio::task::spawn(async move { rpc_clone.send_raw_transaction(tx_hex).await });
+                let send_task = tokio::task::spawn(async move { rpc_clone.send_raw_transaction(tx_hex, None).await });
 
                 let tx_unmined = UnminedTx::from(tx.clone());
                 let expected_request = mempool::Request::Queue(vec![tx_unmined.clone().into()]);


### PR DESCRIPTION
## Motivation

The `sendrawtransaction` RPC in zcashd accepts a second parameters, `allowhighfees`, which allows for adding transactions to the mempool that would otherwise be rejected for having an absurdly high fee.  Zebra's mempool never rejects transactions with excessive fees, so the only change needed to match zcashd here is to accept an unused second parameter in Zebra's `sendrawtransaction` method.

Closes #8946.

## Solution

Accepts an unused second param in `sendrawtransaction` RPC so that the method will ignore a second argument instead of returning a parser error.

### Tests

This works for the `submit_block` method.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

