### PR TITLE
build: speed up dev profile by improving optimization of some dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,48 +165,109 @@ allow-branch = ["main"]
 [profile.dev]
 panic = "abort"
 
-# Speed up tests by optimizing performance-critical crates
+# Speed up tests by optimizing performance-critical crates. The parameters
+# values are the ones from the `release` profile
+# (https://doc.rust-lang.org/cargo/reference/profiles.html#release)
 
 # Cryptographic crates
 
 [profile.dev.package.blake2b_simd]
 opt-level = 3
+debug-assertions = false
+overflow-checks = false
+incremental = false
+codegen-units = 16
 
 [profile.dev.package.ff]
 opt-level = 3
+debug-assertions = false
+overflow-checks = false
+incremental = false
+codegen-units = 16
 
 [profile.dev.package.group]
 opt-level = 3
+debug-assertions = false
+overflow-checks = false
+incremental = false
+codegen-units = 16
 
 [profile.dev.package.pasta_curves]
 opt-level = 3
+debug-assertions = false
+overflow-checks = false
+incremental = false
+codegen-units = 16
 
 [profile.dev.package.halo2_proofs]
 opt-level = 3
+debug-assertions = false
+overflow-checks = false
+incremental = false
+codegen-units = 16
 
 [profile.dev.package.halo2_gadgets]
 opt-level = 3
+debug-assertions = false
+overflow-checks = false
+incremental = false
+codegen-units = 16
 
 [profile.dev.package.bls12_381]
 opt-level = 3
+debug-assertions = false
+overflow-checks = false
+incremental = false
+codegen-units = 16
 
 [profile.dev.package.byteorder]
 opt-level = 3
+debug-assertions = false
+overflow-checks = false
+incremental = false
+codegen-units = 16
 
 [profile.dev.package.equihash]
 opt-level = 3
+debug-assertions = false
+overflow-checks = false
+incremental = false
+codegen-units = 16
 
 [profile.dev.package.zcash_proofs]
 opt-level = 3
+debug-assertions = false
+overflow-checks = false
+incremental = false
+codegen-units = 16
 
 [profile.dev.package.ring]
 opt-level = 3
+debug-assertions = false
+overflow-checks = false
+incremental = false
+codegen-units = 16
 
 [profile.dev.package.spin]
 opt-level = 3
+debug-assertions = false
+overflow-checks = false
+incremental = false
+codegen-units = 16
 
 [profile.dev.package.untrusted]
 opt-level = 3
+debug-assertions = false
+overflow-checks = false
+incremental = false
+codegen-units = 16
+
+[profile.dev.package.bitvec]
+opt-level = 3
+debug-assertions = false
+overflow-checks = false
+incremental = false
+codegen-units = 16
 
 
 [profile.release]


### PR DESCRIPTION

## Motivation

In #9741 , @upbqdn noticed that [a particular test](https://github.com/ZcashFoundation/zebra/pull/9741/files#diff-6928ca8b4f6b3ed3d402856e2cffd5c0a2772abe534006177b257e3e61fea5e0R36) was much slower in the dev/test profile than in the release profile, even though we use `opt-level=3` in dev mode for some key dependencies.

Looking into it, I found out that this gap is caused by:

- Some other optimization flags from the release profile which were not being enabled; and are included in this PR. This reduces the time for that test from ~90s to ~50s IIRC
- The rest of the dependencies not being optimized. However this was a small gain so I did not include that (as it increases build time)
- The `lto = thin` flag not being used. However that greatly increases linking time so I did not include that.
- There is still a gap that I couldn't figure out. Even doing all the above, that particular tests took ~40s instead of ~30s in release mode. However I decided to not look into this further since I had no idea where to start.

(Sorry I should've took better notes of the timings, but the gain was significant)

## Solution

Add the other optimization flags for dependencies

### Tests

You can the code from #9741 with and without this PR changes and run `cargo test -p zebra-rpc -- coinbase --include-ignored` to measure the time

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
