### PR TITLE
refactor(ci): Simplify cached disk selection logic

### DIFF
--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -46,11 +46,6 @@ on:
         options:
           - tip
           - checkpoint
-      prefer_main_cached_state:
-        default: false
-        description: "Prefer cached state from the main branch"
-        required: false
-        type: boolean
       need_cached_disk:
         default: true
         description: "Use a cached state disk"
@@ -157,7 +152,6 @@ jobs:
       network: ${{ inputs.network || vars.ZCASH_NETWORK }}
       disk_prefix: zebrad-cache
       disk_suffix: ${{ inputs.cached_disk_type || 'tip' }}
-      prefer_main_cached_state: ${{ inputs.prefer_main_cached_state || (github.event_name == 'push' && github.ref_name == 'main' && true) || false }}
 
   # Each time this workflow is executed, a build will be triggered to create a new image
   # with the corresponding tags using information from Git

--- a/.github/workflows/scripts/gcp-get-cached-disks.sh
+++ b/.github/workflows/scripts/gcp-get-cached-disks.sh
@@ -3,9 +3,9 @@
 # This script finds a cached Google Cloud Compute image based on specific criteria.
 #
 # If there are multiple disks:
-# - if `PREFER_MAIN_CACHED_STATE` is "true", then select an image from the `main` branch, else
-# - try to find a cached disk image from the current branch (or PR), else
-# - try to find an image from any branch.
+# - try to find a cached disk image from the current branch (or PR),
+# - if no image was found, try to find an image from the `main` branch,
+# - if no image was found, try to find an image from any branch.
 #
 # Within each of these categories:
 # - prefer newer images to older images
@@ -47,12 +47,10 @@ if [[ -n "${DISK_PREFIX}" && -n "${DISK_SUFFIX}" ]]; then
     echo "Finding a ${DISK_PREFIX}-${DISK_SUFFIX} disk image for ${NETWORK}..."
     CACHED_DISK_NAME=""
 
-    # Try to find an image based on the `main` branch if that branch is preferred.
-    if [[ "${PREFER_MAIN_CACHED_STATE}" == "true" ]]; then
-        CACHED_DISK_NAME=$(find_cached_disk_image "main-[0-9a-f]+" "main branch")
-    fi
-    # If no image was found, try to find one from the current branch (or PR).
-    CACHED_DISK_NAME=${CACHED_DISK_NAME:-$(find_cached_disk_image ".+-${GITHUB_REF}" "branch")}
+    # Try to find one from the current branch (or PR).
+    CACHED_DISK_NAME=$(find_cached_disk_image ".+-${GITHUB_REF}" "branch")
+    # If no image was found, try to find an image based on the `main` branch.
+    CACHED_DISK_NAME=${CACHED_DISK_NAME:-$(find_cached_disk_image "main-[0-9a-f]+" "main branch")}
     # If we still have no image, try to find one from any branch.
     CACHED_DISK_NAME=${CACHED_DISK_NAME:-$(find_cached_disk_image ".+-[0-9a-f]+" "any branch")}
 

--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -112,7 +112,7 @@ jobs:
   get-disk-name:
     name: Get disk name
     uses: ./.github/workflows/sub-find-cached-disks.yml
-    if: ${{ inputs.needs_zebra_state || inputs.needs_lwd_state }}
+    if: ${{ (inputs.needs_zebra_state || inputs.needs_lwd_state) || (inputs.saves_to_disk || inputs.force_save_to_disk) }}
     with:
       network: ${{ inputs.network || vars.ZCASH_NETWORK }}
       disk_prefix: ${{ inputs.needs_lwd_state && 'lwd-cache' || inputs.needs_zebra_state && 'zebrad-cache' }}
@@ -133,7 +133,7 @@ jobs:
       cached_disk_name: ${{ needs.get-disk-name.outputs.cached_disk_name }}
       state_version: ${{ needs.get-disk-name.outputs.state_version }}
     env:
-      CACHED_DISK_NAME: ${{ needs.get-disk-name.outputs.cached_disk_name }}
+      CACHED_DISK_NAME: ${{ (inputs.needs_zebra_state || inputs.needs_lwd_state) && needs.get-disk-name.outputs.cached_disk_name || '' }}
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -64,11 +64,6 @@ on:
         type: boolean
         description: 'Does the test use Lightwalletd and Zebra cached state?'
       # main branch states can be outdated and slower, but they can also be more reliable
-      prefer_main_cached_state:
-        required: false
-        type: boolean
-        default: false
-        description: 'Does the test prefer to use a main branch cached state?'
       saves_to_disk:
         required: true
         type: boolean
@@ -122,7 +117,6 @@ jobs:
       network: ${{ inputs.network || vars.ZCASH_NETWORK }}
       disk_prefix: ${{ inputs.needs_lwd_state && 'lwd-cache' || inputs.needs_zebra_state && 'zebrad-cache' }}
       disk_suffix: ${{ inputs.disk_suffix }}
