### PR TITLE
update crate changelogs for 2.5.0 release

### DIFF
--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2025-08-07
+
+Support for NU6.1 testnet activation.
+
+### Breaking Changes
+
+- Renamed `legacy_sigop_count` to `sigops` in `VerifiedUnminedTx`
+- Added `SubsidyError::OneTimeLockboxDisbursementNotFound` enum variant
+- Removed `zebra_chain::parameters::subsidy::output_amounts()`
+- Removed `pre_nu6_funding_streams` and `post_nu6_funding_streams` from
+  `Parameters`, `Network` and `ParametersBuilder`. Use `funding_streams`
+  instead.
+- Removed `PRE_NU6_FUNDING_STREAMS_MAINNET`, `POST_NU6_FUNDING_STREAMS_TESTNET`,
+  `POST_NU6_FUNDING_STREAMS_MAINNET`, `PRE_NU6_FUNDING_STREAMS_TESTNET`;
+  they're now part of `FUNDING_STREAMS_MAINNET/TESTNET`.
+- Removed `ConfiguredFundingStreams::empty()`
+- Changed `ConfiguredFundingStreams::convert_with_default()` to take
+  an `Option<FundingStreams>`.
+
+### Added
+
+- Added `new_from_zec()`, `new()`, `div_exact()` to `Amount<NonNegative>`
+- Added `checked_sub()` to `Amount`
+- Added `DeferredPoolBalanceChange`
+- Added `Network::lockbox_disbursement_total_amount()`,
+  `Network::lockbox_disbursements()`
+- Added `NU6_1_LOCKBOX_DISBURSEMENTS_MAINNET`,
+  `NU6_1_LOCKBOX_DISBURSEMENTS_TESTNET`,
+  `POST_NU6_1_FUNDING_STREAM_FPF_ADDRESSES_TESTNET`
+- Added `ConfiguredLockboxDisbursement`
+- Added `ParametersBuilder::with_funding_streams()/with_lockbox_disbursements()`
+- Added
+  `Parameters::lockbox_disbursement_total_amount()/lockbox_disbursements()`
+- Added `NU6_1_ACTIVATION_HEIGHT_TESTNET`
+
 ## [1.0.0] - 2025-07-11
 
 First "stable" release. However, be advised that the API may still greatly

--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2025-08-07
 
-Support for NU6.1 testnet activation.
+Support for NU6.1 testnet activation; added testnet activation height for NU6.1.
 
 ### Breaking Changes
 

--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -14,31 +14,24 @@ Support for NU6.1 testnet activation.
 - Renamed `legacy_sigop_count` to `sigops` in `VerifiedUnminedTx`
 - Added `SubsidyError::OneTimeLockboxDisbursementNotFound` enum variant
 - Removed `zebra_chain::parameters::subsidy::output_amounts()`
-- Removed `pre_nu6_funding_streams` and `post_nu6_funding_streams` from
-  `Parameters`, `Network` and `ParametersBuilder`. Use `funding_streams`
-  instead.
-- Removed `PRE_NU6_FUNDING_STREAMS_MAINNET`, `POST_NU6_FUNDING_STREAMS_TESTNET`,
-  `POST_NU6_FUNDING_STREAMS_MAINNET`, `PRE_NU6_FUNDING_STREAMS_TESTNET`;
-  they're now part of `FUNDING_STREAMS_MAINNET/TESTNET`.
+- Refactored `{pre, post}_nu6_funding_streams` fields in `testnet::{Parameters, ParametersBuilder}` into one `BTreeMap``funding_streams` field
+- Removed `{PRE, POST}_NU6_FUNDING_STREAMS_{MAINNET, TESTNET}`;
+  they're now part of `FUNDING_STREAMS_{MAINNET, TESTNET}`.
 - Removed `ConfiguredFundingStreams::empty()`
 - Changed `ConfiguredFundingStreams::convert_with_default()` to take
   an `Option<FundingStreams>`.
 
 ### Added
 
-- Added `new_from_zec()`, `new()`, `div_exact()` to `Amount<NonNegative>`
-- Added `checked_sub()` to `Amount`
-- Added `DeferredPoolBalanceChange`
-- Added `Network::lockbox_disbursement_total_amount()`,
-  `Network::lockbox_disbursements()`
-- Added `NU6_1_LOCKBOX_DISBURSEMENTS_MAINNET`,
-  `NU6_1_LOCKBOX_DISBURSEMENTS_TESTNET`,
-  `POST_NU6_1_FUNDING_STREAM_FPF_ADDRESSES_TESTNET`
+- Added `new_from_zec()`, `new()`, `div_exact()` methods for `Amount<NonNegative>`
+- Added `checked_sub()` method for `Amount`
+- Added `DeferredPoolBalanceChange` newtype wrapper around `Amount`s representing deferred pool balance changes
+- Added `Network::lockbox_disbursement_total_amount()` and
+  `Network::lockbox_disbursements()` methods
+- Added `NU6_1_LOCKBOX_DISBURSEMENTS_{MAINNET, TESTNET}`, `POST_NU6_1_FUNDING_STREAM_FPF_ADDRESSES_TESTNET`, and `NU6_1_ACTIVATION_HEIGHT_TESTNET` constants
 - Added `ConfiguredLockboxDisbursement`
