### PR TITLE
refactor(docker): Enhance Zebra configuration options and entrypoint logic

### DIFF
--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -62,8 +62,8 @@ All available Cargo features are listed at
 To configure Zebra using Docker, you have a few options, processed in this order:
 
 1. **Provide a specific config file path:** Set the `ZEBRA_CONF_PATH` environment variable to point to your config file within the container.
-2. **Use the default config file:** If `ZEBRA_CONF_PATH` is not set, Zebra will look for a config file at `/home/zebra/.config/zebrad.toml`. You can mount your custom config file to this location, for example, by uncommenting the `configs` mapping in `docker/docker-compose.yml`.
-3. **Generate config from environment variables:** If neither of the above methods provides a config file, the container's entrypoint script will *automatically generate* a default configuration file at `/home/zebra/.config/zebrad.toml`. This generated file uses specific environment variables (like `NETWORK`, `ZEBRA_RPC_PORT`, `ENABLE_COOKIE_AUTH`, `MINER_ADDRESS`, etc.) to define the settings. Using the `docker/.env` file is the primary way to set these variables for this auto-generation mode.
+2. **Use the default config file:** By default, the `docker-compose.yml` file mounts `./default-zebra-config.toml` to `/home/zebra/.config/zebrad.toml` using the `configs:` mapping. Zebra will use this file if `ZEBRA_CONF_PATH` is not set. To use environment variables instead, you must **comment out** the `configs:` mapping in `docker/docker-compose.yml`.
+3. **Generate config from environment variables:** If neither of the above methods provides a config file (i.e., `ZEBRA_CONF_PATH` is unset *and* the `configs:` mapping in `docker-compose.yml` is commented out), the container's entrypoint script will *automatically generate* a default configuration file at `/home/zebra/.config/zebrad.toml`. This generated file uses specific environment variables (like `NETWORK`, `ZEBRA_RPC_PORT`, `ENABLE_COOKIE_AUTH`, `MINER_ADDRESS`, etc.) to define the settings. Using the `docker/.env` file is the primary way to set these variables for this auto-generation mode.
 
 You can see if your config works as intended by looking at Zebra's logs.
 
@@ -73,8 +73,8 @@ Note that if you provide a configuration file using methods 1 or 2, environment 
 
 Zebra's RPC server is disabled by default. To enable it, you need to define the RPC settings in Zebra's configuration. You can achieve this using one of the configuration methods described above:
 
-*   **Using a config file (methods 1 or 2):** Add or uncomment the `[rpc]` section in your `zebrad.toml` file (like the one provided in `docker/default-zebra-config.toml`). Ensure you set the `listen_addr` (e.g., `"0.0.0.0:8232"` for Mainnet).
-*   **Using environment variables (method 3):** Set the `ZEBRA_RPC_PORT` environment variable (e.g., in `docker/.env`). This tells the entrypoint script to include an enabled `[rpc]` section listening on `0.0.0.0:<ZEBRA_RPC_PORT>` in the auto-generated configuration file.
+* **Using a config file (methods 1 or 2):** Add or uncomment the `[rpc]` section in your `zebrad.toml` file (like the one provided in `docker/default-zebra-config.toml`). Ensure you set the `listen_addr` (e.g., `"0.0.0.0:8232"` for Mainnet).
+* **Using environment variables (method 3):** Set the `ZEBRA_RPC_PORT` environment variable (e.g., in `docker/.env`). This tells the entrypoint script to include an enabled `[rpc]` section listening on `0.0.0.0:<ZEBRA_RPC_PORT>` in the auto-generated configuration file.
 
 **Cookie Authentication:**
 

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -59,19 +59,22 @@ All available Cargo features are listed at
 
 ## Configuring Zebra
 
-To configure Zebra, edit the `docker/default-zebra-config.toml` config file and
-uncomment the `configs` mapping in `docker/docker-compose.yml` so your config
-takes effect. You can see if your config works as intended by looking at Zebra's
-logs.
+To configure Zebra, you have three options:
 
