### PR TITLE
add(consensus): Adds `ZFuture` variant to `NetworkUpgrade`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,7 +225,8 @@ lto = "thin"
 
 
 [workspace.lints.rust]
+# The linter should ignore these expected config flags/values
 unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(tokio_unstable)',
-    'cfg(zcash_unstable, values("zfuture", "nu6.1", "nu7"))'
+    'cfg(tokio_unstable)', # Used by tokio-console
+    'cfg(zcash_unstable, values("zfuture", "nu6.1", "nu7"))' # Used in Zebra and librustzcash
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,3 +222,10 @@ panic = "abort"
 #     - add "-flto=thin" to all C/C++ code builds
 #     - see https://doc.rust-lang.org/rustc/linker-plugin-lto.html#cc-code-as-a-dependency-in-rust
 lto = "thin"
+
+
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(tokio_unstable)',
+    'cfg(zcash_unstable, values("zfuture", "nu6.1", "nu7"))'
+] }

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -48,5 +48,5 @@ tower-test = { workspace = true }
 
 zebra-test = { path = "../zebra-test/", version = "1.0.1" }
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
+[lints]
+workspace = true

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -25,3 +25,6 @@ tracing = { workspace = true }
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
 zebra-test = { path = "../zebra-test/", version = "1.0.1" }
+
+[lints]
+workspace = true

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -164,3 +164,6 @@ required-features = ["bench"]
 [[bench]]
 name = "redpallas"
 harness = false
+
+[lints]
+workspace = true

--- a/zebra-chain/src/block/commitment.rs
+++ b/zebra-chain/src/block/commitment.rs
@@ -139,6 +139,11 @@ impl Commitment {
             (Nu5 | Nu6 | Nu6_1 | Nu7, _) => Ok(ChainHistoryBlockTxAuthCommitment(
                 ChainHistoryBlockTxAuthCommitmentHash(bytes),
             )),
+
+            #[cfg(zcash_unstable = "zfuture")]
+            (ZFuture, _) => Ok(ChainHistoryBlockTxAuthCommitment(
+                ChainHistoryBlockTxAuthCommitmentHash(bytes),
+            )),
         }
     }
 

--- a/zebra-chain/src/history_tree.rs
+++ b/zebra-chain/src/history_tree.rs
@@ -115,6 +115,18 @@ impl NonEmptyHistoryTree {
                 )?;
                 InnerHistoryTree::OrchardOnward(tree)
             }
