### PR TITLE
fix: Pad script in V5 coinbase

### DIFF
--- a/zebra-chain/src/transparent.rs
+++ b/zebra-chain/src/transparent.rs
@@ -248,9 +248,8 @@ impl Input {
         Input::Coinbase {
             height,
             data: CoinbaseData(data),
-
-            // If the caller does not specify the sequence number,
-            // use a sequence number that activates the LockTime.
+            // If the caller does not specify the sequence number, use a sequence number that
+            // activates the LockTime.
             sequence: sequence.unwrap_or(0),
         }
     }

--- a/zebra-rpc/src/methods/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/types/get_block_template.rs
@@ -5,6 +5,9 @@ pub mod parameters;
 pub mod proposal;
 pub mod zip317;
 
+#[cfg(test)]
+mod tests;
+
 use std::{collections::HashMap, fmt, iter, sync::Arc};
 
 use jsonrpsee::core::RpcResult;

--- a/zebra-rpc/src/methods/types/get_block_template/tests.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/tests.rs
@@ -1,0 +1,45 @@
+//! Tests for types and functions for the `getblocktemplate` RPC.
+
+use zcash_address::TryFromRawAddress;
+use zcash_keys::address::Address;
+use zebra_chain::{
+    amount::Amount,
+    block::Height,
+    parameters::testnet::{self, ConfiguredActivationHeights, ConfiguredFundingStreams},
+    serialization::{ZcashDeserializeInto, ZcashSerialize},
+    transaction::Transaction,
+};
+
+use super::generate_coinbase_transaction;
+
+/// Tests that a minimal coinbase transaction can be generated.
+#[test]
+fn minimal_coinbase() -> Result<(), Box<dyn std::error::Error>> {
+    let regtest = testnet::Parameters::build()
+        .with_slow_start_interval(Height::MIN)
+        .with_activation_heights(ConfiguredActivationHeights {
+            nu6: Some(1),
+            ..Default::default()
+        })
+        .with_post_nu6_funding_streams(ConfiguredFundingStreams {
+            height_range: Some(Height(1)..Height(10)),
+            recipients: None,
+        })
+        .to_network();
+
+    // It should be possible to generate a coinbase tx from these params.
+    generate_coinbase_transaction(
+        &regtest,
+        Height(1),
+        &Address::try_from_raw_transparent_p2pkh([0x42; 20]).unwrap(),
+        Amount::zero(),
+        false,
+        vec![],
+    )
+    .transaction
+    .zcash_serialize_to_vec()?
+    // Deserialization contains checks for elementary consensus rules, which must pass.
+    .zcash_deserialize_into::<Transaction>()?;
+
+    Ok(())
+}


### PR DESCRIPTION

## Motivation

- Close #9614 

## Solution

- Include an extra byte in the coinbase data if the data is empty.

### Tests

- Add a test that fails when the consensus rule is not satisfied.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
