### PR TITLE
change(command): Use read-only db instance when running `tip-height` or `copy-state` commands

### DIFF
--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -778,10 +778,7 @@ impl StateService {
 
     /// Return the tip of the current best chain.
     pub fn best_tip(&self) -> Option<(block::Height, block::Hash)> {
-        read::best_tip(
-            &self.read_service.latest_non_finalized_state(),
-            &self.read_service.db,
-        )
+        self.read_service.best_tip()
     }
 
     /// Assert some assumptions about the semantically verified `block` before it is queued.
@@ -817,6 +814,11 @@ impl ReadStateService {
         tracing::debug!("created new read-only state service");
 
         read_service
+    }
+
+    /// Return the tip of the current best chain.
+    pub fn best_tip(&self) -> Option<(block::Height, block::Hash)> {
+        read::best_tip(&self.latest_non_finalized_state(), &self.db)
     }
 
     /// Gets a clone of the latest non-finalized state from the `non_finalized_state_receiver`

--- a/zebrad/src/commands/tip_height.rs
+++ b/zebrad/src/commands/tip_height.rs
@@ -10,11 +10,11 @@ use clap::Parser;
 use color_eyre::eyre::{eyre, Result};
 
 use zebra_chain::{
-    block::{self, Height},
-    chain_tip::ChainTip,
+    block::{self},
     parameters::Network,
 };
-use zebra_state::LatestChainTip;
+
+use zebra_state::ReadStateService;
 
 use crate::prelude::APPLICATION;
 
@@ -46,25 +46,20 @@ impl Runnable for TipHeightCmd {
 impl TipHeightCmd {
     /// Load the chain tip height from the state cache directory.
     fn load_tip_height(&self) -> Result<block::Height> {
-        let latest_chain_tip = self.load_latest_chain_tip();
-
-        latest_chain_tip
-            .best_tip_height()
+        self.load_read_state()
+            .best_tip()
+            .map(|(height, _hash)| height)
             .ok_or_else(|| eyre!("State directory doesn't have a chain tip block"))
     }
 
     /// Starts a state service using the `cache_dir` and `network` from the provided arguments.
-    fn load_latest_chain_tip(&self) -> LatestChainTip {
+    fn load_read_state(&self) -> ReadStateService {
         let mut config = APPLICATION.config().state.clone();
 
         if let Some(cache_dir) = self.cache_dir.clone() {
             config.cache_dir = cache_dir;
         }
 
-        // UTXO verification isn't used here: we're not updating the state.
-        let (_state_service, _read_state_service, latest_chain_tip, _chain_tip_change) =
-            zebra_state::init(config, &self.network, Height::MAX, 0);
-
-        latest_chain_tip
+        zebra_state::init_read_only(config, &self.network).0
     }
 }


### PR DESCRIPTION
## Motivation

It's inconvenient to stop Zebrad to run tip-height or copy-state commands. This PR updates the tip-height command to use a read-only db instance so it can be used while Zebra is running.

Close #9351.

## Solution

- Initializes only a `ReadStateService` with a read-only db instance rather than attempting to open a primary db instance when running the `tip-height` command
- Update the copy-state command so it can be used while Zebra is running

### Tests

Manually tested, copy-state and tip-height now both work when there's a Zebrad instance running.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.
- [ ] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
