### PR TITLE
refactor: change test to use regtest instead of fake activation heights

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -15,10 +15,6 @@ default-filter = 'not test(check_no_git_dependencies)'
 [profile.check-no-git-dependencies]
 default-filter = 'test(check_no_git_dependencies)'
 
-[profile.state-fake-activation-heights]
-slow-timeout = { period = "10m", terminate-after = 1 }
-default-filter = 'package(zebra-state) and test(~with_fake_activation_heights)'
-
 [profile.sync-large-checkpoints-empty]
 slow-timeout = { period = "60m", terminate-after = 2 }
 default-filter = 'package(zebrad) and test(=sync_large_checkpoints_empty)'

--- a/.github/workflows/ci-tests.patch-external.yml
+++ b/.github/workflows/ci-tests.patch-external.yml
@@ -30,13 +30,6 @@ jobs:
     steps:
       - run: 'echo "Skipping job on fork"'
 
-  state-fake-activation-heights:
-    name: Unit tests / Test with fake activation heights
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork }}
-    steps:
-      - run: 'echo "Skipping job on fork"'
-
   sync-large-checkpoints-empty:
     name: Unit tests / Test checkpoint sync from empty state
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-tests.patch.yml
+++ b/.github/workflows/ci-tests.patch.yml
@@ -49,13 +49,6 @@ jobs:
     steps:
       - run: 'echo "No build required"'
 
-  state-fake-activation-heights:
-    name: Unit tests / Test with fake activation heights
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
-    steps:
-      - run: 'echo "No build required"'
-
   sync-large-checkpoints-empty:
     name: Unit tests / Test checkpoint sync from empty state
     runs-on: ubuntu-latest

--- a/.github/workflows/sub-ci-unit-tests-docker.yml
+++ b/.github/workflows/sub-ci-unit-tests-docker.yml
@@ -5,10 +5,9 @@
 # Jobs:
 # 1. Builds a Docker image for tests, adaptable to the specified network (Mainnet or Testnet).
 # 2. 'test-all': Executes all Zebra tests, including normally ignored ones, in a Docker environment.
-# 3. 'state-fake-activation-heights': Runs state tests with fake activation heights, isolating its build products.
-# 4. 'sync-large-checkpoints-empty': Tests Zebra's ability to sync and checkpoint from an empty state.
-# 5. 'test-lightwalletd-integration': Validates integration with 'lightwalletd' starting from an empty state.
-# 6. 'test-docker-configurations': Runs a matrix of configuration tests to validate various Docker configurations.
+# 3. 'sync-large-checkpoints-empty': Tests Zebra's ability to sync and checkpoint from an empty state.
+# 4. 'test-lightwalletd-integration': Validates integration with 'lightwalletd' starting from an empty state.
+# 5. 'test-docker-configurations': Runs a matrix of configuration tests to validate various Docker configurations.
 name: Docker Unit Tests
 
 on:
@@ -53,43 +52,6 @@ jobs:
           docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}
           docker run --tty \
           -e NEXTEST_PROFILE=all-tests \
-          -e NETWORK="${{ inputs.network || vars.ZCASH_NETWORK }}" \
-          -e RUST_LOG=${{ env.RUST_LOG }} \
-          -e RUST_BACKTRACE=${{ env.RUST_BACKTRACE }} \
-          -e RUST_LIB_BACKTRACE=${{ env.RUST_LIB_BACKTRACE }} \
-          -e COLORBT_SHOW_HIDDEN=${{ env.COLORBT_SHOW_HIDDEN }} \
-          -e CARGO_INCREMENTAL=${{ env.CARGO_INCREMENTAL }} \
-          ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}
-
-  # Run state tests with fake activation heights.
-  #
-  # This test changes zebra-chain's activation heights,
-  # which can recompile all the Zebra crates,
-  # so we want its build products to be cached separately.
-  #
-  # Also, we don't want to accidentally use the fake heights in other tests.
-  #
-  # (We activate the test features to avoid recompiling dependencies, but we don't actually run any gRPC tests.)
-  state-fake-activation-heights:
-    name: Test with fake activation heights
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    steps:
-      - uses: r7kamura/rust-problem-matchers@v1.5.0
-
-      - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v5
-        with:
-          short-length: 7
-
-      - name: Run tests with fake activation heights
-        env:
-          NETWORK: ${{ inputs.network || vars.ZCASH_NETWORK }}
-        run: |
-          docker pull ${{ vars.GAR_BASE }}/${{ vars.CI_IMAGE_NAME }}@${{ inputs.image_digest }}
-          docker run --tty \
-          -e NEXTEST_PROFILE=state-fake-activation-heights \
-          -e TEST_FAKE_ACTIVATION_HEIGHTS=1 \
           -e NETWORK="${{ inputs.network || vars.ZCASH_NETWORK }}" \
           -e RUST_LOG=${{ env.RUST_LOG }} \
           -e RUST_BACKTRACE=${{ env.RUST_BACKTRACE }} \
