### PR TITLE
fix(ci): Add Rust environment variables to Docker test workflows

### DIFF
--- a/.github/workflows/sub-build-docker-image.yml
+++ b/.github/workflows/sub-build-docker-image.yml
@@ -166,6 +166,7 @@ jobs:
           build-args: |
             SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}
             RUST_LOG=${{ env.RUST_LOG }}
+            CARGO_INCREMENTAL=${{ env.CARGO_INCREMENTAL }}
             FEATURES=${{ env.FEATURES }}
           push: true
           # It's recommended to build images with max-level provenance attestations

--- a/.github/workflows/sub-ci-unit-tests-docker.yml
+++ b/.github/workflows/sub-ci-unit-tests-docker.yml
@@ -53,10 +53,15 @@ jobs:
       - name: Run all tests
         run: |
           docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}
-          docker run -t \
+          docker run -tty \
           -e RUN_ALL_TESTS=1 \
           -e FEATURES="journald prometheus filter-reload" \
           -e NETWORK="${{ inputs.network || vars.ZCASH_NETWORK }}" \
+          -e RUST_LOG=${{ env.RUST_LOG }} \
+          -e RUST_BACKTRACE=${{ env.RUST_BACKTRACE }} \
+          -e RUST_LIB_BACKTRACE=${{ env.RUST_LIB_BACKTRACE }} \
+          -e COLORBT_SHOW_HIDDEN=${{ env.COLORBT_SHOW_HIDDEN }} \
+          -e CARGO_INCREMENTAL=${{ env.CARGO_INCREMENTAL }} \
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}
 
   # Run state tests with fake activation heights.
@@ -85,9 +90,14 @@ jobs:
           NETWORK: ${{ inputs.network || vars.ZCASH_NETWORK }}
         run: |
           docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}
-          docker run -t \
+          docker run -tty \
           -e TEST_FAKE_ACTIVATION_HEIGHTS=1 \
           -e NETWORK="${{ inputs.network || vars.ZCASH_NETWORK }}" \
+          -e RUST_LOG=${{ env.RUST_LOG }} \
+          -e RUST_BACKTRACE=${{ env.RUST_BACKTRACE }} \
+          -e RUST_LIB_BACKTRACE=${{ env.RUST_LIB_BACKTRACE }} \
+          -e COLORBT_SHOW_HIDDEN=${{ env.COLORBT_SHOW_HIDDEN }} \
+          -e CARGO_INCREMENTAL=${{ env.CARGO_INCREMENTAL }} \
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}
 
   # Test that Zebra syncs and checkpoints a few thousand blocks from an empty state.
@@ -108,7 +118,15 @@ jobs:
           NETWORK: ${{ inputs.network || vars.ZCASH_NETWORK }}
         run: |
           docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}
-          docker run --tty -e TEST_ZEBRA_EMPTY_SYNC=1 ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}
+          docker run --tty \
+          -e TEST_ZEBRA_EMPTY_SYNC=1 \
+          -e NETWORK="${{ inputs.network || vars.ZCASH_NETWORK }}" \
+          -e RUST_LOG=${{ env.RUST_LOG }} \
+          -e RUST_BACKTRACE=${{ env.RUST_BACKTRACE }} \
+          -e RUST_LIB_BACKTRACE=${{ env.RUST_LIB_BACKTRACE }} \
+          -e COLORBT_SHOW_HIDDEN=${{ env.COLORBT_SHOW_HIDDEN }} \
+          -e CARGO_INCREMENTAL=${{ env.CARGO_INCREMENTAL }} \
+          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}
 
   # Test launching lightwalletd with an empty lightwalletd and Zebra state.
   test-lightwalletd-integration:
@@ -128,7 +146,13 @@ jobs:
           NETWORK: ${{ inputs.network || vars.ZCASH_NETWORK }}
         run: |
           docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}
-          docker run --tty -e ZEBRA_TEST_LIGHTWALLETD=1 -e TEST_LWD_INTEGRATION=1 ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}
+          docker run --tty \
+          -e ZEBRA_TEST_LIGHTWALLETD=1 \
+          -e TEST_LWD_INTEGRATION=1 \
+          -e NETWORK="${{ inputs.network || vars.ZCASH_NETWORK }}" \
+          -e RUST_LOG=${{ env.RUST_LOG }} \
+          -e RUST_BACKTRACE=${{ env.RUST_BACKTRACE }} \
+          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}
 
   # Test that Zebra works using the default config with the latest Zebra version.
   test-configuration-file:
@@ -147,8 +171,8 @@ jobs:
     with:
       test_id: "testnet-conf"
       docker_image: ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}
