### PR TITLE
fix(CI): Use desired Rust toolchain

### DIFF
--- a/.github/workflows/ci-build-crates.patch.yml
+++ b/.github/workflows/ci-build-crates.patch.yml
@@ -6,15 +6,15 @@ on:
   pull_request:
     paths-ignore:
       # production code and test code
-      - '**/*.rs'
+      - "**/*.rs"
       # dependencies
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
       # configuration files
-      - '.cargo/config.toml'
-      - '**/clippy.toml'
+      - ".cargo/config.toml"
+      - "**/clippy.toml"
       # workflow definitions
-      - '.github/workflows/ci-build-crates.yml'
+      - ".github/workflows/ci-build-crates.yml"
 
 jobs:
   matrix:
@@ -29,6 +29,7 @@ jobs:
       - name: Setup Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
+          source $HOME/.cargo/env
 
       # This step is meant to dynamically create a JSON containing the values of each crate
       # available in this repo in the root directory. We use `cargo tree` to accomplish this task.
@@ -56,13 +57,13 @@ jobs:
   check-matrix:
     name: Check crates matrix
     runs-on: ubuntu-latest
-    needs: [ matrix ]
+    needs: [matrix]
     steps:
       - run: 'echo "No job required"'
 
   build:
     name: Build ${{ matrix.crate }} crate
-    needs: [ matrix, check-matrix ]
+    needs: [matrix, check-matrix]
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}

--- a/.github/workflows/ci-build-crates.patch.yml
+++ b/.github/workflows/ci-build-crates.patch.yml
@@ -28,8 +28,7 @@ jobs:
       # Setup Rust with stable toolchain and minimal profile
       - name: Setup Rust
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          rustup toolchain install stable --profile minimal
 
       # This step is meant to dynamically create a JSON containing the values of each crate
       # available in this repo in the root directory. We use `cargo tree` to accomplish this task.

--- a/.github/workflows/ci-build-crates.patch.yml
+++ b/.github/workflows/ci-build-crates.patch.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
-          source $HOME/.cargo/env
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       # This step is meant to dynamically create a JSON containing the values of each crate
       # available in this repo in the root directory. We use `cargo tree` to accomplish this task.

--- a/.github/workflows/ci-build-crates.yml
+++ b/.github/workflows/ci-build-crates.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
-          source $HOME/.cargo/env
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       # This step is meant to dynamically create a JSON containing the values of each crate
       # available in this repo in the root directory. We use `cargo tree` to accomplish this task.
@@ -139,7 +139,7 @@ jobs:
       - name: Setup Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
-          source $HOME/.cargo/env
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       # We could use `features: ['', '--all-features', '--no-default-features']` as a matrix argument,
       # but it's faster to run these commands sequentially, so they can re-use the local cargo cache.

--- a/.github/workflows/ci-build-crates.yml
+++ b/.github/workflows/ci-build-crates.yml
@@ -66,8 +66,7 @@ jobs:
       # Setup Rust with stable toolchain and minimal profile
       - name: Setup Rust
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          rustup toolchain install stable --profile minimal
 
       # This step is meant to dynamically create a JSON containing the values of each crate
       # available in this repo in the root directory. We use `cargo tree` to accomplish this task.
@@ -138,8 +137,7 @@ jobs:
       # Setup Rust with stable toolchain and minimal profile
       - name: Setup Rust
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          rustup toolchain install stable --profile minimal
 
       # We could use `features: ['', '--all-features', '--no-default-features']` as a matrix argument,
       # but it's faster to run these commands sequentially, so they can re-use the local cargo cache.

--- a/.github/workflows/ci-build-crates.yml
+++ b/.github/workflows/ci-build-crates.yml
@@ -24,27 +24,27 @@ on:
       - main
     paths:
       # production code and test code
-      - '**/*.rs'
+      - "**/*.rs"
       # dependencies
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
       # configuration files
-      - '.cargo/config.toml'
-      - '**/clippy.toml'
+      - ".cargo/config.toml"
+      - "**/clippy.toml"
       # workflow definitions
-      - '.github/workflows/ci-build-crates.yml'
+      - ".github/workflows/ci-build-crates.yml"
   pull_request:
     paths:
       # production code and test code
-      - '**/*.rs'
+      - "**/*.rs"
       # dependencies
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
       # configuration files
