### PR TITLE
change(network): Broadcast block submissions to all peers in the peer set

### DIFF
--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -163,6 +163,9 @@ mod peer_set;
 mod policies;
 mod protocol;
 
+#[allow(unused)]
+pub(crate) use peer_set::PeerSet;
+
 // Wait until `arti-client`'s dependency `x25519-dalek v1.2.0` is updated to a higher version. (#5492)
 // #[cfg(feature = "tor")]
 // pub use crate::isolated::tor::connect_isolated_tor;

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -1137,7 +1137,7 @@ where
                          Handler::Finished(Ok(Response::Nil))
                     )
             }
-            (AwaitingRequest, AdvertiseBlock(hash)) => {
+            (AwaitingRequest, AdvertiseBlock(hash) | AdvertiseBlockToAll(hash)) => {
                 self
                     .peer_tx
                     .send(Message::Inv(vec![hash.into()]))

--- a/zebra-network/src/peer_set.rs
+++ b/zebra-network/src/peer_set.rs
@@ -10,6 +10,6 @@ pub(crate) use inventory_registry::InventoryChange;
 pub(crate) use limit::{ActiveConnectionCounter, ConnectionTracker};
 
 use inventory_registry::InventoryRegistry;
-use set::PeerSet;
+pub(crate) use set::PeerSet;
 
 pub use initialize::init;

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -1011,6 +1011,7 @@ where
     /// Broadcasts the same request to all ready peers, ignoring return values.
     fn broadcast_all(&mut self, req: Request) -> <Self as tower::Service<Request>>::Future {
         // Broadcasts ignore the response
+        // TODO: If there are some unready peers, queue the request to be sent to the current list of unready peers when they become ready.
         let all_ready_peers = self.ready_services.keys().copied().collect();
         self.send_multiple(req, all_ready_peers)
     }

--- a/zebra-network/src/protocol/internal/request.rs
+++ b/zebra-network/src/protocol/internal/request.rs
@@ -178,7 +178,8 @@ pub enum Request {
     /// [`init`](crate::init).
     ///
     /// The peer set routes this request specially, sending it to *a fraction of*
-    /// the available peers. See [`PeerSet::number_of_peers_to_broadcast`] for more details.
+    /// the available peers. See [`number_of_peers_to_broadcast()`](crate::PeerSet::number_of_peers_to_broadcast)
+    /// for more details.
     ///
     /// # Returns
     ///

--- a/zebra-network/src/protocol/internal/request.rs
+++ b/zebra-network/src/protocol/internal/request.rs
@@ -177,13 +177,19 @@ pub enum Request {
     /// [`Request::BlocksByHash`] against the "inbound" service passed to
     /// [`init`](crate::init).
     ///
-    /// The peer set routes this request specially, sending it to *half of*
-    /// the available peers.
+    /// The peer set routes this request specially, sending it to *a fraction of*
+    /// the available peers. See [`PeerSet::number_of_peers_to_broadcast`] for more details.
     ///
     /// # Returns
     ///
     /// Returns [`Response::Nil`](super::Response::Nil).
     AdvertiseBlock(block::Hash),
+
+    /// Advertise a block to all ready peers. This is equivalent to
+    /// [`Request::AdvertiseBlock`] except that the peer set will route
+    /// this request to all available ready peers. Used by the gossip task
+    /// to broadcast mined blocks to all ready peers.
+    AdvertiseBlockToAll(block::Hash),
 
     /// Request the contents of this node's mempool.
     ///
@@ -221,6 +227,7 @@ impl fmt::Display for Request {
             }
 
             Request::AdvertiseBlock(_) => "AdvertiseBlock".to_string(),
+            Request::AdvertiseBlockToAll(_) => "AdvertiseBlockToAll".to_string(),
             Request::MempoolTransactionIds => "MempoolTransactionIds".to_string(),
         })
     }
@@ -242,7 +249,7 @@ impl Request {
             Request::PushTransaction(_) => "PushTransaction",
             Request::AdvertiseTransactionIds(_) => "AdvertiseTransactionIds",
 
-            Request::AdvertiseBlock(_) => "AdvertiseBlock",
+            Request::AdvertiseBlock(_) | Request::AdvertiseBlockToAll(_) => "AdvertiseBlock",
             Request::MempoolTransactionIds => "MempoolTransactionIds",
         }
     }

