### PR TITLE
fix(ci): check, create and mount lwd cached state for tests

### DIFF
--- a/.github/workflows/sub-ci-integration-tests-gcp.yml
+++ b/.github/workflows/sub-ci-integration-tests-gcp.yml
@@ -316,7 +316,7 @@ jobs:
       app_name: lightwalletd
       test_id: lwd-full-sync
       test_description: Test lightwalletd full sync
-      test_variables: "-e NETWORK=${{ inputs.network || vars.ZCASH_NETWORK }} -e TEST_LWD_FULL_SYNC=1 -e ZEBRA_TEST_LIGHTWALLETD=1 -e ZEBRA_CACHE_DIR=/home/zebra/.cache/zebra"
+      test_variables: "-e NETWORK=${{ inputs.network || vars.ZCASH_NETWORK }} -e TEST_LWD_FULL_SYNC=1 -e ZEBRA_TEST_LIGHTWALLETD=1 -e ZEBRA_CACHE_DIR=/home/zebra/.cache/zebra -e LWD_CACHE_DIR=/home/zebra/.cache/lwd"
       # This test runs for longer than 6 hours, so it needs multiple jobs
       is_long_test: true
       needs_zebra_state: true

--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -414,12 +414,12 @@ jobs:
       # branch names to 12 characters.
       #
       # Passes ${{ inputs.network }} to subsequent steps using $NETWORK env variable.
-      # Passes ${{ env.GITHUB_REF_SLUG_URL }} to subsequent steps using $SHORT_GITHUB_REF env variable.
+      # Passes ${{ env.GITHUB_REF_POINT_SLUG_URL }} to subsequent steps using $SHORT_GITHUB_REF env variable.
       - name: Format network name and branch name for disks
         run: |
           NETWORK_CAPS="${{ inputs.network }}"
           echo "NETWORK=${NETWORK_CAPS,,}" >> "$GITHUB_ENV"
-          LONG_GITHUB_REF="${{ env.GITHUB_REF_SLUG_URL }}"
+          LONG_GITHUB_REF="${{ env.GITHUB_REF_POINT_SLUG_URL }}"
           echo "SHORT_GITHUB_REF=${LONG_GITHUB_REF:0:12}" >> "$GITHUB_ENV"
 
       # Install our SSH secret

--- a/.github/workflows/sub-find-cached-disks.yml
+++ b/.github/workflows/sub-find-cached-disks.yml
@@ -63,6 +63,10 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v5
+        with:
+          short-length: 7
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
@@ -86,12 +90,12 @@ jobs:
       # More info: https://cloud.google.com/compute/docs/naming-resources#resource-name-format
       #
       # Passes ${{ inputs.network }} to subsequent steps using $NETWORK env variable.
-      # Passes ${{ env.GITHUB_REF_SLUG_URL }} to subsequent steps using $SHORT_GITHUB_REF env variable.
+      # Passes ${{ env.GITHUB_REF_POINT_SLUG_URL }} to subsequent steps using $SHORT_GITHUB_REF env variable.
       - name: Format network name and branch name for disks
         run: |
           NETWORK_CAPS="${{ inputs.network }}"
           echo "NETWORK=${NETWORK_CAPS,,}" >> "$GITHUB_ENV"
-          LONG_GITHUB_REF="${{ env.GITHUB_REF_SLUG_URL }}"
+          LONG_GITHUB_REF="${{ env.GITHUB_REF_POINT_SLUG_URL }}"
           echo "SHORT_GITHUB_REF=${LONG_GITHUB_REF:0:12}" >> "$GITHUB_ENV"
 
       # Check if there are cached state disks available for subsequent jobs to use.

