### PR TITLE
feat(config): Modify config to use IPv6 listen_addr by default

### DIFF
--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -62,9 +62,12 @@ pub struct Config {
     /// `address` can be an IP address or a DNS name. DNS names are
     /// only resolved once, when Zebra starts up.
     ///
+    /// By default, Zebra listenes on '[::]' (all IPv6 and IPv4 addresses).
+    /// This enables dual-stack support, accepting both IPv4 and IPv6 connections.
+    /// 
     /// If a specific listener address is configured, Zebra will advertise
     /// it to other nodes. But by default, Zebra uses an unspecified address
-    /// ("0.0.0.0" or "\[::\]"), which is not advertised to other nodes.
+    /// ("\[::\]:port"), which is not advertised to other nodes.
     ///
     /// Zebra does not currently support:
     /// - [Advertising a different external IP address #1890](https://github.com/ZcashFoundation/zebra/issues/1890), or
@@ -559,7 +562,7 @@ impl Default for Config {
         .collect();
 
         Config {
-            listen_addr: "0.0.0.0:8233"
+            listen_addr: "[::]:8233"
                 .parse()
                 .expect("Hardcoded address should be parseable"),
             external_addr: None,
@@ -617,7 +620,7 @@ impl Default for DConfig {
     fn default() -> Self {
         let config = Config::default();
         Self {
-            listen_addr: "0.0.0.0".to_string(),
+            listen_addr: "[::]".to_string(),
             external_addr: None,
             network: Default::default(),
             testnet_parameters: None,

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -62,9 +62,9 @@ pub struct Config {
     /// `address` can be an IP address or a DNS name. DNS names are
     /// only resolved once, when Zebra starts up.
     ///
-    /// By default, Zebra listenes on '[::]' (all IPv6 and IPv4 addresses).
+    /// By default, Zebra listens on '[::]' (all IPv6 and IPv4 addresses).
     /// This enables dual-stack support, accepting both IPv4 and IPv6 connections.
-    /// 
+    ///
     /// If a specific listener address is configured, Zebra will advertise
     /// it to other nodes. But by default, Zebra uses an unspecified address
     /// ("\[::\]:port"), which is not advertised to other nodes.

--- a/zebra-network/src/config/tests/vectors.rs
+++ b/zebra-network/src/config/tests/vectors.rs
@@ -23,6 +23,12 @@ fn parse_config_listen_addr() {
             "listen_addr = '0.0.0.0:8233'\nnetwork = 'Testnet'",
             "0.0.0.0:8233",
         ),
+        ("listen_addr = '[::]'", "[::]:8233"),
+        ("listen_addr = '[::]:9999'", "[::]:9999"),
+        ("listen_addr = '[::]'\nnetwork = 'Testnet'", "[::]:18233"),
+        ("listen_addr = '[::]:8233'\nnetwork = 'Testnet'", "[::]:8233"),
+        ("listen_addr = '[::1]:8233'", "[::1]:8233"),
+        ("listen_addr = '[2001:db8::1]:8233'", "[2001:db8::1]:8233")
     ];
 
     for (config, value) in fixtures {
@@ -64,4 +70,13 @@ fn testnet_params_serialization_roundtrip() {
     let deserialized: Config = toml::from_str(&serialized).unwrap();
 
     assert_eq!(config, deserialized);
+}
+
+#[test]
+fn default_config_uses_ipv6() {
+    let _init_guard = zebra_test::init();
+    let config = Config::default();
+
+    assert_eq!(config.listen_addr.to_string(), "[::]:8233");
+    assert!(config.listen_addr.is_ipv6());
 }

--- a/zebra-network/src/config/tests/vectors.rs
+++ b/zebra-network/src/config/tests/vectors.rs
@@ -26,9 +26,12 @@ fn parse_config_listen_addr() {
         ("listen_addr = '[::]'", "[::]:8233"),
         ("listen_addr = '[::]:9999'", "[::]:9999"),
         ("listen_addr = '[::]'\nnetwork = 'Testnet'", "[::]:18233"),
-        ("listen_addr = '[::]:8233'\nnetwork = 'Testnet'", "[::]:8233"),
+        (
+            "listen_addr = '[::]:8233'\nnetwork = 'Testnet'",
+            "[::]:8233",
+        ),
         ("listen_addr = '[::1]:8233'", "[::1]:8233"),
-        ("listen_addr = '[2001:db8::1]:8233'", "[2001:db8::1]:8233")
+        ("listen_addr = '[2001:db8::1]:8233'", "[2001:db8::1]:8233"),
     ];
 
     for (config, value) in fixtures {

--- a/zebrad/tests/common/configs/v2.4.0.toml
+++ b/zebrad/tests/common/configs/v2.4.0.toml
@@ -1,0 +1,86 @@
+# Default configuration for zebrad.
+#
+# This file can be used as a skeleton for custom configs.
+#
+# Unspecified fields use default values. Optional fields are Some(field) if the
+# field is present and None if it is absent.
+#
+# This file is generated as an example using zebrad's current defaults.
+# You should set only the config options you want to keep, and delete the rest.
+# Only a subset of fields are present in the skeleton, since optional values
+# whose default is None are omitted.
+#
+# The config format (including a complete list of sections and fields) is
+# documented here:
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
+#
+# zebrad attempts to load configs in the following order:
+#
+# 1. The -c flag on the command line, e.g., `zebrad -c myconfig.toml start`;
+# 2. The file `zebrad.toml` in the users's preference directory (platform-dependent);
+# 3. The default config.
+#
+# The user's preference directory and the default path to the `zebrad` config are platform dependent,
+# based on `dirs::preference_dir`, see https://docs.rs/dirs/latest/dirs/fn.preference_dir.html :
+#
+# | Platform | Value                                 | Example                                        |
+# | -------- | ------------------------------------- | ---------------------------------------------- |
+# | Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/zebrad.toml`              |
+# | macOS    | `$HOME/Library/Preferences`           | `/Users/Alice/Library/Preferences/zebrad.toml` |
+# | Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Local\zebrad.toml`     |
+
+[consensus]
+checkpoint_sync = true
+
+[mempool]
+eviction_memory_time = "1h"
+tx_cost_limit = 80000000
+
+[metrics]
+
+[mining]
+debug_like_zcashd = true
+internal_miner = false
+
+[network]
+cache_dir = true
+crawl_new_peer_interval = "1m 1s"
+initial_mainnet_peers = [
+    "dnsseed.z.cash:8233",
+    "dnsseed.str4d.xyz:8233",
+    "mainnet.seeder.zfnd.org:8233",
+    "mainnet.is.yolo.money:8233",
+]
+initial_testnet_peers = [
+    "dnsseed.testnet.z.cash:18233",
+    "testnet.seeder.zfnd.org:18233",
+    "testnet.is.yolo.money:18233",
+]
+listen_addr = "[::]:8233"
+max_connections_per_ip = 1
+network = "Mainnet"
+peerset_initial_target_size = 25
+
+[rpc]
+cookie_dir = "cache_dir"
+debug_force_finished_sync = false
+enable_cookie_auth = true
+parallel_cpu_threads = 0
+
+[state]
+cache_dir = "cache_dir"
+delete_old_database = true
+ephemeral = false
+
+[sync]
+checkpoint_verify_concurrency_limit = 1000
+download_concurrency_limit = 50
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+
+[tracing]
+buffer_limit = 128000
+force_use_color = false
+use_color = true
+use_journald = false
+


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

<!--
- Describe the goals of the PR.
- If it closes any issues, enumerate them here.
-->

This PR updates the default configuration to use IPv6 addresses ([::]) for listen_addr by default, instead of IPv4 (0.0.0.0). 

## Solution

<!-- Describe the changes in the PR. -->

Updated the default listen_addr from "0.0.0.0:8233" to "[::]:8233" for Config and DConfig. Adds new test case to verify the updated default uses an IPv6 address. Updated listen_addr field documentation to clarify the use of [::].

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

Adds a test case to ensure default config uses IPv6 listen_addr.

### Specifications & References

<!-- Provide any relevant references. -->

Closes https://github.com/ZcashFoundation/zebra/issues/9591

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
