### PR TITLE
feat(rpc): support single-string or object params in getaddresstxids (#9784)

### DIFF
--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -364,10 +364,21 @@ pub trait Rpc {
     ///
     /// # Parameters
     ///
-    /// - `request`: (object, required, example={\"addresses\": [\"tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ\"], \"start\": 1000, \"end\": 2000}) A struct with the following named fields:
-    ///     - `addresses`: (json array of string, required) The addresses to get transactions from.
-    ///     - `start`: (numeric, optional) The lower height to start looking for transactions (inclusive).
-    ///     - `end`: (numeric, optional) The top height to stop looking for transactions (inclusive).
+    /// - `params`: (required) Either:
+    ///     - A single address string (e.g., `"tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"`), or
+    ///     - An object with the following named fields:
+    ///         - `addresses`: (array of strings, required) The addresses to get transactions from.
+    ///         - `start`: (numeric, optional) The lower height to start looking for transactions (inclusive).
+    ///         - `end`: (numeric, optional) The upper height to stop looking for transactions (inclusive).
+    ///
+    /// Example of the object form:
+    /// ```json
+    /// {
+    ///   "addresses": ["tmYXBYJj1K7vhejSec5osXK2QsGa5MTisUQ"],
+    ///   "start": 1000,
+    ///   "end": 2000
+    /// }
+    /// ```
     ///
     /// # Notes
     ///
@@ -375,7 +386,7 @@ pub trait Rpc {
     /// <https://github.com/zcash/lightwalletd/blob/631bb16404e3d8b045e74a7c5489db626790b2f6/common/common.go#L97-L102>
     /// - It is recommended that users call the method with start/end heights such that the response can't be too large.
     #[method(name = "getaddresstxids")]
-    async fn get_address_tx_ids(&self, request: GetAddressTxIdsRequest) -> Result<Vec<String>>;
+    async fn get_address_tx_ids(&self, params: GetAddressTxIdsParams) -> Result<Vec<String>>;
 
     /// Returns all unspent outputs for a list of addresses.
     ///
@@ -1961,7 +1972,9 @@ where
         }
     }
 
-    async fn get_address_tx_ids(&self, request: GetAddressTxIdsRequest) -> Result<Vec<String>> {
+    async fn get_address_tx_ids(&self, params: GetAddressTxIdsParams) -> Result<Vec<String>> {
+        let request = params.into_request();
+
         let mut read_state = self.read_state.clone();
         let latest_chain_tip = self.latest_chain_tip.clone();
 
@@ -3966,6 +3979,30 @@ impl GetAddressTxIdsRequest {
             self.start.unwrap_or(0),
             self.end.unwrap_or(0),
         )
+    }
+}
+
+/// Parameters for the `getaddresstxids` RPC method.
+#[derive(Debug, serde::Deserialize)]
+#[serde(untagged)]
+pub enum GetAddressTxIdsParams {
+    /// A single address string.
+    Single(String),
+    /// A full request object with address list and optional height range.
+    Object(GetAddressTxIdsRequest),
+}
+
+impl GetAddressTxIdsParams {
+    /// Converts the enum into a `GetAddressTxIdsRequest`, normalizing the input format.
+    pub fn into_request(self) -> GetAddressTxIdsRequest {
+        match self {
+            GetAddressTxIdsParams::Single(addr) => GetAddressTxIdsRequest {
+                addresses: vec![addr],
+                start: None,
+                end: None,
+            },
+            GetAddressTxIdsParams::Object(req) => req,
+        }
     }
 }
 

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -522,51 +522,51 @@ async fn test_rpc_response_data_for_network(network: &Network) {
 
     // `getaddresstxids`
     let get_address_tx_ids = rpc
-        .get_address_tx_ids(GetAddressTxIdsRequest {
+        .get_address_tx_ids(GetAddressTxIdsParams::Object(GetAddressTxIdsRequest {
             addresses: addresses.clone(),
             start: Some(1),
             end: Some(10),
-        })
+        }))
         .await
         .expect("We should have a vector of strings");
     snapshot_rpc_getaddresstxids_valid("multi_block", get_address_tx_ids, &settings);
 
     let get_address_tx_ids = rpc
-        .get_address_tx_ids(GetAddressTxIdsRequest {
+        .get_address_tx_ids(GetAddressTxIdsParams::Object(GetAddressTxIdsRequest {
             addresses: addresses.clone(),
             start: Some(2),
             end: Some(2),
-        })
+        }))
         .await
         .expect("We should have a vector of strings");
     snapshot_rpc_getaddresstxids_valid("single_block", get_address_tx_ids, &settings);
 
     let get_address_tx_ids = rpc
-        .get_address_tx_ids(GetAddressTxIdsRequest {
+        .get_address_tx_ids(GetAddressTxIdsParams::Object(GetAddressTxIdsRequest {
             addresses: addresses.clone(),
             start: Some(3),
             end: Some(EXCESSIVE_BLOCK_HEIGHT),
-        })
+        }))
         .await
         .expect("We should have a vector of strings");
     snapshot_rpc_getaddresstxids_valid("excessive_end", get_address_tx_ids, &settings);
 
     let get_address_tx_ids = rpc
-        .get_address_tx_ids(GetAddressTxIdsRequest {
+        .get_address_tx_ids(GetAddressTxIdsParams::Object(GetAddressTxIdsRequest {
             addresses: addresses.clone(),
             start: Some(EXCESSIVE_BLOCK_HEIGHT),
             end: Some(EXCESSIVE_BLOCK_HEIGHT + 1),
-        })
+        }))
         .await
         .expect("We should have a vector of strings");
     snapshot_rpc_getaddresstxids_valid("excessive_start", get_address_tx_ids, &settings);
 
     let get_address_tx_ids = rpc
-        .get_address_tx_ids(GetAddressTxIdsRequest {
+        .get_address_tx_ids(GetAddressTxIdsParams::Object(GetAddressTxIdsRequest {
             addresses: addresses.clone(),
             start: Some(2),
             end: Some(1),
-        })
+        }))
         .await;
     snapshot_rpc_getaddresstxids_invalid("end_greater_start", get_address_tx_ids, &settings);
 


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

<!--
- Describe the goals of the PR.
- If it closes any issues, enumerate them here.
-->

Addresses issue #9784 : `getaddresstxids` should accept either a single string or an object with multiple arguments.

## Solution

<!-- Describe the changes in the PR. -->

- Introduced `GetAddressTxIdsParams` enum with `Single(String)` and `Object(GetAddressTxIdsRequest)` variants.
- Updated the RPC method to accept the new enum.
- Used `.into_request()` to normalize both variants into a unified internal request.
- Adjusted documentation to describe the dual input format.
- Added a test to ensure both input types produce identical results.

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

- Added `getaddresstxids_single_equals_object_full_range` integration test.
- Ran the full `zebra-rpc` test suite — all tests pass.
- Verified formatting with `cargo fmt --all`.

### Specifications & References

<!-- Provide any relevant references. -->

- Closes #9784  
- [Zcash RPC docs](https://zcash.github.io/rpc/getaddresstxids.html)

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