--- a/zebra-rpc/src/methods/get_block_template_rpcs.rs
+++ b/zebra-rpc/src/methods/get_block_template_rpcs.rs
@@ -1250,7 +1250,7 @@ where
     }
 
     async fn get_difficulty(&self) -> Result<f64> {
-        chain_tip_difficulty(self.network.clone(), self.state.clone()).await
+        chain_tip_difficulty(self.network.clone(), self.state.clone(), false).await
     }
 
     async fn z_list_unified_receivers(&self, address: String) -> Result<unified_address::Response> {

--- a/zebrad/tests/common/lightwalletd.rs
+++ b/zebrad/tests/common/lightwalletd.rs
@@ -216,23 +216,25 @@ where
             // Only log the directory size if it's expected to exist already.
             // FullSyncFromGenesis creates this directory, so we skip logging for it.
             if !matches!(test_type, TestType::FullSyncFromGenesis { .. }) {
-                let lwd_cache_dir =
-                    std::fs::read_dir(lightwalletd_state_path.join("db/main").as_path())
-                        .expect("unexpected failure reading lightwalletd cache dir");
-                let lwd_cache_dir_size = lwd_cache_dir.into_iter().fold(0, |acc, entry| {
-                    acc + entry
+                let lwd_cache_dir_path = lightwalletd_state_path.join("db/main");
+                let lwd_cache_entries: Vec<_> = std::fs::read_dir(&lwd_cache_dir_path)
+                    .expect("unexpected failure reading lightwalletd cache dir")
+                    .collect();
+
+                let lwd_cache_dir_size = lwd_cache_entries.iter().fold(0, |acc, entry_result| {
+                    acc + entry_result
+                        .as_ref()
                         .map(|entry| entry.metadata().map(|meta| meta.len()).unwrap_or(0))
                         .unwrap_or(0)
                 });
 
                 tracing::info!("{lwd_cache_dir_size} bytes in lightwalletd cache dir");
 
-                let lwd_cache_dir =
-                    std::fs::read_dir(lightwalletd_state_path.join("db/main").as_path())
-                        .expect("unexpected failure reading lightwalletd cache dir");
-
-                for entry in lwd_cache_dir {
-                    tracing::info!("{entry:?} bytes in lightwalletd cache dir");
+                for entry_result in &lwd_cache_entries {
+                    match entry_result {
+                        Ok(entry) => tracing::info!("{entry:?} entry in lightwalletd cache dir"),
+                        Err(e) => tracing::warn!(?e, "error reading entry in lightwalletd cache dir"),
+                    }
                 }
             }
 

--- a/zebrad/tests/common/lightwalletd.rs
+++ b/zebrad/tests/common/lightwalletd.rs
@@ -208,23 +208,28 @@ where
         // the lightwalletd cache directory
         if let Some(lightwalletd_state_path) = lightwalletd_state_path.into() {
             tracing::info!(?lightwalletd_state_path, "using lightwalletd state path");
-            let lwd_cache_dir =
-                std::fs::read_dir(lightwalletd_state_path.join("db/main").as_path())
-                    .expect("unexpected failure reading lightwalletd cache dir");
-            let lwd_cache_dir_size = lwd_cache_dir.into_iter().fold(0, |acc, entry| {
-                acc + entry
-                    .map(|entry| entry.metadata().map(|meta| meta.len()).unwrap_or(0))
-                    .unwrap_or(0)
-            });
 
-            tracing::info!("{lwd_cache_dir_size} bytes in lightwalletd cache dir");
+            // Only log the directory size if it's expected to exist already.
+            // FullSyncFromGenesis creates this directory, so we skip logging for it.
+            if !matches!(test_type, TestType::FullSyncFromGenesis { .. }) {
+                let lwd_cache_dir =
+                    std::fs::read_dir(lightwalletd_state_path.join("db/main").as_path())
+                        .expect("unexpected failure reading lightwalletd cache dir");
+                let lwd_cache_dir_size = lwd_cache_dir.into_iter().fold(0, |acc, entry| {
+                    acc + entry
+                        .map(|entry| entry.metadata().map(|meta| meta.len()).unwrap_or(0))
+                        .unwrap_or(0)
+                });
 
-            let lwd_cache_dir =
-                std::fs::read_dir(lightwalletd_state_path.join("db/main").as_path())
-                    .expect("unexpected failure reading lightwalletd cache dir");
+                tracing::info!("{lwd_cache_dir_size} bytes in lightwalletd cache dir");
 
-            for entry in lwd_cache_dir {
-                tracing::info!("{entry:?} bytes in lightwalletd cache dir");
+                let lwd_cache_dir =
+                    std::fs::read_dir(lightwalletd_state_path.join("db/main").as_path())
+                        .expect("unexpected failure reading lightwalletd cache dir");
+
+                for entry in lwd_cache_dir {
+                    tracing::info!("{entry:?} bytes in lightwalletd cache dir");
+                }
             }
 
             args.set_parameter(

--- a/zebrad/tests/common/lightwalletd.rs
+++ b/zebrad/tests/common/lightwalletd.rs
@@ -111,7 +111,7 @@ pub fn spawn_lightwalletd_for_rpc<S: AsRef<str> + std::fmt::Debug>(
         test_type.lightwalletd_failure_messages();
 
     let mut lightwalletd = lightwalletd_dir
-        .spawn_lightwalletd_child(lightwalletd_state_path, arguments)?
+        .spawn_lightwalletd_child(lightwalletd_state_path, test_type, arguments)?
         .with_timeout(test_type.lightwalletd_timeout())
         .with_failure_regex_iter(lightwalletd_failure_messages, lightwalletd_ignore_messages);
 
@@ -157,6 +157,8 @@ where
     /// as a child process in this test directory,
     /// potentially taking ownership of the tempdir for the duration of the child process.
     ///
+    /// Uses `test_type` to determine logging behavior for the state directory.
+    ///
     /// By default, launch a working test instance with logging, and avoid port conflicts.
     ///
     /// # Panics
@@ -165,6 +167,7 @@ where
     fn spawn_lightwalletd_child(
         self,
         lightwalletd_state_path: impl Into<Option<PathBuf>>,
+        test_type: TestType,
         extra_args: Arguments,
     ) -> Result<TestChild<Self>>;
 
@@ -184,6 +187,7 @@ where
     fn spawn_lightwalletd_child(
         self,
         lightwalletd_state_path: impl Into<Option<PathBuf>>,
+        test_type: TestType,
         extra_args: Arguments,
     ) -> Result<TestChild<Self>> {
         let test_dir = self.as_ref().to_owned();

--- a/zebrad/tests/common/lightwalletd.rs
+++ b/zebrad/tests/common/lightwalletd.rs
@@ -211,13 +211,18 @@ where
             let lwd_cache_dir =
                 std::fs::read_dir(lightwalletd_state_path.join("db/main").as_path())
                     .expect("unexpected failure reading lightwalletd cache dir");
-            let lwd_cache_dir_size = lwd_cache_dir.iter().fold(0, |acc, entry| {
+            let lwd_cache_dir_size = lwd_cache_dir.into_iter().fold(0, |acc, entry| {
                 acc + entry
                     .map(|entry| entry.metadata().map(|meta| meta.len()).unwrap_or(0))
                     .unwrap_or(0)
             });
 
             tracing::info!("{lwd_cache_dir_size} bytes in lightwalletd cache dir");
+
+            let lwd_cache_dir =
+                std::fs::read_dir(lightwalletd_state_path.join("db/main").as_path())
+                    .expect("unexpected failure reading lightwalletd cache dir");
+
             for entry in lwd_cache_dir {
                 tracing::info!("{entry:?} bytes in lightwalletd cache dir");
             }

--- a/zebrad/tests/common/lightwalletd.rs
+++ b/zebrad/tests/common/lightwalletd.rs
@@ -233,7 +233,9 @@ where
                 for entry_result in &lwd_cache_entries {
                     match entry_result {
                         Ok(entry) => tracing::info!("{entry:?} entry in lightwalletd cache dir"),
-                        Err(e) => tracing::warn!(?e, "error reading entry in lightwalletd cache dir"),
+                        Err(e) => {
+                            tracing::warn!(?e, "error reading entry in lightwalletd cache dir")
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Motivation

This PR initially aimed to add checks for the existence of the lightwalletd cached state directory (`LWD_CACHE_DIR`) before running integration tests that require it. During development and testing, several related issues in the CI workflow and test harness were identified and fixed:

1.  Tests requiring a pre-existing `lightwalletd` state (`lwd-update-sync`, `lwd-send-transactions`, `lwd-grpc-wallet`) were timing out. This was traced back to the `lwd-full-sync` test not correctly saving its state to the expected `LWD_CACHE_DIR`, preventing the CI from creating valid `lwd-cache-*` disk images.
2.  The test harness code responsible for launching `lightwalletd` contained debug logging that caused a panic during the `lwd-full-sync` test by attempting to read the state directory before `lightwalletd` created it.
3.  Inconsistencies in constructing disk image names/labels were observed, related to recent updates in the `rlespinasse/github-slug-action` in their v5.

Fixes #9419

## Solution

1.  **CI Workflow (`sub-ci-integration-tests-gcp.yml`, `sub-deploy-integration-tests-gcp.yml`, `sub-find-cached-disks.yml`):**
    *   Added the missing `-e LWD_CACHE_DIR=/home/zebra/.cache/lwd` environment variable to the `lwd-full-sync` test definition in `sub-ci-integration-tests-gcp.yml`. This ensures `lightwalletd` saves its state to the correct location.
    *   The `create-state-image` step in `sub-deploy-integration-tests-gcp.yml` will now correctly capture this state when creating `lwd-cache-*` images.
    *   Updated workflow files to use `env.GITHUB_REF_POINT_SLUG_URL` instead of `env.GITHUB_REF_SLUG_URL` for disk/label naming consistency, to mitigate the issues with `github-slug-action@v5`. (See [rlespinasse/github-slug-action#104](https://github.com/rlespinasse/github-slug-action/issues/104)).
    *   Added `github-slug-action` to `sub-find-cached-disks.yml` to ensure consistent variable availability.

2.  **Test Harness (`zebrad/tests/common/lightwalletd.rs`):**
    *   Modified `spawn_lightwalletd_child` to accept the `TestType` as an argument.
    *   Conditionalized the debug logging that reads the `lightwalletd` state directory size. It now skips this check for `TestType::FullSyncFromGenesis` (used by `lwd-full-sync`) to prevent panics when the directory doesn't initially exist.

3.  **RPC (`zebra-rpc/src/methods.rs`, `zebra-rpc/src/methods/get_block_template_rpcs.rs`):**
    *   Modified `chain_tip_difficulty` to accept a `should_use_default` flag. When true (as used by `getinfo`), it returns a default difficulty value instead of erroring if the state service isn't ready, preventing a potential panic.

### Tests

The primary testing for these changes involves the CI integration tests defined in `sub-ci-integration-tests-gcp.yml`:

-   The fix to `lwd-full-sync` saving its state correctly is verified by the subsequent successful runs of `lwd-update-sync`, `lwd-send-transactions`, and `lwd-grpc-wallet`, which depend on the `lwd-cache-*` disk image created by `lwd-full-sync`. These tests should no longer time out due to missing state.
-   The fix in `lightwalletd.rs` is verified by the `lwd-full-sync` test no longer panicking when attempting to log the cache directory size.

### Specifications & References

-   GitHub Slug Action Issue: [GITHUB_REF_NAME is not correctly filled on pull_request events #104](https://github.com/rlespinasse/github-slug-action/issues/104)

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested (via CI integration tests).
- [x] The documentation is up to date (Internal test harness/CI documentation updated implicitly via code comments).