### PR TITLE
fix(tests): Check if a cached state is present in scanner tests

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -161,7 +161,7 @@ run_tests() {
       --package zebra-state \
       -- --nocapture --include-ignored with_fake_activation_heights
 
-  elif [[ "${TEST_SCAN_TASK_COMMANDS}" -eq "1" ]]; then
+  elif [[ "${TEST_SCANNER}" -eq "1" ]]; then
     # Test the scanner.
     exec cargo test --locked --release --package zebra-scan \
       -- --nocapture --include-ignored scan_task_commands scan_start_where_left

--- a/zebra-scan/tests/scan_task_commands.rs
+++ b/zebra-scan/tests/scan_task_commands.rs
@@ -11,7 +11,7 @@ use std::{fs, time::Duration};
 
 use color_eyre::Result;
 use tokio::sync::mpsc::error::TryRecvError;
-use tower::{Service, util::BoxService};
+use tower::{util::BoxService, Service};
 
 use zebra_chain::{
     block::Height,
@@ -21,7 +21,7 @@ use zebra_chain::{
 
 use zebra_scan::{
     service::ScanTask,
-    storage::{Storage, db::SCANNER_DATABASE_KIND},
+    storage::{db::SCANNER_DATABASE_KIND, Storage},
 };
 
 use zebra_state::{ChainTipChange, LatestChainTip};

--- a/zebra-scan/tests/scanner.rs
+++ b/zebra-scan/tests/scanner.rs
@@ -14,7 +14,7 @@ use zebra_test::{
 };
 
 #[cfg(not(target_os = "windows"))]
-use zebra_grpc::scanner::{Empty, scanner_client::ScannerClient};
+use zebra_grpc::scanner::{scanner_client::ScannerClient, Empty};
 
 mod scan_task_commands;
 

--- a/zebra-scan/tests/scanner.rs
+++ b/zebra-scan/tests/scanner.rs
@@ -141,20 +141,22 @@ async fn scan_binary_starts() -> Result<()> {
 #[tokio::test]
 #[cfg(not(target_os = "windows"))]
 async fn scan_start_where_left() -> Result<()> {
-    use ZECPAGES_SAPLING_VIEWING_KEY;
-
     let _init_guard = zebra_test::init();
 
-    let Ok(zebrad_cachedir) = std::env::var("ZEBRA_CACHED_STATE_DIR") else {
-        tracing::info!("skipping scan_start_where_left test due to missing cached state, \
-                        please set a ZEBRA_CACHED_STATE_DIR env var with a populated and valid path to run this test");
+    let Ok(zebrad_cache_dir) = std::env::var("ZEBRA_CACHED_STATE_DIR") else {
+        tracing::warn!("env var ZEBRA_CACHED_STATE_DIR is not set, skipping test");
         return Ok(());
     };
 
+    if !Path::new(&zebrad_cache_dir).join("state").is_dir() {
+        tracing::warn!("cache dir does not contain cached state, skipping test");
+        return Ok(());
+    }
+
     // Logs the network as zebrad would as part of the metadata when starting up.
     // This is currently needed for the 'Check startup logs' step in CI to pass.
-    let network = zebra_chain::parameters::Network::Mainnet;
-    tracing::info!("Zcash network: {network}");
+    let mainnet = zebra_chain::parameters::Network::Mainnet;
+    tracing::info!("Zcash network: {mainnet}");
 
     let scanning_cache_dir = testdir()?.path().join("scanner").to_path_buf();
 
@@ -164,7 +166,7 @@ async fn scan_start_where_left() -> Result<()> {
     let rpc_listen_addr = "127.0.0.1:18232";
     let args = args![
         "--zebrad-cache-dir",
-        zebrad_cachedir,
+        zebrad_cache_dir,
         "--scanning-cache-dir",
         scanning_cache_dir.to_str().unwrap(),
         "--sapling-keys-to-scan",


### PR DESCRIPTION
## Motivation

The tests

- `scan_task_commands`, and
- `scan_start_where_left`

fail if the env var `ZEBRA_CACHE_DIR` is set but doesn't contain a valid state. The tests should not rely only on the var being set, but on the actual presence of the state.

## Solution

- Check if there's the state is present in `ZEBRA_CACHE_DIR`.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