+
+            #[cfg(zcash_unstable = "zfuture")]
+            NetworkUpgrade::ZFuture => {
+                let tree = Tree::<OrchardOnward>::new_from_cache(
+                    network,
+                    network_upgrade,
+                    size,
+                    &peaks,
+                    &Default::default(),
+                )?;
+                InnerHistoryTree::OrchardOnward(tree)
+            }
         };
         Ok(Self {
             network: network.clone(),
@@ -163,6 +175,17 @@ impl NonEmptyHistoryTree {
             | NetworkUpgrade::Nu6
             | NetworkUpgrade::Nu6_1
             | NetworkUpgrade::Nu7 => {
+                let (tree, entry) = Tree::<OrchardOnward>::new_from_block(
+                    network,
+                    block,
+                    sapling_root,
+                    orchard_root,
+                )?;
+                (InnerHistoryTree::OrchardOnward(tree), entry)
+            }
+
+            #[cfg(zcash_unstable = "zfuture")]
+            NetworkUpgrade::ZFuture => {
                 let (tree, entry) = Tree::<OrchardOnward>::new_from_block(
                     network,
                     block,

--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -148,9 +148,9 @@ impl From<&BTreeMap<Height, NetworkUpgrade>> for ConfiguredActivationHeights {
                 NetworkUpgrade::Nu6 => &mut configured_activation_heights.nu6,
                 NetworkUpgrade::Nu6_1 => &mut configured_activation_heights.nu6_1,
                 NetworkUpgrade::Nu7 => &mut configured_activation_heights.nu7,
-                NetworkUpgrade::Genesis => {
-                    continue;
-                }
+                NetworkUpgrade::Genesis => continue,
+                #[cfg(zcash_unstable = "zfuture")]
+                NetworkUpgrade::ZFuture => continue,
             };
 
             *field = Some(height.0)

--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -328,9 +328,8 @@ pub struct ConfiguredActivationHeights {
     #[serde(rename = "NU7")]
     pub nu7: Option<u32>,
     /// Activation height for `ZFuture` network upgrade.
-    /// Note: This field is ignored unless Zebra is compiled with `zcash_unstable = "zfuture"`
-    ///       (try RUST_FLAGS="--cfg zcash_unstable=\"zfuture\"" cargo build)
     #[serde(rename = "ZFuture")]
+    #[cfg(zcash_unstable = "zfuture")]
     pub zfuture: Option<u32>,
 }
 
@@ -349,6 +348,7 @@ impl ConfiguredActivationHeights {
             nu6,
             nu6_1,
             nu7,
+            #[cfg(zcash_unstable = "zfuture")]
             zfuture,
         } = self;
 
@@ -369,6 +369,7 @@ impl ConfiguredActivationHeights {
             nu6,
             nu6_1,
             nu7,
+            #[cfg(zcash_unstable = "zfuture")]
             zfuture,
         }
     }
@@ -507,6 +508,7 @@ impl ParametersBuilder {
             nu6,
             nu6_1,
             nu7,
+            #[cfg(zcash_unstable = "zfuture")]
             zfuture,
         }: ConfiguredActivationHeights,
     ) -> Self {

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -70,6 +70,9 @@ pub enum NetworkUpgrade {
     /// The Zcash protocol after the NU7 upgrade.
     #[serde(rename = "NU7")]
     Nu7,
+
+    #[cfg(zcash_unstable = "zfuture")]
+    ZFuture,
 }
 
 impl TryFrom<u32> for NetworkUpgrade {
@@ -233,6 +236,8 @@ pub(crate) const CONSENSUS_BRANCH_IDS: &[(NetworkUpgrade, ConsensusBranchId)] = 
     (Nu6_1, ConsensusBranchId(0x4dec4df0)),
     #[cfg(any(test, feature = "zebra-test"))]
     (Nu7, ConsensusBranchId(0x77190ad8)),
+    #[cfg(zcash_unstable = "zfuture")]
+    (ZFuture, ConsensusBranchId(0xffffffff)),
 ];
 
 /// The target block spacing before Blossom.
@@ -401,6 +406,9 @@ impl NetworkUpgrade {
             Blossom | Heartwood | Canopy | Nu5 | Nu6 | Nu6_1 | Nu7 => {
                 POST_BLOSSOM_POW_TARGET_SPACING.into()
             }
+
+            #[cfg(zcash_unstable = "zfuture")]
+            ZFuture => POST_BLOSSOM_POW_TARGET_SPACING.into(),
         };
 
         Duration::seconds(spacing_seconds)
@@ -520,7 +528,10 @@ impl From<zcash_protocol::consensus::NetworkUpgrade> for NetworkUpgrade {
             zcash_protocol::consensus::NetworkUpgrade::Nu5 => Self::Nu5,
             zcash_protocol::consensus::NetworkUpgrade::Nu6 => Self::Nu6,
             zcash_protocol::consensus::NetworkUpgrade::Nu6_1 => Self::Nu6_1,
-            // zcash_protocol::consensus::NetworkUpgrade::Nu7 => Self::Nu7,
+            #[cfg(zcash_unstable = "nu7")]
+            zcash_protocol::consensus::NetworkUpgrade::Nu7 => Self::Nu7,
+            #[cfg(zcash_unstable = "zfuture")]
+            zcash_protocol::consensus::NetworkUpgrade::ZFuture => Self::ZFuture,
         }
     }
 }

--- a/zebra-chain/src/primitives/zcash_history.rs
+++ b/zebra-chain/src/primitives/zcash_history.rs
@@ -278,20 +278,24 @@ impl Version for zcash_history::V1 {
             | NetworkUpgrade::Nu5
             | NetworkUpgrade::Nu6
             | NetworkUpgrade::Nu6_1
-            | NetworkUpgrade::Nu7 => zcash_history::NodeData {
-                consensus_branch_id: branch_id.into(),
-                subtree_commitment: block_hash,
-                start_time: time,
-                end_time: time,
-                start_target: target,
-                end_target: target,
-                start_sapling_root: sapling_root,
-                end_sapling_root: sapling_root,
-                subtree_total_work: work,
-                start_height: height.0 as u64,
-                end_height: height.0 as u64,
-                sapling_tx: sapling_tx_count,
-            },
+            | NetworkUpgrade::Nu7 => {}
+            #[cfg(zcash_unstable = "zfuture")]
+            NetworkUpgrade::ZFuture => {}
+        };
+
+        zcash_history::NodeData {
+            consensus_branch_id: branch_id.into(),
+            subtree_commitment: block_hash,
+            start_time: time,
+            end_time: time,
+            start_target: target,
+            end_target: target,
+            start_sapling_root: sapling_root,
+            end_sapling_root: sapling_root,
+            subtree_total_work: work,
+            start_height: height.0 as u64,
+            end_height: height.0 as u64,
+            sapling_tx: sapling_tx_count,
         }
     }
 }

