### PR TITLE
fix(rpc): fix Sapling cm_u byte order

### DIFF
--- a/zebra-rpc/src/methods/types/transaction.rs
+++ b/zebra-rpc/src/methods/types/transaction.rs
@@ -580,6 +580,8 @@ impl TransactionObject {
             shielded_outputs: tx
                 .sapling_outputs()
                 .map(|output| {
+                    let mut cm_u: [u8; 32] = output.cm_u.to_bytes();
+                    cm_u.reverse();
                     let mut ephemeral_key: [u8; 32] = output.ephemeral_key.into();
                     ephemeral_key.reverse();
                     let enc_ciphertext: [u8; 580] = output.enc_ciphertext.into();
@@ -587,7 +589,7 @@ impl TransactionObject {
 
                     ShieldedOutput {
                         cv: output.cv,
-                        cm_u: output.cm_u.to_bytes(),
+                        cm_u,
                         ephemeral_key,
                         enc_ciphertext,
                         out_ciphertext,


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

The `cm_u` field from `getrawtransaction` is being returned in the wrong byte order.

## Solution

Based on #9668

Reverse the bytes

### Tests

Found and tested with e.g.

```
OUTPUT_DATA_LINE_LIMIT=100000 ZEBRAD_EXTRA_ARGS=-conf=$PWD/zcash.conf ./zebra-utils/zcash-rpc-diff 28232 getrawtransaction 603df6640eade811df35190e544560531b9e4fbe3e13e423a191fa5598b2a0ea 1 | less -R
```

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
