### PR TITLE
fix(ci): disk mounts, alls-green conditions, and permissions

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -56,8 +56,12 @@ jobs:
   release-binaries-success:
     name: Release binaries success
     runs-on: ubuntu-latest
-    # Always run this job to check the status of dependent jobs
-    if: always()
+    # Only run when the Docker Hub update job is allowed to execute
+    if: >-
+      ${{
+        always() &&
+        github.repository_owner == 'ZcashFoundation'
+      }}
     needs:
       - build
       - dockerhub-description

--- a/.github/workflows/zfnd-ci-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-ci-integration-tests-gcp.yml
@@ -633,7 +633,12 @@ jobs:
   integration-tests-success:
     name: integration tests success
     runs-on: ubuntu-latest
-    if: ${{ always() && (github.event_name != 'pull_request' || github.event.label.name == 'run-stateful-tests') }}
+    if: >-
+      ${{
+        always() &&
+        (!startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork) &&
+        (github.event_name != 'pull_request' || github.event.label.name == 'run-stateful-tests')
+      }}
     needs:
       - build
       - sync-to-mandatory-checkpoint

--- a/.github/workflows/zfnd-ci-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-ci-integration-tests-gcp.yml
@@ -197,6 +197,8 @@ jobs:
     concurrency:
       group: ${{ github.event_name == 'workflow_dispatch' && format('manual-{0}-sync-to-mandatory-checkpoint', github.run_id) || 'sync-to-mandatory-checkpoint' }}
       cancel-in-progress: false
+    secrets:
+      GCP_SSH_PRIVATE_KEY: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
     with:
       app_name: zebrad
       test_id: sync-to-mandatory-checkpoint
