### PR TITLE
fix(publish)!: simplify Docker tagging to remove redundant tags

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -23,7 +23,6 @@ jobs:
       dockerfile_path: ./docker/Dockerfile
       dockerfile_target: runtime
       image_name: zebra
-      latest_tag: true
       features: ${{ vars.RUST_PROD_FEATURES }}
       rust_log: ${{ vars.RUST_LOG }}
     # This step needs access to Docker Hub secrets to run successfully

--- a/.github/workflows/sub-build-docker-image.yml
+++ b/.github/workflows/sub-build-docker-image.yml
@@ -35,13 +35,6 @@ on:
       features:
         required: false
         type: string
-      latest_tag:
-        required: false
-        type: boolean
-        default: false
-      tag_suffix:
-        required: false
-        type: string
       no_cache:
         description: "Disable the Docker cache for this build"
         required: false
@@ -96,28 +89,26 @@ jobs:
           images: |
             us-docker.pkg.dev/${{ vars.GCP_PROJECT }}/zebra/${{ inputs.image_name }}
             zfnd/${{ inputs.image_name }},enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
-          # appends inputs.tag_suffix to image tags/names
-          flavor: |
-            suffix=${{ inputs.tag_suffix }}
-            latest=${{ inputs.latest_tag }}
           # generate Docker tags based on the following events/attributes
           tags: |
             # These DockerHub release tags support the following use cases:
-            # - `latest`: always use the latest Zebra release when you pull or update
-            # - `v1.x.y` or `1.x.y`: always use the exact version, don't automatically upgrade
+            # - `latest`: Automatically points to the most recent Zebra release, ensuring users always get the latest stable version when pulling or updating.
+            # - `1.x.y`: Represents a specific semantic version (e.g., 1.2.3), allowing users to pin to an exact version for stability, preventing automatic upgrades.
             #
-            # `semver` adds a "latest" tag if `inputs.latest_tag` is `true`.
             type=semver,pattern={{version}}
-            type=ref,event=tag
-            # DockerHub release and CI tags.
-            # This tag makes sure tests are using exactly the right image, even when multiple PRs run at the same time.
-            type=sha,event=push
-            # These CI-only tags support CI on PRs, the main branch, and scheduled full syncs.
-            # These tags do not appear on DockerHub, because DockerHub images are only published on the release event.
+            # CI-only tags (not published to DockerHub, only in Google Artifact Registry):
+            # - `pr-xxx`: Tags images with the pull request number for CI tracking during PR workflows.
+            # - `branch-name`: Tags images with the branch name (e.g., `main`, `dev`) for CI builds on branch pushes.
+            # - `edge`: Tags the latest build on the default branch (e.g., `main`), used in CI to represent the cutting-edge version for testing.
+            # - `schedule`: Tags images built during scheduled workflows (e.g., nightly or periodic builds) for CI monitoring and testing.
             type=ref,event=pr
             type=ref,event=branch
             type=edge,enable={{is_default_branch}}
             type=schedule
+            # - `sha-xxxxxx`: Uses the commit SHA (shortened) to tag images for precise identification.
+            # Applied during pull requests and branch pushes to ensure CI tests use the exact image from the last commit.
+            type=sha,event=pr
+            type=sha,event=branch
 
       - name: Authenticate to Google Cloud
         id: auth


### PR DESCRIPTION
## Motivation

This PR addresses the issue of redundant tags on Docker Hub for Zebra images, ensuring that only necessary tags are generated and that the `latest` tag points to the production build, not experimental ones. 

Fixes #7415

## Solution

- Removed `latest_tag` and `tag_suffix` inputs from the Docker build workflow to prevent custom tag variations.
- Removed `flavor` customization for suffixes and forced `latest` tags to simplify tagging.
- Split SHA tag generation into separate rules for PR (`type=sha,event=pr`) and branch (`type=sha,event=branch`) events for clarity and precision.
- Removed `type=ref,event=tag` to avoid unnecessary tag event tags.
- Updated comments in the workflow to better reflect tag usage intentions.

### Tests
- Existing CI pipelines will validate that images are still built and pushed correctly to Google Artifact Registry and Docker Hub 
- Manual verification will be required in the next release

### Specifications & References
- https://github.com/docker/metadata-action/blob/v5.7.0/README.md
- https://github.com/docker/metadata-action/blob/master/src/meta.ts

### Follow-up Work

- Monitor Docker Hub tags post-release to confirm no unintended tags are published in future releases.
- Potential follow-up to address any user feedback if the removal of custom tag inputs breaks specific workflows.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.
- [ ] If the PR shouldn't be in the release notes, it has the `C-exclude-from-changelog` label.