### PR TITLE
feat(rpc): add getmempoolinfo RPC method

### DIFF
--- a/zebra-node-services/src/mempool.rs
+++ b/zebra-node-services/src/mempool.rs
@@ -102,6 +102,9 @@ pub enum Request {
     /// when too many slots are reserved but unused:
     /// <https://docs.rs/tower/0.4.10/tower/buffer/struct.Buffer.html#a-note-on-choosing-a-bound>
     CheckForVerifiedTransactions,
+
+    /// Request summary statistics from the mempool for `getmempoolinfo`.
+    QueueStats,
 }
 
 /// A response to a mempool service request.
@@ -159,4 +162,16 @@ pub enum Response {
 
     /// Confirms that the mempool has checked for recently verified transactions.
     CheckedForVerifiedTransactions,
+
+    /// Summary statistics for the mempool: count, total size, memory usage, and regtest info.
+    QueueStats {
+        /// Number of transactions currently in the mempool
+        size: usize,
+        /// Total size in bytes of all transactions
+        bytes: usize,
+        /// Estimated memory usage in bytes
+        usage: usize,
+        /// Whether all transactions have been fully notified (regtest only)
+        fully_notified: Option<bool>,
+    },
 }

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -114,6 +114,7 @@ use types::{
         GetBlockTemplateParameters, GetBlockTemplateResponse,
     },
     get_blockchain_info::GetBlockchainInfoBalance,
+    get_mempool_info::GetMempoolInfoResponse,
     get_mining_info::GetMiningInfoResponse,
     get_raw_mempool::{self, GetRawMempoolResponse},
     long_poll::LongPollInput,
@@ -278,6 +279,12 @@ pub trait Rpc {
     /// tags: blockchain
     #[method(name = "getbestblockheightandhash")]
     fn get_best_block_height_and_hash(&self) -> Result<GetBlockHeightAndHashResponse>;
+
+    /// Returns details on the active state of the TX memory pool.
+    ///
+    /// zcash reference: [`getmempoolinfo`](https://zcash.github.io/rpc/getmempoolinfo.html)
+    #[method(name = "getmempoolinfo")]
+    async fn get_mempool_info(&self) -> Result<GetMempoolInfoResponse>;
 
     /// Returns all transaction ids in the memory pool, as a JSON array.
     ///
@@ -1591,6 +1598,33 @@ where
             .best_tip_height_and_hash()
             .map(|(height, hash)| GetBlockHeightAndHashResponse { height, hash })
             .ok_or_misc_error("No blocks in state")
+    }
+
+    async fn get_mempool_info(&self) -> Result<GetMempoolInfoResponse> {
+        let mut mempool = self.mempool.clone();
+
+        let response = mempool
+            .ready()
+            .and_then(|service| service.call(mempool::Request::QueueStats))
+            .await
+            .map_misc_error()?;
+
+        if let mempool::Response::QueueStats {
+            size,
+            bytes,
+            usage,
+            fully_notified,
+        } = response
+        {
+            Ok(GetMempoolInfoResponse {
+                size,
+                bytes,
+                usage,
+                fully_notified,
+            })
+        } else {
+            unreachable!("unexpected response to QueueStats request")
+        }
     }
 
     async fn get_raw_mempool(&self, verbose: Option<bool>) -> Result<GetRawMempoolResponse> {

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -442,9 +442,6 @@ async fn test_rpc_response_data_for_network(network: &Network) {
         });
 
     let (rsp, _) = futures::join!(rpc.get_mempool_info(), mempool_req);
-
-    println!("{}", serde_json::to_string_pretty(&rsp).unwrap());
-
     if let Ok(inner) = rsp {
         insta::assert_json_snapshot!("get_mempool_info", inner);
     } else {

--- a/zebra-rpc/src/methods/tests/snapshots/get_mempool_info.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_mempool_info.snap
@@ -1,0 +1,9 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+expression: inner
+---
+{
+  "size": 67,
+  "bytes": 32500,
+  "usage": 41000
+}

--- a/zebra-rpc/src/methods/types.rs
+++ b/zebra-rpc/src/methods/types.rs
@@ -3,6 +3,7 @@
 pub mod default_roots;
 pub mod get_block_template;
 pub mod get_blockchain_info;
+pub mod get_mempool_info;
 pub mod get_mining_info;
 pub mod get_raw_mempool;
 pub mod long_poll;

--- a/zebra-rpc/src/methods/types/get_mempool_info.rs
+++ b/zebra-rpc/src/methods/types/get_mempool_info.rs
@@ -1,0 +1,18 @@
+//! Types used in `getmempoolinfo` RPC method.
+
+/// Response to a `getmempoolinfo` RPC request.
+///
+/// See the notes for the [`Rpc::get_mempool_info` method].
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
+pub struct GetMempoolInfoResponse {
+    /// Current tx count
+    pub size: usize,
+    /// Sum of all tx sizes
+    pub bytes: usize,
+    /// Total memory usage for the mempool
+    pub usage: usize,
+    /// Whether the node has finished notifying all listeners/tests about every transaction currently in the mempool.
+    /// This key is returned only when the node is running in regtest.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fully_notified: Option<bool>,
+}

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -900,11 +900,7 @@ impl Service<Request> for Mempool {
 
                     let size = storage.transaction_count();
 
-                    let bytes = storage
-                        .transactions()
-                        .values()
-                        .map(|tx| tx.transaction.size)
-                        .sum();
+                    let bytes = storage.total_serialized_size();
 
                     let usage = bytes; // TODO: Placeholder, should be fixed later
 


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

<!--
- Describe the goals of the PR.
- If it closes any issues, enumerate them here.
-->

Addresses issue #8437 by adding the `getmempoolinfo` RPC method.


## Solution

<!-- Describe the changes in the PR. -->

- Added the `GetMempoolInfoResponse` struct to represent the JSON-RPC response, following the official spec: [Zcash RPC docs](https://zcash.github.io/rpc/getmempoolinfo.html).  
- Registered the `getmempoolinfo` method in the `Rpc` trait.
- Implemented the handler to gather needed mempool stats.
- Extended mempool structures with a `QueueStats` variant to hold detailed mempool state required by the RPC.
- Added a simple integration test to verify the method works and returns the expected structure.


### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

- Ran `cargo fmt --all`.
- Existing tests in the `zebra-rpc` crate pass, including the newly added snapshot test.
- Ran the new tests in the `zebrad` crate via `cargo test -p zebrad mempool::tests::vector` — all tests passed.

Feedback and guidance on improving the design or expanding test coverage would be appreciated.

### Specifications & References

<!-- Provide any relevant references. -->

- Closes #8437 
- [Zcash RPC docs](https://zcash.github.io/rpc/getmempoolinfo.html)

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

- [ ] Replace placeholder `usage = bytes` with an accurate memory usage estimate.
- [ ] Support the `fullyNotified` field in `regtest` mode.
- [ ] Add more thorough integration tests.
- [ ] Add unit/property tests for the `QueueStats` response logic.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
