### PR TITLE
Block proposal validation of mempool transactions

### DIFF
--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -691,6 +691,7 @@ async fn mempool_request_with_unmined_output_spends_is_accepted() {
     let crate::transaction::Response::Mempool {
         transaction: _,
         spent_mempool_outpoints,
+        ..
     } = verifier_response.expect("already checked that response is ok")
     else {
         panic!("unexpected response variant from transaction verifier for Mempool request")
@@ -816,6 +817,7 @@ async fn skips_verification_of_block_transactions_in_mempool() {
     let crate::transaction::Response::Mempool {
         transaction,
         spent_mempool_outpoints,
+        ..
     } = verifier_response.expect("already checked that response is ok")
     else {
         panic!("unexpected response variant from transaction verifier for Mempool request")

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -212,6 +212,7 @@ impl StartCmd {
             peer_set.clone(),
             state.clone(),
             tx_verifier,
+            block_verifier_router.clone(),
             sync_status.clone(),
             latest_chain_tip.clone(),
             chain_tip_change.clone(),

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -972,6 +972,7 @@ async fn setup(
         buffered_peer_set.clone(),
         state_service.clone(),
         buffered_tx_verifier.clone(),
+        block_verifier.clone(),
         sync_status.clone(),
         latest_chain_tip.clone(),
         chain_tip_change.clone(),

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -693,6 +693,10 @@ async fn setup(
     let buffered_tx_verifier = ServiceBuilder::new()
         .buffer(10)
         .service(BoxService::new(mock_tx_verifier.clone()));
+    let mock_block_router_verifier = MockService::build().for_unit_tests();
+    let buffered_block_router_verifier = ServiceBuilder::new()
+        .buffer(10)
+        .service(BoxService::new(mock_block_router_verifier.clone()));
 
     // Mempool
     let (misbehavior_tx, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
@@ -702,6 +706,7 @@ async fn setup(
         peer_set.clone(),
         state_service.clone(),
         buffered_tx_verifier.clone(),
+        buffered_block_router_verifier,
         sync_status.clone(),
         latest_chain_tip.clone(),
         chain_tip_change.clone(),

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -81,6 +81,10 @@ type TxVerifier = Buffer<
     BoxService<transaction::Request, transaction::Response, TransactionError>,
     transaction::Request,
 >;
+type BlockRouterVerifier = Buffer<
+    BoxService<zebra_consensus::Request, block::Hash, zebra_consensus::RouterError>,
+    zebra_consensus::Request,
+>;
 type InboundTxDownloads = TxDownloads<Timeout<Outbound>, Timeout<TxVerifier>, State>;
 
 /// The state of the mempool.
@@ -236,6 +240,10 @@ pub struct Mempool {
     /// Used to construct the transaction downloader.
     tx_verifier: TxVerifier,
 
+    /// Handle to the block router verifier service.
+    /// Used to construct the transaction downloader.
+    block_router_verifier: BlockRouterVerifier,
+
     /// Sender part of a gossip transactions channel.
     /// Used to broadcast transaction ids to peers.
     transaction_sender: broadcast::Sender<HashSet<UnminedTxId>>,
@@ -273,6 +281,7 @@ impl Mempool {
         outbound: Outbound,
         state: State,
         tx_verifier: TxVerifier,
+        block_router_verifier: BlockRouterVerifier,
         sync_status: SyncStatus,
         latest_chain_tip: zs::LatestChainTip,
         chain_tip_change: ChainTipChange,
@@ -291,6 +300,7 @@ impl Mempool {
             outbound,
             state,
             tx_verifier,
+            block_router_verifier,
             transaction_sender,
             misbehavior_sender,
             #[cfg(feature = "progress-bar")]

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -397,18 +397,20 @@ where
                     height: next_height,
                 })
                 .map_ok(|rsp| {
-                    let tx::Response::Mempool { transaction, spent_mempool_outpoints } = rsp else {
+                    let tx::Response::Mempool { transaction, spent_mempool_outpoints, mempool_dependencies } = rsp else {
                         panic!("unexpected non-mempool response to mempool request")
                     };
 
-                    (transaction, spent_mempool_outpoints, tip_height)
+                    (transaction, spent_mempool_outpoints, mempool_dependencies, tip_height)
                 })
                 .await;
 
             // Hide the transaction data to avoid filling the logs
             trace!(?txid, result = ?result.as_ref().map(|_tx| ()), "verified transaction for the mempool");
 
-            result.map_err(|e| TransactionDownloadVerifyError::Invalid { error: e.into(), advertiser_addr } )
+            let (transaction, spent_mempool_outpoints, mempool_dependencies, tip_height) = result.map_err(|e| TransactionDownloadVerifyError::Invalid { error: e.into(), advertiser_addr } )?;
+
+            Ok((transaction, spent_mempool_outpoints, tip_height))
         }
         .map_ok(|(tx, spent_mempool_outpoints, tip_height)| {
             metrics::counter!(

--- a/zebrad/src/components/mempool/tests/prop.rs
+++ b/zebrad/src/components/mempool/tests/prop.rs
@@ -266,6 +266,7 @@ fn setup(
     let peer_set = MockService::build().for_prop_tests();
     let state_service = MockService::build().for_prop_tests();
     let tx_verifier = MockService::build().for_prop_tests();
+    let block_router_verifier = MockService::build().for_prop_tests();
 
     let (sync_status, recent_syncs) = SyncStatus::new();
     let (mut chain_tip_sender, latest_chain_tip, chain_tip_change) =
@@ -280,6 +281,7 @@ fn setup(
         Buffer::new(BoxService::new(peer_set.clone()), 1),
         Buffer::new(BoxService::new(state_service.clone()), 1),
         Buffer::new(BoxService::new(tx_verifier.clone()), 1),
+        Buffer::new(BoxService::new(block_router_verifier.clone()), 1),
         sync_status,
         latest_chain_tip,
         chain_tip_change,

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -1067,6 +1067,7 @@ async fn setup(
     let mut state_service = ServiceBuilder::new().buffer(1).service(state);
 
     let tx_verifier = MockService::build().for_unit_tests();
+    let block_router_verifier = MockService::build().for_unit_tests();
 
     let (sync_status, recent_syncs) = SyncStatus::new();
     let (misbehavior_tx, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
@@ -1078,6 +1079,7 @@ async fn setup(
         Buffer::new(BoxService::new(peer_set.clone()), 1),
         state_service.clone(),
         Buffer::new(BoxService::new(tx_verifier.clone()), 1),
+        Buffer::new(BoxService::new(block_router_verifier.clone()), 1),
         sync_status,
         latest_chain_tip,
         chain_tip_change.clone(),

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -966,6 +966,7 @@ async fn mempool_responds_to_await_output() -> Result<(), Report> {
     let mock_verify_tx_fut = tx_verifier.expect_request_that(|_| true).map(|responder| {
         responder.respond(transaction::Response::Mempool {
             transaction: verified_unmined_tx,
+            mempool_dependencies: Vec::new(),
             spent_mempool_outpoints: Vec::new(),
         });
     });


### PR DESCRIPTION
Will close #9301.

TODO:
- Update mempool's `AwaitOutput` request to accept a transaction hash, and the response for that request to include all direct and indirect transaction dependencies,
- Update the `StateService` to convert `Request::ChainInfo` to a new `ReadRequest::ChainInfo` variant and redirect those requests from the state service to the read state service,
- Update the `download_and_verify()` method of the `TxDownloads` component in the mempool's active state to:
  - Generate minimal (including only the semantically verified transaction and any transactions that it directly or indirectly depends on) valid block templates with the same logic as the `getblocktemplate` RPC,
  - Convert those block templates to block proposals 
  - Call the `block_router_verifier` with `Proposal` requests (@oxarbitrage this part can't be moved to a function in `zebra-state` because it relies on `zebra-consensus`), and
  - Return an error from the `TxDownloads` stream if the block proposal for a semantically verified transaction is not valid.

@oxarbitrage It doesn't seem necessary or cleaner to move block template generation logic from `zebra-rpc` to `zebra-state` as I had suggested earlier. I think we should leave that logic in `zebra-rpc`.