### PR TITLE
change(consensus): Use the correct number of addresses for the FPF funding stream extension on Testnet

### DIFF
--- a/zebra-chain/src/parameters/network/subsidy.rs
+++ b/zebra-chain/src/parameters/network/subsidy.rs
@@ -585,7 +585,7 @@ pub const POST_NU6_FUNDING_STREAMS_NUM_ADDRESSES_TESTNET: usize = 13;
 /// however we know this value beforehand so we prefer to make it a constant instead.
 ///
 /// [7.10]: https://zips.z.cash/protocol/protocol.pdf#fundingstreams
-pub const POST_NU6_1_FUNDING_STREAMS_NUM_ADDRESSES_TESTNET: usize = 37;
+pub const POST_NU6_1_FUNDING_STREAMS_NUM_ADDRESSES_TESTNET: usize = 27;
 
 /// List of addresses for the Major Grants post-NU6 funding stream on Testnet administered by the Financial Privacy Fund (FPF).
 pub const POST_NU6_FUNDING_STREAM_FPF_ADDRESSES_TESTNET: [&str;


### PR DESCRIPTION
## Motivation

We want to match the number of addresses defined in zcashd and ZIP 255 for the FPF funding streams on Testnet.

37 addresses was correct for 1.26M blocks, but only 27 are needed now that the Testnet funding stream ends after 939,500 blocks.

This PR will not change Zebra's behaviour (except that it will use less memory, but only 10 pointers worth / 80B).

## Solution

Updates the `POST_NU6_1_FUNDING_STREAMS_NUM_ADDRESSES_TESTNET` from 37 to 27

### Tests

There are existing tests to ensure that there are not too few funding stream addresses. It's been manually verified that 27 is the minimum required number of addresses.

### Specifications & References

See revision 1 of https://zips.z.cash/zip-0214 (being [updated here](https://github.com/zcash/zips/pull/1058/files#diff-e11a6a8ad34a7d686c41caccf93fe5745663cf0b38deb0ff0dad2917cdfb75e9R414)).

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
