### PR TITLE
allow deserialization of Balance with skipped ID field

### DIFF
--- a/zebra-rpc/src/methods/types/get_blockchain_info.rs
+++ b/zebra-rpc/src/methods/types/get_blockchain_info.rs
@@ -12,7 +12,7 @@ use super::*;
 #[serde(rename_all = "camelCase")]
 pub struct Balance {
     /// Name of the pool
-    #[serde(skip_serializing_if = "String::is_empty")]
+    #[serde(skip_serializing_if = "String::is_empty", default)]
     id: String,
     /// Total amount in the pool, in ZEC
     chain_value: Zec<NonNegative>,


### PR DESCRIPTION
The Balance type will skip serializing the `id` field when the string is empty, but currently fails to deserialize a Balance with no `id` field. 