-      - '.cargo/config.toml'
-      - '**/clippy.toml'
+      - ".cargo/config.toml"
+      - "**/clippy.toml"
       # workflow definitions
-      - '.github/workflows/ci-build-crates.yml'
+      - ".github/workflows/ci-build-crates.yml"
 
 env:
   CARGO_INCREMENTAL: ${{ vars.CARGO_INCREMENTAL }}
@@ -67,6 +67,7 @@ jobs:
       - name: Setup Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
+          source $HOME/.cargo/env
 
       # This step is meant to dynamically create a JSON containing the values of each crate
       # available in this repo in the root directory. We use `cargo tree` to accomplish this task.
@@ -95,7 +96,7 @@ jobs:
   check-matrix:
     name: Check crates matrix
     runs-on: ubuntu-latest
-    needs: [ matrix ]
+    needs: [matrix]
     steps:
       - name: Install json2yaml
         run: |
@@ -111,7 +112,7 @@ jobs:
   build:
     name: Build ${{ matrix.crate }} crate
     timeout-minutes: 90
-    needs: [ matrix, check-matrix ]
+    needs: [matrix, check-matrix]
     # Some of these builds take more than 14GB disk space
     runs-on: ${{ github.repository_owner == 'ZcashFoundation' && 'ubuntu-latest-m' || 'ubuntu-latest' }}
     strategy:
@@ -131,13 +132,14 @@ jobs:
         uses: arduino/setup-protoc@v3.0.0
         with:
           # TODO: increase to latest version after https://github.com/arduino/setup-protoc/issues/33 is fixed
-          version: '23.x'
+          version: "23.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Setup Rust with stable toolchain and minimal profile
       - name: Setup Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
+          source $HOME/.cargo/env
 
       # We could use `features: ['', '--all-features', '--no-default-features']` as a matrix argument,
       # but it's faster to run these commands sequentially, so they can re-use the local cargo cache.
@@ -167,7 +169,7 @@ jobs:
   failure-issue:
     name: Open or update issues for building crates individually failures
     # When a new job is added to this workflow, add it to this list.
-    needs: [ matrix, build ]
+    needs: [matrix, build]
     # Only open tickets for failed or cancelled jobs that are not coming from PRs.
     # (PR statuses are already reported in the PR jobs list, and checked by GitHub's Merge Queue.)
     if: (failure() && github.event.pull_request == null) || (cancelled() && github.event.pull_request == null)

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -76,8 +76,7 @@ jobs:
       # Setup Rust with stable toolchain and minimal profile
       - name: Setup Rust
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal --component=llvm-tools-preview
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          rustup toolchain install stable --profile minimal
 
       - name: Install cargo-llvm-cov cargo command
         run: cargo install cargo-llvm-cov

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -26,32 +26,32 @@ on:
       - main
     paths:
       # code and tests
-      - '**/*.rs'
+      - "**/*.rs"
       # hard-coded checkpoints and proptest regressions
-      - '**/*.txt'
+      - "**/*.txt"
       # test data snapshots
-      - '**/*.snap'
+      - "**/*.snap"
       # dependencies
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
       # configuration files
-      - '.cargo/config.toml'
-      - '**/clippy.toml'
+      - ".cargo/config.toml"
+      - "**/clippy.toml"
       # workflow definitions
-      - 'codecov.yml'
-      - '.github/workflows/ci-coverage.yml'
+      - "codecov.yml"
+      - ".github/workflows/ci-coverage.yml"
 
   pull_request:
     paths:
-      - '**/*.rs'
-      - '**/*.txt'
-      - '**/*.snap'
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
-      - '.cargo/config.toml'
-      - '**/clippy.toml'
-      - 'codecov.yml'
-      - '.github/workflows/ci-coverage.yml'
+      - "**/*.rs"
+      - "**/*.txt"
+      - "**/*.snap"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".cargo/config.toml"
+      - "**/clippy.toml"
+      - "codecov.yml"
+      - ".github/workflows/ci-coverage.yml"
 
 env:
   CARGO_INCREMENTAL: ${{ vars.CARGO_INCREMENTAL }}
@@ -77,6 +77,7 @@ jobs:
       - name: Setup Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal --component=llvm-tools-preview
