### PR TITLE
Add RUST_BACKTRACE="1" to .cargo/config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -88,3 +88,6 @@ rustdocflags = [
     # Links in public docs can point to private items.
     "-Arustdoc::private_intra_doc_links",
 ]
+
+[env]
+RUST_BACKTRACE="1"


### PR DESCRIPTION
## Motivation

It would be nice to have some added debug info when tests panic in CI, or by default locally without having to set the env var.

## Solution

Adds `RUST_BACKTRACE="1"` to `.cargo/config.toml`

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
