### PR TITLE
feat(rpc): implement getnetworkinfo RPC method

### DIFF
--- a/zebra-rpc/src/client.rs
+++ b/zebra-rpc/src/client.rs
@@ -25,7 +25,7 @@ pub use crate::methods::{
         get_blockchain_info::GetBlockchainInfoBalance,
         get_mining_info::GetMiningInfoResponse,
         get_raw_mempool::{GetRawMempoolResponse, MempoolObject},
-        network_info::NetworkInfo,
+        network_info::GetNetworkInfoResponse,
         peer_info::{GetPeerInfoResponse, PeerInfo},
         submit_block::{SubmitBlockErrorResponse, SubmitBlockResponse},
         subsidy::{BlockSubsidy, FundingStream, GetBlockSubsidyResponse},

--- a/zebra-rpc/src/client.rs
+++ b/zebra-rpc/src/client.rs
@@ -25,6 +25,7 @@ pub use crate::methods::{
         get_blockchain_info::GetBlockchainInfoBalance,
         get_mining_info::GetMiningInfoResponse,
         get_raw_mempool::{GetRawMempoolResponse, MempoolObject},
+        network_info::NetworkInfo,
         peer_info::{GetPeerInfoResponse, PeerInfo},
         submit_block::{SubmitBlockErrorResponse, SubmitBlockResponse},
         subsidy::{BlockSubsidy, FundingStream, GetBlockSubsidyResponse},

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -118,7 +118,7 @@ use types::{
     get_mining_info::GetMiningInfoResponse,
     get_raw_mempool::{self, GetRawMempoolResponse},
     long_poll::LongPollInput,
-    network_info::{Network as NetworkInfoNetwork, NetworkInfo},
+    network_info::{GetNetworkInfoResponse, NetworkInfo},
     peer_info::PeerInfo,
     submit_block::{SubmitBlockErrorResponse, SubmitBlockParameters, SubmitBlockResponse},
     subsidy::GetBlockSubsidyResponse,
@@ -2716,9 +2716,9 @@ where
 
         // TODO: make `limited`, `reachable`, and `proxy` dynamic if Zebra supports network filtering
         let networks = vec![
-            NetworkInfoNetwork::new("ipv4".to_string(), false, true, "".to_string()),
-            NetworkInfoNetwork::new("ipv6".to_string(), false, true, "".to_string()),
-            NetworkInfoNetwork::new("onion".to_string(), false, false, "".to_string()),
+            GetNetworkInfoResponse::new("ipv4".to_string(), false, true, "".to_string(), false),
+            GetNetworkInfoResponse::new("ipv6".to_string(), false, true, "".to_string(), false),
+            GetNetworkInfoResponse::new("onion".to_string(), false, false, "".to_string(), false),
         ];
 
         let relay_fee = zebra_chain::transaction::zip317::MIN_MEMPOOL_TX_FEE_RATE as f64

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -554,7 +554,7 @@ pub trait Rpc {
     /// method: post
     /// tags: network
     #[method(name = "getnetworkinfo")]
-    async fn get_network_info(&self) -> Result<NetworkInfo>;
+    async fn get_network_info(&self) -> Result<GetNetworkInfoResponse>;
 
     /// Returns data about each connected network node.
     ///
@@ -2698,7 +2698,7 @@ where
             .expect("per-second solution rate always fits in u64"))
     }
 
-    async fn get_network_info(&self) -> Result<NetworkInfo> {
+    async fn get_network_info(&self) -> Result<GetNetworkInfoResponse> {
         let version = GetInfoResponse::version_from_string(&self.build_version)
             .expect("invalid version string");
 
@@ -2716,9 +2716,9 @@ where
 
         // TODO: make `limited`, `reachable`, and `proxy` dynamic if Zebra supports network filtering
         let networks = vec![
-            GetNetworkInfoResponse::new("ipv4".to_string(), false, true, "".to_string(), false),
-            GetNetworkInfoResponse::new("ipv6".to_string(), false, true, "".to_string(), false),
-            GetNetworkInfoResponse::new("onion".to_string(), false, false, "".to_string(), false),
+            NetworkInfo::new("ipv4".to_string(), false, true, "".to_string(), false),
+            NetworkInfo::new("ipv6".to_string(), false, true, "".to_string(), false),
+            NetworkInfo::new("onion".to_string(), false, false, "".to_string(), false),
         ];
 
         let relay_fee = zebra_chain::transaction::zip317::MIN_MEMPOOL_TX_FEE_RATE as f64
@@ -2730,7 +2730,7 @@ where
         // TODO: return network-level warnings, if Zebra supports them in the future
         let warnings = "".to_string();
 
-        let response = NetworkInfo {
+        let response = GetNetworkInfoResponse {
             version,
             subversion,
             protocol_version,

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -82,7 +82,7 @@ use zebra_chain::{
     },
 };
 use zebra_consensus::{funding_stream_address, RouterError};
-use zebra_network::{address_book_peers::AddressBookPeers, PeerSocketAddr};
+use zebra_network::{address_book_peers::AddressBookPeers, types::PeerServices, PeerSocketAddr};
 use zebra_node_services::mempool;
 use zebra_state::{HashOrHeight, OutputLocation, ReadRequest, ReadResponse, TransactionLocation};
 
@@ -118,6 +118,7 @@ use types::{
     get_mining_info::GetMiningInfoResponse,
     get_raw_mempool::{self, GetRawMempoolResponse},
     long_poll::LongPollInput,
+    network_info::{Network as NetworkInfoNetwork, NetworkInfo},
     peer_info::PeerInfo,
     submit_block::{SubmitBlockErrorResponse, SubmitBlockParameters, SubmitBlockResponse},
     subsidy::GetBlockSubsidyResponse,
@@ -546,6 +547,14 @@ pub trait Rpc {
     ) -> Result<u64> {
         self.get_network_sol_ps(num_blocks, height).await
     }
+
+    /// Returns an object containing various state info regarding P2P networking.
+    ///
+    /// zcashd reference: [`getnetworkinfo`](https://zcash.github.io/rpc/getnetworkinfo.html)
+    /// method: post
+    /// tags: network
+    #[method(name = "getnetworkinfo")]
+    async fn get_network_info(&self) -> Result<NetworkInfo>;
 
     /// Returns data about each connected network node.
     ///
@@ -2687,6 +2696,54 @@ where
         Ok(solution_rate
             .try_into()
             .expect("per-second solution rate always fits in u64"))
+    }
+
+    async fn get_network_info(&self) -> Result<NetworkInfo> {
+        let version = GetInfoResponse::version_from_string(&self.build_version)
+            .expect("invalid version string");
+
+        let subversion = self.user_agent.clone();
+
+        let protocol_version = zebra_network::constants::CURRENT_NETWORK_PROTOCOL_VERSION.0;
+
+        // TODO: return actual supported local services when Zebra exposes them
+        let local_services = format!("{:016x}", PeerServices::NODE_NETWORK);
+
+        // Deprecated: zcashd always returns 0.
+        let timeoffset = 0;
+
+        let connections = self.address_book.recently_live_peers(Utc::now()).len();
+
+        // TODO: make `limited`, `reachable`, and `proxy` dynamic if Zebra supports network filtering
+        let networks = vec![
+            NetworkInfoNetwork::new("ipv4".to_string(), false, true, "".to_string()),
+            NetworkInfoNetwork::new("ipv6".to_string(), false, true, "".to_string()),
+            NetworkInfoNetwork::new("onion".to_string(), false, false, "".to_string()),
+        ];
+
+        let relay_fee = zebra_chain::transaction::zip317::MIN_MEMPOOL_TX_FEE_RATE as f64
+            / (zebra_chain::amount::COIN as f64);
+
+        // TODO: populate local addresses when Zebra supports exposing bound or advertised addresses
+        let local_addresses = vec![];
+
+        // TODO: return network-level warnings, if Zebra supports them in the future
+        let warnings = "".to_string();
+
+        let response = NetworkInfo {
+            version,
+            subversion,
+            protocol_version,
+            local_services,
+            timeoffset,
+            connections,
+            networks,
+            relay_fee,
+            local_addresses,
+            warnings,
+        };
+
+        Ok(response)
     }
 
     async fn get_peer_info(&self) -> Result<Vec<PeerInfo>> {

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -893,7 +893,10 @@ fn snapshot_rpc_getblocksubsidy(
 }
 
 /// Snapshot `getnetworkinfo` response, using `cargo insta` and JSON serialization.
-fn snapshot_rpc_getnetworkinfo(get_network_info: NetworkInfo, settings: &insta::Settings) {
+fn snapshot_rpc_getnetworkinfo(
+    get_network_info: GetNetworkInfoResponse,
+    settings: &insta::Settings,
+) {
     settings.bind(|| insta::assert_json_snapshot!("get_network_info", get_network_info));
 }
 

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -892,6 +892,11 @@ fn snapshot_rpc_getblocksubsidy(
     });
 }
 
+/// Snapshot `getnetworkinfo` response, using `cargo insta` and JSON serialization.
+fn snapshot_rpc_getnetworkinfo(get_network_info: NetworkInfo, settings: &insta::Settings) {
+    settings.bind(|| insta::assert_json_snapshot!("get_network_info", get_network_info));
+}
+
 /// Snapshot `getpeerinfo` response, using `cargo insta` and JSON serialization.
 fn snapshot_rpc_getpeerinfo(get_peer_info: Vec<PeerInfo>, settings: &insta::Settings) {
     settings.bind(|| insta::assert_json_snapshot!("get_peer_info", get_peer_info));
@@ -1112,6 +1117,13 @@ pub async fn test_mining_rpcs<State, ReadState>(
         .await
         .expect("We should have a success response");
     snapshot_rpc_getblocksubsidy("excessive_height", get_block_subsidy, &settings);
+
+    // `getnetworkinfo`
+    let get_network_info = rpc
+        .get_network_info()
+        .await
+        .expect("We should have a success response");
+    snapshot_rpc_getnetworkinfo(get_network_info, &settings);
 
     // `getpeerinfo`
     let get_peer_info = rpc

--- a/zebra-rpc/src/methods/tests/snapshots/get_network_info@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_network_info@mainnet_10.snap
@@ -1,0 +1,35 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+expression: get_network_info
+---
+{
+  "version": 100,
+  "subversion": "RPC test",
+  "protocolversion": 170130,
+  "localservices": "0000000000000001",
+  "timeoffset": 0,
+  "connections": 1,
+  "networks": [
+    {
+      "name": "ipv4",
+      "limited": false,
+      "reachable": true,
+      "proxy": ""
+    },
+    {
+      "name": "ipv6",
+      "limited": false,
+      "reachable": true,
+      "proxy": ""
+    },
+    {
+      "name": "onion",
+      "limited": false,
+      "reachable": false,
+      "proxy": ""
+    }
+  ],
+  "relayfee": 0.000001,
+  "localaddresses": [],
+  "warnings": ""
+}

--- a/zebra-rpc/src/methods/tests/snapshots/get_network_info@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_network_info@mainnet_10.snap
@@ -14,19 +14,22 @@ expression: get_network_info
       "name": "ipv4",
       "limited": false,
       "reachable": true,
-      "proxy": ""
+      "proxy": "",
+      "proxy_randomize_credentials": false
     },
     {
       "name": "ipv6",
       "limited": false,
       "reachable": true,
-      "proxy": ""
+      "proxy": "",
+      "proxy_randomize_credentials": false
     },
     {
       "name": "onion",
       "limited": false,
       "reachable": false,
-      "proxy": ""
+      "proxy": "",
+      "proxy_randomize_credentials": false
     }
   ],
   "relayfee": 0.000001,

--- a/zebra-rpc/src/methods/tests/snapshots/get_network_info@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_network_info@testnet_10.snap
@@ -1,0 +1,35 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+expression: get_network_info
+---
+{
+  "version": 100,
+  "subversion": "RPC test",
+  "protocolversion": 170130,
+  "localservices": "0000000000000001",
+  "timeoffset": 0,
+  "connections": 1,
+  "networks": [
+    {
+      "name": "ipv4",
+      "limited": false,
+      "reachable": true,
+      "proxy": ""
+    },
+    {
+      "name": "ipv6",
+      "limited": false,
+      "reachable": true,
+      "proxy": ""
+    },
+    {
+      "name": "onion",
+      "limited": false,
+      "reachable": false,
+      "proxy": ""
+    }
+  ],
+  "relayfee": 0.000001,
+  "localaddresses": [],
+  "warnings": ""
+}

--- a/zebra-rpc/src/methods/tests/snapshots/get_network_info@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_network_info@testnet_10.snap
@@ -14,19 +14,22 @@ expression: get_network_info
       "name": "ipv4",
       "limited": false,
       "reachable": true,
-      "proxy": ""
+      "proxy": "",
+      "proxy_randomize_credentials": false
     },
     {
       "name": "ipv6",
       "limited": false,
       "reachable": true,
-      "proxy": ""
+      "proxy": "",
+      "proxy_randomize_credentials": false
     },
     {
       "name": "onion",
       "limited": false,
       "reachable": false,
-      "proxy": ""
+      "proxy": "",
+      "proxy_randomize_credentials": false
     }
   ],
   "relayfee": 0.000001,

--- a/zebra-rpc/src/methods/types.rs
+++ b/zebra-rpc/src/methods/types.rs
@@ -7,6 +7,7 @@ pub mod get_mempool_info;
 pub mod get_mining_info;
 pub mod get_raw_mempool;
 pub mod long_poll;
+pub mod network_info;
 pub mod peer_info;
 pub mod submit_block;
 pub mod subsidy;

--- a/zebra-rpc/src/methods/types/network_info.rs
+++ b/zebra-rpc/src/methods/types/network_info.rs
@@ -6,7 +6,7 @@ use derive_new::new;
 ///
 /// See the notes for [`Rpc::get_network_info` method]
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct NetworkInfo {
+pub struct GetNetworkInfoResponse {
     /// The server version
     pub version: u64,
 
@@ -28,7 +28,7 @@ pub struct NetworkInfo {
     pub connections: usize,
 
     /// Information per network
-    pub networks: Vec<GetNetworkInfoResponse>,
+    pub networks: Vec<NetworkInfo>,
 
     /// Minimum relay fee rate for transactions in ZEC per 1000 bytes
     #[serde(rename = "relayfee")]
@@ -44,7 +44,7 @@ pub struct NetworkInfo {
 
 /// Information about a specific network (ipv4, ipv6, onion).
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, new)]
-pub struct GetNetworkInfoResponse {
+pub struct NetworkInfo {
     /// Network (ipv4, ipv6 or onion)
     pub name: String,
 

--- a/zebra-rpc/src/methods/types/network_info.rs
+++ b/zebra-rpc/src/methods/types/network_info.rs
@@ -28,7 +28,7 @@ pub struct NetworkInfo {
     pub connections: usize,
 
     /// Information per network
-    pub networks: Vec<Network>,
+    pub networks: Vec<GetNetworkInfoResponse>,
 
     /// Minimum relay fee rate for transactions in ZEC per 1000 bytes
     #[serde(rename = "relayfee")]
@@ -44,7 +44,7 @@ pub struct NetworkInfo {
 
 /// Information about a specific network (ipv4, ipv6, onion).
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, new)]
-pub struct Network {
+pub struct GetNetworkInfoResponse {
     /// Network (ipv4, ipv6 or onion)
     pub name: String,
 
@@ -56,6 +56,9 @@ pub struct Network {
 
     /// The proxy that is used for this network, or empty if none
     pub proxy: String,
+
+    /// Whether to randomize credentials for the proxy (present in zcashd, undocumented)
+    pub proxy_randomize_credentials: bool,
 }
 
 /// Local address info.

--- a/zebra-rpc/src/methods/types/network_info.rs
+++ b/zebra-rpc/src/methods/types/network_info.rs
@@ -1,0 +1,72 @@
+//! Types used in the `getnetworkinfo` RPC method
+
+use derive_new::new;
+
+/// Response to a `getnetworkinfo` RPC request
+///
+/// See the notes for [`Rpc::get_network_info` method]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct NetworkInfo {
+    /// The server version
+    pub version: u64,
+
+    /// The server sub-version string
+    pub subversion: String,
+
+    /// The protocol version
+    #[serde(rename = "protocolversion")]
+    pub protocol_version: u32,
+
+    /// The services we offer to the network
+    #[serde(rename = "localservices")]
+    pub local_services: String,
+
+    /// The time offset (deprecated; always 0)
+    pub timeoffset: i64,
+
+    /// The total number of connections
+    pub connections: usize,
+
+    /// Information per network
+    pub networks: Vec<Network>,
+
+    /// Minimum relay fee rate for transactions in ZEC per 1000 bytes
+    #[serde(rename = "relayfee")]
+    pub relay_fee: f64,
+
+    /// List of local network addresses
+    #[serde(rename = "localaddresses")]
+    pub local_addresses: Vec<LocalAddress>,
+
+    /// Any network warnings (such as alert messages)
+    pub warnings: String,
+}
+
+/// Information about a specific network (ipv4, ipv6, onion).
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize, new)]
+pub struct Network {
+    /// Network (ipv4, ipv6 or onion)
+    pub name: String,
+
+    /// Is the network limited using -onlynet?
+    pub limited: bool,
+
+    /// Is the network reachable?
+    pub reachable: bool,
+
+    /// The proxy that is used for this network, or empty if none
+    pub proxy: String,
+}
+
+/// Local address info.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct LocalAddress {
+    /// Network address
+    pub address: String,
+
+    /// Network port
+    pub port: u16,
+
+    /// Relative score
+    pub score: u32,
+}

--- a/zebra-rpc/tests/serialization_tests.rs
+++ b/zebra-rpc/tests/serialization_tests.rs
@@ -29,7 +29,7 @@ use zebra_rpc::client::{
     GetBlockTemplateResponse, GetBlockTransaction, GetBlockTrees, GetBlockchainInfoBalance,
     GetBlockchainInfoResponse, GetInfoResponse, GetMiningInfoResponse, GetPeerInfoResponse,
     GetRawMempoolResponse, GetRawTransactionResponse, GetSubtreesByIndexResponse,
-    GetTreestateResponse, Hash, Input, JoinSplit, MempoolObject, Orchard, OrchardAction,
+    GetTreestateResponse, Hash, Input, JoinSplit, MempoolObject, NetworkInfo, Orchard, OrchardAction,
     OrchardFlags, Output, PeerInfo, ScriptPubKey, ScriptSig, SendRawTransactionResponse,
     ShieldedOutput, ShieldedSpend, SubmitBlockErrorResponse, SubmitBlockResponse, SubtreeRpcData,
     TransactionObject, TransactionTemplate, Treestate, Utxo, ValidateAddressResponse,
@@ -1167,6 +1167,73 @@ fn test_get_mining_info() -> Result<(), Box<dyn std::error::Error>> {
         chain,
         testnet,
     );
+    assert_eq!(obj, new_obj);
+
+    Ok(())
+}
+
+#[test]
+fn test_get_network_info() -> Result<(), Box<dyn std::error::Error>> {
+    let json = r#"
+{
+  "version": 2030010,
+  "subversion": "/Zebra:2.3.0/",
+  "protocolversion": 170120,
+  "localservices": "0000000000000001",
+  "timeoffset": 0,
+  "connections": 75,
+  "networks": [
+  {
+    "name": "ipv4",
+    "limited": false,
+    "reachable": true,
+    "proxy": ""
+  },
+  {
+    "name": "ipv6",
+    "limited": false,
+    "reachable": true,
+    "proxy": ""
+  },
+  {
+    "name": "onion",
+    "limited": false,
+    "reachable": false,
+    "proxy": ""
+  }
+  ],
+  "relayfee": 1e-6,
+  "localaddresses": [],
+  "warnings": ""
+}
+"#;
+
+    let obj: NetworkInfo = serde_json::from_str(json)?;
+
+    let version = obj.version;
+    let subversion = obj.subversion.clone();
+    let protocol_version = obj.protocol_version;
+    let local_services = obj.local_services.clone();
+    let timeoffset = obj.timeoffset;
+    let connections = obj.connections;
+    let networks = obj.networks.clone();
+    let relay_fee = obj.relay_fee;
+    let local_addresses = obj.local_addresses.clone();
+    let warnings = obj.warnings.clone();
+
+    let new_obj = NetworkInfo {
+        version,
+        subversion,
+        protocol_version,
+        local_services,
+        timeoffset,
+        connections,
+        networks,
+        relay_fee,
+        local_addresses,
+        warnings,
+    };
+
     assert_eq!(obj, new_obj);
 
     Ok(())

--- a/zebra-rpc/tests/serialization_tests.rs
+++ b/zebra-rpc/tests/serialization_tests.rs
@@ -27,10 +27,10 @@ use zebra_rpc::client::{
     GetBlockHeaderResponse, GetBlockHeightAndHashResponse, GetBlockResponse,
     GetBlockSubsidyResponse, GetBlockTemplateParameters, GetBlockTemplateRequestMode,
     GetBlockTemplateResponse, GetBlockTransaction, GetBlockTrees, GetBlockchainInfoBalance,
-    GetBlockchainInfoResponse, GetInfoResponse, GetMiningInfoResponse, GetPeerInfoResponse,
-    GetRawMempoolResponse, GetRawTransactionResponse, GetSubtreesByIndexResponse,
-    GetTreestateResponse, Hash, Input, JoinSplit, MempoolObject, NetworkInfo, Orchard,
-    OrchardAction, OrchardFlags, Output, PeerInfo, ScriptPubKey, ScriptSig,
+    GetBlockchainInfoResponse, GetInfoResponse, GetMiningInfoResponse, GetNetworkInfoResponse,
+    GetPeerInfoResponse, GetRawMempoolResponse, GetRawTransactionResponse,
+    GetSubtreesByIndexResponse, GetTreestateResponse, Hash, Input, JoinSplit, MempoolObject,
+    Orchard, OrchardAction, OrchardFlags, Output, PeerInfo, ScriptPubKey, ScriptSig,
     SendRawTransactionResponse, ShieldedOutput, ShieldedSpend, SubmitBlockErrorResponse,
     SubmitBlockResponse, SubtreeRpcData, TransactionObject, TransactionTemplate, Treestate, Utxo,
     ValidateAddressResponse, ZListUnifiedReceiversResponse, ZValidateAddressResponse,
@@ -1211,7 +1211,7 @@ fn test_get_network_info() -> Result<(), Box<dyn std::error::Error>> {
 }
 "#;
 
-    let obj: NetworkInfo = serde_json::from_str(json)?;
+    let obj: GetNetworkInfoResponse = serde_json::from_str(json)?;
 
     let version = obj.version;
     let subversion = obj.subversion.clone();
@@ -1224,7 +1224,7 @@ fn test_get_network_info() -> Result<(), Box<dyn std::error::Error>> {
     let local_addresses = obj.local_addresses.clone();
     let warnings = obj.warnings.clone();
 
-    let new_obj = NetworkInfo {
+    let new_obj = GetNetworkInfoResponse {
         version,
         subversion,
         protocol_version,

--- a/zebra-rpc/tests/serialization_tests.rs
+++ b/zebra-rpc/tests/serialization_tests.rs
@@ -29,11 +29,11 @@ use zebra_rpc::client::{
     GetBlockTemplateResponse, GetBlockTransaction, GetBlockTrees, GetBlockchainInfoBalance,
     GetBlockchainInfoResponse, GetInfoResponse, GetMiningInfoResponse, GetPeerInfoResponse,
     GetRawMempoolResponse, GetRawTransactionResponse, GetSubtreesByIndexResponse,
-    GetTreestateResponse, Hash, Input, JoinSplit, MempoolObject, NetworkInfo, Orchard, OrchardAction,
-    OrchardFlags, Output, PeerInfo, ScriptPubKey, ScriptSig, SendRawTransactionResponse,
-    ShieldedOutput, ShieldedSpend, SubmitBlockErrorResponse, SubmitBlockResponse, SubtreeRpcData,
-    TransactionObject, TransactionTemplate, Treestate, Utxo, ValidateAddressResponse,
-    ZListUnifiedReceiversResponse, ZValidateAddressResponse,
+    GetTreestateResponse, Hash, Input, JoinSplit, MempoolObject, NetworkInfo, Orchard,
+    OrchardAction, OrchardFlags, Output, PeerInfo, ScriptPubKey, ScriptSig,
+    SendRawTransactionResponse, ShieldedOutput, ShieldedSpend, SubmitBlockErrorResponse,
+    SubmitBlockResponse, SubtreeRpcData, TransactionObject, TransactionTemplate, Treestate, Utxo,
+    ValidateAddressResponse, ZListUnifiedReceiversResponse, ZValidateAddressResponse,
 };
 
 #[test]
@@ -1187,19 +1187,22 @@ fn test_get_network_info() -> Result<(), Box<dyn std::error::Error>> {
     "name": "ipv4",
     "limited": false,
     "reachable": true,
-    "proxy": ""
+    "proxy": "",
+    "proxy_randomize_credentials": false
   },
   {
     "name": "ipv6",
     "limited": false,
     "reachable": true,
-    "proxy": ""
+    "proxy": "",
+    "proxy_randomize_credentials": false
   },
   {
     "name": "onion",
     "limited": false,
     "reachable": false,
-    "proxy": ""
+    "proxy": "",
+    "proxy_randomize_credentials": false
   }
   ],
   "relayfee": 1e-6,


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

<!--
- Describe the goals of the PR.
- If it closes any issues, enumerate them here.
-->

Implements the `getnetworkinfo` RPC method as specified in the [Zcash RPC documentation](https://zcash.github.io/rpc/getnetworkinfo.html).

Closes #9047.


## Solution

<!-- Describe the changes in the PR. -->

- Added `NetworkInfo`, `Network`, and `LocalAddress` structs based on the Zcash RPC specification.
- Implemented and registered the `getnetworkinfo` method in the `Rpc` trait.
- Populated available fields using internal Zebra state.


### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

- Added a serialization test and a snapshot test following the example of e.g. `getinfo`.
- Verified all `zebra-rpc` tests pass.


### Specifications & References

<!-- Provide any relevant references. -->

- [Zcash RPC docs](https://zcash.github.io/rpc/getnetworkinfo.html)


### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

- Some fields (like `localaddresses`, `limited`, `proxy`, and `warnings`) are placeholders until Zebra exposes this data.
- The `getinfo` and `getnetworkinfo` responses share a lot of overlap; they could be refactored to reduce duplication.

Feedback or suggestions on how best to handle or populate these fields would be greatly appreciated (if possible).

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [ ] The documentation is up to date.