+          source $HOME/.cargo/env
 
       - name: Install cargo-llvm-cov cargo command
         run: cargo install cargo-llvm-cov

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Setup Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal --component=llvm-tools-preview
-          source $HOME/.cargo/env
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Install cargo-llvm-cov cargo command
         run: cargo install cargo-llvm-cov

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Setup Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=default
-          source $HOME/.cargo/env
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - uses: Swatinem/rust-cache@v2.7.8
         with:
@@ -136,7 +136,7 @@ jobs:
       - name: Setup Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=default
-          source $HOME/.cargo/env
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       # We don't cache `fmt` outputs because the job is quick,
       # and we want to use the limited GitHub actions cache space for slower jobs.

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -77,7 +77,7 @@ jobs:
         uses: arduino/setup-protoc@v3.0.0
         with:
           # TODO: increase to latest version after https://github.com/arduino/setup-protoc/issues/33 is fixed
-          version: '23.x'
+          version: "23.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check workflow permissions
@@ -92,6 +92,7 @@ jobs:
       - name: Setup Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=default
+          source $HOME/.cargo/env
 
       - uses: Swatinem/rust-cache@v2.7.8
         with:
@@ -128,13 +129,14 @@ jobs:
         uses: arduino/setup-protoc@v3.0.0
         with:
           # TODO: increase to latest version after https://github.com/arduino/setup-protoc/issues/33 is fixed
-          version: '23.x'
+          version: "23.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Setup Rust with stable toolchain and default profile
       - name: Setup Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=default
+          source $HOME/.cargo/env
 
       # We don't cache `fmt` outputs because the job is quick,
       # and we want to use the limited GitHub actions cache space for slower jobs.
@@ -155,7 +157,7 @@ jobs:
         with:
           level: warning
           fail_on_error: false
-      # This is failing with a JSON schema error, see #8028 for details.        
+      # This is failing with a JSON schema error, see #8028 for details.
       #- name: validate-dependabot
       #  # This gives an error when run on PRs from external repositories, so we skip it.
       #  # If this is a PR, check that the PR source is a local branch. Always runs on non-PRs.
@@ -170,4 +172,3 @@ jobs:
       - uses: codespell-project/actions-codespell@v2.1
         with:
           only_warn: 1
-

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -91,8 +91,7 @@ jobs:
       # Setup Rust with stable toolchain and default profile
       - name: Setup Rust
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=default
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          rustup toolchain install stable --profile default
 
       - uses: Swatinem/rust-cache@v2.7.8
         with:
@@ -135,8 +134,7 @@ jobs:
       # Setup Rust with stable toolchain and default profile
       - name: Setup Rust
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=default
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          rustup toolchain install stable --profile default
 
       # We don't cache `fmt` outputs because the job is quick,
       # and we want to use the limited GitHub actions cache space for slower jobs.

--- a/.github/workflows/ci-unit-tests-os.yml
+++ b/.github/workflows/ci-unit-tests-os.yml
@@ -164,7 +164,7 @@ jobs:
       # Run unit and basic acceptance tests, only showing command output if the test fails.
       #
       # If some tests hang, add "-- --nocapture" for just that test, or for all the tests.
-      - name: Run tests${{ matrix.features }}
+      - name: Run tests ${{ matrix.features }}
         run: |
           cargo test --features "${{ matrix.features }}" --release --verbose --workspace
 

--- a/.github/workflows/ci-unit-tests-os.yml
+++ b/.github/workflows/ci-unit-tests-os.yml
@@ -74,6 +74,9 @@ jobs:
   ### Build and test Zebra on all OSes ###
   ########################################
   test:
+    env:
+      RUSTUP_TOOLCHAIN: ${{ matrix.rust }}
+
     name: Test ${{ matrix.rust }} on ${{ matrix.os }}
     # The large timeout is to accommodate:
     # - macOS and Windows builds (typically 50-90 minutes), and

--- a/.github/workflows/ci-unit-tests-os.yml
+++ b/.github/workflows/ci-unit-tests-os.yml
@@ -22,20 +22,20 @@ on:
   pull_request:
     paths:
       # code and tests
-      - '**/*.rs'
+      - "**/*.rs"
       # hard-coded checkpoints and proptest regressions
-      - '**/*.txt'
+      - "**/*.txt"
       # test data snapshots
-      - '**/*.snap'
+      - "**/*.snap"
       # dependencies
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
-      - '**/deny.toml'
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "**/deny.toml"
       # configuration files
-      - '.cargo/config.toml'
-      - '**/clippy.toml'
+      - ".cargo/config.toml"
+      - "**/clippy.toml"
       # workflow definitions
