### PR TITLE
chore: Update the PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -2,7 +2,7 @@
 name: "🚀 Zebra Release"
 about: 'Zebra team use only'
 title: 'Publish next Zebra release: (version)'
-labels: 'A-release, C-trivial, P-Medium :zap:'
+labels: 'A-release, C-exclude-from-changelog, P-Medium :zap:'
 assignees: ''
 
 ---

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -2,7 +2,7 @@
 name: 'Release Checklist Template'
 about: 'Checklist to create and publish a Zebra release'
 title: 'Release Zebra (version)'
-labels: 'A-release, C-trivial, P-Critical :ambulance:'
+labels: 'A-release, C-exclude-from-changelog, P-Critical :ambulance:'
 assignees: ''
 
 ---

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     # Limit dependabot to 1 PR per reviewer
     open-pull-requests-limit: 6
     labels:
-      - 'C-trivial'
+      - 'C-exclude-from-changelog'
       - 'A-rust'
       - 'A-dependencies'
       - 'P-Low :snowflake:'
@@ -46,7 +46,7 @@ updates:
       timezone: America/New_York
     open-pull-requests-limit: 4
     labels:
-      - 'C-trivial'
+      - 'C-exclude-from-changelog'
       - 'A-devops'
       - 'A-dependencies'
       - 'P-Low :snowflake:'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -44,4 +44,3 @@
 - [ ] The PR has a priority label.
 - [ ] If the PR shouldn't be in release notes, it has the
       `C-exclude-from-changelog` label.
-

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -49,5 +49,6 @@
 - [ ] The solution is tested.
 - [ ] The documentation is up to date.
 - [ ] The PR has a priority label.
-- [ ] If the PR shouldn't be in release notes, it has the `exclude-from-changelog` label.
+- [ ] If the PR shouldn't be in release notes, it has the
+      `C-exclude-from-changelog` label.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,7 +38,7 @@
 
 <!-- Check as many boxes as possible. -->
 
-- [ ] The PR name is suitable for release notes.
+- [ ] The PR name is suitable for the release notes.
 - [ ] The solution is tested.
 - [ ] The documentation is up to date.
 - [ ] The PR has a priority label.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,20 +1,18 @@
 <!--
 - Use this template to quickly write the PR description.
-- Skip or delete the items that don't fit.
+- Skip or delete items that don't fit.
 -->
 
 ## Motivation
 
 <!--
 - Describe the goals of the PR.
-- If it closes any issues, list them here.
+- If it closes any issues, enumerate them here.
 -->
 
 ## Solution
 
-<!--
-- Summarize or list the changes in the PR.
--->
+<!-- Describe the changes in the PR. -->
 
 ### Tests
 
@@ -26,24 +24,20 @@
 
 ### Specifications & References
 
-<!--
-- Provide any references related to the PR.
--->
+<!-- Provide any relevant references. -->
 
 ### Follow-up Work
 
 <!--
-- Describe or list what's missing from the solution.
-- List any follow-up issues.
+- If there's anything missing from the solution, provide a description.
+- List any follow-up issues or PRs.
 - If this PR blocks or is blocked by any other work, provide a description, or
-  list the related issues.
+  enumerate the related issues.
 -->
 
 ### PR Checklist
 
-<!--
-- Aim to check as many boxes as possible.
--->
+<!-- Check as many boxes as possible. -->
 
 - [ ] The PR name is suitable for release notes.
 - [ ] The solution is tested.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,13 @@
+<!--
+- Use this template to quickly write the PR description.
+- Skip or delete the items that don't fit.
+-->
+
 ## Motivation
 
 <!--
 - Describe the goals of the PR.
 - If it closes any issues, list them here.
--->
-
-### Specifications & References
-
-<!--
-- Provide references related to the PR.
 -->
 
 ## Solution
@@ -20,9 +19,15 @@
 ### Tests
 
 <!--
-- Describe how the solution in this PR is tested:
+- Describe how you tested the solution:
   - Describe any manual or automated tests.
-  - If the solution can't be tested, explain why.
+  - If you could not test the solution, explain why.
+-->
+
+### Specifications & References
+
+<!--
+- Provide any references related to the PR.
 -->
 
 ### Follow-up Work
@@ -34,21 +39,15 @@
   list the related issues.
 -->
 
-### PR Author's Checklist
+### PR Checklist
 
-<!-- If you are the author of the PR, check the boxes below before making the PR
-ready for review. -->
+<!--
+- Aim to check as many boxes as possible.
+-->
 
