### PR TITLE
fix(docker): restore directory permissions handling in `entrypoint.sh`

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,6 +8,11 @@
 
 set -eo pipefail
 
+# Default cache directories for Zebra components.
+# These use the config-rs ZEBRA_SECTION__KEY format and will be picked up
+# by zebrad's configuration system automatically.
+: "${ZEBRA_STATE__CACHE_DIR:=${HOME}/.cache/zebra}"
+: "${ZEBRA_RPC__COOKIE_DIR:=${HOME}/.cache/zebra}"
 
 # Use gosu to drop privileges and execute the given command as the specified UID:GID
 exec_as_user() {
@@ -44,6 +49,11 @@ create_owned_directory() {
     chown "${UID}:${GID}" "${parent_dir}"
   fi
 }
+
+# Create and own cache and config directories based on ZEBRA_* environment variables
+[[ -n ${ZEBRA_STATE__CACHE_DIR} ]] && create_owned_directory "${ZEBRA_STATE__CACHE_DIR}"
+[[ -n ${ZEBRA_RPC__COOKIE_DIR} ]] && create_owned_directory "${ZEBRA_RPC__COOKIE_DIR}"
+[[ -n ${ZEBRA_TRACING__LOG_FILE} ]] && create_owned_directory "$(dirname "${ZEBRA_TRACING__LOG_FILE}")"
 
 # --- Optional config file support ---
 # If provided, pass a config file path through to zebrad via CONFIG_FILE_PATH.


### PR DESCRIPTION
## Motivation


The updated `entrypoint.sh` was missing the cache directory creation and permissions handling that was present in the previous version. This caused "Permission denied (os error 13)" errors in tests like `sync_full_mainnet` when `create_cached_database_height` tried to create cached database files.

The new entrypoint was designed to work with `config-rs` but didn't account for the fact that the Docker container still needs to create and secure these directories before zebrad runs.

## Solution

Restored the permissions handling in `entrypoint.sh` but updated it to work with the config-rs approach:

- **Updated environment variables** to use the `ZEBRA_SECTION__KEY` format:
  - `ZEBRA_STATE__CACHE_DIR` for state database cache directory
  - `ZEBRA_TRACING__LOG_FILE` for tracing log file directory
- **Restored directory creation calls** that create and set proper ownership (`UID:GID`) for these directories

This ensures that when zebrad loads its configuration through config-rs, the directories it will try to use already exist with the correct permissions.

### Tests

A test with the `sync_full_mainnet` must be run to confirm it runs

Test executed here: https://github.com/ZcashFoundation/zebra/actions/runs/17677566924?pr=9890

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The solution is tested.
- [x] The documentation is up to date.
