### PR TITLE
Individual service impls

### DIFF
--- a/zebra-scan/src/service/scan_task/scan.rs
+++ b/zebra-scan/src/service/scan_task/scan.rs
@@ -38,7 +38,9 @@ use zebra_chain::{
     transaction::Transaction,
 };
 use zebra_node_services::scan_service::response::ScanResult;
-use zebra_state::{ChainTipChange, ReadStateService, SaplingScannedResult, TransactionIndex};
+use zebra_state::{
+    ChainTipChange, ReadRequest, ReadStateService, SaplingScannedResult, TransactionIndex,
+};
 
 use crate::{
     service::{ScanTask, ScanTaskCommand},
@@ -255,8 +257,7 @@ pub async fn scan_height_and_store_results(
 
     // Get a block from the state.
     // We can't use ServiceExt::oneshot() here, because it causes lifetime errors in init().
-    let block = state
-        .ready()
+    let block = <ReadStateService as ServiceExt<ReadRequest>>::ready(&mut state)
         .await
         .map_err(|e| eyre!(e))?
         .call(zebra_state::ReadRequest::Block(height.into()))
@@ -508,8 +509,7 @@ fn get_min_height(map: &HashMap<String, Height>) -> Option<Height> {
 
 /// Get tip height or return genesis block height if no tip is available.
 async fn tip_height(mut state: State) -> Result<Height, Report> {
-    let tip = state
-        .ready()
+    let tip = <ReadStateService as ServiceExt<ReadRequest>>::ready(&mut state)
         .await
         .map_err(|e| eyre!(e))?
         .call(zebra_state::ReadRequest::Tip)

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -25,8 +25,8 @@ pub mod constants;
 pub mod arbitrary;
 
 mod error;
-mod request;
-mod response;
+pub mod request;
+pub mod response;
 mod service;
 
 #[cfg(test)]

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -915,6 +915,20 @@ impl Request {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UsageInfo;
+
+impl UsageInfo {
+    /// Counts metric for ReadStateService call
+    pub fn count_metric(&self) {
+        metrics::counter!(
+            "state.requests",
+            "service" => "read_state",
+            "type" => "usage_info"
+        )
+        .increment(1);
+    }
+}
+#[derive(Clone, Debug, PartialEq, Eq)]
 /// A read-only query about the chain state, via the
 /// [`ReadStateService`](crate::service::ReadStateService).
 pub enum ReadRequest {
@@ -1198,6 +1212,8 @@ pub enum ReadRequest {
     TipBlockSize,
 }
 
+// TODO: once all are supported individually, this can go away entirely,
+// as they will be handled by the individual calls
 impl ReadRequest {
     fn variant_name(&self) -> &'static str {
         match self {

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -915,6 +915,21 @@ impl Request {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Tip;
+
+impl Tip {
+    /// Counts metric for ReadStateService call
+    pub fn count_metric(&self) {
+        metrics::counter!(
+            "state.requests",
+            "service" => "read_state",
+            "type" => "tip"
+        )
+        .increment(1);
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UsageInfo;
 
 impl UsageInfo {

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -160,6 +160,12 @@ impl From<UsageInfo> for ReadResponse {
         Self::UsageInfo(value.0)
     }
 }
+pub struct Tip(pub Option<(block::Height, block::Hash)>);
+impl From<Tip> for ReadResponse {
+    fn from(value: Tip) -> Self {
+        Self::Tip(value.0)
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// A response to a read-only

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -153,6 +153,14 @@ impl MinedTx {
     }
 }
 
+pub struct UsageInfo(pub u64);
+
+impl From<UsageInfo> for ReadResponse {
+    fn from(value: UsageInfo) -> Self {
+        Self::UsageInfo(value.0)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// A response to a read-only
 /// [`ReadStateService`](crate::service::ReadStateService)'s [`ReadRequest`].


### PR DESCRIPTION
## Motivation

Currently, `ReadStateService`'s `Service` implementation uses large `ReadRequest`/`ReadResponse` enums. There are a lot of places where zaino needs to `call` the service, provide a `ReadRequest`, and assert that the `ReadResponse` is of the appropriate kind. Also, the set of errors returned is the entire set of possible errors for all requests.

## Solution

If we add an individual `Service` implementation for each distinct method offered, each service can have its own concrete response and error types, cutting down on a lot of matching on potentially-unreachable state.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
