### PR TITLE
feat(ci): Enable stateful MIGs and fix release deployment skipping

### DIFF
--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -165,7 +165,6 @@ jobs:
   # The image will be commonly named `zebrad:<short-hash | github-ref | semver>`
   build:
     name: Build CD Docker
-    needs: get-disk-name
     uses: ./.github/workflows/sub-build-docker-image.yml
     with:
       dockerfile_path: ./docker/Dockerfile
@@ -272,17 +271,25 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2.1.4
 
+      # Retrieves a static IP address for long-running nodes.
+      # This step runs only when triggered by a release or a manual workflow_dispatch event.
+      # - Exits immediately if any command fails.
+      # - Attempts to retrieve the static IP for the current network and region.
+      # - Sets the IP_ADDRESS environment variable.
       - name: Get static IP address for long-running nodes
-        # Now runs when triggered by a release or a manual workflow_dispatch event.
         if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
         run: |
-          set -e  # Exit immediately if a command exits with a non-zero status.
-          # Attempt to retrieve the static IP address for the network.
+          set -e
           echo "IP_ADDRESS=$(gcloud compute addresses describe zebra-${NETWORK} --region ${{ vars.GCP_REGION }} --format='value(address)')" >> "$GITHUB_ENV"
 
+      # Creates a GCP instance template with specific disk handling:
+      # - Releases: Uses a fixed disk name (e.g., "zebrad-cache-mainnet") and attempts to re-attach this existing
+      #   persistent disk to maintain node state. A new blank disk is created if not found. Dynamic cached images are NOT used.
+      # - Other Events (push/workflow_dispatch): Uses a unique disk name (branch/SHA). If a cached disk is requested
+      #   and found by 'get-disk-name', its image seeds the new disk. Errors if an expected cached disk isn't available.
       - name: Create instance template for ${{ matrix.network }}
         run: |
-          if [ "${{ github.event_name }}" == "release" ]; then
+          if [ ${{ github.event_name  == 'release' }} ]; then
             DISK_NAME="zebrad-cache-${NETWORK}"
           else
             DISK_NAME="zebrad-cache-${{ env.GITHUB_HEAD_REF_SLUG_URL || env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}-${NETWORK}"
@@ -293,17 +300,21 @@ jobs:
             IP_FLAG=""
           fi
           DISK_PARAMS="name=${DISK_NAME},device-name=${DISK_NAME},size=400GB,type=pd-balanced"
-          if [ -n "${{ env.CACHED_DISK_NAME }}" ]; then
+
+          if [ ${{ github.event_name  == 'release' }} ]; then
+            echo "Release event: Using disk ${DISK_NAME} without a dynamic cached image source."
+          elif [ -n "${{ env.CACHED_DISK_NAME }}" ]; then
+            echo "Non-release event: Using cached disk image ${{ env.CACHED_DISK_NAME }} for disk ${DISK_NAME}."
             DISK_PARAMS+=",image=${{ env.CACHED_DISK_NAME }}"
           elif [ ${{ !inputs.need_cached_disk && github.event_name == 'workflow_dispatch' }} ]; then
-           echo "No cached disk required"
+            echo "Workflow dispatch: No cached disk required by input for disk ${DISK_NAME}."
           else
-            echo "No cached disk found for ${{ matrix.network }} in main branch"
+            echo "Error: A cached disk was expected for disk ${{ matrix.network }} but is not available (event: ${{ github.event_name }}, CACHED_DISK_NAME: '${{ env.CACHED_DISK_NAME }}', inputs.need_cached_disk: '${{ inputs.need_cached_disk }}')."
             exit 1
           fi
 
           # Set log file based on input or default
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+          if [ ${{ github.event_name  == 'workflow_dispatch' }} ]; then
             LOG_FILE="${{ inputs.log_file }}"
           else
             LOG_FILE="${{ vars.CD_LOG_FILE }}"

--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -358,6 +358,19 @@ jobs:
           --region "${{ vars.GCP_REGION }}" \
           --size 1
 
+      # Configure stateful disk policy for release MIGs to ensure disk persistence.
+      # This policy tells the MIG to preserve the disk with the specified device-name
+      # when instances are recreated or deleted, and to reattach it.
+      - name: Configure stateful disk policy for release MIG
+        if: ${{ github.event_name == 'release' }}
+        run: |
+          MIG_NAME="zebrad-${{ needs.versioning.outputs.major_version }}-${NETWORK}"
+          DEVICE_NAME_TO_PRESERVE="zebrad-cache-${NETWORK}"
+          echo "Applying stateful policy to MIG: ${MIG_NAME} for device: ${DEVICE_NAME_TO_PRESERVE}"
+          gcloud compute instance-groups managed set-stateful-policy "${MIG_NAME}" \
+            --region "${{ vars.GCP_REGION }}" \
+            --stateful-disk "device-name=${DEVICE_NAME_TO_PRESERVE},auto-delete=never"
+
       # Rolls out update to existing group using the new instance template
       - name: Update managed instance group for ${{ matrix.network }}
         if: steps.does-group-exist.outcome == 'success'


### PR DESCRIPTION
## Motivation

The CD workflow (`cd-deploy-nodes-gcp.yml`) was skipping deployments on `release` events. Additionally, the handling of persistent state disks for release instances needed to be more robust to ensure state continuity.

## Solution

This PR addresses the above by:

1.  **Ensuring Release Deployments Run:**
    *   Removed the `build` job's dependency on `get-disk-name` (which is skipped for releases).
    *   Adjusted the `Create instance template` script to correctly configure disk parameters for `release` events (using a fixed disk name without a source image).

2.  **Implementing Stateful Disk Persistence for Releases:**
    *   Added a new step, "Configure stateful disk policy for release MIG," to the `deploy-nodes` job. This step applies a stateful policy (`--stateful-disk "device-name=zebrad-cache-${NETWORK},auto-delete=never"`) to the release MIG, ensuring the data disk is preserved and reattached across instance updates.

### Tests

This is hard to test in all use-cases, but we mainly need to:
- Verify workflow runs successfully for `release`, `push` to `main`, and `workflow_dispatch` events.
- Confirm stateful policy application and disk reattachment for release MIGs in GCP.

### Specifications & References

- https://cloud.google.com/compute/docs/instance-groups/stateful-migs#what_makes_a_mig_stateful

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested. (Pending verification)
- [x] The documentation is up to date. (Workflow comments)
