### PR TITLE
fix(ci): make docker builder configurable and temporarily disable provenance

### DIFF
--- a/.github/workflows/sub-build-docker-image.yml
+++ b/.github/workflows/sub-build-docker-image.yml
@@ -141,7 +141,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.10.0
         with:
           version: "lab:latest"
-          driver: cloud
+          driver: ${{ vars.DOCKER_BUILDER || 'docker' }}
           endpoint: "zfnd/zebra"
 
       # Build and push image to Google Artifact Registry, and possibly DockerHub
@@ -162,8 +162,9 @@ jobs:
           push: true
           # It's recommended to build images with max-level provenance attestations
           # https://docs.docker.com/build/ci/github-actions/attestations/
-          provenance: mode=max
-          sbom: true
+          # TODO: Uncomment this once we have a better way to turn on/off provenance
+          # provenance: mode=max
+          # sbom: true
           # Don't read from the cache if the caller disabled it.
           # https://docs.docker.com/engine/reference/commandline/buildx_build/#options
           no-cache: ${{ inputs.no_cache }}


### PR DESCRIPTION
# Motivation

We had an issue with our Docker Build Cloud expending all remaining minutes, and halting our CI (that depends in the docker images being built).

## Solution

Made the Docker builder configurable through the `DOCKER_BUILDER` environment variable:
- Changed from hardcoded `driver: cloud` to `driver: ${{ vars.DOCKER_BUILDER || 'docker' }}`
- Defaults to `docker` driver when the variable is not set
- Commented out `provenance: mode=max` and `sbom: true` due to incompatibility with the docker driver
- Added TODO comment for future re-enablement when we have conditional logic for these features

### Tests

- Verified that CI builds complete successfully with the docker driver
- Confirmed that the variable can be set to re-enable Docker Build Cloud when needed
- Manual testing shows no build failures with attestation features disabled

### Specifications & References

- [Docker Build documentation on drivers](https://docs.docker.com/build/drivers/)
- [GitHub Actions Docker Build documentation](https://docs.docker.com/build/ci/github-actions/)

### Follow-up Work

- Implement conditional logic to enable provenance and sbom only when using compatible drivers

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [ ] The documentation is up to date.