### PR TITLE
fix(docker): add default CMD to test stage in Dockerfile 

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,6 +72,7 @@ ENV GID=${GID}
 ARG USER
 ENV USER=${USER}
 ARG HOME
+ENV HOME=${HOME}
 
 RUN addgroup --quiet --gid ${GID} ${USER} && \
     adduser --quiet --gid ${GID} --uid ${UID} --home ${HOME} ${USER} --disabled-password --gecos ""
@@ -191,6 +192,7 @@ ENV GID=${GID}
 ARG USER
 ENV USER=${USER}
 ARG HOME
+ENV HOME=${HOME}
 
 RUN addgroup --quiet --gid ${GID} ${USER} && \
     adduser --quiet --gid ${GID} --uid ${UID} --home ${HOME} ${USER} --disabled-password --gecos ""

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -133,6 +133,7 @@ COPY --chown=${UID}:${GID} ./ ${HOME}
 COPY --chown=${UID}:${GID} ./docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT [ "entrypoint.sh", "test" ]
+CMD [ "cargo", "test" ]
 
 # This stage builds the zebrad release binary.
 #


### PR DESCRIPTION
## Motivation

When running the container using docker-compose without explicitly 
providing a command, the entrypoint.sh script was attempting to execute
`exec_as_user` with no arguments, resulting in a gosu error:

```shell
exec_as_user
exec gosu 10001:10001
Usage: gosu user-spec command [args]
```

Depends-On: #9333

## Solution

By adding `CMD ["cargo", "test"]` to the test stage in the Dockerfile, we ensure a default command is available for the entrypoint script to execute, preventing the `gosu` error when no command is explicitly provided.

This fix allows `docker-compose.test.yml` to run successfully without needing to specify a command in the service definition.

### Tests

There are no unit tests validating this, but running `docker compose -f docker/docker-compose.test.yml up --build` will trigger it (without this PR).

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.
- [ ] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