@@ -223,6 +225,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/zfnd-deploy-integration-tests-gcp.yml
     if: ${{ !cancelled() && !failure() && (fromJSON(needs.get-available-disks.outputs.zebra_checkpoint_disk) || needs.sync-to-mandatory-checkpoint.result == 'success') && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
+    secrets:
+      GCP_SSH_PRIVATE_KEY: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
     with:
       app_name: zebrad
       test_id: sync-past-mandatory-checkpoint
@@ -256,6 +260,8 @@ jobs:
     concurrency:
       group: ${{ github.event_name == 'workflow_dispatch' && format('manual-{0}-sync-full-mainnet', github.run_id) || 'sync-full-mainnet' }}
       cancel-in-progress: false
+    secrets:
+      GCP_SSH_PRIVATE_KEY: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
     with:
       app_name: zebrad
       test_id: sync-full-mainnet
@@ -286,6 +292,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/zfnd-deploy-integration-tests-gcp.yml
     if: ${{ !cancelled() && !failure() && (fromJSON(needs.get-available-disks.outputs.zebra_tip_disk) || needs.sync-full-mainnet.result == 'success') && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
+    secrets:
+      GCP_SSH_PRIVATE_KEY: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
     with:
       app_name: zebrad
       test_id: sync-update-mainnet
@@ -318,6 +326,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/zfnd-deploy-integration-tests-gcp.yml
     if: ${{ !cancelled() && !failure() && (fromJSON(needs.get-available-disks.outputs.zebra_tip_disk) || needs.sync-full-mainnet.result == 'success') && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
+    secrets:
+      GCP_SSH_PRIVATE_KEY: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
     with:
       app_name: zebrad
       test_id: generate-checkpoints-mainnet
@@ -355,6 +365,8 @@ jobs:
     concurrency:
       group: ${{ github.event_name == 'workflow_dispatch' && format('manual-{0}-sync-full-testnet', github.run_id) || 'sync-full-testnet' }}
       cancel-in-progress: false
+    secrets:
+      GCP_SSH_PRIVATE_KEY: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
     with:
       app_name: zebrad
       test_id: sync-full-testnet
@@ -388,6 +400,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/zfnd-deploy-integration-tests-gcp.yml
     if: ${{ !cancelled() && !failure() && (fromJSON(needs.get-available-disks-testnet.outputs.zebra_tip_disk) || needs.sync-full-testnet.result == 'success') && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
+    secrets:
+      GCP_SSH_PRIVATE_KEY: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
     with:
       app_name: zebrad
       test_id: generate-checkpoints-testnet
@@ -424,6 +438,8 @@ jobs:
     concurrency:
       group: ${{ github.event_name == 'workflow_dispatch' && format('manual-{0}-lwd-sync-full', github.run_id) || 'lwd-sync-full' }}
       cancel-in-progress: false
+    secrets:
+      GCP_SSH_PRIVATE_KEY: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
     with:
       app_name: lightwalletd
       test_id: lwd-sync-full
@@ -453,6 +469,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/zfnd-deploy-integration-tests-gcp.yml
     if: ${{ !cancelled() && !failure() && (inputs.network || vars.ZCASH_NETWORK) == 'Mainnet' && (fromJSON(needs.get-available-disks.outputs.lwd_tip_disk) || needs.lwd-sync-full.result == 'success') && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
+    secrets:
+      GCP_SSH_PRIVATE_KEY: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
     with:
       app_name: lightwalletd
       test_id: lwd-sync-update
@@ -483,6 +501,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/zfnd-deploy-integration-tests-gcp.yml
     if: ${{ !cancelled() && !failure() && (inputs.network || vars.ZCASH_NETWORK) == 'Mainnet' && (fromJSON(needs.get-available-disks.outputs.zebra_tip_disk) || needs.sync-full-mainnet.result == 'success') && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
+    secrets:
+      GCP_SSH_PRIVATE_KEY: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
     with:
       app_name: lightwalletd
       test_id: lwd-rpc-test
@@ -507,6 +527,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/zfnd-deploy-integration-tests-gcp.yml
     if: ${{ !cancelled() && !failure() && (inputs.network || vars.ZCASH_NETWORK) == 'Mainnet' && (fromJSON(needs.get-available-disks.outputs.lwd_tip_disk) || needs.lwd-sync-full.result == 'success') && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
+    secrets:
+      GCP_SSH_PRIVATE_KEY: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
     with:
       app_name: lightwalletd
       test_id: lwd-rpc-send-tx
@@ -532,6 +554,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/zfnd-deploy-integration-tests-gcp.yml
     if: ${{ !cancelled() && !failure() && (inputs.network || vars.ZCASH_NETWORK) == 'Mainnet' && (fromJSON(needs.get-available-disks.outputs.lwd_tip_disk) || needs.lwd-sync-full.result == 'success') && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
+    secrets:
+      GCP_SSH_PRIVATE_KEY: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
     with:
       app_name: lightwalletd
       test_id: lwd-grpc-wallet
@@ -561,6 +585,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/zfnd-deploy-integration-tests-gcp.yml
     if: ${{ !cancelled() && !failure() && (fromJSON(needs.get-available-disks.outputs.zebra_tip_disk) || needs.sync-full-mainnet.result == 'success') && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
+    secrets:
+      GCP_SSH_PRIVATE_KEY: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
     with:
       app_name: zebrad
       test_id: rpc-get-block-template
@@ -586,6 +612,8 @@ jobs:
       id-token: write
     uses: ./.github/workflows/zfnd-deploy-integration-tests-gcp.yml
     if: ${{ !cancelled() && !failure() && (fromJSON(needs.get-available-disks.outputs.zebra_tip_disk) || needs.sync-full-mainnet.result == 'success') && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
+    secrets:
+      GCP_SSH_PRIVATE_KEY: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
     with:
       app_name: zebrad
       test_id: rpc-submit-block

--- a/.github/workflows/zfnd-delete-gcp-resources.yml
+++ b/.github/workflows/zfnd-delete-gcp-resources.yml
@@ -152,8 +152,12 @@ jobs:
   delete-resources-success:
     name: Delete GCP resources success
     runs-on: ubuntu-latest
-    # Always run this job to check the status of dependent jobs
-    if: always()
+    # Only run when the owner-specific cleanup jobs were eligible to execute
+    if: >-
+      ${{
+        always() &&
+        github.repository_owner == 'ZcashFoundation'
+      }}
     needs:
       - delete-resources
       - clean-registries

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -78,6 +78,9 @@ on:
         type: string
         default: zebra
         description: Application name, used to work out when a job is an update job
+    secrets:
+      GCP_SSH_PRIVATE_KEY:
+        required: true
 
 env:
   RUST_LOG: ${{ vars.RUST_LOG }}

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -772,3 +772,4 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe #v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
+          allowed-skips: ${{ (inputs.saves_to_disk || inputs.force_save_to_disk) && '' || 'create-state-image' }}

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -115,6 +115,9 @@ jobs:
   #
   get-disk-name:
     name: Get disk name
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/zfnd-find-cached-disks.yml
     if: ${{ (inputs.needs_zebra_state || inputs.needs_lwd_state) || (inputs.saves_to_disk || inputs.force_save_to_disk) }}
     with:

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -229,47 +229,11 @@ jobs:
             DISK_ATTACH_PARAMS="--create-disk=${DISK_PARAMS}"
           fi
 
-          # Mount the disk(s) to the container
-          # This partition=1 logic differentiates between disk types:
-          # - Only Zebra tip disks (from full sync) have partitions and need partition=1
-          # - LWD disks never have partitions
-          # - Checkpoint disks don't have partitions
-          # TODO: Consider removing this logic once all cached disk images use consistent partitioning.
-
-          # Determine if we should use partition=1 based on specific test requirements
-          # Default to safe approach: no partitions unless explicitly whitelisted
-          USE_PARTITION="false"
-          if [ -n "${{ env.CACHED_DISK_NAME }}" ]; then
-            # All tests that use Zebra tip disks (which have partitions)
-            if [[ "${{ inputs.test_id }}" == "sync-update-mainnet" ]] || \
-               [[ "${{ inputs.test_id }}" == "sync-full-mainnet" ]] || \
-               [[ "${{ inputs.test_id }}" == "generate-checkpoints-mainnet" ]] || \
-               [[ "${{ inputs.test_id }}" == "lwd-rpc-test" ]] || \
-               [[ "${{ inputs.test_id }}" == "rpc-get-block-template" ]] || \
-               [[ "${{ inputs.test_id }}" == "rpc-submit-block" ]]; then
-              USE_PARTITION="true"
-              echo "Using Zebra tip disk with partition=1: ${{ env.CACHED_DISK_NAME }}"
-            # All other tests default to no partition for safety
-            else
-              USE_PARTITION="false"
-              echo "Using cached disk without partition (safe default): ${{ env.CACHED_DISK_NAME }}"
-            fi
-          fi
-
-          # Mount zebra state directory
-          if [[ "$USE_PARTITION" == "true" ]]; then
-            CONTAINER_MOUNT_DISKS="--container-mount-disk=mount-path=${{ inputs.zebra_state_dir }},name=${NAME},mode=rw,partition=1"
-          else
-            CONTAINER_MOUNT_DISKS="--container-mount-disk=mount-path=${{ inputs.zebra_state_dir }},name=${NAME},mode=rw"
-          fi
+          CONTAINER_MOUNT_DISKS="--container-mount-disk=mount-path=${{ inputs.zebra_state_dir }},name=${NAME},mode=rw"
 
           # Mount the same disk to the lwd path if needed
           if [[ "${{ inputs.needs_lwd_state }}" == "true" || "${{ inputs.test_id }}" == "lwd-sync-full" ]]; then
-            if [[ "$USE_PARTITION" == "true" ]]; then
-              CONTAINER_MOUNT_DISKS+=" --container-mount-disk=mount-path=${{ inputs.lwd_state_dir }},name=${NAME},mode=rw,partition=1"
-            else
-              CONTAINER_MOUNT_DISKS+=" --container-mount-disk=mount-path=${{ inputs.lwd_state_dir }},name=${NAME},mode=rw"
-            fi
+            CONTAINER_MOUNT_DISKS+=" --container-mount-disk=mount-path=${{ inputs.lwd_state_dir }},name=${NAME},mode=rw"
           fi
 
           # Environment variables for the container

--- a/.github/workflows/zfnd-deploy-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-nodes-gcp.yml
@@ -375,8 +375,12 @@ jobs:
   deploy-nodes-success:
     name: Deploy nodes success
     runs-on: ubuntu-latest
-    # Always run this job to check the status of dependent jobs
-    if: always()
+    # Only run when the deployment job actually executed
+    if: >-
+      ${{
+        always() &&
+        needs.deploy-nodes.result != 'skipped'
+      }}
     needs:
       - versioning
       - get-disk-name
@@ -389,6 +393,7 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe #v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
+          allowed-skips: versioning
 
   failure-issue:
     name: Open or update issues for release failures


### PR DESCRIPTION
## Motivation

- Keep CI from failing when cached disks lack partitions.
- Ensure the Alls-Green aggregation job reflects the actual dependency guards.
- Minimize permissions for reusable workflows and secrets.

## Solution

- align every Alls-Green “success” job with the dependency conditions and add `allowed-skips` where needed so the aggregator only runs when its inputs are eligible.
- `declare `id-token: write` exactly where the reusable GCP deploy workflow needs it.
- pass `GCP_SSH_PRIVATE_KEY` explicitly from callers and require it in the reusable workflow, avoiding inherited secrets.
- drop the partition-specific mount logic so cached state disks attach as whole devices regardless of layout.

### Tests

- Kick off the CI pipelines that mount cached disks (e.g., `sync-update-mainnet`, `rpc-*`) to confirm they succeed without partition parameters. 

### Specifications & References

- Internal Zebra CI workflows.

### PR Checklist

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the contribution guidelines.
- [ ] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
