### PR TITLE
refactor(state): improve error propagation for `CommitSemanticallyVerifiedBlock`

### DIFF
--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -55,8 +55,8 @@ use crate::{
         queued_blocks::QueuedBlocks,
         watch_receiver::WatchReceiver,
     },
-    BoxError, CheckpointVerifiedBlock, CloneError, Config, ReadRequest, ReadResponse, Request,
-    Response, SemanticallyVerifiedBlock,
+    BoxError, CheckpointVerifiedBlock, CommitSemanticallyVerifiedError, Config,
+    ReadRequest, ReadResponse, Request, Response, SemanticallyVerifiedBlock, ValidateContextError,
 };
 
 pub mod block_iter;
@@ -234,9 +234,9 @@ impl Drop for StateService {
         self.clear_finalized_block_queue(
             "dropping the state: dropped unused finalized state queue block",
         );
-        self.clear_non_finalized_block_queue(
-            "dropping the state: dropped unused non-finalized state queue block",
-        );
+        self.clear_non_finalized_block_queue(CommitSemanticallyVerifiedError::from(
+            ValidateContextError::DroppedUnusedBlock,
+        ));
 
         // Log database metrics before shutting down
         info!("dropping the state: logging database metrics");
@@ -562,7 +562,7 @@ impl StateService {
     }
 
     /// Drops all non-finalized state queue blocks, and sends an error on their result channels.
-    fn clear_non_finalized_block_queue(&mut self, error: impl Into<BoxError> + Clone) {
+    fn clear_non_finalized_block_queue(&mut self, error: CommitSemanticallyVerifiedError) {
         for (_hash, queued) in self.non_finalized_state_queued_blocks.drain() {
             Self::send_semantically_verified_block_error(queued, error.clone());
         }
@@ -571,13 +571,13 @@ impl StateService {
     /// Send an error on a `QueuedSemanticallyVerified` block's result channel, and drop the block
     fn send_semantically_verified_block_error(
         queued: QueuedSemanticallyVerified,
-        error: impl Into<BoxError>,
+        error: CommitSemanticallyVerifiedError,
     ) {
         let (finalized, rsp_tx) = queued;
 
         // The block sender might have already given up on this block,
         // so ignore any channel send errors.
-        let _ = rsp_tx.send(Err(error.into()));
+        let _ = rsp_tx.send(Err(error));
         std::mem::drop(finalized);
     }
 
@@ -592,7 +592,7 @@ impl StateService {
     fn queue_and_commit_to_non_finalized_state(
         &mut self,
         semantically_verrified: SemanticallyVerifiedBlock,
-    ) -> oneshot::Receiver<Result<block::Hash, BoxError>> {
+    ) -> oneshot::Receiver<Result<block::Hash, CommitSemanticallyVerifiedError>> {
         tracing::debug!(block = %semantically_verrified.block, "queueing block for contextual verification");
         let parent_hash = semantically_verrified.block.header.previous_block_hash;
 
@@ -601,9 +601,11 @@ impl StateService {
             .contains(&semantically_verrified.hash)
         {
             let (rsp_tx, rsp_rx) = oneshot::channel();
-            let _ = rsp_tx.send(Err(
-                "block has already been sent to be committed to the state".into(),
-            ));
+            let _ = rsp_tx.send(Err(CommitSemanticallyVerifiedError::from(
+                ValidateContextError::DuplicateCommitRequest {
+                    block_hash: semantically_verrified.hash,
+                },
+            )));
             return rsp_rx;
         }
 
@@ -613,10 +615,11 @@ impl StateService {
             .contains_height(semantically_verrified.height)
         {
             let (rsp_tx, rsp_rx) = oneshot::channel();
-            let _ = rsp_tx.send(Err(
-                "block height is in the finalized state: block is already committed to the state"
-                    .into(),
-            ));
+            let _ = rsp_tx.send(Err(CommitSemanticallyVerifiedError::from(
+                ValidateContextError::AlreadyFinalized {
+                    block_height: semantically_verrified.height,
+                },
+            )));
             return rsp_rx;
         }
 
@@ -630,7 +633,11 @@ impl StateService {
             tracing::debug!("replacing older queued request with new request");
             let (mut rsp_tx, rsp_rx) = oneshot::channel();
             std::mem::swap(old_rsp_tx, &mut rsp_tx);
-            let _ = rsp_tx.send(Err("replaced by newer request".into()));
+            let _ = rsp_tx.send(Err(CommitSemanticallyVerifiedError::from(
+                ValidateContextError::ReplacedByNewerRequest {
+                    block_hash: semantically_verrified.hash,
+                },
+            )));
             rsp_rx
         } else {
             let (rsp_tx, rsp_rx) = oneshot::channel();
@@ -731,11 +738,15 @@ impl StateService {
                         // If Zebra is shutting down, drop blocks and return an error.
                         Self::send_semantically_verified_block_error(
                             queued,
-                            "block commit task exited. Is Zebra shutting down?",
+                            CommitSemanticallyVerifiedError::from(
+                                ValidateContextError::CommitTaskExited,
+                            ),
                         );
 
                         self.clear_non_finalized_block_queue(
-                            "block commit task exited. Is Zebra shutting down?",
+                            CommitSemanticallyVerifiedError::from(
+                                ValidateContextError::CommitTaskExited,
+                            ),
                         );
 
                         return;
@@ -953,18 +964,20 @@ impl Service<Request> for StateService {
                 // The work is all done, the future just waits on a channel for the result
                 timer.finish(module_path!(), line!(), "CommitSemanticallyVerifiedBlock");
 
+                // Await the channel response, mapping any receive error into a BoxError.
+                // Then flatten the nested Result by converting the inner CommitSemanticallyVerifiedError into a BoxError.
                 let span = Span::current();
                 async move {
                     rsp_rx
                         .await
                         .map_err(|_recv_error| {
-                            BoxError::from(
-                                "block was dropped from the queue of non-finalized blocks",
-                            )
+                            BoxError::from(CommitSemanticallyVerifiedError::from(
+                                ValidateContextError::NotReadyToBeCommitted,
+                            ))
                         })
                         // TODO: replace with Result::flatten once it stabilises
                         // https://github.com/rust-lang/rust/issues/70142
-                        .and_then(convert::identity)
+                        .and_then(|res| res.map_err(BoxError::from))
                         .map(Response::Committed)
                 }
                 .instrument(span)

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -55,8 +55,8 @@ use crate::{
         queued_blocks::QueuedBlocks,
         watch_receiver::WatchReceiver,
     },
-    BoxError, CheckpointVerifiedBlock, CommitSemanticallyVerifiedError, Config,
-    ReadRequest, ReadResponse, Request, Response, SemanticallyVerifiedBlock, ValidateContextError,
+    BoxError, CheckpointVerifiedBlock, CommitSemanticallyVerifiedError, Config, ReadRequest,
+    ReadResponse, Request, Response, SemanticallyVerifiedBlock, ValidateContextError,
 };
 
 pub mod block_iter;

--- a/zebra-state/src/service/queued_blocks.rs
+++ b/zebra-state/src/service/queued_blocks.rs
@@ -10,7 +10,10 @@ use tracing::instrument;
 
 use zebra_chain::{block, transparent};
 
-use crate::{BoxError, CheckpointVerifiedBlock, SemanticallyVerifiedBlock};
+use crate::{
+    BoxError, CheckpointVerifiedBlock, CommitSemanticallyVerifiedError, SemanticallyVerifiedBlock,
+    ValidateContextError,
+};
 
 #[cfg(test)]
 mod tests;
@@ -24,7 +27,7 @@ pub type QueuedCheckpointVerified = (
 /// A queued semantically verified block, and its corresponding [`Result`] channel.
 pub type QueuedSemanticallyVerified = (
     SemanticallyVerifiedBlock,
-    oneshot::Sender<Result<block::Hash, BoxError>>,
+    oneshot::Sender<Result<block::Hash, CommitSemanticallyVerifiedError>>,
 );
 
 /// A queue of blocks, awaiting the arrival of parent blocks.
@@ -142,9 +145,11 @@ impl QueuedBlocks {
             let parent_hash = &expired_block.block.header.previous_block_hash;
 
             // we don't care if the receiver was dropped
-            let _ = expired_sender.send(Err(
-                "pruned block at or below the finalized tip height".into()
-            ));
+            let _ = expired_sender.send(Err(CommitSemanticallyVerifiedError::from(
+                ValidateContextError::PrunedBelowFinalizedTip {
+                    block_height: expired_block.height,
+                },
+            )));
 
             // TODO: only remove UTXOs if there are no queued blocks with that UTXO
             //       (known_utxos is best-effort, so this is ok for now)


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

<!--
- Describe the goals of the PR.
- If it closes any issues, enumerate them here.
-->

This PR addresses #9730.

It focuses on improving the precision of error types returned when committing semantically verified blocks to the non-finalized state, as outlined in the issue.

Feedback specifically welcome on the design and handling of validation errors introduced in this PR.

## Solution

<!-- Describe the changes in the PR. -->

- Used and extended `CommitSemanticallyVerifiedError` already defined in `error.rs`.
- Replace the boxed error type in the `CommitSemanticallyVerifiedBlock` response with the concrete `CommitSemanticallyVerifiedError` type.
- Refactor `StateService::call`, `queue_and_commit_to_non_finalized_state`, and related functions to propagate this error.
- Adjust the channels and error handling in `write.rs`.


### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

- All existing tests passed successfully.


### Specifications & References

<!-- Provide any relevant references. -->

#9730 


### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

- Review and potentially refactor other parts of `StateService` in `zebra-state` for consistent error handling.
- Consider adding more targeted comments or clarifying documentation (as outlined in the issue).
- Consider adding more tests.
- Feedback welcomed on whether this direction makes sense before proceeding with broader cleanup.


### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
