### PR TITLE
chore(orchard): correct expect message for Node in arbitrary generator

### DIFF
--- a/zebra-chain/src/orchard/arbitrary.rs
+++ b/zebra-chain/src/orchard/arbitrary.rs
@@ -141,7 +141,7 @@ impl Arbitrary for tree::Root {
         pallas_base_strat()
             .prop_map(|base| {
                 Self::try_from(base.to_repr())
-                    .expect("a valid generated Orchard note commitment tree root")
+                    .expect("a valid generated Orchard note commitment tree node")
             })
             .boxed()
     }


### PR DESCRIPTION
- Replace misleading expect text in impl Arbitrary for tree::Node from “Orchard note commitment tree root” to “Orchard note commitment tree node”.
- This change aligns the error message with the actual type (Node vs Root), preventing confusion during failing proptests and improving diagnostic accuracy.