### PR TITLE
Fix tests for `invalidate_block` and `reconsider_block`

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -3710,7 +3710,13 @@ async fn invalidate_and_reconsider_block() -> Result<()> {
     use common::regtest::MiningRpcMethods;
 
     let _init_guard = zebra_test::init();
-    let mut config = os_assigned_rpc_port_config(false, &Network::new_regtest(Default::default()))?;
+
+    let activation_heights = zebra_chain::parameters::testnet::ConfiguredActivationHeights {
+        nu5: Some(1),
+        ..Default::default()
+    };
+
+    let mut config = os_assigned_rpc_port_config(false, &Network::new_regtest(activation_heights))?;
     config.state.ephemeral = false;
 
     let test_dir = testdir()?.with_config(&mut config)?;


### PR DESCRIPTION
## Motivation

Fix failing tests in #9551.

## Solution

- Since we only support V5 coinbase txs, we need to activate NU5 at height 1.

### Tests

- Fix the `invalidate_and_reconsider_block` test.

### Specifications & References

<!-- Provide any relevant references. -->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
