### PR TITLE
fix(ci): prevent cached state creation from failed tests

### DIFF
--- a/.github/workflows/sub-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/sub-deploy-integration-tests-gcp.yml
@@ -341,7 +341,8 @@ jobs:
     # We run exactly one of without-cached-state or with-cached-state, and we always skip the other one.
     # Normally, if a job is skipped, all the jobs that depend on it are also skipped.
     # So we need to override the default success() check to make this job run.
-    if: ${{ !cancelled() && !failure() && (inputs.saves_to_disk || inputs.force_save_to_disk) }}
+    #! Only create disk images when the test-result job succeeded
+    if: ${{ needs.test-result.result == 'success' && (inputs.saves_to_disk || inputs.force_save_to_disk) }}
     env:
       STATE_VERSION: ${{ needs.test-result.outputs.state_version }}
       CACHED_DISK_NAME: ${{ needs.test-result.outputs.cached_disk_name }}


### PR DESCRIPTION
## Motivation

The create-state-image job condition was using `!cancelled() && !failure()` which checks workflow-level status, not job-specific results. This caused disk images to be created even when the test-result job was cancelled, failed, or timed out, leading to corrupted cached states.

## Solution

Change condition to `needs.test-result.result == 'success'` to only create disk images when the specific test actually succeeded.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [X] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [X] The documentation is up to date.
