### PR TITLE
docs: fix broken platform tier policy links in supported-platforms.md

### DIFF
--- a/book/src/user/supported-platforms.md
+++ b/book/src/user/supported-platforms.md
@@ -13,7 +13,7 @@ Tier 1 platforms can be thought of as "guaranteed to work". The Zebra project
 builds official binary releases for each tier 1 platform, and automated testing
 ensures that each tier 1 platform builds and passes tests after each change.
 
-For the full requirements, see [Tier 1 platform policy](platform-tier-policy.md#tier-1-platform-policy) in the Platform Tier Policy.
+For the full requirements, see [Tier 1 platform policy](target-tier-policies.md#tier-1-platform-policy) in the Platform Tier Policy.
 
 | platform | os | notes | rust | artifacts
 | -------|-------|-------|-------|-------
@@ -28,7 +28,7 @@ not guaranteed to produce a working build, and official builds are not available
 but tier 2 platforms often work to quite a good degree and patches are always
 welcome!
 
-For the full requirements, see [Tier 2 platform policy](platform-tier-policy.md#tier-2-platform-policy) in the Platform Tier Policy.
+For the full requirements, see [Tier 2 platform policy](target-tier-policies.md#tier-2-platform-policy) in the Platform Tier Policy.
 
 | platform | os | notes | rust | artifacts
 | -------|-------|-------|-------|-------
@@ -43,7 +43,7 @@ Tier 3 platforms are those which the Zebra codebase has support for, but which
 the Zebra project does not build or test automatically, so they may or may not
 work. Official builds are not available.
 
-For the full requirements, see [Tier 3 platform policy](platform-tier-policy.md#tier-3-platform-policy) in the Platform Tier Policy.
+For the full requirements, see [Tier 3 platform policy](target-tier-policies.md#tier-3-platform-policy) in the Platform Tier Policy.
 
 | platform | os | notes | rust | artifacts
 | -------|-------|-------|-------|-------


### PR DESCRIPTION
Fix broken links to platform tier policy documentation

- Replace broken references to non-existent 'platform-tier-policy.md' 
- Update all three tier policy links to point to correct 'target-tier-policies.md'
- Fixes links for Tier 1, Tier 2, and Tier 3 platform policies
- Ensures users can properly navigate to platform tier requirements

The platform tier policy information is actually contained in 
target-tier-policies.md, not platform-tier-policy.md as previously referenced.
