### PR TITLE
test: fix cargo test by ignoring tests with requirements

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1792,6 +1792,7 @@ fn lwd_integration() -> Result<()> {
 ///
 /// This test might work on Windows.
 #[test]
+#[ignore]
 fn sync_update_mainnet() -> Result<()> {
     lwd_integration_test(UpdateZebraCachedStateNoRpc)
 }
@@ -2556,6 +2557,7 @@ async fn get_peer_info() -> Result<()> {
 ///
 /// See [`common::get_block_template_rpcs::get_block_template`] for more information.
 #[tokio::test]
+#[ignore]
 async fn rpc_get_block_template() -> Result<()> {
     common::get_block_template_rpcs::get_block_template::run().await
 }
@@ -2564,6 +2566,7 @@ async fn rpc_get_block_template() -> Result<()> {
 ///
 /// See [`common::get_block_template_rpcs::submit_block`] for more information.
 #[tokio::test]
+#[ignore]
 async fn rpc_submit_block() -> Result<()> {
     common::get_block_template_rpcs::submit_block::run().await
 }


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

`cargo test` has been failing locally due to recent refactors that made some tests with cached state requirements being run by default.

## Solution

Add `#[ignore]` to those. This should not affect CI because [it uses `--run-ignore=all`](https://github.com/ZcashFoundation/zebra/blob/c9a38a66a540acc3d12fe6876f1cf03a54cb0b52/docker/entrypoint.sh#L75).

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
