### PR TITLE
ci: fix runs getting stuck on docker config tests

### DIFF
--- a/.github/workflows/ci-tests.patch-external.yml
+++ b/.github/workflows/ci-tests.patch-external.yml
@@ -45,11 +45,77 @@ jobs:
       - run: 'echo "Skipping job on fork"'
 
   test-lightwalletd-integration:
-    name: Unit tests / Test integration with lightwalletd
+    name: Unit tests / Lightwalletd integration
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
     steps:
       - run: 'echo "Skipping job on fork"'
+
+  ####
+  ## The following jobs are related to sub-test-zebra-config.yml
+  ###
+  test-docker-configurations-default:
+    name: Unit tests / Test Zebra Docker configurations / Test Default config
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
+    steps:
+      - run: 'echo "No build required"'
+
+  test-docker-configurations-custom:
+    name: Unit tests / Test Zebra Docker configurations / Test Custom cache and cookie directories
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
+    steps:
+      - run: 'echo "No build required"'
+
+  test-docker-configurations-custom-config:
+    name: Unit tests / Test Zebra Docker configurations / Test Custom config
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
+    steps:
+      - run: 'echo "No build required"'
+
+  test-docker-configurations-mining:
+    name: Unit tests / Test Zebra Docker configurations / Test Mining configuration
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
+    steps:
+      - run: 'echo "No build required"'
+
+  test-docker-configurations-prometheus:
+    name: Unit tests / Test Zebra Docker configurations / Test Prometheus metrics
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
+    steps:
+      - run: 'echo "No build required"'
+
+  test-docker-configurations-rpc:
+    name: Unit tests / Test Zebra Docker configurations / Test RPC config
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
+    steps:
+      - run: 'echo "No build required"'
+
+  test-docker-configurations-rpc-custom-cookie:
+    name: Unit tests / Test Zebra Docker configurations / Test RPC with custom cookie dir
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
+    steps:
+      - run: 'echo "No build required"'
+
+  test-docker-configurations-rpc-custom-port:
+    name: Unit tests / Test Zebra Docker configurations / Test RPC with custom port
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
+    steps:
+      - run: 'echo "No build required"'
+
+  test-docker-configurations-testnet:
+    name: Unit tests / Test Zebra Docker configurations / Test Testnet config
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
+    steps:
+      - run: 'echo "No build required"'
 
   ####
   ####

--- a/.github/workflows/ci-tests.patch.yml
+++ b/.github/workflows/ci-tests.patch.yml
@@ -64,7 +64,73 @@ jobs:
       - run: 'echo "No build required"'
 
   test-lightwalletd-integration:
-    name: Unit tests / Test integration with lightwalletd
+    name: Unit tests / Lightwalletd integration
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+    steps:
+      - run: 'echo "No build required"'
+
+  ####
+  ## The following jobs are related to sub-test-zebra-config.yml
+  ###
+  test-docker-configurations-default:
+    name: Unit tests / Test Zebra Docker configurations / Test Default config
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+    steps:
+      - run: 'echo "No build required"'
+
+  test-docker-configurations-custom:
+    name: Unit tests / Test Zebra Docker configurations / Test Custom cache and cookie directories
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+    steps:
+      - run: 'echo "No build required"'
+
+  test-docker-configurations-custom-config:
+    name: Unit tests / Test Zebra Docker configurations / Test Custom config
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+    steps:
+      - run: 'echo "No build required"'
+
+  test-docker-configurations-mining:
+    name: Unit tests / Test Zebra Docker configurations / Test Mining configuration
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+    steps:
+      - run: 'echo "No build required"'
+
+  test-docker-configurations-prometheus:
+    name: Unit tests / Test Zebra Docker configurations / Test Prometheus metrics
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+    steps:
+      - run: 'echo "No build required"'
+
+  test-docker-configurations-rpc:
+    name: Unit tests / Test Zebra Docker configurations / Test RPC config
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+    steps:
+      - run: 'echo "No build required"'
+
+  test-docker-configurations-rpc-custom-cookie:
+    name: Unit tests / Test Zebra Docker configurations / Test RPC with custom cookie dir
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+    steps:
+      - run: 'echo "No build required"'
+
+  test-docker-configurations-rpc-custom-port:
+    name: Unit tests / Test Zebra Docker configurations / Test RPC with custom port
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+    steps:
+      - run: 'echo "No build required"'
+
+  test-docker-configurations-testnet:
+    name: Unit tests / Test Zebra Docker configurations / Test Testnet config
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     steps:


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

Some CI jobs got stuck waiting for a required check that did not exist.

The jobs comes from a sub-sub-workflow starting in https://github.com/ZcashFoundation/zebra/blob/96fd15c3c69d37a388bdc01d6e745a5ded7e8dcc/.github/workflows/sub-test-zebra-config.yml#L30

## Solution

Patch jobs were out of sync and were missing some jobs.

I also edited the repo config - "Test integration with lightwalletd" was marked as required, but that name was only being used in the patch job. I changed the repo config to require "Lightwalletd integration" to match the main job.

Closes #9691 (hopefully)

### Tests

This PR tests itself since it does not trigger the main workflow and relies on the patch workflow running, since it changes files that are not in the `paths` config of `ci-tests.yml` (maybe a bug in itself?).

If CI passes here then it's very likely that it works (the remaining case is for external PRs which we'll need to test separately)

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
