### PR TITLE
fix(consensus): reuse sighasher when validating txs

### DIFF
--- a/zebra-chain/src/error.rs
+++ b/zebra-chain/src/error.rs
@@ -1,6 +1,6 @@
 //! Errors that can occur inside any `zebra-chain` submodule.
 
-use std::io;
+use std::{io, sync::Arc};
 use thiserror::Error;
 
 // TODO: Move all these enums into a common enum at the bottom.
@@ -57,17 +57,47 @@ pub enum AddressError {
 }
 
 /// `zebra-chain`'s errors
-#[derive(Error, Debug)]
+#[derive(Clone, Error, Debug)]
 pub enum Error {
     /// Invalid consensus branch ID.
     #[error("invalid consensus branch id")]
     InvalidConsensusBranchId,
 
     /// Zebra's type could not be converted to its librustzcash equivalent.
-    #[error("Zebra's type could not be converted to its librustzcash equivalent: ")]
-    Conversion(#[from] io::Error),
+    #[error("Zebra's type could not be converted to its librustzcash equivalent: {0}")]
+    Conversion(#[from] Arc<io::Error>),
 
     /// The transaction is missing a network upgrade.
     #[error("the transaction is missing a network upgrade")]
     MissingNetworkUpgrade,
 }
+
+/// Allow converting `io::Error` to `Error`; we need this since we
+/// use `Arc<io::Error>` in `Error::Conversion`.
+impl From<io::Error> for Error {
+    fn from(value: io::Error) -> Self {
+        Arc::new(value).into()
+    }
+}
+
+// We need to implement this manually because io::Error does not implement
+// PartialEq.
+impl PartialEq for Error {
+    fn eq(&self, other: &Self) -> bool {
+        match self {
+            Error::InvalidConsensusBranchId => matches!(other, Error::InvalidConsensusBranchId),
+            Error::Conversion(e) => {
+                if let Error::Conversion(o) = other {
+                    // Not perfect, but good enough for testing, which
+                    // is the main purpose for our usage of PartialEq for errors
+                    e.to_string() == o.to_string()
+                } else {
+                    false
+                }
+            }
+            Error::MissingNetworkUpgrade => matches!(other, Error::MissingNetworkUpgrade),
+        }
+    }
+}
+
+impl Eq for Error {}

--- a/zebra-chain/src/primitives/zcash_primitives.rs
+++ b/zebra-chain/src/primitives/zcash_primitives.rs
@@ -1,7 +1,7 @@
 //! Contains code that interfaces with the zcash_primitives crate from
 //! librustzcash.
 
-use std::{io, ops::Deref};
+use std::{io, ops::Deref, sync::Arc};
 
 use zcash_primitives::transaction::{self as zp_tx, TxDigests};
 use zcash_protocol::value::BalanceError;
@@ -19,17 +19,17 @@ use crate::{
 // Used by boilerplate code below.
 
 #[derive(Clone, Debug)]
-struct TransparentAuth<'a> {
-    all_prev_outputs: &'a [transparent::Output],
+struct TransparentAuth {
+    all_prev_outputs: Arc<Vec<transparent::Output>>,
 }
 
-impl zcash_transparent::bundle::Authorization for TransparentAuth<'_> {
+impl zcash_transparent::bundle::Authorization for TransparentAuth {
     type ScriptSig = zcash_primitives::legacy::Script;
 }
 
 // In this block we convert our Output to a librustzcash to TxOut.
 // (We could do the serialize/deserialize route but it's simple enough to convert manually)
-impl zcash_transparent::sighash::TransparentAuthorizingContext for TransparentAuth<'_> {
+impl zcash_transparent::sighash::TransparentAuthorizingContext for TransparentAuth {
     fn input_amounts(&self) -> Vec<zcash_protocol::value::Zatoshis> {
         self.all_prev_outputs
             .iter()
@@ -56,13 +56,12 @@ impl zcash_transparent::sighash::TransparentAuthorizingContext for TransparentAu
 // to compute sighash.
 // TODO: remove/change if they improve the API to not require this.
 
-struct MapTransparent<'a> {
-    auth: TransparentAuth<'a>,
+struct MapTransparent {
+    auth: TransparentAuth,
 }
 
-impl<'a>
-    zcash_transparent::bundle::MapAuth<zcash_transparent::bundle::Authorized, TransparentAuth<'a>>
-    for MapTransparent<'a>
+impl zcash_transparent::bundle::MapAuth<zcash_transparent::bundle::Authorized, TransparentAuth>
+    for MapTransparent
 {
     fn map_script_sig(
         &self,
@@ -71,7 +70,7 @@ impl<'a>
         s
     }
 
-    fn map_authorization(&self, _: zcash_transparent::bundle::Authorized) -> TransparentAuth<'a> {
+    fn map_authorization(&self, _: zcash_transparent::bundle::Authorized) -> TransparentAuth {
         // TODO: This map should consume self, so we can move self.auth
         self.auth.clone()
     }
@@ -133,12 +132,10 @@ impl zp_tx::components::orchard::MapAuth<orchard::bundle::Authorized, orchard::b
 }
 
 #[derive(Debug)]
-struct PrecomputedAuth<'a> {
-    _phantom: std::marker::PhantomData<&'a ()>,
-}
+struct PrecomputedAuth {}
 
-impl<'a> zp_tx::Authorization for PrecomputedAuth<'a> {
-    type TransparentAuth = TransparentAuth<'a>;
+impl zp_tx::Authorization for PrecomputedAuth {
+    type TransparentAuth = TransparentAuth;
     type SaplingAuth = sapling_crypto::bundle::Authorized;
     type OrchardAuth = orchard::bundle::Authorized;
 }
@@ -197,13 +194,13 @@ impl From<Script> for zcash_primitives::legacy::Script {
 
 /// Precomputed data used for sighash or txid computation.
 #[derive(Debug)]
-pub(crate) struct PrecomputedTxData<'a> {
-    tx_data: zp_tx::TransactionData<PrecomputedAuth<'a>>,
+pub(crate) struct PrecomputedTxData {
+    tx_data: zp_tx::TransactionData<PrecomputedAuth>,
     txid_parts: TxDigests<blake2b_simd::Hash>,
-    all_previous_outputs: &'a [transparent::Output],
+    all_previous_outputs: Arc<Vec<transparent::Output>>,
 }
 
-impl<'a> PrecomputedTxData<'a> {
+impl PrecomputedTxData {
     /// Computes the data used for sighash or txid computation.
     ///
     /// # Inputs
@@ -238,10 +235,10 @@ impl<'a> PrecomputedTxData<'a> {
     /// [ZIP-252]: <https://zips.z.cash/zip-0252>
     /// [ZIP-253]: <https://zips.z.cash/zip-0253>
     pub(crate) fn new(
-        tx: &'a Transaction,
+        tx: &Transaction,
         nu: NetworkUpgrade,
-        all_previous_outputs: &'a [transparent::Output],
-    ) -> PrecomputedTxData<'a> {
+        all_previous_outputs: Arc<Vec<transparent::Output>>,
+    ) -> PrecomputedTxData {
         let tx = tx
             .to_librustzcash(nu)
             .expect("`zcash_primitives` and Zebra tx formats must be compatible");
@@ -250,7 +247,7 @@ impl<'a> PrecomputedTxData<'a> {
 
         let f_transparent = MapTransparent {
             auth: TransparentAuth {
-                all_prev_outputs: all_previous_outputs,
+                all_prev_outputs: all_previous_outputs.clone(),
             },
         };
 

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -1,6 +1,6 @@
 //! Transactions and transaction-related structures.
 
-use std::{collections::HashMap, fmt, iter};
+use std::{collections::HashMap, fmt, iter, sync::Arc};
 
 use halo2::pasta::pallas;
 
@@ -245,7 +245,7 @@ impl Transaction {
         &self,
         nu: NetworkUpgrade,
         hash_type: sighash::HashType,
-        all_previous_outputs: &[transparent::Output],
+        all_previous_outputs: Arc<Vec<transparent::Output>>,
         input_index_script_code: Option<(usize, Vec<u8>)>,
     ) -> SigHash {
         sighash::SigHasher::new(self, nu, all_previous_outputs)
@@ -253,11 +253,11 @@ impl Transaction {
     }
 
     /// Return a [`SigHasher`] for this transaction.
-    pub fn sighasher<'a>(
-        &'a self,
+    pub fn sighasher(
+        &self,
         nu: NetworkUpgrade,
-        all_previous_outputs: &'a [transparent::Output],
-    ) -> sighash::SigHasher<'a> {
+        all_previous_outputs: Arc<Vec<transparent::Output>>,
+    ) -> sighash::SigHasher {
         sighash::SigHasher::new(self, nu, all_previous_outputs)
     }
 

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -51,6 +51,7 @@ use crate::{
         CoinbaseSpendRestriction::{self, *},
     },
     value_balance::{ValueBalance, ValueBalanceError},
+    Error,
 };
 
 /// A Zcash transaction.
@@ -247,9 +248,9 @@ impl Transaction {
         hash_type: sighash::HashType,
         all_previous_outputs: Arc<Vec<transparent::Output>>,
         input_index_script_code: Option<(usize, Vec<u8>)>,
-    ) -> SigHash {
-        sighash::SigHasher::new(self, nu, all_previous_outputs)
-            .sighash(hash_type, input_index_script_code)
+    ) -> Result<SigHash, Error> {
+        Ok(sighash::SigHasher::new(self, nu, all_previous_outputs)?
+            .sighash(hash_type, input_index_script_code))
     }
 
     /// Return a [`SigHasher`] for this transaction.
@@ -257,7 +258,7 @@ impl Transaction {
         &self,
         nu: NetworkUpgrade,
         all_previous_outputs: Arc<Vec<transparent::Output>>,
-    ) -> sighash::SigHasher {
+    ) -> Result<sighash::SigHasher, Error> {
         sighash::SigHasher::new(self, nu, all_previous_outputs)
     }
 

--- a/zebra-chain/src/transaction/sighash.rs
+++ b/zebra-chain/src/transaction/sighash.rs
@@ -1,5 +1,7 @@
 //! Signature hashes for Zcash transactions
 
+use std::sync::Arc;
+
 use zcash_transparent::sighash::SighashType;
 
 use super::Transaction;
@@ -67,24 +69,24 @@ impl AsRef<[u8]> for SigHash {
 /// A SigHasher context which stores precomputed data that is reused
 /// between sighash computations for the same transaction.
 #[derive(Debug)]
-pub struct SigHasher<'a> {
-    precomputed_tx_data: PrecomputedTxData<'a>,
+pub struct SigHasher {
+    precomputed_tx_data: PrecomputedTxData,
 }
 
-impl<'a> SigHasher<'a> {
+impl SigHasher {
     /// Create a new SigHasher for the given transaction.
     ///
     /// # Panics
     ///
     /// - If `trans` can't be converted to its `librustzcash` equivalent. This could happen, for
     ///   example, if `trans` contains the `nConsensusBranchId` field, and `nu` doesn't match it.
-    ///   More details in [`PrecomputedTxData::new`].
-    /// - If `nu` doesn't contain a consensus branch id convertible to its `librustzcash`
+    ///   More details [`PrecomputedTxData::new`].
+    /// - If `nu` doesn't contain a consensuranch id convertible to its `librustzcash`
     ///   equivalent.
     pub fn new(
-        trans: &'a Transaction,
+        trans: &Transaction,
         nu: NetworkUpgrade,
-        all_previous_outputs: &'a [transparent::Output],
+        all_previous_outputs: Arc<Vec<transparent::Output>>,
     ) -> Self {
         SigHasher {
             precomputed_tx_data: PrecomputedTxData::new(trans, nu, all_previous_outputs),

--- a/zebra-chain/src/transaction/sighash.rs
+++ b/zebra-chain/src/transaction/sighash.rs
@@ -7,7 +7,7 @@ use zcash_transparent::sighash::SighashType;
 use super::Transaction;
 
 use crate::parameters::NetworkUpgrade;
-use crate::transparent;
+use crate::{transparent, Error};
 
 use crate::primitives::zcash_primitives::{sighash, PrecomputedTxData};
 
@@ -87,10 +87,10 @@ impl SigHasher {
         trans: &Transaction,
         nu: NetworkUpgrade,
         all_previous_outputs: Arc<Vec<transparent::Output>>,
-    ) -> Self {
-        SigHasher {
-            precomputed_tx_data: PrecomputedTxData::new(trans, nu, all_previous_outputs),
-        }
+    ) -> Result<Self, Error> {
+        Ok(SigHasher {
+            precomputed_tx_data: PrecomputedTxData::new(trans, nu, all_previous_outputs)?,
+        })
     }
 
     /// Calculate the sighash for the current transaction.

--- a/zebra-chain/src/transaction/sighash.rs
+++ b/zebra-chain/src/transaction/sighash.rs
@@ -80,8 +80,8 @@ impl SigHasher {
     ///
     /// - If `trans` can't be converted to its `librustzcash` equivalent. This could happen, for
     ///   example, if `trans` contains the `nConsensusBranchId` field, and `nu` doesn't match it.
-    ///   More details [`PrecomputedTxData::new`].
-    /// - If `nu` doesn't contain a consensuranch id convertible to its `librustzcash`
+    ///   More details in [`PrecomputedTxData::new`].
+    /// - If `nu` doesn't contain a consensus branch id convertible to its `librustzcash`
     ///   equivalent.
     pub fn new(
         trans: &Transaction,

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -874,20 +874,16 @@ fn consensus_branch_id() {
             tx.to_librustzcash(any_other_nu)
                 .expect_err("tx is not convertible under nu other than the tx one");
 
-            std::panic::catch_unwind(|| {
-                PrecomputedTxData::new(&tx, any_other_nu, Arc::new(Vec::new()))
-            })
-            .expect_err("precomputing tx sighash data panics under nu other than the tx one");
+            let err = PrecomputedTxData::new(&tx, any_other_nu, Arc::new(Vec::new())).unwrap_err();
+            assert!(matches!(err, crate::Error::InvalidConsensusBranchId));
 
-            std::panic::catch_unwind(|| {
-                sighash::SigHasher::new(&tx, any_other_nu, Arc::new(Vec::new()))
-            })
-            .expect_err("creating the sighasher panics under nu other than the tx one");
+            let err = sighash::SigHasher::new(&tx, any_other_nu, Arc::new(Vec::new())).unwrap_err();
+            assert!(matches!(err, crate::Error::InvalidConsensusBranchId));
 
-            std::panic::catch_unwind(|| {
-                tx.sighash(any_other_nu, HashType::ALL, Arc::new(Vec::new()), None)
-            })
-            .expect_err("the sighash computation panics under nu other than the tx one");
+            let err = tx
+                .sighash(any_other_nu, HashType::ALL, Arc::new(Vec::new()), None)
+                .unwrap_err();
+            assert!(matches!(err, crate::Error::InvalidConsensusBranchId));
         }
     }
 }

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -875,15 +875,24 @@ fn consensus_branch_id() {
                 .expect_err("tx is not convertible under nu other than the tx one");
 
             let err = PrecomputedTxData::new(&tx, any_other_nu, Arc::new(Vec::new())).unwrap_err();
-            assert!(matches!(err, crate::Error::InvalidConsensusBranchId));
+            assert!(
+                matches!(err, crate::Error::InvalidConsensusBranchId),
+                "precomputing tx sighash data errors under nu other than the tx one"
+            );
 
             let err = sighash::SigHasher::new(&tx, any_other_nu, Arc::new(Vec::new())).unwrap_err();
-            assert!(matches!(err, crate::Error::InvalidConsensusBranchId));
+            assert!(
+                matches!(err, crate::Error::InvalidConsensusBranchId),
+                "creating the sighasher errors under nu other than the tx one"
+            );
 
             let err = tx
                 .sighash(any_other_nu, HashType::ALL, Arc::new(Vec::new()), None)
                 .unwrap_err();
-            assert!(matches!(err, crate::Error::InvalidConsensusBranchId));
+            assert!(
+                matches!(err, crate::Error::InvalidConsensusBranchId),
+                "the sighash computation errors under nu other than the tx one"
+            );
         }
     }
 }

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -490,7 +490,8 @@ fn test_vec143_1() -> Result<()> {
         &transaction,
         NetworkUpgrade::Overwinter,
         Arc::new(Vec::new()),
-    );
+    )
+    .expect("network upgrade is valid for tx");
 
     let hash = hasher.sighash(HashType::ALL, None);
     let expected = "a1f1a4e5cd9bd522322d661edd2af1bf2a7019cfab94ece18f4ba935b0a19073";
@@ -526,7 +527,8 @@ fn test_vec143_2() -> Result<()> {
         &transaction,
         NetworkUpgrade::Overwinter,
         Arc::new(all_previous_outputs),
-    );
+    )
+    .expect("network upgrade is valid for tx");
 
     let hash = hasher.sighash(
         HashType::SINGLE,
@@ -553,7 +555,8 @@ fn test_vec243_1() -> Result<()> {
 
     let transaction = ZIP243_1.zcash_deserialize_into::<Transaction>()?;
 
-    let hasher = SigHasher::new(&transaction, NetworkUpgrade::Sapling, Arc::new(Vec::new()));
+    let hasher = SigHasher::new(&transaction, NetworkUpgrade::Sapling, Arc::new(Vec::new()))
+        .expect("network upgrade is valid for tx");
 
     let hash = hasher.sighash(HashType::ALL, None);
     let expected = "63d18534de5f2d1c9e169b73f9c783718adbef5c8a7d55b5e7a37affa1dd3ff3";
@@ -568,7 +571,8 @@ fn test_vec243_1() -> Result<()> {
     assert_eq!(expected, result);
 
     let precomputed_tx_data =
-        PrecomputedTxData::new(&transaction, NetworkUpgrade::Sapling, Arc::new(Vec::new()));
+        PrecomputedTxData::new(&transaction, NetworkUpgrade::Sapling, Arc::new(Vec::new()))
+            .expect("network upgrade is valid for tx");
     let alt_sighash =
         crate::primitives::zcash_primitives::sighash(&precomputed_tx_data, HashType::ALL, None);
     let result = hex::encode(alt_sighash);
@@ -596,7 +600,8 @@ fn test_vec243_2() -> Result<()> {
         &transaction,
         NetworkUpgrade::Sapling,
         Arc::new(all_previous_outputs),
-    );
+    )
+    .expect("network upgrade is valid for tx");
 
     let hash = hasher.sighash(
         HashType::NONE,
@@ -625,7 +630,8 @@ fn test_vec243_2() -> Result<()> {
         &transaction,
         NetworkUpgrade::Sapling,
         Arc::new(all_previous_outputs),
-    );
+    )
+    .expect("network upgrade is valid for tx");
     let alt_sighash = crate::primitives::zcash_primitives::sighash(
         &precomputed_tx_data,
         HashType::NONE,
@@ -657,7 +663,8 @@ fn test_vec243_3() -> Result<()> {
         &transaction,
         NetworkUpgrade::Sapling,
         Arc::new(all_previous_outputs),
-    );
+    )
+    .expect("network upgrade is valid for tx");
 
     let hash = hasher.sighash(
         HashType::ALL,
@@ -688,7 +695,8 @@ fn test_vec243_3() -> Result<()> {
         &transaction,
         NetworkUpgrade::Sapling,
         Arc::new(all_previous_outputs),
-    );
+    )
+    .expect("network upgrade is valid for tx");
     let alt_sighash = crate::primitives::zcash_primitives::sighash(
         &precomputed_tx_data,
         HashType::ALL,
@@ -720,17 +728,21 @@ fn zip143_sighash() -> Result<()> {
             Some(output) => mock_pre_v5_output_list(output, input_index.unwrap()),
             None => vec![],
         };
-        let result = hex::encode(transaction.sighash(
-            NetworkUpgrade::try_from(test.consensus_branch_id).expect("network upgrade"),
-            HashType::from_bits(test.hash_type).expect("must be a valid HashType"),
-            Arc::new(all_previous_outputs),
-            input_index.map(|input_index| {
-                (
-                    input_index,
-                    output.unwrap().lock_script.as_raw_bytes().to_vec(),
+        let result = hex::encode(
+            transaction
+                .sighash(
+                    NetworkUpgrade::try_from(test.consensus_branch_id).expect("network upgrade"),
+                    HashType::from_bits(test.hash_type).expect("must be a valid HashType"),
+                    Arc::new(all_previous_outputs),
+                    input_index.map(|input_index| {
+                        (
+                            input_index,
+                            output.unwrap().lock_script.as_raw_bytes().to_vec(),
+                        )
+                    }),
                 )
-            }),
-        ));
+                .expect("network upgrade is valid for tx"),
+        );
         let expected = hex::encode(test.sighash);
         assert_eq!(expected, result, "test #{i}: sighash does not match");
     }
@@ -758,17 +770,21 @@ fn zip243_sighash() -> Result<()> {
             Some(output) => mock_pre_v5_output_list(output, input_index.unwrap()),
             None => vec![],
         };
-        let result = hex::encode(transaction.sighash(
-            NetworkUpgrade::try_from(test.consensus_branch_id).expect("network upgrade"),
-            HashType::from_bits(test.hash_type).expect("must be a valid HashType"),
-            Arc::new(all_previous_outputs),
-            input_index.map(|input_index| {
-                (
-                    input_index,
-                    output.unwrap().lock_script.as_raw_bytes().to_vec(),
+        let result = hex::encode(
+            transaction
+                .sighash(
+                    NetworkUpgrade::try_from(test.consensus_branch_id).expect("network upgrade"),
+                    HashType::from_bits(test.hash_type).expect("must be a valid HashType"),
+                    Arc::new(all_previous_outputs),
+                    input_index.map(|input_index| {
+                        (
+                            input_index,
+                            output.unwrap().lock_script.as_raw_bytes().to_vec(),
+                        )
+                    }),
                 )
-            }),
-        ));
+                .expect("network upgrade is valid for tx"),
+        );
         let expected = hex::encode(test.sighash);
         assert_eq!(expected, result, "test #{i}: sighash does not match");
     }
@@ -794,24 +810,30 @@ fn zip244_sighash() -> Result<()> {
                 .collect(),
         );
 
-        let result = hex::encode(transaction.sighash(
-            NetworkUpgrade::Nu5,
-            HashType::ALL,
-            all_previous_outputs.clone(),
-            None,
-        ));
+        let result = hex::encode(
+            transaction
+                .sighash(
+                    NetworkUpgrade::Nu5,
+                    HashType::ALL,
+                    all_previous_outputs.clone(),
+                    None,
+                )
+                .expect("network upgrade is valid for tx"),
+        );
         let expected = hex::encode(test.sighash_shielded);
         assert_eq!(expected, result, "test #{i}: sighash does not match");
 
         if let Some(sighash_all) = test.sighash_all {
             let result = hex::encode(
-                transaction.sighash(
-                    NetworkUpgrade::Nu5,
-                    HashType::ALL,
-                    all_previous_outputs,
-                    test.transparent_input
-                        .map(|idx| (idx as _, test.script_pubkeys[idx as usize].clone())),
-                ),
+                transaction
+                    .sighash(
+                        NetworkUpgrade::Nu5,
+                        HashType::ALL,
+                        all_previous_outputs,
+                        test.transparent_input
+                            .map(|idx| (idx as _, test.script_pubkeys[idx as usize].clone())),
+                    )
+                    .expect("network upgrade is valid for tx"),
             );
             let expected = hex::encode(sighash_all);
             assert_eq!(expected, result, "test #{i}: sighash does not match");
@@ -840,9 +862,12 @@ fn consensus_branch_id() {
 
             tx.to_librustzcash(tx_nu)
                 .expect("tx is convertible under tx nu");
-            PrecomputedTxData::new(&tx, tx_nu, Arc::new(Vec::new()));
-            sighash::SigHasher::new(&tx, tx_nu, Arc::new(Vec::new()));
-            tx.sighash(tx_nu, HashType::ALL, Arc::new(Vec::new()), None);
+            PrecomputedTxData::new(&tx, tx_nu, Arc::new(Vec::new()))
+                .expect("network upgrade is valid for tx");
+            sighash::SigHasher::new(&tx, tx_nu, Arc::new(Vec::new()))
+                .expect("network upgrade is valid for tx");
+            tx.sighash(tx_nu, HashType::ALL, Arc::new(Vec::new()), None)
+                .expect("network upgrade is valid for tx");
 
             // All computations should fail under an nu other than the tx one.
 
@@ -898,7 +923,9 @@ fn binding_signatures() {
                         ..
                     } => {
                         if let Some(sapling_shielded_data) = sapling_shielded_data {
-                            let sighash = tx.sighash(nu, HashType::ALL, Arc::new(Vec::new()), None);
+                            let sighash = tx
+                                .sighash(nu, HashType::ALL, Arc::new(Vec::new()), None)
+                                .expect("network upgrade is valid for tx");
 
                             let bvk = redjubjub::VerificationKey::try_from(
                                 sapling_shielded_data.binding_verification_key(),
@@ -927,7 +954,9 @@ fn binding_signatures() {
                                 continue;
                             }
 
-                            let sighash = tx.sighash(nu, HashType::ALL, Arc::new(Vec::new()), None);
+                            let sighash = tx
+                                .sighash(nu, HashType::ALL, Arc::new(Vec::new()), None)
+                                .expect("network upgrade is valid for tx");
 
                             let bvk = redjubjub::VerificationKey::try_from(
                                 sapling_shielded_data.binding_verification_key(),
@@ -957,7 +986,9 @@ fn binding_signatures() {
                                 continue;
                             }
 
-                            let sighash = tx.sighash(nu, HashType::ALL, Arc::new(Vec::new()), None);
+                            let sighash = tx
+                                .sighash(nu, HashType::ALL, Arc::new(Vec::new()), None)
+                                .expect("network upgrade is valid for tx");
 
                             let bvk = redjubjub::VerificationKey::try_from(
                                 sapling_shielded_data.binding_verification_key(),

--- a/zebra-consensus/src/block/tests.rs
+++ b/zebra-consensus/src/block/tests.rs
@@ -17,7 +17,6 @@ use zebra_chain::{
     transaction::{arbitrary::transaction_to_fake_v5, LockTime, Transaction},
     work::difficulty::{ParameterDifficulty as _, INVALID_COMPACT_DIFFICULTY},
 };
-use zebra_script::CachedFfiTransaction;
 use zebra_test::transcript::{ExpectedTranscriptError, Transcript};
 
 use crate::transaction;
@@ -703,9 +702,7 @@ fn legacy_sigops_count_for_large_generated_blocks() {
     let block = large_single_transaction_block_many_inputs();
     let mut legacy_sigop_count = 0;
     for transaction in block.transactions {
-        let cached_ffi_transaction =
-            Arc::new(CachedFfiTransaction::new(transaction.clone(), Vec::new()));
-        let tx_sigop_count = cached_ffi_transaction.legacy_sigop_count();
+        let tx_sigop_count = zebra_script::legacy_sigop_count(&transaction);
         assert_eq!(tx_sigop_count, Ok(0));
         legacy_sigop_count += tx_sigop_count.expect("unexpected invalid sigop count");
     }
@@ -715,9 +712,7 @@ fn legacy_sigops_count_for_large_generated_blocks() {
     let block = large_multi_transaction_block();
     let mut legacy_sigop_count = 0;
     for transaction in block.transactions {
-        let cached_ffi_transaction =
-            Arc::new(CachedFfiTransaction::new(transaction.clone(), Vec::new()));
-        let tx_sigop_count = cached_ffi_transaction.legacy_sigop_count();
+        let tx_sigop_count = zebra_script::legacy_sigop_count(&transaction);
         assert_eq!(tx_sigop_count, Ok(1));
         legacy_sigop_count += tx_sigop_count.expect("unexpected invalid sigop count");
     }
@@ -738,10 +733,7 @@ fn legacy_sigops_count_for_historic_blocks() {
             .zcash_deserialize_into()
             .expect("block test vector is valid");
         for transaction in block.transactions {
-            let cached_ffi_transaction =
-                Arc::new(CachedFfiTransaction::new(transaction.clone(), Vec::new()));
-            legacy_sigop_count += cached_ffi_transaction
-                .legacy_sigop_count()
+            legacy_sigop_count += zebra_script::legacy_sigop_count(&transaction)
                 .expect("unexpected invalid sigop count");
         }
         // Test that historic blocks pass the sigops check.

--- a/zebra-consensus/src/block/tests.rs
+++ b/zebra-consensus/src/block/tests.rs
@@ -702,9 +702,10 @@ fn legacy_sigops_count_for_large_generated_blocks() {
     let block = large_single_transaction_block_many_inputs();
     let mut legacy_sigop_count = 0;
     for transaction in block.transactions {
-        let tx_sigop_count = zebra_script::legacy_sigop_count(&transaction);
-        assert_eq!(tx_sigop_count, Ok(0));
-        legacy_sigop_count += tx_sigop_count.expect("unexpected invalid sigop count");
+        let tx_sigop_count =
+            zebra_script::legacy_sigop_count(&transaction).expect("unexpected invalid sigop count");
+        assert_eq!(tx_sigop_count, 0);
+        legacy_sigop_count += tx_sigop_count;
     }
     // We know this block has no sigops.
     assert_eq!(legacy_sigop_count, 0);
@@ -712,9 +713,10 @@ fn legacy_sigops_count_for_large_generated_blocks() {
     let block = large_multi_transaction_block();
     let mut legacy_sigop_count = 0;
     for transaction in block.transactions {
-        let tx_sigop_count = zebra_script::legacy_sigop_count(&transaction);
-        assert_eq!(tx_sigop_count, Ok(1));
-        legacy_sigop_count += tx_sigop_count.expect("unexpected invalid sigop count");
+        let tx_sigop_count =
+            zebra_script::legacy_sigop_count(&transaction).expect("unexpected invalid sigop count");
+        assert_eq!(tx_sigop_count, 1);
+        legacy_sigop_count += tx_sigop_count;
     }
     // Test that large blocks can actually fail the sigops check.
     assert!(legacy_sigop_count > MAX_BLOCK_SIGOPS);

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -491,7 +491,7 @@ where
 
             let nu = req.upgrade(&network);
             let cached_ffi_transaction =
-                Arc::new(CachedFfiTransaction::new(tx.clone(), Arc::new(spent_outputs), nu));
+                Arc::new(CachedFfiTransaction::new(tx.clone(), Arc::new(spent_outputs), nu).map_err(|_| TransactionError::UnsupportedByNetworkUpgrade(tx.version(), nu))?);
 
             tracing::trace!(?tx_id, "got state UTXOs");
 

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -1791,7 +1791,7 @@ fn v4_transaction_with_conflicting_sprout_nullifier_inside_joinsplit_is_rejected
         };
 
         // Sign the transaction
-        let sighash = transaction.sighash(nu, HashType::ALL, &[], None);
+        let sighash = transaction.sighash(nu, HashType::ALL, Arc::new(Vec::new()), None);
 
         match &mut transaction {
             Transaction::V4 {
@@ -1864,7 +1864,7 @@ fn v4_transaction_with_conflicting_sprout_nullifier_across_joinsplits_is_rejecte
         };
 
         // Sign the transaction
-        let sighash = transaction.sighash(nu, HashType::ALL, &[], None);
+        let sighash = transaction.sighash(nu, HashType::ALL, Arc::new(Vec::new()), None);
 
         match &mut transaction {
             Transaction::V4 {

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -1791,7 +1791,9 @@ fn v4_transaction_with_conflicting_sprout_nullifier_inside_joinsplit_is_rejected
         };
 
         // Sign the transaction
-        let sighash = transaction.sighash(nu, HashType::ALL, Arc::new(Vec::new()), None);
+        let sighash = transaction
+            .sighash(nu, HashType::ALL, Arc::new(Vec::new()), None)
+            .expect("network upgrade should be valid for tx");
 
         match &mut transaction {
             Transaction::V4 {
@@ -1864,7 +1866,9 @@ fn v4_transaction_with_conflicting_sprout_nullifier_across_joinsplits_is_rejecte
         };
 
         // Sign the transaction
-        let sighash = transaction.sighash(nu, HashType::ALL, Arc::new(Vec::new()), None);
+        let sighash = transaction
+            .sighash(nu, HashType::ALL, Arc::new(Vec::new()), None)
+            .expect("network upgrade should be valid for tx");
 
         match &mut transaction {
             Transaction::V4 {

--- a/zebra-rpc/src/methods/types/transaction.rs
+++ b/zebra-rpc/src/methods/types/transaction.rs
@@ -15,7 +15,6 @@ use zebra_chain::{
     transparent::Script,
 };
 use zebra_consensus::groth16::Description;
-use zebra_script::CachedFfiTransaction;
 use zebra_state::IntoDisk;
 
 use super::zec::Zec;
@@ -117,12 +116,10 @@ impl TransactionTemplate<NegativeOrZero> {
             .constrain()
             .expect("negating a NonNegative amount always results in a valid NegativeOrZero");
 
-        let legacy_sigop_count = CachedFfiTransaction::new(tx.transaction.clone(), Vec::new())
-            .legacy_sigop_count()
-            .expect(
-                "invalid generated coinbase transaction: \
+        let legacy_sigop_count = zebra_script::legacy_sigop_count(&tx.transaction).expect(
+            "invalid generated coinbase transaction: \
                  failure in zcash_script sigop count",
-            );
+        );
 
         Self {
             data: tx.transaction.as_ref().into(),

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -83,7 +83,10 @@ pub struct CachedFfiTransaction {
 
     /// The outputs from previous transactions that match each input in the transaction
     /// being verified.
-    all_previous_outputs: Vec<transparent::Output>,
+    all_previous_outputs: Arc<Vec<transparent::Output>>,
+
+    /// The sighasher context to use to compute sighashes.
+    sighasher: SigHasher,
 }
 
 /// A sighash context used for the zcash_script sighash callback.
@@ -91,7 +94,7 @@ struct SigHashContext<'a> {
     /// The index of the input being verified.
     input_index: usize,
     /// The SigHasher for the transaction being verified.
-    sighasher: SigHasher<'a>,
+    sighasher: &'a SigHasher,
 }
 
 /// The sighash callback to use with zcash_script.
@@ -127,11 +130,14 @@ impl CachedFfiTransaction {
     /// being verified.
     pub fn new(
         transaction: Arc<Transaction>,
-        all_previous_outputs: Vec<transparent::Output>,
+        all_previous_outputs: Arc<Vec<transparent::Output>>,
+        nu: NetworkUpgrade,
     ) -> Self {
+        let sighasher = transaction.sighasher(nu, all_previous_outputs.clone());
         Self {
             transaction,
             all_previous_outputs,
+            sighasher,
         }
     }
 
@@ -146,10 +152,15 @@ impl CachedFfiTransaction {
         &self.all_previous_outputs
     }
 
+    /// Return the sighasher being used for this transaction.
+    pub fn sighasher(&self) -> &SigHasher {
+        &self.sighasher
+    }
+
     /// Verify if the script in the input at `input_index` of a transaction correctly spends the
     /// matching [`transparent::Output`] it refers to.
     #[allow(clippy::unwrap_in_result)]
-    pub fn is_valid(&self, nu: NetworkUpgrade, input_index: usize) -> Result<(), Error> {
+    pub fn is_valid(&self, input_index: usize) -> Result<(), Error> {
         let previous_output = self
             .all_previous_outputs
             .get(input_index)
@@ -193,7 +204,7 @@ impl CachedFfiTransaction {
 
         let ctx = Box::new(SigHashContext {
             input_index: n_in,
-            sighasher: SigHasher::new(&self.transaction, nu, &self.all_previous_outputs),
+            sighasher: &self.sighasher,
         });
         // SAFETY: The `script_*` fields are created from a valid Rust `slice`.
         let ret = unsafe {
@@ -217,46 +228,46 @@ impl CachedFfiTransaction {
             Err(Error::from(err))
         }
     }
+}
 
-    /// Returns the number of transparent signature operations in the
-    /// transparent inputs and outputs of this transaction.
-    #[allow(clippy::unwrap_in_result)]
-    pub fn legacy_sigop_count(&self) -> Result<u64, Error> {
-        let mut count: u64 = 0;
+/// Returns the number of transparent signature operations in the
+/// transparent inputs and outputs of the given transaction.
+#[allow(clippy::unwrap_in_result)]
+pub fn legacy_sigop_count(transaction: &Transaction) -> Result<u64, Error> {
+    let mut count: u64 = 0;
 
-        for input in self.transaction.inputs() {
-            count += match input {
-                transparent::Input::PrevOut {
-                    outpoint: _,
-                    unlock_script,
-                    sequence: _,
-                } => {
-                    let script = unlock_script.as_raw_bytes();
-                    // SAFETY: `script` is created from a valid Rust `slice`.
-                    unsafe {
-                        zcash_script::zcash_script_legacy_sigop_count_script(
-                            script.as_ptr(),
-                            script.len() as u32,
-                        )
-                    }
+    for input in transaction.inputs() {
+        count += match input {
+            transparent::Input::PrevOut {
+                outpoint: _,
+                unlock_script,
+                sequence: _,
+            } => {
+                let script = unlock_script.as_raw_bytes();
+                // SAFETY: `script` is created from a valid Rust `slice`.
+                unsafe {
+                    zcash_script::zcash_script_legacy_sigop_count_script(
+                        script.as_ptr(),
+                        script.len() as u32,
+                    )
                 }
-                transparent::Input::Coinbase { .. } => 0,
-            } as u64;
-        }
-
-        for output in self.transaction.outputs() {
-            let script = output.lock_script.as_raw_bytes();
-            // SAFETY: `script` is created from a valid Rust `slice`.
-            let ret = unsafe {
-                zcash_script::zcash_script_legacy_sigop_count_script(
-                    script.as_ptr(),
-                    script.len() as u32,
-                )
-            };
-            count += ret as u64;
-        }
-        Ok(count)
+            }
+            transparent::Input::Coinbase { .. } => 0,
+        } as u64;
     }
+
+    for output in transaction.outputs() {
+        let script = output.lock_script.as_raw_bytes();
+        // SAFETY: `script` is created from a valid Rust `slice`.
+        let ret = unsafe {
+            zcash_script::zcash_script_legacy_sigop_count_script(
+                script.as_ptr(),
+                script.len() as u32,
+            )
+        };
+        count += ret as u64;
+    }
+    Ok(count)
 }
 
 #[cfg(test)]
@@ -292,9 +303,9 @@ mod tests {
         };
         let input_index = 0;
 
-        let previous_output = vec![output];
-        let verifier = super::CachedFfiTransaction::new(transaction, previous_output);
-        verifier.is_valid(nu, input_index)?;
+        let previous_output = Arc::new(vec![output]);
+        let verifier = super::CachedFfiTransaction::new(transaction, previous_output, nu);
+        verifier.is_valid(input_index)?;
 
         Ok(())
     }
@@ -318,8 +329,7 @@ mod tests {
         let transaction =
             SCRIPT_TX.zcash_deserialize_into::<Arc<zebra_chain::transaction::Transaction>>()?;
 
-        let cached_tx = super::CachedFfiTransaction::new(transaction, Vec::new());
-        assert_eq!(cached_tx.legacy_sigop_count()?, 1);
+        assert_eq!(super::legacy_sigop_count(&transaction)?, 1);
 
         Ok(())
     }
@@ -337,9 +347,13 @@ mod tests {
             lock_script: transparent::Script::new(&SCRIPT_PUBKEY.clone()[..]),
         };
         let input_index = 0;
-        let verifier = super::CachedFfiTransaction::new(transaction, vec![output]);
+        let verifier = super::CachedFfiTransaction::new(
+            transaction,
+            Arc::new(vec![output]),
+            NetworkUpgrade::Blossom,
+        );
         verifier
-            .is_valid(NetworkUpgrade::Blossom, input_index)
+            .is_valid(input_index)
             .expect_err("verification should fail");
 
         Ok(())
@@ -358,12 +372,16 @@ mod tests {
             lock_script: transparent::Script::new(&SCRIPT_PUBKEY.clone()),
         };
 
-        let verifier = super::CachedFfiTransaction::new(transaction, vec![output]);
+        let verifier = super::CachedFfiTransaction::new(
+            transaction,
+            Arc::new(vec![output]),
+            NetworkUpgrade::Blossom,
+        );
 
         let input_index = 0;
 
-        verifier.is_valid(NetworkUpgrade::Blossom, input_index)?;
-        verifier.is_valid(NetworkUpgrade::Blossom, input_index)?;
+        verifier.is_valid(input_index)?;
+        verifier.is_valid(input_index)?;
 
         Ok(())
     }
@@ -381,13 +399,17 @@ mod tests {
         let transaction =
             SCRIPT_TX.zcash_deserialize_into::<Arc<zebra_chain::transaction::Transaction>>()?;
 
-        let verifier = super::CachedFfiTransaction::new(transaction, vec![output]);
+        let verifier = super::CachedFfiTransaction::new(
+            transaction,
+            Arc::new(vec![output]),
+            NetworkUpgrade::Blossom,
+        );
 
         let input_index = 0;
 
-        verifier.is_valid(NetworkUpgrade::Blossom, input_index)?;
+        verifier.is_valid(input_index)?;
         verifier
-            .is_valid(NetworkUpgrade::Blossom, input_index + 1)
+            .is_valid(input_index + 1)
             .expect_err("verification should fail");
 
         Ok(())
@@ -406,14 +428,18 @@ mod tests {
         let transaction =
             SCRIPT_TX.zcash_deserialize_into::<Arc<zebra_chain::transaction::Transaction>>()?;
 
-        let verifier = super::CachedFfiTransaction::new(transaction, vec![output]);
+        let verifier = super::CachedFfiTransaction::new(
+            transaction,
+            Arc::new(vec![output]),
+            NetworkUpgrade::Blossom,
+        );
 
         let input_index = 0;
 
         verifier
-            .is_valid(NetworkUpgrade::Blossom, input_index + 1)
+            .is_valid(input_index + 1)
             .expect_err("verification should fail");
-        verifier.is_valid(NetworkUpgrade::Blossom, input_index)?;
+        verifier.is_valid(input_index)?;
 
         Ok(())
     }
@@ -431,16 +457,20 @@ mod tests {
         let transaction =
             SCRIPT_TX.zcash_deserialize_into::<Arc<zebra_chain::transaction::Transaction>>()?;
 
-        let verifier = super::CachedFfiTransaction::new(transaction, vec![output]);
+        let verifier = super::CachedFfiTransaction::new(
+            transaction,
+            Arc::new(vec![output]),
+            NetworkUpgrade::Blossom,
+        );
 
         let input_index = 0;
 
         verifier
-            .is_valid(NetworkUpgrade::Blossom, input_index + 1)
+            .is_valid(input_index + 1)
             .expect_err("verification should fail");
 
         verifier
-            .is_valid(NetworkUpgrade::Blossom, input_index + 1)
+            .is_valid(input_index + 1)
             .expect_err("verification should fail");
 
         Ok(())
@@ -460,9 +490,13 @@ mod tests {
             Output::zcash_deserialize(&hex::decode(serialized_output).unwrap().to_vec()[..])
                 .unwrap();
 
-        let verifier = super::CachedFfiTransaction::new(Arc::new(tx), vec![previous_output]);
+        let verifier = super::CachedFfiTransaction::new(
+            Arc::new(tx),
+            Arc::new(vec![previous_output]),
+            NetworkUpgrade::Nu5,
+        );
 
-        verifier.is_valid(NetworkUpgrade::Nu5, 0)?;
+        verifier.is_valid(0)?;
 
         Ok(())
     }


### PR DESCRIPTION
## Motivation

We were creating a new sighasher context for each input being verified, which is incredibly wasteful - not only because the sighasher context can be reused, but also because building the sighasher requires converting from a Zebra tx to a librustzcash tx via serializing/deserializing, and librustzcash deserializing also suffers from #7939 

Closes #9532 

## Solution

Create a sighasher in `CachedFfiTransaction::new()` and use it for all validations. Also reuse it when verifying shielded transactions.

This required changing the wrap the `all_previous_outputs` `Vec<Output>` in an `Arc`. It was possible to just move it all the way down to the `PrecomputedData` and add getters for it all the way back to `CachedFfiTransaction`, but using `Arc` seemed much simpler and mimics how `Transaction` is handled (also with an `Arc`)

I also moved `legacy_sigop_count()` out of `CachedFfiTransaction` because otherwise using it would require creating a `CachedFfiTransaction` with a dummy network upgrade; and I think it didn't actually belong there because it does not use anything in `CachedFfiTransaction` other then the transaction reference itself.

### Tests

Existing tests should ensure it will work.

We don't have benchmarks for this but the performance gains should be immediate. I'll also run a full sync to see what happens.


### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
