### PR TITLE
zebra-rpc: Correctly set optional `scriptPubKey` fields of transactions

### DIFF
--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@mainnet_10.snap
@@ -30,9 +30,7 @@ expression: block
           "scriptPubKey": {
             "asm": "",
             "hex": "21027a46eb513588b01b37ea24303f4b628afd12cc20df789fede0921e43cad3e875ac",
-            "reqSigs": 0,
-            "type": "",
-            "addresses": []
+            "type": ""
           }
         },
         {

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@testnet_10.snap
@@ -30,9 +30,7 @@ expression: block
           "scriptPubKey": {
             "asm": "",
             "hex": "21025229e1240a21004cf8338db05679fa34753706e84f6aebba086ba04317fd8f99ac",
-            "reqSigs": 0,
-            "type": "",
-            "addresses": []
+            "type": ""
           }
         },
         {

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@mainnet_10.snap
@@ -30,9 +30,7 @@ expression: block
           "scriptPubKey": {
             "asm": "",
             "hex": "21027a46eb513588b01b37ea24303f4b628afd12cc20df789fede0921e43cad3e875ac",
-            "reqSigs": 0,
-            "type": "",
-            "addresses": []
+            "type": ""
           }
         },
         {

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@testnet_10.snap
@@ -30,9 +30,7 @@ expression: block
           "scriptPubKey": {
             "asm": "",
             "hex": "21025229e1240a21004cf8338db05679fa34753706e84f6aebba086ba04317fd8f99ac",
-            "reqSigs": 0,
-            "type": "",
-            "addresses": []
+            "type": ""
           }
         },
         {

--- a/zebra-rpc/src/methods/tests/snapshots/getrawtransaction_verbosity=1@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/getrawtransaction_verbosity=1@mainnet_10.snap
@@ -21,9 +21,7 @@ expression: rsp
         "scriptPubKey": {
           "asm": "",
           "hex": "21027a46eb513588b01b37ea24303f4b628afd12cc20df789fede0921e43cad3e875ac",
-          "reqSigs": 0,
-          "type": "",
-          "addresses": []
+          "type": ""
         }
       },
       {

--- a/zebra-rpc/src/methods/tests/snapshots/getrawtransaction_verbosity=1@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/getrawtransaction_verbosity=1@testnet_10.snap
@@ -21,9 +21,7 @@ expression: rsp
         "scriptPubKey": {
           "asm": "",
           "hex": "21025229e1240a21004cf8338db05679fa34753706e84f6aebba086ba04317fd8f99ac",
-          "reqSigs": 0,
-          "type": "",
-          "addresses": []
+          "type": ""
         }
       },
       {


### PR DESCRIPTION
Closes ZcashFoundation/zebra#9535.

<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

The current `ScriptPubKey` RPC type does not match the output of `zcashd`'s `ScriptPubKeyToUniv`, which breaks Zaino when using `zebra-rpc` as a client connected to `zcashd`.

Additionally, the `zcashd` semantics of `ScriptPubKeyToUniv` mean that the `addresses` and `reqSigs` fields are omitted when the script is non-standard (and thus "required sigs" is a potentially meaningless concept, and also potentially incorrect to set to 0).

## Solution

Does what it says on the tin: alters the implementation to match `zcashd`.

### Tests

Tested in Zallet, and I haven't reproduced the error I was getting before this PR (about the `reqSigs` field missing in the JSON-RPC response).

### Specifications & References

https://github.com/zcash/zcash/blob/1f1f7a385adc048154e7f25a3a0de76f3658ca09/src/core_write.cpp#L124-L149

### Follow-up Work

I found some required fields being set to empty strings, and added TODO comments for them so that it is obvious in the source.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
