### PR TITLE
cleanup(logger): Replace last log mutex with watch channel

### DIFF
--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -979,6 +979,7 @@ where
     let mempool = MockService::build().for_prop_tests();
     let state = MockService::build().for_prop_tests();
 
+    let (_tx, rx) = tokio::sync::watch::channel(None);
     let (rpc, mempool_tx_queue) = RpcImpl::new(
         "0.0.1",
         "RPC test",
@@ -989,7 +990,7 @@ where
         Buffer::new(state.clone(), 1),
         chain_tip,
         MockAddressBookPeers::new(vec![]),
-        crate::methods::LoggedLastEvent::new(None.into()),
+        rx,
     );
 
     (mempool, state, rpc, mempool_tx_queue)

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -108,6 +108,7 @@ async fn test_z_get_treestate() {
 
     let (_, state, tip, _) = zebra_state::populated_state(blocks.clone(), &testnet).await;
 
+    let (_tx, rx) = tokio::sync::watch::channel(None);
     let (rpc, _) = RpcImpl::new(
         "",
         "",
@@ -118,7 +119,7 @@ async fn test_z_get_treestate() {
         state,
         tip,
         MockAddressBookPeers::new(vec![]),
-        crate::methods::LoggedLastEvent::new(None.into()),
+        rx,
     );
 
     // Request the treestate by a hash.
@@ -200,6 +201,7 @@ async fn test_rpc_response_data_for_network(network: &Network) {
     .await;
 
     // Init RPC
+    let (_tx, rx) = tokio::sync::watch::channel(None);
     let (rpc, _rpc_tx_queue_task_handle) = RpcImpl::new(
         "0.0.1",
         "/Zebra:RPC test/",
@@ -210,7 +212,7 @@ async fn test_rpc_response_data_for_network(network: &Network) {
         read_state,
         latest_chain_tip,
         MockAddressBookPeers::new(vec![]),
-        crate::methods::LoggedLastEvent::new(None.into()),
+        rx,
     );
 
     // We only want a snapshot of the `getblocksubsidy` and `getblockchaininfo` methods for the non-default Testnet (with an NU6 activation height).
@@ -529,6 +531,7 @@ async fn test_mocked_rpc_response_data_for_network(network: &Network) {
     let mut state = MockService::build().for_unit_tests();
     let mempool = MockService::build().for_unit_tests();
 
+    let (_tx, rx) = tokio::sync::watch::channel(None);
     let (rpc, _) = RpcImpl::new(
         "0.0.1",
         "/Zebra:RPC test/",
@@ -539,7 +542,7 @@ async fn test_mocked_rpc_response_data_for_network(network: &Network) {
         state.clone(),
         latest_chain_tip,
         MockAddressBookPeers::new(vec![]),
-        crate::methods::LoggedLastEvent::new(None.into()),
+        rx,
     );
 
     // Test the response format from `z_getsubtreesbyindex` for Sapling.

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -29,6 +29,7 @@ async fn rpc_getinfo() {
     let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
     let mut state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
 
+    let (_tx, rx) = tokio::sync::watch::channel(None);
     let (rpc, rpc_tx_queue_task_handle) = RpcImpl::new(
         "0.0.1",
         "/Zebra:RPC test/",
@@ -39,7 +40,7 @@ async fn rpc_getinfo() {
         Buffer::new(state.clone(), 1),
         NoChainTip,
         MockAddressBookPeers::new(vec![]),
-        crate::methods::LoggedLastEvent::new(None.into()),
+        rx,
     );
 
     let getinfo_future = tokio::spawn(async move { rpc.get_info().await });
@@ -143,6 +144,7 @@ async fn rpc_getblock() {
         zebra_state::populated_state(blocks.clone(), &Mainnet).await;
 
     // Init RPC
+    let (_tx, rx) = tokio::sync::watch::channel(None);
     let (rpc, rpc_tx_queue_task_handle) = RpcImpl::new(
         "0.0.1",
         "RPC test",
@@ -153,7 +155,7 @@ async fn rpc_getblock() {
         read_state.clone(),
         latest_chain_tip,
         MockAddressBookPeers::new(vec![]),
-        crate::methods::LoggedLastEvent::new(None.into()),
+        rx,
     );
 
     // Make height calls with verbosity=0 and check response
@@ -486,6 +488,7 @@ async fn rpc_getblock_parse_error() {
     let mut state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
 
     // Init RPC
+    let (_tx, rx) = tokio::sync::watch::channel(None);
     let (rpc, rpc_tx_queue_task_handle) = RpcImpl::new(
         "0.0.1",
         "RPC test",
@@ -496,7 +499,7 @@ async fn rpc_getblock_parse_error() {
         Buffer::new(state.clone(), 1),
         NoChainTip,
         MockAddressBookPeers::new(vec![]),
-        crate::methods::LoggedLastEvent::new(None.into()),
+        rx,
     );
 
     // Make sure we get an error if Zebra can't parse the block height.
@@ -531,6 +534,7 @@ async fn rpc_getblock_missing_error() {
     let mut state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
 
     // Init RPC
+    let (_tx, rx) = tokio::sync::watch::channel(None);
     let (rpc, rpc_tx_queue_task_handle) = RpcImpl::new(
         "0.0.1",
         "RPC test",
@@ -541,7 +545,7 @@ async fn rpc_getblock_missing_error() {
         Buffer::new(state.clone(), 1),
         NoChainTip,
         MockAddressBookPeers::new(vec![]),
-        crate::methods::LoggedLastEvent::new(None.into()),
+        rx,
     );
 
     // Make sure Zebra returns the correct error code `-8` for missing blocks
@@ -595,6 +599,7 @@ async fn rpc_getblockheader() {
         zebra_state::populated_state(blocks.clone(), &Mainnet).await;
 
     // Init RPC
+    let (_tx, rx) = tokio::sync::watch::channel(None);
     let (rpc, rpc_tx_queue_task_handle) = RpcImpl::new(
         "0.0.1",
         "RPC test",
@@ -605,7 +610,7 @@ async fn rpc_getblockheader() {
         read_state.clone(),
         latest_chain_tip,
         MockAddressBookPeers::new(vec![]),
-        crate::methods::LoggedLastEvent::new(None.into()),
+        rx,
     );
 
     // Make height calls with verbose=false and check response
@@ -708,6 +713,7 @@ async fn rpc_getbestblockhash() {
         zebra_state::populated_state(blocks.clone(), &Mainnet).await;
 
     // Init RPC
+    let (_tx, rx) = tokio::sync::watch::channel(None);
     let (rpc, rpc_tx_queue_task_handle) = RpcImpl::new(
         "0.0.1",
         "RPC test",
@@ -718,7 +724,7 @@ async fn rpc_getbestblockhash() {
         read_state,
         latest_chain_tip,
         MockAddressBookPeers::new(vec![]),
-        crate::methods::LoggedLastEvent::new(None.into()),
+        rx,
     );
 
     // Get the tip hash using RPC method `get_best_block_hash`
@@ -756,6 +762,7 @@ async fn rpc_getrawtransaction() {
     latest_chain_tip_sender.send_best_tip_height(Height(10));
 
     // Init RPC
+    let (_tx, rx) = tokio::sync::watch::channel(None);
     let (rpc, rpc_tx_queue_task_handle) = RpcImpl::new(
         "0.0.1",
         "RPC test",
@@ -766,7 +773,7 @@ async fn rpc_getrawtransaction() {
         read_state.clone(),
         latest_chain_tip,
         MockAddressBookPeers::new(vec![]),
-        crate::methods::LoggedLastEvent::new(None.into()),
+        rx,
     );
 
     // Test case where transaction is in mempool.
@@ -934,6 +941,7 @@ async fn rpc_getaddresstxids_invalid_arguments() {
     let (_state, read_state, latest_chain_tip, _chain_tip_change) =
         zebra_state::populated_state(blocks.clone(), &Mainnet).await;
 
+    let (_tx, rx) = tokio::sync::watch::channel(None);
     let (rpc, rpc_tx_queue_task_handle) = RpcImpl::new(
         "0.0.1",
         "RPC test",
@@ -944,7 +952,7 @@ async fn rpc_getaddresstxids_invalid_arguments() {
         Buffer::new(read_state.clone(), 1),
         latest_chain_tip,
         MockAddressBookPeers::new(vec![]),
-        crate::methods::LoggedLastEvent::new(None.into()),
+        rx,
     );
 
     // call the method with an invalid address string
@@ -1085,6 +1093,7 @@ async fn rpc_getaddresstxids_response_with(
 ) {
     let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
 
+    let (_tx, rx) = tokio::sync::watch::channel(None);
     let (rpc, rpc_tx_queue_task_handle) = RpcImpl::new(
         "0.0.1",
         "RPC test",
@@ -1095,7 +1104,7 @@ async fn rpc_getaddresstxids_response_with(
         Buffer::new(read_state.clone(), 1),
         latest_chain_tip.clone(),
         MockAddressBookPeers::new(vec![]),
-        crate::methods::LoggedLastEvent::new(None.into()),
+        rx,
     );
 
     // call the method with valid arguments
@@ -1139,6 +1148,7 @@ async fn rpc_getaddressutxos_invalid_arguments() {
     let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
     let mut state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
 
+    let (_tx, rx) = tokio::sync::watch::channel(None);
     let rpc = RpcImpl::new(
         "0.0.1",
         "RPC test",
@@ -1149,7 +1159,7 @@ async fn rpc_getaddressutxos_invalid_arguments() {
         Buffer::new(state.clone(), 1),
         NoChainTip,
         MockAddressBookPeers::new(vec![]),
-        crate::methods::LoggedLastEvent::new(None.into()),
+        rx,
     );
 
     // call the method with an invalid address string
@@ -1186,6 +1196,7 @@ async fn rpc_getaddressutxos_response() {
     let (_state, read_state, latest_chain_tip, _chain_tip_change) =
         zebra_state::populated_state(blocks.clone(), &Mainnet).await;
 
+    let (_tx, rx) = tokio::sync::watch::channel(None);
     let rpc = RpcImpl::new(
         "0.0.1",
         "RPC test",
@@ -1196,7 +1207,7 @@ async fn rpc_getaddressutxos_response() {
         Buffer::new(read_state.clone(), 1),
         latest_chain_tip,
         MockAddressBookPeers::new(vec![]),
-        crate::methods::LoggedLastEvent::new(None.into()),
+        rx,
     );
 
     // call the method with a valid address

--- a/zebra-rpc/src/server/tests/vectors.rs
+++ b/zebra-rpc/src/server/tests/vectors.rs
@@ -44,6 +44,7 @@ async fn rpc_server_spawn() {
 
     info!("spawning RPC server...");
 
+    let (_tx, rx) = watch::channel(None);
     let _rpc_server_task_handle = RpcServer::spawn(
         config,
         Default::default(),
@@ -57,7 +58,7 @@ async fn rpc_server_spawn() {
         NoChainTip,
         Mainnet,
         None,
-        crate::methods::LoggedLastEvent::new(None.into()),
+        rx,
     );
 
     info!("spawned RPC server, checking services...");
@@ -105,6 +106,7 @@ async fn rpc_spawn_unallocated_port(do_shutdown: bool) {
 
     info!("spawning RPC server...");
 
+    let (_tx, rx) = watch::channel(None);
     let rpc_server_task_handle = RpcServer::spawn(
         config,
         Default::default(),
@@ -118,7 +120,7 @@ async fn rpc_spawn_unallocated_port(do_shutdown: bool) {
         NoChainTip,
         Mainnet,
         None,
-        crate::methods::LoggedLastEvent::new(None.into()),
+        rx,
     )
     .await
     .expect("");
@@ -162,6 +164,7 @@ async fn rpc_server_spawn_port_conflict() {
 
     info!("spawning RPC server 1...");
 
+    let (_tx, rx) = watch::channel(None);
     let _rpc_server_1_task_handle = RpcServer::spawn(
         config.clone(),
         Default::default(),
@@ -175,7 +178,7 @@ async fn rpc_server_spawn_port_conflict() {
         NoChainTip,
         Mainnet,
         None,
-        crate::methods::LoggedLastEvent::new(None.into()),
+        rx.clone(),
     )
     .await;
 
@@ -196,7 +199,7 @@ async fn rpc_server_spawn_port_conflict() {
         NoChainTip,
         Mainnet,
         None,
-        crate::methods::LoggedLastEvent::new(None.into()),
+        rx,
     )
     .await;
 

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -14,6 +14,7 @@ use abscissa_core::{
 };
 use semver::{BuildMetadata, Version};
 
+use tokio::sync::watch;
 use zebra_network::constants::PORT_IN_USE_ERROR;
 use zebra_state::{
     constants::LOCK_FILE_ERROR, state_database_format_version_in_code,
@@ -38,7 +39,7 @@ pub static APPLICATION: AppCell<ZebradApp> = AppCell::new();
 
 lazy_static::lazy_static! {
     /// The last log event that occurred in the application.
-    pub static ref LAST_LOG_EVENT: Arc<std::sync::Mutex<Option<(String, tracing::Level, chrono::DateTime<chrono::Utc>)>>> = Arc::new(std::sync::Mutex::new(None));
+    pub static ref LAST_WARN_ERROR_LOG_SENDER: watch::Sender<Option<(String, tracing::Level, chrono::DateTime<chrono::Utc>)>> = watch::Sender::new(None);
 }
 
 /// Returns the `zebrad` version for this build, in SemVer 2.0 format.

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -90,7 +90,7 @@ use zebra_rpc::server::RpcServer;
 use zebra_rpc::methods::get_block_template_rpcs::types::submit_block::SubmitBlockChannel;
 
 use crate::{
-    application::{build_version, user_agent, LAST_LOG_EVENT},
+    application::{build_version, user_agent, LAST_WARN_ERROR_LOG_SENDER},
     components::{
         inbound::{self, InboundSetupData, MAX_INBOUND_RESPONSE_TIME},
         mempool::{self, Mempool},
@@ -273,7 +273,7 @@ impl StartCmd {
                     Some(submit_block_channel.sender()),
                     #[cfg(not(feature = "getblocktemplate-rpcs"))]
                     None,
-                    LAST_LOG_EVENT.clone(),
+                    LAST_WARN_ERROR_LOG_SENDER.subscribe(),
                 );
                 rpc_task_handle.await.unwrap()
             } else {


### PR DESCRIPTION
This is a cleanup PR for replacing a `Mutex` sharing the last warning or error log message with a watch channel.

There should be no concurrency issues with the `Mutex` as it's currently used, so this is only cleanup to enable extending its use without any concurrency considerations.