### PR TITLE
add(consensus): NU6.1 Testnet implementation and deployment

### DIFF
--- a/zebra-chain/src/amount.rs
+++ b/zebra-chain/src/amount.rs
@@ -74,6 +74,16 @@ impl Amount<NonNegative> {
         assert!(zatoshis <= MAX_MONEY && zatoshis >= 0);
         Self(zatoshis, PhantomData)
     }
+
+    /// Divide an [`Amount`] by a value that the amount fits into evenly such that there is no remainder.
+    pub const fn div_exact(self, rhs: i64) -> Self {
+        let result = self.0.checked_div(rhs).expect("divisor must be non-zero");
+        if self.0 % rhs != 0 {
+            panic!("divisor must divide amount evenly, no remainder");
+        }
+
+        Self(result, PhantomData)
+    }
 }
 
 impl<C> Amount<C> {

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -309,9 +309,9 @@ impl Network {
         };
 
         let expected_lockbox_disbursements = match self {
-            Self::Mainnet => subsidy::NU6_1_LOCKBOX_DISBURSEMENTS_MAINNET,
+            Self::Mainnet => subsidy::NU6_1_LOCKBOX_DISBURSEMENTS_MAINNET.to_vec(),
             Self::Testnet(params) if params.is_default_testnet() => {
-                subsidy::NU6_1_LOCKBOX_DISBURSEMENTS_TESTNET
+                subsidy::NU6_1_LOCKBOX_DISBURSEMENTS_TESTNET.to_vec()
             }
             Self::Testnet(params) => return params.lockbox_disbursements(),
         };

--- a/zebra-chain/src/parameters/network/subsidy.rs
+++ b/zebra-chain/src/parameters/network/subsidy.rs
@@ -19,7 +19,7 @@ use lazy_static::lazy_static;
 use crate::{
     amount::{self, Amount, NonNegative, COIN},
     block::{Height, HeightDiff},
-    parameters::{Network, NetworkUpgrade},
+    parameters::{Network, NetworkUpgrade, NU6_1_ACTIVATION_HEIGHT_TESTNET},
     transparent,
 };
 
@@ -286,6 +286,27 @@ lazy_static! {
             .into_iter()
             .collect(),
         },
+        FundingStreams {
+            // See discussed NU6 activation height and funding stream start/end heights:
+            // <https://discord.com/channels/809218587167293450/811004767043977288/1400566147585409074>
+            // <https://github.com/zcash/zcash/blob/b65b008a7b334a2f7c2eaae1b028e011f2e21dd1/src/chainparams.cpp#L472>
+            // <https://github.com/zcash/zcash/blob/b65b008a7b334a2f7c2eaae1b028e011f2e21dd1/src/chainparams.cpp#L608-L618>
+            // <https://github.com/zcash/zips/pull/1058/files?diff=unified&w=0#diff-e11a6a8ad34a7d686c41caccf93fe5745663cf0b38deb0ff0dad2917cdfb75e9R209-R210>
+            // TODO: Remove these references once <https://github.com/zcash/zips/pull/1058> has merged.
+            height_range: NU6_1_ACTIVATION_HEIGHT_TESTNET..Height(4_476_000),
+            recipients: [
+                (
+                    FundingStreamReceiver::Deferred,
+                    FundingStreamRecipient::new::<[&str; 0], &str>(12, []),
+                ),
+                (
+                    FundingStreamReceiver::MajorGrants,
+                    FundingStreamRecipient::new(8, POST_NU6_1_FUNDING_STREAM_FPF_ADDRESSES_TESTNET),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        },
     ];
 }
 
@@ -302,8 +323,12 @@ pub const NU6_1_LOCKBOX_DISBURSEMENTS_MAINNET: [(&str, Amount<NonNegative>); 0] 
 
 /// The one-time lockbox disbursement output addresses and amounts expected in the NU6.1 activation block's
 /// coinbase transaction on Testnet.
-// TODO: Update this with specified values once the ZIP is finalized.
-pub const NU6_1_LOCKBOX_DISBURSEMENTS_TESTNET: [(&str, Amount<NonNegative>); 0] = [];
+// See: <https://github.com/zcash/zcash/commit/56878f92b7e178c7c89ac00f42e7c2b0b2d7b25f#diff-ff53e63501a5e89fd650b378c9708274df8ad5d38fcffa6c64be417c4d438b6dR626-R635>
+// TODO: Add a reference to the ZIP once the ZIP is finalized and remove reference to zcashd code.
+pub const NU6_1_LOCKBOX_DISBURSEMENTS_TESTNET: [(&str, Amount<NonNegative>); 10] = [(
+    "t2RnBRiqrN1nW4ecZs1Fj3WWjNdnSs4kiX8",
+    EXPECTED_NU6_1_LOCKBOX_DISBURSEMENTS_TOTAL_TESTNET.div_exact(10),
+); 10];
 
 /// The expected total amount of the one-time lockbox disbursement on Mainnet.
 // TODO: Add a reference to the ZIP and update this value if needed.
@@ -555,10 +580,22 @@ pub const FUNDING_STREAM_MG_ADDRESSES_TESTNET: [&str; FUNDING_STREAMS_NUM_ADDRES
 /// [7.10]: https://zips.z.cash/protocol/protocol.pdf#fundingstreams
 pub const POST_NU6_FUNDING_STREAMS_NUM_ADDRESSES_TESTNET: usize = 13;
 
+/// Number of addresses for each post-NU6 funding stream in the Testnet.
+/// In the spec ([protocol specification §7.10][7.10]) this is defined as: `fs.addressindex(fs.endheight - 1)`
+/// however we know this value beforehand so we prefer to make it a constant instead.
+///
+/// [7.10]: https://zips.z.cash/protocol/protocol.pdf#fundingstreams
+pub const POST_NU6_1_FUNDING_STREAMS_NUM_ADDRESSES_TESTNET: usize = 37;
+
 /// List of addresses for the Major Grants post-NU6 funding stream on Testnet administered by the Financial Privacy Fund (FPF).
 pub const POST_NU6_FUNDING_STREAM_FPF_ADDRESSES_TESTNET: [&str;
     POST_NU6_FUNDING_STREAMS_NUM_ADDRESSES_TESTNET] =
     ["t2HifwjUj9uyxr9bknR8LFuQbc98c3vkXtu"; POST_NU6_FUNDING_STREAMS_NUM_ADDRESSES_TESTNET];
+
+/// List of addresses for the Major Grants post-NU6.1 funding stream on Testnet administered by the Financial Privacy Fund (FPF).
+pub const POST_NU6_1_FUNDING_STREAM_FPF_ADDRESSES_TESTNET: [&str;
+    POST_NU6_1_FUNDING_STREAMS_NUM_ADDRESSES_TESTNET] =
+    ["t2HifwjUj9uyxr9bknR8LFuQbc98c3vkXtu"; POST_NU6_1_FUNDING_STREAMS_NUM_ADDRESSES_TESTNET];
 
 /// Returns the address change period
 /// as described in [protocol specification §7.10][7.10]

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -25,7 +25,6 @@ const NETWORK_UPGRADES_IN_ORDER: &[NetworkUpgrade] = &[
     Canopy,
     Nu5,
     Nu6,
-    #[cfg(any(test, feature = "zebra-test"))]
     Nu6_1,
     #[cfg(any(test, feature = "zebra-test"))]
     Nu7,

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -130,6 +130,11 @@ const FAKE_MAINNET_ACTIVATION_HEIGHTS: &[(block::Height, NetworkUpgrade)] = &[
     (block::Height(50), Nu7),
 ];
 
+/// The block height at which NU6.1 activates on the default Testnet.
+// See NU6.1 Testnet activation height in zcashd:
+// <https://github.com/zcash/zcash/blob/b65b008a7b334a2f7c2eaae1b028e011f2e21dd1/src/chainparams.cpp#L472>
+pub const NU6_1_ACTIVATION_HEIGHT_TESTNET: block::Height = block::Height(3_536_500);
+
 /// Testnet network upgrade activation heights.
 ///
 /// This is actually a bijective map, but it is const, so we use a vector, and
@@ -150,6 +155,7 @@ pub(super) const TESTNET_ACTIVATION_HEIGHTS: &[(block::Height, NetworkUpgrade)] 
     (block::Height(1_028_500), Canopy),
     (block::Height(1_842_420), Nu5),
     (block::Height(2_976_000), Nu6),
+    (NU6_1_ACTIVATION_HEIGHT_TESTNET, Nu6_1),
 ];
 
 /// Fake testnet network upgrade activation heights, used in tests.
@@ -257,7 +263,6 @@ pub(crate) const CONSENSUS_BRANCH_IDS: &[(NetworkUpgrade, ConsensusBranchId)] = 
     (Canopy, ConsensusBranchId(0xe9ff75a6)),
     (Nu5, ConsensusBranchId(0xc2d6d0b4)),
     (Nu6, ConsensusBranchId(0xc8e71055)),
-    #[cfg(any(test, feature = "zebra-test"))]
     (Nu6_1, ConsensusBranchId(0x4dec4df0)),
     #[cfg(any(test, feature = "zebra-test"))]
     (Nu7, ConsensusBranchId(0x77190ad8)),

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -2126,8 +2126,9 @@ async fn v5_coinbase_transaction_expiry_height() {
 
     // Setting the new expiry height as the block height will activate NU6, so we need to set NU6
     // for the tx as well.
+    let height = new_expiry_height;
     new_transaction
-        .update_network_upgrade(NetworkUpgrade::Nu6)
+        .update_network_upgrade(NetworkUpgrade::current(&network, height))
         .expect("updating the network upgrade for a V5 tx should succeed");
 
     let verification_result = verifier
@@ -2137,7 +2138,7 @@ async fn v5_coinbase_transaction_expiry_height() {
             transaction: Arc::new(new_transaction.clone()),
             known_utxos: Arc::new(HashMap::new()),
             known_outpoint_hashes: Arc::new(HashSet::new()),
-            height: new_expiry_height,
+            height,
             time: DateTime::<Utc>::MAX_UTC,
         })
         .await;

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -340,10 +340,11 @@ pub const TIMESTAMP_TRUNCATION_SECONDS: u32 = 30 * 60;
 ///
 /// This version of Zebra draws the current network protocol version from
 /// [ZIP-253](https://zips.z.cash/zip-0253).
-// TODO: Update this constant to the correct value after NU6.1 & NU7 activation,
-// pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_140); // NU6.1
-// pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_160); // NU7
-pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_120);
+// TODO: Update this constant to the correct value after NU6.1 & NU7 activation (see NU deployment ZIPs),
+// pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_140); // NU6.1 Mainnet
+// pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_150); // NU7 Testnet.
+// pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_160); // NU7 Mainnet.
+pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_130);
 
 /// The default RTT estimate for peer responses.
 ///

