### PR TITLE
chore: fix worker docs, rename BufferLayer debug, update trace

### DIFF
--- a/tower-batch-control/src/layer.rs
+++ b/tower-batch-control/src/layer.rs
@@ -67,7 +67,7 @@ where
 
 impl<Request> fmt::Debug for BatchLayer<Request> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("BufferLayer")
+        f.debug_struct("BatchLayer")
             .field("max_items_weight_in_batch", &self.max_items_weight_in_batch)
             .field("max_batches", &self.max_batches)
             .field("max_latency", &self.max_latency)

--- a/tower-batch-control/src/service.rs
+++ b/tower-batch-control/src/service.rs
@@ -302,7 +302,7 @@ where
     }
 
     fn call(&mut self, request: Request) -> Self::Future {
-        tracing::trace!("sending request to buffer worker");
+        tracing::trace!("sending request to batch worker");
         let _permit = self
             .permit
             .take()

--- a/tower-batch-control/src/worker.rs
+++ b/tower-batch-control/src/worker.rs
@@ -292,7 +292,7 @@ where
     /// Register an inner service failure.
     ///
     /// The underlying service failed when we called `poll_ready` on it with the given `error`. We
-    /// need to communicate this to all the `Buffer` handles. To do so, we wrap up the error in
+    /// need to communicate this to all the `Batch` handles. To do so, we wrap up the error in
     /// an `Arc`, send that `Arc<E>` to all pending requests, and store it so that subsequent
     /// requests will also fail with the same error.
     fn failed(&mut self, error: crate::BoxError) {


### PR DESCRIPTION
This crate was forked from Tower’s buffer; several doc strings and names still referenced Buffer/Executor. Update worker.rs docs to describe the batch worker, change “Buffer handles” to “Batch handles”, fix BatchLayer’s Debug name, and change a trace to “batch worker”.