### PR TITLE
fix(ci): delete scan-test

### DIFF
--- a/.github/workflows/sub-ci-integration-tests-gcp.yml
+++ b/.github/workflows/sub-ci-integration-tests-gcp.yml
@@ -480,29 +480,6 @@ jobs:
       saves_to_disk: false
     secrets: inherit
 
-  # Test that the scan task registers keys, deletes keys, and subscribes to results for keys while running.
-  #
-  # Runs:
-  # - after every PR is merged to `main`
-  # - on every PR update
-  #
-  # If the state version has changed, waits for the new cached states to be created.
-  # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
-  test-scanner:
-    name: Scanner tests
-    needs: [test-full-sync, get-available-disks]
-    uses: ./.github/workflows/sub-deploy-integration-tests-gcp.yml
-    if: ${{ !cancelled() && !failure() && (fromJSON(needs.get-available-disks.outputs.zebra_tip_disk) || needs.test-full-sync.result == 'success') && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
-    with:
-      app_name: zebra-scan
-      test_id: scanner-tests
-      test_description: Tests the scanner.
-      test_variables: "-e NETWORK=${{ inputs.network || vars.ZCASH_NETWORK }} -e TEST_SCANNER=1 -e ZEBRA_CACHE_DIR=/home/zebra/.cache/zebra"
-      needs_zebra_state: true
-      needs_lwd_state: false
-      saves_to_disk: false
-    secrets: inherit
-
   failure-issue:
     name: Open or update issues for main branch failures
     # When a new test is added to this workflow, add it to this list.
@@ -523,7 +500,6 @@ jobs:
         lightwalletd-grpc-test,
         get-block-template-test,
         submit-block-test,
-        test-scanner,
       ]
     # Only open tickets for failed scheduled jobs, manual workflow runs, or `main` branch merges.
     # (PR statuses are already reported in the PR jobs list, and checked by GitHub's Merge Queue.)


### PR DESCRIPTION
## Motivation

The `scan-test` is failing in all the newest pull requests. 

https://github.com/ZcashFoundation/zebra/actions/runs/15037225945/job/42261502063?pr=9526
https://github.com/ZcashFoundation/zebra/actions/runs/15029895378/job/42240336770?pr=9525
https://github.com/ZcashFoundation/zebra/actions/runs/15037110014/job/42261332337?pr=9494
etc

## Solution

As the scanner code is going to be deprecated, instead of trying to figure out what is the problem, we can just remove the test.

### Tests

### Follow-up Work

https://github.com/ZcashFoundation/zebra/issues/9428

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
