### PR TITLE
fix(cd): deploy long-lived instances without health-checks

### DIFF
--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -343,7 +343,6 @@ jobs:
           gcloud compute instance-groups managed create \
           "zebrad-${{ needs.versioning.outputs.major_version || env.GITHUB_REF_SLUG_URL }}-${NETWORK}" \
           --template "zebrad-${{ needs.versioning.outputs.major_version || env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-${NETWORK}" \
-          --health-check zebrad-tracing-filter \
           --initial-delay 30 \
           --region "${{ vars.GCP_REGION }}" \
           --size 1


### PR DESCRIPTION
## Motivation

Release instances are not being raised as they're waiting for this healthcheck to return a 200 OK value, and that's not happening.

**This is a blocker for the release**

## Solution

Previously GCP did not allow to create instance instance-groups without a health-check and now they do, so it's preferable to remove it until we have an appropriate way to health check Zebra with an external endpoint.

### Tests

- Doing a manual deploy from this branch

The manual deploy worked: https://github.com/ZcashFoundation/zebra/actions/runs/14504438420/job/40691361917 ✅ 

### Specifications & References

- https://cloud.google.com/sdk/gcloud/reference/compute/instance-groups/managed/create#--health-check

### PR Checklist

<!-- Check as many boxes as possible. -->

- [X] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [X] The documentation is up to date.
- [X] The PR has a priority label.
- [X] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
