### PR TITLE
release(activation): Add Nu6.1 testnet activation

### DIFF
--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -150,6 +150,7 @@ pub(super) const TESTNET_ACTIVATION_HEIGHTS: &[(block::Height, NetworkUpgrade)] 
     (block::Height(1_028_500), Canopy),
     (block::Height(1_842_420), Nu5),
     (block::Height(2_976_000), Nu6),
+    (block::Height(3_536_500), Nu6_1),
 ];
 
 /// Fake testnet network upgrade activation heights, used in tests.
@@ -257,7 +258,6 @@ pub(crate) const CONSENSUS_BRANCH_IDS: &[(NetworkUpgrade, ConsensusBranchId)] = 
     (Canopy, ConsensusBranchId(0xe9ff75a6)),
     (Nu5, ConsensusBranchId(0xc2d6d0b4)),
     (Nu6, ConsensusBranchId(0xc8e71055)),
-    #[cfg(any(test, feature = "zebra-test"))]
     (Nu6_1, ConsensusBranchId(0x4dec4df0)),
     #[cfg(any(test, feature = "zebra-test"))]
     (Nu7, ConsensusBranchId(0x77190ad8)),

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -343,7 +343,7 @@ pub const TIMESTAMP_TRUNCATION_SECONDS: u32 = 30 * 60;
 // TODO: Update this constant to the correct value after NU6.1 & NU7 activation,
 // pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_140); // NU6.1
 // pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_160); // NU7
-pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_120);
+pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_130);
 
 /// The default RTT estimate for peer responses.
 ///


### PR DESCRIPTION

## Motivation

Close https://github.com/ZcashFoundation/zebra/issues/9749

## Solution

- Added activation height, protocol version. 
- Removed feature flag from Nu6.1 `ConsensusBranchId`.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
