### PR TITLE
fix(log): Downgrade verbose info message

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -1228,7 +1228,7 @@ impl DiskDb {
             );
         } else {
             #[cfg(not(test))]
-            info!(
+            debug!(
                 ?current_limit,
                 min_limit = ?DiskDb::MIN_OPEN_FILE_LIMIT,
                 ideal_limit = ?DiskDb::IDEAL_OPEN_FILE_LIMIT,


### PR DESCRIPTION
## Motivation

When running Zallet with Zebra as the backend, every RPC call from Zallet triggers repeated log messages from Zebra:

```
...
2025-04-19T22:20:32.470020Z  INFO read_state: zebra_state::service::finalized_state::disk_db: the open file limit is high enough for Zebra current_limit=1024 min_limit=512 ideal_limit=1024
2025-04-19T22:20:32.527583Z  INFO read_state: zebra_state::service::finalized_state::disk_db: the open file limit is high enough for Zebra current_limit=1024 min_limit=512 ideal_limit=1024
2025-04-19T22:20:32.580809Z  INFO read_state: zebra_state::service::finalized_state::disk_db: the open file limit is high enough for Zebra current_limit=1024 min_limit=512 ideal_limit=1024
...
```

These messages flood the logs, even though they only contain an informative status that doesn't change.

## Solution

Downgrade the log level of this message from `info` to `debug`. A more sophisticated solution could be considered later, but this is a simple fix for now.

### Tests

Manual testing confirms that the log spam is no longer present.

### Follow-up Work

Consider opening a follow-up ticket to explore root causes, smarter logging or maybe just remove the log completely when the limit is enough.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.
- [ ] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
