### PR TITLE
fix(ci): pin lightwalletd to `v0.4.17` to prevent CI failures

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -114,7 +114,7 @@ RUN --mount=type=bind,source=zebrad,target=zebrad \
     cp ${HOME}/target/release/zebra-checkpoints /usr/local/bin
 
 # Copy the lightwalletd binary and source files to be able to run tests
-COPY --from=electriccoinco/lightwalletd:latest /usr/local/bin/lightwalletd /usr/local/bin/
+COPY --from=electriccoinco/lightwalletd:v0.4.17 /usr/local/bin/lightwalletd /usr/local/bin/
 
 # Copy the gosu binary to be able to run the entrypoint as non-root user
 # and allow to change permissions for mounted cache directories


### PR DESCRIPTION
## Motivation

The latest lightwalletd broke our lightwalletd integration tests.

## Solution

- Pin the version in our CI Dockerfile

### Tests

Failing test should pass here: `Test integration with lightwalletd`

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [x] The documentation is up to date.
