### PR TITLE
tower-batch-control: Fix `Batch::new` compilation with `tokio_unstable`

### DIFF
--- a/tower-batch-control/src/service.rs
+++ b/tower-batch-control/src/service.rs
@@ -137,6 +137,7 @@ where
             tokio::task::Builder::new()
                 .name(&format!("{} batch", batch_kind))
                 .spawn(worker.run().instrument(span))
+                .expect("panic on error to match tokio::spawn")
         };
         #[cfg(not(tokio_unstable))]
         let worker_handle = tokio::spawn(worker.run().instrument(span));


### PR DESCRIPTION
The stable version uses the panicking `tokio::spawn` API; we unwrap the fallible unstable API to match.

Closes ZcashFoundation/zebra#9546.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
