### PR TITLE
change(rpc): Always return `1.0` from `getblockchaininfo` as the verification progress on Regtest

### DIFF
--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1089,6 +1089,12 @@ where
             // TODO: Add a `genesis_block_time()` method on `Network` to use here.
             .unwrap_or((Height::MIN, 0.0));
 
+        let verification_progress = if network.is_regtest() {
+            1.0
+        } else {
+            verification_progress
+        };
+
         // `upgrades` object
         //
         // Get the network upgrades in height order, like `zcashd`.


### PR DESCRIPTION
## Motivation

We want to match `zcashd`'s RPC output on Regtest.

Closes #9904.

## Solution

Always return 1.0 from the `getblockchaininfo` RPC as the verification progress.

### Tests

<details>
<summary>
Manually tested
</summary>

`curl --data-binary '{"jsonrpc": "1.0", "id":"curltest", "method": "getblockchaininfo", "params": [] }' -H 'Content-type: application/json' http://127.0.0.1:8300/ | jq`

</details>

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
