### PR TITLE
change(consensus): Allow funding streams to be active across multiple disjoint height ranges

### DIFF
--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -90,7 +90,11 @@ pub struct ConfiguredLockboxDisbursement {
 
 /// Configurable funding streams for configured Testnets.
 #[derive(Serialize, Deserialize, Clone, Default, Debug)]
-#[serde(deny_unknown_fields, from = "DConfiguredFundingStreams")]
+#[serde(
+    deny_unknown_fields,
+    from = "DConfiguredFundingStreams",
+    into = "DConfiguredFundingStreams"
+)]
 pub struct ConfiguredFundingStreams {
     /// Start and end height for funding streams see [`FundingStreams::height_ranges`] for more details.
     pub height_ranges: Option<Vec<std::ops::Range<Height>>>,
@@ -99,10 +103,11 @@ pub struct ConfiguredFundingStreams {
 }
 
 /// An intermediate type used to deserialize [`ConfiguredFundingStreams`].
-#[derive(Clone, Debug, serde::Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct DConfiguredFundingStreams {
     /// Start and end height for funding streams see [`FundingStreams::height_ranges`] for more details.
-    height_ranges: Option<DHeightRanges>,
+    height_range: Option<DHeightRanges>,
     /// Funding stream recipients, see [`FundingStreams::recipients`] for more details.
     recipients: Option<Vec<ConfiguredFundingStreamRecipient>>,
 }
