### PR TITLE
fix(ci): prevent Google Cloud workflow failures on fork PRs

### DIFF
--- a/.github/workflows/cd-deploy-nodes-gcp.patch-external.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.patch-external.yml
@@ -24,6 +24,6 @@ jobs:
     name: Build CD Docker / Build images
     # Only run on PRs from external repositories, skipping ZF branches and tags.
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'

--- a/.github/workflows/cd-deploy-nodes-gcp.yml
+++ b/.github/workflows/cd-deploy-nodes-gcp.yml
@@ -160,6 +160,7 @@ jobs:
   build:
     name: Build CD Docker
     uses: ./.github/workflows/sub-build-docker-image.yml
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     with:
       dockerfile_path: ./docker/Dockerfile
       dockerfile_target: runtime


### PR DESCRIPTION
## Motivation

Resolves authentication errors when workflows run from forked repositories, for example https://github.com/ZcashFoundation/zebra/actions/runs/15329084682/job/43131092455?pr=8751


## Solution

- Add missing fork condition to build job in main CD workflow
- Fix inverted fork condition in patch-external workflow


### Tests

Hard to test without a fork, but trust me :) 

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [x] The documentation is up to date.
