### PR TITLE
feat(rpc): support side chains in getrawtransaction

### DIFF
--- a/zebra-rpc/qa/pull-tester/rpc-tests.py
+++ b/zebra-rpc/qa/pull-tester/rpc-tests.py
@@ -44,7 +44,8 @@ BASE_SCRIPTS= [
     'wallet.py',
     'feature_nu6.py',
     'feature_nu6_1.py',
-    'feature_backup_non_finalized_state.py']
+    'feature_backup_non_finalized_state.py',
+    'getrawtransaction_sidechain.py']
 
 ZMQ_SCRIPTS = [
     # ZMQ test can only be run if bitcoin was built with zmq-enabled.

--- a/zebra-rpc/qa/rpc-tests/getrawtransaction_sidechain.py
+++ b/zebra-rpc/qa/rpc-tests/getrawtransaction_sidechain.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright (c) 2022-2024 The Zcash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+#
+# Test the effect of reorgs on the Orchard commitment tree.
+#
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    BLOSSOM_BRANCH_ID,
+    HEARTWOOD_BRANCH_ID,
+    CANOPY_BRANCH_ID,
+    NU5_BRANCH_ID,
+    assert_equal,
+    get_coinbase_address,
+    nuparams,
+    start_nodes,
+    wait_and_assert_operationid_status,
+)
+
+
+class GetRawTransactionSideChainTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 1
+        self.cache_behavior = 'clean'
+
+    def setup_nodes(self):
+        return start_nodes(self.num_nodes, self.options.tmpdir)
+
+    def setup_network(self, split=False, do_mempool_sync=True):
+        self.nodes = self.setup_nodes()
+
+    def run_test(self):
+        n = self.nodes[0]
+        # Generate two blocks
+        n.generate(2)
+
+        # Get a transaction from block at height 1
+        block_hash_a = n.getbestblockhash()
+        txid_a = n.getblock("-1", 1)['tx'][0]
+
+        # Invalidate last block (height 1)
+        n.invalidateblock(block_hash_a)
+        # Regenerate a height 1 block
+        n.generate(1)
+        # Get a transaction from the new block at height 1
+        txid_b = n.getblock("-1", 1)['tx'][0]
+        # Reconsider the invalidated block
+        n.reconsiderblock(block_hash_a)
+
+        # We now have two chains. Try to get transactions from both.
+        tx_a = n.getrawtransaction(txid_a, 1)
+        tx_b = n.getrawtransaction(txid_b, 1)
+        assert(tx_a['txid'] != tx_b['txid'])
+
+
+if __name__ == '__main__':
+    GetRawTransactionSideChainTest().main()

--- a/zebra-rpc/qa/rpc-tests/getrawtransaction_sidechain.py
+++ b/zebra-rpc/qa/rpc-tests/getrawtransaction_sidechain.py
@@ -8,7 +8,8 @@
 #
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import start_nodes
+from test_framework.util import start_nodes, assert_equal
+from test_framework.proxy import JSONRPCException
 
 
 class GetRawTransactionSideChainTest(BitcoinTestFramework):
@@ -25,26 +26,45 @@ class GetRawTransactionSideChainTest(BitcoinTestFramework):
 
     def run_test(self):
         n = self.nodes[0]
+
         # Generate two blocks
-        n.generate(2)
+        hashes = n.generate(2)
 
-        # Get a transaction from block at height 1
+        # Get a transaction from block at height 2
         block_hash_a = n.getbestblockhash()
-        txid_a = n.getblock("-1", 1)['tx'][0]
+        txid_a = n.getblock("2", 1)['tx'][0]
+        tx_a = n.getrawtransaction(txid_a, 1)
+        assert_equal(tx_a['height'], 2)
 
-        # Invalidate last block (height 1)
+        # Invalidate last block (height 2)
         n.invalidateblock(block_hash_a)
