### PR TITLE
docs(openapi): Remove getblocktemplate file from scrtipt

### DIFF
--- a/zebra-utils/src/bin/openapi-generator/main.rs
+++ b/zebra-utils/src/bin/openapi-generator/main.rs
@@ -83,19 +83,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let current_path = env!("CARGO_MANIFEST_DIR");
 
     // Define the paths to the Zebra RPC methods
-    let paths = vec![
-        (
-            format!("{}/../zebra-rpc/src/methods.rs", current_path),
-            "Rpc",
-        ),
-        (
-            format!(
-                "{}/../zebra-rpc/src/methods/get_block_template_rpcs.rs",
-                current_path
-            ),
-            "GetBlockTemplateRpc",
-        ),
-    ];
+    let paths = vec![(
+        format!("{}/../zebra-rpc/src/methods.rs", current_path),
+        "Rpc",
+    )];
 
     // Create an indexmap to store the method names and configuration
     let mut methods = IndexMap::new();


### PR DESCRIPTION
## Motivation

The OpenAPI generation script is currently failing in https://github.com/ZcashFoundation/zebra/pull/9459

The script needs updating, and it’s likely to be replaced by https://github.com/ZcashFoundation/zebra/issues/9477, but we can fix the current failure now:

```
cargo run --bin openapi-generator --features="openapi-generator"
...
Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

## Solution

Remove the reference to the missing file so that the script can execute.