@@ -110,14 +115,23 @@ struct DConfiguredFundingStreams {
 impl From<DConfiguredFundingStreams> for ConfiguredFundingStreams {
     fn from(value: DConfiguredFundingStreams) -> Self {
         Self {
-            height_ranges: value.height_ranges.map(Into::into),
+            height_ranges: value.height_range.map(Into::into),
+            recipients: value.recipients,
+        }
+    }
+}
+
+impl From<ConfiguredFundingStreams> for DConfiguredFundingStreams {
+    fn from(value: ConfiguredFundingStreams) -> Self {
+        Self {
+            height_range: value.height_ranges.map(DHeightRanges::Ranges),
             recipients: value.recipients,
         }
     }
 }
 
 /// An intermediate type used to deserialize [`std::ops::Range<Height>>`].
-#[derive(Clone, Debug, Eq, PartialEq, Hash, serde::Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(untagged)]
 enum DHeightRanges {
     /// A list of height ranges.

--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -130,7 +130,7 @@ impl From<ConfiguredFundingStreams> for DConfiguredFundingStreams {
     }
 }
 
-/// An intermediate type used to deserialize [`std::ops::Range<Height>>`].
+/// An intermediate type used to deserialize [`std::ops::Range<Height>`].
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(untagged)]
 enum DHeightRanges {

--- a/zebra-consensus/src/block/subsidy/funding_streams/tests.rs
+++ b/zebra-consensus/src/block/subsidy/funding_streams/tests.rs
@@ -20,8 +20,21 @@ fn test_funding_stream_values() -> Result<(), Report> {
     let canopy_activation_height = Canopy.activation_height(network).unwrap();
     let nu6_activation_height = Nu6.activation_height(network).unwrap();
 
-    let dev_fund_height_range = network.pre_nu6_funding_streams().height_range();
-    let nu6_fund_height_range = network.post_nu6_funding_streams().height_range();
+    let dev_fund_height_range = network.pre_nu6_funding_streams().height_ranges()[0].clone();
+    // TODO: Update this test to check the second height range of post-nu6 funding streams (#9598).
+    let nu6_fund_height_range = network.post_nu6_funding_streams().height_ranges()[0].clone();
+
+    assert_eq!(
+        network.pre_nu6_funding_streams().height_ranges().len(),
+        1,
+        "there should only be one pre-nu6 funding stream height range on Mainnet"
+    );
+    assert_eq!(
+        network.post_nu6_funding_streams().height_ranges().len(),
+        1,
+        "there should only be one post-nu6 funding stream height range on Mainnet \
+        (update ahead of NU6.1 Mainnet deployment)"
+    );
 
     let nu6_fund_end = Height(3_146_400);
 

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -26,7 +26,6 @@ use zebra_chain::{
     chain_tip::mock::MockChainTip,
     orchard,
     parameters::{
-        subsidy::POST_NU6_FUNDING_STREAMS_TESTNET,
         testnet::{self, ConfiguredActivationHeights, Parameters},
         Network::{self, Mainnet},
         NetworkKind, NetworkUpgrade,
@@ -76,7 +75,12 @@ async fn test_rpc_response_data() {
         .with_network_name("NU6Testnet")
         .with_activation_heights(ConfiguredActivationHeights {
             blossom: Some(584_000),
-            nu6: Some(POST_NU6_FUNDING_STREAMS_TESTNET.height_range().start.0),
+            nu6: Some(
+                NetworkUpgrade::Nu6
+                    .activation_height(&default_testnet)
+                    .unwrap()
+                    .0,
+            ),
             ..Default::default()
         })
         .to_network();

--- a/zebra-rpc/src/methods/types/get_block_template/tests.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/tests.rs
@@ -23,7 +23,7 @@ fn minimal_coinbase() -> Result<(), Box<dyn std::error::Error>> {
             ..Default::default()
         })
         .with_post_nu6_funding_streams(ConfiguredFundingStreams {
-            height_range: Some(Height(1)..Height(10)),
+            height_ranges: Some(vec![Height(1)..Height(10)]),
             recipients: None,
         })
         .to_network();

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -3284,7 +3284,7 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
         .clone()
         .with_post_nu6_funding_streams(ConfiguredFundingStreams {
             // Start checking funding streams from block height 1
-            height_range: Some(Height(1)..Height(100)),
+            height_ranges: Some(vec![Height(1)..Height(100)]),
             // Use default post-NU6 recipients
             recipients: None,
         })
@@ -3464,7 +3464,7 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
     let network = base_network_params
         .clone()
         .with_post_nu6_funding_streams(ConfiguredFundingStreams {
-            height_range: Some(Height(1)..Height(100)),
+            height_ranges: Some(vec![Height(1)..Height(100)]),
             recipients: make_configured_recipients_with_lockbox_numerator(0),
         })
         .to_network();
@@ -3522,7 +3522,7 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
     let network = base_network_params
         .clone()
         .with_post_nu6_funding_streams(ConfiguredFundingStreams {
-            height_range: Some(Height(1)..Height(100)),
+            height_ranges: Some(vec![Height(1)..Height(100)]),
             recipients: make_configured_recipients_with_lockbox_numerator(20),
         })
         .to_network();

--- a/zebrad/tests/common/configs/v2.5.0.toml
+++ b/zebrad/tests/common/configs/v2.5.0.toml
@@ -1,0 +1,220 @@
+# Default configuration for zebrad.
+#
+# This file can be used as a skeleton for custom configs.
+#
+# Unspecified fields use default values. Optional fields are Some(field) if the
+# field is present and None if it is absent.
+#
+# This file is generated as an example using zebrad's current defaults.
+# You should set only the config options you want to keep, and delete the rest.
+# Only a subset of fields are present in the skeleton, since optional values
+# whose default is None are omitted.
+#
+# The config format (including a complete list of sections and fields) is
+# documented here:
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
+#
+# zebrad attempts to load configs in the following order:
+#
+# 1. The -c flag on the command line, e.g., `zebrad -c myconfig.toml start`;
+# 2. The file `zebrad.toml` in the users's preference directory (platform-dependent);
+# 3. The default config.
+#
+# The user's preference directory and the default path to the `zebrad` config are platform dependent,
+# based on `dirs::preference_dir`, see https://docs.rs/dirs/latest/dirs/fn.preference_dir.html :
+#
+# | Platform | Value                                 | Example                                        |
+# | -------- | ------------------------------------- | ---------------------------------------------- |
+# | Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/zebrad.toml`              |
+# | macOS    | `$HOME/Library/Preferences`           | `/Users/Alice/Library/Preferences/zebrad.toml` |
+# | Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Local\zebrad.toml`     |
+
+[consensus]
+checkpoint_sync = true
+
+[mempool]
+eviction_memory_time = "1h"
+tx_cost_limit = 80000000
+
+[metrics]
+
+[mining]
+
+[network]
+cache_dir = true
+crawl_new_peer_interval = "1m 1s"
+initial_mainnet_peers = [
+    "dnsseed.z.cash:8233",
+    "dnsseed.str4d.xyz:8233",
+    "mainnet.seeder.zfnd.org:8233",
+    "mainnet.is.yolo.money:8233",
+]
+initial_testnet_peers = []
+listen_addr = "0.0.0.0:8233"
+max_connections_per_ip = 1
+network = "Testnet"
+peerset_initial_target_size = 25
+
+[network.testnet_parameters]
+network_name = "ConfiguredTestnet_1"
+network_magic = [0, 0, 0, 0]
+slow_start_interval = 0
+target_difficulty_limit = "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"
+disable_pow = true
+genesis_hash = "00040fe8ec8471911baa1db1266ea15dd06b4a8a5c453883c000b031973dce08"
+
+[network.testnet_parameters.activation_heights]
+BeforeOverwinter = 1
+Overwinter = 207_500
+Sapling = 280_000
+Blossom = 584_000
+Heartwood = 903_800
+Canopy = 1_028_500
+NU5 = 1_842_420
+NU6 = 2_000_000
+"NU6.1" = 2_000_001
+NU7 = 2_000_002
+
+[[network.testnet_parameters.pre_nu6_funding_streams.height_range]]
+start = 0
+end = 100
+
+[[network.testnet_parameters.pre_nu6_funding_streams.height_range]]
+start = 0
+end = 100
+
+[[network.testnet_parameters.post_nu6_funding_streams.recipients]]
+receiver = "ECC"
+numerator = 7
+addresses = [    
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+]
+
+[[network.testnet_parameters.post_nu6_funding_streams.recipients]]
+receiver = "ZcashFoundation"
+numerator = 5
+addresses = [    
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+]
+
+[rpc]
+debug_force_finished_sync = false
+parallel_cpu_threads = 0
+
+[state]
+cache_dir = "cache_dir"
+delete_old_database = true
+ephemeral = false
+
+[sync]
+checkpoint_verify_concurrency_limit = 1000
+download_concurrency_limit = 50
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+
+[tracing]
+buffer_limit = 128000
+force_use_color = false
+use_color = true
+use_journald = false


### PR DESCRIPTION
## Motivation

We want to allow for disjoint funding streams height ranges to deploy NU6.1 on Testnet, where the post-NU6 funding streams have already ended.

A quick but suboptimal fix for the urgent motivation in #9736.

## Solution

- Updates `FundingStream` to include a list of height ranges rather than a single height range,
- Updates config deserialization to preserve its previous behaviour when one height range is defined for a configured funding stream, and when no height range is defined, while adding support for deserializing a list of height ranges per funding stream, and
- Updates `funding_stream_address_index()` to work with multiple height ranges per funding stream, where the funding stream address index for each height range of a funding stream starts at the next index after the last address index of the previous height range of that funding stream.

### Tests

This PR adds a stored config to test that the updated deserialization logic works as expected.

The rest will be tested manually and by existing tests in the follow-up PR implementing ZIP 271 for Testnet.

### Follow-up Work

- https://github.com/ZcashFoundation/zebra/issues/9736

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
