### PR TITLE
fix(ci): use log exit code instead of docker stop

### DIFF
--- a/.github/workflows/sub-test-zebra-config.yml
+++ b/.github/workflows/sub-test-zebra-config.yml
@@ -123,5 +123,7 @@ jobs:
               exit 1;
           else
             echo "SUCCESS: Found the expected pattern in logs.";
-            exit $EXIT_STATUS;
+            # Exit successfully if grep passed, even if docker stop resulted in SIGKILL (137 or 139)
+            # See ticket #7898 for details.
+            exit 0;
           fi


### PR DESCRIPTION
## Motivation

The `sub-test-zebra-config.yml` reusable workflow sometimes reports failures with exit codes like `137` (SIGKILL) or `139` (SIGSEGV), even when the core test condition (checking logs via `grep`) passes successfully. This happens because the `docker stop` command forcefully terminates the `zebrad` container if it doesn't shut down gracefully within the timeout period, leading to a non-zero exit code from `docker wait`. This makes CI results misleading, indicating a failure when the configuration test actually succeeded.

This issue was previously addressed in PR #8107 and its related to issue #7898. This PR re-applies the same fix after being removed in the Docker refactor in #9344

## Solution

Modified the final exit logic within the `Run ${{ matrix.name }} test` step in `.github/workflows/sub-test-zebra-config.yml`.

If the `grep` command successfully finds the required pattern in the logs (`LOGS_EXIT_STATUS -eq 0`), the script will now explicitly `exit 0`. This ensures the workflow step is marked as successful based on the primary test condition (log content verification), regardless of the exit code returned by `docker wait` after `docker stop` is called.

This aligns the step's success/failure status with the intended test validation and mirrors the logic previously implemented in PR #8107.

### Tests

This change is within the CI testing workflow itself.

### Specifications & References

-   Original Fix PR: https://github.com/ZcashFoundation/zebra/pull/8107
-   Related Issue: https://github.com/ZcashFoundation/zebra/issues/7898 (Based on PR #8107)
-   Linux Signals: `man 7 signal` (SIGKILL=9, SIGSEGV=11)
-   Exit Codes > 128: `128 + signal_number` (e.g., 137 = 128 + 9)

### Follow-up Work

While this fixes the CI reporting, the underlying reason why `zebrad` sometimes fails to shut down gracefully within the default `docker stop` timeout could be investigated further. However, this change ensures CI accurately reflects the test outcome based on log verification.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [X] The PR name is suitable for the release notes.
- [X] The solution is tested.
- [X] The documentation is up to date.
- [X] The PR has a priority label.
- [X] If the PR shouldn't be in the release notes, it has the
      `C-exclude-from-changelog` label.
