### PR TITLE
fix(log): Downgrade verbose mempool message

### DIFF
--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -769,11 +769,7 @@ impl Service<Request> for Mempool {
 
                     let res: HashSet<_> = storage.tx_ids().collect();
 
-                    // This log line is checked by tests,
-                    // because lightwalletd doesn't return mempool transactions at the moment.
-                    //
-                    // TODO: downgrade to trace level when we can check transactions via gRPC
-                    info!(?req, res_count = ?res.len(), "answered mempool request");
+                    trace!(?req, res_count = ?res.len(), "answered mempool request");
 
                     async move { Ok(Response::TransactionIds(res)) }.boxed()
                 }


### PR DESCRIPTION
## Motivation

Reduce the verbosity of a log message.
Closes [#9682](https://github.com/ZcashFoundation/zebra/issues/9682).

## Solution

Downgraded the log level to `trace`. This should be safe now that the test that previously relied on this log output has been updated in [#9052](https://github.com/ZcashFoundation/zebra/pull/9052).

### Tests

- CI should pass

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
