### PR TITLE
fix(network): Allow local outbound connections on Regtest

### DIFF
--- a/book/src/user/custom-testnets.md
+++ b/book/src/user/custom-testnets.md
@@ -156,7 +156,7 @@ The remaining consensus differences between Mainnet and Testnet could be made co
 ## Differences Between Custom Testnets and Regtest
 
 Zebra's Regtest network is a special case of a custom Testnet that:
-- Won't make peer connections[^fn4],
+- Won't make remote peer connections[^fn4],
 - Skips Proof-of-Work validation,
 - Uses a reserved network magic and network name,
 - Activates network upgrades up to and including Canopy at block height 1,
@@ -183,4 +183,4 @@ Zebra nodes on custom Testnets will also reject peer connections with nodes that
 
 [^fn3]: Configuring any of the Testnet parameters that are currently configurable except the network name will result in an incompatible custom Testnet, these are: the network magic, network upgrade activation heights, slow start interval, genesis hash, disabled Proof-of-Work and target difficulty limit.
 
-[^fn4]: Zebra won't make outbound peer connections on Regtest, but currently still listens for inbound peer connections, which will be rejected unless they use the Regtest network magic, and Zcash nodes using the Regtest network magic should not be making outbound peer connections. It may be updated to skip initialization of the peerset service altogether so that it won't listen for peer connections at all when support for isolated custom Testnets is added.
+[^fn4]: Zebra won't make remote outbound peer connections on Regtest, but currently still listens for remote inbound peer connections, which will be rejected unless they use the Regtest network magic, and Zcash nodes using the Regtest network magic should not be making outbound peer connections. It may be updated to skip initialization of the peerset service altogether so that it won't listen for peer connections at all when support for isolated custom Testnets is added.

--- a/zebra-network/src/meta_addr/peer_addr.rs
+++ b/zebra-network/src/meta_addr/peer_addr.rs
@@ -77,7 +77,7 @@ impl PeerSocketAddr {
         **self
     }
 
-    /// Returns true if the inner [`SocketAddr`]'s IP address is `127.0.0.1` or `::1` the localhost IP.
+    /// Returns true if the inner [`SocketAddr`]'s IP is the localhost IP.
     pub fn is_localhost(&self) -> bool {
         let ip = self.0.ip();
         ip == Ipv4Addr::LOCALHOST || ip == Ipv6Addr::LOCALHOST

--- a/zebra-network/src/meta_addr/peer_addr.rs
+++ b/zebra-network/src/meta_addr/peer_addr.rs
@@ -3,7 +3,7 @@
 
 use std::{
     fmt,
-    net::{Ipv4Addr, SocketAddr},
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
     ops::{Deref, DerefMut},
     str::FromStr,
 };
@@ -75,5 +75,11 @@ impl PeerSocketAddr {
     /// be printed and logged.
     pub fn remove_socket_addr_privacy(&self) -> SocketAddr {
         **self
+    }
+
+    /// Returns true if the inner [`SocketAddr`]'s IP address is `127.0.0.1` or `::1` the localhost IP.
+    pub fn is_localhost(&self) -> bool {
+        let ip = self.0.ip();
+        ip == Ipv4Addr::LOCALHOST || ip == Ipv6Addr::LOCALHOST
     }
 }


### PR DESCRIPTION
## Motivation

We want to allow outbound connections to peers on localhost when using Regtest.

Closes #9182.

## Solution

Instead of returning an empty set as the initial peer list for Regtest, filter out any configured initial peer addresses that are not on localhost

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [x] The documentation is up to date.
