### PR TITLE
chore: Bump Rust from 1.84.0 to 1.85.0 in Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@
 # We first set default values for build arguments used across the stages.
 # Each stage must define the build arguments (ARGs) it uses.
 
-ARG RUST_VERSION=1.84.0
+ARG RUST_VERSION=1.85.0
 
 # In this stage we download all system requirements to build the project
 #


### PR DESCRIPTION


### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.
- [x] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
