### PR TITLE
Release Zebra 2.4.1

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -74,11 +74,11 @@ fastmod --fixed-strings '1.58' '1.65'
 - [ ] Freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
 - [ ] Mark all the release PRs as `Critical` priority, so they go in the `urgent` Mergify queue.
 - [ ] Mark all non-release PRs with `do-not-merge`, because Mergify checks approved PRs against every commit, even when a queue is frozen.
-- [ ] Add the `A-release` tag to the release pull request in order for the `check_no_git_refs_in_cargo_lock` to run.
+- [ ] Add the `A-release` tag to the release pull request in order for the `check-no-git-dependencies` to run.
 
 ## Zebra git sources dependencies
 
-- [ ] Ensure the `check_no_git_refs_in_cargo_lock` check passes.
+- [ ] Ensure the `check-no-git-dependencies` check passes.
 
 This check runs automatically on pull requests with the `A-release` label. It must pass for crates to be published to crates.io. If the check fails, you should either halt the release process or proceed with the understanding that the crates will not be published on crates.io.
 
@@ -175,8 +175,15 @@ The end of support height is calculated from the current blockchain height:
 ## Publish Crates
 
 - [ ] [Run `cargo login`](https://zebra.zfnd.org/dev/crate-owners.html#logging-in-to-cratesio)
-- [ ] Run `cargo clean` in the zebra repo (optional)
-- [ ] Publish the crates to crates.io: `cargo release publish --verbose --workspace --execute`
+- [ ] It is recommended that the following step be run from a fresh checkout of
+      the repo, to avoid accidentally publishing files like e.g. logs that might
+      be lingering around
+- [ ] Publish the crates to crates.io:
+
+```
+for c in zebra-test tower-fallback zebra-chain tower-batch-control zebra-node-services zebra-script zebra-state zebra-consensus zebra-network zebra-rpc zebra-utils zebrad; do cargo release publish --verbose --execute -p $c; done
+```
+
 - [ ] Check that Zebra can be installed from `crates.io`:
       `cargo install --locked --force --version 1.minor.patch zebrad && ~/.cargo/bin/zebrad`
       and put the output in a comment on the PR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Zebra 2.4.1](https://github.com/ZcashFoundation/zebra/releases/tag/v2.4.1) - 2025-07-22
+
+This release fixes a database upgrade bug that was introduce in 2.4.0 (which has
+been removed). If you have upgraded to 2.4.1, your Zebra address index has
+become corrupted. This does not affect consensus, but will make the RPC
+interface return invalid data for calls like `getaddressutxos` and other
+address-related calls.
+
+Zebra now prints a warning upon starting if you have been impacted by the bug. The
+log line will look like:
+
+```
+2025-07-17T17:12:41.636549Z  WARN zebra_state::service::finalized_state::zebra_db: You have been impacted by the Zebra 2.4.0 address indexer corruption bug. If you rely on the data from the RPC interface, you will need to recover your database. Follow the instructions in the 2.4.1 release notes: https://github.com/ZcashFoundation/zebra/releases/tag/v2.4.1 If you just run the node for consensus and don't use data from the RPC interface, you can ignore this warning.
+```
+
+If you rely on the RPC data, you will need to restore your database. If you have
+backed up the state up before upgrading to 2.4.0, you can simply restore the backup
+and run 2.4.1 from it. If you have not, you have two options:
+
+- Stop Zebra, delete the state (e.g. `~/.cache/zebra/state/v27/mainnet` and
+  `testnet` too if applicable), upgrade to 2.4.1, and start Zebra. It will sync
+  from scratch, which will take around 48 hours to complete, depending on the
+  machine specifications.
+- Use the `copy-state` subcommand to regenerate a valid state.
+  This will require an additional ~300 GB of free disk size.
+  - Stop Zebra.
+  - Rename the old corrupted state folder, e.g. `mv ~/.cache/zebra ~/.cache/zebra.old`
+  - Copy your current `zebrad.toml` file to a `zebrad-source.toml` file and edit
+    the `cache_dir` config to the renamed folder, e.g. `cache_dir = '/home/zebrad/.cache/zebra.old'`
+  - Run the `copy-state` command: `zebrad -c zebrad-source.toml copy-state
+    --target-config-path zebrad.toml`. The command will take several hours to
+    complete.
+
+### Fixed
+
+- Fix 2.4.0 DB upgrade; add warning if impacted ([#9709](https://github.com/ZcashFoundation/zebra/pull/9709))
+- Downgrade verbose mempool message ([#9700](https://github.com/ZcashFoundation/zebra/pull/9700))
+
+### Contributors
+
+Thanks to @ebfull for reporting the bug and helping investigating its cause.
+
+
 ## [Zebra 2.4.0](https://github.com/ZcashFoundation/zebra/releases/tag/v2.4.0) - 2025-07-11
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Zebra 2.4.1](https://github.com/ZcashFoundation/zebra/releases/tag/v2.4.1) - 2025-07-22
 
-This release fixes a database upgrade bug that was introduce in 2.4.0 (which has
-been removed). If you have upgraded to 2.4.1, your Zebra address index has
-become corrupted. This does not affect consensus, but will make the RPC
-interface return invalid data for calls like `getaddressutxos` and other
-address-related calls.
+This release fixes a database upgrade bug that was introduced in the 2.4.0
+release (which has been removed). If you have upgraded to 2.4.0, your Zebra
+address index has become corrupted. This does not affect consensus, but will
+make the RPC interface return invalid data for calls like `getaddressutxos` and
+other address-related calls.
 
-Zebra now prints a warning upon starting if you have been impacted by the bug. The
-log line will look like:
+Zebra 2.4.1 prints a warning upon starting if you have been impacted by the bug.
+The log line will look like:
 
 ```
 2025-07-17T17:12:41.636549Z  WARN zebra_state::service::finalized_state::zebra_db: You have been impacted by the Zebra 2.4.0 address indexer corruption bug. If you rely on the data from the RPC interface, you will need to recover your database. Follow the instructions in the 2.4.1 release notes: https://github.com/ZcashFoundation/zebra/releases/tag/v2.4.1 If you just run the node for consensus and don't use data from the RPC interface, you can ignore this warning.
@@ -25,15 +25,18 @@ backed up the state up before upgrading to 2.4.0, you can simply restore the bac
 and run 2.4.1 from it. If you have not, you have two options:
 
 - Stop Zebra, delete the state (e.g. `~/.cache/zebra/state/v27/mainnet` and
-  `testnet` too if applicable), upgrade to 2.4.1, and start Zebra. It will sync
-  from scratch, which will take around 48 hours to complete, depending on the
-  machine specifications.
+  `testnet` too if applicable), upgrade to 2.4.1 (if you haven't already), and
+  start Zebra. It will sync from scratch, which will take around 48 hours to
+  complete, depending on the machine specifications.
 - Use the `copy-state` subcommand to regenerate a valid state.
   This will require an additional ~300 GB of free disk size.
   - Stop Zebra.
   - Rename the old corrupted state folder, e.g. `mv ~/.cache/zebra ~/.cache/zebra.old`
   - Copy your current `zebrad.toml` file to a `zebrad-source.toml` file and edit
     the `cache_dir` config to the renamed folder, e.g. `cache_dir = '/home/zebrad/.cache/zebra.old'`
+  - The `copy-state` command that will be run requires a bigger amount of opened
+    files. Increase the limit by running `ulimit -n 2048`; refer to your OS
+    documentation if that does not work.
   - Run the `copy-state` command: `zebrad -c zebrad-source.toml copy-state
     --target-config-path zebrad.toml`. The command will take several hours to
     complete.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6644,7 +6644,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bincode",
  "chrono",
@@ -6749,7 +6749,7 @@ dependencies = [
 
 [[package]]
 name = "zebrad"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "abscissa_core",
  "atty",

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -29,7 +29,7 @@ docker run \
 You can also use `docker compose`, which we recommend. First get the repo:
 
 ```shell
-git clone --depth 1 --branch v2.4.0 https://github.com/ZcashFoundation/zebra.git
+git clone --depth 1 --branch v2.4.1 https://github.com/ZcashFoundation/zebra.git
 cd zebra
 ```
 

--- a/book/src/user/install.md
+++ b/book/src/user/install.md
@@ -75,7 +75,7 @@ To compile Zebra directly from GitHub, or from a GitHub release source archive:
 ```sh
 git clone https://github.com/ZcashFoundation/zebra.git
 cd zebra
-git checkout v2.4.0
+git checkout v2.4.1
 ```
 
 3. Build and Run `zebrad`
@@ -88,7 +88,7 @@ target/release/zebrad start
 ### Compiling from git using cargo install
 
 ```sh
-cargo install --git https://github.com/ZcashFoundation/zebra --tag v2.4.0 zebrad
+cargo install --git https://github.com/ZcashFoundation/zebra --tag v2.4.1 zebrad
 ```
 
 ### Compiling on ARM

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -62,7 +62,7 @@ tower-fallback = { path = "../tower-fallback/", version = "0.2.41" }
 tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41" }
 
 zebra-script = { path = "../zebra-script", version = "1.0.0" }
-zebra-state = { path = "../zebra-state", version = "1.0.0" }
+zebra-state = { path = "../zebra-state", version = "1.0.1" }
 zebra-node-services = { path = "../zebra-node-services", version = "1.0.0" }
 zebra-chain = { path = "../zebra-chain", version = "1.0.0" }
 
@@ -89,6 +89,6 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zebra-state = { path = "../zebra-state", version = "1.0.0", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", version = "1.0.1", features = ["proptest-impl"] }
 zebra-chain = { path = "../zebra-chain", version = "1.0.0", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/", version = "1.0.0" }

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -94,7 +94,7 @@ zebra-node-services = { path = "../zebra-node-services", version = "1.0.0", feat
     "rpc-client",
 ] }
 zebra-script = { path = "../zebra-script", version = "1.0.0" }
-zebra-state = { path = "../zebra-state", version = "1.0.0" }
+zebra-state = { path = "../zebra-state", version = "1.0.1" }
 
 [build-dependencies]
 tonic-build = { workspace = true }
@@ -116,7 +116,7 @@ zebra-consensus = { path = "../zebra-consensus", version = "1.0.0", features = [
 zebra-network = { path = "../zebra-network", version = "1.0.0", features = [
     "proptest-impl",
 ] }
-zebra-state = { path = "../zebra-state", version = "1.0.0", features = [
+zebra-state = { path = "../zebra-state", version = "1.0.1", features = [
     "proptest-impl",
 ] }
 

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-07-22
+
+### Fixed
+
+- Fix 2.4.0 DB upgrade; add warning if impacted ([#9709](https://github.com/ZcashFoundation/zebra/pull/9709)).
+  See the Zebra changelog for more details.
+
+
 ## [1.0.0] - 2025-07-11
 
 First "stable" release. However, be advised that the API may still greatly

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-state"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "State contextual verification and storage code for Zebra"
 license = "MIT OR Apache-2.0"

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate metadata
 name = "zebrad"
-version = "2.4.0"
+version = "2.4.1"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The Zcash Foundation's independent, consensus-compatible implementation of a Zcash node"
 license = "MIT OR Apache-2.0"
@@ -162,7 +162,7 @@ zebra-consensus = { path = "../zebra-consensus", version = "1.0.0" }
 zebra-network = { path = "../zebra-network", version = "1.0.0" }
 zebra-node-services = { path = "../zebra-node-services", version = "1.0.0", features = ["rpc-client"] }
 zebra-rpc = { path = "../zebra-rpc", version = "1.0.0" }
-zebra-state = { path = "../zebra-state", version = "1.0.0" }
+zebra-state = { path = "../zebra-state", version = "1.0.1" }
 # zebra-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
 # enabling it in the other imports of zcash-script.)
@@ -291,7 +291,7 @@ color-eyre = { workspace = true }
 zebra-chain = { path = "../zebra-chain", version = "1.0.0", features = ["proptest-impl"] }
 zebra-consensus = { path = "../zebra-consensus", version = "1.0.0", features = ["proptest-impl"] }
 zebra-network = { path = "../zebra-network", version = "1.0.0", features = ["proptest-impl"] }
-zebra-state = { path = "../zebra-state", version = "1.0.0", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", version = "1.0.1", features = ["proptest-impl"] }
 
 zebra-test = { path = "../zebra-test", version = "1.0.0" }
 

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 2_987_000;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_003_000;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.


### PR DESCRIPTION
---
name: 'Release Checklist Template'
about: 'Checklist to create and publish a Zebra release'
title: 'Release Zebra (version)'
labels: 'A-release, C-exclude-from-changelog, P-Critical :ambulance:'
assignees: ''

---

# Prepare for the Release

- [x] Make sure there has been [at least one successful full sync test in the main branch](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-tests.yml?query=branch%3Amain) since the last state change, or start a manual full sync.
- [x] Make sure the PRs with the new checkpoint hashes and missed dependencies are already merged.
      (See the release ticket checklist for details)


# Summarise Release Changes

These steps can be done a few days before the release, in the same PR:

## Change Log

**Important**: Any merge into `main` deletes any edits to the draft changelog.
Once you are ready to tag a release, copy the draft changelog into `CHANGELOG.md`.

We use [the Release Drafter workflow](https://github.com/marketplace/actions/release-drafter) to automatically create a [draft changelog](https://github.com/ZcashFoundation/zebra/releases). We follow the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.

To create the final change log:
- [x] Copy the **latest** draft changelog into `CHANGELOG.md` (there can be multiple draft releases)
- [x] Delete any trivial changes
    - [x] Put the list of deleted changelog entries in a PR comment to make reviewing easier
- [x] Combine duplicate changes
- [x] Edit change descriptions so they will make sense to Zebra users
- [x] Check the category for each change
  - Prefer the "Fix" category if you're not sure

## README

README updates can be skipped for urgent releases.

Update the README to:
- [x] Remove any "Known Issues" that have been fixed since the last release.
- [x] Update the "Build and Run Instructions" with any new dependencies.
      Check for changes in the `Dockerfile` since the last tag: `git diff <previous-release-tag> docker/Dockerfile`.
- [x] If Zebra has started using newer Rust language features or standard library APIs, update the known working Rust version in the README, book, and `Cargo.toml`s

You can use a command like:
```sh
fastmod --fixed-strings '1.58' '1.65'
```

## Create the Release PR

- [x] Push the updated changelog and README into a new branch
      for example: `bump-v1.0.0` - this needs to be different to the tag name
- [x] Create a release PR by adding `&template=release-checklist.md` to the comparing url ([Example](https://github.com/ZcashFoundation/zebra/compare/bump-v1.0.0?expand=1&template=release-checklist.md)).
- [x] Freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [x] Mark all the release PRs as `Critical` priority, so they go in the `urgent` Mergify queue.
- [x] Mark all non-release PRs with `do-not-merge`, because Mergify checks approved PRs against every commit, even when a queue is frozen.
- [x] Add the `A-release` tag to the release pull request in order for the `check_no_git_refs_in_cargo_lock` to run.

## Zebra git sources dependencies

- [ ] Ensure the `check_no_git_refs_in_cargo_lock` check passes.

This check runs automatically on pull requests with the `A-release` label. It must pass for crates to be published to crates.io. If the check fails, you should either halt the release process or proceed with the understanding that the crates will not be published on crates.io.

# Update Versions and End of Support

## Update Zebra Version

### Choose a Release Level

Zebra follows [semantic versioning](https://semver.org). Semantic versions look like: MAJOR.MINOR.PATCH[-TAG.PRE-RELEASE]

Choose a release level for `zebrad`. Release levels are based on user-visible changes from the changelog:
- Mainnet Network Upgrades are `major` releases
- significant new features or behaviour changes; changes to RPCs, command-line, or configs; and deprecations or removals are `minor` releases
- otherwise, it is a `patch` release

### Update Crate Versions

If you're publishing crates for the first time, [log in to crates.io](https://zebra.zfnd.org/dev/crate-owners.html#logging-in-to-cratesio),
and make sure you're a member of owners group.

Check that the release will work:
- [x] Update crate versions, commit the changes to the release branch, and do a release dry-run:

```sh
# Update everything except for alpha crates and zebrad:
cargo release version --verbose --execute --allow-branch '*' --workspace --exclude zebrad beta
# Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
# Update zebrad:
cargo release version --verbose --execute --allow-branch '*' --package zebrad patch # [ major | minor | patch ]
# Continue with the release process:
cargo release replace --verbose --execute --allow-branch '*' --package zebrad
cargo release commit --verbose --execute --allow-branch '*'
```

- [x] Push the above version changes to the release branch.

## Update End of Support

The end of support height is calculated from the current blockchain height:
- [x] Find where the Zcash blockchain tip is now by using a [Zcash Block Explorer](https://mainnet.zcashexplorer.app/) or other tool.
- [x] Replace `ESTIMATED_RELEASE_HEIGHT` in [`end_of_support.rs`](https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/sync/end_of_support.rs) with the height you estimate the release will be tagged.

<details>

<summary>Optional: calculate the release tagging height</summary>

- Add `1152` blocks for each day until the release
- For example, if the release is in 3 days, add `1152 * 3` to the current Mainnet block height

</details>

## Update the Release PR

- [x] Push the version increments and the release constants to the release branch.


# Publish the Zebra Release

## Create the GitHub Pre-Release

- [x] Wait for all the release PRs to be merged
- [x] Create a new release using the draft release as a base, by clicking the Edit icon in the [draft release](https://github.com/ZcashFoundation/zebra/releases)
- [x] Set the tag name to the version tag,
      for example: `v1.0.0`
- [x] Set the release to target the `main` branch
- [x] Set the release title to `Zebra ` followed by the version tag,
      for example: `Zebra 1.0.0`
- [x] Replace the prepopulated draft changelog in the release description with the final changelog you created;
      starting just _after_ the title `## [Zebra ...` of the current version being released,
      and ending just _before_ the title of the previous release.
- [x] Mark the release as 'pre-release', until it has been built and tested
- [x] Publish the pre-release to GitHub using "Publish Release"
- [ ] Delete all the [draft releases from the list of releases](https://github.com/ZcashFoundation/zebra/releases)

## Test the Pre-Release

- [ ] Wait until the Docker binaries have been built on `main`, and the quick tests have passed:
    - [ ] [ci-tests.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-tests.yml?query=branch%3Amain)
- [ ] Wait until the [pre-release deployment machines have successfully launched](https://github.com/ZcashFoundation/zebra/actions/workflows/cd-deploy-nodes-gcp.yml?query=event%3Arelease)

## Publish Release

- [ ] [Publish the release to GitHub](https://github.com/ZcashFoundation/zebra/releases) by disabling 'pre-release', then clicking "Set as the latest release"

## Publish Crates

- [x] [Run `cargo login`](https://zebra.zfnd.org/dev/crate-owners.html#logging-in-to-cratesio)
- [x] Run `cargo clean` in the zebra repo (optional)
- [ ] Publish the crates to crates.io: `cargo release publish --verbose --workspace --execute`
- [ ] Check that Zebra can be installed from `crates.io`:
      `cargo install --locked --force --version 1.minor.patch zebrad && ~/.cargo/bin/zebrad`
      and put the output in a comment on the PR.

## Publish Docker Images

- [ ] Wait for the [the Docker images to be published successfully](https://github.com/ZcashFoundation/zebra/actions/workflows/release-binaries.yml?query=event%3Arelease).
- [ ] Wait for the new tag in the [dockerhub zebra space](https://hub.docker.com/r/zfnd/zebra/tags)
- [ ] Un-freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [ ] Remove `do-not-merge` from the PRs you added it to

## Release Failures

If building or running fails after tagging:

<details>

<summary>Tag a new release, following these instructions...</summary>

1. Fix the bug that caused the failure
2. Start a new `patch` release
3. Skip the **Release Preparation**, and start at the **Release Changes** step
4. Update `CHANGELOG.md` with details about the fix
5. Follow the release checklist for the new Zebra version

</details>
