### PR TITLE
fix: fix redundant #[non_exhaustive] attributes on enum variants

### DIFF
--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -31,22 +31,16 @@ use zebra_chain::{
 #[non_exhaustive]
 pub enum Error {
     /// script verification failed
-    #[non_exhaustive]
     ScriptInvalid,
     /// could not deserialize tx
-    #[non_exhaustive]
     TxDeserialize,
     /// input index out of bounds
-    #[non_exhaustive]
     TxIndex,
     /// tx has an invalid size
-    #[non_exhaustive]
     TxSizeMismatch,
     /// tx is a coinbase transaction and should not be verified
-    #[non_exhaustive]
     TxCoinbase,
     /// unknown error from zcash_script: {0}
-    #[non_exhaustive]
     Unknown(zcash_script_error_t),
 }
 


### PR DESCRIPTION
## Motivation  
The `#[non_exhaustive]` attribute was applied to both the `Error` enum and its individual variants, which is unnecessary. The attribute is only required at the enum level to ensure compatibility when adding new variants in the future. By removing it from each variant, we simplify the code without losing the intended flexibility.

## Solution  
I’ve removed the redundant `#[non_exhaustive]` attributes from the individual variants of the `Error` enum. The attribute remains at the enum level, which is sufficient for indicating that new variants can be added without breaking compatibility.

### Tests  
The functionality of the code should remain unaffected, and no additional tests are required for this change. Existing tests for error handling should verify the correctness of the logic.

### Specifications & References  
- The `#[non_exhaustive]` attribute is applied at the enum level to indicate potential future additions.
- No need for the attribute on each variant, as the presence on the enum is enough.

### Follow-up Work  
There’s no immediate follow-up work needed. This change is more about cleaning up redundant code.

### PR Checklist  
- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.
- [x] If the PR shouldn't be in the release notes, it has the `C-exclude-from-changelog` label.