### PR TITLE
Reduce config dump logging level to debug to avoid leaking sensitive data

### DIFF
--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -469,7 +469,7 @@ impl Application for ZebradApp {
                 info!("No config file provided, using default configuration");
             }
 
-            info!("{config:?}");
+            debug!("{config:?}");
 
             // Explicitly log the configured miner address so CI can assert env override
             if let Some(miner_address) = &config.mining.miner_address {


### PR DESCRIPTION

```markdown
### Summary
Lower the full configuration dump from info to debug level to reduce the risk of exposing sensitive settings in production logs.

### What Changed
- `zebrad/src/application.rs`: `info!("{config:?}")` → `debug!("{config:?}")`

### Rationale
Dumping the entire config at info level can inadvertently log secrets or internal endpoints. Debug level preserves diagnostic value without polluting standard operational logs.
```
