### PR TITLE
fix(clippy): last lints

### DIFF
--- a/zebra-chain/src/amount/tests/vectors.rs
+++ b/zebra-chain/src/amount/tests/vectors.rs
@@ -335,9 +335,7 @@ fn test_sum() -> Result<()> {
     let times: usize = (i64::MAX / MAX_MONEY)
         .try_into()
         .expect("4392 can always be converted to usize");
-    let amounts: Vec<Amount> = std::iter::repeat(MAX_MONEY.try_into()?)
-        .take(times + 1)
-        .collect();
+    let amounts: Vec<Amount> = std::iter::repeat_n(MAX_MONEY.try_into()?, times + 1).collect();
 
     let sum_ref = amounts.iter().sum::<Result<Amount, Error>>();
     let sum_value = amounts.into_iter().sum::<Result<Amount, Error>>();
@@ -357,7 +355,7 @@ fn test_sum() -> Result<()> {
         .expect("4392 can always be converted to usize");
     let neg_max_money: Amount<NegativeAllowed> = (-MAX_MONEY).try_into()?;
     let amounts: Vec<Amount<NegativeAllowed>> =
-        std::iter::repeat(neg_max_money).take(times + 1).collect();
+        std::iter::repeat_n(neg_max_money, times + 1).collect();
 
     let sum_ref = amounts.iter().sum::<Result<Amount, Error>>();
     let sum_value = amounts.into_iter().sum::<Result<Amount, Error>>();

--- a/zebra-chain/src/block/merkle.rs
+++ b/zebra-chain/src/block/merkle.rs
@@ -1,6 +1,6 @@
 //! The Bitcoin-inherited Merkle tree of transactions.
 
-use std::{fmt, io::Write, iter};
+use std::{fmt, io::Write};
 
 use hex::{FromHex, ToHex};
 
@@ -404,7 +404,7 @@ impl std::iter::FromIterator<transaction::AuthDigest> for AuthDataRoot {
         // https://zips.z.cash/zip-0244#block-header-changes
         // Pad with enough leaves to make the tree full (a power of 2).
         let pad_count = hashes.len().next_power_of_two() - hashes.len();
-        hashes.extend(iter::repeat([0u8; 32]).take(pad_count));
+        hashes.extend(std::iter::repeat_n([0u8; 32], pad_count));
         assert!(hashes.len().is_power_of_two());
 
         while hashes.len() > 1 {

--- a/zebra-chain/src/block/tests/generate.rs
+++ b/zebra-chain/src/block/tests/generate.rs
@@ -131,9 +131,8 @@ fn multi_transaction_block(oversized: bool) -> Block {
     }
 
     // Create transactions to be just below or just above the limit
-    let transactions = std::iter::repeat(Arc::new(transaction))
-        .take(max_transactions_in_block)
-        .collect::<Vec<_>>();
+    let transactions =
+        std::iter::repeat_n(Arc::new(transaction), max_transactions_in_block).collect::<Vec<_>>();
 
     // Add the transactions into a block
     let block = Block {
@@ -193,9 +192,7 @@ fn single_transaction_block_many_inputs(oversized: bool) -> Block {
     let mut outputs = Vec::new();
 
     // Create inputs to be just below the limit
-    let inputs = std::iter::repeat(input)
-        .take(max_inputs_in_tx)
-        .collect::<Vec<_>>();
+    let inputs = std::iter::repeat_n(input, max_inputs_in_tx).collect::<Vec<_>>();
 
     // 1 single output
     outputs.push(output);
@@ -268,9 +265,7 @@ fn single_transaction_block_many_outputs(oversized: bool) -> Block {
     let inputs = vec![input];
 
     // Create outputs to be just below the limit
-    let outputs = std::iter::repeat(output)
-        .take(max_outputs_in_tx)
-        .collect::<Vec<_>>();
+    let outputs = std::iter::repeat_n(output, max_outputs_in_tx).collect::<Vec<_>>();
 
     // Create a big transaction
     let big_transaction = Transaction::V1 {

--- a/zebra-chain/src/primitives/zcash_primitives.rs
+++ b/zebra-chain/src/primitives/zcash_primitives.rs
@@ -279,8 +279,8 @@ impl<'a> PrecomputedTxData<'a> {
 ///   signature hash is being computed.
 /// - `hash_type`: the type of hash (SIGHASH) being used.
 /// - `input_index_script_code`: a tuple with the index of the transparent Input
-///    for which we are producing a sighash and the respective script code being
-///    validated, or None if it's a shielded input.
+///   for which we are producing a sighash and the respective script code being
+///   validated, or None if it's a shielded input.
 pub(crate) fn sighash(
     precomputed_tx_data: &PrecomputedTxData,
     hash_type: HashType,

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -41,7 +41,7 @@ lazy_static! {
 /// given index is read. Therefore, we just need a list where `array[index]`
 /// is the given `output`.
 fn mock_pre_v5_output_list(output: transparent::Output, index: usize) -> Vec<transparent::Output> {
-    iter::repeat(output).take(index + 1).collect()
+    std::iter::repeat_n(output, index + 1).collect()
 }
 
 #[test]
@@ -233,9 +233,7 @@ fn deserialize_large_transaction() {
     let tx_inputs_num = MAX_BLOCK_BYTES as usize / input_data.len();
 
     // Set the precalculated amount of inputs and a single output.
-    let inputs = std::iter::repeat(input)
-        .take(tx_inputs_num)
-        .collect::<Vec<_>>();
+    let inputs = std::iter::repeat_n(input, tx_inputs_num).collect::<Vec<_>>();
 
     // Create an oversized transaction. Adding the output and lock time causes
     // the transaction to overflow the threshold.

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -86,7 +86,7 @@ type QueuedBlockList = Vec<QueuedBlock>;
 ///
 /// This value is a tradeoff between:
 /// - rejecting bad blocks: if we queue more blocks, we need fewer network
-///                         retries, but use a bit more CPU when verifying,
+///   retries, but use a bit more CPU when verifying,
 /// - avoiding a memory DoS: if we queue fewer blocks, we use less memory.
 ///
 /// Memory usage is controlled by the sync service, because it controls block

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -27,9 +27,9 @@ use crate::error::TransactionError;
 ///
 /// Arguments:
 /// - `block_height`: the height of the mined block, or the height of the next block for mempool
-///                   transactions
+///   transactions
 /// - `block_time`: the time in the mined block header, or the median-time-past of the next block
-///                 for the mempool. Optional if the lock time is a height.
+///   for the mempool. Optional if the lock time is a height.
 ///
 /// # Panics
 ///

--- a/zebra-network/src/isolated.rs
+++ b/zebra-network/src/isolated.rs
@@ -42,7 +42,7 @@ mod tests;
 /// - `network`: the Zcash [`Network`] used for this connection.
 ///
 /// - `data_stream`: an existing data stream. This can be a non-anonymised TCP connection,
-///                  or a Tor client `arti_client::DataStream`.
+///   or a Tor client `arti_client::DataStream`.
 ///
 /// - `user_agent`: a valid BIP14 user-agent, e.g., the empty string.
 pub fn connect_isolated<PeerTransport>(

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -163,11 +163,11 @@ pub struct MetaAddr {
     ///
     /// The exact meaning depends on `last_connection_state`:
     ///   - `Responded`: the services advertised by this peer, the last time we
-    ///      performed a handshake with it
+    ///     performed a handshake with it
     ///   - `NeverAttempted`: the unverified services advertised by another peer,
-    ///      then gossiped by the peer that sent us this address
+    ///     then gossiped by the peer that sent us this address
     ///   - `Failed` or `AttemptPending`: unverified services via another peer,
-    ///      or services advertised in a previous handshake
+    ///     or services advertised in a previous handshake
     ///
     /// ## Security
     ///

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -110,8 +110,8 @@ impl Handler {
             Handler::Ping(_) => "Ping".into(),
             Handler::Peers => "Peers".into(),
 
-            Handler::FindBlocks { .. } => "FindBlocks".into(),
-            Handler::FindHeaders { .. } => "FindHeaders".into(),
+            Handler::FindBlocks => "FindBlocks".into(),
+            Handler::FindHeaders => "FindHeaders".into(),
 
             Handler::BlocksByHash { .. } => "BlocksByHash".into(),
             Handler::TransactionsById { .. } => "TransactionsById".into(),
@@ -1189,7 +1189,7 @@ where
                 self.fail_with(PeerError::DuplicateHandshake).await;
                 Consumed
             }
-            Message::Verack { .. } => {
+            Message::Verack => {
                 self.fail_with(PeerError::DuplicateHandshake).await;
                 Consumed
             }
@@ -1218,9 +1218,7 @@ where
                 Unused
             }
             // These messages should never be sent by peers.
-            Message::FilterLoad { .. }
-            | Message::FilterAdd { .. }
-            | Message::FilterClear { .. } => {
+            Message::FilterLoad { .. } | Message::FilterAdd { .. } | Message::FilterClear => {
                 // # Security
                 //
                 // Zcash connections are not authenticated, so malicious nodes can send fake messages,

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -281,16 +281,16 @@ where
     /// - `discover`: handles peer connects and disconnects;
     /// - `demand_signal`: requests more peers when all peers are busy (unready);
     /// - `handle_rx`: receives background task handles,
-    ///                monitors them to make sure they're still running,
-    ///                and shuts down all the tasks as soon as one task exits;
+    ///   monitors them to make sure they're still running,
+    ///   and shuts down all the tasks as soon as one task exits;
     /// - `inv_stream`: receives inventory changes from peers,
-    ///                 allowing the peer set to direct inventory requests;
+    ///   allowing the peer set to direct inventory requests;
     /// - `bans_receiver`: receives a map of banned IP addresses that should be dropped;
     /// - `address_book`: when peer set is busy, it logs address book diagnostics.
     /// - `minimum_peer_version`: endpoint to see the minimum peer protocol version in real time.
     /// - `max_conns_per_ip`: configured maximum number of peers that can be in the
-    ///                       peer set per IP, defaults to the config value or to
-    ///                       [`crate::constants::DEFAULT_MAX_CONNS_PER_IP`].
+    ///   peer set per IP, defaults to the config value or to
+    ///   [`crate::constants::DEFAULT_MAX_CONNS_PER_IP`].
     pub fn new(
         config: &Config,
         discover: D,

--- a/zebra-network/src/protocol/external/codec.rs
+++ b/zebra-network/src/protocol/external/codec.rs
@@ -138,12 +138,12 @@ impl Encoder<Message> for Codec {
         // of length 12, as they must be &[u8; 12].
         let command = match item {
             Version { .. } => b"version\0\0\0\0\0",
-            Verack { .. } => b"verack\0\0\0\0\0\0",
+            Verack => b"verack\0\0\0\0\0\0",
             Ping { .. } => b"ping\0\0\0\0\0\0\0\0",
             Pong { .. } => b"pong\0\0\0\0\0\0\0\0",
             Reject { .. } => b"reject\0\0\0\0\0\0",
             Addr { .. } => b"addr\0\0\0\0\0\0\0\0",
-            GetAddr { .. } => b"getaddr\0\0\0\0\0",
+            GetAddr => b"getaddr\0\0\0\0\0",
             Block { .. } => b"block\0\0\0\0\0\0\0",
             GetBlocks { .. } => b"getblocks\0\0\0",
             Headers { .. } => b"headers\0\0\0\0\0",
@@ -152,10 +152,10 @@ impl Encoder<Message> for Codec {
             GetData { .. } => b"getdata\0\0\0\0\0",
             NotFound { .. } => b"notfound\0\0\0\0",
             Tx { .. } => b"tx\0\0\0\0\0\0\0\0\0\0",
-            Mempool { .. } => b"mempool\0\0\0\0\0",
+            Mempool => b"mempool\0\0\0\0\0",
             FilterLoad { .. } => b"filterload\0\0",
             FilterAdd { .. } => b"filteradd\0\0\0",
-            FilterClear { .. } => b"filterclear\0",
+            FilterClear => b"filterclear\0",
         };
         trace!(?item, len = body_length);
 

--- a/zebra-network/src/protocol/external/message.rs
+++ b/zebra-network/src/protocol/external/message.rs
@@ -218,7 +218,7 @@ pub enum Message {
     /// When a peer requests a list of transaction hashes, `zcashd` returns:
     ///   - a batch of messages containing found transactions, then
     ///   - a `notfound` message containing a list of transaction hashes that
-    ///      aren't available in its mempool or state.
+    ///     aren't available in its mempool or state.
     ///
     /// But when a peer requests blocks or headers, any missing items are
     /// silently skipped, without any `notfound` messages.

--- a/zebra-node-services/src/scan_service/request.rs
+++ b/zebra-node-services/src/scan_service/request.rs
@@ -53,9 +53,7 @@ impl Request {
 
 #[test]
 fn test_check_num_keys() {
-    let fake_keys: Vec<_> = std::iter::repeat(String::new())
-        .take(MAX_REQUEST_KEYS + 1)
-        .collect();
+    let fake_keys: Vec<_> = std::iter::repeat_n(String::new(), MAX_REQUEST_KEYS + 1).collect();
 
     let bad_requests = [
         Request::DeleteKeys(vec![]),

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -86,11 +86,11 @@ use self::queued_blocks::{QueuedCheckpointVerified, QueuedSemanticallyVerified, 
 ///
 /// This service modifies and provides access to:
 /// - the non-finalized state: the ~100 most recent blocks.
-///                            Zebra allows chain forks in the non-finalized state,
-///                            stores it in memory, and re-downloads it when restarted.
+///   Zebra allows chain forks in the non-finalized state,
+///   stores it in memory, and re-downloads it when restarted.
 /// - the finalized state: older blocks that have many confirmations.
-///                        Zebra stores the single best chain in the finalized state,
-///                        and re-loads it from disk when restarted.
+///   Zebra stores the single best chain in the finalized state,
+///   and re-loads it from disk when restarted.
 ///
 /// Read requests to this service are buffered, then processed concurrently.
 /// Block write requests are buffered, then queued, then processed in order by a separate task.

--- a/zebra-state/src/tests/setup.rs
+++ b/zebra-state/src/tests/setup.rs
@@ -26,7 +26,7 @@ use crate::{
 /// Arguments:
 /// - `transaction_version_override`: See `LedgerState::height_strategy` for details.
 /// - `transaction_has_valid_network_upgrade`: See `LedgerState::height_strategy` for details.
-///    Note: `false` allows zero or more invalid network upgrades.
+///   Note: `false` allows zero or more invalid network upgrades.
 /// - `blocks_after_nu_activation`: The number of blocks the strategy will generate
 ///   after the provided `network_upgrade`.
 /// - `network_upgrade` - The network upgrade that we are using to simulate from where the

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -894,8 +894,7 @@ impl Service<Request> for Mempool {
                     Request::Queue(gossiped_txs) => Response::Queued(
                         // Special case; we can signal the error inside the response,
                         // because the inbound service ignores inner errors.
-                        iter::repeat(MempoolError::Disabled)
-                            .take(gossiped_txs.len())
+                        iter::repeat_n(MempoolError::Disabled, gossiped_txs.len())
                             .map(BoxError::from)
                             .map(Err)
                             .collect(),

--- a/zebrad/tests/common/lightwalletd/sync.rs
+++ b/zebrad/tests/common/lightwalletd/sync.rs
@@ -193,7 +193,7 @@ pub fn are_zebrad_and_lightwalletd_tips_synced(
             // Block number is the last word of the message. We rely on that specific for this to work.
             let last = msg
                 .split(' ')
-                .last()
+                .next_back()
                 .expect("always possible to get the last word of a separated by space string");
             lightwalletd_next_height = last
                 .parse()

--- a/zebrad/tests/common/lightwalletd/wallet_grpc_test.rs
+++ b/zebrad/tests/common/lightwalletd/wallet_grpc_test.rs
@@ -20,9 +20,9 @@
 //! - `GetTaddressBalanceStream`: Covered.
 //!
 //! - `GetMempoolTx`: Covered by the send_transaction_test,
-//!                   currently disabled by `lightwalletd`.
+//!   currently disabled by `lightwalletd`.
 //! - `GetMempoolStream`: Covered by the send_transaction_test,
-//!                       currently disabled by `lightwalletd`.
+//!   currently disabled by `lightwalletd`.
 //!
 //! - `GetTreeState`: Covered.
 //!


### PR DESCRIPTION
## Motivation

We need to fix the last clippy lints.

Most of them fixed with `clippy fix`, indentation in doc comments was done manually as the command was not doing it for me.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.
- [x] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
