### PR TITLE
serialise zebradconfig

### DIFF
--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -5,6 +5,8 @@
 //! for specifying it.
 
 use serde::{Deserialize, Serialize};
+use zebra_chain::parameters::testnet::ConfiguredActivationHeights;
+use zebra_network::config::{DConfig, DTestnetParameters};
 
 /// Configuration for `zebrad`.
 ///
@@ -53,4 +55,30 @@ pub struct ZebradConfig {
 
     /// Mining configuration
     pub mining: zebra_rpc::config::mining::Config,
+}
+
+#[test]
+fn serialising_config() {
+    let d_config = DConfig {
+        listen_addr: "127.0.0.1:3000".to_string(),
+        testnet_parameters: Some(DTestnetParameters {
+            network_name: Some("name".to_owned()),
+            disable_pow: Some(true),
+            activation_heights: Some(ConfiguredActivationHeights {
+                overwinter: Some(1),
+                before_overwinter: Some(2),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let config: ZebradConfig = ZebradConfig {
+        network: zebra_network::Config::try_from(d_config).unwrap(),
+        ..Default::default()
+    };
+
+    let serialised = toml::to_string_pretty(&config).unwrap();
+    println!("{}", serialised)
 }

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -5,9 +5,6 @@
 //! for specifying it.
 
 use serde::{Deserialize, Serialize};
-use zebra_chain::parameters::testnet::ConfiguredActivationHeights;
-use zebra_network::config::{DConfig, DTestnetParameters};
-
 /// Configuration for `zebrad`.
 ///
 /// The `zebrad` config is a TOML-encoded version of this structure. The meaning
@@ -58,27 +55,20 @@ pub struct ZebradConfig {
 }
 
 #[test]
-fn serialising_config() {
-    let d_config = DConfig {
-        listen_addr: "127.0.0.1:3000".to_string(),
-        testnet_parameters: Some(DTestnetParameters {
-            network_name: Some("name".to_owned()),
-            disable_pow: Some(true),
-            activation_heights: Some(ConfiguredActivationHeights {
-                overwinter: Some(1),
-                before_overwinter: Some(2),
-                ..Default::default()
-            }),
+/// temporary, just to show the intended effect of this changes. Delete before merging
+fn intended_usage() {
+    // Idea is to enable this sort of construction for consumers, to generate config files.
+    let config = ZebradConfig {
+        consensus: zebra_consensus::Config {
+            checkpoint_sync: false,
+        },
+        network: zebra_network::Config::try_from(zebra_network::config::DConfig {
+            listen_addr: "127.0.0.1:3000".into(),
             ..Default::default()
-        }),
+        })
+        .unwrap(),
         ..Default::default()
     };
-
-    let config: ZebradConfig = ZebradConfig {
-        network: zebra_network::Config::try_from(d_config).unwrap(),
-        ..Default::default()
-    };
-
-    let serialised = toml::to_string_pretty(&config).unwrap();
-    println!("{}", serialised)
+    let toml_string = toml::to_string(&config).unwrap();
+    println!("{}", toml_string)
 }


### PR DESCRIPTION
## Motivation

At zaino we need an ergonomic way of setting different configs for our test with zebras involved.
So far we have been using templated toml strings, but being able to build them from proper types would allow us several folds of greater flexibility and assurance that we are keeping up with upstream changes.

Also, for configuration reference, [the docs](https://zebra.zfnd.org/user/run.html#running-zebra) point to [`ZebradConfig`'s doc page](https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html), which makes no mention of the intermediate type `zebra_network::config::DConfig`, which ultimately is the struct that zebra deserialises the toml from.

## Solution

Making the `ZebradConfig` serialisable and exposing the intermediate types to allow contruction of a config though code and subsequent serialisation.
For this I refactored the deserialise impl for `zebra_network::config::Config` into a `impl TryFrom<DConfig> for Config` and a deserialise impl. That way a full `ZebradConfig` can be constructed in code just like it would on a toml (see the test i added to see what i mean).

For the doc part, maybe updating the docs to mention the intermediate type for the network config? (I didn't add that on this PR)

### Tests

I wrote a simple test to showcase the usage and check that it's indeed serialising all the way. Wouldn't say it properly tests the changes yet.

### Follow-up Work

If the zebra team agrees that they want to support this, all those intermediate types now made public would need documenting.
I think there's also potential for a `ZebradConfigBuilder` pattern support, which would be massively useful not only for zaino but for anybody else managing tests with zebras or even deploying them programatically.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [X] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
