### PR TITLE
fix(test): update lightwalletd log regex patterns for JSON output format

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -2001,12 +2001,12 @@ fn lightwalletd_integration_test(test_type: TestType) -> Result<()> {
         // getblockchaininfo
         if test_type.needs_zebra_cached_state() {
             lightwalletd.expect_stdout_line_matches(
-                "Got sapling height 419200 block height [0-9]{7} chain main branchID [0-9a-f]{8}",
+                r#""msg":"Got sapling height 419200 block height [0-9]{7} chain main branchID [0-9a-f]{8}""#,
             )?;
         } else {
             // Timeout the test if we're somehow accidentally using a cached state in our temp dir
             lightwalletd.expect_stdout_line_matches(
-                "Got sapling height 419200 block height [0-9]{1,6} chain main branchID 00000000",
+                r#""msg":"Got sapling height 419200 block height [0-9]{1,6} chain main branchID 00000000""#,
             )?;
         }
 


### PR DESCRIPTION
## Motivation

The latest lightwalletd version now outputs structured JSON logs instead of plain text messages. Updated regex patterns in lightwalletd_integration_test to match the new JSON format by looking for messages within the "msg" field.

Previously expected: `"Got sapling height 419200 block height..."`
Now expects: `"msg":"Got sapling height 419200 block height..."`

This change ensures the acceptance tests pass with the updated lightwalletd container image from electriccoinco/lightwalletd:latest.

## Solution

Update the regex pattern

### Specifications & References

References: https://hub.docker.com/layers/electriccoinco/lightwalletd/latest/images/sha256-7791924635f3d9ca59900278e4f167b511928decfd37dcb75778fc59bd52255e

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