-      grep_patterns: '-e "net.*=.*Test.*estimated progress to chain tip.*Genesis" -e "net.*=.*Test.*estimated progress to chain tip.*BeforeOverwinter"'
       test_variables: "-e NETWORK=Testnet"
+      grep_patterns: '-e "net.*=.*Test.*estimated progress to chain tip.*Genesis" -e "net.*=.*Test.*estimated progress to chain tip.*BeforeOverwinter"'
 
   # Test that Zebra works using $ZEBRA_CONF_PATH config
   test-zebra-conf-path:
@@ -198,4 +222,11 @@ jobs:
       - name: Run check_no_git_refs_in_cargo_lock
         run: |
           docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}
-          docker run --tty -e RUN_CHECK_NO_GIT_REFS=1 ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}
+          docker run --tty \
+          -e RUN_CHECK_NO_GIT_REFS=1 \
+          -e NETWORK="${{ inputs.network || vars.ZCASH_NETWORK }}" \
+          -e RUST_LOG=${{ env.RUST_LOG }} \
+          -e RUST_BACKTRACE=${{ env.RUST_BACKTRACE }} \
+          -e RUST_LIB_BACKTRACE=${{ env.RUST_LIB_BACKTRACE }} \
+          -e COLORBT_SHOW_HIDDEN=${{ env.COLORBT_SHOW_HIDDEN }} \
+          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}

--- a/.github/workflows/sub-ci-unit-tests-docker.yml
+++ b/.github/workflows/sub-ci-unit-tests-docker.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run all tests
         run: |
           docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}
-          docker run -tty \
+          docker run --tty \
           -e RUN_ALL_TESTS=1 \
           -e FEATURES="journald prometheus filter-reload" \
           -e NETWORK="${{ inputs.network || vars.ZCASH_NETWORK }}" \
@@ -90,7 +90,7 @@ jobs:
           NETWORK: ${{ inputs.network || vars.ZCASH_NETWORK }}
         run: |
           docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}
-          docker run -tty \
+          docker run --tty \
           -e TEST_FAKE_ACTIVATION_HEIGHTS=1 \
           -e NETWORK="${{ inputs.network || vars.ZCASH_NETWORK }}" \
           -e RUST_LOG=${{ env.RUST_LOG }} \

--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -85,6 +85,11 @@ on:
         description: 'Application name, used to work out when a job is an update job'
 
 env:
+  RUST_LOG: ${{ vars.RUST_LOG }}
+  RUST_BACKTRACE: ${{ vars.RUST_BACKTRACE }}
+  RUST_LIB_BACKTRACE: ${{ vars.RUST_LIB_BACKTRACE }}
+  COLORBT_SHOW_HIDDEN: ${{ vars.COLORBT_SHOW_HIDDEN }}
+  CARGO_INCREMENTAL: ${{ vars.CARGO_INCREMENTAL }}
   # How many previous log lines we show at the start of each new log job.
   # Increase this number if some log lines are skipped between jobs
   #
@@ -95,7 +100,6 @@ env:
   # How many blocks to wait before creating an updated cached state image.
   # 1 day is approximately 1152 blocks.
   CACHED_STATE_UPDATE_LIMIT: 576
-
 jobs:
   # Find a cached state disk for ${{ inputs.test_id }}, matching all of:
   # - disk cached state prefix -> zebrad-cache or lwd-cache
@@ -279,6 +283,11 @@ jobs:
           --tty \
           --detach \
           ${{ inputs.test_variables }} \
+          -e RUST_LOG=${{ env.RUST_LOG }} \
+          -e RUST_BACKTRACE=${{ env.RUST_BACKTRACE }} \
+          -e RUST_LIB_BACKTRACE=${{ env.RUST_LIB_BACKTRACE }} \
+          -e COLORBT_SHOW_HIDDEN=${{ env.COLORBT_SHOW_HIDDEN }} \
+          -e CARGO_INCREMENTAL=${{ env.CARGO_INCREMENTAL }} \
           ${MOUNT_FLAGS} \
           ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }} \
           '

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -191,7 +191,7 @@ FROM debian:bookworm-slim AS runtime
 ARG FEATURES
 ENV FEATURES=${FEATURES}
 
-# Create a non-privileged system user for running `zebrad`.
+# Create a non-privileged user for running `zebrad`.
 #
 # We use a high UID/GID (10001) to avoid overlap with host system users.
 # This reduces the risk of container user namespace conflicts with host accounts,
@@ -217,7 +217,6 @@ ENV USER=${USER}
 RUN addgroup --gid ${GID} ${USER} && \
     adduser --gid ${GID} --uid ${UID} --home ${HOME} ${USER}
 
