### PR TITLE
Transaction and block deserialization

### DIFF
--- a/zebra-chain/src/block/serialize.rs
+++ b/zebra-chain/src/block/serialize.rs
@@ -4,6 +4,7 @@ use std::{borrow::Borrow, io};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use chrono::{TimeZone, Utc};
+use hex::{FromHex, FromHexError};
 
 use crate::{
     block::{header::ZCASH_BLOCK_VERSION, merkle, Block, CountedHeader, Hash, Header},
@@ -192,5 +193,14 @@ impl AsRef<[u8]> for SerializedBlock {
 impl From<Vec<u8>> for SerializedBlock {
     fn from(bytes: Vec<u8>) -> Self {
         Self { bytes }
+    }
+}
+
+impl FromHex for SerializedBlock {
+    type Error = FromHexError;
+
+    fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
+        let bytes = Vec::from_hex(hex)?;
+        Ok(SerializedBlock { bytes })
     }
 }

--- a/zebra-chain/src/sapling/commitment.rs
+++ b/zebra-chain/src/sapling/commitment.rs
@@ -396,11 +396,7 @@ impl FromHex for NotSmallOrderValueCommitment {
         // Convert from big-endian (display) to little-endian (internal)
         bytes.reverse();
 
-        // Try to construct ValueCommitment from raw bytes
-        let vc = ValueCommitment::try_from(bytes).map_err(|_| FromHexError::InvalidStringLength)?;
-
-        // Check small order and wrap
-        vc.try_into().map_err(|_| FromHexError::InvalidStringLength)
+        Self::zcash_deserialize(Cursor::new(&bytes)).map_err(|_| FromHexError::InvalidStringLength)
     }
 }
 

--- a/zebra-chain/src/sapling/commitment.rs
+++ b/zebra-chain/src/sapling/commitment.rs
@@ -396,7 +396,8 @@ impl FromHex for NotSmallOrderValueCommitment {
         // Convert from big-endian (display) to little-endian (internal)
         bytes.reverse();
 
-        Self::zcash_deserialize(Cursor::new(&bytes)).map_err(|_| FromHexError::InvalidStringLength)
+        Self::zcash_deserialize(io::Cursor::new(&bytes))
+            .map_err(|_| FromHexError::InvalidStringLength)
     }
 }
 

--- a/zebra-chain/src/sapling/commitment.rs
+++ b/zebra-chain/src/sapling/commitment.rs
@@ -563,20 +563,35 @@ mod tests {
     }
 
     #[test]
-    fn not_small_order_value_commitment_hex_roundtrip() {
+    fn value_commitment_hex_roundtrip() {
         use hex::{FromHex, ToHex};
 
         let _init_guard = zebra_test::init();
 
-        let identity_commitment = ValueCommitment(jubjub::AffinePoint::identity());
-        let not_small = NotSmallOrderValueCommitment::try_from(identity_commitment)
-            .expect("identity point is not of small order");
+        let g_point = jubjub::AffinePoint::from_raw_unchecked(
+            jubjub::Fq::from_raw([
+                0xe4b3_d35d_f1a7_adfe,
+                0xcaf5_5d1b_29bf_81af,
+                0x8b0f_03dd_d60a_8187,
+                0x62ed_cbb8_bf37_87c8,
+            ]),
+            jubjub::Fq::from_raw([
+                0x0000_0000_0000_000b,
+                0x0000_0000_0000_0000,
+                0x0000_0000_0000_0000,
+                0x0000_0000_0000_0000,
+            ]),
+        );
 
-        let hex_str = (&not_small).encode_hex::<String>();
+        let value_commitment = ValueCommitment(g_point);
+        let original = NotSmallOrderValueCommitment::try_from(value_commitment)
+            .expect("constructed point must not be small order");
+
+        let hex_str = (&original).encode_hex::<String>();
 
         let decoded = NotSmallOrderValueCommitment::from_hex(&hex_str)
-            .expect("should decode from hex correctly");
+            .expect("hex string should decode successfully");
 
-        assert_eq!(not_small, decoded);
+        assert_eq!(original, decoded);
     }
 }

--- a/zebra-chain/src/transparent/script.rs
+++ b/zebra-chain/src/transparent/script.rs
@@ -2,7 +2,7 @@
 
 use std::{fmt, io};
 