--- a/zebra-rpc/qa/rpc-tests/addnode.py
+++ b/zebra-rpc/qa/rpc-tests/addnode.py
@@ -70,13 +70,9 @@ class AddNodeTest (BitcoinTestFramework):
         for i in range(0, len(self.nodes)):
             assert_equal(self.nodes[i].getbestblockheightandhash()['height'], 4)
 
-        # TODO: We can't do generate(x | x > 1) because the Zebra `submitblock` RPC
-        # will broadcast only the last block to the network.
-        # Instead, we can mine 10 blocks in a loop
         # Mine 10 blocks from node0
-        for n in range(1, 11):
-            self.nodes[0].generate(1)
-            self.sync_all(False)
+        self.nodes[0].generate(10)
+        self.sync_all(False)
 
         for i in range(0, len(self.nodes)):
             assert_equal(self.nodes[i].getbestblockheightandhash()['height'], 14)

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -2559,7 +2559,11 @@ where
 
                 self.gbt
                     .advertise_mined_block(hash, height)
-                    .map_error_with_prefix(0, "failed to send mined block")?;
+                    .map_error_with_prefix(
+                        0,
+                        "failed to send mined block to gossip task, \
+                         mined block channel is closed, block gossip task may have unexpectedly exited",
+                    )?;
 
                 return Ok(SubmitBlockResponse::Accepted);
             }

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -50,7 +50,7 @@ use jsonrpsee::core::{async_trait, RpcResult as Result};
 use jsonrpsee_proc_macros::rpc;
 use jsonrpsee_types::{ErrorCode, ErrorObject};
 use tokio::{
-    sync::{broadcast, watch},
+    sync::{broadcast, mpsc, watch},
     task::JoinHandle,
 };
 use tower::{Service, ServiceExt};
@@ -880,7 +880,7 @@ where
         latest_chain_tip: Tip,
         address_book: AddressBook,
         last_warn_error_log_rx: LoggedLastEvent,
-        mined_block_sender: Option<watch::Sender<(block::Hash, block::Height)>>,
+        mined_block_sender: Option<mpsc::Sender<(block::Hash, block::Height)>>,
     ) -> (Self, JoinHandle<()>)
     where
         VersionString: ToString + Clone + Send + 'static,
@@ -2559,11 +2559,7 @@ where
 
                 self.gbt
                     .advertise_mined_block(hash, height)
-                    .map_error_with_prefix(
-                        0,
-                        "failed to send mined block to gossip task, \
-                         mined block channel is closed, block gossip task may have unexpectedly exited",
-                    )?;
+                    .map_error_with_prefix(0, "failed to send mined block to gossip task")?;
 
                 return Ok(SubmitBlockResponse::Accepted);
             }

