### PR TITLE
refactor(validate_address): expose logic for consumers

### DIFF
--- a/zebra-rpc/src/methods/types/validate_address.rs
+++ b/zebra-rpc/src/methods/types/validate_address.rs
@@ -2,6 +2,8 @@
 
 use derive_getters::Getters;
 use derive_new::new;
+use jsonrpsee::core::RpcResult;
+use zebra_chain::{parameters::Network, primitives};
 
 /// `validateaddress` response
 #[derive(
@@ -29,5 +31,45 @@ impl ValidateAddressResponse {
     /// Creates an empty response with `isvalid` of false.
     pub fn invalid() -> Self {
         Self::default()
+    }
+}
+
+/// Checks if a zcash transparent address of type P2PKH, P2SH or TEX is valid.
+/// Returns information about the given address if valid.
+pub fn validate_address(
+    network: Network,
+    raw_address: String,
+) -> RpcResult<ValidateAddressResponse> {
+    let Ok(address) = raw_address.parse::<zcash_address::ZcashAddress>() else {
+        return Ok(ValidateAddressResponse::invalid());
+    };
+
+    let address = match address.convert::<primitives::Address>() {
+        Ok(address) => address,
+        Err(err) => {
+            tracing::debug!(?err, "conversion error");
+            return Ok(ValidateAddressResponse::invalid());
+        }
+    };
+
+    // We want to match zcashd's behaviour
+    if !address.is_transparent() {
+        return Ok(ValidateAddressResponse::invalid());
+    }
+
+    if address.network() == network.kind() {
+        Ok(ValidateAddressResponse {
+            address: Some(raw_address),
+            is_valid: true,
+            is_script: Some(address.is_script_hash()),
+        })
+    } else {
+        tracing::info!(
+            ?network,
+            address_network = ?address.network(),
+            "invalid address in validateaddress RPC: Zebra's configured network must match address network"
+        );
+
+        Ok(ValidateAddressResponse::invalid())
     }
 }


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

Zaino needs to expose a `validateaddress` JSON-RPC endpoint, which Zebra already implements.

## Solution

Moving `validate_address`'s body into a public function should allow consumers to re-use the address validation logic.

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
