### PR TITLE
suggestion for #9329: change coinbase field and add valueSat field to match zcashd

### DIFF
--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -922,3 +922,21 @@ fn binding_signatures() {
         assert!(at_least_one_v5_checked);
     }
 }
+
+#[test]
+fn test_coinbase_script() -> Result<()> {
+    let _init_guard = zebra_test::init();
+
+    let tx = hex::decode("0400008085202f89010000000000000000000000000000000000000000000000000000000000000000ffffffff0503b0e72100ffffffff04e8bbe60e000000001976a914ba92ff06081d5ff6542af8d3b2d209d29ba6337c88ac40787d010000000017a914931fec54c1fea86e574462cc32013f5400b891298738c94d010000000017a914c7a4285ed7aed78d8c0e28d7f1839ccb4046ab0c87286bee000000000017a914d45cb1adffb5215a42720532a076f02c7c778c908700000000b0e721000000000000000000000000").unwrap();
+
+    let transaction = tx.zcash_deserialize_into::<Transaction>()?;
+
+    let recoded_tx = transaction.zcash_serialize_to_vec().unwrap();
+    assert_eq!(tx, recoded_tx);
+
+    let data = transaction.inputs()[0].coinbase_script().unwrap();
+    let expected = hex::decode("03b0e72100").unwrap();
+    assert_eq!(data, expected);
+
+    Ok(())
+}

--- a/zebra-chain/src/transparent.rs
+++ b/zebra-chain/src/transparent.rs
@@ -254,6 +254,22 @@ impl Input {
         }
     }
 
+    /// Returns the full coinbase script (the encoded height along with the
+    /// extra data) if this is an [`Input::Coinbase`]. Also returns `None` if
+    /// the coinbase is for the genesis block but does not match the expected
+    /// genesis coinbase data.
+    pub fn coinbase_script(&self) -> Option<Vec<u8>> {
+        match self {
+            Input::PrevOut { .. } => None,
+            Input::Coinbase { height, data, .. } => {
+                let mut height_and_data = Vec::new();
+                serialize::write_coinbase_height(*height, data, &mut height_and_data).ok()?;
+                height_and_data.extend(&data.0);
+                Some(height_and_data)
+            }
+        }
+    }
+
     /// Returns the input's sequence number.
     pub fn sequence(&self) -> u32 {
         match self {

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@mainnet_10.snap
@@ -18,7 +18,7 @@ expression: block
       "confirmations": 10,
       "vin": [
         {
-          "coinbase": "00",
+          "coinbase": "5100",
           "sequence": 4294967295
         }
       ],

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@testnet_10.snap
@@ -18,7 +18,7 @@ expression: block
       "confirmations": 10,
       "vin": [
         {
-          "coinbase": "0101",
+          "coinbase": "510101",
           "sequence": 4294967295
         }
       ],

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@mainnet_10.snap
@@ -18,7 +18,7 @@ expression: block
       "confirmations": 10,
       "vin": [
         {
-          "coinbase": "00",
+          "coinbase": "5100",
           "sequence": 4294967295
         }
       ],

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@testnet_10.snap
@@ -18,7 +18,7 @@ expression: block
       "confirmations": 10,
       "vin": [
         {
-          "coinbase": "0101",
+          "coinbase": "510101",
           "sequence": 4294967295
         }
       ],

--- a/zebra-rpc/src/methods/tests/snapshots/getrawtransaction_verbosity=1@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/getrawtransaction_verbosity=1@mainnet_10.snap
@@ -9,7 +9,7 @@ expression: rsp
     "confirmations": 10,
     "vin": [
       {
-        "coinbase": "00",
+        "coinbase": "5100",
         "sequence": 4294967295
       }
     ],

--- a/zebra-rpc/src/methods/tests/snapshots/getrawtransaction_verbosity=1@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/getrawtransaction_verbosity=1@testnet_10.snap
@@ -9,7 +9,7 @@ expression: rsp
     "confirmations": 10,
     "vin": [
       {
-        "coinbase": "0101",
+        "coinbase": "510101",
         "sequence": 4294967295
       }
     ],

--- a/zebra-rpc/src/methods/types/transaction.rs
+++ b/zebra-rpc/src/methods/types/transaction.rs
@@ -104,9 +104,6 @@ pub struct Output {
     /// The value in zats.
     #[serde(rename = "valueZat")]
     value_zat: i64,
-    /// The value in zats (again with a different name for some reason).
-    #[serde(rename = "valueSat")]
-    value_sat: i64,
     /// index.
     n: u32,
     /// The scriptPubKey.
@@ -308,7 +305,6 @@ impl TransactionObject {
                         Output {
                             value: types::Zec::from(output.1.value).lossy_zec(),
                             value_zat: output.1.value.zatoshis(),
-                            value_sat: output.1.value.zatoshis(),
                             n: output.0 as u32,
                             script_pub_key: ScriptPubKey {
                                 asm: "".to_string(),


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

#9329 looks good but it shows two specific discrepancies between zcashd output: the `coinbase` field does not match (zcashd uses the whole coinbase script, while zebrad returned just the extra data after the encoded height) and the `valueSat` field was missing (which is the same as `valueZat` and seems useless, but it's easy to add so why not)

## Solution

<!-- Describe the changes in the PR. -->

### Tests

Tested with zcash-rpc-diff:

`OUTPUT_DATA_LINE_LIMIT=100000 ZEBRAD_EXTRA_ARGS=-conf=$PWD/zcash.conf ./zebra-utils/zcash-rpc-diff 28232 getrawtransaction 21f2c7d10cc8857e60fd225f0f089126d9274e892f8d4e135e9e915adb06b72d 1`

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.
- [ ] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
