### PR TITLE
docs(rpc): Add note to `getaddresstxids` RPC method

### DIFF
--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -371,8 +371,9 @@ pub trait Rpc {
     ///
     /// # Notes
     ///
-    /// Only the multi-argument format is used by lightwalletd and this is what we currently support:
+    /// - Only the multi-argument format is used by lightwalletd and this is what we currently support:
     /// <https://github.com/zcash/lightwalletd/blob/631bb16404e3d8b045e74a7c5489db626790b2f6/common/common.go#L97-L102>
+    /// - It is recommended that users call the method with start/end heights such that the response can't be too large.
     #[method(name = "getaddresstxids")]
     async fn get_address_tx_ids(&self, request: GetAddressTxIdsRequest) -> Result<Vec<String>>;
 


### PR DESCRIPTION
## Motivation

Close https://github.com/ZcashFoundation/zebra/issues/9743

## Solution

Recommend users to use start and end heights to avoid a too large response.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [x] The documentation is up to date.
