### PR TITLE
fix(test): wait for sync to start before launching lightwalletd

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1983,7 +1983,8 @@ fn lightwalletd_integration_test(test_type: TestType) -> Result<()> {
             "waiting for zebrad to sync genesis block before launching lightwalletd...",
         );
         // Wait for zebrad to commit the genesis block to the state.
-        zebrad.expect_stdout_line_matches("committed finalized block.*Height(0)")?;
+        // Use the syncer's state tip log message, as the specific commit log might not appear reliably.
+        zebrad.expect_stdout_line_matches("starting sync, obtaining new tips state_tip=Some\\(Height\\(0\\)\\)")?;
     }
 
     // Launch lightwalletd, if needed

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1984,7 +1984,9 @@ fn lightwalletd_integration_test(test_type: TestType) -> Result<()> {
         );
         // Wait for zebrad to commit the genesis block to the state.
         // Use the syncer's state tip log message, as the specific commit log might not appear reliably.
-        zebrad.expect_stdout_line_matches("starting sync, obtaining new tips state_tip=Some\\(Height\\(0\\)\\)")?;
+        zebrad.expect_stdout_line_matches(
+            "starting sync, obtaining new tips state_tip=Some\\(Height\\(0\\)\\)",
+        )?;
     }
 
     // Launch lightwalletd, if needed


### PR DESCRIPTION
## Motivation

The `lightwalletd_integration` acceptance test (`zebrad/tests/acceptance.rs`) was failing intermittently, particularly within the Docker CI environment (`.github/workflows/sub-ci-unit-tests-docker.yml`). The failure occurred specifically when running the test variant that launches `lightwalletd` against a `zebrad` instance starting with an empty state (`LaunchWithEmptyState` test type).

`lightwalletd` would attempt to initialize its connection to `zebrad` before `zebrad` was ready to sync. `lightwalletd` treats a completely empty state during its startup sequence as a fatal error, causing it to exit and fail the test.

Closes #8976
Closes #9104

## Solution

This adds a wait step specifically for the empty state scenario. The test now waits for `zebrad` to log that it has started to sync before launching the `lightwalletd` process. This ensures `zebrad` is ready and prevents `lightwalletd` from exiting prematurely.

### Tests

The effectiveness of the solution is verified by the successful execution of this test case in the CI environment after the changes are applied.

This should be run several times for confirmation, as this was a flaky test.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [X] The PR name is suitable for the release notes.
- [X] The solution is tested.
- [X] The documentation is up to date.
- [X] The PR has a priority label.
- [X] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
