### PR TITLE
fix(usability): Improve the cache dir and database startup panics

### DIFF
--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -118,5 +118,5 @@ pub const MAX_INVALIDATED_BLOCKS: usize = 100;
 
 lazy_static! {
     /// Regex that matches the RocksDB error when its lock file is already open.
-    pub static ref LOCK_FILE_ERROR: Regex = Regex::new("(lock file).*(temporarily unavailable)|(in use)|(being used by another process)").expect("regex is valid");
+    pub static ref LOCK_FILE_ERROR: Regex = Regex::new("(Database already open).*").expect("regex is valid");
 }

--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -118,5 +118,5 @@ pub const MAX_INVALIDATED_BLOCKS: usize = 100;
 
 lazy_static! {
     /// Regex that matches the RocksDB error when its lock file is already open.
-    pub static ref LOCK_FILE_ERROR: Regex = Regex::new("(Database already open).*").expect("regex is valid");
+    pub static ref LOCK_FILE_ERROR: Regex = Regex::new("(lock file).*(temporarily unavailable)|(in use)|(being used by another process)|(Database likely already open)").expect("regex is valid");
 }

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -22,7 +22,7 @@ use std::{
 use itertools::Itertools;
 use rlimit::increase_nofile_limit;
 
-use rocksdb::{ColumnFamilyDescriptor, Options, ReadOptions};
+use rocksdb::{ColumnFamilyDescriptor, ErrorKind, Options, ReadOptions};
 use semver::Version;
 use zebra_chain::{parameters::Network, primitives::byte_array::increment_big_endian};
 

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -836,7 +836,7 @@ impl DiskDb {
     ///
     /// # Panics
     ///
-    /// - If the cache directory do not exist and can't be created.
+    /// - If the cache directory does not exist and can't be created.
     /// - If the database cannot be opened for whatever reason.
     pub fn new(
         config: &Config,
@@ -911,20 +911,16 @@ impl DiskDb {
                 db
             }
 
-            Err(e) => {
-                if e.kind() == rocksdb::ErrorKind::Busy || e.kind() == rocksdb::ErrorKind::IOError {
-                    panic!(
-                        "Database already open {path:?} \
+            Err(e) if matches!(e.kind(), ErrorKind::Busy | ErrorKind::IOError) => panic!(
+                "Database likely already open {path:?} \
                          Hint: Check if another zebrad process is running."
-                    )
-                } else {
-                    panic!(
-                        "Opening database {path:?} failed. \
+            ),
+
+            Err(e) => panic!(
+                "Opening database {path:?} failed. \
                         Hint: Try changing the state cache_dir in the Zebra config. \
                         Error: {e}",
-                    )
-                }
-            }
+            ),
         }
     }
 


### PR DESCRIPTION
## Motivation

Currently, Zebra will panic any time it can’t create or open its state database. For example, if the cache directory is invalid, the disk is full, permissions are wrong, or the RocksDB instance is already in use. The default panic messages are ugly and make it hard for end users to diagnose the real cause.

Close https://github.com/ZcashFoundation/zebra/issues/8617

## Solution

We now split these failures into two categories:

- **OS‑level errors** (`std::io::ErrorKind`) related to the cache directory:
   - Permission denied  
   - Disk full  
   - Etc.

- **RocksDB errors** (`rocksdb::ErrorKind`) at the database-opening stage:
   - Database already in use
   - Other RocksDB‑specific failures

In `DiskDB::new`:

- **Initialize the cache directory**  
   Attempt to create or open the cache directory first, and convert any `std::io::ErrorKind` into a descriptive panic.

- **Open the RocksDB database**  
   Once the directory is validated, build the full DB path and open RocksDB, catching any `rocksdb::ErrorKind` and panicking.

This separation makes sure that each panic points more directly to its root cause and suggests an actionable hint.

### Tests

- Updated the existing unit test to expect the new, more specific panic message.  
- Manual verification test for both an OS‑level error (e.g., read‑only directory) and a RocksDB “already in use” error.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.
- [ ] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
