### PR TITLE
change(build): Adds `prometheus` as a default feature in zebrad

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -58,6 +58,13 @@ $( [[ -n ${ZEBRA_COOKIE_DIR} ]] && echo "cookie_dir = \"${ZEBRA_COOKIE_DIR}\"" )
 SUB_EOF
 )
 
+$( ( ! [[ " ${FEATURES} " =~ " prometheus " ]] ) && cat <<-SUB_EOF
+
+[metrics]
+# endpoint_addr = "${METRICS_ENDPOINT_ADDR:=0.0.0.0}:${METRICS_ENDPOINT_PORT:=9999}"
+SUB_EOF
+)
+
 $( [[ " ${FEATURES} " =~ " prometheus " ]] && cat <<-SUB_EOF
 
 [metrics]

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -254,6 +254,9 @@ jsonrpsee-types = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true }
 insta = { workspace = true, features = ["json"] }
+bytes = { workspace = true }
+http-body-util = { workspace = true }
+hyper-util = { workspace = true }
 
 # zebra-rpc needs the preserve_order feature, it also makes test results more stable
 serde_json = { workspace = true, features = ["preserve_order"] }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -53,7 +53,7 @@ features = [
 
 [features]
 # In release builds, don't compile debug logging code, to improve performance.
-default = ["release_max_level_info", "progress-bar"]
+default = ["release_max_level_info", "progress-bar", "prometheus"]
 
 # Default features for official ZF binary release builds
 default-release-binaries = ["default", "sentry"]


### PR DESCRIPTION
## Motivation

Closes #9158.

## Solution

- Adds `prometheus` to the list of default features in `zebrad`, and
- Adds a commented-out `metrics.endpoint_addr` to the docker config

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [x] The documentation is up to date.
