### PR TITLE
Fix: constructor doc PrecomputedTransaction → CachedFfiTransaction

### DIFF
--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -96,7 +96,7 @@ pub struct CachedFfiTransaction {
 }
 
 impl CachedFfiTransaction {
-    /// Construct a `PrecomputedTransaction` from a `Transaction` and the outputs
+    /// Construct a `CachedFfiTransaction` from a `Transaction` and the outputs
     /// from previous transactions that match each input in the transaction
     /// being verified.
     pub fn new(


### PR DESCRIPTION
incorrect backticked type name in CachedFfiTransaction::new doc from PrecomputedTransaction to CachedFfiTransaction. This corrects a leftover from an earlier naming and prevents confusion, since no PrecomputedTransaction type exists in the codebase and all usages reference CachedFfiTransaction.