@@ -172,7 +134,6 @@ jobs:
     needs:
       [
         test-all,
-        state-fake-activation-heights,
         sync-large-checkpoints-empty,
         test-lightwalletd-integration,
         test-docker-configurations,

--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -102,8 +102,11 @@ pub struct LedgerState {
 }
 
 /// Overrides for arbitrary [`LedgerState`]s.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct LedgerStateOverride {
+    /// Use the given network instead of Mainnet
+    pub network_override: Option<Network>,
+
     /// Every chain starts at this block. Single blocks have this height.
     pub height_override: Option<Height>,
 
@@ -138,6 +141,7 @@ impl LedgerState {
     /// overrides.
     pub fn no_override_strategy() -> BoxedStrategy<Self> {
         Self::arbitrary_with(LedgerStateOverride {
+            network_override: None,
             height_override: None,
             previous_block_hash_override: None,
             network_upgrade_override: None,
@@ -157,6 +161,7 @@ impl LedgerState {
         transaction_has_valid_network_upgrade: bool,
     ) -> BoxedStrategy<Self> {
         Self::arbitrary_with(LedgerStateOverride {
+            network_override: None,
             height_override: None,
             previous_block_hash_override: None,
             network_upgrade_override: Some(network_upgrade_override),
@@ -176,6 +181,7 @@ impl LedgerState {
         transaction_has_valid_network_upgrade: bool,
     ) -> BoxedStrategy<Self> {
         Self::arbitrary_with(LedgerStateOverride {
+            network_override: None,
             height_override: None,
             previous_block_hash_override: None,
             network_upgrade_override: network_upgrade_override.into(),
@@ -194,11 +200,13 @@ impl LedgerState {
     /// Use the `Genesis` network upgrade to get a random genesis block, with
     /// Zcash genesis features.
     pub fn genesis_strategy(
+        network_override: impl Into<Option<Network>>,
         network_upgrade_override: impl Into<Option<NetworkUpgrade>>,
         transaction_version_override: impl Into<Option<u32>>,
         transaction_has_valid_network_upgrade: bool,
     ) -> BoxedStrategy<Self> {
         Self::arbitrary_with(LedgerStateOverride {
+            network_override: network_override.into(),
             height_override: Some(Height(0)),
             previous_block_hash_override: Some(GENESIS_PREVIOUS_BLOCK_HASH),
             network_upgrade_override: network_upgrade_override.into(),
@@ -219,6 +227,7 @@ impl LedgerState {
         transaction_has_valid_network_upgrade: bool,
     ) -> BoxedStrategy<Self> {
         Self::arbitrary_with(LedgerStateOverride {
+            network_override: None,
             height_override: Some(height),
             previous_block_hash_override: None,
             network_upgrade_override: network_upgrade_override.into(),
@@ -289,6 +298,7 @@ impl Default for LedgerStateOverride {
         };
 
         LedgerStateOverride {
+            network_override: None,
             height_override: None,
             previous_block_hash_override: None,
             network_upgrade_override: nu5_override,
@@ -318,7 +328,11 @@ impl Arbitrary for LedgerState {
                 move |(height, network, transaction_has_valid_network_upgrade, has_coinbase)| {
                     LedgerState {
                         height: ledger_override.height_override.unwrap_or(height),
-                        network,
+                        network: ledger_override
+                            .network_override
+                            .as_ref()
+                            .unwrap_or(&network)
+                            .clone(),
                         network_upgrade_override: ledger_override.network_upgrade_override,
                         previous_block_hash_override: ledger_override.previous_block_hash_override,
                         transaction_version_override: ledger_override.transaction_version_override,

--- a/zebra-chain/src/block/tests/prop.rs
+++ b/zebra-chain/src/block/tests/prop.rs
@@ -161,7 +161,7 @@ fn block_genesis_strategy() -> Result<()> {
     let _init_guard = zebra_test::init();
 
     let strategy =
-        LedgerState::genesis_strategy(None, None, false).prop_flat_map(Block::arbitrary_with);
+        LedgerState::genesis_strategy(None, None, None, false).prop_flat_map(Block::arbitrary_with);
 
     proptest!(|(block in strategy)| {
         prop_assert_eq!(block.coinbase_height(), Some(Height(0)));
@@ -179,7 +179,7 @@ fn block_genesis_strategy() -> Result<()> {
 fn genesis_partial_chain_strategy() -> Result<()> {
     let _init_guard = zebra_test::init();
 
-    let strategy = LedgerState::genesis_strategy(None, None, false).prop_flat_map(|init| {
+    let strategy = LedgerState::genesis_strategy(None, None, None, false).prop_flat_map(|init| {
         Block::partial_chain_strategy(
             init,
             PREVOUTS_CHAIN_HEIGHT,

--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -670,10 +670,6 @@ pub struct Parameters {
     /// The genesis block hash
     genesis_hash: block::Hash,
     /// The network upgrade activation heights for this network.
-    ///
-    /// Note: This value is ignored by `Network::activation_list()` when `zebra-chain` is
-    ///       compiled with the `zebra-test` feature flag AND the `TEST_FAKE_ACTIVATION_HEIGHTS`
-    ///       environment variable is set.
     activation_heights: BTreeMap<Height, NetworkUpgrade>,
     /// Slow start interval for this network
     slow_start_interval: Height,

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -113,22 +113,6 @@ pub(super) const MAINNET_ACTIVATION_HEIGHTS: &[(block::Height, NetworkUpgrade)] 
     (block::Height(2_726_400), Nu6),
 ];
 
-/// Fake mainnet network upgrade activation heights, used in tests.
-#[allow(unused)]
-const FAKE_MAINNET_ACTIVATION_HEIGHTS: &[(block::Height, NetworkUpgrade)] = &[
-    (block::Height(0), Genesis),
-    (block::Height(5), BeforeOverwinter),
-    (block::Height(10), Overwinter),
-    (block::Height(15), Sapling),
-    (block::Height(20), Blossom),
-    (block::Height(25), Heartwood),
-    (block::Height(30), Canopy),
-    (block::Height(35), Nu5),
-    (block::Height(40), Nu6),
-    (block::Height(45), Nu6_1),
-    (block::Height(50), Nu7),
-];
-
 /// The block height at which NU6.1 activates on the default Testnet.
 // See NU6.1 Testnet activation height in zcashd:
 // <https://github.com/zcash/zcash/blob/b65b008a7b334a2f7c2eaae1b028e011f2e21dd1/src/chainparams.cpp#L472>
@@ -155,22 +139,6 @@ pub(super) const TESTNET_ACTIVATION_HEIGHTS: &[(block::Height, NetworkUpgrade)] 
     (block::Height(1_842_420), Nu5),
     (block::Height(2_976_000), Nu6),
     (NU6_1_ACTIVATION_HEIGHT_TESTNET, Nu6_1),
-];
-
-/// Fake testnet network upgrade activation heights, used in tests.
-#[allow(unused)]
-const FAKE_TESTNET_ACTIVATION_HEIGHTS: &[(block::Height, NetworkUpgrade)] = &[
-    (block::Height(0), Genesis),
-    (block::Height(5), BeforeOverwinter),
-    (block::Height(10), Overwinter),
-    (block::Height(15), Sapling),
-    (block::Height(20), Blossom),
-    (block::Height(25), Heartwood),
-    (block::Height(30), Canopy),
-    (block::Height(35), Nu5),
-    (block::Height(40), Nu6),
-    (block::Height(45), Nu6_1),
-    (block::Height(50), Nu7),
 ];
 
 /// The Consensus Branch Id, used to bind transactions and blocks to a
@@ -304,33 +272,10 @@ impl Network {
     ///
     /// This is actually a bijective map.
     ///
-    /// When the environment variable TEST_FAKE_ACTIVATION_HEIGHTS is set
-    /// and it's a test build, this returns a list of fake activation heights
-    /// used by some tests.
-    ///
     /// Note: This skips implicit network upgrade activations, use [`Network::full_activation_list`]
     ///       to get an explicit list of all network upgrade activations.
     pub fn activation_list(&self) -> BTreeMap<block::Height, NetworkUpgrade> {
         match self {
-            // To prevent accidentally setting this somehow, only check the env var
-            // when being compiled for tests. We can't use cfg(test) since the
-            // test that uses this is in zebra-state, and cfg(test) is not
-            // set for dependencies. However, zebra-state does set the
-            // zebra-test feature of zebra-chain if it's a dev dependency.
-            //
-            // Cargo features are additive, so all test binaries built along with
-            // zebra-state will have this feature enabled. But we are using
-            // Rust Edition 2021 and Cargo resolver version 2, so the "zebra-test"
-            // feature should only be enabled for tests:
-            // https://doc.rust-lang.org/cargo/reference/features.html#resolver-version-2-command-line-flags
-            #[cfg(feature = "zebra-test")]
-            Mainnet if std::env::var_os("TEST_FAKE_ACTIVATION_HEIGHTS").is_some() => {
-                FAKE_MAINNET_ACTIVATION_HEIGHTS.iter().cloned().collect()
-            }
-            #[cfg(feature = "zebra-test")]
-            Testnet(_) if std::env::var_os("TEST_FAKE_ACTIVATION_HEIGHTS").is_some() => {
-                FAKE_TESTNET_ACTIVATION_HEIGHTS.iter().cloned().collect()
-            }
             Mainnet => MAINNET_ACTIVATION_HEIGHTS.iter().cloned().collect(),
             Testnet(params) => params.activation_heights().clone(),
         }

--- a/zebra-state/src/service/arbitrary.rs
+++ b/zebra-state/src/service/arbitrary.rs
@@ -117,6 +117,16 @@ impl PreparedChain {
         self.generate_valid_commitments = true;
         self
     }
+
+    /// Set the ledger strategy for the prepared chain.
+    #[allow(dead_code)]
+    pub(crate) fn with_ledger_strategy(
+        mut self,
+        ledger_strategy: BoxedStrategy<LedgerState>,
+    ) -> Self {
+        self.ledger_strategy = Some(ledger_strategy);
+        self
+    }
 }
 
 impl Strategy for PreparedChain {
@@ -129,7 +139,7 @@ impl Strategy for PreparedChain {
         if chain.is_none() {
             // TODO: use the latest network upgrade (#1974)
             let default_ledger_strategy =
-                LedgerState::genesis_strategy(NetworkUpgrade::Nu5, None, false);
+                LedgerState::genesis_strategy(None, NetworkUpgrade::Nu5, None, false);
             let ledger_strategy = self
                 .ledger_strategy
                 .as_ref()


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

The test `all_upgrades_and_wrong_commitments_with_fake_activation_heights` used "fake" activation heights in order to test some of the commitment validation logic. Those heights had to be enabled with a env variable, which in turn had to be enabled in CI along with a explicit call for the test, etc. which is super annoying.

## Solution

With regtest support we can remove all that.

### Tests

The test kept passing indicating it worked.

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