-# System users have no home dirs, but we set one for users' convenience.
 WORKDIR ${HOME}
 
 # We set the default locations of the conf and cache dirs according to the XDG

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -60,14 +60,6 @@ ARG SHORT_SHA
 # https://github.com/ZcashFoundation/zebra/blob/9ebd56092bcdfc1a09062e15a0574c94af37f389/zebrad/src/application.rs#L179-L182
 ENV SHORT_SHA=${SHORT_SHA:-}
 
-# Set the working directory for the build.
-ARG HOME
-WORKDIR ${HOME}
-ENV HOME=${HOME}
-ENV CARGO_HOME="${HOME}/.cargo/"
-
-ENV USER=${USER}
-
 # This stage builds tests without running them.
 #
 # We also download needed dependencies for tests to work, from other images.
@@ -84,14 +76,21 @@ ENV ZEBRA_SKIP_IPV6_TESTS=${ZEBRA_SKIP_IPV6_TESTS:-1}
 # This environment setup is almost identical to the `runtime` target so that the
 # `tests` target differs minimally. In fact, a subset of this setup is used for
 # the `runtime` target.
-
 ARG UID
+ENV UID=${UID}
 ARG GID
+ENV GID=${GID}
 ARG HOME
+ENV HOME=${HOME}
 ARG USER
+ENV USER=${USER}
 
 RUN addgroup --gid ${GID} ${USER} && \
     adduser --gid ${GID} --uid ${UID} --home ${HOME} ${USER}
+
+# Set the working directory for the build.
+WORKDIR ${HOME}
+ENV CARGO_HOME="${HOME}/.cargo/"
 
 # Build Zebra test binaries, but don't run them
 
@@ -193,13 +192,7 @@ ARG FEATURES
 ENV FEATURES=${FEATURES}
 
 # Create a non-privileged system user for running `zebrad`.
-ARG USER
-ENV USER=${USER}
-
-# System users have no home dirs, but we set one for users' convenience.
-ARG HOME
-WORKDIR ${HOME}
-
+#
 # We use a high UID/GID (10001) to avoid overlap with host system users.
 # This reduces the risk of container user namespace conflicts with host accounts,
 # which could potentially lead to privilege escalation if a container escape occurs.
@@ -216,9 +209,16 @@ ARG UID
 ENV UID=${UID}
 ARG GID
 ENV GID=${GID}
+ARG HOME
+ENV HOME=${HOME}
+ARG USER
+ENV USER=${USER}
 
 RUN addgroup --gid ${GID} ${USER} && \
     adduser --gid ${GID} --uid ${UID} --home ${HOME} ${USER}
+
+# System users have no home dirs, but we set one for users' convenience.
+WORKDIR ${HOME}
 
 # We set the default locations of the conf and cache dirs according to the XDG
 # spec: https://specifications.freedesktop.org/basedir-spec/latest/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,6 +52,9 @@ ENV RUST_LIB_BACKTRACE=${RUST_LIB_BACKTRACE:-1}
 ARG COLORBT_SHOW_HIDDEN
 ENV COLORBT_SHOW_HIDDEN=${COLORBT_SHOW_HIDDEN:-1}
 
+ARG CARGO_INCREMENTAL
+ENV CARGO_INCREMENTAL=${CARGO_INCREMENTAL:-0}
+
 ARG SHORT_SHA
 # If this is not set, it must be an empty string, so Zebra can try an alternative git commit source:
 # https://github.com/ZcashFoundation/zebra/blob/9ebd56092bcdfc1a09062e15a0574c94af37f389/zebrad/src/application.rs#L179-L182


### PR DESCRIPTION
## Motivation

It's hard to debug tests if we don't have access to the full backtrace and other options are expected to be set by our GitHub variables, but in the end not all of those are being fully used at runtime.

## Solution

Enhance test workflows by adding Rust-specific environment variables:
- Include `RUST_LOG` for logging configuration
- Add `RUST_BACKTRACE` and `RUST_LIB_BACKTRACE` for improved error tracing
- Include `COLORBT_SHOW_HIDDEN` for detailed backtraces
- Add `CARGO_INCREMENTAL` for build performance optimization

This also fixes user creation issues in the Dockerfile:
- Move WORKDIR after user creation to prevent home directory ownership issues
- Properly set environment variables for UID, GID, HOME, and USER in each stage
- Reorganize Dockerfile to ensure home directory is created after user setup
- Fix interactive prompts during adduser by ensuring proper directory ownership

### Tests

- Existing non-failing tests should run as expected

### Follow-up Work

- Track the Test All issue

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [X] The solution is tested.
- [X] The documentation is up to date.
- [X] The PR has a priority label.
- [X] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
