### PR TITLE
Update PR template and contribution guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -39,5 +39,7 @@
 <!-- Check as many boxes as possible. -->
 
 - [ ] The PR name is suitable for the release notes.
+- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
+- [ ] The library crate changelogs are up to date.
 - [ ] The solution is tested.
 - [ ] The documentation is up to date.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,9 @@ PRs are welcome for small and large changes, but please don't make large PRs
 without coordinating with us via the [issue tracker](https://github.com/ZcashFoundation/zebra/issues) or [Discord](https://discord.gg/yVNhQwQE68). This helps
 increase development coordination and makes PRs easier to merge. Low-effort PRs, including but not limited to fixing typos and grammatical corrections, will generally be redone by us to dissuade metric farming.
 
+Issues in this repository may not need to be addressed here, Zebra is meant to exclude any new features that are not strictly needed by the validator node. It may be desirable to implement features that support wallets, 
+block explorers, and other clients, particularly features that require database format changes, in [Zaino](https://github.com/zingolabs/zaino), [Zallet](https://github.com/zcash/wallet), or [librustzcash](https://github.com/zcash/librustzcash/). 
+
 Check out the [help wanted][hw] or [good first issue][gfi] labels if you're
 looking for a place to get started!
 


### PR DESCRIPTION
## Motivation

We want to remind authors and reviewers to:
- Update the library crate changelogs in PRs that change the public API of Zebra crates, and
- Ensure that PRs being opened follow Zebra's contribution guidelines.

We also want to update the contribution guidelines to note that we may want to implement new features which are not strictly required for a Zcash validator node in Zaino, Zallet, or librustzcash.