-      - '.github/workflows/ci-unit-tests-os.yml'
+      - ".github/workflows/ci-unit-tests-os.yml"
 
   # we build Rust caches on main,
   # so they can be shared by all branches:
@@ -45,21 +45,21 @@ on:
       - main
     paths:
       # production code and test code
-      - '**/*.rs'
+      - "**/*.rs"
       # hard-coded checkpoints
       # TODO: skip proptest regressions?
-      - '**/*.txt'
+      - "**/*.txt"
       # test data snapshots
-      - '**/*.snap'
+      - "**/*.snap"
       # dependencies
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
-      - '**/deny.toml'
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "**/deny.toml"
       # configuration files
-      - '.cargo/config.toml'
-      - '**/clippy.toml'
+      - ".cargo/config.toml"
+      - "**/clippy.toml"
       # workflow definitions
-      - '.github/workflows/ci-unit-tests-os.yml'
+      - ".github/workflows/ci-unit-tests-os.yml"
 
 env:
   CARGO_INCREMENTAL: ${{ vars.CARGO_INCREMENTAL }}
@@ -87,10 +87,10 @@ jobs:
         # Other feature combinations are tested in specific workflows
         features: ["default-release-binaries"]
         exclude:
-        # We're excluding macOS beta for the following reasons:
-        # - the concurrent macOS runner limit is much lower than the Linux limit
-        # - macOS is slower than Linux, and shouldn't have a build or test difference with Linux
-        # - macOS is a second-tier Zebra support platform
+          # We're excluding macOS beta for the following reasons:
+          # - the concurrent macOS runner limit is much lower than the Linux limit
+          # - macOS is slower than Linux, and shouldn't have a build or test difference with Linux
+          # - macOS is a second-tier Zebra support platform
           - os: macos-latest
             rust: beta
 
@@ -104,14 +104,14 @@ jobs:
         uses: arduino/setup-protoc@v3.0.0
         with:
           # TODO: increase to latest version after https://github.com/arduino/setup-protoc/issues/33 is fixed
-          version: '23.x'
+          version: "23.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Setup Rust with ${{ matrix.rust }} toolchain and minimal profile
       - name: Setup Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=${{ matrix.rust }} --profile=minimal
-
+          source $HOME/.cargo/env
 
       - uses: Swatinem/rust-cache@v2.7.8
         # TODO: change Rust cache target directory on Windows,
@@ -192,13 +192,14 @@ jobs:
         uses: arduino/setup-protoc@v3.0.0
         with:
           # TODO: increase to latest version after https://github.com/arduino/setup-protoc/issues/33 is fixed
-          version: '23.x'
+          version: "23.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Setup Rust with stable toolchain and minimal profile
       - name: Setup Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
+          source $HOME/.cargo/env
 
       - name: Install zebrad
         run: |
@@ -220,13 +221,14 @@ jobs:
       - name: Install last version of Protoc
         uses: arduino/setup-protoc@v3.0.0
         with:
-          version: '23.x'
+          version: "23.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Setup Rust with stable toolchain and minimal profile
       - name: Setup Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
+          source $HOME/.cargo/env
 
       - uses: Swatinem/rust-cache@v2.7.8
         with:
@@ -247,7 +249,7 @@ jobs:
         # We don't need to check `--no-default-features` here, because (except in very rare cases):
         # - disabling features isn't going to add duplicate dependencies
         # - disabling features isn't going to add more crate sources
-        features: ['', '--features default-release-binaries', '--all-features']
+        features: ["", "--features default-release-binaries", "--all-features"]
       # Always run the --all-features job, to get accurate "skip tree root was not found" warnings
       fail-fast: false
 
@@ -285,6 +287,7 @@ jobs:
       - name: Setup Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
+          source $HOME/.cargo/env
 
       - name: Install cargo-machete
         uses: baptiste0928/cargo-install@v3.3.0
@@ -310,7 +313,14 @@ jobs:
   failure-issue:
     name: Open or update issues for OS integration failures
     # When a new job is added to this workflow, add it to this list.
