### PR TITLE
fix(rpc): `z_gettreestate` optional fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6438,6 +6438,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_with",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -56,6 +56,7 @@ hyper = { workspace = true }
 http-body-util = { workspace = true }
 semver = { workspace = true }
 serde_json = { workspace = true }
+serde_with = { workspace = true, features = ["hex"] }
 indexmap = { workspace = true, features = ["serde"] }
 
 # RPC endpoint basic auth

--- a/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_by_hash@custom_testnet.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_by_hash@custom_testnet.snap
@@ -5,5 +5,11 @@ expression: treestate
 {
   "hash": "05a60a92d99d85997cce3b87616c089f6124d7342af37106edc76126334a2c38",
   "height": 0,
-  "time": 1477648033
+  "time": 1477648033,
+  "sapling": {
+    "commitments": {}
+  },
+  "orchard": {
+    "commitments": {}
+  }
 }

--- a/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_empty_Sapling_treestate@custom_testnet.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_empty_Sapling_treestate@custom_testnet.snap
@@ -10,5 +10,8 @@ expression: treestate
     "commitments": {
       "finalState": "000000"
     }
+  },
+  "orchard": {
+    "commitments": {}
   }
 }

--- a/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_no_treestate@custom_testnet.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/z_get_treestate_no_treestate@custom_testnet.snap
@@ -5,5 +5,11 @@ expression: treestate
 {
   "hash": "025579869bcf52a989337342f5f57a84f3a28b968f7d6a8307902b065a668d23",
   "height": 1,
-  "time": 1477674473
+  "time": 1477674473,
+  "sapling": {
+    "commitments": {}
+  },
+  "orchard": {
+    "commitments": {}
+  }
 }


### PR DESCRIPTION
## Motivation

Fix https://github.com/ZcashFoundation/zebra/issues/9445

## Solution

- Make the optional fields like zcashd

### Tests

We have a few snapshots, i also did a small amount of tests between zcashd and zebrad.

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
- [ ] The PR has a priority label.
- [ ] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
