### PR TITLE
change(ci): Remove check for custom configs from GCP deployments

### DIFF
--- a/.github/workflows/cd-deploy-nodes-gcp.patch-external.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.patch-external.yml
@@ -45,11 +45,3 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
-
-  test-zebra-conf-path:
-    name: Test CD custom Docker config file / Test custom-conf in Docker
-    needs: build
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
-    steps:
-      - run: 'echo "Skipping job on fork"'

--- a/.github/workflows/cd-deploy-nodes-gcp.patch.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.patch.yml
@@ -55,10 +55,3 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "No build required"'
-
-  test-zebra-conf-path:
-    name: Test CD custom Docker config file / Test custom-conf in Docker
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
-    steps:
-      - run: 'echo "No build required"'

--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -256,8 +256,7 @@ jobs:
         build,
         versioning,
         test-configuration-file,
-        # TODO: Re-enable this test once we have a way to mount a custom config file just for this test
-        # test-zebra-conf-path,
+        test-zebra-conf-path,
         get-disk-name,
       ]
     runs-on: ubuntu-latest

--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -6,7 +6,6 @@
 # 2. `build`: Builds a Docker image named `zebrad` with the necessary tags derived from Git.
 # 3. `test-configuration-file`: Validates Zebra using the default config with the latest version.
 # 4. `test-configuration-file-testnet`: Tests the Docker image for the testnet configuration.
-# 5. `test-zebra-conf-path`: Verifies Zebra with a custom Docker config file.
 # 6. `deploy-nodes`: Deploys Managed Instance Groups (MiGs) for Mainnet and Testnet. If triggered by main branch pushes, it always replaces the MiG. For releases, MiGs are replaced only if deploying the same major version; otherwise, a new major version is deployed.
 # 7. `deploy-instance`: Deploys a single node in a specified GCP zone for testing specific commits. Instances from this job aren't auto-replaced or deleted.
 #
@@ -157,20 +156,9 @@ jobs:
     if: ${{ (github.event_name != 'release' && !(github.event.pull_request.head.repo.fork)) && (github.event_name != 'workflow_dispatch' || inputs.need_cached_disk) }}
     with:
       network: ${{ inputs.network || vars.ZCASH_NETWORK }}
-      disk_prefix: zebrad-cache 
+      disk_prefix: zebrad-cache
       disk_suffix: ${{ inputs.cached_disk_type || 'tip' }}
       prefer_main_cached_state: ${{ inputs.prefer_main_cached_state || (github.event_name == 'push' && github.ref_name == 'main' && true) || false }}
-
-  # Test that Zebra works using $ZEBRA_CONF_PATH config
-  test-zebra-conf-path:
-    name: Test CD custom Docker config file
-    needs: build
-    uses: ./.github/workflows/sub-test-zebra-config.yml
-    with:
-      test_id: "custom-conf"
-      docker_image: ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
-      test_variables: '-e ZEBRA_CONF_PATH="zebrad/tests/common/configs/custom-conf.toml"'
-      grep_patterns: '-e "extra_coinbase_data:\sSome\(\"do you even shield\?\"\)"'
 
   # Each time this workflow is executed, a build will be triggered to create a new image
   # with the corresponding tags using information from Git
@@ -255,7 +243,6 @@ jobs:
         build,
         versioning,
         test-configuration-file,
-        test-zebra-conf-path,
         get-disk-name,
       ]
     runs-on: ubuntu-latest
@@ -388,7 +375,7 @@ jobs:
   failure-issue:
     name: Open or update issues for release failures
     # When a new job is added to this workflow, add it to this list.
-    needs: [ versioning, build, deploy-nodes ]
+    needs: [versioning, build, deploy-nodes]
 
     # Only open tickets for failed or cancelled jobs that are not coming from PRs.
     # (PR statuses are already reported in the PR jobs list, and checked by GitHub's Merge Queue.)

--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -161,17 +161,16 @@ jobs:
       disk_suffix: ${{ inputs.cached_disk_type || 'tip' }}
       prefer_main_cached_state: ${{ inputs.prefer_main_cached_state || (github.event_name == 'push' && github.ref_name == 'main' && true) || false }}
 
-  # TODO: Re-enable this test once we have a way to mount a custom config file just for this test
   # Test that Zebra works using $ZEBRA_CONF_PATH config
-  # test-zebra-conf-path:
-  #   name: Test CD custom Docker config file
-  #   needs: build
-  #   uses: ./.github/workflows/sub-test-zebra-config.yml
-  #   with:
-  #     test_id: "custom-conf"
-  #     docker_image: ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
-  #     test_variables: '-e ZEBRA_CONF_PATH="zebrad/tests/common/configs/custom-conf.toml"'
-  #     grep_patterns: '-e "extra_coinbase_data:\sSome\(\"do you even shield\?\"\)"'
+  test-zebra-conf-path:
+    name: Test CD custom Docker config file
+    needs: build
+    uses: ./.github/workflows/sub-test-zebra-config.yml
+    with:
+      test_id: "custom-conf"
+      docker_image: ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}
+      test_variables: '-e ZEBRA_CONF_PATH="zebrad/tests/common/configs/custom-conf.toml"'
+      grep_patterns: '-e "extra_coinbase_data:\sSome\(\"do you even shield\?\"\)"'
 
   # Each time this workflow is executed, a build will be triggered to create a new image
   # with the corresponding tags using information from Git


### PR DESCRIPTION
## Motivation

The `test-zebra-conf-path` check in `cd-deploy-nodes-gcp.yml` tries to configure Zebra running in a Docker container with a custom config file. However, it always fails because the container doesn't contain the file as it is built for the `runtime` target and contains only files needed in production. This test used to falsely pass because the entrypoint script used to create a new config file on the fly if the specified one was missing. We have the same check for a Docker container built for the `tests` target in `sub-ci-unit-tests-docker.yml`. This check works as intended because those containers contain the custom config file.

## Solution

- Remove the `test-zebra-conf-path` from `cd-deploy-noes-gcp.yml`.

An alternative solution would be to move the custom config file to the container, but that would require a lot more work, and I thought it wasn't worth it since we test the same functionality elsewhere.

### Tests

N/A

### PR Author's Checklist

- [x] The PR name will make sense to users.
- [ ] The PR provides a CHANGELOG summary.
- [ ] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.