### PR TITLE
re-export zcash-primitives to unify LRZ versions:

### DIFF
--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -42,6 +42,7 @@ pub mod value_balance;
 pub mod work;
 
 pub use error::Error;
+pub use zcash_primitives;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 pub use block::LedgerState;

--- a/zebra-chain/src/lib.rs
+++ b/zebra-chain/src/lib.rs
@@ -42,6 +42,9 @@ pub mod value_balance;
 pub mod work;
 
 pub use error::Error;
+
+// Re-export librustzcash crates so consumers use Zebra’s versions directly,
+// avoiding duplicate builds or version mismatches.
 pub use zcash_primitives;
 
 #[cfg(any(test, feature = "proptest-impl"))]


### PR DESCRIPTION
## Motivation

The Z3 project is several things including a new version of the Zcash reference implementation!

It's also:

 * a radical expansion of mindshare.

Crudely speaking something like 4-times as many developers are immersed in core Zcash code-bases full-time.  I say crudely because it's non-trivial to understand who is participating in wider audiences.

 * a coordination experiment where multiple **independent** and autonomous communities are cooperating with each other.

We're mostly operating according to our own best discretion, from the bottom up, and meeting fellow autono-matons where we need each other.   We are unambiguously aligned in [our mission, To Empower ALL People With Economic Freedom](https://electriccoin.co/blog/refining-and-recommitting-to-the-ecc-mission/), and that axiom makes amazing new results possible.

### Specific Augmentation:

#### To best coordinate complex systems, it best to refer unambiguously to a single source of truth where possible.

`zaino` is a consumer of `librustzcash`, and `zebra`, but `zebra` is also a consumer of `librustzcash`.  This means it's possible for `zaino` to depend on two different versions of `librustzcash` during build.

## Solution

I am operating under several assumptions:

(1) zaino MUST depend on (specific crates in) zebra
(2) zebra MUST depend on (specific crates in) LRZ
(3) zaino can coordinate requirement (from LRZ) with zebra
(4) the feature-set required by zebra is at *least* the feature set required by zaino (this is a very good reason to:
  AVOID CONDITIONAL COMPILATION, WHEREVER POSSIBLE (please try to build smaller crates instead)

BENEFITS:

By "re-exporting" librustzcash *from* zebra for consumption, this PR enables consumers (such as Zaino) to unify their dependency graph, depending on `librustzcash` only via `zebra`.   The effect is that the version of LRZ used by Zaino becomes the same as that consumed by Zebra.

It's important to understand what this means.  It's not simply that it gives consumers (of Zebra) a simpler dependency tree, there's something else that happens that's *more* important:

* It unifies the interests of Zebra and Zaino relative to librustzcash.  This is a very good thing.  It means that this interface between these project receives more attention, and that attention is framed in a systematic and unambiguous way.
   Concretely:
        - every time Zebra changes the version of LRZ it uses, Zaino devs **will** notice
        - every time LRZ developers change LRZ to support Zaino..   Zebra developers **will** notice

COSTS:

Zaino is more tightly coupled to the code versions that Zebra uses.
LRZ, Zebra, and Zaino developers must collaborate more closely.
Less flexibility in code versions in available.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ x ] The PR name is suitable for the release notes.
