### PR TITLE
fix: update zebra-rpc config struct link in lightwalletd guide

### DIFF
--- a/book/src/user/lightwalletd.md
+++ b/book/src/user/lightwalletd.md
@@ -64,7 +64,7 @@ enable_cookie_auth = false
 ```
 
 **WARNING:** This config allows multiple Zebra instances to share the same RPC port.
-See the [RPC config documentation](https://docs.rs/zebra_rpc/latest/zebra_rpc/config/struct.Config.html) for details.
+See the [RPC config documentation](https://docs.rs/zebra-rpc/latest/zebra_rpc/config/rpc/struct.Config.html) for details.
 
 ## Sync Zebra
 


### PR DESCRIPTION
Replaces the generic zebra-rpc config module link with the precise docs.rs link to the Config struct documentation. This ensures users are directed to the exact API reference for all available configuration fields.