### PR TITLE
fix(crash): Fix Nu6.1 blocks crash

### DIFF
--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -292,9 +292,11 @@ pub fn miner_fees_are_valid(
         (transparent_value_balance - sapling_value_balance - orchard_value_balance
             + expected_deferred_pool_balance_change.value())
         .map_err(|_| SubsidyError::SumOverflow)?;
-    let total_input_value =
-        (expected_block_subsidy + block_miner_fees).map_err(|_| SubsidyError::SumOverflow)?;
 
+    let lockbox_deferred_input = network.lockbox_disbursement_total_amount(height);
+
+    let total_input_value = (expected_block_subsidy + block_miner_fees + lockbox_deferred_input)
+        .map_err(|_| SubsidyError::SumOverflow)?;
     // # Consensus
     //
     // > [Pre-NU6] The total output of a coinbase transaction MUST NOT be greater than its total


### PR DESCRIPTION
## Motivation

During private custom testnet we found Zebra crashing in Nu6.1 blocks.

## Solution

Apply fixes from the used private testnet branch.

@arya2 can confirm if this is the fix.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
