### PR TITLE
fix(arbitrary): fix UTXO selection loop to iterate over entries instead of repeating first

### DIFF
--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -666,17 +666,9 @@ where
     let has_shielded_outputs = transaction.has_shielded_outputs();
     let delete_transparent_outputs =
         CoinbaseSpendRestriction::CheckCoinbaseMaturity { spend_height };
-    let mut attempts: usize = 0;
-
-    // choose an arbitrary spendable UTXO, in hash set order
-    while let Some((candidate_outpoint, candidate_utxo)) = utxos.iter().next() {
-        attempts += 1;
-
-        // Avoid O(n^2) algorithmic complexity by giving up early,
-        // rather than exhaustively checking the entire UTXO set
-        if attempts > 100 {
-            return None;
-        }
+    // choose an arbitrary spendable UTXO, in hash set order, with a bounded scan
+    for (attempts, (candidate_outpoint, candidate_utxo)) in utxos.iter().take(100).enumerate() {
+        // Avoid O(n^2) algorithmic complexity by limiting the number of checks
 
         // try the utxo as-is, then try it with deleted transparent outputs
         if check_transparent_coinbase_spend(

--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -667,7 +667,7 @@ where
     let delete_transparent_outputs =
         CoinbaseSpendRestriction::CheckCoinbaseMaturity { spend_height };
     // choose an arbitrary spendable UTXO, in hash set order, with a bounded scan
-    for (attempts, (candidate_outpoint, candidate_utxo)) in utxos.iter().take(100).enumerate() {
+    for (candidate_outpoint, candidate_utxo) in utxos.iter().take(100) {
         // Avoid O(n^2) algorithmic complexity by limiting the number of checks
 
         // try the utxo as-is, then try it with deleted transparent outputs


### PR DESCRIPTION
The find_valid_utxo_for_spend function was incorrectly using a while loop with
utxos.iter().next() which always returned the same first UTXO entry. This caused
the function to either select the first UTXO or fail after 100 attempts, instead
of properly scanning through available UTXOs.

Changed the loop to iterate over utxos.iter().take(100) to properly scan
different UTXO entries while maintaining the existing 100-entry limit for
performance reasons.

This fix improves the quality of generated test chains by enabling more
transparent spends from different UTXOs rather than repeatedly attempting
to spend the same first entry.