### PR TITLE
Enforce strict non-empty funding stream height ranges

### DIFF
--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -204,7 +204,7 @@ impl ConfiguredFundingStreams {
             });
 
         assert!(
-            height_range.start <= height_range.end,
+            height_range.start < height_range.end,
             "funding stream end height must be above start height"
         );
 


### PR DESCRIPTION
Replace the non-strict start <= end assert with a strict start < end in ConfiguredFundingStreams::convert_with_default() to ensure funding stream height ranges are non-empty. This aligns the check with the error message and prevents potential panics in num_funding_stream_addresses_required_for_height_range() where .end.previous() and subsequent arithmetic assume start < end.