### PR TITLE
fix(ci): set `ZEBRA_CACHE_DIR` in full and checkpoint syncs

### DIFF
--- a/.github/workflows/sub-ci-integration-tests-gcp.yml
+++ b/.github/workflows/sub-ci-integration-tests-gcp.yml
@@ -79,7 +79,7 @@ jobs:
       app_name: zebrad
       test_id: sync-to-checkpoint
       test_description: Test sync up to mandatory checkpoint
-      test_variables: "-e NETWORK=${{ inputs.network || vars.ZCASH_NETWORK }} -e TEST_DISK_REBUILD=1 ZEBRA_CACHE_DIR=/home/zebra/.cache/zebra"
+      test_variables: "-e NETWORK=${{ inputs.network || vars.ZCASH_NETWORK }} -e TEST_DISK_REBUILD=1 -e ZEBRA_CACHE_DIR=/home/zebra/.cache/zebra"
       needs_zebra_state: false
       saves_to_disk: true
       force_save_to_disk: ${{ inputs.force_save_to_disk || false }}
@@ -138,7 +138,7 @@ jobs:
       test_description: Test a full sync up to the tip
       # The value of FULL_SYNC_MAINNET_TIMEOUT_MINUTES is currently ignored.
       # TODO: update the test to use {{ input.network }} instead?
-      test_variables: "-e NETWORK=Mainnet -e FULL_SYNC_MAINNET_TIMEOUT_MINUTES=0 ZEBRA_CACHE_DIR=/home/zebra/.cache/zebra"
+      test_variables: "-e NETWORK=Mainnet -e FULL_SYNC_MAINNET_TIMEOUT_MINUTES=0 -e ZEBRA_CACHE_DIR=/home/zebra/.cache/zebra"
       # This test runs for longer than 6 hours, so it needs multiple jobs
       is_long_test: true
       needs_zebra_state: false
@@ -241,7 +241,7 @@ jobs:
       test_id: full-sync-testnet
       test_description: Test a full sync up to the tip on testnet
       # The value of FULL_SYNC_TESTNET_TIMEOUT_MINUTES is currently ignored.
-      test_variables: "-e NETWORK=Testnet -e FULL_SYNC_TESTNET_TIMEOUT_MINUTES=0 ZEBRA_CACHE_DIR=/home/zebra/.cache/zebra"
+      test_variables: "-e NETWORK=Testnet -e FULL_SYNC_TESTNET_TIMEOUT_MINUTES=0 -e ZEBRA_CACHE_DIR=/home/zebra/.cache/zebra"
       network: "Testnet"
       # A full testnet sync could take 2-10 hours in April 2023.
       # The time varies a lot due to the small number of nodes.

--- a/.github/workflows/sub-ci-integration-tests-gcp.yml
+++ b/.github/workflows/sub-ci-integration-tests-gcp.yml
@@ -79,7 +79,7 @@ jobs:
       app_name: zebrad
       test_id: sync-to-checkpoint
       test_description: Test sync up to mandatory checkpoint
-      test_variables: "-e NETWORK=${{ inputs.network || vars.ZCASH_NETWORK }} -e TEST_DISK_REBUILD=1"
+      test_variables: "-e NETWORK=${{ inputs.network || vars.ZCASH_NETWORK }} -e TEST_DISK_REBUILD=1 ZEBRA_CACHE_DIR=/home/zebra/.cache/zebra"
       needs_zebra_state: false
       saves_to_disk: true
       force_save_to_disk: ${{ inputs.force_save_to_disk || false }}
@@ -138,7 +138,7 @@ jobs:
       test_description: Test a full sync up to the tip
       # The value of FULL_SYNC_MAINNET_TIMEOUT_MINUTES is currently ignored.
       # TODO: update the test to use {{ input.network }} instead?
-      test_variables: "-e NETWORK=Mainnet -e FULL_SYNC_MAINNET_TIMEOUT_MINUTES=0"
+      test_variables: "-e NETWORK=Mainnet -e FULL_SYNC_MAINNET_TIMEOUT_MINUTES=0 ZEBRA_CACHE_DIR=/home/zebra/.cache/zebra"
       # This test runs for longer than 6 hours, so it needs multiple jobs
       is_long_test: true
       needs_zebra_state: false
@@ -241,7 +241,7 @@ jobs:
       test_id: full-sync-testnet
       test_description: Test a full sync up to the tip on testnet
       # The value of FULL_SYNC_TESTNET_TIMEOUT_MINUTES is currently ignored.
-      test_variables: "-e NETWORK=Testnet -e FULL_SYNC_TESTNET_TIMEOUT_MINUTES=0"
+      test_variables: "-e NETWORK=Testnet -e FULL_SYNC_TESTNET_TIMEOUT_MINUTES=0 ZEBRA_CACHE_DIR=/home/zebra/.cache/zebra"
       network: "Testnet"
       # A full testnet sync could take 2-10 hours in April 2023.
       # The time varies a lot due to the small number of nodes.


### PR DESCRIPTION
## Motivation

The rationale for this change is to address permission issues encountered during tests that attempt to create or access a cached database directory. By setting ZEBRA_CACHE_DIR to a specific path within the user's home directory, we ensure that the test has the necessary write permissions to create and manage the cache directory, avoiding 'Permission denied (os error 13)' errors that occur when using default or system directories without adequate access rights.

Fixes #9437

## Solution

Updates the GitHub Actions workflows for GCP integration tests to explicitly set the ZEBRA_CACHE_DIR environment variable to `/home/zebra/.cache/zebra` for the following test jobs:
- regenerate-stateful-disks (Zebra checkpoint sync to mandatory checkpoint)
- test-full-sync (Zebra full sync to tip on Mainnet)
- test-full-sync-testnet (Zebra full sync to tip on Testnet)


### Tests

- Run a checkpoint and full sync from this branch
	- Checkpoint sync: https://github.com/ZcashFoundation/zebra/actions/runs/14510376898/job/40708015766
	- Zebra full full sync: https://github.com/ZcashFoundation/zebra/actions/runs/14510376898/job/40708016338

### PR Checklist

<!-- Check as many boxes as possible. -->

- [X] The PR name is suitable for the release notes.
- [X] The solution is tested.
- [X] The documentation is up to date.
- [X] The PR has a priority label.
- [X] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
