### PR TITLE
fix(CI): Export each var to env of child processes

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,7 +10,7 @@
 #   the script will look for a default config at ${HOME}/.config/zebrad.toml,
 #   or generate one using environment variables.
 
-set -eo pipefail
+set -aeo pipefail
 
 # These are the default cached state directories for Zebra and lightwalletd.
 #


### PR DESCRIPTION
## Motivation

- Close #9438.
- Close #9437.

## Solution

- Each variable or function created or modified by the entrypoint script is given the export attribute and marked for export to the environment of subsequent commands. 

### Tests

None of these tests should contain the error in #9437.

- Checkpoint sync https://github.com/ZcashFoundation/zebra/actions/runs/14514841260?pr=9439.
- Full sync https://github.com/ZcashFoundation/zebra/actions/runs/14514929382.

### Specifications & References

- https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [x] The documentation is up to date.
- [x] The PR has a priority label.
- [x] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