--- a/zebra-chain/src/primitives/zcash_primitives.rs
+++ b/zebra-chain/src/primitives/zcash_primitives.rs
@@ -139,6 +139,9 @@ impl zp_tx::Authorization for PrecomputedAuth {
     type TransparentAuth = TransparentAuth;
     type SaplingAuth = sapling_crypto::bundle::Authorized;
     type OrchardAuth = orchard::bundle::Authorized;
+
+    #[cfg(zcash_unstable = "zfuture")]
+    type TzeAuth = zp_tx::components::tze::Authorized;
 }
 
 // End of (mostly) copied code
@@ -250,9 +253,13 @@ impl PrecomputedTxData {
             },
         };
 
-        let tx_data: zp_tx::TransactionData<PrecomputedAuth> =
-            tx.into_data()
-                .map_authorization(f_transparent, IdentityMap, IdentityMap);
+        let tx_data: zp_tx::TransactionData<PrecomputedAuth> = tx.into_data().map_authorization(
+            f_transparent,
+            IdentityMap,
+            IdentityMap,
+            #[cfg(zcash_unstable = "zfuture")]
+            (),
+        );
 
         Ok(PrecomputedTxData {
             tx_data,

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -786,6 +786,13 @@ impl Arbitrary for Transaction {
                 Self::v5_strategy(ledger_state)
             ]
             .boxed(),
+
+            #[cfg(zcash_unstable = "zfuture")]
+            NetworkUpgrade::ZFuture => prop_oneof![
+                Self::v4_strategy(ledger_state.clone()),
+                Self::v5_strategy(ledger_state)
+            ]
+            .boxed(),
         }
     }
 

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -95,3 +95,6 @@ tracing-subscriber = { workspace = true }
 zebra-state = { path = "../zebra-state", version = "2.0.0", features = ["proptest-impl"] }
 zebra-chain = { path = "../zebra-chain", version = "2.0.0", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/", version = "1.0.1" }
+
+[lints]
+workspace = true

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -935,6 +935,9 @@ where
             | NetworkUpgrade::Nu6_1
             | NetworkUpgrade::Nu7 => Ok(()),
 
+            #[cfg(zcash_unstable = "zfuture")]
+            NetworkUpgrade::ZFuture => Ok(()),
+
             // Does not support V4 transactions
             NetworkUpgrade::Genesis
             | NetworkUpgrade::BeforeOverwinter
@@ -1019,6 +1022,9 @@ where
             | NetworkUpgrade::Nu6
             | NetworkUpgrade::Nu6_1
             | NetworkUpgrade::Nu7 => Ok(()),
+
+            #[cfg(zcash_unstable = "zfuture")]
+            NetworkUpgrade::ZFuture => Ok(()),
 
             // Does not support V5 transactions
             NetworkUpgrade::Genesis

--- a/zebra-consensus/src/transaction/tests/prop.rs
+++ b/zebra-consensus/src/transaction/tests/prop.rs
@@ -349,6 +349,9 @@ fn sanitize_transaction_version(
             Sapling | Blossom | Heartwood | Canopy => 4,
             // FIXME: Use 6 for Nu7
             Nu5 | Nu6 | Nu6_1 | Nu7 => 5,
+
+            #[cfg(zcash_unstable = "zfuture")]
+            NetworkUpgrade::ZFuture => u8::MAX,
         }
     };
 

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -95,3 +95,6 @@ toml = { workspace = true }
 
 zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/" }