-Alternatively, you can configure Zebra by setting the environment variables in
-the `docker/.env` file. Note that the config options of this file are limited to
-the variables already present in the commented out blocks in it and adding new
-ones will not be effective. Also note that the values of the variables take
-precedence over the values set in the `docker/default-zebra-config.toml` config
-file. The `docker/.env` file serves as a quick way to override the most commonly
-used settings for Zebra, whereas the `docker/default-zebra-config.toml` file
-provides full config capabilities.
+1. Edit the `docker/default-zebra-config.toml` config file and uncomment the `configs` mapping in `docker/docker-compose.yml` so your config takes effect.
+2. Provide a path to your own config file via the `ZEBRA_CONF_PATH` environment variable.
+3. Let Zebra generate a default config file automatically from environment variables (if neither of the above methods is used).
+
+The entrypoint script follows this sequence:
+
+1. If `ZEBRA_CONF_PATH` is set and a file exists at that path, it uses that file
+2. If `ZEBRA_CONF_PATH` is not set but a default config exists at `${HOME}/.config/zebrad.toml`, it uses that file
+3. If neither exists, it generates a default config at `${HOME}/.config/zebrad.toml` based on environment variables
+4. Environment variables from the `docker/.env` only take effect if a configuration file is not mounted, and thus are only effective if you don't provide a custom config file.
+
+You can see if your config works as intended by looking at Zebra's logs.
+
+Note that the environment variable overrides in the `docker/.env` file are limited to the variables already present in the commented out blocks and adding new ones will not be effective. The `docker/.env` file serves as a quick way to override the most commonly used settings, whereas a custom config file provides full configuration capabilities.
 
 ### RPC
 

--- a/docker/.env
+++ b/docker/.env
@@ -3,7 +3,6 @@
 # Sets the path to a custom Zebra config file. If not set, Zebra will look for a config at
 # ${HOME}/.config/zebrad.toml or generate one using environment variables below.
 # ! Setting ZEBRA_CONF_PATH will make most of the following environment variables ineffective.
-# TODO: zebrad should be able to read from both the config file and environment variables.
 #
 # ZEBRA_CONF_PATH="/path/to/your/custom/zebrad.toml"
 
@@ -36,7 +35,6 @@
 # FEATURES=""
 
 # Sets the listen address and port for Prometheus metrics.
-# Only active when the 'prometheus' feature is enabled.
 #
 # METRICS_ENDPOINT_ADDR="0.0.0.0"
 # METRICS_ENDPOINT_PORT=9999

--- a/docker/.env
+++ b/docker/.env
@@ -11,20 +11,10 @@
 #
 # NETWORK=Mainnet
 
-# Sets the listen address for Zebra's peer-to-peer network connections.
-#
-# ZEBRA_LISTEN_ADDR="0.0.0.0"
-
 # Zebra's RPC server is disabled by default. To enable it, set its port number.
 #
 # ZEBRA_RPC_PORT=8232   # Default RPC port number on Mainnet.
 # ZEBRA_RPC_PORT=18232  # Default RPC port number on Testnet.
-
-# Sets the listen address and port for Zebra's RPC server.
-# RPC_PORT will be used if ZEBRA_RPC_PORT is not set.
-#
-# RPC_LISTEN_ADDR="0.0.0.0"
-# RPC_PORT=8232   # Default RPC port number on Mainnet
 
 # To disable cookie authentication, set the value below to false.
 #
@@ -37,10 +27,6 @@
 # Sets a custom directory for the state and network caches.
 #
 # ZEBRA_CACHE_DIR="/home/zebra/.cache/zebra"
-
-# Sets a custom directory for the lightwalletd cache.
-#
-# LWD_CACHE_DIR="/home/zebra/.cache/lwd"
 
 # Sets custom Cargo features. Available features are listed at
 # <https://docs.rs/zebrad/latest/zebrad/index.html#zebra-feature-flags>.

--- a/docker/.env
+++ b/docker/.env
@@ -1,22 +1,46 @@
 # Configuration variables for running Zebra in Docker
 
+# Sets the path to a custom Zebra config file. If not set, Zebra will look for a config at
+# ${HOME}/.config/zebrad.toml or generate one using environment variables below.
+# ! Setting ZEBRA_CONF_PATH will make most of the following environment variables ineffective.
+# TODO: zebrad should be able to read from both the config file and environment variables.
+#
+# ZEBRA_CONF_PATH="/path/to/your/custom/zebrad.toml"
+
 # Sets the network Zebra runs will run on.
 #
 # NETWORK=Mainnet
 
+# Sets the listen address for Zebra's peer-to-peer network connections.
+#
+# ZEBRA_LISTEN_ADDR="0.0.0.0"
+
 # Zebra's RPC server is disabled by default. To enable it, set its port number.
 #
 # ZEBRA_RPC_PORT=8232   # Default RPC port number on Mainnet.
