### PR TITLE
chore: Bump MSRV from 1.85 to 1.89

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@
 # We first set default values for build arguments used across the stages.
 # Each stage must define the build arguments (ARGs) it uses.
 
-ARG RUST_VERSION=1.88.0
+ARG RUST_VERSION=1.89.0
 
 # Keep in sync with vars.RUST_PROD_FEATURES in GitHub
 # https://github.com/ZcashFoundation/zebra/settings/variables/actions

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2021"
 
 # Zebra is only supported on the latest stable Rust version. See the README for details.
 # Any Zebra release can break compatibility with older Rust versions.
-rust-version = "1.85.0"
+rust-version = "1.89.0"
 
 # Settings that impact runtime behaviour
 


### PR DESCRIPTION
- Fix https://github.com/ZcashFoundation/zebra/actions/runs/16852707101/job/47741281391?pr=9764#step:10:943.
- Based atop #9774.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
