### PR TITLE
zebrad: increase timeout in trusted_chain_sync_handles_forks_correctly

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -3252,7 +3252,7 @@ async fn trusted_chain_sync_handles_forks_correctly() -> Result<()> {
     tracing::info!("waiting for finalized chain tip changes");
 
     timeout(
-        Duration::from_secs(100),
+        Duration::from_secs(200),
         tokio::spawn(async move {
             for _ in 0..2 {
                 chain_tip_change


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

We're having timeouts in trusted_chain_sync_handles_forks_correctly

## Solution

Try to increase the timeout

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

We might want to look into why it's suddenly timing out

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
