### PR TITLE
fix(docker): set `HOME` environment variable explicitly in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,6 +72,7 @@ ENV GID=${GID}
 ARG USER
 ENV USER=${USER}
 ARG HOME
+ENV HOME=${HOME}
 
 RUN addgroup --quiet --gid ${GID} ${USER} && \
     adduser --quiet --gid ${GID} --uid ${UID} --home ${HOME} ${USER} --disabled-password --gecos ""
@@ -191,6 +192,7 @@ ENV GID=${GID}
 ARG USER
 ENV USER=${USER}
 ARG HOME
+ENV HOME=${HOME}
 
 RUN addgroup --quiet --gid ${GID} ${USER} && \
     adduser --quiet --gid ${GID} --uid ${UID} --home ${HOME} ${USER} --disabled-password --gecos ""


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

The `HOME` environment variable was defaulting to `/root` when the container started, causing cache directories to be incorrectly set up under `/root/.cache/zebra` instead of `/home/zebra/.cache/zebra`

This happens as the user running the `entrypoint.sh` (before using `gosu`) is the `root` user

The initial intention was not to override the default linux `$HOME`, but in this controlled environment there's no actual benefit in not doing so.

## Solution

- This explicit setting ensures the `HOME` environment variable is correctly set to the zebra user's home directory.

### Tests

- Carefully check the unit tests:
  - **Test default-conf in Docker**
  - **Test testnet-conf in Docker**
  - **Test custom-conf in Docker**

As their exit code is not being handled correctly

### Follow-up Work

- Docker configuration tests should exit with the appropriate exit code when this kind of scenarios happen

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.
- [x] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