-    needs: [ test,  install-from-lockfile-no-cache, check-cargo-lock, cargo-deny, unused-deps ]
+    needs:
+      [
+        test,
+        install-from-lockfile-no-cache,
+        check-cargo-lock,
+        cargo-deny,
+        unused-deps,
+      ]
     # Only open tickets for failed or cancelled jobs that are not coming from PRs.
     # (PR statuses are already reported in the PR jobs list, and checked by GitHub's Merge Queue.)
     if: (failure() || cancelled()) && github.repository_owner == 'ZcashFoundation' && github.event.pull_request == null

--- a/.github/workflows/ci-unit-tests-os.yml
+++ b/.github/workflows/ci-unit-tests-os.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Setup Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
-          source $HOME/.cargo/env
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Install zebrad
         run: |
@@ -237,7 +237,7 @@ jobs:
       - name: Setup Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
-          source $HOME/.cargo/env
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - uses: Swatinem/rust-cache@v2.7.8
         with:
@@ -296,7 +296,7 @@ jobs:
       - name: Setup Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
-          source $HOME/.cargo/env
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Install cargo-machete
         uses: baptiste0928/cargo-install@v3.3.0

--- a/.github/workflows/ci-unit-tests-os.yml
+++ b/.github/workflows/ci-unit-tests-os.yml
@@ -108,19 +108,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Setup Rust with ${{ matrix.rust }} toolchain and minimal profile
-      - name: Install Rust (Linux/macOS)
-        if: runner.os != 'Windows'
-        shell: bash
+      - name: Setup Rust
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=${{ matrix.rust }} --profile=minimal
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-      - name: Install Rust (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          curl.exe --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=${{ matrix.rust }} --profile=minimal
-          "$env:USERPROFILE\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH
+          rustup toolchain install ${{ matrix.rust }} --profile minimal
 
       - uses: Swatinem/rust-cache@v2.7.8
         # TODO: change Rust cache target directory on Windows,
@@ -207,8 +197,7 @@ jobs:
       # Setup Rust with stable toolchain and minimal profile
       - name: Setup Rust
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          rustup toolchain install stable --profile minimal
 
       - name: Install zebrad
         run: |
@@ -236,8 +225,7 @@ jobs:
       # Setup Rust with stable toolchain and minimal profile
       - name: Setup Rust
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          rustup toolchain install stable --profile minimal
 
       - uses: Swatinem/rust-cache@v2.7.8
         with:
@@ -295,8 +283,7 @@ jobs:
       # Setup Rust with stable toolchain and minimal profile
       - name: Setup Rust
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          rustup toolchain install stable --profile minimal
 
       - name: Install cargo-machete
         uses: baptiste0928/cargo-install@v3.3.0

--- a/.github/workflows/ci-unit-tests-os.yml
+++ b/.github/workflows/ci-unit-tests-os.yml
@@ -109,9 +109,18 @@ jobs:
 
       # Setup Rust with ${{ matrix.rust }} toolchain and minimal profile
       - name: Setup Rust
+        shell: bash
+        if: runner.os != 'Windows'
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=${{ matrix.rust }} --profile=minimal
           source $HOME/.cargo/env
+
+      - name: Setup Rust (Windows)
+        shell: pwsh
+        if: runner.os == 'Windows'
+        run: |
+          curl.exe --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=${{ matrix.rust }} --profile=minimal
+          $env:Path = "$env:USERPROFILE\.cargo\bin;$env:Path"
 
       - uses: Swatinem/rust-cache@v2.7.8
         # TODO: change Rust cache target directory on Windows,

--- a/.github/workflows/ci-unit-tests-os.yml
+++ b/.github/workflows/ci-unit-tests-os.yml
@@ -108,19 +108,11 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Setup Rust with ${{ matrix.rust }} toolchain and minimal profile
-      - name: Setup Rust
-        shell: bash
-        if: runner.os != 'Windows'
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=${{ matrix.rust }} --profile=minimal
-          source $HOME/.cargo/env
-
-      - name: Setup Rust (Windows)
-        shell: pwsh
-        if: runner.os == 'Windows'
-        run: |
-          curl.exe --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=${{ matrix.rust }} --profile=minimal
-          $env:Path = "$env:USERPROFILE\.cargo\bin;$env:Path"
+      - name: Setup Rust (${{ matrix.rust }})
+        uses: dtolnay/rust-toolchain@${{ matrix.rust }}
+        with:
+          profile: minimal
+          override: true
 
       - uses: Swatinem/rust-cache@v2.7.8
         # TODO: change Rust cache target directory on Windows,

--- a/.github/workflows/ci-unit-tests-os.yml
+++ b/.github/workflows/ci-unit-tests-os.yml
@@ -62,7 +62,6 @@ on:
       - ".github/workflows/ci-unit-tests-os.yml"
 
 env:
-  RUSTUP_TOOLCHAIN: $${{ matrix.rust }}
   CARGO_INCREMENTAL: ${{ vars.CARGO_INCREMENTAL }}
   RUST_LOG: ${{ vars.RUST_LOG }}
   RUST_BACKTRACE: ${{ vars.RUST_BACKTRACE }}

--- a/.github/workflows/ci-unit-tests-os.yml
+++ b/.github/workflows/ci-unit-tests-os.yml
@@ -108,11 +108,19 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Setup Rust with ${{ matrix.rust }} toolchain and minimal profile
-      - name: Setup Rust (${{ matrix.rust }})
-        uses: dtolnay/rust-toolchain@${{ matrix.rust }}
-        with:
-          profile: minimal
-          override: true
+      - name: Install Rust (Linux/macOS)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=${{ matrix.rust }} --profile=minimal
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Install Rust (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          curl.exe --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=${{ matrix.rust }} --profile=minimal
+          "$env:USERPROFILE\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH
 
       - uses: Swatinem/rust-cache@v2.7.8
         # TODO: change Rust cache target directory on Windows,

--- a/.github/workflows/ci-unit-tests-os.yml
+++ b/.github/workflows/ci-unit-tests-os.yml
@@ -62,6 +62,7 @@ on:
       - ".github/workflows/ci-unit-tests-os.yml"
 
 env:
+  RUSTUP_TOOLCHAIN: $${{ matrix.rust }}
   CARGO_INCREMENTAL: ${{ vars.CARGO_INCREMENTAL }}
   RUST_LOG: ${{ vars.RUST_LOG }}
   RUST_BACKTRACE: ${{ vars.RUST_BACKTRACE }}

--- a/.github/workflows/docs-deploy-firebase.yml
+++ b/.github/workflows/docs-deploy-firebase.yml
@@ -55,6 +55,7 @@ on:
       - ".github/workflows/docs-deploy-firebase.yml"
 
 env:
+  RUSTUP_TOOLCHAIN: beta
   RUST_LOG: ${{ vars.RUST_LOG }}
   RUST_BACKTRACE: ${{ vars.RUST_BACKTRACE }}
   RUST_LIB_BACKTRACE: ${{ vars.RUST_LIB_BACKTRACE }}

--- a/.github/workflows/docs-deploy-firebase.yml
+++ b/.github/workflows/docs-deploy-firebase.yml
@@ -160,7 +160,7 @@ jobs:
         run: |
           rustup toolchain install beta --profile default
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@v2.7.8
 
       - name: Build internal docs
         run: |

--- a/.github/workflows/docs-deploy-firebase.yml
+++ b/.github/workflows/docs-deploy-firebase.yml
@@ -156,10 +156,9 @@ jobs:
       # Setup Rust with beta toolchain and default profile (to include rust-docs)
       - name: Setup Rust
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=beta --profile=default
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          rustup toolchain install beta --profile default
 
-      - uses: Swatinem/rust-cache@v2.7.8
+      - uses: Swatinem/rust-cache@v2
 
       - name: Build internal docs
         run: |

--- a/.github/workflows/docs-deploy-firebase.yml
+++ b/.github/workflows/docs-deploy-firebase.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Setup Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=beta --profile=default
-          source $HOME/.cargo/env
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - uses: Swatinem/rust-cache@v2.7.8
 

--- a/.github/workflows/docs-deploy-firebase.yml
+++ b/.github/workflows/docs-deploy-firebase.yml
@@ -55,7 +55,6 @@ on:
       - ".github/workflows/docs-deploy-firebase.yml"
 
 env:
-  RUSTUP_TOOLCHAIN: beta
   RUST_LOG: ${{ vars.RUST_LOG }}
   RUST_BACKTRACE: ${{ vars.RUST_BACKTRACE }}
   RUST_LIB_BACKTRACE: ${{ vars.RUST_LIB_BACKTRACE }}
@@ -131,6 +130,8 @@ jobs:
           target: docs-book
 
   build-docs-internal:
+    env:
+      RUSTUP_TOOLCHAIN: beta
     name: Build and Deploy Zebra Internal Docs
     if: ${{ !startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork }}
     timeout-minutes: 45

--- a/.github/workflows/docs-deploy-firebase.yml
+++ b/.github/workflows/docs-deploy-firebase.yml
@@ -22,37 +22,37 @@ on:
       - main
     paths:
       # doc source files
-      - 'book/**'
-      - '**/firebase.json'
-      - '**/.firebaserc'
-      - 'katex-header.html'
+      - "book/**"
+      - "**/firebase.json"
+      - "**/.firebaserc"
+      - "katex-header.html"
       # rustdoc source files
-      - '**/*.rs'
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
       # configuration files
-      - '.cargo/config.toml'
-      - '**/clippy.toml'
+      - ".cargo/config.toml"
+      - "**/clippy.toml"
       # workflow definitions
-      - '.github/workflows/docs-deploy-firebase.yml'
+      - ".github/workflows/docs-deploy-firebase.yml"
 
   pull_request:
     # Skip PRs where docs, Rust code, and dependencies aren't modified.
     paths:
       # doc source files
-      - 'book/**'
-      - '**/firebase.json'
-      - '**/.firebaserc'
-      - 'katex-header.html'
+      - "book/**"
+      - "**/firebase.json"
+      - "**/.firebaserc"
+      - "katex-header.html"
       # rustdoc source files
-      - '**/*.rs'
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
       # configuration files
-      - '.cargo/config.toml'
-      - '**/clippy.toml'
+      - ".cargo/config.toml"
+      - "**/clippy.toml"
       # workflow definitions
-      - '.github/workflows/docs-deploy-firebase.yml'
+      - ".github/workflows/docs-deploy-firebase.yml"
 
 env:
   RUST_LOG: ${{ vars.RUST_LOG }}
@@ -80,8 +80,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
       pull-requests: write
     steps:
       - name: Checkout the source code
@@ -95,7 +95,7 @@ jobs:
         uses: jontze/action-mdbook@v4.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          mdbook-version: '~0.4'
+          mdbook-version: "~0.4"
           use-linkcheck: true
           use-mermaid: true
 
@@ -109,8 +109,8 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2.1.10
         with:
-          workload_identity_provider: '${{ vars.GCP_WIF }}'
-          service_account: '${{ vars.GCP_FIREBASE_SA }}'
+          workload_identity_provider: "${{ vars.GCP_WIF }}"
+          service_account: "${{ vars.GCP_FIREBASE_SA }}"
 
       # TODO: remove this step after issue https://github.com/FirebaseExtended/action-hosting-deploy/issues/174 is fixed
 
@@ -136,8 +136,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
       pull-requests: write
     steps:
       - name: Checkout the source code
@@ -150,13 +150,14 @@ jobs:
       - name: Install last version of Protoc
         uses: arduino/setup-protoc@v3.0.0
         with:
-          version: '23.x'
+          version: "23.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Setup Rust with beta toolchain and default profile (to include rust-docs)
       - name: Setup Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=beta --profile=default
+          source $HOME/.cargo/env
 
       - uses: Swatinem/rust-cache@v2.7.8
 
@@ -170,8 +171,8 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2.1.10
         with:
-          workload_identity_provider: '${{ vars.GCP_WIF }}'
-          service_account: '${{ vars.GCP_FIREBASE_SA }}'
+          workload_identity_provider: "${{ vars.GCP_WIF }}"
+          service_account: "${{ vars.GCP_FIREBASE_SA }}"
 
       # TODO: remove this step after issue https://github.com/FirebaseExtended/action-hosting-deploy/issues/174 is fixed
       - name: Add $GCP_FIREBASE_SA_PATH to env


### PR DESCRIPTION
## Motivation

- Close #9775.
- Close #9206.
- Fix [ZcashFoundation/zebra/actions/runs/16852914063/job/47741762339?pr=9773#step:7:550](https://github.com/ZcashFoundation/zebra/actions/runs/16852914063/job/47741762339?pr=9773#step:7:550).

The issue arose when we added the [`rust-toolchain.toml`](https://github.com/ZcashFoundation/zebra/blob/main/rust-toolchain.toml) file to the repo.

## Solution

- Simplify setting up Rust in CI.
- Override the contents of the [`rust-toolchain.toml`](https://github.com/ZcashFoundation/zebra/blob/main/rust-toolchain.toml) file.
- Unrelated clean-up: Autoformat the edited files.

### PR Checklist

- [ ] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