--- a/zebra-rpc/src/methods/types/submit_block.rs
+++ b/zebra-rpc/src/methods/types/submit_block.rs
@@ -80,7 +80,15 @@ pub struct SubmitBlockChannel {
 impl SubmitBlockChannel {
     /// Creates a new submit block channel
     pub fn new() -> Self {
-        let (sender, receiver) = mpsc::channel(10_000);
+        /// How many unread messages the submit block channel should buffer before rejecting sends.
+        ///
+        /// This should be large enough to usually avoid rejecting sends. This channel is used by
+        /// the block hash gossip task, which waits for a ready peer in the peer set while
+        /// processing messages from this channel and could be much slower to gossip block hashes
+        /// than it is to commit blocks and produce new block templates.
+        const SUBMIT_BLOCK_CHANNEL_CAPACITY: usize = 10_000;
+
+        let (sender, receiver) = mpsc::channel(SUBMIT_BLOCK_CHANNEL_CAPACITY);
         Self { sender, receiver }
     }
 

--- a/zebra-rpc/src/methods/types/submit_block.rs
+++ b/zebra-rpc/src/methods/types/submit_block.rs
@@ -1,8 +1,8 @@
 //! Parameter and response types for the `submitblock` RPC.
 
-use tokio::sync::watch;
+use tokio::sync::mpsc;
 
-use zebra_chain::{block, parameters::GENESIS_PREVIOUS_BLOCK_HASH};
+use zebra_chain::block;
 
 // Allow doc links to these imports.
 #[allow(unused_imports)]
@@ -72,26 +72,26 @@ impl From<SubmitBlockErrorResponse> for SubmitBlockResponse {
 /// A submit block channel, used to inform the gossip task about mined blocks.
 pub struct SubmitBlockChannel {
     /// The channel sender
-    sender: watch::Sender<(block::Hash, block::Height)>,
+    sender: mpsc::Sender<(block::Hash, block::Height)>,
     /// The channel receiver
-    receiver: watch::Receiver<(block::Hash, block::Height)>,
+    receiver: mpsc::Receiver<(block::Hash, block::Height)>,
 }
 
 impl SubmitBlockChannel {
-    /// Create a new submit block channel
+    /// Creates a new submit block channel
     pub fn new() -> Self {
-        let (sender, receiver) = watch::channel((GENESIS_PREVIOUS_BLOCK_HASH, block::Height::MIN));
+        let (sender, receiver) = mpsc::channel(10_000);
         Self { sender, receiver }
     }
 
     /// Get the channel sender
-    pub fn sender(&self) -> watch::Sender<(block::Hash, block::Height)> {
+    pub fn sender(&self) -> mpsc::Sender<(block::Hash, block::Height)> {
         self.sender.clone()
     }
 
     /// Get the channel receiver
-    pub fn receiver(&self) -> watch::Receiver<(block::Hash, block::Height)> {
-        self.receiver.clone()
+    pub fn receiver(self) -> mpsc::Receiver<(block::Hash, block::Height)> {
+        self.receiver
     }
 }
 

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -554,6 +554,11 @@ impl ChainTipChange {
         Some(tip_action)
     }
 
+    /// Sets the `last_change_hash` as the provided hash.
+    pub fn mark_last_change_hash(&mut self, hash: block::Hash) {
+        self.last_change_hash = Some(hash);
+    }
+
     /// Return an action based on `block` and the last change we returned.
     fn action(&self, block: ChainTipBlock) -> TipAction {
         // check for an edge case that's dealt with by other code

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -556,6 +556,8 @@ impl Service<zn::Request> for Inbound {
             zn::Request::Ping(_) => {
                 unreachable!("ping requests are handled internally");
             }
+
+            zn::Request::AdvertiseBlockToAll(_) => unreachable!("should always be decoded as `AdvertiseBlock` request")
         }
     }
 }

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -1002,6 +1002,8 @@ async fn setup(
     //
     // (The genesis block gets skipped, because block 1 is committed before the task is spawned.)
     for block in committed_blocks.iter().skip(1) {
+        tokio::time::sleep(PEER_GOSSIP_DELAY).await;
+
         peer_set
             .expect_request(Request::AdvertiseBlock(block.hash()))
             .await

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -873,6 +873,12 @@ mod submitblock_test {
 
         // Start the block gossip task with a SubmitBlockChannel
         let submitblock_channel = SubmitBlockChannel::new();
+        // Send a block top the channel
+        submitblock_channel
+            .sender()
+            .send((block::Hash([1; 32]), block::Height(1)))
+            .await
+            .unwrap();
         let gossip_task_handle = tokio::spawn(
             sync::gossip_best_tip_block_hashes(
                 sync_status.clone(),
@@ -882,12 +888,6 @@ mod submitblock_test {
             )
             .in_current_span(),
         );
-
-        // Send a block top the channel
-        submitblock_channel
-            .sender()
-            .send((block::Hash([1; 32]), block::Height(1)))
-            .unwrap();
 
         // Wait for the block gossip task to process the block
         tokio::time::sleep(PEER_GOSSIP_DELAY).await;

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -873,7 +873,7 @@ mod submitblock_test {
 
         // Start the block gossip task with a SubmitBlockChannel
         let submitblock_channel = SubmitBlockChannel::new();
-        // Send a block top the channel
+        // Send a block to the channel
         submitblock_channel
             .sender()
             .send((block::Hash([1; 32]), block::Height(1)))

--- a/zebrad/src/components/sync/gossip.rs
+++ b/zebrad/src/components/sync/gossip.rs
@@ -64,9 +64,14 @@ where
     let mut broadcast_network = Timeout::new(broadcast_network, TIPS_RESPONSE_TIMEOUT);
 
     loop {
+        // TODO: Refactor this into a struct and move the contents of this loop into its own method.
         let mut sync_status = sync_status.clone();
         let mut chain_tip = chain_state.clone();
+
+        // TODO: Move the contents of this async block to its own method
         let tip_change_close_to_network_tip_fut = async move {
+            /// A brief duration to wait after a tip change for a new message in the mined block channel.
+            // TODO: Add a test to check that Zebra does not advertise mined blocks to peers twice.
             const WAIT_FOR_BLOCK_SUBMISSION_DELAY: Duration = Duration::from_micros(100);
 
             // wait for at least the network timeout between gossips
@@ -101,6 +106,7 @@ where
         }
         .in_current_span();
 
+        // TODO: Move this logic for selecting the first ready future and updating `chain_state` to its own method.
         let (((hash, height), log_msg, updated_chain_state), is_block_submission) =
             if let Some(mined_block_receiver) = mined_block_receiver.as_mut() {
                 tokio::select! {
@@ -117,6 +123,8 @@ where
             };
 
         chain_state = updated_chain_state;
+
+        // TODO: Move logic for calling the peer set to its own method.
 
         // block broadcasts inform other nodes about new blocks,
         // so our internal Grow or Reset state doesn't matter to them
@@ -137,6 +145,8 @@ where
         // `AdvertiseBlockToAll` requests when there are unready peers.
         // Broadcast requests don't return errors, and we'd just want to ignore them anyway.
         tokio::spawn(broadcast_fut);
+
+        // TODO: Move this logic for marking the last change hash as seen to its own method.
 
         // Mark the last change hash of `chain_state` as the last block submission hash to avoid
         // advertising a block hash to some peers twice.

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -3453,7 +3453,8 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
     );
 
     // Check that the submitblock channel received the submitted block
-    let submit_block_channel_data = *submitblock_channel.receiver().borrow_and_update();
+    let mut submit_block_receiver = submitblock_channel.receiver();
+    let submit_block_channel_data = submit_block_receiver.recv().await.expect("channel is open");
     assert_eq!(
         submit_block_channel_data,
         (


### PR DESCRIPTION
## Motivation

It would be nice to broadcast accepted block submissions to all ready peers.

## Solution

- Adds a `AdvertiseBlockToAll` variant to the zebra-network `Request` type
- Handles the new request variant in the peer set by sending it to all ready peers
  - Factors logic for sending a request to multiple peers out of `route_multiple()`
  - Adds a `broadcast_all()` method which sends a request to every ready peer
- Updates the `gossip_best_tip_block_hashes()` task to call the peer set with a `AdvertiseBlockToAll` request instead of `AdvertiseBlock` if the block hash/height being advertised were received from the mined block channel.

Related changes:
- Corrects a doc comment on `AdvertiseBlock` (it routes to a third of ready peers, not half)
- Updates error message from the `submitblock` RPC when the mined block channel is closed


### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
