### PR TITLE
fix(ci): mark `sync-to-checkpoint` test as long-running

### DIFF
--- a/.github/workflows/sub-ci-integration-tests-gcp.yml
+++ b/.github/workflows/sub-ci-integration-tests-gcp.yml
@@ -80,6 +80,8 @@ jobs:
       test_id: sync-to-checkpoint
       test_description: Test sync up to mandatory checkpoint
       test_variables: "NETWORK=${{ inputs.network || vars.ZCASH_NETWORK }},TEST_DISK_REBUILD=1,ZEBRA_CACHE_DIR=/home/zebra/.cache/zebra"
+      # This test commonly less than 3 hours by October 2024, but now it takes longer
+      is_long_test: true
       needs_zebra_state: false
       saves_to_disk: true
       force_save_to_disk: ${{ inputs.force_save_to_disk || false }}

--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -310,12 +310,9 @@ jobs:
           --ssh-flag="-o ConnectTimeout=5" \
           --command="
           echo 'Streaming logs and waiting for test success message...';
-          sudo docker logs
-          --tail all
-          --follow
-          ${CONTAINER_ID}
-          | tee --output-error=exit-nopipe /dev/stderr
-          | grep --max-count=1 --extended-regexp --color=always
+          sudo docker logs --tail all --follow ${CONTAINER_ID} \
+          | tee --output-error=exit-nopipe /dev/stderr \
+          | grep --max-count=1 --extended-regexp --color=always \
           'test result: .*ok.* [1-9][0-9]* passed.*finished in';
           LOGS_EXIT_STATUS=\$?;
           echo 'Waiting for container ${CONTAINER_ID} to exit...';

--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -302,18 +302,13 @@ jobs:
       - name: Result of ${{ inputs.test_id }} test
         run: |
           CONTAINER_ID="${{ steps.find-container.outputs.CONTAINER_ID }}"
+          echo "Using pre-discovered container ID: ${CONTAINER_ID}"
           gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ vars.GCP_ZONE }} \
           --ssh-flag="-o ServerAliveInterval=5" \
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
           --command=' \
-          echo "Waiting for container to start..."; \
-          CONTAINER_ID=""; \
-          CONTAINER_PREFIX="klt-${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}"; \
-          for i in {1..30}; do CONTAINER_ID=$(sudo docker ps --filter name=${CONTAINER_PREFIX} -q --no-trunc); if [ -n "${CONTAINER_ID}" ]; then break; fi; echo "Waiting for container ID starting with ${CONTAINER_PREFIX}... ($i/30)"; sleep 2; done; \
-          if [ -z "${CONTAINER_ID}" ]; then echo "Container ID starting with ${CONTAINER_PREFIX} not found after waiting."; exit 1; fi; \
-          echo "Found test container ID: ${CONTAINER_ID}"; \
           echo "Streaming logs and waiting for test success message..."; \
           sudo docker logs \
           --tail all \

--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -132,6 +132,7 @@ jobs:
     outputs:
       cached_disk_name: ${{ (inputs.needs_zebra_state || inputs.needs_lwd_state) && needs.get-disk-name.outputs.cached_disk_name || '' }}
       state_version: ${{ (inputs.needs_zebra_state || inputs.needs_lwd_state) && needs.get-disk-name.outputs.state_version || '' }}
+      container_id: ${{ steps.find-container.outputs.CONTAINER_ID }}
     env:
       CACHED_DISK_NAME: ${{ (inputs.needs_zebra_state || inputs.needs_lwd_state) && needs.get-disk-name.outputs.cached_disk_name || '' }}
     permissions:
@@ -232,6 +233,7 @@ jobs:
           --container-tty \
           --container-image="${GAR_BASE_TRIMMED}/${{ vars.CI_IMAGE_NAME }}:sha-${{ env.GITHUB_SHA_SHORT }}" \
           --container-env="${CONTAINER_ENV}" \
+          --container-restart-policy=never \
           --subnet=${{ vars.GCP_SUBNETWORK }} \
           --scopes cloud-platform \
           --service-account=${{ vars.GCP_DEPLOYMENTS_SA }} \
@@ -257,6 +259,36 @@ jobs:
           sudo journalctl -b \
           '
 
