### PR TITLE
fix(state): fix 2.4.0 DB upgrade; add warning if impacted

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_format/transparent.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/transparent.rs
@@ -224,12 +224,16 @@ impl<C: Constraint + Copy + std::fmt::Debug> std::ops::Add for AddressBalanceLoc
             // Keep in mind that `AddressBalanceLocationChange` reuses this type
             // (AddressBalanceLocationInner) and this addition method. The
             // `block_info_and_address_received` database upgrade uses the
-            // empty/zero location as a dummy value for
-            // `AddressBalanceLocationChange`. Therefore, when adding, we should
-            // ignore these dummy values (which are 0). Using `max` achieves
-            // this. It is also possible that two zero-location balance changes
-            // are added, and `max` will correctly keep the zero value.
-            location: self.location.max(rhs.location),
+            // usize::MAX dummy location value returned from
+            // `AddressBalanceLocationChange::empty()`. Therefore, when adding,
+            // we should ignore these dummy values. Using `min` achieves this.
+            // It is also possible that two dummy-location balance changes are
+            // added, and `min` will correctly keep the same dummy value. The
+            // reason we haven't used zero as a dummy value and `max()` here is
+            // because we use the minimum UTXO location as the canonical
+            // location for an address; and using `min()` will work if a
+            // non-canonical location is added.
+            location: self.location.min(rhs.location),
         })
     }
 }

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/block_info_and_address_received.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/block_info_and_address_received.rs
@@ -307,10 +307,9 @@ impl AddressBalanceLocationChange {
     /// a dummy (all one bits) location. See `AddressBalanceLocationInner::add()`
     /// for the rationale for using this dummy value.
     fn empty() -> Self {
-        Self::new(AddressLocation::from_usize(
-            MAX_ON_DISK_HEIGHT,
-            usize::MAX,
-            usize::MAX,
+        Self::new(AddressLocation::from_output_index(
+            TransactionLocation::from_index(MAX_ON_DISK_HEIGHT, u16::MAX),
+            u32::MAX,
         ))
     }
 }

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/block_info_and_address_received.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/block_info_and_address_received.rs
@@ -119,8 +119,8 @@ impl DiskFormatUpgrade for Upgrade {
                         for output in tx.outputs() {
                             if let Some(address) = output.address(&network) {
                                 // Note: using `empty()` will set the location
-                                // to a dummy zero value. This only works
-                                // because the addition operator for
+                                // to a dummy value. This only works because the
+                                // addition operator for
                                 // `AddressBalanceLocationChange` (which reuses
                                 // the `AddressBalanceLocationInner` addition
                                 // operator) will ignore these dummy values when
@@ -302,8 +302,14 @@ impl DiskFormatUpgrade for Upgrade {
 }
 
 impl AddressBalanceLocationChange {
-    /// Creates a new [`AddressBalanceLocationChange`] with all zero values and a dummy location.
+    /// Creates a new [`AddressBalanceLocationChange`] with all zero values and
+    /// a dummy (all one bits) location. See `AddressBalanceLocationInner::add()`
+    /// for the rationale for using this dummy value.
     fn empty() -> Self {
-        Self::new(AddressLocation::from_usize(Height(0), 0, 0))
+        Self::new(AddressLocation::from_usize(
+            crate::MAX_ON_DISK_HEIGHT,
+            usize::MAX,
+            usize::MAX,
+        ))
     }
 }

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/block_info_and_address_received.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/block_info_and_address_received.rs
@@ -118,6 +118,13 @@ impl DiskFormatUpgrade for Upgrade {
 
                         for output in tx.outputs() {
                             if let Some(address) = output.address(&network) {
+                                // Note: using `empty()` will set the location
+                                // to a dummy zero value. This only works
+                                // because the addition operator for
+                                // `AddressBalanceLocationChange` (which reuses
+                                // the `AddressBalanceLocationInner` addition
+                                // operator) will ignore these dummy values when
+                                // adding balances during the merge operator.
                                 *address_balance_changes
                                     .entry(address)
                                     .or_insert_with(AddressBalanceLocationChange::empty)
@@ -202,6 +209,8 @@ impl DiskFormatUpgrade for Upgrade {
 
             // Update transparent addresses that received funds in this block.
             for (address, change) in address_balance_changes {
+                // Note that the logic of the merge operator is set up by
+                // calling `set_merge_operator_associative()` in `DiskDb`.
                 batch.zs_merge(balance_by_transparent_addr, address, change);
             }
 

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/block_info_and_address_received.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/block_info_and_address_received.rs
@@ -16,8 +16,9 @@ use zebra_chain::{
 };
 
 use crate::{
-    service::finalized_state::disk_format::transparent::{
-        AddressBalanceLocationChange, AddressLocation,
+    service::finalized_state::{
+        disk_format::transparent::{AddressBalanceLocationChange, AddressLocation},
+        MAX_ON_DISK_HEIGHT,
     },
     DiskWriteBatch, HashOrHeight, TransactionLocation, WriteDisk,
 };
@@ -307,7 +308,7 @@ impl AddressBalanceLocationChange {
     /// for the rationale for using this dummy value.
     fn empty() -> Self {
         Self::new(AddressLocation::from_usize(
-            crate::MAX_ON_DISK_HEIGHT,
+            MAX_ON_DISK_HEIGHT,
             usize::MAX,
             usize::MAX,
         ))

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -26,7 +26,7 @@ use crate::{
             upgrade::{DbFormatChange, DbFormatChangeThreadHandle},
         },
     },
-    write_database_format_version_to_disk, BoxError, Config, OutputLocation,
+    write_database_format_version_to_disk, BoxError, Config,
 };
 
 use super::disk_format::upgrade::restorable_db_versions;

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -14,7 +14,7 @@ use std::{path::Path, sync::Arc};
 use crossbeam_channel::bounded;
 use semver::Version;
 
-use zebra_chain::{diagnostic::task::WaitForPanics, parameters::Network};
+use zebra_chain::{block::Height, diagnostic::task::WaitForPanics, parameters::Network};
 
 use crate::{
     config::database_format_version_on_disk,
@@ -22,10 +22,11 @@ use crate::{
         disk_db::DiskDb,
         disk_format::{
             block::MAX_ON_DISK_HEIGHT,
+            transparent::AddressLocation,
             upgrade::{DbFormatChange, DbFormatChangeThreadHandle},
         },
     },
-    write_database_format_version_to_disk, BoxError, Config,
+    write_database_format_version_to_disk, BoxError, Config, OutputLocation,
 };
 
 use super::disk_format::upgrade::restorable_db_versions;
@@ -138,6 +139,17 @@ impl ZebraDb {
                 read_only,
             ),
         };
+
+        let zero_location_utxos =
+            db.address_utxo_locations(AddressLocation::from_usize(Height(0), 0, 0));
+        if !zero_location_utxos.is_empty() {
+            warn!(
+                "You have been impacted by the Zebra 2.4.0 address indexer corruption bug. \
+                If you rely on the data from the RPC interface, you will need to recover your database. \
+                Follow the instructions in the 2.4.1 release notes: https://github.com/ZcashFoundation/zebra/releases/tag/v2.4.1 \
+                If you just run the node for consensus and don't use data from the RPC interface, you can ignore this warning."
+            )
+        }
 
         db.spawn_format_change(format_change);
 


### PR DESCRIPTION
## Motivation

The last database upgrade unfortunately had a bug:

- In the upgrade, we create an empty AddressBalanceLocationChange (if a previous doesn't exist for the address) and update its received field [https://github.com/ZcashFoundation/zebra/blob/cb736ef38b6950e5529e765ea5a73eec8557[…]ed_state/disk_format/upgrade/block_info_and_address_received.rs](https://github.com/ZcashFoundation/zebra/blob/cb736ef38b6950e5529e765ea5a73eec85576c9b/zebra-state/src/service/finalized_state/disk_format/upgrade/block_info_and_address_received.rs#L123)
- We add it as a merge to the batch in [https://github.com/ZcashFoundation/zebra/blob/cb736ef38b6950e5529e765ea5a73eec8557[…]ed_state/disk_format/upgrade/block_info_and_address_received.rs](https://github.com/ZcashFoundation/zebra/blob/cb736ef38b6950e5529e765ea5a73eec85576c9b/zebra-state/src/service/finalized_state/disk_format/upgrade/block_info_and_address_received.rs#L205). Note however that only the received field is set, balance and location are set to 0
- Upon merge, we simply read the existing value as a Change and add to other changes [https://github.com/ZcashFoundation/zebra/blob/cb736ef38b6950e5529e765ea5a73eec8557[…]zebra-state/src/service/finalized_state/zebra_db/transparent.rs](https://github.com/ZcashFoundation/zebra/blob/cb736ef38b6950e5529e765ea5a73eec85576c9b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs#L70)
- The add operator, however, sets the location to the mininum of both locations; since the change was set to 0, it will set the final value to 0 [https://github.com/ZcashFoundation/zebra/blob/cb736ef38b6950e5529e765ea5a73eec8557[…]ra-state/src/service/finalized_state/disk_format/transparent.rs](https://github.com/ZcashFoundation/zebra/blob/cb736ef38b6950e5529e765ea5a73eec85576c9b/zebra-state/src/service/finalized_state/disk_format/transparent.rs#L225)
- The end result being all locations being set to 0 during upgrade

Closes https://github.com/ZcashFoundation/zebra/issues/9685

## Solution

This fixes the underlying bug, but impacted users will still have to do a recovery procedure with `copy-state` which we will explain in the 2.4.1 release notes.

This also adds a warning to impacted users.

### Tests

I tested this manually:

- From a v26 backup, I started the node. It did the database upgrade. I confirmed that it worked by checking that  `zcash-cli  getaddressutxos '{"addresses": ["t1UVpBZR9VSJi2V28xhfXFn7pQz4VFkokp3"]}'` returned empty. The lack of warning also confirmed it worked.
- Running from my corrupted v27 state, I confirmed that the warning was logged.

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
