### PR TITLE
fix(rpc): reuse txid in getrawtransaction

### DIFF
--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1285,6 +1285,7 @@ where
                                         Some(block_time),
                                         Some(hash.0),
                                         Some(true),
+                                        tx.hash(),
                                     ),
                                 ))
                             })
@@ -1608,6 +1609,7 @@ where
                                     None,
                                     None,
                                     Some(false),
+                                    txid,
                                 ),
                             ))
                         } else {
@@ -1681,6 +1683,7 @@ where
                     Some(tx.block_time),
                     block_hash,
                     Some(true),
+                    txid,
                 )))
             } else {
                 let hex = tx.tx.into();

--- a/zebra-rpc/src/methods/types/transaction.rs
+++ b/zebra-rpc/src/methods/types/transaction.rs
@@ -454,6 +454,7 @@ impl Default for TransactionObject {
 impl TransactionObject {
     /// Converts `tx` and `height` into a new `GetRawTransaction` in the `verbose` format.
     #[allow(clippy::unwrap_in_result)]
+    #[allow(clippy::too_many_arguments)]
     pub fn from_transaction(
         tx: Arc<Transaction>,
         height: Option<block::Height>,
@@ -462,6 +463,7 @@ impl TransactionObject {
         block_time: Option<DateTime<Utc>>,
         block_hash: Option<block::Hash>,
         in_active_chain: Option<bool>,
+        txid: transaction::Hash,
     ) -> Self {
         let block_time = block_time.map(|bt| bt.timestamp());
         Self {
@@ -633,7 +635,7 @@ impl TransactionObject {
             },
             size: tx.as_bytes().len().try_into().ok(),
             time: block_time,
-            txid: tx.hash(),
+            txid,
             in_active_chain,
             auth_digest: tx.auth_digest(),
             overwintered: tx.is_overwintered(),


### PR DESCRIPTION
## Motivation

This was [suggested](https://github.com/ZcashFoundation/zebra/pull/9624#pullrequestreview-2925996789) in https://github.com/ZcashFoundation/zebra/pull/9624 but https://github.com/ZcashFoundation/zebra/pull/9636, which was on top of it, got merged and we missed that.

Instead of always recomputing the txid, reuse it when if it has been computed before.

## Solution

Change `TransactionObject::from_transaction()` to also take a txid. We still compute it inside `getblock` (we could optimize that but it would require changing `ReadRequest::BlockAndSize` to also return txids).

### Tests

Existing test should cover it.

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