+      # Find the container ID and save it for use in subsequent steps
+      - name: Find container ID
+        id: find-container
+        run: |
+          INSTANCE_NAME="${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}"
+          CONTAINER_PREFIX="klt-${INSTANCE_NAME}"
+
+          echo "Looking for container with prefix: ${CONTAINER_PREFIX}"
+
+          # Wait up to 60 seconds for container to start
+          for attempt in {1..30}; do
+            echo "Attempt ${attempt}/30: Checking for running container..."
+            CONTAINER_ID=$(gcloud compute ssh ${INSTANCE_NAME} \
+              --zone ${{ vars.GCP_ZONE }} \
+              --ssh-flag="-o ServerAliveInterval=5" \
+              --ssh-flag="-o ConnectionAttempts=20" \
+              --ssh-flag="-o ConnectTimeout=5" \
+              --command="sudo docker ps --filter name=${CONTAINER_PREFIX} -q --no-trunc" 2>/dev/null || echo "")
+            if [ -n "${CONTAINER_ID}" ]; then
+              echo "Found running container: ${CONTAINER_ID}"
+              echo "CONTAINER_ID=${CONTAINER_ID}" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+            echo "No running container found yet, waiting 2 seconds..."
+            sleep 2
+          done
+
+          echo "Container not found after 60 seconds"
+          exit 1
+
       # Check that the container executed at least 1 Rust test harness test, and that all tests passed.
       # Then wait for the container to finish, and exit with the test's exit status.
       # Also shows all the test logs.
@@ -269,6 +301,7 @@ jobs:
       # (`docker wait` can also wait for multiple containers, but we only ever wait for a single container.)
       - name: Result of ${{ inputs.test_id }} test
         run: |
+          CONTAINER_ID="${{ steps.find-container.outputs.CONTAINER_ID }}"
           gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
           --zone ${{ vars.GCP_ZONE }} \
           --ssh-flag="-o ServerAliveInterval=5" \
@@ -424,20 +457,14 @@ jobs:
           INSTANCE_NAME="${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}"
 
           echo "Fetching first 1000 log entries via SSH for instance ${INSTANCE_NAME} to find DB versions..."
+          CONTAINER_ID="${{ steps.find-container.outputs.CONTAINER_ID }}"
           DOCKER_LOGS=$( \
           gcloud compute ssh ${INSTANCE_NAME} \
           --zone ${{ vars.GCP_ZONE }} \
           --ssh-flag="-o ServerAliveInterval=5" \
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
-          --command=' \
-          CONTAINER_ID=$(sudo docker ps -q --no-trunc | head -n 1); \
-          if [ -n "${CONTAINER_ID}" ]; then \
-             sudo docker logs ${CONTAINER_ID} | head -1000; \
-          else \
-             echo "Error: No running container found."; exit 1; \
-          fi; \
-          ' \
+          --command="sudo docker logs ${CONTAINER_ID} | head -1000" \
           )
 
           if [[ $? -ne 0 ]] || [[ -z "$DOCKER_LOGS" ]] || [[ "$DOCKER_LOGS" == *"Error: No running container found."* ]]; then
@@ -527,20 +554,14 @@ jobs:
           INSTANCE_NAME="${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}"
 
           echo "Fetching last 200 log entries via SSH for instance ${INSTANCE_NAME} to find sync height..."
+          CONTAINER_ID="${{ steps.find-container.outputs.CONTAINER_ID }}"
           DOCKER_LOGS=$( \
           gcloud compute ssh ${INSTANCE_NAME} \
           --zone ${{ vars.GCP_ZONE }} \
           --ssh-flag="-o ServerAliveInterval=5" \
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
-          --command=' \
-          CONTAINER_ID=$(sudo docker ps -q --no-trunc | head -n 1); \
-          if [ -n "${CONTAINER_ID}" ]; then \
-             sudo docker logs --tail 200 ${CONTAINER_ID}; \
-          else \
-             echo "Error: No running container found."; exit 1; \
-          fi; \
-          ' \
+          --command="sudo docker logs --tail 200 ${CONTAINER_ID}" \
           )
 
           if [[ $? -ne 0 ]] || [[ -z "$DOCKER_LOGS" ]] || [[ "$DOCKER_LOGS" == *"Error: No running container found."* ]]; then

--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -308,37 +308,33 @@ jobs:
           --ssh-flag="-o ServerAliveInterval=5" \
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
-          --command=' \
-          echo "Streaming logs and waiting for test success message..."; \
-          sudo docker logs \
-          --tail all \
-          --follow \
-          ${CONTAINER_ID} \
-          | tee --output-error=exit-nopipe /dev/stderr \
-          | grep --max-count=1 --extended-regexp --color=always \
-          "test result: .*ok.* [1-9][0-9]* passed.*finished in";
-          LOGS_EXIT_STATUS=$?;
-          echo "Waiting for container ${CONTAINER_ID} to exit...";
-          EXIT_STATUS=$(sudo docker wait ${CONTAINER_ID} || echo "Error retrieving exit status");
-          echo "Container exit status: $EXIT_STATUS";
+          --command="
+          echo 'Streaming logs and waiting for test success message...';
+          sudo docker logs
+          --tail all
+          --follow
+          ${CONTAINER_ID}
+          | tee --output-error=exit-nopipe /dev/stderr
+          | grep --max-count=1 --extended-regexp --color=always
+          'test result: .*ok.* [1-9][0-9]* passed.*finished in';
+          LOGS_EXIT_STATUS=\$?;
+          echo 'Waiting for container ${CONTAINER_ID} to exit...';
+          EXIT_STATUS=\$(sudo docker wait ${CONTAINER_ID} || echo 'Error retrieving exit status');
+          echo 'Container exit status: '\$EXIT_STATUS;
 