-- Added `ParametersBuilder::with_funding_streams()/with_lockbox_disbursements()`
-- Added
-  `Parameters::lockbox_disbursement_total_amount()/lockbox_disbursements()`
-- Added `NU6_1_ACTIVATION_HEIGHT_TESTNET`
+- Added `ParametersBuilder::{with_funding_streams(), with_lockbox_disbursements()}` and
+  `Parameters::{lockbox_disbursement_total_amount(), lockbox_disbursements()}` methods
 
 ## [1.0.0] - 2025-07-11
 

--- a/zebra-chain/src/parameters/network/subsidy.rs
+++ b/zebra-chain/src/parameters/network/subsidy.rs
@@ -332,12 +332,12 @@ pub const NU6_1_LOCKBOX_DISBURSEMENTS_TESTNET: [(&str, Amount<NonNegative>); 10]
 
 /// The expected total amount of the one-time lockbox disbursement on Mainnet.
 // TODO: Add a reference to the ZIP and update this value if needed.
-pub const EXPECTED_NU6_1_LOCKBOX_DISBURSEMENTS_TOTAL_MAINNET: Amount<NonNegative> =
+pub(crate) const EXPECTED_NU6_1_LOCKBOX_DISBURSEMENTS_TOTAL_MAINNET: Amount<NonNegative> =
     Amount::new_from_zec(78_750);
 
 /// The expected total amount of the one-time lockbox disbursement on Testnet.
 // TODO: Add a reference to the ZIP and update this value if needed.
-pub const EXPECTED_NU6_1_LOCKBOX_DISBURSEMENTS_TOTAL_TESTNET: Amount<NonNegative> =
+pub(crate) const EXPECTED_NU6_1_LOCKBOX_DISBURSEMENTS_TOTAL_TESTNET: Amount<NonNegative> =
     Amount::new_from_zec(78_750);
 
 /// The number of blocks contained in the post-NU6 funding streams height ranges on Mainnet or Testnet, as specified

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2025-08-07
+
+Support for NU6.1 testnet activation.
+
+### Breaking Changes
+
+- Renamed `legacy_sigop_count` to `sigops` in
+  `BlockError::TooManyTransparentSignatureOperations` and `Response::Block`.
+
+
 ## [1.0.0] - 2025-07-11
 
 First "stable" release. However, be advised that the API may still greatly

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -11,8 +11,7 @@ Support for NU6.1 testnet activation.
 
 ### Breaking Changes
 
-- Renamed `legacy_sigop_count` to `sigops` in
-  `BlockError::TooManyTransparentSignatureOperations` and `Response::Block`.
+- Renamed `legacy_sigop_count` to `sigops` in `BlockError::TooManyTransparentSignatureOperations` and `transaction::Response::Block`.
 
 
 ## [1.0.0] - 2025-07-11

--- a/zebra-network/CHANGELOG.md
+++ b/zebra-network/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2025-08-07
+
+Support for NU6.1 testnet activation.
+
+### Added
+
+- Added support for a new config field, `funding_streams`
+
+### Deprecated
+
+- The `pre_nu6_funding_streams` and `post_nu6_funding_streams` config
+  fields are now deprecated; use `funding_streams` instead.
+
+
 ## [1.0.0] - 2025-07-11
 
 First "stable" release. However, be advised that the API may still greatly

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [2.0.0] - 2025-08-07
 
-### Changes 
+### Breaking Changes
+
+- Changed the `deferred` value pool identifier to `lockbox` in `getblock` and
+  `getblockchaininfo`.
+
+### Changed
 
 - Slice `[GetBlockchainInfoBalance; 5]` type is aliased as `BlockchainValuePoolBalances`
+
 ## [1.0.0] - 2025-07-11
 
 First "stable" release. However, be advised that the API may still greatly

--- a/zebra-script/CHANGELOG.md
+++ b/zebra-script/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2025-08-07
+
+### Breaking Changes
+
+- Removed  `legacy_sigop_count`; use the `Sigops` trait instead.
+
 ## [1.0.0] - 2025-07-11
 
 First "stable" release. However, be advised that the API may still greatly

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2025-08-07
+
+### Breaking Changes
+
+- Renamed `SemanticallyVerifiedBlock::with_deferred_balance()` to
+  `with_deferred_pool_balance_change()`
+- Renamed `SemanticallyVerifiedBlock::deferred_balance` to
+  `SemanticallyVerifiedBlock::deferred_pool_balance_change`
+
+
 ## [1.0.1] - 2025-07-22
 
 ### Fixed

--- a/zebra-test/CHANGELOG.md
+++ b/zebra-test/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-08-07
+
+## Changed
+
+- Clippy fixes
+
 ## [1.0.0] - 2025-07-11
 
 First "stable" release. However, be advised that the API may still greatly

--- a/zebra-utils/CHANGELOG.md
+++ b/zebra-utils/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2025-08-07
+
+## Breaking Changes
+
+- Removed unused `zcash_client_backend` dependency.
+
 ## [1.0.0] - 2025-07-11
 
 First "stable" release. However, be advised that the API may still greatly


### PR DESCRIPTION
## Motivation

We need to update the crate changelogs for the 2.5.0 release.

## Solution

This is the first time we do a non-trivial instance of that, so there is probably a lot of stuff we can do to improve the process. I basically ran `cargo semver-checks -p <crate> --default-features` to list breaking changes and `git diff v2.4.2 <crate>/` to extract the list other non-breaking changes (it's a pain).

I changed two constants to be `pub(crate)` instead of `pub` because I though they really don't need to be part of the public API.

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
