### PR TITLE
test(lockbox): QA test

### DIFF
--- a/zebra-rpc/qa/base_config.toml
+++ b/zebra-rpc/qa/base_config.toml
@@ -17,3 +17,4 @@ cache_dir = ""
 [network.testnet_parameters.activation_heights]
 NU5 = 290
 NU6 = 291
+"NU6.1" = 295

--- a/zebra-rpc/qa/pull-tester/rpc-tests.py
+++ b/zebra-rpc/qa/pull-tester/rpc-tests.py
@@ -42,7 +42,8 @@ BASE_SCRIPTS= [
     'getmininginfo.py',
     'nuparams.py',
     'addnode.py',
-    'wallet.py']
+    'wallet.py',
+    'pools.py']
 
 ZMQ_SCRIPTS = [
     # ZMQ test can only be run if bitcoin was built with zmq-enabled.

--- a/zebra-rpc/qa/rpc-tests/pools.py
+++ b/zebra-rpc/qa/rpc-tests/pools.py
@@ -56,21 +56,21 @@ class PoolsTest(BitcoinTestFramework):
         value_pools_from_getblock = self.nodes[0].getblock('0')['valuePools']
         (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblock)
 
-        assert_equal(transparent_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(sapling_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(orchard_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(transparent_pool['chainValue'], Decimal('0'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0'))
 
         getblockchaininfo = self.nodes[0].getblockchaininfo()
         value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
         (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
 
-        assert_equal(transparent_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(sapling_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(orchard_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(transparent_pool['chainValue'], Decimal('0'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0'))
 
         (overwinter, sapling, blossom, heartwood, canopy, nu5, nu6) = get_network_upgrades(getblockchaininfo)
         
@@ -82,9 +82,11 @@ class PoolsTest(BitcoinTestFramework):
         assert_equal(nu5['status'], 'pending')
         assert_equal(nu6['status'], 'pending')
 
-        # TODO: A call to `getblocksubsidy` here will fail as not supported before first halving.
-        # add an expected exception when the call is made.
-        # self.nodes[0].getblocksubsidy()
+        # `getblocksubsidy` is not supported before first halving.
+        try :
+            block_subsidy = self.nodes[0].getblocksubsidy()
+        except Exception as e:
+            return
 
         print("block 1")
         self.nodes[0].generate(1)
@@ -94,22 +96,22 @@ class PoolsTest(BitcoinTestFramework):
         (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblock)
 
         assert_equal(transparent_pool['chainValue'], Decimal('6.25'))
-        assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(sapling_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(orchard_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0'))
 
         getblockchaininfo = self.nodes[0].getblockchaininfo()
         value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
         (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
 
         assert_equal(transparent_pool['chainValue'], Decimal('6.25'))
-        assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(sapling_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(orchard_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0'))
 
-        # Check the upgrades
+        # Up to Canopy is active at block 1
         (overwinter, sapling, blossom, heartwood, canopy, nu5, nu6) = get_network_upgrades(getblockchaininfo)
 
         assert_equal(overwinter['status'], 'active')
@@ -120,71 +122,29 @@ class PoolsTest(BitcoinTestFramework):
         assert_equal(nu5['status'], 'pending')
         assert_equal(nu6['status'], 'pending')
 
-        print("Activating NU5")
-        self.nodes[0].generate(289)
-
-        # Check the value pools
-        value_pools_from_getblock = self.nodes[0].getblock('290')['valuePools']
-        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblock)
-
-        assert_equal(transparent_pool['chainValue'], Decimal('1800'))
-        assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(sapling_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(orchard_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
-
-        getblockchaininfo = self.nodes[0].getblockchaininfo()
-        value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
-        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
-
-        assert_equal(transparent_pool['chainValue'], Decimal('1800'))
-        assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(sapling_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(orchard_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
-
-        # Check the upgrades
-        (overwinter, sapling, blossom, heartwood, canopy, nu5, nu6) = get_network_upgrades(getblockchaininfo)
-
-        assert_equal(overwinter['status'], 'active')
-        assert_equal(sapling['status'], 'active')
-        assert_equal(blossom['status'], 'active')
-        assert_equal(heartwood['status'], 'active')
-        assert_equal(canopy['status'], 'active')
-        assert_equal(nu5['status'], 'active')
-        assert_equal(nu6['status'], 'pending')
-
-        # We can call getblocksubsidy now
-        block_subsidy = self.nodes[0].getblocksubsidy()
-        assert_equal(block_subsidy['miner'], Decimal('3.125'))
-        assert_equal(block_subsidy['founders'], Decimal('0'))
-        assert_equal(block_subsidy['fundingstreamstotal'], Decimal('0'))
-        assert_equal(block_subsidy['lockboxtotal'], Decimal('0'))
-        assert_equal(block_subsidy['totalblocksubsidy'], Decimal('3.125'))
-
         print("Activating NU6")
-        self.nodes[0].generate(1)
+        self.nodes[0].generate(290)
 
         # Check the value pools
         value_pools_from_getblock = self.nodes[0].getblock('291')['valuePools']
         (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblock)
 
         assert_equal(transparent_pool['chainValue'], Decimal('1803.125'))
-        assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(sapling_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(orchard_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0'))
 
         getblockchaininfo = self.nodes[0].getblockchaininfo()
         value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
         (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
 
         assert_equal(transparent_pool['chainValue'], Decimal('1803.125'))
-        assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(sapling_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(orchard_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0'))
         # TODO: Should not be 0
-        assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0'))
 
         # Check the upgrades
         (overwinter, sapling, blossom, heartwood, canopy, nu5, nu6) = get_network_upgrades(getblockchaininfo)
@@ -214,21 +174,21 @@ class PoolsTest(BitcoinTestFramework):
         (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblock)
 
         assert_equal(transparent_pool['chainValue'], Decimal('1809.375'))
-        assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(sapling_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(orchard_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0'))
 
         getblockchaininfo = self.nodes[0].getblockchaininfo()
         value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
         (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
 
         assert_equal(transparent_pool['chainValue'], Decimal('1809.375'))
-        assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(sapling_pool['chainValue'], Decimal('0.00000000'))
-        assert_equal(orchard_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0'))
         # TODO: Should not be 0
-        assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0'))
 
         # Check the upgrades
         (overwinter, sapling, blossom, heartwood, canopy, nu5, nu6) = get_network_upgrades(getblockchaininfo)
@@ -249,6 +209,32 @@ class PoolsTest(BitcoinTestFramework):
         # TODO: Should not be 0
         assert_equal(block_subsidy['lockboxtotal'], Decimal('0'))
         assert_equal(block_subsidy['totalblocksubsidy'], Decimal('3.125'))
+
+        print("Activating nu6.1")
+        self.nodes[0].generate(2)
+
+        # Check the value pools
+        value_pools_from_getblock = self.nodes[0].getblock('295')['valuePools']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblock)
+
+        assert_equal(transparent_pool['chainValue'], Decimal('1815.625'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0'))
+
+        getblockchaininfo = self.nodes[0].getblockchaininfo()
+        value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
+
+        assert_equal(transparent_pool['chainValue'], Decimal('1815.625'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0'))
+        # Period is over, zero is ok.
+        assert_equal(deferred_pool['chainValue'], Decimal('0'))
+
+        # Pass nu6.1
 
 if __name__ == '__main__':
     PoolsTest().main()

--- a/zebra-rpc/qa/rpc-tests/pools.py
+++ b/zebra-rpc/qa/rpc-tests/pools.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 The Zcash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+from decimal import Decimal
+
+from test_framework.util import (
+    assert_equal,
+    start_nodes,
+)
+
+from test_framework.test_framework import BitcoinTestFramework
+
+
+# Verify the value pools at different network upgrades.
+class PoolsTest(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 1
+        self.cache_behavior = 'clean'
+
+    def setup_network(self):
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+
+    def run_test(self):
+        print("Block 0")
+
+        # Check the value pools
+        value_pools_from_getblock = self.nodes[0].getblock('0')['valuePools']
+        pools_by_id = { pool['id']: pool for pool in value_pools_from_getblock }
+        transparent_pool = pools_by_id['transparent']
+        sprout_pool = pools_by_id['sprout']
+        sapling_pool = pools_by_id['sapling']
+        orchard_pool = pools_by_id['orchard']
+        deferred_pool = pools_by_id['deferred']
+
+        assert_equal(transparent_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
+
+        getblockchaininfo = self.nodes[0].getblockchaininfo()
+        value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
+        pools_by_id = { pool['id']: pool for pool in value_pools_from_getblockchaininfo }
+        transparent_pool = pools_by_id['transparent']
+        sprout_pool = pools_by_id['sprout']
+        sapling_pool = pools_by_id['sapling']
+        orchard_pool = pools_by_id['orchard']
+        deferred_pool = pools_by_id['deferred']
+
+        assert_equal(transparent_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
+
+        # Check the upgrades
+        upgrades_by_name = {
+            upgrade['name']: {
+                k: v for k, v in upgrade.items() if k != 'name'
+            }
+            for upgrade in getblockchaininfo['upgrades'].values()
+        }
+        
+        overwinter = upgrades_by_name['Overwinter']
+        sapling = upgrades_by_name['Sapling']
+        blossom = upgrades_by_name['Blossom']
+        heartwood = upgrades_by_name['Heartwood']
+        canopy = upgrades_by_name['Canopy']
+        nu5 = upgrades_by_name['NU5']
+        nu6 = upgrades_by_name['NU6']
+        # TODO: Nu6.1 is not present in the upgrade list, but it should be as there is an activation height in the config.
+        #nu6_1 = pools_by_id['NU6.1']
+
+        assert_equal(overwinter['status'], 'pending')
+        assert_equal(sapling['status'], 'pending')
+        assert_equal(blossom['status'], 'pending')
+        assert_equal(heartwood['status'], 'pending')
+        assert_equal(canopy['status'], 'pending')
+        assert_equal(nu5['status'], 'pending')
+        assert_equal(nu6['status'], 'pending')
+
+        # TODO: A call to `getblocksubsidy` here will fail as not supported before first halving.
+        # add an expected exception when the call is made.
+        # self.nodes[0].getblocksubsidy()
+
+        print("block 1")
+        self.nodes[0].generate(1)
+
+        # Check the value pools
+        value_pools_from_getblock = self.nodes[0].getblock('1')['valuePools']
+        pools_by_id = { pool['id']: pool for pool in value_pools_from_getblock }
+        transparent_pool = pools_by_id['transparent']
+        sprout_pool = pools_by_id['sprout']
+        sapling_pool = pools_by_id['sapling']
+        orchard_pool = pools_by_id['orchard']
+        deferred_pool = pools_by_id['deferred']
+
+        assert_equal(transparent_pool['chainValue'], Decimal('6.25'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
+
+        getblockchaininfo = self.nodes[0].getblockchaininfo()
+        value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
+        pools_by_id = { pool['id']: pool for pool in value_pools_from_getblockchaininfo }
+        transparent_pool = pools_by_id['transparent']
+        sprout_pool = pools_by_id['sprout']
+        sapling_pool = pools_by_id['sapling']
+        orchard_pool = pools_by_id['orchard']
+        deferred_pool = pools_by_id['deferred']
+
+        assert_equal(transparent_pool['chainValue'], Decimal('6.25'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
+
+        # Check the upgrades
+        upgrades_by_name = {
+            upgrade['name']: {
+                k: v for k, v in upgrade.items() if k != 'name'
+            }
+            for upgrade in getblockchaininfo['upgrades'].values()
+        }
+        
+        overwinter = upgrades_by_name['Overwinter']
+        sapling = upgrades_by_name['Sapling']
+        blossom = upgrades_by_name['Blossom']
+        heartwood = upgrades_by_name['Heartwood']
+        canopy = upgrades_by_name['Canopy']
+        nu5 = upgrades_by_name['NU5']
+        nu6 = upgrades_by_name['NU6']
+
+        assert_equal(overwinter['status'], 'active')
+        assert_equal(sapling['status'], 'active')
+        assert_equal(blossom['status'], 'active')
+        assert_equal(heartwood['status'], 'active')
+        assert_equal(canopy['status'], 'active')
+        assert_equal(nu5['status'], 'pending')
+        assert_equal(nu6['status'], 'pending')
+
+        print("Activating NU5")
+        self.nodes[0].generate(289)
+
+        # Check the value pools
+        value_pools_from_getblock = self.nodes[0].getblock('290')['valuePools']
+        pools_by_id = { pool['id']: pool for pool in value_pools_from_getblock }
+        transparent_pool = pools_by_id['transparent']
+        sprout_pool = pools_by_id['sprout']
+        sapling_pool = pools_by_id['sapling']
+        orchard_pool = pools_by_id['orchard']
+        deferred_pool = pools_by_id['deferred']
+
+        assert_equal(transparent_pool['chainValue'], Decimal('1800'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
+
+        getblockchaininfo = self.nodes[0].getblockchaininfo()
+        value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
+        pools_by_id = { pool['id']: pool for pool in value_pools_from_getblockchaininfo }
+        transparent_pool = pools_by_id['transparent']
+        sprout_pool = pools_by_id['sprout']
+        sapling_pool = pools_by_id['sapling']
+        orchard_pool = pools_by_id['orchard']
+        deferred_pool = pools_by_id['deferred']
+
+        assert_equal(transparent_pool['chainValue'], Decimal('1800'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
+
+        # Check the upgrades
+        upgrades_by_name = {
+            upgrade['name']: {
+                k: v for k, v in upgrade.items() if k != 'name'
+            }
+            for upgrade in getblockchaininfo['upgrades'].values()
+        }
+        
+        overwinter = upgrades_by_name['Overwinter']
+        sapling = upgrades_by_name['Sapling']
+        blossom = upgrades_by_name['Blossom']
+        heartwood = upgrades_by_name['Heartwood']
+        canopy = upgrades_by_name['Canopy']
+        nu5 = upgrades_by_name['NU5']
+        nu6 = upgrades_by_name['NU6']
+
+        assert_equal(overwinter['status'], 'active')
+        assert_equal(sapling['status'], 'active')
+        assert_equal(blossom['status'], 'active')
+        assert_equal(heartwood['status'], 'active')
+        assert_equal(canopy['status'], 'active')
+        assert_equal(nu5['status'], 'active')
+        assert_equal(nu6['status'], 'pending')
+
+        # We can call getblocksubsidy now
+        block_subsidy = self.nodes[0].getblocksubsidy()
+        assert_equal(block_subsidy['miner'], Decimal('3.125'))
+        assert_equal(block_subsidy['founders'], Decimal('0'))
+        assert_equal(block_subsidy['fundingstreamstotal'], Decimal('0'))
+        assert_equal(block_subsidy['lockboxtotal'], Decimal('0'))
+        assert_equal(block_subsidy['totalblocksubsidy'], Decimal('3.125'))
+
+        print("Activating NU6")
+        self.nodes[0].generate(1)
+
+        # Check the value pools
+        value_pools_from_getblock = self.nodes[0].getblock('291')['valuePools']
+        pools_by_id = { pool['id']: pool for pool in value_pools_from_getblock }
+        transparent_pool = pools_by_id['transparent']
+        sprout_pool = pools_by_id['sprout']
+        sapling_pool = pools_by_id['sapling']
+        orchard_pool = pools_by_id['orchard']
+        deferred_pool = pools_by_id['deferred']
+
+        assert_equal(transparent_pool['chainValue'], Decimal('1803.125'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
+
+        getblockchaininfo = self.nodes[0].getblockchaininfo()
+        value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
+        pools_by_id = { pool['id']: pool for pool in value_pools_from_getblockchaininfo }
+        transparent_pool = pools_by_id['transparent']
+        sprout_pool = pools_by_id['sprout']
+        sapling_pool = pools_by_id['sapling']
+        orchard_pool = pools_by_id['orchard']
+        deferred_pool = pools_by_id['deferred']
+
+        assert_equal(transparent_pool['chainValue'], Decimal('1803.125'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0.00000000'))
+        # TODO: Should not be 0
+        assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
+
+        # Check the upgrades
+        upgrades_by_name = {
+            upgrade['name']: {
+                k: v for k, v in upgrade.items() if k != 'name'
+            }
+            for upgrade in getblockchaininfo['upgrades'].values()
+        }
+        
+        overwinter = upgrades_by_name['Overwinter']
+        sapling = upgrades_by_name['Sapling']
+        blossom = upgrades_by_name['Blossom']
+        heartwood = upgrades_by_name['Heartwood']
+        canopy = upgrades_by_name['Canopy']
+        nu5 = upgrades_by_name['NU5']
+        nu6 = upgrades_by_name['NU6']
+
+        assert_equal(overwinter['status'], 'active')
+        assert_equal(sapling['status'], 'active')
+        assert_equal(blossom['status'], 'active')
+        assert_equal(heartwood['status'], 'active')
+        assert_equal(canopy['status'], 'active')
+        assert_equal(nu5['status'], 'active')
+        assert_equal(nu6['status'], 'active')
+
+        # We can call getblocksubsidy now
+        block_subsidy = self.nodes[0].getblocksubsidy()
+        assert_equal(block_subsidy['miner'], Decimal('3.125'))
+        assert_equal(block_subsidy['founders'], Decimal('0'))
+        assert_equal(block_subsidy['fundingstreamstotal'], Decimal('0'))
+        # TODO: Should not be 0
+        assert_equal(block_subsidy['lockboxtotal'], Decimal('0'))
+        assert_equal(block_subsidy['totalblocksubsidy'], Decimal('3.125'))
+
+        print("Passing nu6")
+        self.nodes[0].generate(2)
+
+        # Check the value pools
+        value_pools_from_getblock = self.nodes[0].getblock('293')['valuePools']
+        pools_by_id = { pool['id']: pool for pool in value_pools_from_getblock }
+        transparent_pool = pools_by_id['transparent']
+        sprout_pool = pools_by_id['sprout']
+        sapling_pool = pools_by_id['sapling']
+        orchard_pool = pools_by_id['orchard']
+        deferred_pool = pools_by_id['deferred']
+
+        assert_equal(transparent_pool['chainValue'], Decimal('1809.375'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
+
+        getblockchaininfo = self.nodes[0].getblockchaininfo()
+        value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
+        pools_by_id = { pool['id']: pool for pool in value_pools_from_getblockchaininfo }
+        transparent_pool = pools_by_id['transparent']
+        sprout_pool = pools_by_id['sprout']
+        sapling_pool = pools_by_id['sapling']
+        orchard_pool = pools_by_id['orchard']
+        deferred_pool = pools_by_id['deferred']
+
+        assert_equal(transparent_pool['chainValue'], Decimal('1809.375'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0.00000000'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0.00000000'))
+        # TODO: Should not be 0
+        assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
+
+        # Check the upgrades
+        upgrades_by_name = {
+            upgrade['name']: {
+                k: v for k, v in upgrade.items() if k != 'name'
+            }
+            for upgrade in getblockchaininfo['upgrades'].values()
+        }
+        
+        overwinter = upgrades_by_name['Overwinter']
+        sapling = upgrades_by_name['Sapling']
+        blossom = upgrades_by_name['Blossom']
+        heartwood = upgrades_by_name['Heartwood']
+        canopy = upgrades_by_name['Canopy']
+        nu5 = upgrades_by_name['NU5']
+        nu6 = upgrades_by_name['NU6']
+        # TODO: Nu6.1 is not present in the upgrade list, but it should be as there is an activation height in the config.
+        #nu6_1 = pools_by_id['NU6.1']
+
+        assert_equal(overwinter['status'], 'active')
+        assert_equal(sapling['status'], 'active')
+        assert_equal(blossom['status'], 'active')
+        assert_equal(heartwood['status'], 'active')
+        assert_equal(canopy['status'], 'active')
+        assert_equal(nu5['status'], 'active')
+        assert_equal(nu6['status'], 'active')
+
+        # We can call getblocksubsidy now
+        block_subsidy = self.nodes[0].getblocksubsidy()
+        assert_equal(block_subsidy['miner'], Decimal('3.125'))
+        assert_equal(block_subsidy['founders'], Decimal('0'))
+        assert_equal(block_subsidy['fundingstreamstotal'], Decimal('0'))
+        # TODO: Should not be 0
+        assert_equal(block_subsidy['lockboxtotal'], Decimal('0'))
+        assert_equal(block_subsidy['totalblocksubsidy'], Decimal('3.125'))
+
+
+if __name__ == '__main__':
+    PoolsTest().main()

--- a/zebra-rpc/qa/rpc-tests/pools.py
+++ b/zebra-rpc/qa/rpc-tests/pools.py
@@ -25,16 +25,36 @@ class PoolsTest(BitcoinTestFramework):
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
 
     def run_test(self):
+
+        def get_value_pools(value_pools):
+            pools_by_id = { pool['id']: pool for pool in value_pools_from_getblock }
+            return (pools_by_id['transparent'],
+                    pools_by_id['sprout'],
+                    pools_by_id['sapling'],
+                    pools_by_id['orchard'],
+                    pools_by_id['deferred'])
+
+        def get_network_upgrades(getblockchaininfo):
+            upgrades_by_name = {
+                upgrade['name']: {
+                    k: v for k, v in upgrade.items() if k != 'name'
+                }
+                for upgrade in getblockchaininfo['upgrades'].values()
+            }
+            # TODO: Nu6.1 is not present in the upgrade list, but it should be as there is an activation height in the config.
+            return (upgrades_by_name['Overwinter'],
+                    upgrades_by_name['Sapling'],
+                    upgrades_by_name['Blossom'],
+                    upgrades_by_name['Heartwood'],
+                    upgrades_by_name['Canopy'],
+                    upgrades_by_name['NU5'],
+                    upgrades_by_name['NU6'])
+
         print("Block 0")
 
         # Check the value pools
         value_pools_from_getblock = self.nodes[0].getblock('0')['valuePools']
-        pools_by_id = { pool['id']: pool for pool in value_pools_from_getblock }
-        transparent_pool = pools_by_id['transparent']
-        sprout_pool = pools_by_id['sprout']
-        sapling_pool = pools_by_id['sapling']
-        orchard_pool = pools_by_id['orchard']
-        deferred_pool = pools_by_id['deferred']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblock)
 
         assert_equal(transparent_pool['chainValue'], Decimal('0.00000000'))
         assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
@@ -44,12 +64,7 @@ class PoolsTest(BitcoinTestFramework):
 
         getblockchaininfo = self.nodes[0].getblockchaininfo()
         value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
-        pools_by_id = { pool['id']: pool for pool in value_pools_from_getblockchaininfo }
-        transparent_pool = pools_by_id['transparent']
-        sprout_pool = pools_by_id['sprout']
-        sapling_pool = pools_by_id['sapling']
-        orchard_pool = pools_by_id['orchard']
-        deferred_pool = pools_by_id['deferred']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
 
         assert_equal(transparent_pool['chainValue'], Decimal('0.00000000'))
         assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
@@ -57,24 +72,8 @@ class PoolsTest(BitcoinTestFramework):
         assert_equal(orchard_pool['chainValue'], Decimal('0.00000000'))
         assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
 
-        # Check the upgrades
-        upgrades_by_name = {
-            upgrade['name']: {
-                k: v for k, v in upgrade.items() if k != 'name'
-            }
-            for upgrade in getblockchaininfo['upgrades'].values()
-        }
+        (overwinter, sapling, blossom, heartwood, canopy, nu5, nu6) = get_network_upgrades(getblockchaininfo)
         
-        overwinter = upgrades_by_name['Overwinter']
-        sapling = upgrades_by_name['Sapling']
-        blossom = upgrades_by_name['Blossom']
-        heartwood = upgrades_by_name['Heartwood']
-        canopy = upgrades_by_name['Canopy']
-        nu5 = upgrades_by_name['NU5']
-        nu6 = upgrades_by_name['NU6']
-        # TODO: Nu6.1 is not present in the upgrade list, but it should be as there is an activation height in the config.
-        #nu6_1 = pools_by_id['NU6.1']
-
         assert_equal(overwinter['status'], 'pending')
         assert_equal(sapling['status'], 'pending')
         assert_equal(blossom['status'], 'pending')
@@ -92,12 +91,7 @@ class PoolsTest(BitcoinTestFramework):
 
         # Check the value pools
         value_pools_from_getblock = self.nodes[0].getblock('1')['valuePools']
-        pools_by_id = { pool['id']: pool for pool in value_pools_from_getblock }
-        transparent_pool = pools_by_id['transparent']
-        sprout_pool = pools_by_id['sprout']
-        sapling_pool = pools_by_id['sapling']
-        orchard_pool = pools_by_id['orchard']
-        deferred_pool = pools_by_id['deferred']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblock)
 
         assert_equal(transparent_pool['chainValue'], Decimal('6.25'))
         assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
@@ -107,12 +101,7 @@ class PoolsTest(BitcoinTestFramework):
 
         getblockchaininfo = self.nodes[0].getblockchaininfo()
         value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
-        pools_by_id = { pool['id']: pool for pool in value_pools_from_getblockchaininfo }
-        transparent_pool = pools_by_id['transparent']
-        sprout_pool = pools_by_id['sprout']
-        sapling_pool = pools_by_id['sapling']
-        orchard_pool = pools_by_id['orchard']
-        deferred_pool = pools_by_id['deferred']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
 
         assert_equal(transparent_pool['chainValue'], Decimal('6.25'))
         assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
@@ -121,20 +110,7 @@ class PoolsTest(BitcoinTestFramework):
         assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
 
         # Check the upgrades
-        upgrades_by_name = {
-            upgrade['name']: {
-                k: v for k, v in upgrade.items() if k != 'name'
-            }
-            for upgrade in getblockchaininfo['upgrades'].values()
-        }
-        
-        overwinter = upgrades_by_name['Overwinter']
-        sapling = upgrades_by_name['Sapling']
-        blossom = upgrades_by_name['Blossom']
-        heartwood = upgrades_by_name['Heartwood']
-        canopy = upgrades_by_name['Canopy']
-        nu5 = upgrades_by_name['NU5']
-        nu6 = upgrades_by_name['NU6']
+        (overwinter, sapling, blossom, heartwood, canopy, nu5, nu6) = get_network_upgrades(getblockchaininfo)
 
         assert_equal(overwinter['status'], 'active')
         assert_equal(sapling['status'], 'active')
@@ -149,12 +125,7 @@ class PoolsTest(BitcoinTestFramework):
 
         # Check the value pools
         value_pools_from_getblock = self.nodes[0].getblock('290')['valuePools']
-        pools_by_id = { pool['id']: pool for pool in value_pools_from_getblock }
-        transparent_pool = pools_by_id['transparent']
-        sprout_pool = pools_by_id['sprout']
-        sapling_pool = pools_by_id['sapling']
-        orchard_pool = pools_by_id['orchard']
-        deferred_pool = pools_by_id['deferred']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblock)
 
         assert_equal(transparent_pool['chainValue'], Decimal('1800'))
         assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
@@ -164,12 +135,7 @@ class PoolsTest(BitcoinTestFramework):
 
         getblockchaininfo = self.nodes[0].getblockchaininfo()
         value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
-        pools_by_id = { pool['id']: pool for pool in value_pools_from_getblockchaininfo }
-        transparent_pool = pools_by_id['transparent']
-        sprout_pool = pools_by_id['sprout']
-        sapling_pool = pools_by_id['sapling']
-        orchard_pool = pools_by_id['orchard']
-        deferred_pool = pools_by_id['deferred']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
 
         assert_equal(transparent_pool['chainValue'], Decimal('1800'))
         assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
@@ -178,20 +144,7 @@ class PoolsTest(BitcoinTestFramework):
         assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
 
         # Check the upgrades
-        upgrades_by_name = {
-            upgrade['name']: {
-                k: v for k, v in upgrade.items() if k != 'name'
-            }
-            for upgrade in getblockchaininfo['upgrades'].values()
-        }
-        
-        overwinter = upgrades_by_name['Overwinter']
-        sapling = upgrades_by_name['Sapling']
-        blossom = upgrades_by_name['Blossom']
-        heartwood = upgrades_by_name['Heartwood']
-        canopy = upgrades_by_name['Canopy']
-        nu5 = upgrades_by_name['NU5']
-        nu6 = upgrades_by_name['NU6']
+        (overwinter, sapling, blossom, heartwood, canopy, nu5, nu6) = get_network_upgrades(getblockchaininfo)
 
         assert_equal(overwinter['status'], 'active')
         assert_equal(sapling['status'], 'active')
@@ -214,12 +167,7 @@ class PoolsTest(BitcoinTestFramework):
 
         # Check the value pools
         value_pools_from_getblock = self.nodes[0].getblock('291')['valuePools']
-        pools_by_id = { pool['id']: pool for pool in value_pools_from_getblock }
-        transparent_pool = pools_by_id['transparent']
-        sprout_pool = pools_by_id['sprout']
-        sapling_pool = pools_by_id['sapling']
-        orchard_pool = pools_by_id['orchard']
-        deferred_pool = pools_by_id['deferred']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblock)
 
         assert_equal(transparent_pool['chainValue'], Decimal('1803.125'))
         assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
@@ -229,12 +177,7 @@ class PoolsTest(BitcoinTestFramework):
 
         getblockchaininfo = self.nodes[0].getblockchaininfo()
         value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
-        pools_by_id = { pool['id']: pool for pool in value_pools_from_getblockchaininfo }
-        transparent_pool = pools_by_id['transparent']
-        sprout_pool = pools_by_id['sprout']
-        sapling_pool = pools_by_id['sapling']
-        orchard_pool = pools_by_id['orchard']
-        deferred_pool = pools_by_id['deferred']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
 
         assert_equal(transparent_pool['chainValue'], Decimal('1803.125'))
         assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
@@ -244,20 +187,7 @@ class PoolsTest(BitcoinTestFramework):
         assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
 
         # Check the upgrades
-        upgrades_by_name = {
-            upgrade['name']: {
-                k: v for k, v in upgrade.items() if k != 'name'
-            }
-            for upgrade in getblockchaininfo['upgrades'].values()
-        }
-        
-        overwinter = upgrades_by_name['Overwinter']
-        sapling = upgrades_by_name['Sapling']
-        blossom = upgrades_by_name['Blossom']
-        heartwood = upgrades_by_name['Heartwood']
-        canopy = upgrades_by_name['Canopy']
-        nu5 = upgrades_by_name['NU5']
-        nu6 = upgrades_by_name['NU6']
+        (overwinter, sapling, blossom, heartwood, canopy, nu5, nu6) = get_network_upgrades(getblockchaininfo)
 
         assert_equal(overwinter['status'], 'active')
         assert_equal(sapling['status'], 'active')
@@ -281,12 +211,7 @@ class PoolsTest(BitcoinTestFramework):
 
         # Check the value pools
         value_pools_from_getblock = self.nodes[0].getblock('293')['valuePools']
-        pools_by_id = { pool['id']: pool for pool in value_pools_from_getblock }
-        transparent_pool = pools_by_id['transparent']
-        sprout_pool = pools_by_id['sprout']
-        sapling_pool = pools_by_id['sapling']
-        orchard_pool = pools_by_id['orchard']
-        deferred_pool = pools_by_id['deferred']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblock)
 
         assert_equal(transparent_pool['chainValue'], Decimal('1809.375'))
         assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
@@ -296,12 +221,7 @@ class PoolsTest(BitcoinTestFramework):
 
         getblockchaininfo = self.nodes[0].getblockchaininfo()
         value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
-        pools_by_id = { pool['id']: pool for pool in value_pools_from_getblockchaininfo }
-        transparent_pool = pools_by_id['transparent']
-        sprout_pool = pools_by_id['sprout']
-        sapling_pool = pools_by_id['sapling']
-        orchard_pool = pools_by_id['orchard']
-        deferred_pool = pools_by_id['deferred']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
 
         assert_equal(transparent_pool['chainValue'], Decimal('1809.375'))
         assert_equal(sprout_pool['chainValue'], Decimal('0.00000000'))
@@ -311,22 +231,7 @@ class PoolsTest(BitcoinTestFramework):
         assert_equal(deferred_pool['chainValue'], Decimal('0.00000000'))
 
         # Check the upgrades
-        upgrades_by_name = {
-            upgrade['name']: {
-                k: v for k, v in upgrade.items() if k != 'name'
-            }
-            for upgrade in getblockchaininfo['upgrades'].values()
-        }
-        
-        overwinter = upgrades_by_name['Overwinter']
-        sapling = upgrades_by_name['Sapling']
-        blossom = upgrades_by_name['Blossom']
-        heartwood = upgrades_by_name['Heartwood']
-        canopy = upgrades_by_name['Canopy']
-        nu5 = upgrades_by_name['NU5']
-        nu6 = upgrades_by_name['NU6']
-        # TODO: Nu6.1 is not present in the upgrade list, but it should be as there is an activation height in the config.
-        #nu6_1 = pools_by_id['NU6.1']
+        (overwinter, sapling, blossom, heartwood, canopy, nu5, nu6) = get_network_upgrades(getblockchaininfo)
 
         assert_equal(overwinter['status'], 'active')
         assert_equal(sapling['status'], 'active')
@@ -344,7 +249,6 @@ class PoolsTest(BitcoinTestFramework):
         # TODO: Should not be 0
         assert_equal(block_subsidy['lockboxtotal'], Decimal('0'))
         assert_equal(block_subsidy['totalblocksubsidy'], Decimal('3.125'))
-
 
 if __name__ == '__main__':
     PoolsTest().main()


### PR DESCRIPTION
## Motivation

My initial goal was to port the NU6.1 test introduced in this Zcash pull request:
https://github.com/zcash/zcash/blob/658fba5cda37bc8446a13e28cbeffe153a0b9ab4/qa/rpc-tests/feature_nu6_1.py

However, we're not fully ready to do that in Zebra yet, for several reasons that I'll explain elsewhere.

Still, we can test parts of the NU6.1 functionality, specifically related to lockboxes and value pools on the node side, using a simpler test that focuses on the RPC behavior.

Unfortunately, this currently doesn't work in regtest mode, as the value pools are empty. This PR serves as a draft to highlight the missing functionality. It is mainly informative for now.

The relevant commits are:
https://github.com/ZcashFoundation/zebra/commit/168461eb0a10e1f8854463e25a07306f94973d97 and https://github.com/ZcashFoundation/zebra/pull/9705/commits/1a6f05e550504b3d43dcee104f013e4fed79a75e
(The other commits are from merging `main` into the original PR branch, which was needed due to unrelated fixes.)

Once Zebra is built with zebra build, you can run the test with:

```
alfredo@spaceship:~/zebra/zebra-rpc$ PYTHON_DEBUG=1  ./qa/pull-tester/rpc-tests.py pools.py
```

