### PR TITLE
fix(clippy, build): fix latest Clippy lints introduced in v1.87.0 and migrate from vergen to vergen_git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,16 +640,16 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.18.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1180,6 +1180,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,9 +1667,9 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "git2"
-version = "0.19.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
 dependencies = [
  "bitflags 2.9.0",
  "libc",
@@ -2534,9 +2565,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.17.0+1.8.1"
+version = "0.18.1+1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+checksum = "e1dcb20f84ffcdd825c7a311ae347cce604a6f084a767dec4a4929829645290e"
 dependencies = [
  "cc",
  "libc",
@@ -5402,18 +5433,43 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
-version = "8.3.2"
+version = "9.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2990d9ea5967266ea0ccf413a4aa5c42a93dbcfda9cb49a97de6931726b12566"
+checksum = "6b2bf58be11fc9414104c6d3a2e464163db5ef74b12296bda593cac37b6e4777"
 dependencies = [
  "anyhow",
  "cargo_metadata",
- "cfg-if",
- "git2",
+ "derive_builder",
  "regex",
  "rustc_version",
  "rustversion",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-git2"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f6ee511ec45098eabade8a0750e76eec671e7fb2d9360c563911336bea9cac1"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "git2",
+ "rustversion",
  "time",
+ "vergen",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
 ]
 
 [[package]]
@@ -6684,7 +6740,7 @@ dependencies = [
  "tracing-journald",
  "tracing-subscriber",
  "tracing-test",
- "vergen",
+ "vergen-git2",
  "zebra-chain",
  "zebra-consensus",
  "zebra-grpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ tracing-journald = "0.3.0"
 tracing-subscriber = "0.3.19"
 tracing-test = "0.2.4"
 uint = "0.10.0"
-vergen = { version = "8.3.2", default-features = false }
+vergen-git2 = { version = "1.0.0", default-features = false }
 wagyu-zcash-parameters = "0.2.0"
 x25519-dalek = "2.0.1"
 zcash_note_encryption = "0.4.1"

--- a/zebra-chain/src/block/serialize.rs
+++ b/zebra-chain/src/block/serialize.rs
@@ -64,7 +64,7 @@ fn check_version(version: u32) -> Result<(), &'static str> {
 impl ZcashSerialize for Header {
     #[allow(clippy::unwrap_in_result)]
     fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
-        check_version(self.version).map_err(|msg| io::Error::new(io::ErrorKind::Other, msg))?;
+        check_version(self.version).map_err(io::Error::other)?;
 
         writer.write_u32::<LittleEndian>(self.version)?;
         self.previous_block_hash.zcash_serialize(&mut writer)?;

--- a/zebra-chain/src/transparent/serialize.rs
+++ b/zebra-chain/src/transparent/serialize.rs
@@ -208,8 +208,7 @@ pub(crate) fn write_coinbase_height<W: io::Write>(
         // TODO: update this check based on the consensus rule changes in
         //       https://github.com/zcash/zips/issues/540
         if coinbase_data.0 != GENESIS_COINBASE_DATA {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
+            return Err(io::Error::other(
                 "invalid genesis coinbase data",
             ));
         }

--- a/zebra-chain/src/transparent/serialize.rs
+++ b/zebra-chain/src/transparent/serialize.rs
@@ -208,9 +208,7 @@ pub(crate) fn write_coinbase_height<W: io::Write>(
         // TODO: update this check based on the consensus rule changes in
         //       https://github.com/zcash/zips/issues/540
         if coinbase_data.0 != GENESIS_COINBASE_DATA {
-            return Err(io::Error::other(
-                "invalid genesis coinbase data",
-            ));
+            return Err(io::Error::other("invalid genesis coinbase data"));
         }
     } else if let h @ 1..=16 = height.0 {
         w.write_u8(0x50 + (h as u8))?;

--- a/zebra-test/src/command.rs
+++ b/zebra-test/src/command.rs
@@ -292,10 +292,8 @@ pub fn check_failure_regexes(
     }
 
     // Otherwise, if the process logged a failure message, return an error
-    let error = std::io::Error::new(
-        ErrorKind::Other,
-        format!(
-            "test command:\n\
+    let error = std::io::Error::other(format!(
+        "test command:\n\
              {cmd}\n\n\
              Logged a failure message:\n\
              {line}\n\n\
@@ -303,9 +301,8 @@ pub fn check_failure_regexes(
              {failure_matches:#?}\n\n\
              All Failure regexes: \
              {:#?}\n",
-            failure_regexes.patterns(),
-        ),
-    );
+        failure_regexes.patterns(),
+    ));
 
     Err(error)
 }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -241,7 +241,7 @@ proptest-derive = { workspace = true, optional = true }
 console-subscriber = { workspace = true, optional = true }
 
 [build-dependencies]
-vergen = { workspace = true, features = ["cargo", "git", "git2", "rustc"] }
+vergen-git2 = { workspace = true, features = ["cargo", "rustc"] }
 
 # test feature lightwalletd-grpc-tests
 tonic-build = { workspace = true, optional = true }

--- a/zebrad/build.rs
+++ b/zebrad/build.rs
@@ -6,36 +6,55 @@
 //! When compiling the `lightwalletd` gRPC tests, also builds a gRPC client
 //! Rust API for `lightwalletd`.
 
-use vergen::EmitBuilder;
+use vergen_git2::{CargoBuilder, Emitter, Git2Builder, RustcBuilder};
 
-/// Returns a new `vergen` builder, configured for everything except for `git` env vars.
+/// Configures an [`Emitter`] for everything except for `git` env vars.
 /// This builder fails the build on error.
-fn base_vergen_builder() -> EmitBuilder {
-    let mut vergen = EmitBuilder::builder();
-
-    vergen.all_cargo().all_rustc();
-
-    vergen
+fn add_base_emitter_instructions(emitter: &mut Emitter) {
+    emitter
+        .add_instructions(
+            &CargoBuilder::all_cargo().expect("all_cargo() should build successfully"),
+        )
+        .expect("adding all_cargo() instructions should succeed")
+        .add_instructions(
+            &RustcBuilder::all_rustc().expect("all_rustc() should build successfully"),
+        )
+        .expect("adding all_rustc() instructions should succeed");
 }
 
 /// Process entry point for `zebrad`'s build script
 #[allow(clippy::print_stderr)]
 fn main() {
-    let mut vergen = base_vergen_builder();
+    let mut emitter = Emitter::default();
+    add_base_emitter_instructions(&mut emitter);
 
-    vergen.all_git().git_sha(true);
-    // git adds a "-dirty" flag if there are uncommitted changes.
-    // This doesn't quite match the  SemVer 2.0 format, which uses dot separators.
-    vergen.git_describe(true, true, Some("v*.*.*"));
+    let all_git = Git2Builder::default()
+        .branch(true)
+        .commit_author_email(true)
+        .commit_author_name(true)
+        .commit_count(true)
+        .commit_date(true)
+        .commit_message(true)
+        .commit_timestamp(true)
+        .describe(false, false, None)
+        .sha(true)
+        .dirty(false)
+        .describe(true, true, Some("v*.*.*"))
+        .build()
+        .expect("all_git + describe + sha should build successfully");
+
+    emitter
+        .add_instructions(&all_git)
+        .expect("adding all_git + describe + sha instructions should succeed");
 
     // Disable git if we're building with an invalid `zebra/.git`
-    match vergen.fail_on_error().emit() {
+    match emitter.fail_on_error().emit() {
         Ok(_) => {}
         Err(e) => {
             eprintln!("git error in vergen build script: skipping git env vars: {e:?}",);
-            base_vergen_builder()
-                .emit()
-                .expect("non-git vergen should succeed");
+            let mut emitter = Emitter::default();
+            add_base_emitter_instructions(&mut emitter);
+            emitter.emit().expect("base emit should succeed");
         }
     }
 


### PR DESCRIPTION
## Motivation

We want Zebra to build with the latest version of `rustc`

## Solution

- Fixes the latest clippy lints, mostly with `cargo clippy --fix`.
- Migrate from `vergen` to `vergen_git` ([guide](https://github.com/rustyhorde/vergen/blob/master/MIGRATING_v8_to_v9.md), [new docs](https://docs.rs/vergen-git2/latest/vergen_git2/), [old docs](https://docs.rs/vergen/8.3.2/vergen/))

### Testing

Manually tested to check that the panic output still includes all of the relevant information.