### PR TITLE
update README with Arch build patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ sudo pacman -S rust clang protobuf
 
 Note that the package `clang` includes `libclang` as well as the C++ compiler.
 
+Recently the GCC version on Arch has broken a build script in the `rocksdb` dependency. A workaround is:
+```sh
+export CXXFLAGS="$CXXFLAGS -include cstdint"
+```
+
 </details>
 
 Once you have the dependencies in place, you can build and install Zebra with:

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ sudo pacman -S rust clang protobuf
 Note that the package `clang` includes `libclang` as well as the C++ compiler.
 
 Recently the GCC version on Arch has broken a build script in the `rocksdb` dependency. A workaround is:
+
 ```sh
 export CXXFLAGS="$CXXFLAGS -include cstdint"
 ```


### PR DESCRIPTION
Building on unembellished Arch Linux currently fails on running a build script of the `rocksdb` dependency. This appears to be because this script breaks when using a new version of GCC. We could provide a minimal recreation soon. The suggestion in the README can patch this problem.

<!-- Check as many boxes as possible. -->

- [X] The PR name is suitable for the release notes.
- [X] The solution is tested.
- [X] The documentation is up to date.
