### PR TITLE
zebra-state: Return only the history tree root in GetBlockTemplateChainInfo response

### DIFF
--- a/zebra-rpc/src/methods/get_block_template_rpcs/get_block_template.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/get_block_template.rs
@@ -275,7 +275,7 @@ pub fn generate_coinbase_and_roots(
     block_template_height: Height,
     miner_address: &transparent::Address,
     mempool_txs: &[VerifiedUnminedTx],
-    history_tree: Arc<zebra_chain::history_tree::HistoryTree>,
+    chain_history_root: Option<ChainHistoryMmrRootHash>,
     like_zcashd: bool,
     extra_coinbase_data: Vec<u8>,
 ) -> (TransactionTemplate<NegativeOrZero>, DefaultRoots) {
@@ -293,8 +293,7 @@ pub fn generate_coinbase_and_roots(
     // Calculate block default roots
     //
     // TODO: move expensive root, hash, and tree cryptography to a rayon thread?
-    let chain_history_root = history_tree
-        .hash()
+    let chain_history_root = chain_history_root
         .or_else(|| {
             (NetworkUpgrade::Heartwood.activation_height(network) == Some(block_template_height))
                 .then_some([0; 32].into())

--- a/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs/types/get_block_template.rs
@@ -291,7 +291,7 @@ impl GetBlockTemplate {
             next_block_height,
             miner_address,
             &mempool_txs,
-            chain_tip_and_local_time.history_tree.clone(),
+            chain_tip_and_local_time.chain_history_root,
             like_zcashd,
             extra_coinbase_data,
         );

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -11,6 +11,7 @@ use thiserror::Error;
 use tokio::sync::oneshot;
 use tower::buffer::Buffer;
 
+use zebra_chain::history_tree::HistoryTree;
 use zebra_chain::{
     amount::{Amount, NonNegative},
     block::{Block, Height},
@@ -394,7 +395,7 @@ proptest! {
                         .respond(zebra_state::ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
                             tip_hash: genesis_hash,
                             tip_height: Height::MIN,
-                            history_tree: Default::default(),
+                            chain_history_root: HistoryTree::default().hash(),
                             expected_difficulty: Default::default(),
                             cur_time: DateTime32::now(),
                             min_time: DateTime32::now(),
@@ -468,7 +469,7 @@ proptest! {
                         .respond(zebra_state::ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
                             tip_hash: block_hash,
                             tip_height: block_height,
-                            history_tree: Default::default(),
+                            chain_history_root: HistoryTree::default().hash(),
                             expected_difficulty: Default::default(),
                             cur_time: DateTime32::now(),
                             min_time: DateTime32::now(),

--- a/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/tests/snapshot/get_block_template_rpcs.rs
@@ -256,7 +256,7 @@ pub async fn test_responses<State, ReadState>(
                     cur_time: fake_cur_time,
                     min_time: fake_min_time,
                     max_time: fake_max_time,
-                    history_tree: fake_history_tree(network),
+                    chain_history_root: fake_history_tree(network).hash(),
                 }));
         }
     };

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -9,6 +9,7 @@ use zebra_chain::{
     amount::Amount,
     block::Block,
     chain_tip::{mock::MockChainTip, NoChainTip},
+    history_tree::HistoryTree,
     parameters::Network::*,
     serialization::{ZcashDeserializeInto, ZcashSerialize},
     transaction::UnminedTxId,
@@ -52,7 +53,7 @@ async fn rpc_getinfo() {
         GetBlockTemplateChainInfo {
             tip_hash: Mainnet.genesis_hash(),
             tip_height: Height::MIN,
-            history_tree: Default::default(),
+            chain_history_root: HistoryTree::default().hash(),
             expected_difficulty: Default::default(),
             cur_time: zebra_chain::serialization::DateTime32::now(),
             min_time: zebra_chain::serialization::DateTime32::now(),
@@ -1880,7 +1881,7 @@ async fn rpc_getblocktemplate_mining_address(use_p2pkh: bool) {
                     cur_time: fake_cur_time,
                     min_time: fake_min_time,
                     max_time: fake_max_time,
-                    history_tree: fake_history_tree(&Mainnet),
+                    chain_history_root: fake_history_tree(&Mainnet).hash(),
                 }));
         }
     };
@@ -2353,7 +2354,7 @@ async fn rpc_getdifficulty() {
                 cur_time: fake_cur_time,
                 min_time: fake_min_time,
                 max_time: fake_max_time,
-                history_tree: fake_history_tree(&Mainnet),
+                chain_history_root: fake_history_tree(&Mainnet).hash(),
             }));
     };
 
@@ -2379,7 +2380,7 @@ async fn rpc_getdifficulty() {
                 cur_time: fake_cur_time,
                 min_time: fake_min_time,
                 max_time: fake_max_time,
-                history_tree: fake_history_tree(&Mainnet),
+                chain_history_root: fake_history_tree(&Mainnet).hash(),
             }));
     };
 