-- [ ] The PR name will make sense to users.
-- [ ] The PR provides a CHANGELOG summary.
+- [ ] The PR name is suitable for release notes.
 - [ ] The solution is tested.
 - [ ] The documentation is up to date.
 - [ ] The PR has a priority label.
-
-### PR Reviewer's Checklist
-
-<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->
-
-- [ ] The PR Author's checklist is complete.
-- [ ] The PR resolves the issue.
+- [ ] If the PR shouldn't be in release notes, it has the `exclude-from-changelog` label.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,10 +29,9 @@
 ### Follow-up Work
 
 <!--
-- If there's anything missing from the solution, provide a description.
+- If there's anything missing from the solution, describe it here.
 - List any follow-up issues or PRs.
-- If this PR blocks or is blocked by any other work, provide a description, or
-  enumerate the related issues.
+- If this PR blocks or depends on other issues or PRs, enumerate them here.
 -->
 
 ### PR Checklist

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,5 +42,5 @@
 - [ ] The solution is tested.
 - [ ] The documentation is up to date.
 - [ ] The PR has a priority label.
-- [ ] If the PR shouldn't be in release notes, it has the
+- [ ] If the PR shouldn't be in the release notes, it has the
       `C-exclude-from-changelog` label.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -51,48 +51,46 @@ include-pre-releases: false
 
 # Categories in rough order of importance to users.
 # Based on https://keepachangelog.com/en/1.0.0/
-category-template: '### $TITLE'
+category-template: "### $TITLE"
 categories:
-  - title: 'Security'
+  - title: "Security"
     labels:
-      - 'C-security'
+      - "C-security"
       # Other labels that are usually security issues
-      - 'I-invalid-data'
-      - 'I-consensus'
-      - 'I-crash'
-      - 'I-destructive'
-      - 'I-hang'
-      - 'I-lose-funds'
-      - 'I-privacy'
-      - 'I-remote-node-overload'
-      - 'I-unbounded-growth'
-      - 'I-memory-safety'
-  - title: 'Removed'
+      - "I-invalid-data"
+      - "I-consensus"
+      - "I-crash"
+      - "I-destructive"
+      - "I-hang"
+      - "I-lose-funds"
+      - "I-privacy"
+      - "I-remote-node-overload"
+      - "I-unbounded-growth"
+      - "I-memory-safety"
+  - title: "Removed"
     labels:
-      - 'C-removal'
-  - title: 'Deprecated'
+      - "C-removal"
+  - title: "Deprecated"
     labels:
-      - 'C-deprecation'
+      - "C-deprecation"
       # TODO: when release drafter has per-category templates, add this to the Deprecated category template:
       # 'These features might be removed in Zebra $NEXT_MINOR_VERSION'
-  - title: 'Added'
+  - title: "Added"
     labels:
-      - 'C-feature'
-  - title: 'Changed'
+      - "C-feature"
+  - title: "Changed"
     labels:
-      - 'C-enhancement'
-  - title: 'Fixed'  
+      - "C-enhancement"
+  - title: "Fixed"
     labels:
-      - 'C-bug'
+      - "C-bug"
       # Other labels that are usually bugs
-      - 'I-build-fail'
-      - 'I-integration-fail'
-      - 'I-panic'
-  # TODO: if we're happy with the trivial PRs, use "exclude-labels:" instead
-  - title: 'Trivial *TODO:* put this in a PR comment, not the CHANGELOG'
+      - "I-build-fail"
+      - "I-integration-fail"
+      - "I-panic"
+  - title: "Excluded *TODO:* put this in a PR comment, not the CHANGELOG"
     labels:
-      - 'C-trivial'
-      - 'C-cleanup'
+      - "C-exclude-from-changelog"
 
 # The next release's $RESOLVED_VERSION, based on the labels of the PRs in the release.
 #
@@ -106,15 +104,15 @@ version-resolver:
   #    - # network upgrade release PRs
   minor:
     labels:
-      - 'C-feature'
-      - 'C-breaking'
-      - 'C-removal'
-      - 'C-deprecation'
+      - "C-feature"
+      - "C-breaking"
+      - "C-removal"
+      - "C-deprecation"
   # We increment the patch version for every release
   default: patch
 
 # How PR names get turned into CHANGELOG entries.
-change-template: '- $TITLE ([#$NUMBER]($URL))'
+change-template: "- $TITLE ([#$NUMBER]($URL))"
 sort-by: title
 sort-direction: ascending
 # Characters escaped when converting PR titles to CHANGELOG entries.
@@ -123,31 +121,30 @@ change-title-escapes: '\<*_&#@'
 # Strip PR series numbers, leading spaces, and conventional commit prefixes from PR titles.
 replacers:
   - search: '/- [0-9\. ]*([a-zA-Z0-9\(\)!]+:)?/'
