### PR TITLE
Deduplicate dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ dependencies = [
  "hmac",
  "rand_core 0.6.4",
  "ripemd 0.2.0-pre.4",
- "secp256k1 0.29.1",
+ "secp256k1",
  "sha2 0.11.0-pre.4",
  "subtle",
  "zeroize",
@@ -4047,30 +4047,12 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secp256k1"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
-dependencies = [
- "secp256k1-sys 0.8.1",
- "serde",
-]
-
-[[package]]
-name = "secp256k1"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "secp256k1-sys 0.10.1",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
-dependencies = [
- "cc",
+ "secp256k1-sys",
+ "serde",
 ]
 
 [[package]]
@@ -6003,7 +5985,7 @@ dependencies = [
  "redjubjub 0.8.0",
  "ripemd 0.1.3",
  "sapling-crypto",
- "secp256k1 0.29.1",
+ "secp256k1",
  "sha2 0.10.8",
  "subtle",
  "tracing",
@@ -6088,7 +6070,7 @@ dependencies = [
  "hex",
  "proptest",
  "ripemd 0.1.3",
- "secp256k1 0.29.1",
+ "secp256k1",
  "sha2 0.10.8",
  "subtle",
  "zcash_address",
@@ -6137,7 +6119,7 @@ dependencies = [
  "redjubjub 0.7.0",
  "ripemd 0.1.3",
  "sapling-crypto",
- "secp256k1 0.27.0",
+ "secp256k1",
  "serde",
  "serde-big-array",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3673,25 +3673,13 @@ dependencies = [
 
 [[package]]
 name = "redjubjub"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a60db2c3bc9c6fd1e8631fee75abc008841d27144be744951d6b9b75f9b569c"
-dependencies = [
- "rand_core 0.6.4",
- "reddsa",
- "serde",
- "thiserror 1.0.69",
- "zeroize",
-]
-
-[[package]]
-name = "redjubjub"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b0ac1bc6bb3696d2c6f52cff8fba57238b81da8c0214ee6cd146eb8fde364e"
 dependencies = [
  "rand_core 0.6.4",
  "reddsa",
+ "serde",
  "thiserror 1.0.69",
  "zeroize",
 ]
@@ -4031,7 +4019,7 @@ dependencies = [
  "memuse",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "redjubjub 0.8.0",
+ "redjubjub",
  "subtle",
  "tracing",
  "zcash_note_encryption",
@@ -5982,7 +5970,7 @@ dependencies = [
  "orchard",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "redjubjub 0.8.0",
+ "redjubjub",
  "ripemd 0.1.3",
  "sapling-crypto",
  "secp256k1",
@@ -6014,7 +6002,7 @@ dependencies = [
  "known-folders",
  "lazy_static",
  "rand_core 0.6.4",
- "redjubjub 0.8.0",
+ "redjubjub",
  "sapling-crypto",
  "tracing",
  "xdg",
@@ -6116,7 +6104,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rayon",
  "reddsa",
- "redjubjub 0.7.0",
+ "redjubjub",
  "ripemd 0.1.3",
  "sapling-crypto",
  "secp256k1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ rand_chacha = "0.3.1"
 rand_core = "0.6.4"
 rayon = "1.10.0"
 reddsa = "0.5.1"
-redjubjub = "0.7.0"
+redjubjub = "0.8"
 regex = "1.11.0"
 reqwest = { version = "0.12.9", default-features = false }
 ripemd = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ reqwest = { version = "0.12.9", default-features = false }
 ripemd = "0.1.3"
 rlimit = "0.10.2"
 rocksdb = { version = "0.22.0", default-features = false }
-secp256k1 = "0.27.0"
+secp256k1 = "0.29"
 semver = "1.0.25"
 sentry = { version = "0.36.0", default-features = false }
 serde = "1.0.217"


### PR DESCRIPTION
## Motivation

Zallet will soon depend on a bunch of Zebra code due to Zaino. As such, Zebra dependencies now affect Zallet, and in particular duplicate dependencies like `secp256k1` that are backed by C libraries can cause issues on some platforms.

## Solution

Deduplicates several dependencies, that were missed when upgrading other Zcash crates.

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.
- [ ] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
