### PR TITLE
refactor(ci): do not run workflows tied to `ZcashFoundation` infra in forks

### DIFF
--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -227,12 +227,9 @@ jobs:
   # - on every push to the `main` branch
   # - on every release, when it's published
   # - on workflow_dispatch for manual deployments
-  
+
   # Determine which networks to deploy based on the trigger
-  
-  
-  
-  :
+  set-matrix:
     runs-on: ubuntu-latest
     outputs:
       networks: ${{ steps.set-networks.outputs.matrix }}

--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -265,7 +265,7 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
-    if: ${{ !cancelled() && !failure() && ((github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
+    if: ${{ !cancelled() && !failure() && github.repository_owner == 'ZcashFoundation' && ((github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
 
     steps:
       - uses: actions/checkout@v4.2.2

--- a/.github/workflows/chore-delete-gcp-resources.yml
+++ b/.github/workflows/chore-delete-gcp-resources.yml
@@ -34,6 +34,7 @@ env:
 jobs:
   delete-resources:
     name: Delete old GCP resources
+    if: github.repository_owner == 'ZcashFoundation'
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -105,6 +106,7 @@ jobs:
   # The same artifacts are used for both mainnet and testnet.
   clean-registries:
     name: Delete unused artifacts in registry
+    if: github.repository_owner == 'ZcashFoundation''
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'

--- a/.github/workflows/ci-unit-tests-os.yml
+++ b/.github/workflows/ci-unit-tests-os.yml
@@ -309,7 +309,7 @@ jobs:
     needs: [ test,  install-from-lockfile-no-cache, check-cargo-lock, cargo-deny, unused-deps ]
     # Only open tickets for failed or cancelled jobs that are not coming from PRs.
     # (PR statuses are already reported in the PR jobs list, and checked by GitHub's Merge Queue.)
-    if: (failure() && github.event.pull_request == null) || (cancelled() && github.event.pull_request == null)
+    if: (failure() || cancelled()) && github.repository_owner == 'ZcashFoundation' && github.event.pull_request == null
     runs-on: ubuntu-latest
     steps:
       - uses: jayqi/failed-build-issue-action@v1

--- a/.github/workflows/docs-deploy-firebase.yml
+++ b/.github/workflows/docs-deploy-firebase.yml
@@ -105,6 +105,7 @@ jobs:
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
+        if: github.repository_owner == 'ZcashFoundation'
         id: auth
         uses: google-github-actions/auth@v2.1.8
         with:
@@ -114,11 +115,13 @@ jobs:
       # TODO: remove this step after issue https://github.com/FirebaseExtended/action-hosting-deploy/issues/174 is fixed
 
       - name: Add $GCP_FIREBASE_SA_PATH to env
+        if: github.repository_owner == 'ZcashFoundation'
         run: |
           # shellcheck disable=SC2002
           echo "GCP_FIREBASE_SA_PATH=$(cat ${{ steps.auth.outputs.credentials_file_path }} | tr -d '\n')" >> "$GITHUB_ENV"
 
       - name: Deploy Zebra book to firebase
+        if: github.repository_owner == 'ZcashFoundation'
         uses: FirebaseExtended/action-hosting-deploy@v0.9.0
         with:
           firebaseServiceAccount: ${{ env.GCP_FIREBASE_SA_PATH }}
@@ -163,6 +166,7 @@ jobs:
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
+        if: github.repository_owner == 'ZcashFoundation'
         id: auth
         uses: google-github-actions/auth@v2.1.8
         with:
@@ -171,11 +175,13 @@ jobs:
 
       # TODO: remove this step after issue https://github.com/FirebaseExtended/action-hosting-deploy/issues/174 is fixed
       - name: Add $GCP_FIREBASE_SA_PATH to env
+        if: github.repository_owner == 'ZcashFoundation'
         run: |
           # shellcheck disable=SC2002
           echo "GCP_FIREBASE_SA_PATH=$(cat ${{ steps.auth.outputs.credentials_file_path }} | tr -d '\n')" >> "$GITHUB_ENV"
 
       - name: Deploy internal docs to firebase
+        if: github.repository_owner == 'ZcashFoundation'
         uses: FirebaseExtended/action-hosting-deploy@v0.9.0
         with:
           firebaseServiceAccount: ${{ env.GCP_FIREBASE_SA_PATH }}

--- a/.github/workflows/docs-dockerhub-description.yml
+++ b/.github/workflows/docs-dockerhub-description.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   dockerHubDescription:
+    if: github.repository_owner == 'ZcashFoundation'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2

--- a/.github/workflows/sub-build-docker-image.yml
+++ b/.github/workflows/sub-build-docker-image.yml
@@ -61,6 +61,7 @@ env:
 jobs:
   build:
     name: Build images
+    if: github.repository_owner == 'ZcashFoundation'
     timeout-minutes: 210
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'release' && 'prod' || 'dev' }}
@@ -111,7 +112,7 @@ jobs:
             # DockerHub release and CI tags.
             # This tag makes sure tests are using exactly the right image, even when multiple PRs run at the same time.
             type=sha,event=push
-            # These CI-only tags support CI on PRs, the main branch, and scheduled full syncs. 
+            # These CI-only tags support CI on PRs, the main branch, and scheduled full syncs.
             # These tags do not appear on DockerHub, because DockerHub images are only published on the release event.
             type=ref,event=pr
             type=ref,event=branch

--- a/.github/workflows/sub-ci-integration-tests-gcp.yml
+++ b/.github/workflows/sub-ci-integration-tests-gcp.yml
@@ -523,7 +523,7 @@ jobs:
         lightwalletd-grpc-test,
         get-block-template-test,
         submit-block-test,
-        scan-task-commands-test,
+        test-scanner,
       ]
     # Only open tickets for failed scheduled jobs, manual workflow runs, or `main` branch merges.
     # (PR statuses are already reported in the PR jobs list, and checked by GitHub's Merge Queue.)


### PR DESCRIPTION
## Motivation

Various workflows fail whenever I push to `main` on my fork. And one workflow is on a cron job which runs daily and emails me every day.

The failures are generally due to something like needing ZF credentials for some service, like DockerHub or GCP.

## Solution

This disables a bunch of CI jobs if they are run outside of the ZcashFoundation org.

There are also two workflows that simply had bugs in them. Those have also been fixed. Both bugs are caught by GitHub’s workflow file checks, so neither workflow gets run (i.e., they are not logic bugs in the steps that are performed, but references from one job to a job that doesn’t exist).

### Tests

Basically pushing these changes to `main` on my fork until I don’t get any failures. Some of the workflows don’t run right away, so it’s possible another failure may show up in a day.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [x] The PR Author's checklist is complete.
- [x] The PR resolves the issue.