-# ZEBRA_RPC_PORT=18323  # Default RPC port number on Testnet.
+# ZEBRA_RPC_PORT=18232  # Default RPC port number on Testnet.
+
+# Sets the listen address and port for Zebra's RPC server.
+# RPC_PORT will be used if ZEBRA_RPC_PORT is not set.
+#
+# RPC_LISTEN_ADDR="0.0.0.0"
+# RPC_PORT=8232   # Default RPC port number on Mainnet
 
 # To disable cookie authentication, set the value below to false.
 #
 # ENABLE_COOKIE_AUTH=true
 
-# Sets a custom directory for the state and network caches. Zebra will also
-# store its cookie authentication file in this directory.
+# Sets a custom directory for the cookie authentication file.
+#
+# ZEBRA_COOKIE_DIR="/home/zebra/.config/cookie"
+
+# Sets a custom directory for the state and network caches.
 #
 # ZEBRA_CACHE_DIR="/home/zebra/.cache/zebra"
+
+# Sets a custom directory for the lightwalletd cache.
+#
+# LWD_CACHE_DIR="/home/zebra/.cache/lwd"
 
 # Sets custom Cargo features. Available features are listed at
 # <https://docs.rs/zebrad/latest/zebrad/index.html#zebra-feature-flags>.
@@ -24,6 +48,12 @@
 # Must be set at build time.
 #
 # FEATURES=""
+
+# Sets the listen address and port for Prometheus metrics.
+# Only active when the 'prometheus' feature is enabled.
+#
+# METRICS_ENDPOINT_ADDR="0.0.0.0"
+# METRICS_ENDPOINT_PORT=9999
 
 # Logging to a file is disabled by default. To enable it, uncomment the line
 # below and alternatively set your own path.
@@ -40,6 +70,12 @@
 # To disable logging to journald, set the value to false.
 #
 # USE_JOURNALD=true
+
+# Sets the listen address and port for the tracing endpoint.
+# Only active when the 'filter-reload' feature is enabled.
+#
+# TRACING_ENDPOINT_ADDR="0.0.0.0"
+# TRACING_ENDPOINT_PORT=3000
 
 # If you are going to use Zebra as a backend for a mining pool, set your mining
 # address.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,6 +72,7 @@ ENV GID=${GID}
 ARG USER
 ENV USER=${USER}
 ARG HOME
+ENV HOME=${HOME}
 
 RUN addgroup --quiet --gid ${GID} ${USER} && \
     adduser --quiet --gid ${GID} --uid ${UID} --home ${HOME} ${USER} --disabled-password --gecos ""
@@ -119,10 +120,6 @@ COPY --from=electriccoinco/lightwalletd:latest /usr/local/bin/lightwalletd /usr/
 # and allow to change permissions for mounted cache directories
 COPY --from=tianon/gosu:bookworm /gosu /usr/local/bin/
 
-# Use the same default config as in the production environment.
-ENV ZEBRA_CONF_PATH="${HOME}/.config/zebrad.toml"
-COPY --chown=${UID}:${GID} ./docker/default-zebra-config.toml ${ZEBRA_CONF_PATH}
-
 # As the build has already run with the root user,
 # we need to set the correct permissions for the home and cargo home dirs owned by it.
 RUN chown -R ${UID}:${GID} "${HOME}" && \
@@ -139,7 +136,9 @@ ENTRYPOINT [ "entrypoint.sh", "test" ]
 # `test` stage. The resulting zebrad binary is used in the `runtime` stage.
 FROM deps AS release
 
+# Set the working directory for the build.
 ARG HOME
+WORKDIR ${HOME}
 
 RUN --mount=type=bind,source=tower-batch-control,target=tower-batch-control \
     --mount=type=bind,source=tower-fallback,target=tower-fallback \
@@ -191,19 +190,13 @@ ENV GID=${GID}
 ARG USER
 ENV USER=${USER}
 ARG HOME
+ENV HOME=${HOME}
 
 RUN addgroup --quiet --gid ${GID} ${USER} && \
     adduser --quiet --gid ${GID} --uid ${UID} --home ${HOME} ${USER} --disabled-password --gecos ""
 
 WORKDIR ${HOME}
-
-# We set the default locations of the conf and cache dirs according to the XDG
-# spec: https://specifications.freedesktop.org/basedir-spec/latest/
-
 RUN chown -R ${UID}:${GID} ${HOME}