-use hex::ToHex;
+use hex::{FromHex, FromHexError, ToHex};
 
 use crate::serialization::{
     zcash_serialize_bytes, SerializationError, ZcashDeserialize, ZcashSerialize,
@@ -73,6 +73,15 @@ impl ToHex for Script {
 
     fn encode_hex_upper<T: FromIterator<char>>(&self) -> T {
         (&self).encode_hex_upper()
+    }
+}
+
+impl FromHex for Script {
+    type Error = FromHexError;
+
+    fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
+        let bytes = Vec::from_hex(hex)?;
+        Ok(Script::new(&bytes))
     }
 }
 

--- a/zebra-chain/src/work/equihash.rs
+++ b/zebra-chain/src/work/equihash.rs
@@ -2,7 +2,7 @@
 
 use std::{fmt, io};
 
-use hex::ToHex;
+use hex::{FromHex, FromHexError, ToHex};
 use serde_big_array::BigArray;
 
 use crate::{
@@ -284,5 +284,14 @@ impl ToHex for Solution {
 
     fn encode_hex_upper<T: FromIterator<char>>(&self) -> T {
         (&self).encode_hex_upper()
+    }
+}
+
+impl FromHex for Solution {
+    type Error = FromHexError;
+
+    fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
+        let bytes = Vec::from_hex(hex)?;
+        Solution::from_bytes(&bytes).map_err(|_| FromHexError::InvalidStringLength)
     }
 }

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -3007,7 +3007,7 @@ impl GetBlockChainInfo {
 ///
 /// This is used for the input parameter of [`RpcServer::get_address_balance`],
 /// [`RpcServer::get_address_tx_ids`] and [`RpcServer::get_address_utxos`].
-#[derive(Clone, Debug, Eq, PartialEq, Hash, serde::Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, serde::Deserialize, serde::Serialize)]
 pub struct AddressStrings {
     /// A list of transparent address strings.
     addresses: Vec<String>,
@@ -3056,7 +3056,9 @@ impl AddressStrings {
 }
 
 /// The transparent balance of a set of addresses.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash, serde::Serialize)]
+#[derive(
+    Clone, Copy, Debug, Default, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize,
+)]
 pub struct AddressBalance {
     /// The total transparent balance.
     pub balance: u64,
@@ -3191,7 +3193,7 @@ impl SentTransactionHash {
 /// Response to a `getblock` RPC request.
 ///
 /// See the notes for the [`RpcServer::get_block`] method.
-#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(untagged)]
 #[allow(clippy::large_enum_variant)] //TODO: create a struct for the Object and Box it
 pub enum GetBlock {
@@ -3315,7 +3317,7 @@ impl Default for GetBlock {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(untagged)]
 /// The transaction list in a `getblock` call. Can be a list of transaction
 /// IDs or the full transaction details depending on verbosity.
@@ -3329,7 +3331,7 @@ pub enum GetBlockTransaction {
 /// Response to a `getblockheader` RPC request.
 ///
 /// See the notes for the [`RpcServer::get_block_header`] method.
-#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(untagged)]
 pub enum GetBlockHeader {
     /// The request block header, hex-encoded.
@@ -3339,7 +3341,7 @@ pub enum GetBlockHeader {
     Object(Box<GetBlockHeaderObject>),
 }
 
-#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 /// Verbose response to a `getblockheader` RPC request.
 ///
 /// See the notes for the [`RpcServer::get_block_header`] method.
@@ -3469,7 +3471,7 @@ impl Default for GetBlockHash {
 /// Response to a `getrawtransaction` RPC request.
 ///
 /// See the notes for the [`Rpc::get_raw_transaction` method].
-#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(untagged)]
 pub enum GetRawTransaction {
     /// The raw transaction, encoded as hex bytes.
@@ -3487,7 +3489,7 @@ impl Default for GetRawTransaction {
 /// Response to a `getaddressutxos` RPC request.
 ///
 /// See the notes for the [`Rpc::get_address_utxos` method].
-#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct GetAddressUtxos {
     /// The transparent address, base58check encoded
     address: transparent::Address,
@@ -3574,7 +3576,7 @@ impl GetAddressUtxos {
 /// A struct to use as parameter of the `getaddresstxids`.
 ///
 /// See the notes for the [`Rpc::get_address_tx_ids` method].
-#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct GetAddressTxIdsRequest {
     // A list of addresses to get transactions from.
     addresses: Vec<String>,
@@ -3764,11 +3766,12 @@ pub fn height_from_signed_int(index: i32, tip_height: Height) -> Result<Height> 
     }
 }
 
-/// A helper module to serialize `Option<T: ToHex>` as a hex string.
-mod opthex {
-    use hex::ToHex;
-    use serde::Serializer;
+/// A helper module to serialize and deserialize `Option<T: ToHex>` as a hex string.
+pub mod opthex {
+    use hex::{FromHex, ToHex};
+    use serde::{de, Deserialize, Deserializer, Serializer};
 
+    #[allow(missing_docs)]
     pub fn serialize<S, T>(data: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -3781,6 +3784,64 @@ mod opthex {
             }
             None => serializer.serialize_none(),
         }
+    }
+
+    #[allow(missing_docs)]
+    pub fn deserialize<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+    where
+        D: Deserializer<'de>,
+        T: FromHex,
+    {
+        let opt = Option::<String>::deserialize(deserializer)?;
+        match opt {
+            Some(s) => T::from_hex(&s)
+                .map(Some)
+                .map_err(|_e| de::Error::custom("failed to convert hex string")),
+            None => Ok(None),
+        }
+    }
+}
+
+/// A helper module to serialize and deserialize `[u8; N]` as a hex string.
+pub mod arrayhex {
+    use serde::{Deserializer, Serializer};
+    use std::fmt;
+
+    #[allow(missing_docs)]
+    pub fn serialize<S, const N: usize>(data: &[u8; N], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let hex_string = hex::encode(data);
+        serializer.serialize_str(&hex_string)
+    }
+
+    #[allow(missing_docs)]
+    pub fn deserialize<'de, D, const N: usize>(deserializer: D) -> Result<[u8; N], D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct HexArrayVisitor<const N: usize>;
+
+        impl<const N: usize> serde::de::Visitor<'_> for HexArrayVisitor<N> {
+            type Value = [u8; N];
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "a hex string representing exactly {} bytes", N)
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                let vec = hex::decode(v).map_err(E::custom)?;
+                vec.clone().try_into().map_err(|_| {
+                    E::invalid_length(vec.len(), &format!("expected {} bytes", N).as_str())
+                })
+            }
+        }
+
+        deserializer.deserialize_str(HexArrayVisitor::<N>)
     }
 }
 

--- a/zebra-rpc/src/methods/types/transaction.rs
+++ b/zebra-rpc/src/methods/types/transaction.rs
@@ -219,8 +219,8 @@ pub enum Input {
         /// The value of the output being spent in ZEC.
         #[serde(skip_serializing_if = "Option::is_none")]
         value: Option<f64>,
-        /// The value of the output being spent, in zats.
-        #[serde(rename = "valueZat", skip_serializing_if = "Option::is_none")]
+        /// The value of the output being spent, in zats, named to match zcashd.
+        #[serde(rename = "valueSat", skip_serializing_if = "Option::is_none")]
         value_zat: Option<i64>,
         /// The address of the output being spent.
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/zebra-rpc/src/methods/types/transaction.rs
+++ b/zebra-rpc/src/methods/types/transaction.rs
@@ -1,6 +1,7 @@
 //! Transaction-related types.
 
 use super::zec::Zec;
+use crate::methods::arrayhex;
 use chrono::{DateTime, Utc};
 use hex::ToHex;
 use std::sync::Arc;
@@ -141,7 +142,7 @@ impl TransactionTemplate<NegativeOrZero> {
 
 /// A Transaction object as returned by `getrawtransaction` and `getblock` RPC
 /// requests.
-#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct TransactionObject {
     /// The raw transaction, encoded as hex bytes.
     #[serde(with = "hex")]
@@ -194,7 +195,7 @@ pub struct TransactionObject {
 }
 
 /// The transparent input of a transaction.
-#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(untagged)]
 pub enum Input {
     /// A coinbase input.
@@ -228,7 +229,7 @@ pub enum Input {
 }
 
 /// The transparent output of a transaction.
-#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Output {
     /// The value in ZEC.
     value: f64,
@@ -243,7 +244,7 @@ pub struct Output {
 }
 
 /// The scriptPubKey of a transaction output.
-#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ScriptPubKey {
     /// the asm.
     // #9330: The `asm` field is not currently populated.
@@ -262,7 +263,7 @@ pub struct ScriptPubKey {
 }
 
 /// The scriptSig of a transaction input.
-#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ScriptSig {
     /// The asm.
     // #9330: The `asm` field is not currently populated.
@@ -273,7 +274,7 @@ pub struct ScriptSig {
 }
 
 /// A Sapling spend of a transaction.
-#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ShieldedSpend {
     /// Value commitment to the input note.
     #[serde(with = "hex")]
@@ -296,7 +297,7 @@ pub struct ShieldedSpend {
 }
 
 /// A Sapling output of a transaction.
-#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ShieldedOutput {
     /// Value commitment to the input note.
     #[serde(with = "hex")]
@@ -308,7 +309,7 @@ pub struct ShieldedOutput {
     #[serde(rename = "ephemeralKey", with = "hex")]
     ephemeral_key: [u8; 32],
     /// The output note encrypted to the recipient.
-    #[serde(rename = "encCiphertext", with = "hex")]
+    #[serde(rename = "encCiphertext", with = "arrayhex")]
     enc_ciphertext: [u8; 580],
     /// A ciphertext enabling the sender to recover the output note.
     #[serde(rename = "outCiphertext", with = "hex")]
@@ -319,7 +320,7 @@ pub struct ShieldedOutput {
 }
 
 /// Object with Orchard-specific information.
-#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Orchard {
     /// Array of Orchard actions.
     actions: Vec<OrchardAction>,
@@ -332,7 +333,7 @@ pub struct Orchard {
 }
 
 /// The Orchard action of a transaction.
-#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct OrchardAction {
     /// A value commitment to the net value of the input note minus the output note.
     #[serde(with = "hex")]
@@ -350,7 +351,7 @@ pub struct OrchardAction {
     #[serde(rename = "ephemeralKey", with = "hex")]
     ephemeral_key: [u8; 32],
     /// The output note encrypted to the recipient.
-    #[serde(rename = "encCiphertext", with = "hex")]
+    #[serde(rename = "encCiphertext", with = "arrayhex")]
     enc_ciphertext: [u8; 580],
     /// A ciphertext enabling the sender to recover the output note.
     #[serde(rename = "spendAuthSig", with = "hex")]

--- a/zebra-rpc/src/methods/types/transaction.rs
+++ b/zebra-rpc/src/methods/types/transaction.rs
@@ -385,7 +385,7 @@ impl Default for TransactionObject {
 impl TransactionObject {
     /// Converts `tx` and `height` into a new `GetRawTransaction` in the `verbose` format.
     #[allow(clippy::unwrap_in_result)]
-    pub(crate) fn from_transaction(
+    pub fn from_transaction(
         tx: Arc<Transaction>,
         height: Option<block::Height>,
         confirmations: Option<u32>,

--- a/zebra-rpc/src/methods/types/transaction.rs
+++ b/zebra-rpc/src/methods/types/transaction.rs
@@ -269,7 +269,6 @@ pub struct ScriptSig {
     // #9330: The `asm` field is not currently populated.
     asm: String,
     /// The hex.
-    #[serde(with = "hex")]
     hex: Script,
 }
 

--- a/zebra-rpc/src/methods/types/transaction.rs
+++ b/zebra-rpc/src/methods/types/transaction.rs
@@ -213,6 +213,7 @@ pub enum Input {
         /// The vout index.
         vout: u32,
         /// The script.
+        #[serde(rename = "scriptSig")]
         script_sig: ScriptSig,
         /// The script sequence number.
         sequence: u32,


### PR DESCRIPTION
Adds deserialisation to block and transaction structs in zebra for consumption by Zaino.

Fixes several serialisation incompatibilities between zcashd and zebrad.


## Motivation
Currently Zaino uses serialisation impls from zebra but must manually implement `serde::Deserialize` as zebra does not derive this. We would like to use a single source for both serialisation and deserialisation for these structs to avoid changes being made one way but not the other.

## Solution
Adds serde deserialisation to block and transaction structs in zebra that already implement `serde::Serialize`.

Adds deserialisation to `opthex` mod and exposes as pub for consumption by zaino (this code has been in zaino for some time but it would be good to unify).

Adds `arrayhex` serialisation mod for arrays of non standard lengths.

Fixes serialisation incompatibilities in transparent input fields (https://zcash.github.io/rpc/getrawtransaction.html):
\- script_sig: Added serde rename "scriptSig".
\- value_zat: Changed serde rename to match zcashd and zcash RPC spec "valueSat".

Removes double `#[serde(with = "hex")]` declaration for ScriptSig hex field. 

### Tests
Adds `zebra-chain::sapling::commitment::value_commitment_hex_roundtrip` to check `NotSmallOrderValueCommitment` FromHex impl.

### Specifications & References
NA

### Follow-up Work
NA

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
