### PR TITLE
rpc: add missing Orchard fields to getrawtransaction

### DIFF
--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `{sapling,orchard}::Root::bytes_in_display_order()`
-- Added `bytes_in_display_order()` for multiple `sprout` types.
+- Added `bytes_in_display_order()` for multiple `sprout` types,
+  as well for `orchard::tree::Root` and `Halo2Proof`.
 
 ## [2.0.0] - 2025-08-07
 

--- a/zebra-chain/src/primitives/proofs/halo2.rs
+++ b/zebra-chain/src/primitives/proofs/halo2.rs
@@ -14,6 +14,13 @@ use crate::serialization::{
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Halo2Proof(pub Vec<u8>);
 
+impl Halo2Proof {
+    /// Encode as bytes for RPC usage.
+    pub fn bytes_in_display_order(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+}
+
 impl fmt::Debug for Halo2Proof {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("Halo2Proof")

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -16,6 +16,7 @@ delete this before the release.)
 
 - Changed the `GetTreestateResponse::new()` to take an optional Sprout tree state;
   changed `Commitments::new()` to take the `final_root` parameter.
+- Added new arguments to `Orchard::new()`
 
 ## [2.0.0] - 2025-08-07
 

--- a/zebra-rpc/src/client.rs
+++ b/zebra-rpc/src/client.rs
@@ -28,8 +28,8 @@ pub use crate::methods::{
         submit_block::{SubmitBlockErrorResponse, SubmitBlockResponse},
         subsidy::{BlockSubsidy, FundingStream, GetBlockSubsidyResponse},
         transaction::{
-            Input, JoinSplit, Orchard, OrchardAction, Output, ScriptPubKey, ScriptSig,
-            ShieldedOutput, ShieldedSpend, TransactionObject, TransactionTemplate,
+            Input, JoinSplit, Orchard, OrchardAction, OrchardFlags, Output, ScriptPubKey,
+            ScriptSig, ShieldedOutput, ShieldedSpend, TransactionObject, TransactionTemplate,
         },
         unified_address::ZListUnifiedReceiversResponse,
         validate_address::ValidateAddressResponse,

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@mainnet_10.snap
@@ -52,6 +52,11 @@ expression: block
       "vShieldedSpend": [],
       "vShieldedOutput": [],
       "vjoinsplit": [],
+      "orchard": {
+        "actions": [],
+        "valueBalance": 0.0,
+        "valueBalanceZat": 0
+      },
       "valueBalance": 0.0,
       "valueBalanceZat": 0,
       "size": 129,

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@testnet_10.snap
@@ -52,6 +52,11 @@ expression: block
       "vShieldedSpend": [],
       "vShieldedOutput": [],
       "vjoinsplit": [],
+      "orchard": {
+        "actions": [],
+        "valueBalance": 0.0,
+        "valueBalanceZat": 0
+      },
       "valueBalance": 0.0,
       "valueBalanceZat": 0,
       "size": 130,

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@mainnet_10.snap
@@ -52,6 +52,11 @@ expression: block
       "vShieldedSpend": [],
       "vShieldedOutput": [],
       "vjoinsplit": [],
+      "orchard": {
+        "actions": [],
+        "valueBalance": 0.0,
+        "valueBalanceZat": 0
+      },
       "valueBalance": 0.0,
       "valueBalanceZat": 0,
       "size": 129,

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@testnet_10.snap
@@ -52,6 +52,11 @@ expression: block
       "vShieldedSpend": [],
       "vShieldedOutput": [],
       "vjoinsplit": [],
+      "orchard": {
+        "actions": [],
+        "valueBalance": 0.0,
+        "valueBalanceZat": 0
+      },
       "valueBalance": 0.0,
       "valueBalanceZat": 0,
       "size": 130,

--- a/zebra-rpc/src/methods/tests/snapshots/getrawtransaction_verbosity=1@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/getrawtransaction_verbosity=1@mainnet_10.snap
@@ -43,6 +43,11 @@ expression: rsp
     "vShieldedSpend": [],
     "vShieldedOutput": [],
     "vjoinsplit": [],
+    "orchard": {
+      "actions": [],
+      "valueBalance": 0.0,
+      "valueBalanceZat": 0
+    },
     "valueBalance": 0.0,
     "valueBalanceZat": 0,
     "size": 129,

--- a/zebra-rpc/src/methods/tests/snapshots/getrawtransaction_verbosity=1@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/getrawtransaction_verbosity=1@testnet_10.snap
@@ -43,6 +43,11 @@ expression: rsp
     "vShieldedSpend": [],
     "vShieldedOutput": [],
     "vjoinsplit": [],
+    "orchard": {
+      "actions": [],
+      "valueBalance": 0.0,
+      "valueBalanceZat": 0
+    },
     "valueBalance": 0.0,
     "valueBalanceZat": 0,
     "size": 130,

--- a/zebra-rpc/tests/serialization_tests.rs
+++ b/zebra-rpc/tests/serialization_tests.rs
@@ -21,7 +21,7 @@ use zebra_rpc::client::{
         transparent::{OutputIndex, Script},
         work::difficulty::{CompactDifficulty, ExpandedDifficulty},
     },
-    GetBlockchainInfoBalance, JoinSplit,
+    GetBlockchainInfoBalance, JoinSplit, OrchardFlags,
 };
 use zebra_rpc::client::{
     BlockHeaderObject, BlockObject, BlockTemplateResponse, Commitments, DefaultRoots,
@@ -807,7 +807,20 @@ fn test_get_raw_transaction_true() -> Result<(), Box<dyn std::error::Error>> {
             .collect();
         let value_balance = bundle.value_balance();
         let value_balance_zat = bundle.value_balance_zat();
-        Orchard::new(actions, value_balance, value_balance_zat)
+        let spends_flag = bundle.flags().as_ref().map(|f| f.enable_spends());
+        let outputs_flag = bundle.flags().as_ref().map(|f| f.enable_outputs());
+        let anchor = bundle.anchor();
+        let proof = bundle.proof().clone();
+        let binding_sig = bundle.binding_sig();
+        Orchard::new(
+            actions,
+            value_balance,
+            value_balance_zat,
+            spends_flag.map(|_| OrchardFlags::new(spends_flag.unwrap(), outputs_flag.unwrap())),
+            anchor,
+            proof,
+            binding_sig,
+        )
     });
     let binding_sig = tx.binding_sig();
     let joinsplit_pub_key = tx.joinsplit_pub_key();


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

Based on #9805 

Closes  #9632

## Solution

Adds the missing fields.

I also changed it so that `orchard` key is always returned with `valueBalance(Zat)` and `actions`. This matches `zcashd` behaviour.


### Tests

Manually with `zcash-rpc-diff`

```
OUTPUT_DATA_LINE_LIMIT=100000 ZEBRAD_EXTRA_ARGS=-conf=$PWD/zcash.conf ./zebra-utils/zcash-rpc-diff 28232 getrawtransaction 07d54b9c61a53002a4b1c13d3e8b341428ba74671d1eb2ba0088ffb5d39a9b14 1
```

```diff
--- /tmp/tmp.79M42geYyO.rpc-diff/zebrad-main-3034094-getrawtransaction.json	2025-08-18 18:39:50.026241257 -0300
+++ /tmp/tmp.79M42geYyO.rpc-diff/zcashd-main-3034095-getrawtransaction.json	2025-08-18 18:39:50.030241250 -0300
@@ -2,11 +2,10 @@
   "authdigest": "6102b844edb2d865965dece424ddbc056b30765fc2ba621f6faf84cb65e423c4",
   "blockhash": "0000000000e276478d8af4351f6006a88bcc24256bfd0cf6acbba6651f5699e4",
   "blocktime": 1755542699,
-  "confirmations": 146,
+  "confirmations": 147,
   "expiryheight": 3033989,
   "height": 3033949,
   "hex": "(snip)",
-  "in_active_chain": true,
   "locktime": 0,
   "orchard": {
     "actions": [
@@ -38,7 +37,7 @@
       "enableSpends": true
     },
     "proof": "(snip)",
-    "valueBalance": 0.0001,
+    "valueBalance": 0.00010000,
     "valueBalanceZat": 10000
   },
   "overwintered": true,
@@ -47,7 +46,7 @@
   "txid": "07d54b9c61a53002a4b1c13d3e8b341428ba74671d1eb2ba0088ffb5d39a9b14",
   "vShieldedOutput": [],
   "vShieldedSpend": [],
-  "valueBalance": 0.0,
+  "valueBalance": 0E-8,
   "valueBalanceZat": 0,
   "version": 5,
   "versiongroupid": "26a7270a",

```

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