-        # Regenerate a height 1 block
-        n.generate(1)
-        # Get a transaction from the new block at height 1
-        txid_b = n.getblock("-1", 1)['tx'][0]
+        try:
+            tx_a = n.getrawtransaction(txid_a, 1)
+            assert False, "getrawtransaction should have failed"
+        except JSONRPCException:
+            pass
+
+        # Regenerate a height 2 block
+        hashes = n.generate(1)
+        txid_b = n.getblock(hashes[0], 1)['tx'][0]
+
+        # Get a transaction from the new block at height 2
+        tx_b = n.getrawtransaction(txid_b, 1)
+        assert_equal(tx_b['height'], 2)
+
         # Reconsider the invalidated block
         n.reconsiderblock(block_hash_a)
 
         # We now have two chains. Try to get transactions from both.
         tx_a = n.getrawtransaction(txid_a, 1)
         tx_b = n.getrawtransaction(txid_b, 1)
-        assert(tx_a['txid'] != tx_b['txid'])
+        assert(tx_a['blockhash'] != tx_b['blockhash'])
+        # Exactly one of the transactions should be in a side chain
+        assert((tx_a['confirmations'] == 0) ^ (tx_b['confirmations'] == 0))
+        assert((tx_a['height'] == -1) ^ (tx_b['height'] == -1))
+        # Exactly one of the transactions should be in the main chain
+        assert((tx_a['height'] == 2) ^ (tx_b['height'] == 2))
+        assert((tx_a['confirmations'] == 1) ^ (tx_b['confirmations'] == 1))
 
 
 if __name__ == '__main__':

--- a/zebra-rpc/qa/rpc-tests/getrawtransaction_sidechain.py
+++ b/zebra-rpc/qa/rpc-tests/getrawtransaction_sidechain.py
@@ -1,24 +1,14 @@
 #!/usr/bin/env python3
-# Copyright (c) 2022-2024 The Zcash developers
+# Copyright (c) 2025 The Zcash developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 #
-# Test the effect of reorgs on the Orchard commitment tree.
+# Test getrawtransaction on side chains
 #
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import (
-    BLOSSOM_BRANCH_ID,
-    HEARTWOOD_BRANCH_ID,
-    CANOPY_BRANCH_ID,
-    NU5_BRANCH_ID,
-    assert_equal,
-    get_coinbase_address,
-    nuparams,
-    start_nodes,
-    wait_and_assert_operationid_status,
-)
+from test_framework.util import start_nodes
 
 
 class GetRawTransactionSideChainTest(BitcoinTestFramework):

--- a/zebra-rpc/qa/rpc-tests/getrawtransaction_sidechain.py
+++ b/zebra-rpc/qa/rpc-tests/getrawtransaction_sidechain.py
@@ -35,6 +35,7 @@ class GetRawTransactionSideChainTest(BitcoinTestFramework):
         txid_a = n.getblock("2", 1)['tx'][0]
         tx_a = n.getrawtransaction(txid_a, 1)
         assert_equal(tx_a['height'], 2)
+        assert_equal(tx_a['blockhash'], block_hash_a)
 
         # Invalidate last block (height 2)
         n.invalidateblock(block_hash_a)

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -639,7 +639,7 @@ pub trait Rpc {
     /// - `block_hash`: (hex-encoded block hash, required) The block hash to invalidate.
     // TODO: Invalidate block hashes even if they're not present in the non-finalized state (#9553).
     #[method(name = "invalidateblock")]
-    async fn invalidate_block(&self, block_hash: block::Hash) -> Result<()>;
+    async fn invalidate_block(&self, block_hash: String) -> Result<()>;
 
     /// Reconsiders a previously invalidated block if it exists in the cache of previously invalidated blocks.
     ///
@@ -647,7 +647,7 @@ pub trait Rpc {
     ///
     /// - `block_hash`: (hex-encoded block hash, required) The block hash to reconsider.
     #[method(name = "reconsiderblock")]
-    async fn reconsider_block(&self, block_hash: block::Hash) -> Result<Vec<block::Hash>>;
+    async fn reconsider_block(&self, block_hash: String) -> Result<Vec<block::Hash>>;
 
     #[method(name = "generate")]
     /// Mine blocks immediately. Returns the block hashes of the generated blocks.
@@ -2869,7 +2869,11 @@ where
         ))
     }
 