-      prefer_main_cached_state: ${{ inputs.prefer_main_cached_state }}
       test_id: ${{ inputs.test_id }}
 
   # Show all the test logs, then follow the logs of the test we just launched, until it finishes.

--- a/.github/workflows/sub-find-cached-disks.yml
+++ b/.github/workflows/sub-find-cached-disks.yml
@@ -20,9 +20,6 @@ on:
       disk_suffix:
         required: false
         type: string
-      prefer_main_cached_state:
-        required: false
-        type: boolean
       test_id:
         description: 'The test ID requiring the cached state disks'
         required: false
@@ -106,7 +103,6 @@ jobs:
           NETWORK: ${{ env.NETWORK }} # use lowercase version from env, not input
           DISK_PREFIX: ${{ inputs.disk_prefix }}
           DISK_SUFFIX: ${{ inputs.disk_suffix }}
-          PREFER_MAIN_CACHED_STATE: ${{ inputs.prefer_main_cached_state }}
         run: |
           source ./.github/workflows/scripts/gcp-get-cached-disks.sh
           echo "state_version=${LOCAL_STATE_VERSION}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Motivation

The previous cached disk selection logic in our CI workflows had a `prefer_main_cached_state` option that, while intended to provide flexibility, made the selection process more complex than necessary and sometimes led to suboptimal cached states choices.

The goal of this change is to simplify the logic and ensure a more reliable and intuitive order for selecting cached states:
1.  Always try to use a cached state from the current branch/PR first.
2.  If not found, fall back to the `main` branch, which is generally the most stable.
3.  If still not found, then look for a cache from any other branch.

This order aims to prevent PRs or other branches from inadvertently using potentially unstable or incompatible cached states from other non-main development branches when their own or `main`'s cache is unavailable. The `main` branch itself will effectively prefer its own cache.

Additionally, we identified an issue where cached disk images could be created without the Zebra state version in their names (e.g., an image named `...-v-...` instead of `...-vX.Y.Z-...`). This typically occurred when the test job responsible for creating the image didn't require an *input* cached state (like full syncs or state regeneration tasks). In such cases, the internal step to determine the current codebase's state version was skipped, leading to the version being omitted from the new image's name.

## Solution

**1. Cached Disk Selection Refinements:**
    -   Removed the `prefer_main_cached_state` input from the following GitHub Actions workflow files:
        -   `.github/workflows/cd-deploy-nodes-gcp.yml`
        -   `.github/workflows/sub-deploy-integration-tests-gcp.yml`
        -   `.github/workflows/sub-find-cached-disks.yml`
    -   Updated the `.github/workflows/scripts/gcp-get-cached-disks.sh` script to reflect the new selection order:
        1.  Search for a cached disk image from the current branch (or PR).
        2.  If no image is found, search for an image from the `main` branch.
        3.  If still no image is found, search for an image from any branch.
    This makes the logic more straightforward and aligns with the desired priority for cache selection.

**2. Ensuring State Version in Image Names:**
    -   The `if` condition for the internal `get-disk-name` job (which calls `sub-find-cached-disks.yml`) has been updated to:
        `if: ${{ (inputs.needs_zebra_state || inputs.needs_lwd_state) || (inputs.saves_to_disk || inputs.force_save_to_disk) }}`.
        This ensures that this job runs (and thus determines the `state_version` from the codebase) not only when an input disk is needed for the test, but critically, also whenever an output disk image is going to be saved (`inputs.saves_to_disk` or `inputs.force_save_to_disk` is true).
    -   The `env.CACHED_DISK_NAME` variable in the `test-result` job (which determines the *input* image for the VM) is now set conditionally:
        `CACHED_DISK_NAME: ${{ (inputs.needs_zebra_state || inputs.needs_lwd_state) && needs.get-disk-name.outputs.cached_disk_name || '' }}`.
        This ensures that an *input* cached disk is only attached to the test VM if `inputs.needs_zebra_state` or `inputs.needs_lwd_state` is true. If these are false (e.g., for a test that generates state from scratch), `CACHED_DISK_NAME` will be empty, and no input image will be used for the VM, even if `get-disk-name` ran to fetch the `state_version` for output labeling.

These combined changes ensure that:
    - The `state_version` (derived from the current codebase) is always determined and available for correctly labeling any newly created disk image.
    - Tests that are *not* supposed to use a pre-existing cached state as input correctly start with a fresh disk, while still allowing the output image to be versioned.


### Tests

These changes are to the CI workflow configuration. Testing will be done by:
-   Observing successful CI runs on this PR, ensuring they:
    - Pick up appropriate cached states or build new ones as expected, following the new disk selection logic.
-   Monitoring CI runs on the `main` branch after this is merged to confirm the new logic behaves correctly across different scenarios.

### PR Checklist

- [X] The PR name is suitable for the release notes.
- [X] The solution is tested.
- [X] The documentation is up to date. <!-- (Consider if any internal CI docs need updating) -->