--- a/zebra-rpc/src/methods/tests/snapshots/get_blockchain_info@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_blockchain_info@testnet_10.snap
@@ -86,6 +86,11 @@ expression: info
       "name": "NU6",
       "activationheight": 2976000,
       "status": "pending"
+    },
+    "4dec4df0": {
+      "name": "NU6.1",
+      "activationheight": 3536500,
+      "status": "pending"
     }
   },
   "consensus": {

--- a/zebra-rpc/src/methods/tests/snapshots/get_info@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_info@mainnet_10.snap
@@ -6,7 +6,7 @@ expression: info
   "version": 100,
   "build": "v0.0.1",
   "subversion": "[SubVersion]",
-  "protocolversion": 170120,
+  "protocolversion": 170130,
   "blocks": 10,
   "connections": 0,
   "difficulty": 1.0,

--- a/zebra-rpc/src/methods/tests/snapshots/get_info@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_info@testnet_10.snap
@@ -6,7 +6,7 @@ expression: info
   "version": 100,
   "build": "v0.0.1",
   "subversion": "[SubVersion]",
-  "protocolversion": 170120,
+  "protocolversion": 170130,
   "blocks": 10,
   "connections": 0,
   "difficulty": 1.0,


### PR DESCRIPTION
## Motivation

We want to deploy NU6.1 on Testnet.

This PR implements ZIP 271 and the rest of https://zips.z.cash/zip-0255 for Testnet as implemented in zcashd (the ZIPs need a small update) using the one-time lockbox disbursement mechanism added in https://github.com/ZcashFoundation/zebra/pull/9603.

Close https://github.com/ZcashFoundation/zebra/issues/9749

## Solution

- Adds a `Amount::div_exact()` method,
- Sets NU6.1 testnet activation height, 
- Adds new funding stream for the funding stream extension in ZIP 271
- Adds ZIP 271 one-time lockbox disbursements on Testnet, and
- Bumps current network protocol version

### Follow-up Work

Cleanup docs and code comments.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
