### PR TITLE
fix(rpc): Regroup imports

### DIFF
--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -1,28 +1,19 @@
 //! Randomised property tests for RPC methods.
 
-use crate::methods::{
-    self,
-    types::{
-        get_blockchain_info,
-        get_raw_mempool::{GetRawMempool, MempoolObject},
-    },
-};
-
-use super::super::{
-    AddressBalance, AddressStrings, NetworkUpgradeStatus, RpcImpl, RpcServer, SentTransactionHash,
-};
-use futures::{join, FutureExt, TryFutureExt};
-use hex::{FromHex, ToHex};
-use jsonrpsee_types::{ErrorCode, ErrorObject};
-use proptest::{collection::vec, prelude::*};
 use std::{
     collections::{HashMap, HashSet},
     fmt::Debug,
     sync::Arc,
 };
+
+use futures::{join, FutureExt, TryFutureExt};
+use hex::{FromHex, ToHex};
+use jsonrpsee_types::{ErrorCode, ErrorObject};
+use proptest::{collection::vec, prelude::*};
 use thiserror::Error;
 use tokio::sync::oneshot;
 use tower::buffer::Buffer;
+
 use zebra_chain::{
     amount::{Amount, NonNegative},
     block::{self, Block, Height},
@@ -40,6 +31,18 @@ use zebra_network::address_book_peers::MockAddressBookPeers;
 use zebra_node_services::mempool;
 use zebra_state::{BoxError, GetBlockTemplateChainInfo};
 use zebra_test::mock_service::MockService;
+
+use crate::methods::{
+    self,
+    types::{
+        get_blockchain_info,
+        get_raw_mempool::{GetRawMempool, MempoolObject},
+    },
+};
+
+use super::super::{
+    AddressBalance, AddressStrings, NetworkUpgradeStatus, RpcImpl, RpcServer, SentTransactionHash,
+};
 
 proptest! {
     /// Test that when sending a raw transaction, it is received by the mempool service.

--- a/zebra-rpc/src/methods/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/types/get_block_template.rs
@@ -5,30 +5,13 @@ pub mod parameters;
 pub mod proposal;
 pub mod zip317;
 
-pub use constants::{
-    CAPABILITIES_FIELD, DEFAULT_SOLUTION_RATE_WINDOW_SIZE,
-    MAX_ESTIMATED_DISTANCE_TO_NETWORK_CHAIN_TIP, MEMPOOL_LONG_POLL_INTERVAL, MUTABLE_FIELD,
-    NONCE_RANGE_FIELD, NOT_SYNCED_ERROR_CODE, ZCASHD_FUNDING_STREAM_ORDER,
-};
-pub use parameters::{GetBlockTemplateRequestMode, JsonParameters};
-pub use proposal::{ProposalResponse, TimeSource};
+use std::{collections::HashMap, fmt, iter, sync::Arc};
 
-use crate::{
-    config,
-    methods::{
-        types::{
-            default_roots::DefaultRoots, long_poll::LongPollId, submit_block,
-            transaction::TransactionTemplate,
-        },
-        GetBlockHash,
-    },
-    server::error::OkOrError,
-};
 use jsonrpsee::core::RpcResult;
 use jsonrpsee_types::{ErrorCode, ErrorObject};
-use std::{collections::HashMap, fmt, iter, sync::Arc};
 use tokio::sync::watch::{self, error::SendError};
 use tower::{Service, ServiceExt};
+
 use zebra_chain::{
     amount::{self, Amount, NegativeOrZero, NonNegative},
     block::{
@@ -52,6 +35,26 @@ use zebra_consensus::{
 };
 use zebra_node_services::mempool::{self, TransactionDependencies};
 use zebra_state::GetBlockTemplateChainInfo;
+
+use crate::{
+    config,
+    methods::{
+        types::{
+            default_roots::DefaultRoots, long_poll::LongPollId, submit_block,
+            transaction::TransactionTemplate,
+        },
+        GetBlockHash,
+    },
+    server::error::OkOrError,
+};
+
+pub use constants::{
+    CAPABILITIES_FIELD, DEFAULT_SOLUTION_RATE_WINDOW_SIZE,
+    MAX_ESTIMATED_DISTANCE_TO_NETWORK_CHAIN_TIP, MEMPOOL_LONG_POLL_INTERVAL, MUTABLE_FIELD,
+    NONCE_RANGE_FIELD, NOT_SYNCED_ERROR_CODE, ZCASHD_FUNDING_STREAM_ORDER,
+};
+pub use parameters::{GetBlockTemplateRequestMode, JsonParameters};
+pub use proposal::{ProposalResponse, TimeSource};
 
 /// An alias to indicate that a usize value represents the depth of in-block dependencies of a
 /// transaction.

--- a/zebra-rpc/src/methods/types/get_block_template/zip317.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/zip317.rs
@@ -6,16 +6,13 @@
 //! > when computing `size_target`, since there is no consensus requirement for this to be
 //! > exactly the same between implementations.
 
-#[cfg(test)]
-use crate::methods::types::get_block_template::InBlockTxDependenciesDepth;
-use crate::methods::{
-    get_block_template::generate_coinbase_transaction, types::transaction::TransactionTemplate,
-};
+use std::collections::{HashMap, HashSet};
+
 use rand::{
     distributions::{Distribution, WeightedIndex},
     prelude::thread_rng,
 };
-use std::collections::{HashMap, HashSet};
+
 use zebra_chain::{
     amount::NegativeOrZero,
     block::{Height, MAX_BLOCK_BYTES},
@@ -26,8 +23,15 @@ use zebra_chain::{
 use zebra_consensus::MAX_BLOCK_SIGOPS;
 use zebra_node_services::mempool::TransactionDependencies;
 
+use crate::methods::{
+    get_block_template::generate_coinbase_transaction, types::transaction::TransactionTemplate,
+};
+
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+use crate::methods::types::get_block_template::InBlockTxDependenciesDepth;
 
 /// Used in the return type of [`select_mempool_transactions()`] for test compilations.
 #[cfg(test)]

--- a/zebra-rpc/src/methods/types/get_blockchain_info.rs
+++ b/zebra-rpc/src/methods/types/get_blockchain_info.rs
@@ -4,6 +4,7 @@ use zebra_chain::{
     amount::{Amount, NonNegative},
     value_balance::ValueBalance,
 };
+
 use zec::Zec;
 
 use super::*;

--- a/zebra-rpc/src/methods/types/get_raw_mempool.rs
+++ b/zebra-rpc/src/methods/types/get_raw_mempool.rs
@@ -1,12 +1,10 @@
 //! Types used in `getrawmempool` RPC method.
 
-use std::collections::HashMap;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use hex::ToHex as _;
 
-use zebra_chain::transaction::VerifiedUnminedTx;
-use zebra_chain::{amount::NonNegative, block::Height};
+use zebra_chain::{amount::NonNegative, block::Height, transaction::VerifiedUnminedTx};
 use zebra_node_services::mempool::TransactionDependencies;
 
 use super::zec::Zec;

--- a/zebra-rpc/src/methods/types/transaction.rs
+++ b/zebra-rpc/src/methods/types/transaction.rs
@@ -1,13 +1,13 @@
 //! Transaction-related types.
 
-use super::zec::Zec;
+use std::sync::Arc;
+
 use chrono::{DateTime, Utc};
 use hex::ToHex;
-use std::sync::Arc;
+
 use zebra_chain::{
     amount::{self, Amount, NegativeOrZero, NonNegative},
-    block,
-    block::merkle::AUTH_DIGEST_PLACEHOLDER,
+    block::{self, merkle::AUTH_DIGEST_PLACEHOLDER},
     parameters::Network,
     sapling::NotSmallOrderValueCommitment,
     transaction::{self, SerializedTransaction, Transaction, UnminedTx, VerifiedUnminedTx},
@@ -16,6 +16,8 @@ use zebra_chain::{
 use zebra_consensus::groth16::Description;
 use zebra_script::CachedFfiTransaction;
 use zebra_state::IntoDisk;
+
+use super::zec::Zec;
 
 /// Transaction data and fields needed to generate blocks using the `getblocktemplate` RPC.
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/zebra-rpc/src/server/tests/vectors.rs
+++ b/zebra-rpc/src/server/tests/vectors.rs
@@ -3,17 +3,21 @@
 // These tests call functions which can take unit arguments if some features aren't enabled.
 #![allow(clippy::unit_arg)]
 
-use super::super::*;
-use config::rpc::Config;
 use std::net::{Ipv4Addr, SocketAddrV4};
+
 use tokio::sync::watch;
 use tower::buffer::Buffer;
+
 use zebra_chain::{
     chain_sync_status::MockSyncStatus, chain_tip::NoChainTip, parameters::Network::*,
 };
 use zebra_network::address_book_peers::MockAddressBookPeers;
 use zebra_node_services::BoxError;
 use zebra_test::mock_service::MockService;
+
+use super::super::*;
+
+use config::rpc::Config;
 
 /// Test that the JSON-RPC server spawns.
 #[tokio::test]

--- a/zebra-utils/src/bin/block-template-to-proposal/args.rs
+++ b/zebra-utils/src/bin/block-template-to-proposal/args.rs
@@ -3,6 +3,7 @@
 //! For usage please refer to the program help: `block-template-to-proposal --help`
 
 use structopt::StructOpt;
+
 use zebra_rpc::methods::types::get_block_template::TimeSource;
 
 /// block-template-to-proposal arguments

--- a/zebra-utils/src/bin/block-template-to-proposal/main.rs
+++ b/zebra-utils/src/bin/block-template-to-proposal/main.rs
@@ -4,6 +4,8 @@
 //!
 //! For usage please refer to the program help: `block-template-to-proposal --help`
 
+mod args;
+
 use std::io::Read;
 
 use color_eyre::eyre::Result;
@@ -19,8 +21,6 @@ use zebra_rpc::methods::types::{
     long_poll::LONG_POLL_ID_LENGTH,
 };
 use zebra_utils::init_tracing;
-
-mod args;
 
 /// The minimum number of characters in a valid `getblocktemplate JSON response.
 ///

--- a/zebra-utils/src/bin/openapi-generator/main.rs
+++ b/zebra-utils/src/bin/openapi-generator/main.rs
@@ -8,8 +8,9 @@ use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use serde::Serialize;
 use syn::LitStr;
 
-use types::{get_mining_info, submit_block, subsidy, validate_address, z_validate_address};
 use zebra_rpc::methods::{trees::GetTreestate, *};
+
+use types::{get_mining_info, submit_block, subsidy, validate_address, z_validate_address};
 
 // The API server
 const SERVER: &str = "http://localhost:8232";

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -73,8 +73,22 @@
 //!
 //! Some of the diagnostic features are optional, and need to be enabled at compile-time.
 
-#[cfg(feature = "internal-miner")]
-use crate::components;
+use std::sync::Arc;
+
+use abscissa_core::{config, Command, FrameworkError};
+use color_eyre::eyre::{eyre, Report};
+use futures::FutureExt;
+use tokio::{pin, select, sync::oneshot};
+use tower::{builder::ServiceBuilder, util::BoxService, ServiceExt};
+use tracing_futures::Instrument;
+
+use zebra_chain::block::genesis::regtest_genesis_block;
+use zebra_consensus::{router::BackgroundTaskHandles, ParameterCheckpoint};
+use zebra_rpc::{
+    methods::{types::submit_block::SubmitBlockChannel, RpcImpl},
+    server::RpcServer,
+};
+
 use crate::{
     application::{build_version, user_agent, LAST_WARN_ERROR_LOG_SENDER},
     components::{
@@ -87,19 +101,9 @@ use crate::{
     config::ZebradConfig,
     prelude::*,
 };
-use abscissa_core::{config, Command, FrameworkError};
-use color_eyre::eyre::{eyre, Report};
-use futures::FutureExt;
-use std::sync::Arc;
-use tokio::{pin, select, sync::oneshot};
-use tower::{builder::ServiceBuilder, util::BoxService, ServiceExt};
-use tracing_futures::Instrument;
-use zebra_chain::block::genesis::regtest_genesis_block;
-use zebra_consensus::{router::BackgroundTaskHandles, ParameterCheckpoint};
-use zebra_rpc::{
-    methods::{types::submit_block::SubmitBlockChannel, RpcImpl},
-    server::RpcServer,
-};
+
+#[cfg(feature = "internal-miner")]
+use crate::components;
 
 /// Start the application (default command)
 #[derive(Command, Debug, Default, clap::Parser)]

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -1,21 +1,12 @@
 //! Inbound service tests with a fake peer set.
 
-use crate::{
-    components::{
-        inbound::{downloads::MAX_INBOUND_CONCURRENCY, Inbound, InboundSetupData},
-        mempool::{
-            gossip_mempool_transaction_id, Config as MempoolConfig, Mempool, MempoolError,
-            SameEffectsChainRejectionError, UnboxMempoolError,
-        },
-        sync::{self, BlockGossipError, SyncStatus, PEER_GOSSIP_DELAY},
-    },
-    BoxError,
-};
-use futures::FutureExt;
 use std::{collections::HashSet, iter, net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
+
+use futures::FutureExt;
 use tokio::{sync::oneshot, task::JoinHandle, time::timeout};
 use tower::{buffer::Buffer, builder::ServiceBuilder, util::BoxService, Service, ServiceExt};
 use tracing::{Instrument, Span};
+
 use zebra_chain::{
     amount::Amount,
     block::{Block, Height},
@@ -36,6 +27,19 @@ use zebra_node_services::mempool;
 use zebra_rpc::methods::types::submit_block::SubmitBlockChannel;
 use zebra_state::{ChainTipChange, Config as StateConfig, CHAIN_TIP_UPDATE_WAIT_LIMIT};
 use zebra_test::mock_service::{MockService, PanicAssertion};
+
+use crate::{
+    components::{
+        inbound::{downloads::MAX_INBOUND_CONCURRENCY, Inbound, InboundSetupData},
+        mempool::{
+            gossip_mempool_transaction_id, Config as MempoolConfig, Mempool, MempoolError,
+            SameEffectsChainRejectionError, UnboxMempoolError,
+        },
+        sync::{self, BlockGossipError, SyncStatus, PEER_GOSSIP_DELAY},
+    },
+    BoxError,
+};
+
 use InventoryResponse::*;
 
 /// Maximum time to wait for a network service request.

--- a/zebrad/src/components/miner.rs
+++ b/zebrad/src/components/miner.rs
@@ -6,13 +6,15 @@
 //!   <https://github.com/zcash/zcash/blob/6fdd9f1b81d3b228326c9826fa10696fc516444b/src/miner.cpp#L865-L880>
 //! - move common code into zebra-chain or zebra-node-services and remove the RPC dependency.
 
+use std::{cmp::min, sync::Arc, thread::available_parallelism, time::Duration};
+
 use color_eyre::Report;
 use futures::{stream::FuturesUnordered, StreamExt};
-use std::{cmp::min, sync::Arc, thread::available_parallelism, time::Duration};
 use thread_priority::{ThreadBuilder, ThreadPriority};
 use tokio::{select, sync::watch, task::JoinHandle, time::sleep};
 use tower::Service;
 use tracing::{Instrument, Span};
+
 use zebra_chain::{
     block::{self, Block, Height},
     chain_sync_status::ChainSyncStatus,

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -148,6 +148,8 @@
 //! export TMPDIR=/path/to/disk/directory
 //! ```
 
+mod common;
+
 use std::{
     cmp::Ordering,
     collections::HashSet,
@@ -185,10 +187,6 @@ use zebra_rpc::{
     server::OPENED_RPC_ENDPOINT_MSG,
 };
 use zebra_state::{constants::LOCK_FILE_ERROR, state_database_format_version_in_code};
-
-#[cfg(not(target_os = "windows"))]
-use zebra_network::constants::PORT_IN_USE_ERROR;
-
 use zebra_test::{
     args,
     command::{to_regex::CollectRegexSet, ContextFrom},
@@ -196,11 +194,15 @@ use zebra_test::{
 };
 
 #[cfg(not(target_os = "windows"))]
+use zebra_network::constants::PORT_IN_USE_ERROR;
+#[cfg(not(target_os = "windows"))]
 use zebra_test::net::random_known_port;
 
-mod common;
-
 use common::{
+    cached_state::{
+        wait_for_state_version_message, wait_for_state_version_upgrade,
+        DATABASE_FORMAT_UPGRADE_IS_LONG,
+    },
     check::{is_zebrad_version, EphemeralCheck, EphemeralConfig},
     config::{
         config_file_full_path, configs_dir, default_test_config, external_address_test_config,
@@ -219,10 +221,6 @@ use common::{
         TINY_CHECKPOINT_TIMEOUT,
     },
     test_type::TestType::{self, *},
-};
-
-use crate::common::cached_state::{
-    wait_for_state_version_message, wait_for_state_version_upgrade, DATABASE_FORMAT_UPGRADE_IS_LONG,
 };
 
 /// The maximum amount of time that we allow the creation of a future to block the `tokio` executor.

--- a/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
+++ b/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
@@ -5,14 +5,11 @@
 //!
 //! After finishing the sync, it will call getblocktemplate.
 
-use crate::common::{
-    launch::{can_spawn_zebrad_for_test_type, spawn_zebrad_for_rpc},
-    sync::{check_sync_logs_until, MempoolBehavior, SYNC_FINISHED_REGEX},
-    test_type::TestType,
-};
+use std::time::Duration;
+
 use color_eyre::eyre::{eyre, Context, Result};
 use futures::FutureExt;
-use std::time::Duration;
+
 use zebra_chain::{
     parameters::{Network, NetworkUpgrade},
     serialization::ZcashSerialize,
@@ -21,6 +18,12 @@ use zebra_node_services::rpc_client::RpcRequestClient;
 use zebra_rpc::methods::types::get_block_template::{
     proposal::proposal_block_from_template, GetBlockTemplate, JsonParameters, ProposalResponse,
     TimeSource,
+};
+
+use crate::common::{
+    launch::{can_spawn_zebrad_for_test_type, spawn_zebrad_for_rpc},
+    sync::{check_sync_logs_until, MempoolBehavior, SYNC_FINISHED_REGEX},
+    test_type::TestType,
 };
 
 /// Delay between getting block proposal results and cancelling long poll requests.

--- a/zebrad/tests/common/regtest.rs
+++ b/zebrad/tests/common/regtest.rs
@@ -3,14 +3,12 @@
 //! This test will get block templates via the `getblocktemplate` RPC method and submit them as new blocks
 //! via the `submitblock` RPC method on Regtest.
 
-use crate::common::{
-    config::{os_assigned_rpc_port_config, read_listen_addr_from_logs, testdir},
-    launch::ZebradTestDirExt,
-};
-use color_eyre::eyre::{eyre, Context, Result};
 use std::{net::SocketAddr, sync::Arc, time::Duration};
+
+use color_eyre::eyre::{eyre, Context, Result};
 use tower::BoxError;
 use tracing::*;
+
 use zebra_chain::{
     block::{Block, Height},
     parameters::{testnet::REGTEST_NU5_ACTIVATION_HEIGHT, Network, NetworkUpgrade},
@@ -31,6 +29,11 @@ use zebra_rpc::{
     server::{self, OPENED_RPC_ENDPOINT_MSG},
 };
 use zebra_test::args;
+
+use crate::common::{
+    config::{os_assigned_rpc_port_config, read_listen_addr_from_logs, testdir},
+    launch::ZebradTestDirExt,
+};
 
 /// Number of blocks that should be submitted before the test is considered successful.
 const NUM_BLOCKS_TO_SUBMIT: usize = 200;


### PR DESCRIPTION

## Motivation

- PR #9459 messed up a bunch of imports by merging them into one group.

## Solution

- Regroup the imports and order the groups according to how close the group's imports are relative to the given module:
  1. `std`
  2. non-workspace
  3. workspace
  4. crate
  5. submodules

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
