### PR TITLE
feat(state): Implements reconsider_block method

### DIFF
--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -117,11 +117,11 @@ pub const MAX_FIND_BLOCK_HEADERS_RESULTS: u32 = 160;
 /// These database versions can be recreated from their directly preceding versions.
 pub const RESTORABLE_DB_VERSIONS: [u64; 1] = [26];
 
-/// The maximum number of invalidated blocks per entry.
+/// The maximum number of invalidated block records.
 ///
-/// This limits the memory for each entry to around:
-/// `256 blocks * 2 MB per block = 0.5 GB`
-pub const MAX_INVALIDATED_BLOCKS: usize = 256;
+/// This limits the memory use to around:
+/// `100 entries * up to 99 blocks * 2 MB per block = 20 GB`
+pub const MAX_INVALIDATED_BLOCKS: usize = 100;
 
 lazy_static! {
     /// Regex that matches the RocksDB error when its lock file is already open.

--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -117,6 +117,12 @@ pub const MAX_FIND_BLOCK_HEADERS_RESULTS: u32 = 160;
 /// These database versions can be recreated from their directly preceding versions.
 pub const RESTORABLE_DB_VERSIONS: [u64; 1] = [26];
 
+/// The maximum number of invalidated blocks per entry.
+///
+/// This limits the memory for each entry to around:
+/// `256 blocks * 2 MB per block = 0.5 GB`
+pub const MAX_INVALIDATED_BLOCKS: usize = 256;
+
 lazy_static! {
     /// Regex that matches the RocksDB error when its lock file is already open.
     pub static ref LOCK_FILE_ERROR: Regex = Regex::new("(lock file).*(temporarily unavailable)|(in use)|(being used by another process)").expect("regex is valid");

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -59,9 +59,6 @@ pub enum ReconsiderError {
     #[error("Invalidated blocks list is empty when it should contain at least one block")]
     InvalidatedBlocksEmpty,
 
-    #[error("Invalid height {0:?}: parent height would be negative")]
-    InvalidHeight(block::Height),
-
     #[error("{0}")]
     ValidationError(#[from] ValidateContextError),
 }

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -46,6 +46,18 @@ pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 #[error("block is not contextually valid: {}", .0)]
 pub struct CommitSemanticallyVerifiedError(#[from] ValidateContextError);
 
+/// An error describing the reason a block or its descendants could not be reconsidered after
+/// potentially being invalidated from the chain_set.
+#[derive(Debug, Error)]
+pub enum ReconsiderError {
+    #[error("Block with hash {0} was not previously invalidated")]
+    NonPreviouslyInvalidatedBlock(block::Hash),
+    #[error("Parent chain not found for block {0}")]
+    ParentChainNotFound(block::Hash),
+    #[error("{0}")]
+    ValidationError(#[from] ValidateContextError),
+}
+
 /// An error describing why a block failed contextual validation.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 #[non_exhaustive]

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -51,9 +51,17 @@ pub struct CommitSemanticallyVerifiedError(#[from] ValidateContextError);
 #[derive(Debug, Error)]
 pub enum ReconsiderError {
     #[error("Block with hash {0} was not previously invalidated")]
-    NonPreviouslyInvalidatedBlock(block::Hash),
+    MissingInvalidatedBlock(block::Hash),
+
     #[error("Parent chain not found for block {0}")]
     ParentChainNotFound(block::Hash),
+
+    #[error("Invalidated blocks list is empty when it should contain at least one block")]
+    InvalidatedBlocksEmpty,
+
+    #[error("Invalid height {0:?}: parent height would be negative")]
+    InvalidHeight(block::Height),
+
     #[error("{0}")]
     ValidationError(#[from] ValidateContextError),
 }
@@ -63,6 +71,10 @@ pub enum ReconsiderError {
 #[non_exhaustive]
 #[allow(missing_docs)]
 pub enum ValidateContextError {
+    #[error("block hash {block_hash} was previously invalidated")]
+    #[non_exhaustive]
+    BlockPreviouslyInvalidated { block_hash: block::Hash },
+
     #[error("block parent not found in any chain, or not enough blocks in chain")]
     #[non_exhaustive]
     NotReadyToBeCommitted,

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -18,7 +18,7 @@ use zebra_chain::{
 };
 
 use crate::{
-    constants::MAX_NON_FINALIZED_CHAIN_FORKS,
+    constants::{MAX_INVALIDATED_BLOCKS, MAX_NON_FINALIZED_CHAIN_FORKS},
     error::ReconsiderError,
     request::{ContextuallyVerifiedBlock, FinalizableBlock},
     service::{check, finalized_state::ZebraDb},
@@ -31,9 +31,6 @@ mod chain;
 mod tests;
 
 pub(crate) use chain::{Chain, SpendingTransactionId};
-
-/// Maxium number of invalidated blocks per entry.
-const MAX_INVALIDATED_BLOCKS: usize = 50;
 
 /// The state of the chains in memory, including queued blocks.
 ///

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -359,7 +359,7 @@ impl Chain {
         (block, treestate)
     }
 
-    // Returns the block at the provided height and all of its descendant blocks.
+    /// Returns the block at the provided height and all of its descendant blocks.
     pub fn child_blocks(&self, block_height: &block::Height) -> Vec<ContextuallyVerifiedBlock> {
         self.blocks
             .range(block_height..)
@@ -367,7 +367,7 @@ impl Chain {
             .collect()
     }
 
-    // Returns a new chain without the invalidated block or its descendants.
+    /// Returns a new chain without the invalidated block or its descendants.
     pub fn invalidate_block(
         &self,
         block_hash: block::Hash,

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -216,6 +216,17 @@ fn finalize_pops_from_best_chain_for_network(network: Network) -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn invalidate_block_removes_block_and_descendants_from_chain() -> Result<()> {
+    let _init_guard = zebra_test::init();
+
+    for network in Network::iter() {
+        invalidate_block_removes_block_and_descendants_from_chain_for_network(network)?;
+    }
+
+    Ok(())
+}
+
 fn invalidate_block_removes_block_and_descendants_from_chain_for_network(
     network: Network,
 ) -> Result<()> {
@@ -294,12 +305,84 @@ fn invalidate_block_removes_block_and_descendants_from_chain_for_network(
 }
 
 #[test]
-fn invalidate_block_removes_block_and_descendants_from_chain() -> Result<()> {
+fn reconsider_block_and_reconsider_chain_correctly_reconsiders_blocks_and_descendants() -> Result<()>
+{
     let _init_guard = zebra_test::init();
 
     for network in Network::iter() {
-        invalidate_block_removes_block_and_descendants_from_chain_for_network(network)?;
+        reconsider_block_inserts_block_and_descendants_into_chain_for_network(network.clone())?;
     }
+
+    Ok(())
+}
+
+fn reconsider_block_inserts_block_and_descendants_into_chain_for_network(
+    network: Network,
+) -> Result<()> {
+    let block1: Arc<Block> = Arc::new(network.test_block(653599, 583999).unwrap());
+    let block2 = block1.make_fake_child().set_work(10);
+    let block3 = block2.make_fake_child().set_work(1);
+
+    let mut state = NonFinalizedState::new(&network);
+    let finalized_state = FinalizedState::new(
+        &Config::ephemeral(),
+        &network,
+        #[cfg(feature = "elasticsearch")]
+        false,
+    );
+
+    let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
+    finalized_state.set_finalized_value_pool(fake_value_pool);
+
+    state.commit_new_chain(block1.clone().prepare(), &finalized_state)?;
+    state.commit_block(block2.clone().prepare(), &finalized_state)?;
+    state.commit_block(block3.clone().prepare(), &finalized_state)?;
+
+    assert_eq!(
+        state
+            .best_chain()
+            .unwrap_or(&Arc::new(Chain::default()))
+            .blocks
+            .len(),
+        3
+    );
+
+    // Invalidate block2 to update the invalidated_blocks NonFinalizedState
+    state.invalidate_block(block2.hash());
+
+    // Perform checks to ensure the invalidated_block and descendants were added to the invalidated_block
+    // state
+    let post_invalidated_chain = state.best_chain().unwrap();
+
+    assert_eq!(post_invalidated_chain.blocks.len(), 1);
+    assert!(
+        post_invalidated_chain.contains_block_hash(block1.hash()),
+        "the new modified chain should contain block1"
+    );
+
+    assert!(
+        !post_invalidated_chain.contains_block_hash(block2.hash()),
+        "the new modified chain should not contain block2"
+    );
+    assert!(
+        !post_invalidated_chain.contains_block_hash(block3.hash()),
+        "the new modified chain should not contain block3"
+    );
+
+    // Reconsider block2 and check that both block2 and block3 were `reconsidered` into the
+    // best chain
+    state.reconsider_block(block2.hash())?;
+
+    let best_chain = state.best_chain().unwrap();
+
+    assert!(
+        best_chain.contains_block_hash(block2.hash()),
+        "the best chain should again contain block2"
+    );
+    assert!(
+        best_chain.contains_block_hash(block3.hash()),
+        "the best chain should again contain block3"
+    );
 
     Ok(())
 }

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -381,7 +381,7 @@ fn reconsider_block_inserts_block_and_descendants_into_chain_for_network(
 
     // Reconsider block2 and check that both block2 and block3 were `reconsidered` into the
     // best chain
-    state.reconsider_block(block2.hash())?;
+    state.reconsider_block(block2.hash(), &finalized_state.db)?;
 
     let best_chain = state.best_chain().unwrap();
 


### PR DESCRIPTION
## Motivation
<!--
- Describe the goals of the PR.
- If it closes any issues, list them here.
-->

The changes create and test a reconsider_block method to later be integrated into the zebra RPC. This method reconsiders previously invalidated_blocks into a chain that exist in the chain_set. Closes #8842.

### Specifications & References

<!--
- Provide references related to the PR.
-->

- https://github.com/ZcashFoundation/zebra/issues/8634
- https://github.com/ZcashFoundation/zebra/issues/8842

## Solution

<!--
- Summarize or list the changes in the PR.
-->

- Added a `reconsider_block` method to `NonFinalizedState` that allows previously invalidated blocks to be reconsidered and re-inserted into the chain. 

### Tests

<!--
- Describe how the solution in this PR is tested:
  - Describe any manual or automated tests.
  - If the solution can't be tested, explain why.
-->

- Added test coverage in 'zebra/zebra-state/src/service/non_finalized_state/tests/vectors.rs'

### Follow-up Work

<!--
- Describe or list what's missing from the solution.
- List any follow-up issues.
- If this PR blocks or is blocked by any other work, provide a description, or
  list the related issues.
-->

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [ ] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

