### PR TITLE
fix(db): Ensure secondary rocksdb instance has caught up to the primary instance

### DIFF
--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -150,6 +150,14 @@ impl TrustedChainSync {
                     }
                 };
 
+                // # Correctness
+                //
+                // Ensure that the secondary rocksdb instance has caught up to the primary instance
+                // before attempting to commit the new block to the non-finalized state. It is sufficient
+                // to call this once here, as a new chain tip block has already been retrieved and so
+                // we know that the primary rocksdb instance has already been updated.
+                self.try_catch_up_with_primary().await;
+
                 let block_hash = block.hash;
                 let commit_result = if self.non_finalized_state.chain_count() == 0 {
                     self.non_finalized_state


### PR DESCRIPTION
## Motivation

Fix https://github.com/ZcashFoundation/zebra/issues/9322

## Solution

TBD

### Tests

TBD

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.
- [ ] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
