### PR TITLE
Temporarily activate NU5 at height 1 in tests for Regtest

### DIFF
--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -669,8 +669,11 @@ impl Parameters {
     pub fn new_regtest(
         ConfiguredActivationHeights { nu5, nu6, nu7, .. }: ConfiguredActivationHeights,
     ) -> Self {
-        #[cfg(any(test, feature = "proptest-impl"))]
-        let nu5 = nu5.or(Some(100));
+        let (canopy, nu5) = if cfg!(test) || cfg!(feature = "proptest-impl") {
+            (None, nu5.or(Some(1)))
+        } else {
+            (Some(1), nu5.or(Some(100)))
+        };
 
         let parameters = Self::build()
             .with_genesis_hash(REGTEST_GENESIS_HASH)
@@ -682,7 +685,7 @@ impl Parameters {
             // Removes default Testnet activation heights if not configured,
             // most network upgrades are disabled by default for Regtest in zcashd
             .with_activation_heights(ConfiguredActivationHeights {
-                canopy: Some(1),
+                canopy,
                 nu5,
                 nu6,
                 nu7,

--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -669,6 +669,7 @@ impl Parameters {
     pub fn new_regtest(
         ConfiguredActivationHeights { nu5, nu6, nu7, .. }: ConfiguredActivationHeights,
     ) -> Self {
+        // TODO: Activate Canopy at height 1 at NU5 at height 100 once #9605 is done.
         let (canopy, nu5) = if cfg!(test) || cfg!(feature = "proptest-impl") {
             (None, nu5.or(Some(1)))
         } else {

--- a/zebra-chain/src/parameters/network/tests/vectors.rs
+++ b/zebra-chain/src/parameters/network/tests/vectors.rs
@@ -136,9 +136,7 @@ fn activates_network_upgrades_correctly() {
 
     let expected_default_regtest_activation_heights = &[
         (Height(0), NetworkUpgrade::Genesis),
-        (Height(1), NetworkUpgrade::Canopy),
-        // TODO: Remove this once the testnet parameters are being serialized (#8920).
-        (Height(100), NetworkUpgrade::Nu5),
+        (Height(1), NetworkUpgrade::Nu5),
     ];
 
     for (network, expected_activation_heights) in [

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -170,10 +170,7 @@ use zcash_keys::address::Address;
 use zebra_chain::{
     block::{self, genesis::regtest_genesis_block, ChainHistoryBlockTxAuthCommitmentHash, Height},
     chain_tip::ChainTip,
-    parameters::{
-        testnet::ConfiguredActivationHeights,
-        Network::{self, *},
-    },
+    parameters::Network::{self, *},
 };
 use zebra_consensus::ParameterCheckpoint;
 use zebra_node_services::rpc_client::RpcRequestClient;
@@ -2983,12 +2980,7 @@ async fn trusted_chain_sync_handles_forks_correctly() -> Result<()> {
 
     let _init_guard = zebra_test::init();
 
-    let activation_heights = ConfiguredActivationHeights {
-        nu5: Some(1),
-        ..Default::default()
-    };
-
-    let mut config = os_assigned_rpc_port_config(false, &Network::new_regtest(activation_heights))?;
+    let mut config = os_assigned_rpc_port_config(false, &Network::new_regtest(Default::default()))?;
     config.state.ephemeral = false;
     let network = config.network.network.clone();
 

--- a/zebrad/tests/common/regtest.rs
+++ b/zebrad/tests/common/regtest.rs
@@ -40,12 +40,7 @@ const NUM_BLOCKS_TO_SUBMIT: usize = 200;
 pub(crate) async fn submit_blocks_test() -> Result<()> {
     let _init_guard = zebra_test::init();
 
-    let activation_heights = zebra_chain::parameters::testnet::ConfiguredActivationHeights {
-        nu5: Some(1),
-        ..Default::default()
-    };
-
-    let network = Network::new_regtest(activation_heights);
+    let network = Network::new_regtest(Default::default());
     let mut config = os_assigned_rpc_port_config(false, &network)?;
     config.mempool.debug_enable_at_height = Some(0);
 


### PR DESCRIPTION
## Motivation

After #9627, Zebra temporarily constructs only V5 coinbase txs. Currently, we activate NU5 at height 100 and Canopy at height 1 in tests for Regtest, which makes those tests that generate coinbase txs in that height range fail since Canopy doesn't support V5 txs. We will support generating V4 coinbase txs again once we finish #9605, so we can revert this PR then.

## Solution

- Activate NU5 at height 1 in tests for Regtest.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
