### PR TITLE
chore(chain): remove output_amounts()

### DIFF
--- a/zebra-chain/src/parameters/network/subsidy.rs
+++ b/zebra-chain/src/parameters/network/subsidy.rs
@@ -12,7 +12,7 @@
 //! Typically, consensus parameters are accessed via a function that takes a
 //! `Network` and `block::Height`.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use lazy_static::lazy_static;
 
@@ -20,7 +20,6 @@ use crate::{
     amount::{self, Amount, NonNegative, COIN},
     block::{Height, HeightDiff},
     parameters::{Network, NetworkUpgrade},
-    transaction::Transaction,
     transparent,
 };
 
@@ -780,14 +779,4 @@ pub fn miner_subsidy(
             .sum();
 
     expected_block_subsidy - total_funding_stream_amount?
-}
-
-/// Returns all output amounts in `Transaction`.
-pub fn output_amounts(transaction: &Transaction) -> HashSet<Amount<NonNegative>> {
-    transaction
-        .outputs()
-        .iter()
-        .map(|o| &o.value)
-        .cloned()
-        .collect()
 }


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

This is a small cleanup. No rush in getting this merged.

The `output_amounts()` function returning a HashSet caused a bug on a caller relying on it to include all amounts, even repeated ones. The fix we did for that just stopped using the function altogether and the function is no longer used. To avoid it being accidentally used, this PR removes it.

## Solution

Delete the function

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
