### PR TITLE
fix(ci): change dependabot to only update lockfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,9 @@ updates:
   # Rust section
   - package-ecosystem: cargo
     directory: '/'
+    # Update only the lockfile. We shouldn't update Cargo.toml unless it's for
+    # a security issue, or if we need a new feature of the dependency.
+    versioning-strategy: lockfile-only
     # serde, clap, and other dependencies sometimes have multiple updates in a week
     schedule:
       interval: monthly


### PR DESCRIPTION
## Motivation

dependabot bumps both `Cargo.lock` and `Cargo.toml`. However, that is not ideal for the crates, because crate users will be forced to use that specific version of the dependency (or newer) which might not be desirable.

For the zebrad binary, it doesn't really matter, since what really matters is the lockfile.

## Solution

Change the dependabot [config](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#versioning-strategy--) to only update the lockfile.

The only downside is that dependabot won't notify when a major version is released (AFAICT, ["Ignore any new versions that would require package manifest changes."](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#versioning-strategy--)), so we need some process to periodically check if we should migrate to new major versions of our dependencies.

Closes https://github.com/ZcashFoundation/zebra/issues/9398

### Tests

We'll need to merge this to check if it works.

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.
- [ ] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
