### PR TITLE
tests(qa): Ensure funds are available in wallet tests

### DIFF
--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -143,6 +143,11 @@ impl std::fmt::Debug for Network {
             Self::Testnet(params) if params.is_regtest() => f
                 .debug_struct("Regtest")
                 .field("activation_heights", params.activation_heights())
+                .field("pre_nu6_funding_streams", params.pre_nu6_funding_streams())
+                .field(
+                    "post_nu6_funding_streams",
+                    params.post_nu6_funding_streams(),
+                )
                 .finish(),
             Self::Testnet(params) if params.is_default_testnet() => {
                 write!(f, "{self}")

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -164,12 +164,8 @@ impl Network {
     }
 
     /// Creates a new [`Network::Testnet`] with `Regtest` parameters and the provided network upgrade activation heights.
-    pub fn new_regtest(
-        configured_activation_heights: testnet::ConfiguredActivationHeights,
-    ) -> Self {
-        Self::new_configured_testnet(testnet::Parameters::new_regtest(
-            configured_activation_heights,
-        ))
+    pub fn new_regtest(params: testnet::RegtestParameters) -> Self {
+        Self::new_configured_testnet(testnet::Parameters::new_regtest(params))
     }
 
     /// Returns true if the network is the default Testnet, or false otherwise.

--- a/zebra-chain/src/parameters/network/subsidy.rs
+++ b/zebra-chain/src/parameters/network/subsidy.rs
@@ -142,6 +142,11 @@ impl FundingStreams {
         }
     }
 
+    /// Creates a new empty [`FundingStreams`] representing no funding streams.
+    pub fn empty() -> Self {
+        Self::new(Height::MAX..Height::MAX, HashMap::new())
+    }
+
     /// Returns height range where these [`FundingStreams`] should apply.
     pub fn height_range(&self) -> &std::ops::Range<Height> {
         &self.height_range

--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -796,8 +796,8 @@ impl Parameters {
             activation_heights: _,
             slow_start_interval,
             slow_start_shift,
-            pre_nu6_funding_streams,
-            post_nu6_funding_streams,
+            pre_nu6_funding_streams: _,
+            post_nu6_funding_streams: _,
             target_difficulty_limit,
             disable_pow,
             should_allow_unshielded_coinbase_spends,
@@ -809,8 +809,6 @@ impl Parameters {
             && self.genesis_hash == genesis_hash
             && self.slow_start_interval == slow_start_interval
             && self.slow_start_shift == slow_start_shift
-            && self.pre_nu6_funding_streams == pre_nu6_funding_streams
-            && self.post_nu6_funding_streams == post_nu6_funding_streams
             && self.target_difficulty_limit == target_difficulty_limit
             && self.disable_pow == disable_pow
             && self.should_allow_unshielded_coinbase_spends

--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -688,14 +688,11 @@ impl Parameters {
     /// Creates an instance of [`Parameters`] with `Regtest` values.
     pub fn new_regtest(
         RegtestParameters {
-            activation_heights: ConfiguredActivationHeights { nu5, nu6, nu7, .. },
+            activation_heights,
             pre_nu6_funding_streams,
             post_nu6_funding_streams,
         }: RegtestParameters,
     ) -> Self {
-        #[cfg(any(test, feature = "proptest-impl"))]
-        let nu5 = nu5.or(Some(100));
-
         // Configure no funding streams by default if none are provided rather than the default testnet funding streams.
         let pre_nu6_funding_streams =
             pre_nu6_funding_streams.unwrap_or(ConfiguredFundingStreams::empty());
@@ -711,13 +708,7 @@ impl Parameters {
             .with_slow_start_interval(Height::MIN)
             // Removes default Testnet activation heights if not configured,
             // most network upgrades are disabled by default for Regtest in zcashd
-            .with_activation_heights(ConfiguredActivationHeights {
-                canopy: Some(1),
-                nu5,
-                nu6,
-                nu7,
-                ..Default::default()
-            })
+            .with_activation_heights(activation_heights)
             .with_halving_interval(PRE_BLOSSOM_REGTEST_HALVING_INTERVAL)
             .with_pre_nu6_funding_streams(pre_nu6_funding_streams)
             .with_post_nu6_funding_streams(post_nu6_funding_streams);

--- a/zebra-chain/src/parameters/network/tests/vectors.rs
+++ b/zebra-chain/src/parameters/network/tests/vectors.rs
@@ -12,7 +12,8 @@ use crate::{
         },
         testnet::{
             self, ConfiguredActivationHeights, ConfiguredFundingStreamRecipient,
-            ConfiguredFundingStreams, MAX_NETWORK_NAME_LENGTH, RESERVED_NETWORK_NAMES,
+            ConfiguredFundingStreams, RegtestParameters, MAX_NETWORK_NAME_LENGTH,
+            RESERVED_NETWORK_NAMES,
         },
         Network, NetworkUpgrade, MAINNET_ACTIVATION_HEIGHTS, TESTNET_ACTIVATION_HEIGHTS,
     },
@@ -447,4 +448,24 @@ fn check_configured_funding_stream_constraints() {
     );
     expected_panic_wrong_addr_network
         .expect_err("should panic when recipient addresses are for Mainnet");
+}
+
+/// Check that `new_regtest()` constructs a network with the provided funding streams.
+#[test]
+fn check_configured_funding_stream_regtest() {
+    let default_testnet = Network::new_default_testnet();
+    let regtest = Network::new_regtest(RegtestParameters {
+        activation_heights: (&default_testnet.activation_list()).into(),
+        pre_nu6_funding_streams: Some(default_testnet.pre_nu6_funding_streams().into()),
+        post_nu6_funding_streams: Some(default_testnet.post_nu6_funding_streams().into()),
+    });
+
+    assert_eq!(
+        default_testnet.pre_nu6_funding_streams(),
+        regtest.pre_nu6_funding_streams()
+    );
+    assert_eq!(
+        default_testnet.post_nu6_funding_streams(),
+        regtest.post_nu6_funding_streams()
+    );
 }

--- a/zebra-chain/src/parameters/network/tests/vectors.rs
+++ b/zebra-chain/src/parameters/network/tests/vectors.rs
@@ -286,14 +286,16 @@ fn check_network_name() {
 fn check_full_activation_list() {
     let network = testnet::Parameters::build()
         .with_activation_heights(ConfiguredActivationHeights {
-            nu6_1: Some(1),
+            // Update this to be the latest network upgrade in Zebra, and update
+            // the code below to expect the latest number of network upgrades.
+            nu7: Some(1),
             ..Default::default()
         })
         .clear_funding_streams()
         .to_network();
 
-    // We expect the first 10 network upgrades to be included, up to and including NU6.1
-    let expected_network_upgrades = NetworkUpgrade::iter().take(10);
+    // We expect the first 11 network upgrades to be included, up to and including NU7
+    let expected_network_upgrades = NetworkUpgrade::iter().take(11);
     let full_activation_list_network_upgrades: Vec<_> = network
         .full_activation_list()
         .into_iter()

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -1001,6 +1001,8 @@ async fn mempool_request_with_transparent_coinbase_spend_is_accepted_on_regtest(
 
     let network = Network::new_regtest(
         ConfiguredActivationHeights {
+            canopy: Some(1),
+            nu5: Some(100),
             nu6: Some(1_000),
             ..Default::default()
         }

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -999,10 +999,13 @@ async fn mempool_request_with_immature_spend_is_rejected() {
 async fn mempool_request_with_transparent_coinbase_spend_is_accepted_on_regtest() {
     let _init_guard = zebra_test::init();
 
-    let network = Network::new_regtest(ConfiguredActivationHeights {
-        nu6: Some(1_000),
-        ..Default::default()
-    });
+    let network = Network::new_regtest(
+        ConfiguredActivationHeights {
+            nu6: Some(1_000),
+            ..Default::default()
+        }
+        .into(),
+    );
     let mut state: MockService<_, _, _, _> = MockService::build().for_unit_tests();
     let verifier = Verifier::new_for_tests(&network, state.clone());
 

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -16,7 +16,7 @@ use tracing::Span;
 use zebra_chain::{
     common::atomic_write,
     parameters::{
-        testnet::{self, ConfiguredActivationHeights, ConfiguredFundingStreams},
+        testnet::{self, ConfiguredActivationHeights, ConfiguredFundingStreams, RegtestParameters},
         Magic, Network, NetworkKind,
     },
     work::difficulty::U256,
@@ -729,11 +729,22 @@ impl<'de> Deserialize<'de> for Config {
             (NetworkKind::Mainnet, _) => Network::Mainnet,
             (NetworkKind::Testnet, None) => Network::new_default_testnet(),
             (NetworkKind::Regtest, testnet_parameters) => {
-                let configured_activation_heights = testnet_parameters
-                    .and_then(|params| params.activation_heights)
+                let params = testnet_parameters
+                    .map(
+                        |DTestnetParameters {
+                             activation_heights,
+                             pre_nu6_funding_streams,
+                             post_nu6_funding_streams,
+                             ..
+                         }| RegtestParameters {
+                            activation_heights: activation_heights.unwrap_or_default(),
+                            pre_nu6_funding_streams,
+                            post_nu6_funding_streams,
+                        },
+                    )
                     .unwrap_or_default();
 
-                Network::new_regtest(configured_activation_heights)
+                Network::new_regtest(params)
             }
             (
                 NetworkKind::Testnet,

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -16,6 +16,7 @@ use tracing::Span;
 use zebra_chain::{
     common::atomic_write,
     parameters::{
+        subsidy::FundingStreams,
         testnet::{self, ConfiguredActivationHeights, ConfiguredFundingStreams, RegtestParameters},
         Magic, Network, NetworkKind,
     },
@@ -636,6 +637,14 @@ impl Default for DConfig {
 
 impl From<Arc<testnet::Parameters>> for DTestnetParameters {
     fn from(params: Arc<testnet::Parameters>) -> Self {
+        fn replace_empty_with_none(fs: &FundingStreams) -> Option<ConfiguredFundingStreams> {
+            if fs.recipients().is_empty() {
+                None
+            } else {
+                Some(fs.into())
+            }
+        }
+
         Self {
             network_name: Some(params.network_name().to_string()),
             network_magic: Some(params.network_magic().0),
@@ -644,8 +653,8 @@ impl From<Arc<testnet::Parameters>> for DTestnetParameters {
             disable_pow: Some(params.disable_pow()),
             genesis_hash: Some(params.genesis_hash().to_string()),
             activation_heights: Some(params.activation_heights().into()),
-            pre_nu6_funding_streams: Some(params.pre_nu6_funding_streams().into()),
-            post_nu6_funding_streams: Some(params.post_nu6_funding_streams().into()),
+            pre_nu6_funding_streams: replace_empty_with_none(params.pre_nu6_funding_streams()),
+            post_nu6_funding_streams: replace_empty_with_none(params.post_nu6_funding_streams()),
             pre_blossom_halving_interval: Some(
                 params
                     .pre_blossom_halving_interval()

--- a/zebra-rpc/qa/README.md
+++ b/zebra-rpc/qa/README.md
@@ -69,6 +69,13 @@ Possible options, which apply to each individual test run:
 If you set the environment variable `PYTHON_DEBUG=1` you will get some debug
 output (example: `PYTHON_DEBUG=1 qa/pull-tester/rpc-tests.py wallet`).
 
+To get real time output during a test you can run it using the
+`python3` binary such as:
+
+```
+python3 qa/rpc-tests/wallet.py
+```
+
 A 200-block -regtest blockchain and wallets for four nodes
 is created the first time a regression test is run and
 is stored in the cache/ directory.  Each node has the miner

--- a/zebra-rpc/qa/base_config.toml
+++ b/zebra-rpc/qa/base_config.toml
@@ -17,3 +17,35 @@ cache_dir = ""
 [network.testnet_parameters.activation_heights]
 NU5 = 290
 NU6 = 291
+
+[[network.testnet_parameters.pre_nu6_funding_streams.recipients]]
+receiver = "ECC"
+numerator = 7
+addresses = ["t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz"]
+
+[[network.testnet_parameters.pre_nu6_funding_streams.recipients]]
+receiver = "ZcashFoundation"
+numerator = 5
+addresses = ["t27eWDgjFYJGVXmzrXeVjnb5J3uXDM9xH9v"]
+
+[[network.testnet_parameters.pre_nu6_funding_streams.recipients]]
+receiver = "MajorGrants"
+numerator = 8
+addresses = ["t2Gvxv2uNM7hbbACjNox4H6DjByoKZ2Fa3P"]
+
+[network.testnet_parameters.pre_nu6_funding_streams.height_range]
+start = 290
+end = 291
+
+[[network.testnet_parameters.post_nu6_funding_streams.recipients]]
+receiver = "MajorGrants"
+numerator = 8
+addresses = ["t2Gvxv2uNM7hbbACjNox4H6DjByoKZ2Fa3P"]
+
+[[network.testnet_parameters.post_nu6_funding_streams.recipients]]
+receiver = "Deferred"
+numerator = 12
+
+[network.testnet_parameters.post_nu6_funding_streams.height_range]
+start = 291
+end = 293

--- a/zebra-rpc/qa/base_config.toml
+++ b/zebra-rpc/qa/base_config.toml
@@ -18,34 +18,3 @@ cache_dir = ""
 NU5 = 290
 NU6 = 291
 
-[[network.testnet_parameters.pre_nu6_funding_streams.recipients]]
-receiver = "ECC"
-numerator = 7
-addresses = ["t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz"]
-
-[[network.testnet_parameters.pre_nu6_funding_streams.recipients]]
-receiver = "ZcashFoundation"
-numerator = 5
-addresses = ["t27eWDgjFYJGVXmzrXeVjnb5J3uXDM9xH9v"]
-
-[[network.testnet_parameters.pre_nu6_funding_streams.recipients]]
-receiver = "MajorGrants"
-numerator = 8
-addresses = ["t2Gvxv2uNM7hbbACjNox4H6DjByoKZ2Fa3P"]
-
-[network.testnet_parameters.pre_nu6_funding_streams.height_range]
-start = 290
-end = 291
-
-[[network.testnet_parameters.post_nu6_funding_streams.recipients]]
-receiver = "MajorGrants"
-numerator = 8
-addresses = ["t2Gvxv2uNM7hbbACjNox4H6DjByoKZ2Fa3P"]
-
-[[network.testnet_parameters.post_nu6_funding_streams.recipients]]
-receiver = "Deferred"
-numerator = 12
-
-[network.testnet_parameters.post_nu6_funding_streams.height_range]
-start = 291
-end = 293

--- a/zebra-rpc/qa/pull-tester/rpc-tests.py
+++ b/zebra-rpc/qa/pull-tester/rpc-tests.py
@@ -42,7 +42,8 @@ BASE_SCRIPTS= [
     'getmininginfo.py',
     'nuparams.py',
     'addnode.py',
-    'wallet.py']
+    'wallet.py',
+    'feature_nu6.py']
 
 ZMQ_SCRIPTS = [
     # ZMQ test can only be run if bitcoin was built with zmq-enabled.

--- a/zebra-rpc/qa/rpc-tests/addnode.py
+++ b/zebra-rpc/qa/rpc-tests/addnode.py
@@ -16,7 +16,8 @@ class AddNodeTest (BitcoinTestFramework):
         self.num_nodes = 3
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes , self.options.tmpdir)
+        args = [[False] * self.num_nodes]
+        self.nodes = start_nodes(self.num_nodes , self.options.tmpdir, args)
 
         # connect all the nodes to each other
         connect_nodes_bi(self.nodes,0,1)

--- a/zebra-rpc/qa/rpc-tests/addnode.py
+++ b/zebra-rpc/qa/rpc-tests/addnode.py
@@ -16,7 +16,11 @@ class AddNodeTest (BitcoinTestFramework):
         self.num_nodes = 3
 
     def setup_network(self, split=False):
-        args = [False, False, False]
+        args = [
+            [False, "tmSRd1r8gs77Ja67Fw1JcdoXytxsyrLTPJm"],
+            [False, "tmSRd1r8gs77Ja67Fw1JcdoXytxsyrLTPJm"],
+            [False, "tmSRd1r8gs77Ja67Fw1JcdoXytxsyrLTPJm"]
+        ]
         self.nodes = start_nodes(self.num_nodes , self.options.tmpdir, extra_args=args)
 
         # connect all the nodes to each other

--- a/zebra-rpc/qa/rpc-tests/addnode.py
+++ b/zebra-rpc/qa/rpc-tests/addnode.py
@@ -16,8 +16,8 @@ class AddNodeTest (BitcoinTestFramework):
         self.num_nodes = 3
 
     def setup_network(self, split=False):
-        args = [[False] * self.num_nodes]
-        self.nodes = start_nodes(self.num_nodes , self.options.tmpdir, args)
+        args = [False, False, False]
+        self.nodes = start_nodes(self.num_nodes , self.options.tmpdir, extra_args=args)
 
         # connect all the nodes to each other
         connect_nodes_bi(self.nodes,0,1)

--- a/zebra-rpc/qa/rpc-tests/feature_nu6.py
+++ b/zebra-rpc/qa/rpc-tests/feature_nu6.py
@@ -28,7 +28,7 @@ class PoolsTest(BitcoinTestFramework):
 
     def setup_network(self):
         # Add pre and post NU6 funding streams to the node.
-        args = [True]
+        args = [[True, "tmSRd1r8gs77Ja67Fw1JcdoXytxsyrLTPJm"]]
 
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, extra_args=args)
 

--- a/zebra-rpc/qa/rpc-tests/feature_nu6.py
+++ b/zebra-rpc/qa/rpc-tests/feature_nu6.py
@@ -28,14 +28,14 @@ class PoolsTest(BitcoinTestFramework):
 
     def setup_network(self):
         # Add pre and post NU6 funding streams to the node.
-        args = [[True] * self.num_nodes]
+        args = [True]
 
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, extra_args=args)
 
     def run_test(self):
 
         def get_value_pools(value_pools):
-            pools_by_id = { pool['id']: pool for pool in value_pools_from_getblock }
+            pools_by_id = { pool['id']: pool for pool in value_pools }
             return (pools_by_id['transparent'],
                     pools_by_id['sprout'],
                     pools_by_id['sapling'],
@@ -57,6 +57,16 @@ class PoolsTest(BitcoinTestFramework):
                     upgrades_by_name['NU5'],
                     upgrades_by_name['NU6'])
 
+        def assert_value_pools_equals(pool1,  pool2):
+            (transparent_pool1, sapling_pool1, sprout_pool1, orchard_pool1, deferred_pool1) = get_value_pools(pool1)
+            (transparent_pool2, sapling_pool2, sprout_pool2, orchard_pool2, deferred_pool2) = get_value_pools(pool1)
+
+            assert_equal(transparent_pool1['chainValue'], transparent_pool2['chainValue'])
+            assert_equal(sapling_pool1['chainValue'], sapling_pool2['chainValue'])
+            assert_equal(sprout_pool1['chainValue'], sprout_pool2['chainValue'])
+            assert_equal(orchard_pool1['chainValue'], orchard_pool2['chainValue'])
+            assert_equal(deferred_pool1['chainValue'], deferred_pool2['chainValue'])
+
         print("Initial Conditions at Block 0")
 
         # Check all value pools are empty
@@ -73,7 +83,7 @@ class PoolsTest(BitcoinTestFramework):
         value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
         (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
 
-        assert_equal(get_value_pools(value_pools_from_getblock), get_value_pools(value_pools_from_getblockchaininfo))
+        assert_value_pools_equals(value_pools_from_getblock, value_pools_from_getblockchaininfo)
 
         # Check the network upgrades are all pending
         (overwinter, sapling, blossom, heartwood, canopy, nu5, nu6) = get_network_upgrades(getblockchaininfo)
@@ -103,7 +113,7 @@ class PoolsTest(BitcoinTestFramework):
         value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
         (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
 
-        assert_equal(get_value_pools(value_pools_from_getblock), get_value_pools(value_pools_from_getblockchaininfo))
+        assert_value_pools_equals(value_pools_from_getblock, value_pools_from_getblockchaininfo)
 
         # Check the network upgrades up to Canopy are active
         (overwinter, sapling, blossom, heartwood, canopy, nu5, nu6) = get_network_upgrades(getblockchaininfo)
@@ -119,7 +129,7 @@ class PoolsTest(BitcoinTestFramework):
         print("Activating NU5 at Block 290")
         self.nodes[0].generate(289)
 
-        # chjeck that the only value pool with value is still the transparent and nothing else
+        # Check that the only value pool with value is still the transparent and nothing else
         value_pools_from_getblock = self.nodes[0].getblock('290')['valuePools']
         (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblock)
 
@@ -133,7 +143,7 @@ class PoolsTest(BitcoinTestFramework):
         value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
         (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
 
-        assert_equal(get_value_pools(value_pools_from_getblock), get_value_pools(value_pools_from_getblockchaininfo))
+        assert_value_pools_equals(value_pools_from_getblock, value_pools_from_getblockchaininfo)
 
         # Check that NU5 is now active
         (overwinter, sapling, blossom, heartwood, canopy, nu5, nu6) = get_network_upgrades(getblockchaininfo)
@@ -152,6 +162,7 @@ class PoolsTest(BitcoinTestFramework):
         assert_equal(block_subsidy['founders'], Decimal('0'))
         assert_equal(block_subsidy['fundingstreamstotal'], Decimal('0.625'))
         assert_equal(block_subsidy['lockboxtotal'], Decimal('0'))
+        print(block_subsidy)
         assert_equal(block_subsidy['totalblocksubsidy'], Decimal('3.125'))
 
         print("Activating NU6")
@@ -171,7 +182,7 @@ class PoolsTest(BitcoinTestFramework):
         value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
         (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
 
-        assert_equal(get_value_pools(value_pools_from_getblock), get_value_pools(value_pools_from_getblockchaininfo))
+        assert_value_pools_equals(value_pools_from_getblock, value_pools_from_getblockchaininfo)
 
         # Check all upgrades up to NU6 are active
         (overwinter, sapling, blossom, heartwood, canopy, nu5, nu6) = get_network_upgrades(getblockchaininfo)
@@ -209,7 +220,7 @@ class PoolsTest(BitcoinTestFramework):
         value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
         (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
 
-        assert_equal(get_value_pools(value_pools_from_getblock), get_value_pools(value_pools_from_getblockchaininfo))
+        assert_value_pools_equals(value_pools_from_getblock, value_pools_from_getblockchaininfo)
 
         print("Pass the range of the lockbox, tip now at Block 294")
         self.nodes[0].generate(2)
@@ -228,7 +239,7 @@ class PoolsTest(BitcoinTestFramework):
         value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
         (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
 
-        assert_equal(get_value_pools(value_pools_from_getblock), get_value_pools(value_pools_from_getblockchaininfo))
+        assert_value_pools_equals(value_pools_from_getblock, value_pools_from_getblockchaininfo)
 
         # Check there are no fundingstreams or lockbox rewards after the range
         block_subsidy = self.nodes[0].getblocksubsidy()

--- a/zebra-rpc/qa/rpc-tests/feature_nu6.py
+++ b/zebra-rpc/qa/rpc-tests/feature_nu6.py
@@ -27,7 +27,10 @@ class PoolsTest(BitcoinTestFramework):
         self.cache_behavior = 'clean'
 
     def setup_network(self):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+        # Add pre and post NU6 funding streams to the node.
+        args = [[True] * self.num_nodes]
+
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, extra_args=args)
 
     def run_test(self):
 

--- a/zebra-rpc/qa/rpc-tests/feature_nu6.py
+++ b/zebra-rpc/qa/rpc-tests/feature_nu6.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 The Zcash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+from decimal import Decimal
+
+from test_framework.util import (
+    assert_equal,
+    start_nodes,
+)
+
+from test_framework.test_framework import BitcoinTestFramework
+
+
+# Check the behaviour of the value pools and funding streams at NU6.
+#
+# - The funding streams are updated at NU6.
+# - The lockbox pool and rewards are activated at NU6.
+# - The lockbox accumulates after NU6 inside the configured range.
+# - The lockbox rewrards and NU6 funding streams end after the configured range.
+class PoolsTest(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 1
+        self.cache_behavior = 'clean'
+
+    def setup_network(self):
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+
+    def run_test(self):
+
+        def get_value_pools(value_pools):
+            pools_by_id = { pool['id']: pool for pool in value_pools_from_getblock }
+            return (pools_by_id['transparent'],
+                    pools_by_id['sprout'],
+                    pools_by_id['sapling'],
+                    pools_by_id['orchard'],
+                    pools_by_id['deferred'])
+
+        def get_network_upgrades(getblockchaininfo):
+            upgrades_by_name = {
+                upgrade['name']: {
+                    k: v for k, v in upgrade.items() if k != 'name'
+                }
+                for upgrade in getblockchaininfo['upgrades'].values()
+            }
+            return (upgrades_by_name['Overwinter'],
+                    upgrades_by_name['Sapling'],
+                    upgrades_by_name['Blossom'],
+                    upgrades_by_name['Heartwood'],
+                    upgrades_by_name['Canopy'],
+                    upgrades_by_name['NU5'],
+                    upgrades_by_name['NU6'])
+
+        print("Initial Conditions at Block 0")
+
+        # Check all value pools are empty
+        value_pools_from_getblock = self.nodes[0].getblock('0')['valuePools']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblock)
+
+        assert_equal(transparent_pool['chainValue'], Decimal('0'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0'))
+
+        getblockchaininfo = self.nodes[0].getblockchaininfo()
+        value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
+
+        assert_equal(get_value_pools(value_pools_from_getblock), get_value_pools(value_pools_from_getblockchaininfo))
+
+        # Check the network upgrades are all pending
+        (overwinter, sapling, blossom, heartwood, canopy, nu5, nu6) = get_network_upgrades(getblockchaininfo)
+
+        assert_equal(overwinter['status'], 'pending')
+        assert_equal(sapling['status'], 'pending')
+        assert_equal(blossom['status'], 'pending')
+        assert_equal(heartwood['status'], 'pending')
+        assert_equal(canopy['status'], 'pending')
+        assert_equal(nu5['status'], 'pending')
+        assert_equal(nu6['status'], 'pending')
+
+        print("Activating Overwinter, Sapling, Blossom, Heartwood and Canopy at Block 1")
+        self.nodes[0].generate(1)
+
+        # Check that the transparent pool is the only one with value
+        value_pools_from_getblock = self.nodes[0].getblock('1')['valuePools']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblock)
+
+        assert_equal(transparent_pool['chainValue'], Decimal('6.25'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0'))
+
+        getblockchaininfo = self.nodes[0].getblockchaininfo()
+        value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
+
+        assert_equal(get_value_pools(value_pools_from_getblock), get_value_pools(value_pools_from_getblockchaininfo))
+
+        # Check the network upgrades up to Canopy are active
+        (overwinter, sapling, blossom, heartwood, canopy, nu5, nu6) = get_network_upgrades(getblockchaininfo)
+
+        assert_equal(overwinter['status'], 'active')
+        assert_equal(sapling['status'], 'active')
+        assert_equal(blossom['status'], 'active')
+        assert_equal(heartwood['status'], 'active')
+        assert_equal(canopy['status'], 'active')
+        assert_equal(nu5['status'], 'pending')
+        assert_equal(nu6['status'], 'pending')
+
+        print("Activating NU5 at Block 290")
+        self.nodes[0].generate(289)
+
+        # chjeck that the only value pool with value is still the transparent and nothing else
+        value_pools_from_getblock = self.nodes[0].getblock('290')['valuePools']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblock)
+
+        assert_equal(transparent_pool['chainValue'], Decimal('1800'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0'))
+
+        getblockchaininfo = self.nodes[0].getblockchaininfo()
+        value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
+
+        assert_equal(get_value_pools(value_pools_from_getblock), get_value_pools(value_pools_from_getblockchaininfo))
+
+        # Check that NU5 is now active
+        (overwinter, sapling, blossom, heartwood, canopy, nu5, nu6) = get_network_upgrades(getblockchaininfo)
+
+        assert_equal(overwinter['status'], 'active')
+        assert_equal(sapling['status'], 'active')
+        assert_equal(blossom['status'], 'active')
+        assert_equal(heartwood['status'], 'active')
+        assert_equal(canopy['status'], 'active')
+        assert_equal(nu5['status'], 'active')
+        assert_equal(nu6['status'], 'pending')
+    
+        # Check we have fundingstream rewards but no lockbox rewards yet
+        block_subsidy = self.nodes[0].getblocksubsidy()
+        assert_equal(block_subsidy['miner'], Decimal('2.5'))
+        assert_equal(block_subsidy['founders'], Decimal('0'))
+        assert_equal(block_subsidy['fundingstreamstotal'], Decimal('0.625'))
+        assert_equal(block_subsidy['lockboxtotal'], Decimal('0'))
+        assert_equal(block_subsidy['totalblocksubsidy'], Decimal('3.125'))
+
+        print("Activating NU6")
+        self.nodes[0].generate(1)
+
+        # Check the deferred pool has value now
+        value_pools_from_getblock = self.nodes[0].getblock('291')['valuePools']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblock)
+
+        assert_equal(transparent_pool['chainValue'], Decimal('1802.75'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0.375'))
+
+        getblockchaininfo = self.nodes[0].getblockchaininfo()
+        value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
+
+        assert_equal(get_value_pools(value_pools_from_getblock), get_value_pools(value_pools_from_getblockchaininfo))
+
+        # Check all upgrades up to NU6 are active
+        (overwinter, sapling, blossom, heartwood, canopy, nu5, nu6) = get_network_upgrades(getblockchaininfo)
+
+        assert_equal(overwinter['status'], 'active')
+        assert_equal(sapling['status'], 'active')
+        assert_equal(blossom['status'], 'active')
+        assert_equal(heartwood['status'], 'active')
+        assert_equal(canopy['status'], 'active')
+        assert_equal(nu5['status'], 'active')
+        assert_equal(nu6['status'], 'active')
+
+        # Check that we have fundingstreams and lockbox rewards
+        block_subsidy = self.nodes[0].getblocksubsidy()
+        assert_equal(block_subsidy['miner'], Decimal('2.5'))
+        assert_equal(block_subsidy['founders'], Decimal('0'))
+        assert_equal(block_subsidy['fundingstreamstotal'], Decimal('0.25'))
+        assert_equal(block_subsidy['lockboxtotal'], Decimal('0.375'))
+        assert_equal(block_subsidy['totalblocksubsidy'], Decimal('3.125'))
+
+        print("Pass NU6 by one block, tip now at Block 292, inside the range of the lockbox rewards")
+        self.nodes[0].generate(1)
+
+        # Check the deferred pool has more value now
+        value_pools_from_getblock = self.nodes[0].getblock('292')['valuePools']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblock)
+
+        assert_equal(transparent_pool['chainValue'], Decimal('1805.5'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0.75'))
+
+        getblockchaininfo = self.nodes[0].getblockchaininfo()
+        value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
+
+        assert_equal(get_value_pools(value_pools_from_getblock), get_value_pools(value_pools_from_getblockchaininfo))
+
+        print("Pass the range of the lockbox, tip now at Block 294")
+        self.nodes[0].generate(2)
+
+        # Check the final deferred pool remains the same (locked until NU6.1)
+        value_pools_from_getblock = self.nodes[0].getblock('294')['valuePools']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblock)
+
+        assert_equal(transparent_pool['chainValue'], Decimal('1811.75'))
+        assert_equal(sprout_pool['chainValue'], Decimal('0'))
+        assert_equal(sapling_pool['chainValue'], Decimal('0'))
+        assert_equal(orchard_pool['chainValue'], Decimal('0'))
+        assert_equal(deferred_pool['chainValue'], Decimal('0.75'))
+
+        getblockchaininfo = self.nodes[0].getblockchaininfo()
+        value_pools_from_getblockchaininfo = getblockchaininfo['valuePools']
+        (transparent_pool, sapling_pool, sprout_pool, orchard_pool, deferred_pool) = get_value_pools(value_pools_from_getblockchaininfo)
+
+        assert_equal(get_value_pools(value_pools_from_getblock), get_value_pools(value_pools_from_getblockchaininfo))
+
+        # Check there are no fundingstreams or lockbox rewards after the range
+        block_subsidy = self.nodes[0].getblocksubsidy()
+        assert_equal(block_subsidy['miner'], Decimal('3.125'))
+        assert_equal(block_subsidy['founders'], Decimal('0'))
+        assert_equal(block_subsidy['fundingstreamstotal'], Decimal('0'))
+        assert_equal(block_subsidy['lockboxtotal'], Decimal('0'))
+        assert_equal(block_subsidy['totalblocksubsidy'], Decimal('3.125'))
+        
+
+if __name__ == '__main__':
+    PoolsTest().main()

--- a/zebra-rpc/qa/rpc-tests/getmininginfo.py
+++ b/zebra-rpc/qa/rpc-tests/getmininginfo.py
@@ -18,7 +18,7 @@ class GetMiningInfoTest(BitcoinTestFramework):
         self.cache_behavior = 'clean'
 
     def setup_network(self, split=False):
-        args = [[False] * self.num_nodes]
+        args = [False * self.num_nodes]
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, args)
         self.is_network_split = False
         self.sync_all()

--- a/zebra-rpc/qa/rpc-tests/getmininginfo.py
+++ b/zebra-rpc/qa/rpc-tests/getmininginfo.py
@@ -18,7 +18,7 @@ class GetMiningInfoTest(BitcoinTestFramework):
         self.cache_behavior = 'clean'
 
     def setup_network(self, split=False):
-        args = [False * self.num_nodes]
+        args = [[False, "tmSRd1r8gs77Ja67Fw1JcdoXytxsyrLTPJm"]]
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, args)
         self.is_network_split = False
         self.sync_all()

--- a/zebra-rpc/qa/rpc-tests/getmininginfo.py
+++ b/zebra-rpc/qa/rpc-tests/getmininginfo.py
@@ -18,7 +18,8 @@ class GetMiningInfoTest(BitcoinTestFramework):
         self.cache_behavior = 'clean'
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+        args = [[False] * self.num_nodes]
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, args)
         self.is_network_split = False
         self.sync_all()
 

--- a/zebra-rpc/qa/rpc-tests/nuparams.py
+++ b/zebra-rpc/qa/rpc-tests/nuparams.py
@@ -32,7 +32,7 @@ class NuparamsTest(BitcoinTestFramework):
         self.cache_behavior = 'clean'
 
     def setup_network(self, split=False):
-        args = [[] * self.num_nodes]
+        args = [[False] * self.num_nodes]
 
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, args)
         self.is_network_split = False

--- a/zebra-rpc/qa/rpc-tests/nuparams.py
+++ b/zebra-rpc/qa/rpc-tests/nuparams.py
@@ -32,7 +32,7 @@ class NuparamsTest(BitcoinTestFramework):
         self.cache_behavior = 'clean'
 
     def setup_network(self, split=False):
-        args = [[False] * self.num_nodes]
+        args = [False * self.num_nodes]
 
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, args)
         self.is_network_split = False

--- a/zebra-rpc/qa/rpc-tests/nuparams.py
+++ b/zebra-rpc/qa/rpc-tests/nuparams.py
@@ -32,7 +32,7 @@ class NuparamsTest(BitcoinTestFramework):
         self.cache_behavior = 'clean'
 
     def setup_network(self, split=False):
-        args = [False * self.num_nodes]
+        args = [[False, "tmSRd1r8gs77Ja67Fw1JcdoXytxsyrLTPJm"]]
 
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, args)
         self.is_network_split = False

--- a/zebra-rpc/qa/rpc-tests/reindex.py
+++ b/zebra-rpc/qa/rpc-tests/reindex.py
@@ -23,7 +23,9 @@ class ReindexTest(BitcoinTestFramework):
     def setup_network(self):
         self.nodes = []
         self.is_network_split = False
-        self.nodes.append(start_node(0, self.options.tmpdir))
+        args = [False]
+
+        self.nodes.append(start_node(0, self.options.tmpdir, args))
 
     def reindex(self, justchainstate=False):
         # When zebra reindexes, it will only do it up to the finalized chain height. 

--- a/zebra-rpc/qa/rpc-tests/reindex.py
+++ b/zebra-rpc/qa/rpc-tests/reindex.py
@@ -23,7 +23,7 @@ class ReindexTest(BitcoinTestFramework):
     def setup_network(self):
         self.nodes = []
         self.is_network_split = False
-        args = [False]
+        args = [[False, "tmSRd1r8gs77Ja67Fw1JcdoXytxsyrLTPJm"]]
 
         self.nodes.append(start_node(0, self.options.tmpdir, args))
 
@@ -31,6 +31,7 @@ class ReindexTest(BitcoinTestFramework):
         # When zebra reindexes, it will only do it up to the finalized chain height. 
         # This happens after the first 100 blocks, so we need to generate 100 blocks
         # for the reindex to be able to catch block 1.
+        # https://github.com/ZcashFoundation/zebra/issues/9708
         finalized_height = 100
 
         self.nodes[0].generate(finalized_height)

--- a/zebra-rpc/qa/rpc-tests/test_framework/util.py
+++ b/zebra-rpc/qa/rpc-tests/test_framework/util.py
@@ -577,7 +577,10 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
     if binary is None:
         binary = zcashd_binary()
 
-    config = update_zebrad_conf(datadir, rpc_port(i), p2p_port(i), funding_streams = extra_args[i])
+    if extra_args is not None:
+        config = update_zebrad_conf(datadir, rpc_port(i), p2p_port(i), funding_streams = extra_args[i])
+    else:
+        config = update_zebrad_conf(datadir, rpc_port(i), p2p_port(i))
     args = [ binary, "-c="+config, "start" ]
 
     #if extra_args is not None: args.extend(extra_args)
@@ -623,7 +626,7 @@ def start_nodes(num_nodes, dirname, extra_args=None, rpchost=None, binary=None):
     rpcs = []
     try:
         for i in range(num_nodes):
-            rpcs.append(start_node(i, dirname, extra_args[i], rpchost, binary=binary[i]))
+            rpcs.append(start_node(i, dirname, extra_args, rpchost, binary=binary[i]))
     except: # If one node failed to start, stop the others
         stop_nodes(rpcs)
         raise
@@ -922,7 +925,7 @@ def update_zallet_conf(datadir, validator_port, zallet_port):
     config_file['rpc']['bind'][0] = '127.0.0.1:'+str(zallet_port)
     config_file['indexer']['validator_address'] = '127.0.0.1:'+str(validator_port)
 
-    config_file['wallet_db'] = os.path.join(datadir, 'datadir/data.sqlite')
+    config_file['database']['wallet'] = os.path.join(datadir, 'datadir/data.sqlite')
     config_file['indexer']['db_path'] = os.path.join(datadir, 'datadir/zaino')
     config_file['keystore']['identity'] = os.path.join(datadir, 'datadir/identity.txt')
 

--- a/zebra-rpc/qa/rpc-tests/test_framework/util.py
+++ b/zebra-rpc/qa/rpc-tests/test_framework/util.py
@@ -927,7 +927,7 @@ def update_zallet_conf(datadir, validator_port, zallet_port):
 
     config_file['database']['wallet'] = os.path.join(datadir, 'datadir/data.sqlite')
     config_file['indexer']['db_path'] = os.path.join(datadir, 'datadir/zaino')
-    config_file['keystore']['identity'] = os.path.join(datadir, 'datadir/identity.txt')
+    config_file['keystore']['encryption_identity'] = os.path.join(datadir, 'datadir/identity.txt')
 
     with open(config_path, 'w') as f:
         toml.dump(config_file, f)

--- a/zebra-rpc/qa/rpc-tests/wallet.py
+++ b/zebra-rpc/qa/rpc-tests/wallet.py
@@ -18,7 +18,7 @@ class WalletTest (BitcoinTestFramework):
         self.num_nodes = 4
 
     def setup_network(self, split=False):
-        args = [[False] * self.num_nodes]
+        args = [False, False, False]
         self.nodes = start_nodes(3, self.options.tmpdir, args)
 
         connect_nodes_bi(self.nodes,0,1)

--- a/zebra-rpc/qa/rpc-tests/wallet.py
+++ b/zebra-rpc/qa/rpc-tests/wallet.py
@@ -5,58 +5,31 @@
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 from decimal import Decimal
-import time
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, start_nodes, start_wallets, connect_nodes_bi
+from test_framework.util import assert_equal, start_nodes, start_wallets
 
 class WalletTest (BitcoinTestFramework):
 
     def __init__(self):
         super().__init__()
         self.cache_behavior = 'clean'
-        self.num_nodes = 4
+        self.num_nodes = 1
 
     def setup_network(self, split=False):
-        args = [False, False, False]
-        self.nodes = start_nodes(3, self.options.tmpdir, args)
+        args = [False]
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, args)
 
-        connect_nodes_bi(self.nodes,0,1)
-        connect_nodes_bi(self.nodes,1,2)
-        connect_nodes_bi(self.nodes,0,2)
-        self.is_network_split=False
-        self.sync_all()
-
-        # If nodes were connected, only one of them would generate a block
         self.nodes[0].generate(1)
-        self.sync_all()
 
         # TODO: Wallets can be started but we need to add miner address at least one of them:
         # https://github.com/ZcashFoundation/zebra/issues/9557
-        self.wallets = start_wallets(3, self.options.tmpdir)
+        self.wallets = start_wallets(self.num_nodes, self.options.tmpdir)
 
     def run_test(self):
-        print("checking connections...")
-
-        # As we connected the nodes to each other, they should have,
-        # at least 4 peers. Poll for that.
-        # TODO: Move this check to its own function.
-        timeout_for_connetions = 180
-        wait_time = 1
-        while timeout_for_connetions > 0:
-            if (len(self.nodes[0].getpeerinfo()) < 4 or
-                len(self.nodes[1].getpeerinfo()) < 4 or
-                len(self.nodes[2].getpeerinfo()) < 4):
-                timeout_for_connetions -= wait_time
-                time.sleep(wait_time)
-            else:
-                break
-        assert timeout_for_connetions > 0, "Timeout waiting for connections"
-
         print("Mining blocks...")
 
         self.nodes[0].generate(1)
-        self.sync_all()
 
         walletinfo = self.wallets[0].getwalletinfo()
         # TODO: getwalletinfo data is not implemented:

--- a/zebra-rpc/qa/rpc-tests/wallet.py
+++ b/zebra-rpc/qa/rpc-tests/wallet.py
@@ -18,7 +18,8 @@ class WalletTest (BitcoinTestFramework):
         self.num_nodes = 4
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(3, self.options.tmpdir)
+        args = [[False] * self.num_nodes]
+        self.nodes = start_nodes(3, self.options.tmpdir, args)
 
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)

--- a/zebra-rpc/qa/rpc-tests/wallet.py
+++ b/zebra-rpc/qa/rpc-tests/wallet.py
@@ -5,10 +5,12 @@
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 from decimal import Decimal
+import time
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, start_nodes, start_wallets
 
+# Test that we can create a wallet and use an address from it to mine blocks.
 class WalletTest (BitcoinTestFramework):
 
     def __init__(self):
@@ -17,27 +19,75 @@ class WalletTest (BitcoinTestFramework):
         self.num_nodes = 1
 
     def setup_network(self, split=False):
-        args = [False]
+        args = [[False, "tmSRd1r8gs77Ja67Fw1JcdoXytxsyrLTPJm"]]
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, args)
 
+        # Zallet needs a block to start
         self.nodes[0].generate(1)
 
-        # TODO: Wallets can be started but we need to add miner address at least one of them:
-        # https://github.com/ZcashFoundation/zebra/issues/9557
         self.wallets = start_wallets(self.num_nodes, self.options.tmpdir)
 
     def run_test(self):
-        print("Mining blocks...")
+        # Generate a new account
+        account = self.wallets[0].z_getnewaccount("test_account")
 
+        # Get an address for the account
+        address = self.wallets[0].z_getaddressforaccount(account['account_uuid'])
+
+        # Get the receivers from the generated unified address
+        receivers = self.wallets[0].z_listunifiedreceivers(address['address'])
+
+        # Get the transparent address from the receivers
+        transparent_address = receivers['p2pkh']
+
+        # Stop the wallet
+        try:
+            self.wallets[0].stop()
+        except Exception as e:
+            print("Ignoring stopping wallet error: ", e)
+        time.sleep(1)
+
+        # Hack for https://github.com/ZcashFoundation/zebra/issues/9708
+        # We Stop the wallet which has 1 block, generate 100 blocks in zebra,
+        # so when restarting Zebra it will have 1 block, just as the wallet.
+        self.nodes[0].generate(100)
+
+        # Stop the node
+        self.nodes[0].stop()
+        time.sleep(1)
+
+        # Restart the node with the generated address as the miner address
+        args = [[False, transparent_address]]
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, args)
+
+        # Restart the wallet
+        self.wallets = start_wallets(self.num_nodes, self.options.tmpdir)
+
+        # TODO: Use getwalletinfo when implemented
+        # https://github.com/zcash/wallet/issues/55
+
+        # No balance for the address in the node yet
+        node_balance = self.nodes[0].getaddressbalance(transparent_address)
+        assert_equal(node_balance['balance'], 0)
+
+        # No balance for the address in the wallet either
+        wallet_balance = self.wallets[0].z_gettotalbalance(1, True)
+        # TODO: Result is a string (https://github.com/zcash/wallet/issues/15)
+        assert_equal(wallet_balance['transparent'], '0.00000000')
+
+        # Mine a block
         self.nodes[0].generate(1)
 
-        walletinfo = self.wallets[0].getwalletinfo()
-        # TODO: getwalletinfo data is not implemented:
-        # https://github.com/zcash/wallet/issues/55
-        # TODO: Miner address is not in the wallet:
-        # https://github.com/ZcashFoundation/zebra/issues/9557
-        #assert_equal(Decimal(walletinfo['immature_balance']), Decimal('40'))
-        assert_equal(Decimal(walletinfo['balance']), Decimal('0'))
+        # Wait for the wallet to sync
+        time.sleep(1)
+
+        # Balance for the address increases in the node
+        node_balance = self.nodes[0].getaddressbalance(transparent_address)
+        assert_equal(node_balance['balance'], 625000000)
+
+        # Balance for the address increases in the wallet
+        wallet_balance = self.wallets[0].z_gettotalbalance(1, True)
+        assert_equal(wallet_balance['transparent'], '6.25000000')
 
 if __name__ == '__main__':
     WalletTest ().main ()

--- a/zebra-rpc/qa/zallet-datadir/zallet.toml
+++ b/zebra-rpc/qa/zallet-datadir/zallet.toml
@@ -32,7 +32,7 @@ validator_password = ".."
 db_path = "zaino"
 
 [keystore]
-identity = "identity.txt"
+encryption_identity = "identity.txt"
 
 [note_management]
 

--- a/zebra-rpc/qa/zallet-datadir/zallet.toml
+++ b/zebra-rpc/qa/zallet-datadir/zallet.toml
@@ -1,6 +1,8 @@
-network = "regtest"
-wallet_db = "data.sqlite"
+[builder.limits]
+orchard_actions = 250
 
+[consensus]
+network = "regtest"
 regtest_nuparams = [
     "5ba81b19:1",
     "76b809bb:1",
@@ -11,7 +13,17 @@ regtest_nuparams = [
     "c8e71055:291"
 ]
 
-[builder]
+[database]
+wallet = "data.sqlite"
+
+[external]
+
+[features]
+as_of_version = "0.0.0"
+
+[features.deprecated]
+
+[features.experimental]
 
 [indexer]
 validator_address = "127.0.0.1:0"
@@ -22,8 +34,7 @@ db_path = "zaino"
 [keystore]
 identity = "identity.txt"
 
-[limits]
-orchard_actions = 250
+[note_management]
 
 [rpc]
 bind = ["127.0.0.1:0"]

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -122,6 +122,7 @@ async fn test_z_get_treestate() {
             nu5: Some(10),
             ..Default::default()
         })
+        .clear_funding_streams()
         .with_network_name("custom_testnet")
         .to_network();
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -171,6 +171,7 @@ use zcash_keys::address::Address;
 use zebra_chain::{
     block::{self, genesis::regtest_genesis_block, ChainHistoryBlockTxAuthCommitmentHash, Height},
     parameters::{
+        testnet::ConfiguredActivationHeights,
         Network::{self, *},
         NetworkUpgrade,
     },
@@ -2973,7 +2974,13 @@ async fn trusted_chain_sync_handles_forks_correctly() -> Result<()> {
 
     let _init_guard = zebra_test::init();
 
-    let network = Network::new_regtest(Default::default());
+    let network = Network::new_regtest(
+        ConfiguredActivationHeights {
+            nu7: Some(1),
+            ..Default::default()
+        }
+        .into(),
+    );
     let mut config = os_assigned_rpc_port_config(false, &network)?;
 
     config.state.ephemeral = false;
@@ -3745,7 +3752,13 @@ async fn invalidate_and_reconsider_block() -> Result<()> {
     use common::regtest::MiningRpcMethods;
 
     let _init_guard = zebra_test::init();
-    let net = Network::new_regtest(Default::default());
+    let net = Network::new_regtest(
+        ConfiguredActivationHeights {
+            nu7: Some(100),
+            ..Default::default()
+        }
+        .into(),
+    );
     let mut config = os_assigned_rpc_port_config(false, &net)?;
     config.state.ephemeral = false;
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -2976,7 +2976,7 @@ async fn trusted_chain_sync_handles_forks_correctly() -> Result<()> {
 
     let network = Network::new_regtest(
         ConfiguredActivationHeights {
-            nu7: Some(1),
+            nu5: Some(100),
             ..Default::default()
         }
         .into(),

--- a/zebrad/tests/common/regtest.rs
+++ b/zebrad/tests/common/regtest.rs
@@ -35,7 +35,7 @@ pub(crate) async fn submit_blocks_test() -> Result<()> {
 
     let network = Network::new_regtest(
         ConfiguredActivationHeights {
-            nu7: Some(1),
+            nu5: Some(100),
             ..Default::default()
         }
         .into(),

--- a/zebrad/tests/common/regtest.rs
+++ b/zebrad/tests/common/regtest.rs
@@ -10,7 +10,7 @@ use tower::BoxError;
 
 use zebra_chain::{
     block::{Block, Height},
-    parameters::Network,
+    parameters::{testnet::ConfiguredActivationHeights, Network},
     primitives::byte_array::increment_big_endian,
     serialization::{ZcashDeserializeInto, ZcashSerialize},
 };
@@ -33,7 +33,13 @@ const NUM_BLOCKS_TO_SUBMIT: usize = 200;
 pub(crate) async fn submit_blocks_test() -> Result<()> {
     let _init_guard = zebra_test::init();
 
-    let network = Network::new_regtest(Default::default());
+    let network = Network::new_regtest(
+        ConfiguredActivationHeights {
+            nu7: Some(1),
+            ..Default::default()
+        }
+        .into(),
+    );
     let mut config = os_assigned_rpc_port_config(false, &network)?;
     config.mempool.debug_enable_at_height = Some(0);
 


### PR DESCRIPTION
## Motivation

A core requirement for all wallet-related tests is to ensure that the wallet has access to funds. This enables testing of transaction creation, balance tracking, and related functionality.

Closes [#9557](https://github.com/ZcashFoundation/zebra/issues/9557)

Depends on:

- https://github.com/ZcashFoundation/zebra/pull/9710
- https://github.com/zcash/wallet/pull/177

## Solution

- Simplified the wallet QA tests to use a single Zebra node and a single wallet instance. (A simple multi node test can be seen in `addnode.py`)
- Updated the test setup to reflect recent changes in Zallet, which continues to evolve.
- Added a wallet test that:
  - Creates an account and obtains an address.
  - Stops the services and restarts Zebra using the newly obtained address as the miner address.
  - Mines blocks and verifies that balances are available both in the node and in the wallet.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
