### PR TITLE
feat(rpc): fill size field in getblock with verbosity=2

### DIFF
--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@mainnet_10.snap
@@ -5,6 +5,7 @@ expression: block
 {
   "hash": "0007bc227e1c57a4a70e237cad00e7b7ce565155ab49166bc57397a26d339283",
   "confirmations": 10,
+  "size": 1617,
   "height": 1,
   "version": 4,
   "merkleroot": "851bf6fbf7a976327817c738c489d7fa657752445430922d94c983c0b9ed4609",

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@testnet_10.snap
@@ -5,6 +5,7 @@ expression: block
 {
   "hash": "025579869bcf52a989337342f5f57a84f3a28b968f7d6a8307902b065a668d23",
   "confirmations": 10,
+  "size": 1618,
   "height": 1,
   "version": 4,
   "merkleroot": "f37e9f691fffb635de0999491d906ee85ba40cd36dae9f6e5911a8277d7c5f75",

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@mainnet_10.snap
@@ -5,6 +5,7 @@ expression: block
 {
   "hash": "0007bc227e1c57a4a70e237cad00e7b7ce565155ab49166bc57397a26d339283",
   "confirmations": 10,
+  "size": 1617,
   "height": 1,
   "version": 4,
   "merkleroot": "851bf6fbf7a976327817c738c489d7fa657752445430922d94c983c0b9ed4609",

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@testnet_10.snap
@@ -5,6 +5,7 @@ expression: block
 {
   "hash": "025579869bcf52a989337342f5f57a84f3a28b968f7d6a8307902b065a668d23",
   "confirmations": 10,
+  "size": 1618,
   "height": 1,
   "version": 4,
   "merkleroot": "f37e9f691fffb635de0999491d906ee85ba40cd36dae9f6e5911a8277d7c5f75",

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -316,7 +316,7 @@ async fn rpc_getblock() {
                     }))
                     .collect(),
                 trees,
-                size: None,
+                size: Some(block.zcash_serialize_to_vec().unwrap().len() as i64),
                 version: Some(block.header.version),
                 merkle_root: Some(block.header.merkle_root),
                 block_commitments: Some(expected_block_commitments),
@@ -364,7 +364,7 @@ async fn rpc_getblock() {
                     }))
                     .collect(),
                 trees,