@@ -2402,7 +2403,7 @@ async fn rpc_getdifficulty() {
                 cur_time: fake_cur_time,
                 min_time: fake_min_time,
                 max_time: fake_max_time,
-                history_tree: fake_history_tree(&Mainnet),
+                chain_history_root: fake_history_tree(&Mainnet).hash(),
             }));
     };
 
@@ -2425,7 +2426,7 @@ async fn rpc_getdifficulty() {
                 cur_time: fake_cur_time,
                 min_time: fake_min_time,
                 max_time: fake_max_time,
-                history_tree: fake_history_tree(&Mainnet),
+                chain_history_root: fake_history_tree(&Mainnet).hash(),
             }));
     };
 

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -4,7 +4,7 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use zebra_chain::{
     amount::{Amount, NonNegative},
-    block::{self, Block},
+    block::{self, Block, ChainHistoryMmrRootHash},
     orchard, sapling,
     serialization::DateTime32,
     subtree::{NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex},
@@ -277,9 +277,9 @@ pub struct GetBlockTemplateChainInfo {
     /// Depends on the `tip_hash`.
     pub tip_height: block::Height,
 
-    /// The history tree of the current best chain.
+    /// The FlyClient chain history root as of the end of the chain tip block.
     /// Depends on the `tip_hash`.
-    pub history_tree: Arc<zebra_chain::history_tree::HistoryTree>,
+    pub chain_history_root: Option<ChainHistoryMmrRootHash>,
 
     // Data derived from the state tip and recent blocks, and the current local clock.
     //

--- a/zebra-state/src/service/read/difficulty.rs
+++ b/zebra-state/src/service/read/difficulty.rs
@@ -250,7 +250,7 @@ fn difficulty_time_and_history_tree(
     let mut result = GetBlockTemplateChainInfo {
         tip_hash,
         tip_height,
-        history_tree,
+        chain_history_root: history_tree.hash(),
         expected_difficulty,
         cur_time,
         min_time,

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -3092,8 +3092,7 @@ async fn trusted_chain_sync_handles_forks_correctly() -> Result<()> {
 
         header.previous_block_hash = chain_info.tip_hash;
         header.commitment_bytes = chain_info
-            .history_tree
-            .hash()
+            .chain_history_root
             .or(is_chain_history_activation_height.then_some([0; 32].into()))
             .expect("history tree can't be empty")
             .bytes_in_serialized_order()
@@ -3440,8 +3439,9 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
 
     let valid_original_block_template = block_template.clone();
 
-    let zebra_state::GetBlockTemplateChainInfo { history_tree, .. } =
-        fetch_state_tip_and_local_time(read_state.clone()).await?;
+    let zebra_state::GetBlockTemplateChainInfo {
+        chain_history_root, ..
+    } = fetch_state_tip_and_local_time(read_state.clone()).await?;
 
     let network = base_network_params
         .clone()
@@ -3456,7 +3456,7 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
         Height(block_template.height),
         &miner_address,
         &[],
-        history_tree.clone(),
+        chain_history_root,
         true,
         vec![],
     );
@@ -3499,7 +3499,7 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
         Height(block_template.height),
         &miner_address,
         &[],
-        history_tree.clone(),
+        chain_history_root,
         true,
         vec![],
     );


### PR DESCRIPTION
The `HistoryTree` type is intended for internal use within the node; it should not be exposed via the ReadStateService response. Instead, this response should simply include the hash needed for block template construction.

<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

<!--
- Describe the goals of the PR.
- If it closes any issues, enumerate them here.
-->

## Solution

<!-- Describe the changes in the PR. -->

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.
- [ ] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