-    async fn invalidate_block(&self, block_hash: block::Hash) -> Result<()> {
+    async fn invalidate_block(&self, block_hash: String) -> Result<()> {
+        let block_hash = block_hash
+            .parse()
+            .map_error(server::error::LegacyCode::InvalidParameter)?;
+
         self.state
             .clone()
             .oneshot(zebra_state::Request::InvalidateBlock(block_hash))
@@ -2878,7 +2882,11 @@ where
             .map_misc_error()
     }
 
-    async fn reconsider_block(&self, block_hash: block::Hash) -> Result<Vec<block::Hash>> {
+    async fn reconsider_block(&self, block_hash: String) -> Result<Vec<block::Hash>> {
+        let block_hash = block_hash
+            .parse()
+            .map_error(server::error::LegacyCode::InvalidParameter)?;
+
         self.state
             .clone()
             .oneshot(zebra_state::Request::ReconsiderBlock(block_hash))

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1833,7 +1833,7 @@ where
                         {
                             zebra_state::ReadResponse::BlockHash(block_hash) => block_hash,
                             _ => unreachable!(
-                                "unmatched response to a `AnyChainTransaction` request"
+                                "unmatched response to a `BestChainBlockHash` request"
                             ),
                         };
 

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1832,9 +1832,9 @@ where
                             .map_misc_error()?
                         {
                             zebra_state::ReadResponse::BlockHash(block_hash) => block_hash,
-                            _ => unreachable!(
-                                "unmatched response to a `BestChainBlockHash` request"
-                            ),
+                            _ => {
+                                unreachable!("unmatched response to a `BestChainBlockHash` request")
+                            }
                         };
 
                         GetRawTransactionResponse::Object(Box::new(
@@ -1866,10 +1866,8 @@ where
                     )),
                 }
             } else {
-                let hex = match tx {
-                    AnyTx::Mined(mined_tx) => mined_tx.tx.into(),
-                    AnyTx::Side((transaction, _block_hash)) => transaction.into(),
-                };
+                let tx: Arc<Transaction> = tx.into();
+                let hex = tx.into();
                 GetRawTransactionResponse::Raw(hex)
             }),
 

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -345,8 +345,8 @@ proptest! {
                 .map_ok(|r| r.respond(mempool::Response::Transactions(vec![])));
 
             let state_query = state
-                .expect_request(zebra_state::ReadRequest::Transaction(unknown_txid))
-                .map_ok(|r| r.respond(zebra_state::ReadResponse::Transaction(None)));
+                .expect_request(zebra_state::ReadRequest::AnyChainTransaction(unknown_txid))
+                .map_ok(|r| r.respond(zebra_state::ReadResponse::AnyChainTransaction(None)));
 
             let rpc_query = rpc.get_raw_transaction(unknown_txid.encode_hex(), Some(1), None);
 

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -1127,7 +1127,7 @@ async fn rpc_getrawtransaction() {
             let confirmations = confirmations.expect("state requests should have confirmations");
 
             assert_eq!(hex.as_ref(), tx.zcash_serialize_to_vec().unwrap());
-            assert_eq!(height, block_idx as u32);
+            assert_eq!(height, block_idx as i32);
 
             let depth_response = read_state
                 .oneshot(zebra_state::ReadRequest::Depth(block.hash()))

--- a/zebra-rpc/src/methods/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/types/get_block_template.rs
@@ -519,6 +519,10 @@ where
     }
 
     /// Changes the extra coinbase data.
+    ///
+    /// # Panics
+    ///
+    /// If `extra_coinbase_data` exceeds [`EXTRA_COINBASE_DATA_LIMIT`].
     pub fn set_extra_coinbase_data(&mut self, extra_coinbase_data: Vec<u8>) {
         assert!(
             extra_coinbase_data.len() <= EXTRA_COINBASE_DATA_LIMIT,

--- a/zebra-rpc/src/methods/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/types/get_block_template.rs
@@ -446,6 +446,10 @@ where
     mined_block_sender: watch::Sender<(block::Hash, block::Height)>,
 }
 
+// A limit on the configured extra coinbase data, regardless of the current block height.
+// This is different from the consensus rule, which limits the total height + data.
+const EXTRA_COINBASE_DATA_LIMIT: usize = MAX_COINBASE_DATA_LEN - MAX_COINBASE_HEIGHT_DATA_LEN;
+
 impl<BlockVerifierRouter, SyncStatus> GetBlockTemplateHandler<BlockVerifierRouter, SyncStatus>
 where
     BlockVerifierRouter: Service<zebra_consensus::Request, Response = block::Hash, Error = zebra_consensus::BoxError>
@@ -478,11 +482,6 @@ where
                 panic!("miner_address can't receive transparent funds")
             }
         });
