### PR TITLE
fix(warning): could not canonicalize startup warning

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -984,6 +984,11 @@ impl DiskDb {
             let db_kind = db_kind.as_ref();
 
             let old_path = config.db_path(db_kind, major_db_ver - 1, network);
+            // Exit early if the path doesn't exist or there's an error checking it.
+            if !fs::exists(&old_path).unwrap_or(false) {
+                return;
+            }
+
             let new_path = config.db_path(db_kind, major_db_ver, network);
 
             let old_path = match fs::canonicalize(&old_path) {


### PR DESCRIPTION
## Motivation

There is an annoying warning when zebrad starts that i want to fix since a while. There was a comment about it in the discord so pushed a fix. https://discordapp.com/channels/809218587167293450/809251029673312267/1359249649155833878

## Solution

Exit early from the `try_reusing_previous_db_after_major_upgrade` function if `old_path` don't exist.

### Tests

Manual test, warning is gone.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.
- [ ] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
