### PR TITLE
change(consensus): Implements draft ZIP 2003 for NU7 and uses Testnet network protocol versions on Regtest

### DIFF
--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -934,13 +934,13 @@ where
             | NetworkUpgrade::Canopy
             | NetworkUpgrade::Nu5
             | NetworkUpgrade::Nu6
-            | NetworkUpgrade::Nu6_1
-            | NetworkUpgrade::Nu7 => Ok(()),
+            | NetworkUpgrade::Nu6_1 => Ok(()),
 
             // Does not support V4 transactions
             NetworkUpgrade::Genesis
             | NetworkUpgrade::BeforeOverwinter
-            | NetworkUpgrade::Overwinter => Err(TransactionError::UnsupportedByNetworkUpgrade(
+            | NetworkUpgrade::Overwinter
+            | NetworkUpgrade::Nu7 => Err(TransactionError::UnsupportedByNetworkUpgrade(
                 transaction.version(),
                 network_upgrade,
             )),

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -96,19 +96,27 @@ impl Version {
             (Testnet(params), Sapling) if params.is_default_testnet() => 170_007,
             (Testnet(params), Sapling) if params.is_regtest() => 170_006,
             (Mainnet, Sapling) => 170_007,
-            (Testnet(params), Blossom) if params.is_default_testnet() => 170_008,
+            (Testnet(params), Blossom) if params.is_default_testnet() || params.is_regtest() => {
+                170_008
+            }
             (Mainnet, Blossom) => 170_009,
-            (Testnet(params), Heartwood) if params.is_default_testnet() => 170_010,
+            (Testnet(params), Heartwood) if params.is_default_testnet() || params.is_regtest() => {
+                170_010
+            }
             (Mainnet, Heartwood) => 170_011,
-            (Testnet(params), Canopy) if params.is_default_testnet() => 170_012,
+            (Testnet(params), Canopy) if params.is_default_testnet() || params.is_regtest() => {
+                170_012
+            }
             (Mainnet, Canopy) => 170_013,
-            (Testnet(params), Nu5) if params.is_default_testnet() => 170_050,
+            (Testnet(params), Nu5) if params.is_default_testnet() || params.is_regtest() => 170_050,
             (Mainnet, Nu5) => 170_100,
-            (Testnet(params), Nu6) if params.is_default_testnet() => 170_110,
+            (Testnet(params), Nu6) if params.is_default_testnet() || params.is_regtest() => 170_110,
             (Mainnet, Nu6) => 170_120,
-            (Testnet(params), Nu6_1) if params.is_default_testnet() => 170_130,
+            (Testnet(params), Nu6_1) if params.is_default_testnet() || params.is_regtest() => {
+                170_130
+            }
             (Mainnet, Nu6_1) => 170_140,
-            (Testnet(params), Nu7) if params.is_default_testnet() => 170_150,
+            (Testnet(params), Nu7) if params.is_default_testnet() || params.is_regtest() => 170_150,
             (Mainnet, Nu7) => 170_160,
 
             // It should be fine to reject peers with earlier network protocol versions on custom testnets for now.


### PR DESCRIPTION
## Motivation

We want to use the same network protocol versions on Regtest as those used in zcashd and likely want to implement ZIP 2003 for NU7.

See: [Regtest protocol versions in zcashd](https://github.com/zcash/zcash/blob/master/src/chainparams.cpp#L778-L793)

Closes #9593.

## Solution

- Implements draft [ZIP 2003](https://zips.z.cash/zip-2003) for NU7, and
- Updates `Version::min_specified_for_upgrade()` to use the Testnet network protocol versions on Regtest for network upgrades after Sapling

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