-
-ARG ZEBRA_CONF_PATH="${HOME}/.config/zebrad.toml"
-ENV ZEBRA_CONF_PATH=${ZEBRA_CONF_PATH}
 
 # We're explicitly NOT using the USER directive here.
 # Instead, we run as root initially and use gosu in the entrypoint.sh
@@ -214,7 +207,6 @@ ENV ZEBRA_CONF_PATH=${ZEBRA_CONF_PATH}
 # Copy the gosu binary to be able to run the entrypoint as non-root user
 COPY --from=tianon/gosu:bookworm /gosu /usr/local/bin/
 COPY --from=release /usr/local/bin/zebrad /usr/local/bin/
-COPY --chown=${UID}:${GID} ./docker/default-zebra-config.toml ${ZEBRA_CONF_PATH}
 COPY --chown=${UID}:${GID} ./docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT [ "entrypoint.sh" ]

--- a/docker/default-zebra-config.toml
+++ b/docker/default-zebra-config.toml
@@ -23,7 +23,7 @@ cache_dir = "/home/zebra/.cache/zebra"
 # listen_addr = "0.0.0.0:8232" # Mainnet
 # listen_addr = "0.0.0.0:18232" # Testnet
 
-cookie_dir = "/home/zebra/.cache/zebra"
+cookie_dir = "/home/zebra/.config/cookie"
 
 # To disable cookie authentication, uncomment the line below and set the value
 # to false.

--- a/docker/default-zebra-config.toml
+++ b/docker/default-zebra-config.toml
@@ -23,7 +23,7 @@ cache_dir = "/home/zebra/.cache/zebra"
 # listen_addr = "0.0.0.0:8232" # Mainnet
 # listen_addr = "0.0.0.0:18232" # Testnet
 
-cookie_dir = "/home/zebra/.config/cookie"
+cookie_dir = "/home/zebra/.cache/zebra"
 
 # To disable cookie authentication, uncomment the line below and set the value
 # to false.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,8 +15,8 @@ services:
       - zebrad-cache:/home/zebra/.cache/zebra
     # Having `tty` set to true makes Zebra use colored logs.
     tty: true
-    # ! Comment out the `configs` mapping below to not use our default configuration file.
-    # ! This will use the environment variables in the `.env` file.
+    # ! Comment out the `configs` mapping below to use the environment variables in the
+    # ! `.env` file, instead of the default configuration file.
     configs:
       - source: zebra-config
         target: /home/zebra/.config/zebrad.toml

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,13 +15,12 @@ services:
       - zebrad-cache:/home/zebra/.cache/zebra
     # Having `tty` set to true makes Zebra use colored logs.
     tty: true
-    #! Uncomment the `configs` mapping below to make your custom configuration
-    #! take effect.
-    #
-    # configs:
-    #   - source: zebra-config
-    #     target: /home/zebra/.config/zebrad.toml
-    #
+    # ! Comment out the `configs` mapping below to not use our default configuration file.
+    # ! This will use the environment variables in the `.env` file.
+    configs:
+      - source: zebra-config
+        target: /home/zebra/.config/zebrad.toml
+
     # Uncomment the `ports` mapping below to map ports between the container and
     # host.
     #

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -83,6 +83,13 @@ miner_address = "${MINER_ADDRESS}"
 SUB_EOF
 )
 EOF