-
-        // A limit on the configured extra coinbase data, regardless of the current block height.
-        // This is different from the consensus rule, which limits the total height + data.
-        const EXTRA_COINBASE_DATA_LIMIT: usize =
-            MAX_COINBASE_DATA_LEN - MAX_COINBASE_HEIGHT_DATA_LEN;
 
         // Hex-decode to bytes if possible, otherwise UTF-8 encode to bytes.
         let extra_coinbase_data = conf
@@ -517,6 +516,17 @@ where
     /// Returns the extra coinbase data.
     pub fn extra_coinbase_data(&self) -> Vec<u8> {
         self.extra_coinbase_data.clone()
+    }
+
+    /// Changes the extra coinbase data.
+    pub fn set_extra_coinbase_data(&mut self, extra_coinbase_data: Vec<u8>) {
+        assert!(
+            extra_coinbase_data.len() <= EXTRA_COINBASE_DATA_LIMIT,
+            "extra coinbase data is {} bytes, but Zebra's limit is {}.",
+            extra_coinbase_data.len(),
+            EXTRA_COINBASE_DATA_LIMIT,
+        );
+        self.extra_coinbase_data = extra_coinbase_data;
     }
 
     /// Returns the sync status.

--- a/zebra-rpc/src/methods/types/transaction.rs
+++ b/zebra-rpc/src/methods/types/transaction.rs
@@ -628,13 +628,21 @@ impl TransactionObject {
             hex: tx.clone().into(),
             height: if in_active_chain.unwrap_or_default() {
                 height.map(|height| height.0 as i32)
-            } else {
+            } else if block_hash.is_some() {
+                // Side chain
                 Some(-1)
+            } else {
+                // Mempool
+                None
             },
             confirmations: if in_active_chain.unwrap_or_default() {
                 confirmations
-            } else {
+            } else if block_hash.is_some() {
+                // Side chain
                 Some(0)
+            } else {
+                // Mempool
+                None
             },
             inputs: tx
                 .inputs()

--- a/zebra-rpc/src/methods/types/transaction.rs
+++ b/zebra-rpc/src/methods/types/transaction.rs
@@ -8,7 +8,6 @@ use derive_getters::Getters;
 use derive_new::new;
 use hex::ToHex;
 
-use serde_with::serde_as;
 use zebra_chain::{
     amount::{self, Amount, NegativeOrZero, NonNegative},
     block::{self, merkle::AUTH_DIGEST_PLACEHOLDER, Height},

--- a/zebra-rpc/src/methods/types/transaction.rs
+++ b/zebra-rpc/src/methods/types/transaction.rs
@@ -158,13 +158,14 @@ pub struct TransactionObject {
     /// The raw transaction, encoded as hex bytes.
     #[serde(with = "hex")]
     pub(crate) hex: SerializedTransaction,
-    /// The height of the block in the best chain that contains the tx or `None` if the tx is in
-    /// the mempool.
+    /// The height of the block in the best chain that contains the tx, -1 is
+    /// it's in a side chain block, or `None` if the tx is in the mempool.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[getter(copy)]
-    pub(crate) height: Option<u32>,
-    /// The height diff between the block containing the tx and the best chain tip + 1 or `None`
-    /// if the tx is in the mempool.
+    pub(crate) height: Option<i32>,
+    /// The height diff between the block containing the tx and the best chain
+    /// tip + 1, 0 if it's in a side chain, or `None` if the tx is in the
+    /// mempool.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[getter(copy)]
     pub(crate) confirmations: Option<u32>,
@@ -625,8 +626,16 @@ impl TransactionObject {
         let block_time = block_time.map(|bt| bt.timestamp());
         Self {
             hex: tx.clone().into(),
-            height: height.map(|height| height.0),
-            confirmations,
+            height: if in_active_chain.unwrap_or_default() {
+                height.map(|height| height.0 as i32)
+            } else {
+                Some(-1)
+            },
+            confirmations: if in_active_chain.unwrap_or_default() {
+                confirmations
+            } else {
+                Some(0)
+            },
             inputs: tx
                 .inputs()
                 .iter()

--- a/zebra-rpc/src/methods/types/transaction.rs
+++ b/zebra-rpc/src/methods/types/transaction.rs
@@ -158,7 +158,7 @@ pub struct TransactionObject {
     /// The raw transaction, encoded as hex bytes.
     #[serde(with = "hex")]
     pub(crate) hex: SerializedTransaction,
-    /// The height of the block in the best chain that contains the tx, -1 is
+    /// The height of the block in the best chain that contains the tx, -1 if
     /// it's in a side chain block, or `None` if the tx is in the mempool.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[getter(copy)]

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -48,7 +48,7 @@ pub use request::{
 #[cfg(feature = "indexer")]
 pub use request::Spend;
 
-pub use response::{GetBlockTemplateChainInfo, KnownBlock, MinedTx, ReadResponse, Response};
+pub use response::{AnyTx, GetBlockTemplateChainInfo, KnownBlock, MinedTx, ReadResponse, Response};
 pub use service::{
     chain_tip::{ChainTipBlock, ChainTipChange, ChainTipSender, LatestChainTip, TipAction},
     check,

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -733,6 +733,14 @@ pub enum Request {
     /// * [`Response::Transaction(None)`](Response::Transaction) otherwise.
     Transaction(transaction::Hash),
 
+    /// Looks up a transaction by hash in the current best chain.
+    ///
+    /// Returns
+    ///
+    /// * [`Response::AnyChainTransaction(Some(Arc<Transaction>))`](Response::AnyChainTransaction) if the transaction is in the best chain;
+    /// * [`Response::AnyChainTransaction(None)`](Response::AnyChainTransaction) otherwise.
+    AnyChainTransaction(transaction::Hash),
+
     /// Looks up a UTXO identified by the given [`OutPoint`](transparent::OutPoint),
     /// returning `None` immediately if it is unknown.
     ///
@@ -884,6 +892,7 @@ impl Request {
             Request::Tip => "tip",
             Request::BlockLocator => "block_locator",
             Request::Transaction(_) => "transaction",
+            Request::AnyChainTransaction(_) => "any_chain_transaction",
             Request::UnspentBestChainUtxo { .. } => "unspent_best_chain_utxo",
             Request::Block(_) => "block",
             Request::BlockAndSize(_) => "block_and_size",
@@ -980,6 +989,16 @@ pub enum ReadRequest {
     /// * [`ReadResponse::Transaction(None)`](ReadResponse::Transaction) otherwise.
     Transaction(transaction::Hash),
 
+    /// Looks up a transaction by hash in any chain.
+    ///
+    /// Returns
+    ///
+    /// * [`ReadResponse::AnyChainTransaction(Some(AnyTx))`](ReadResponse::AnyChainTransaction)
+    ///   if the transaction is in any chain;
+    /// * [`ReadResponse::AnyChainTransaction(None)`](ReadResponse::AnyChainTransaction)
+    ///   otherwise.
+    AnyChainTransaction(transaction::Hash),
+
     /// Looks up the transaction IDs for a block, using a block hash or height.
     ///
     /// Returns
@@ -991,6 +1010,20 @@ pub enum ReadRequest {
     ///
     /// Returned txids are in the order they appear in the block.
     TransactionIdsForBlock(HashOrHeight),
+
+    /// Looks up the transaction IDs for a block, using a block hash or height,
+    /// for any chain.
+    ///
+    /// Returns
+    ///
+    /// * An ordered list of transaction hashes and a flag indicating whether
+    ///   the block is in the best chain, or
+    /// * `None` if the block was not found.
+    ///
+    /// Note: Each block has at least one transaction: the coinbase transaction.
+    ///
+    /// Returned txids are in the order they appear in the block.
+    AnyChainTransactionIdsForBlock(HashOrHeight),
 
     /// Looks up a UTXO identified by the given [`OutPoint`](transparent::OutPoint),
     /// returning `None` immediately if it is unknown.
@@ -1213,7 +1246,9 @@ impl ReadRequest {
             ReadRequest::BlockAndSize(_) => "block_and_size",
             ReadRequest::BlockHeader(_) => "block_header",
             ReadRequest::Transaction(_) => "transaction",
+            ReadRequest::AnyChainTransaction(_) => "any_chain_transaction",
             ReadRequest::TransactionIdsForBlock(_) => "transaction_ids_for_block",
+            ReadRequest::AnyChainTransactionIdsForBlock(_) => "any_chain_transaction_ids_for_block",
             ReadRequest::UnspentBestChainUtxo { .. } => "unspent_best_chain_utxo",
             ReadRequest::AnyChainUtxo { .. } => "any_chain_utxo",
             ReadRequest::BlockLocator => "block_locator",
@@ -1269,6 +1304,7 @@ impl TryFrom<Request> for ReadRequest {
             Request::BlockAndSize(hash_or_height) => Ok(ReadRequest::BlockAndSize(hash_or_height)),
             Request::BlockHeader(hash_or_height) => Ok(ReadRequest::BlockHeader(hash_or_height)),
             Request::Transaction(tx_hash) => Ok(ReadRequest::Transaction(tx_hash)),
+            Request::AnyChainTransaction(tx_hash) => Ok(ReadRequest::AnyChainTransaction(tx_hash)),
             Request::UnspentBestChainUtxo(outpoint) => {
                 Ok(ReadRequest::UnspentBestChainUtxo(outpoint))
             }

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -733,12 +733,14 @@ pub enum Request {
     /// * [`Response::Transaction(None)`](Response::Transaction) otherwise.
     Transaction(transaction::Hash),
 
-    /// Looks up a transaction by hash in the current best chain.
+    /// Looks up a transaction by hash in any chain.
     ///
     /// Returns
     ///
-    /// * [`Response::AnyChainTransaction(Some(Arc<Transaction>))`](Response::AnyChainTransaction) if the transaction is in the best chain;
-    /// * [`Response::AnyChainTransaction(None)`](Response::AnyChainTransaction) otherwise.
+    /// * [`Response::AnyChainTransaction(Some(AnyTx))`](Response::AnyChainTransaction)
+    ///   if the transaction is in any chain;
+    /// * [`Response::AnyChainTransaction(None)`](Response::AnyChainTransaction)
+    ///   otherwise.
     AnyChainTransaction(transaction::Hash),
 
     /// Looks up a UTXO identified by the given [`OutPoint`](transparent::OutPoint),

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -129,8 +129,8 @@ pub enum KnownBlock {
 pub enum AnyTx {
     /// A transaction in the best chain.
     Mined(MinedTx),
-    /// A transaction in a side chain.
-    Side(Arc<Transaction>),
+    /// A transaction in a side chain, and the hash of the block it is in.
+    Side((Arc<Transaction>, block::Hash)),
 }
 
 /// Information about a transaction in the best chain

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -133,6 +133,15 @@ pub enum AnyTx {
     Side((Arc<Transaction>, block::Hash)),
 }
 
+impl From<AnyTx> for Arc<Transaction> {
+    fn from(any_tx: AnyTx) -> Self {
+        match any_tx {
+            AnyTx::Mined(mined_tx) => mined_tx.tx,
+            AnyTx::Side((tx, _)) => tx,
+        }
+    }
+}
+
 /// Information about a transaction in the best chain
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MinedTx {

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1222,6 +1222,7 @@ impl Service<Request> for StateService {
             | Request::BestChainBlockHash(_)
             | Request::BlockLocator
             | Request::Transaction(_)
+            | Request::AnyChainTransaction(_)
             | Request::UnspentBestChainUtxo(_)
             | Request::Block(_)
             | Request::BlockAndSize(_)
@@ -1553,6 +1554,30 @@ impl Service<ReadRequest> for ReadStateService {
                 .wait_for_panics()
             }
 
+            ReadRequest::AnyChainTransaction(hash) => {
+                let state = self.clone();
+
+                tokio::task::spawn_blocking(move || {
+                    span.in_scope(move || {
+                        let tx = state.non_finalized_state_receiver.with_watch_data(
+                            |non_finalized_state| {
+                                read::any_transaction(
+                                    non_finalized_state.chain_iter(),
+                                    &state.db,
+                                    hash,
+                                )
+                            },
+                        );
+
+                        // The work is done in the future.
+                        timer.finish(module_path!(), line!(), "ReadRequest::AnyChainTransaction");
+
+                        Ok(ReadResponse::AnyChainTransaction(tx))
+                    })
+                })
+                .wait_for_panics()
+            }
+
             // Used by the getblock (verbose) RPC.
             ReadRequest::TransactionIdsForBlock(hash_or_height) => {
                 let state = self.clone();
@@ -1577,6 +1602,37 @@ impl Service<ReadRequest> for ReadStateService {
                         );
 
                         Ok(ReadResponse::TransactionIdsForBlock(transaction_ids))
+                    })
+                })
+                .wait_for_panics()
+            }
+
+            // Used by the getblock (verbose) RPC.
+            ReadRequest::AnyChainTransactionIdsForBlock(hash_or_height) => {
+                let state = self.clone();
+
+                tokio::task::spawn_blocking(move || {
+                    span.in_scope(move || {
+                        let transaction_ids = state.non_finalized_state_receiver.with_watch_data(
+                            |non_finalized_state| {
+                                read::transaction_hashes_for_any_block(
+                                    non_finalized_state.chain_iter(),
+                                    &state.db,
+                                    hash_or_height,
+                                )
+                            },
+                        );
+
+                        // The work is done in the future.
+                        timer.finish(
+                            module_path!(),
+                            line!(),
+                            "ReadRequest::AnyChainTransactionIdsForBlock",
+                        );
+
+                        Ok(ReadResponse::AnyChainTransactionIdsForBlock(
+                            transaction_ids,
+                        ))
                     })
                 })
                 .wait_for_panics()

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1604,7 +1604,6 @@ impl Service<ReadRequest> for ReadStateService {
                 .wait_for_panics()
             }
 
-            // Used by the getblock (verbose) RPC.
             ReadRequest::AnyChainTransactionIdsForBlock(hash_or_height) => {
                 let state = self.clone();
 

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -528,7 +528,11 @@ impl NonFinalizedState {
         prepared: SemanticallyVerifiedBlock,
         finalized_state: &ZebraDb,
     ) -> Result<Arc<Chain>, ValidateContextError> {
-        if self.invalidated_blocks.contains_key(&prepared.height) {
+        if self
+            .invalidated_blocks
+            .values()
+            .any(|blocks| blocks.iter().any(|block| block.hash == prepared.hash))
+        {
             return Err(ValidateContextError::BlockPreviouslyInvalidated {
                 block_hash: prepared.hash,
             });

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -29,8 +29,8 @@ pub use address::{
     utxo::{address_utxos, AddressUtxos},
 };
 pub use block::{
-    any_utxo, block, block_and_size, block_header, block_info, mined_transaction,
-    transaction_hashes_for_block, unspent_utxo,
+    any_transaction, any_utxo, block, block_and_size, block_header, block_info, mined_transaction,
+    transaction_hashes_for_any_block, transaction_hashes_for_block, unspent_utxo,
 };
 
 #[cfg(feature = "indexer")]

--- a/zebra-state/src/service/read/block.rs
+++ b/zebra-state/src/service/read/block.rs
@@ -25,7 +25,7 @@ use zebra_chain::{
 };
 
 use crate::{
-    response::MinedTx,
+    response::{AnyTx, MinedTx},
     service::{
         finalized_state::ZebraDb,
         non_finalized_state::{Chain, NonFinalizedState},
@@ -149,6 +149,42 @@ where
     Some(MinedTx::new(tx, height, confirmations, time))
 }
 
+/// Returns a [`AnyTx`] for a [`Transaction`] with [`transaction::Hash`],
+/// if one exists in any chain in `chains` or finalized `db`.
+/// The first chain in `chains` must be the best chain.
+pub fn any_transaction<'a>(
+    chains: impl Iterator<Item = &'a Arc<Chain>>,
+    db: &ZebraDb,
+    hash: transaction::Hash,
+) -> Option<AnyTx> {
+    // # Correctness
+    //
+    // It is ok to do this lookup in multiple different calls. Finalized state updates
+    // can only add overlapping blocks, and hashes are unique.
+    let mut best_chain = None;
+    let (tx, height, time, in_best_chain) = chains
+        .enumerate()
+        .find_map(|(i, chain)| {
+            chain.as_ref().transaction(hash).map(|(tx, height, time)| {
+                if i == 0 {
+                    best_chain = Some(chain);
+                }
+                (tx.clone(), height, time, i == 0)
+            })
+        })
+        .or_else(|| {
+            db.transaction(hash)
+                .map(|(tx, height, time)| (tx.clone(), height, time, true))
+        })?;
+
+    if in_best_chain {
+        let confirmations = 1 + tip_height(best_chain, db)?.0 - height.0;
+        Some(AnyTx::Mined(MinedTx::new(tx, height, confirmations, time)))
+    } else {
+        Some(AnyTx::Side(tx))
+    }
+}
+
 /// Returns the [`transaction::Hash`]es for the block with `hash_or_height`,
 /// if it exists in the non-finalized `chain` or finalized `db`.
 ///
@@ -172,6 +208,37 @@ where
         .as_ref()
         .and_then(|chain| chain.as_ref().transaction_hashes_for_block(hash_or_height))
         .or_else(|| db.transaction_hashes_for_block(hash_or_height))
+}
+
+/// Returns the [`transaction::Hash`]es for the block with `hash_or_height`,
+/// if it exists in any chain in `chains` or finalized `db`.
+/// The first chain in `chains` must be the best chain.
+///
+/// The returned hashes are in block order.
+///
+/// Returns `None` if the block is not found.
+pub fn transaction_hashes_for_any_block<'a>(
+    chains: impl Iterator<Item = &'a Arc<Chain>>,
+    db: &ZebraDb,
+    hash_or_height: HashOrHeight,
+) -> Option<(Arc<[transaction::Hash]>, bool)> {
+    // # Correctness
+    //
+    // Since blocks are the same in the finalized and non-finalized state, we
+    // check the most efficient alternative first. (`chain` is always in memory,
+    // but `db` stores blocks on disk, with a memory cache.)
+    chains
+        .enumerate()
+        .find_map(|(i, chain)| {
+            chain
+                .as_ref()
+                .transaction_hashes_for_block(hash_or_height)
+                .map(|hashes| (hashes.clone(), i == 0))
+        })
+        .or_else(|| {
+            db.transaction_hashes_for_block(hash_or_height)
+                .map(|hashes| (hashes, true))
+        })
 }
 
 /// Returns the [`Utxo`] for [`transparent::OutPoint`], if it exists in the

--- a/zebrad/src/components/tracing/component.rs
+++ b/zebrad/src/components/tracing/component.rs
@@ -97,7 +97,8 @@ impl Tracing {
         let flame_root = &config.flamegraph;
 
         // Only show the intro for user-focused node server commands like `start`
-        if uses_intro {
+        // Also skip the intro for regtest, since it pollutes the QA test logs
+        if uses_intro && !network.is_regtest() {
             // If it's a terminal and color escaping is enabled: clear screen and
             // print Zebra logo (here `use_color` is being interpreted as
             // "use escape codes")

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -3833,7 +3833,11 @@ async fn invalidate_and_reconsider_block() -> Result<()> {
     tracing::info!("invalidating blocks");
 
     // Note: This is the block at height 7, it's the 6th generated block.
-    let block_6_hash = blocks.get(5).expect("should have 50 blocks").hash();
+    let block_6_hash = blocks
+        .get(5)
+        .expect("should have 50 blocks")
+        .hash()
+        .to_string();
     let params = serde_json::to_string(&vec![block_6_hash]).expect("should serialize successfully");
 
     let _: () = rpc_client


### PR DESCRIPTION
## Motivation

Closes #9873

## Solution

Add new state methods to find blocks and transactions in any chains.
Change `getrawtransaction` to use those.

I also changed the `invalidateblock` and `reconsiderblock`, which are used in the test, because they weren't working in JSON-RPC.

### Tests

I added a Python test for this, since it seemed easier. I think those aren't being run in CI yet, but we can do that later.

```
PYTHON_DEBUG=1 CARGO_BIN_EXE_zebrad=~/zebra/target/debug/zebrad PYTHON_DEBUG=1 ./qa/rpc-tests/getrawtransaction_sidechain.py
```

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