-                size: None,
+                size: Some(block.zcash_serialize_to_vec().unwrap().len() as i64),
                 version: Some(block.header.version),
                 merkle_root: Some(block.header.merkle_root),
                 block_commitments: Some(expected_block_commitments),

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -51,7 +51,9 @@ pub use request::Spend;
 pub use response::{GetBlockTemplateChainInfo, KnownBlock, MinedTx, ReadResponse, Response};
 pub use service::{
     chain_tip::{ChainTipBlock, ChainTipChange, ChainTipSender, LatestChainTip, TipAction},
-    check, init, init_read_only,
+    check,
+    finalized_state::FinalizedState,
+    init, init_read_only,
     non_finalized_state::NonFinalizedState,
     spawn_init, spawn_init_read_only,
     watch_receiver::WatchReceiver,

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -715,6 +715,14 @@ pub enum Request {
     /// [`block::Height`] using `.into()`.
     Block(HashOrHeight),
 
+    //// Same as Block, but also returns serialized block size.
+    ////
+    /// Returns
+    ///
+    /// * [`ReadResponse::BlockAndSize(Some((Arc<Block>, usize)))`](ReadResponse::BlockAndSize) if the block is in the best chain;
+    /// * [`ReadResponse::BlockAndSize(None)`](ReadResponse::BlockAndSize) otherwise.
+    BlockAndSize(HashOrHeight),
+
     /// Looks up a block header by hash or height in the current best chain.
     ///
     /// Returns
@@ -837,6 +845,7 @@ impl Request {
             Request::Transaction(_) => "transaction",
             Request::UnspentBestChainUtxo { .. } => "unspent_best_chain_utxo",
             Request::Block(_) => "block",
+            Request::BlockAndSize(_) => "block_and_size",
             Request::BlockHeader(_) => "block_header",
             Request::FindBlockHashes { .. } => "find_block_hashes",
             Request::FindBlockHeaders { .. } => "find_block_headers",
@@ -896,6 +905,14 @@ pub enum ReadRequest {
     /// Note: the [`HashOrHeight`] can be constructed from a [`block::Hash`] or
     /// [`block::Height`] using `.into()`.
     Block(HashOrHeight),
+
+    //// Same as Block, but also returns serialized block size.
+    ////
+    /// Returns
+    ///
+    /// * [`ReadResponse::BlockAndSize(Some((Arc<Block>, usize)))`](ReadResponse::BlockAndSize) if the block is in the best chain;
+    /// * [`ReadResponse::BlockAndSize(None)`](ReadResponse::BlockAndSize) otherwise.
+    BlockAndSize(HashOrHeight),
 
     /// Looks up a block header by hash or height in the current best chain.
     ///
@@ -1143,6 +1160,7 @@ impl ReadRequest {
             ReadRequest::TipPoolValues => "tip_pool_values",
             ReadRequest::Depth(_) => "depth",
             ReadRequest::Block(_) => "block",
+            ReadRequest::BlockAndSize(_) => "block_and_size",
             ReadRequest::BlockHeader(_) => "block_header",
             ReadRequest::Transaction(_) => "transaction",
             ReadRequest::TransactionIdsForBlock(_) => "transaction_ids_for_block",
@@ -1200,6 +1218,7 @@ impl TryFrom<Request> for ReadRequest {
             Request::BestChainBlockHash(hash) => Ok(ReadRequest::BestChainBlockHash(hash)),
 
             Request::Block(hash_or_height) => Ok(ReadRequest::Block(hash_or_height)),
+            Request::BlockAndSize(hash_or_height) => Ok(ReadRequest::BlockAndSize(hash_or_height)),
             Request::BlockHeader(hash_or_height) => Ok(ReadRequest::BlockHeader(hash_or_height)),
             Request::Transaction(tx_hash) => Ok(ReadRequest::Transaction(tx_hash)),
             Request::UnspentBestChainUtxo(outpoint) => {

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -50,6 +50,9 @@ pub enum Response {
     /// Response to [`Request::Block`] with the specified block.
     Block(Option<Arc<Block>>),
 
+    /// Response to [`Request::BlockAndSize`] with the specified block and size.
+    BlockAndSize(Option<(Arc<Block>, usize)>),
+
     /// The response to a `BlockHeader` request.
     BlockHeader {
         /// The header of the requested block
@@ -156,6 +159,10 @@ pub enum ReadResponse {
 
     /// Response to [`ReadRequest::Block`] with the specified block.
     Block(Option<Arc<Block>>),
+
+    /// Response to [`ReadRequest::BlockAndSize`] with the specified block and
+    /// serialized size.
+    BlockAndSize(Option<(Arc<Block>, usize)>),
 
     /// The response to a `BlockHeader` request.
     BlockHeader {
@@ -311,6 +318,7 @@ impl TryFrom<ReadResponse> for Response {
             ReadResponse::BlockHash(hash) => Ok(Response::BlockHash(hash)),
 
             ReadResponse::Block(block) => Ok(Response::Block(block)),
+            ReadResponse::BlockAndSize(block) => Ok(Response::BlockAndSize(block)),
             ReadResponse::BlockHeader {
                 header,
                 hash,

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1092,6 +1092,7 @@ impl Service<Request> for StateService {
             | Request::Transaction(_)
             | Request::UnspentBestChainUtxo(_)
             | Request::Block(_)
+            | Request::BlockAndSize(_)
             | Request::BlockHeader(_)
             | Request::FindBlockHashes { .. }
             | Request::FindBlockHeaders { .. }
@@ -1306,6 +1307,31 @@ impl Service<ReadRequest> for ReadStateService {
                         timer.finish(module_path!(), line!(), "ReadRequest::Block");
 
                         Ok(ReadResponse::Block(block))
+                    })
+                })
+                .wait_for_panics()
+            }
+
+            // Used by the get_block (raw) RPC and the StateService.
+            ReadRequest::BlockAndSize(hash_or_height) => {
+                let state = self.clone();
+
+                tokio::task::spawn_blocking(move || {
+                    span.in_scope(move || {
+                        let block_and_size = state.non_finalized_state_receiver.with_watch_data(
+                            |non_finalized_state| {
+                                read::block_and_size(
+                                    non_finalized_state.best_chain(),
+                                    &state.db,
+                                    hash_or_height,
+                                )
+                            },
+                        );
+
+                        // The work is done in the future.
+                        timer.finish(module_path!(), line!(), "ReadRequest::BlockAndSize");
+
+                        Ok(ReadResponse::BlockAndSize(block_and_size))
                     })
                 })
                 .wait_for_panics()

--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -191,8 +191,11 @@ impl ZebraDb {
         // transactions. This requires summing them all and also adding the
         // size of the CompactSize-encoded transaction count.
         // See https://developer.bitcoin.org/reference/block_chain.html#serialized-blocks
-        let tx_count = CompactSizeMessage::try_from(txs.len()).unwrap();
-        let tx_raw = tx_count.zcash_serialize_to_vec().unwrap();
+        let tx_count = CompactSizeMessage::try_from(txs.len())
+            .expect("must work for a previously serialized block");
+        let tx_raw = tx_count
+            .zcash_serialize_to_vec()
+            .expect("must work for a previously serialized block");
         let size = raw_header.raw_bytes().len()
             + raw_txs
                 .iter()

--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -24,7 +24,7 @@ use zebra_chain::{
     parallel::tree::NoteCommitmentTrees,
     parameters::{Network, GENESIS_PREVIOUS_BLOCK_HASH},
     sapling,
-    serialization::TrustedPreallocate,
+    serialization::{CompactSizeMessage, TrustedPreallocate, ZcashSerialize as _},
     transaction::{self, Transaction},
     transparent,
     value_balance::ValueBalance,
@@ -39,6 +39,7 @@ use crate::{
             transparent::{AddressBalanceLocation, OutputLocation},
         },
         zebra_db::{metrics::block_precommit_metrics, ZebraDb},
+        FromDisk, RawBytes,
     },
     BoxError, HashOrHeight,
 };
@@ -132,6 +133,19 @@ impl ZebraDb {
         Some(header)
     }
 
+    /// Returns the raw [`block::Header`] with [`block::Hash`] or [`Height`], if
+    /// it exists in the finalized chain.
+    #[allow(clippy::unwrap_in_result)]
+    fn raw_block_header(&self, hash_or_height: HashOrHeight) -> Option<RawBytes> {
+        // Block Header
+        let block_header_by_height = self.db.cf_handle("block_header_by_height").unwrap();
+
+        let height = hash_or_height.height_or_else(|hash| self.height(hash))?;
+        let header: RawBytes = self.db.zs_get(&block_header_by_height, &height)?;
+
+        Some(header)
+    }
+
     /// Returns the [`Block`] with [`block::Hash`] or
     /// [`Height`], if it exists in the finalized chain.
     //
@@ -159,6 +173,56 @@ impl ZebraDb {
             header,
             transactions,
         }))
+    }
+
+    /// Returns the [`Block`] with [`block::Hash`] or [`Height`], if it exists
+    /// in the finalized chain, and its serialized size.
+    #[allow(clippy::unwrap_in_result)]
+    pub fn block_and_size(&self, hash_or_height: HashOrHeight) -> Option<(Arc<Block>, usize)> {
+        let (raw_header, raw_txs) = self.raw_block(hash_or_height)?;
+
+        let header = Arc::<block::Header>::from_bytes(raw_header.raw_bytes());
+        let txs: Vec<_> = raw_txs
+            .iter()
+            .map(|raw_tx| Arc::<Transaction>::from_bytes(raw_tx.raw_bytes()))
+            .collect();
+
+        // Compute the size of the block from the size of header and size of
+        // transactions. This requires summing them all and also adding the
+        // size of the CompactSize-encoded transaction count.
+        // See https://developer.bitcoin.org/reference/block_chain.html#serialized-blocks
+        let tx_count = CompactSizeMessage::try_from(txs.len()).unwrap();
+        let tx_raw = tx_count.zcash_serialize_to_vec().unwrap();
+        let size = raw_header.raw_bytes().len()
+            + raw_txs
+                .iter()
+                .map(|raw_tx| raw_tx.raw_bytes().len())
+                .sum::<usize>()
+            + tx_raw.len();
+
+        let block = Block {
+            header,
+            transactions: txs,
+        };
+        Some((Arc::new(block), size))
+    }
+
+    /// Returns the raw [`Block`] with [`block::Hash`] or
+    /// [`Height`], if it exists in the finalized chain.
+    #[allow(clippy::unwrap_in_result)]
+    fn raw_block(&self, hash_or_height: HashOrHeight) -> Option<(RawBytes, Vec<RawBytes>)> {
+        // Block
+        let height = hash_or_height.height_or_else(|hash| self.height(hash))?;
+        let header = self.raw_block_header(height.into())?;
+
+        // Transactions
+
+        let transactions = self
+            .raw_transactions_by_height(height)
+            .map(|(_, tx)| tx)
+            .collect();
+
+        Some((header, transactions))
     }
 
     /// Returns the Sapling [`note commitment tree`](sapling::tree::NoteCommitmentTree) specified by
@@ -233,6 +297,19 @@ impl ZebraDb {
         )
     }
 
+    /// Returns an iterator of all raw [`Transaction`]s for a provided block
+    /// height in finalized state.
+    #[allow(clippy::unwrap_in_result)]
+    fn raw_transactions_by_height(
+        &self,
+        height: Height,
+    ) -> impl Iterator<Item = (TransactionLocation, RawBytes)> + '_ {
+        self.raw_transactions_by_location_range(
+            TransactionLocation::min_for_height(height)
+                ..=TransactionLocation::max_for_height(height),
+        )
+    }
+
     /// Returns an iterator of all [`Transaction`]s in the provided range
     /// of [`TransactionLocation`]s in finalized state.
     #[allow(clippy::unwrap_in_result)]
@@ -240,6 +317,20 @@ impl ZebraDb {
         &self,
         range: R,
     ) -> impl Iterator<Item = (TransactionLocation, Transaction)> + '_
+    where
+        R: RangeBounds<TransactionLocation>,
+    {
+        let tx_by_loc = self.db.cf_handle("tx_by_loc").unwrap();
+        self.db.zs_forward_range_iter(tx_by_loc, range)
+    }
+
+    /// Returns an iterator of all raw [`Transaction`]s in the provided range
+    /// of [`TransactionLocation`]s in finalized state.
+    #[allow(clippy::unwrap_in_result)]
+    fn raw_transactions_by_location_range<R>(
+        &self,
+        range: R,
+    ) -> impl Iterator<Item = (TransactionLocation, RawBytes)> + '_
     where
         R: RangeBounds<TransactionLocation>,
     {

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -29,7 +29,8 @@ pub use address::{
     utxo::{address_utxos, AddressUtxos},
 };
 pub use block::{
-    any_utxo, block, block_header, mined_transaction, transaction_hashes_for_block, unspent_utxo,
+    any_utxo, block, block_and_size, block_header, mined_transaction, transaction_hashes_for_block,
+    unspent_utxo,
 };
 
 #[cfg(feature = "indexer")]


### PR DESCRIPTION
## Motivation

This fills the `size` field in the `getblock` RPC when `verbosity=2`.

To support `verbosity=1` we would need to either take a performance hit (load all transactions from a block to get their sizes) or change the database to create a tx -> size index (which would be good to avoid if possible)

Might close #9020

## Solution

Add a `BlockAndSize` request to the state which reads the raw block header and txs, gets their sizes, computes the block size from them, and finally parses it all to return the block.

### Tests

I adjusted existing tests. I also tested it manually with `zcash-rpc-diff`.

The block size calculation logic was also tested manually with a throwaway program that computed block sizes from the state with both approaches and asserted that they are equal.

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

We need to decide if this is enough for now or if we want to support verbosity=1. In that case, we will need to create a new issue for it.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.
- [ ] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