+
+# Ensure the config file itself has the correct ownership
+#
+# This is safe in this context because prepare_conf_file is called only when
+# ZEBRA_CONF_PATH is not set, and there's no file mounted at that path.
+chown "${UID}:${GID}" "${ZEBRA_CONF_PATH}" || exit_error "Failed to secure config file: ${ZEBRA_CONF_PATH}"
+
 }
 
 # Helper function

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -43,7 +43,7 @@ prepare_conf_file() {
   cat >"${ZEBRA_CONF_PATH}" <<EOF
 [network]
 network = "${NETWORK:=Mainnet}"
-listen_addr = "${ZEBRA_LISTEN_ADDR:=0.0.0.0}"
+listen_addr = "0.0.0.0"
 cache_dir = "${ZEBRA_CACHE_DIR}"
 
 [state]
@@ -53,7 +53,7 @@ $( [[ -n ${ZEBRA_RPC_PORT} ]] && cat <<-SUB_EOF
 
 [rpc]
 listen_addr = "${RPC_LISTEN_ADDR:=0.0.0.0}:${ZEBRA_RPC_PORT}"
-enable_cookie_auth = ${ENABLE_COOKIE_AUTH:=false}
+enable_cookie_auth = ${ENABLE_COOKIE_AUTH:=true}
 $( [[ -n ${ZEBRA_COOKIE_DIR} ]] && echo "cookie_dir = \"${ZEBRA_COOKIE_DIR}\"" )
 SUB_EOF
 )

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -19,7 +19,7 @@ set -eo pipefail
 # `ZEBRA_CACHE_DIR` and `LWD_CACHE_DIR` environment variables.
 : "${ZEBRA_CACHE_DIR:=${HOME}/.cache/zebra}"
 : "${LWD_CACHE_DIR:=${HOME}/.cache/lwd}"
-: "${ZEBRA_COOKIE_DIR:=${HOME}/.config/cookie}"
+: "${ZEBRA_COOKIE_DIR:=${HOME}/.cache/zebra}"
 
 # Use gosu to drop privileges and execute the given command as the specified UID:GID
 exec_as_user() {

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -21,15 +21,6 @@ set -eo pipefail
 : "${LWD_CACHE_DIR:=${HOME}/.cache/lwd}"
 : "${ZEBRA_COOKIE_DIR:=${HOME}/.config/cookie}"
 
-# Set default RPC_PORT based on NETWORK if RPC_PORT is not already set.
-if [[ -z "${RPC_PORT}" ]]; then
-  if [[ "${NETWORK}" = "Mainnet" ]]; then
-    : "${RPC_PORT:=8232}"
-  elif [[ "${NETWORK}" = "Testnet" ]]; then
-    : "${RPC_PORT:=18232}"
-  fi
-fi
-
 # Use gosu to drop privileges and execute the given command as the specified UID:GID
 exec_as_user() {
   user=$(id -u)
@@ -61,7 +52,7 @@ cache_dir = "${ZEBRA_CACHE_DIR}"
 $( [[ -n ${ZEBRA_RPC_PORT} ]] && cat <<-SUB_EOF
 
 [rpc]
-listen_addr = "${RPC_LISTEN_ADDR:=0.0.0.0}:${RPC_PORT:=8232}"
+listen_addr = "${RPC_LISTEN_ADDR:=0.0.0.0}:${ZEBRA_RPC_PORT}"
 enable_cookie_auth = ${ENABLE_COOKIE_AUTH:=false}
 $( [[ -n ${ZEBRA_COOKIE_DIR} ]] && echo "cookie_dir = \"${ZEBRA_COOKIE_DIR}\"" )
 SUB_EOF

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,10 +6,11 @@
 #
 # ## Notes
 #
-# - `$ZEBRA_CONF_PATH` must point to a Zebra conf file.
+# - `$ZEBRA_CONF_PATH` can point to an existing Zebra config file, or if not set,
+#   the script will look for a default config at ${HOME}/.config/zebrad.toml,
+#   or generate one using environment variables.
 
 set -eo pipefail
-
 
 # These are the default cached state directories for Zebra and lightwalletd.
 #
@@ -18,101 +19,112 @@ set -eo pipefail
 # `ZEBRA_CACHE_DIR` and `LWD_CACHE_DIR` environment variables.
 : "${ZEBRA_CACHE_DIR:=${HOME}/.cache/zebra}"
 : "${LWD_CACHE_DIR:=${HOME}/.cache/lwd}"
+: "${ZEBRA_COOKIE_DIR:=${HOME}/.config/cookie}"
 
-# Exit early if `ZEBRA_CONF_PATH` does not point to a file.
-if [[ ! -f "${ZEBRA_CONF_PATH}" ]]; then
-  echo "ERROR: No Zebra config file found at ZEBRA_CONF_PATH (${ZEBRA_CONF_PATH})."
-  echo "Please ensure the file exists or mount your custom config file and set ZEBRA_CONF_PATH accordingly."
-  exit 1
+# Set default RPC_PORT based on NETWORK if RPC_PORT is not already set.
+if [[ -z "${RPC_PORT}" ]]; then
+  if [[ "${NETWORK}" = "Mainnet" ]]; then
+    : "${RPC_PORT:=8232}"
+  elif [[ "${NETWORK}" = "Testnet" ]]; then
+    : "${RPC_PORT:=18232}"
+  fi
 fi
 
 # Use gosu to drop privileges and execute the given command as the specified UID:GID
 exec_as_user() {
-  exec gosu "${UID}:${GID}" "$@"
+  user=$(id -u)
+  if [[ ${user} == '0' ]]; then
+    exec gosu "${UID}:${GID}" "$@"
+  else
+    exec "$@"
+  fi
 }
 
-# Modifies the existing Zebra config file at ZEBRA_CONF_PATH using environment variables.
+# Modifies the Zebra config file using environment variables.
 #
-# The config options this function supports are also listed in the "docker/.env" file.
+# This function generates a new config file from scratch at ZEBRA_CONF_PATH
+# using the provided environment variables.
 #
-# This function modifies the existing file in-place and prints its location.
+# It creates a complete configuration with network settings, state, RPC,
+# metrics, tracing, and mining sections based on environment variables.
 prepare_conf_file() {
-  # Set a custom network.
-  if [[ -n "${NETWORK}" ]]; then
-    sed -i '/network = ".*"/s/".*"/"'"${NETWORK//\"/}"'"/' "${ZEBRA_CONF_PATH}"
-  fi
+  # Base configuration
+  cat >"${ZEBRA_CONF_PATH}" <<EOF
+[network]
+network = "${NETWORK:=Mainnet}"
+listen_addr = "${ZEBRA_LISTEN_ADDR:=0.0.0.0}"
+cache_dir = "${ZEBRA_CACHE_DIR}"
 
-  # Enable the RPC server by setting its port.
-  if [[ -n "${ZEBRA_RPC_PORT}" ]]; then
-    sed -i '/# listen_addr = "0.0.0.0:18232" # Testnet/d' "${ZEBRA_CONF_PATH}"
-    sed -i 's/ *# Mainnet$//' "${ZEBRA_CONF_PATH}"
-    sed -i '/# listen_addr = "0.0.0.0:8232"/s/^# //; s/8232/'"${ZEBRA_RPC_PORT//\"/}"'/' "${ZEBRA_CONF_PATH}"
-  fi
+[state]
+cache_dir = "${ZEBRA_CACHE_DIR}"
 
-  # Disable or enable cookie authentication.
-  if [[ -n "${ENABLE_COOKIE_AUTH}" ]]; then
-    sed -i '/# enable_cookie_auth = true/s/^# //; s/true/'"${ENABLE_COOKIE_AUTH//\"/}"'/' "${ZEBRA_CONF_PATH}"
-  fi
+$( [[ -n ${ZEBRA_RPC_PORT} ]] && cat <<-SUB_EOF
 
-  # Set a custom state, network and cookie cache dirs.
-  #
-  # We're pointing all three cache dirs at the same location, so users will find
-  # all cached data in that single location. We can introduce more env vars and
-  # use them to set the cache dirs separately if needed.
-  if [[ -n "${ZEBRA_CACHE_DIR}" ]]; then
-    mkdir -p "${ZEBRA_CACHE_DIR//\"/}"
-    chown -R "${UID}:${GID}" "${ZEBRA_CACHE_DIR//\"/}"
-    sed -i 's|_dir = ".*"|_dir = "'"${ZEBRA_CACHE_DIR//\"/}"'"|' "${ZEBRA_CONF_PATH}"
-  fi
+[rpc]
+listen_addr = "${RPC_LISTEN_ADDR:=0.0.0.0}:${RPC_PORT:=8232}"
+enable_cookie_auth = ${ENABLE_COOKIE_AUTH:=false}
+$( [[ -n ${ZEBRA_COOKIE_DIR} ]] && echo "cookie_dir = \"${ZEBRA_COOKIE_DIR}\"" )
+SUB_EOF
+)
 
-  # Set a custom lightwalletd cache dir.
-  if [[ -n "${LWD_CACHE_DIR}" ]]; then
-    mkdir -p "${LWD_CACHE_DIR//\"/}"
-    chown -R "${UID}:${GID}" "${LWD_CACHE_DIR//\"/}"
-  fi
+$( [[ " ${FEATURES} " =~ " prometheus " ]] && cat <<-SUB_EOF
 
-  # Enable the Prometheus metrics endpoint.
-  if [[ "${FEATURES}" == *"prometheus"* ]]; then
-    sed -i '/# endpoint_addr = "0.0.0.0:9999" # Prometheus/s/^# //' "${ZEBRA_CONF_PATH}"
-  fi
+[metrics]
+endpoint_addr = "${METRICS_ENDPOINT_ADDR:=0.0.0.0}:${METRICS_ENDPOINT_PORT:=9999}"
+SUB_EOF
+)
 
-  # Enable logging to a file by setting a custom log file path.
-  if [[ -n "${LOG_FILE}" ]]; then
-    mkdir -p "$(dirname "${LOG_FILE//\"/}")"
-    chown -R "${UID}:${GID}" "$(dirname "${LOG_FILE//\"/}")"
-    sed -i 's|# log_file = ".*"|log_file = "'"${LOG_FILE//\"/}"'"|' "${ZEBRA_CONF_PATH}"
-  fi
+$( [[ -n ${LOG_FILE} || -n ${LOG_COLOR} || -n ${TRACING_ENDPOINT_ADDR} || -n ${USE_JOURNALD} ]] && cat <<-SUB_EOF
 
-  # Enable or disable colored logs.
-  if [[ -n "${LOG_COLOR}" ]]; then
-    sed -i '/# force_use_color = true/s/^# //' "${ZEBRA_CONF_PATH}"
-    sed -i '/use_color = true/s/true/'"${LOG_COLOR//\"/}"'/' "${ZEBRA_CONF_PATH}"
-  fi
+[tracing]
+$( [[ -n ${USE_JOURNALD} ]] && echo "use_journald = ${USE_JOURNALD}" )
+$( [[ " ${FEATURES} " =~ " filter-reload " ]] && echo "endpoint_addr = \"${TRACING_ENDPOINT_ADDR:=0.0.0.0}:${TRACING_ENDPOINT_PORT:=3000}\"" )
+$( [[ -n ${LOG_FILE} ]] && echo "log_file = \"${LOG_FILE}\"" )
+$( [[ ${LOG_COLOR} == "true" ]] && echo "force_use_color = true" )
+$( [[ ${LOG_COLOR} == "false" ]] && echo "use_color = false" )
+SUB_EOF
+)
 
-  # Enable or disable logging to systemd-journald.
-  if [[ -n "${USE_JOURNALD}" ]]; then
-    sed -i '/# use_journald = true/s/^# //; s/true/'"${USE_JOURNALD//\"/}"'/' "${ZEBRA_CONF_PATH}"
-  fi
+$( [[ -n ${MINER_ADDRESS} ]] && cat <<-SUB_EOF
 
-  # Set a mining address.
-  if [[ -n "${MINER_ADDRESS}" ]]; then
-    sed -i '/# miner_address = ".*"/{s/^# //; s/".*"/"'"${MINER_ADDRESS//\"/}"'"/}' "${ZEBRA_CONF_PATH}"
-  fi
-
-  # Trim all comments and empty lines.
-  sed -i '/^#/d; /^$/d' "${ZEBRA_CONF_PATH}"
-
-  echo "${ZEBRA_CONF_PATH}"
+[mining]
+miner_address = "${MINER_ADDRESS}"
+SUB_EOF
+)
+EOF
 }
+
+# Helper function
+exit_error() {
+  echo "$1" >&2
+  exit 1
+}
+
+# Creates a directory if it doesn't exist and sets ownership to specified UID:GID.
+#
+# ## Parameters
+#
+# - $1: Directory path to create and own
+create_owned_directory() {
+  local dir="$1"
+  [[ -z ${dir} ]] && return
+
+  mkdir -p "${dir}" || exit_error "Failed to create directory: ${dir}"
+  chown -R "${UID}:${GID}" "${dir}" || exit_error "Failed to secure directory: ${dir}"
+}
+
+# Create and own cache and config directories
+[[ -n ${ZEBRA_CACHE_DIR} ]] && create_owned_directory "${ZEBRA_CACHE_DIR}"
+[[ -n ${LWD_CACHE_DIR} ]] && create_owned_directory "${LWD_CACHE_DIR}"
+[[ -n ${ZEBRA_COOKIE_DIR} ]] && create_owned_directory "${ZEBRA_COOKIE_DIR}"
+[[ -n ${LOG_FILE} ]] && create_owned_directory "$(dirname "${LOG_FILE}")"
 
 # Runs cargo test with an arbitrary number of arguments.
 #
 # Positional Parameters
 #
-# - '$1' must contain
-#   - either cargo FEATURES as described here:
-#     https://doc.rust-lang.org/cargo/reference/features.html#command-line-feature-options,
-#   - or be empty.
+# - '$1' must contain cargo FEATURES as described here:
+#   https://doc.rust-lang.org/cargo/reference/features.html#command-line-feature-options
 # - The remaining params will be appended to a command starting with
 #   `exec_as_user cargo test ... -- ...`
 run_cargo_test() {
@@ -255,12 +267,39 @@ run_tests() {
 }
 
 # Main Script Logic
+#
+# 1. First check if ZEBRA_CONF_PATH is explicitly set or if a file exists at that path
+# 2. If not set but default config exists, use that
+# 3. If neither exists, generate a default config at ${HOME}/.config/zebrad.toml
+# 4. Print environment variables and config for debugging
+# 5. Process command-line arguments and execute appropriate action
+if [[ -n ${ZEBRA_CONF_PATH} ]]; then
+  if [[ -f ${ZEBRA_CONF_PATH} ]]; then
+    echo "ZEBRA_CONF_PATH was set to ${ZEBRA_CONF_PATH} and a file exists."
+    echo "Using user-provided config file"
+  else
+    echo "ERROR: ZEBRA_CONF_PATH was set and no config file found at ${ZEBRA_CONF_PATH}."
+    echo "Please ensure a config file exists or set ZEBRA_CONF_PATH to point to your config file."
+    exit 1
+  fi
+else
+  if [[ -f "${HOME}/.config/zebrad.toml" ]]; then
+    echo "ZEBRA_CONF_PATH was not set."
+    echo "Using default config at ${HOME}/.config/zebrad.toml"
+    ZEBRA_CONF_PATH="${HOME}/.config/zebrad.toml"
+  else
+    echo "ZEBRA_CONF_PATH was not set and no default config found at ${HOME}/.config/zebrad.toml"
+    echo "Preparing a default one..."
+    ZEBRA_CONF_PATH="${HOME}/.config/zebrad.toml"
+    mkdir -p "$(dirname "${ZEBRA_CONF_PATH}")"
+    prepare_conf_file
+  fi
+fi
 
-prepare_conf_file "${ZEBRA_CONF_PATH}"
 echo "INFO: Using the following environment variables:"
 printenv
 
-echo "Prepared the following Zebra config:"
+echo "Using Zebra config at ${ZEBRA_CONF_PATH}:"
 cat "${ZEBRA_CONF_PATH}"
 
 # - If "$1" is "--", "-", or "zebrad", run `zebrad` with the remaining params.


### PR DESCRIPTION
## Motivation

We had some issues with how we were dealing with configuration files:
- If the user mounted a configuration file, zebra would (try to) overwrite it. This could cause odd behaviors like:
  - #9325 
- When mounting a configuration file using the [docker compose configs](https://docs.docker.com/reference/compose-file/configs/) this would cause an error as the mounted directory is _read-only_
- We should be able to differentiate between a _user-provided_ configuration file, our _default_ configuration file (mainly used with docker compose), and if there's no configuration file provided, so we can build it _on-the-fly_ with the provided variables by the user.

A possible approach to fix this was using a temporal directory, and using the resulting config from that directory instead from the original mounted dir, but this was also problematic if the temporal directory was mounted as read-only from the host, which also led to the decision of not using `sed` and trying to replace the content of the file or creating a new file in a location that could potentially be `read-only` by external host limitations.

Fixes #9325 

## Solution

**Key changes:**
- Do not mount a default configuration file in our Dockerfile (`default-zebra-config.toml`), to allow more flexibility: default configuration build, default config file mounting, user-provided config file mounting with a custom `$ZEBRA_CONF_PATH`
  - Validate if the user is mounting its own file (this requires them to set `$ZEBRA_CONF_PATH` to a valid mounted file)
  - If the user doesn't set `ZEBRA_CONF_PATH` then validate if the default `${HOME}/.config/zebrad.toml` is mounted (commonly provided with our docker compose https://github.com/ZcashFoundation/zebra/blob/ac25192afcb1c3280ff32d2bb2e75f91f1d9ceb0/docker/docker-compose.yml#L23)
  - Otherwise, create a zebra configuration file based on the variables set by the user (or using the default values)
- Do not try to overwrite mounted files, dynamic configuration should only happen `on-the-fly` and must be avoided if a configuration file was provided (this changes `sed` to `cat` as using `sed` is no longer required)

**Other (required) changes**
- `exec_as_user` must validate if the actual user is root, otherwise running `gosu` will fail when that's not the case
- If cache or other directories were configured with the environment variables, make sure they exists and change their ownership to the user running `zebrad`.
- Do not mount the `.cookies` directory in the same directory as the `.cache` as mounting a cached state would override the cookies directory.

### Tests

All tests should be passing, and building with the docker compose, with our without a mount file, should give the expected configuration results.

### Follow-up Work

Validate which other configurations should be added using variables

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.
- [ ] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
