### PR TITLE
change(rpc): Update `getaddressbalance` RPC to return `received` field

### DIFF
--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -3019,7 +3019,7 @@ impl From<DAddressStrings> for AddressStrings {
     fn from(address_strings: DAddressStrings) -> Self {
         match address_strings {
             DAddressStrings::Addresses { addresses } => AddressStrings { addresses },
-            DAddressStrings::Address { address } => AddressStrings {
+            DAddressStrings::Address(address) => AddressStrings {
                 addresses: vec![address],
             },
         }
@@ -3033,7 +3033,7 @@ enum DAddressStrings {
     /// A list of address strings.
     Addresses { addresses: Vec<String> },
     /// A single address string.
-    Address { address: String },
+    Address(String),
 }
 
 impl AddressStrings {

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1026,8 +1026,9 @@ where
         let response = state.oneshot(request).await.map_misc_error()?;
 
         match response {
-            zebra_state::ReadResponse::AddressBalance { balance, .. } => Ok(AddressBalance {
+            zebra_state::ReadResponse::AddressBalance { balance, received } => Ok(AddressBalance {
                 balance: u64::from(balance),
+                received,
             }),
             _ => unreachable!("Unexpected response from state service: {response:?}"),
         }
@@ -3008,9 +3009,31 @@ impl GetBlockChainInfo {
 /// This is used for the input parameter of [`RpcServer::get_address_balance`],
 /// [`RpcServer::get_address_tx_ids`] and [`RpcServer::get_address_utxos`].
 #[derive(Clone, Debug, Eq, PartialEq, Hash, serde::Deserialize, serde::Serialize)]
+#[serde(from = "DAddressStrings")]
 pub struct AddressStrings {
     /// A list of transparent address strings.
     addresses: Vec<String>,
+}
+
+impl From<DAddressStrings> for AddressStrings {
+    fn from(address_strings: DAddressStrings) -> Self {
+        match address_strings {
+            DAddressStrings::Addresses(addresses) => AddressStrings { addresses },
+            DAddressStrings::Address(address) => AddressStrings {
+                addresses: vec![address],
+            },
+        }
+    }
+}
+
+/// An intermediate type used to deserialize [`AddressStrings`].
+#[derive(Clone, Debug, Eq, PartialEq, Hash, serde::Deserialize)]
+#[serde(untagged)]
+enum DAddressStrings {
+    /// A list of address strings.
+    Addresses(Vec<String>),
+    /// A single address string.
+    Address(String),
 }
 
 impl AddressStrings {
@@ -3062,6 +3085,8 @@ impl AddressStrings {
 pub struct AddressBalance {
     /// The total transparent balance.
     pub balance: u64,
+    /// The total received balance, including change.
+    pub received: u64,
 }
 
 /// A hex-encoded [`ConsensusBranchId`] string.

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -3018,8 +3018,8 @@ pub struct AddressStrings {
 impl From<DAddressStrings> for AddressStrings {
     fn from(address_strings: DAddressStrings) -> Self {
         match address_strings {
-            DAddressStrings::Addresses(addresses) => AddressStrings { addresses },
-            DAddressStrings::Address(address) => AddressStrings {
+            DAddressStrings::Addresses { addresses } => AddressStrings { addresses },
+            DAddressStrings::Address { address } => AddressStrings {
                 addresses: vec![address],
             },
         }
@@ -3031,9 +3031,9 @@ impl From<DAddressStrings> for AddressStrings {
 #[serde(untagged)]
 enum DAddressStrings {
     /// A list of address strings.
-    Addresses(Vec<String>),
+    Addresses { addresses: Vec<String> },
     /// A single address string.
-    Address(String),
+    Address { address: String },
 }
 
 impl AddressStrings {

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -647,7 +647,7 @@ proptest! {
             let state_query = state
                 .expect_request(zebra_state::ReadRequest::AddressBalance(addresses))
                 .map_ok(|responder| {
-                    responder.respond(zebra_state::ReadResponse::AddressBalance { balance, received: Default::default() })
+                    responder.respond(zebra_state::ReadResponse::AddressBalance { balance, received: balance.into() })
                 });
 
             // Await the RPC call and the state query
@@ -658,7 +658,7 @@ proptest! {
             // Check that response contains the expected balance
             let received_balance = response?;
 
-            prop_assert_eq!(received_balance, AddressBalance { balance: balance.into() });
+            prop_assert_eq!(received_balance, AddressBalance { balance: balance.into(), received: balance.into() });
 
             // Check no further requests were made during this test
             mempool.expect_no_requests().await?;

--- a/zebra-rpc/src/methods/tests/snapshots/get_address_balance@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_address_balance@mainnet_10.snap
@@ -1,8 +1,8 @@
 ---
 source: zebra-rpc/src/methods/tests/snapshot.rs
-assertion_line: 192
 expression: address_balance
 ---
 {
-  "balance": 687500
+  "balance": 687500,
+  "received": 687500
 }

--- a/zebra-rpc/src/methods/tests/snapshots/get_address_balance@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_address_balance@testnet_10.snap
@@ -1,8 +1,8 @@
 ---
 source: zebra-rpc/src/methods/tests/snapshot.rs
-assertion_line: 192
 expression: address_balance
 ---
 {
-  "balance": 687500
+  "balance": 687500,
+  "received": 687500
 }

--- a/zebra-rpc/tests/serialization_tests.rs
+++ b/zebra-rpc/tests/serialization_tests.rs
@@ -112,6 +112,7 @@ fn test_get_address_balance() -> Result<(), Box<dyn std::error::Error>> {
     let obj: AddressBalance = serde_json::from_str(json)?;
     let new_obj = AddressBalance {
         balance: obj.balance,
+        received: obj.received,
     };
 
     assert_eq!(obj, new_obj);

--- a/zebra-rpc/tests/serialization_tests.rs
+++ b/zebra-rpc/tests/serialization_tests.rs
@@ -106,7 +106,8 @@ fn test_get_address_balance() -> Result<(), Box<dyn std::error::Error>> {
     // Test response
     let json = r#"
 {
-  "balance": 11290259389
+  "balance": 11290259389,
+  "received": 11290259390
 }
 "#;
     let obj: AddressBalance = serde_json::from_str(json)?;


### PR DESCRIPTION
## Motivation

Updates the `getaddressbalance` RPC to accept either a single address string or a list of them to match zcashd, and adds the `received` field on the method's response.

Closes #8452.
Closes #9463.

Depends-On: #9539.

## Solution

- Bumps db format version for address balances to include a `received` field, and adds an in-place format upgrade,
- Adds a mechanism for freezing block commits until some in-place format upgrades are complete,
- Parses single address strings passed to RPC methods accepting `AddressStrings` as a `Vec` with one item, and
- Adds the `received` field to the `getaddressbalance` RPC output.

### Tests

This PR still needs a manual test to check that the output matches zcashd.
The changes to the RPC should be covered by existing snapshot tests.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.
- [ ] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