+
+[lints]
+workspace = true

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -113,6 +113,11 @@ impl Version {
 
             // It should be fine to reject peers with earlier network protocol versions on custom testnets for now.
             (Testnet(_), _) => CURRENT_NETWORK_PROTOCOL_VERSION.0,
+
+            #[cfg(zcash_unstable = "zfuture")]
+            (Mainnet, ZFuture) => {
+                panic!("ZFuture network upgrade should not be active on Mainnet")
+            }
         })
     }
 }

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -50,3 +50,6 @@ reqwest = { workspace = true, features = ["rustls-tls"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 jsonrpsee-types = { workspace = true }
+
+[lints]
+workspace = true

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -122,3 +122,6 @@ zebra-state = { path = "../zebra-state", version = "2.0.0", features = [
 ] }
 
 zebra-test = { path = "../zebra-test", version = "1.0.1" }
+
+[lints]
+workspace = true

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -32,3 +32,6 @@ thiserror = { workspace = true }
 hex = { workspace = true }
 lazy_static = { workspace = true }
 zebra-test = { path = "../zebra-test", version = "1.0.1" }
+
+[lints]
+workspace = true

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -108,3 +108,6 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
 zebra-chain = { path = "../zebra-chain", version = "2.0.0", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/", version = "1.0.1" }
+
+[lints]
+workspace = true

--- a/zebra-test/Cargo.toml
+++ b/zebra-test/Cargo.toml
@@ -45,3 +45,6 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -108,3 +108,5 @@ serde_yml = { workspace = true, optional = true }
 serde = { workspace = true, features = ["serde_derive"], optional = true }
 indexmap = { workspace = true }
 
+[lints]
+workspace = true

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -302,5 +302,5 @@ zebra-test = { path = "../zebra-test", version = "1.0.1" }
 # zebra-utils { path = "../zebra-utils", artifact = "bin:zebra-checkpoints" }
 zebra-utils = { path = "../zebra-utils", version = "2.0.0" }
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
+[lints]
+workspace = true


### PR DESCRIPTION
## Motivation

This PR adds a `ZFuture` network upgrade for @azmr and Shielded Labs to use when deploying parts of their Crosslink implementation on a public custom Testnet.

Close https://github.com/ZcashFoundation/zebra/issues/9812
Close https://github.com/ZcashFoundation/zebra/issues/9811

## Solution

- Adds a `ZFuture` variant to `NetworkUpgrade` behind a rust config flag and updates match statements
- Adds a match arm for converting `NetworkUpgrade::Nu7` to librustzcash type when `zcash_unstable = nu7`
- Uses the unit type as the type that implements `tze::MapAuth<A::TzeAuth, B::TzeAuth>` (@nuttycom could you open an issue for replacing the unit type here later, if needed?)

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
