### PR TITLE
fix(ci): temporarily disable `test-zebra-conf-path`

### DIFF
--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -256,7 +256,8 @@ jobs:
         build,
         versioning,
         test-configuration-file,
-        test-zebra-conf-path,
+        # TODO: Re-enable this test once we have a way to mount a custom config file just for this test
+        # test-zebra-conf-path,
         get-disk-name,
       ]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

This was not caught on a recent PR, and main branch deployment are being skipped

### PR Author's Checklist

<!-- If you are the author of the PR, check the boxes below before making the PR
ready for review. -->

- [x] The PR name will make sense to users.
- [x] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.

### PR Reviewer's Checklist

<!-- If you are a reviewer of the PR, check the boxes below before approving it. -->

- [ ] The PR Author's checklist is complete.
- [ ] The PR resolves the issue.