-          if [ $LOGS_EXIT_STATUS -ne 0 ]; then
-            # Grep failed (pattern not found)
-            echo "Test failed: Success log pattern not found (grep exit status: $LOGS_EXIT_STATUS).";
+          if [ \$LOGS_EXIT_STATUS -ne 0 ]; then
+            echo 'Test failed: Success log pattern not found (grep exit status: '\$LOGS_EXIT_STATUS').';
             exit 1;
           else
-            # Grep succeeded (pattern found), now check specific exit code
-            if [ "$EXIT_STATUS" -eq 1 ]; then
-              # Explicit failure code 1
-              echo "Test failed: Success log pattern found BUT container exited with status 1.";
+            if [ \"\$EXIT_STATUS\" -eq 1 ]; then
+              echo 'Test failed: Success log pattern found BUT container exited with status 1.';
               exit 1;
             else
-              # Grep succeeded and exit status is not 1
-              echo "Test successful: Success log pattern found. Container exit status $EXIT_STATUS ignored (as it is not 1).";
+              echo 'Test successful: Success log pattern found. Container exit status '\$EXIT_STATUS' ignored (as it is not 1).';
               exit 0;
             fi
-          fi \
-          '
+          fi
+          "
 
   # create a state image from the instance's state disk, if requested by the caller
   create-state-image:

--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -445,7 +445,7 @@ jobs:
           INSTANCE_NAME="${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}"
 
           echo "Fetching first 1000 log entries via SSH for instance ${INSTANCE_NAME} to find DB versions..."
-          CONTAINER_ID="${{ steps.find-container.outputs.CONTAINER_ID }}"
+          CONTAINER_ID="${{ needs.test-result.outputs.container_id }}"
           DOCKER_LOGS=$( \
           gcloud compute ssh ${INSTANCE_NAME} \
           --zone ${{ vars.GCP_ZONE }} \
@@ -455,8 +455,8 @@ jobs:
           --command="sudo docker logs ${CONTAINER_ID} | head -1000" \
           )
 
-          if [[ $? -ne 0 ]] || [[ -z "$DOCKER_LOGS" ]] || [[ "$DOCKER_LOGS" == *"Error: No running container found."* ]]; then
-              echo "Failed to retrieve logs via SSH or no container found."
+          if [[ $? -ne 0 ]] || [[ -z "$DOCKER_LOGS" ]]; then
+              echo "Failed to retrieve logs via SSH."
               exit 1
           fi
 
@@ -542,7 +542,7 @@ jobs:
           INSTANCE_NAME="${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}"
 
           echo "Fetching last 200 log entries via SSH for instance ${INSTANCE_NAME} to find sync height..."
-          CONTAINER_ID="${{ steps.find-container.outputs.CONTAINER_ID }}"
+          CONTAINER_ID="${{ needs.test-result.outputs.container_id }}"
           DOCKER_LOGS=$( \
           gcloud compute ssh ${INSTANCE_NAME} \
           --zone ${{ vars.GCP_ZONE }} \
@@ -552,8 +552,8 @@ jobs:
           --command="sudo docker logs --tail 200 ${CONTAINER_ID}" \
           )
 
-          if [[ $? -ne 0 ]] || [[ -z "$DOCKER_LOGS" ]] || [[ "$DOCKER_LOGS" == *"Error: No running container found."* ]]; then
-              echo "Failed to retrieve logs via SSH or no container found."
+          if [[ $? -ne 0 ]] || [[ -z "$DOCKER_LOGS" ]]; then
+              echo "Failed to retrieve logs via SSH."
               exit 1
           fi
 


### PR DESCRIPTION
## Motivation

The sync-to-checkpoint test has been timing out in our main branch and re-running several times. This started happening after a database upgrade which invalidated the previous checkpoint cached state. Since this test doesn't commonly run, it's now taking longer than it did in the last run (October 2024).

## Solution

Added `is_long_test: true` to the sync-to-checkpoint test configuration to allow it to run for more than 3 hours.

### Specifications & References

- Previous successful test run: October 2024
- Current behavior: Test times out after 3 hours
- Root cause: Database upgrade invalidated cached state

### Follow-up Work

- Monitor the test duration to ensure it completes successfully with the new timeout
- Consider if we need to optimize the test or database operations to reduce the runtime

### PR Checklist

- [x] The PR name is suitable for the release notes
- [x] The solution is tested
- [x] The documentation is up to date