### PR TITLE
fix(ci): prevent duplicate draft releases in release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -77,7 +77,10 @@ autolabeler:
 name-template: 'Zebra $RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 tag-prefix: 'v'
-prerelease: true
+# Do not mark the draft release as a pre-release
+prerelease: false
+# Do not include pre-releases in the draft release
+include-pre-releases: false
 
 # Categories in rough order of importance to users.
 # Based on https://keepachangelog.com/en/1.0.0/

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,8 +16,8 @@ on:
       - main
   # pull_request event is required only for autolabeler
   pull_request:
-    # Only following types are handled by the action, but one can default to all as well
-    #types: [opened, reopened, synchronize]
+    # Only following types are handled by the action
+    types: [opened, reopened, synchronize]
   # pull_request_target event is required for autolabeler to support PRs from forks
   pull_request_target:
     #types: [opened, reopened, synchronize]


### PR DESCRIPTION
## Motivation

Release Drafter v6.1.0 has a regression that creates multiple duplicate draft releases instead of updating existing ones.

See: release-drafter/release-drafter#1425

This got reverted as dependabot updgrade it after our fix: https://github.com/ZcashFoundation/zebra/commit/7445d81295101886ae39183634e2f3037c3b6a8b

## Solution

This change:
- Disables pre-release flag for draft releases
- Excludes pre-releases from being included in drafts
- Explicitly defines PR event types in workflow

### Follow-up Work

If this continue, we might have to disable this temporarily or look for an alternative.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [X] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [X] The documentation is up to date.
- [X] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