-    replace: '- '
+    replace: "- "
 
 # The list of contributors to each release.
 exclude-contributors:
-  - 'dependabot' # 'dependabot[bot]'
-  - 'mergifyio' # 'mergify[bot]'
+  - "dependabot" # 'dependabot[bot]'
+  - "mergifyio" # 'mergify[bot]'
 
 # The template for the draft CHANGELOG.
 template: |
   ## [Zebra $RESOLVED_VERSION](https://github.com/ZcashFoundation/zebra/releases/tag/v$RESOLVED_VERSION) - *TODO*: date
-  
+
   This release *TODO*: a summary of the significant user-visible changes in the release
-  
+
   ### Breaking Changes
-  
+
   This release has the following breaking changes:
   - *TODO*: Check the `Removed` and `Deprecated` sections for any breaking changes
   - *TODO*: Add a short description of the user impact of each breaking change, and any actions users need to take
-  
+
   $CHANGES
-  
+
   ### Contributors
-  
+
   Thank you to everyone who contributed to this release, we couldn't make Zebra without you:
   $CONTRIBUTORS
-  
-  
+
 # the trailing newlines in the template are deliberate

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,77 +6,44 @@
 # Automatically label PRs based on their branch, title, or changed files.
 # This helps categorise PRs in the CHANGELOG.
 autolabeler:
-  - label: 'C-security'
+  - label: "C-security"
     branch:
-      - '/secur/i'
+      - "/secur/i"
     title:
-      - '/secur/i'
-      - '/crash/i'
-      - '/destr/i'
-      - '/unsafe/i'
-  - label: 'C-deprecated'
+      - "/secur/i"
+      - "/crash/i"
+      - "/destr/i"
+      - "/unsafe/i"
+  - label: "C-deprecated"
     branch:
-      - '/deprecat/i'
+      - "/deprecat/i"
     title:
-      - '/deprecat/i'
-  - label: 'extra-reviews'
+      - "/deprecat/i"
+  - label: "extra-reviews"
     branch:
-      - '/remov/i'
-      - '/deprecat/i'
+      - "/remov/i"
+      - "/deprecat/i"
     title:
-      - '/remov/i'
-      - '/deprecat/i'
-      - '/crash/i'
-      - '/destr/i'
-      - '/unsafe/i'
-  - label: 'C-feature'
+      - "/remov/i"
+      - "/deprecat/i"
+      - "/crash/i"
+      - "/destr/i"
+      - "/unsafe/i"
+  - label: "C-feature"
     branch:
-      - '/feat/i'
+      - "/feat/i"
     title:
-      - '/feat/i'
-  - label: 'C-bug'
+      - "/feat/i"
+  - label: "C-bug"
     branch:
-      - '/bug/i'
+      - "/bug/i"
     title:
-      - '/bug/i'
-  # Changes that are almost always trivial for users
-  - label: 'C-trivial'
-    branch:
-      - '/clean/i'
-      - '/chore/i'
-      - '/clippy/i'
-      - '/test/i'
-    title:
-      - '/clean/i'
-      - '/chore/i'
-      - '/clippy/i'
-      - '/test/i'
-      - '/(ci)/i'
-      - '/(cd)/i'
-      - '/job/i'
-      - '/patch/i'
-      - '/actions/i'
-    files:
-      # Regular changes that don't need to go in the CHANGELOG
-      - 'CHANGELOG.md'
-      - 'zebra-consensus/src/checkpoint/*-checkpoints.txt'
-      # Developer-only changes
-      - '.gitignore'
-      - '.dockerignore'
-      # Test-only changes
-      - 'zebra-test'
-      - '.cargo/config.toml'
-      - 'clippy.toml'
-      # CI-only changes
-      - '.github'
-      - '.codespellrc'
-      - 'codecov.yml'
-      - 'deny.toml'
+      - "/bug/i"
 
 # The release name, tag, and settings for the draft CHANGELOG.
-name-template: 'Zebra $RESOLVED_VERSION'
-tag-template: 'v$RESOLVED_VERSION'
-tag-prefix: 'v'
+name-template: "Zebra $RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+tag-prefix: "v"
 # Do not mark the draft release as a pre-release
 prerelease: false
 # Do not include pre-releases in the draft release


### PR DESCRIPTION
## Motivation

- We don't use the current PR template we intended to.
- The `C-trivial` label is automatically assigned to PRs it doesn't belong to.

## Solution

- Simplify the PR template.
- Remove the automatic assignment of the `C-trivial` label.
- Use a new `C-exclude-from-changelog` label instead of the `C-trivial` one.

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.