### PR TITLE
refactor(state): improve error propagation for ReconsiderError

### DIFF
--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -59,6 +59,15 @@ pub enum ReconsiderError {
     #[error("Invalidated blocks list is empty when it should contain at least one block")]
     InvalidatedBlocksEmpty,
 
+    #[error("cannot reconsider blocks while still committing checkpointed blocks")]
+    CheckpointCommitInProgress,
+
+    #[error("failed to send reconsider block request to block write task")]
+    ReconsiderSendFailed,
+
+    #[error("reconsider block request was unexpectedly dropped")]
+    ReconsiderResponseDropped,
+
     #[error("{0}")]
     ValidationError(#[from] Box<ValidateContextError>),
 }


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

<!--
- Describe the goals of the PR.
- If it closes any issues, enumerate them here.
-->

This PR addresses #9730 and focuses on the `ReconsiderBlock` path.


## Solution

<!-- Describe the changes in the PR. -->

- Used and extended `ReconsiderError` already defined in `error.rs`.
- Replaced the boxed error type in the `ReconsiderBlock` response with the concrete `ReconsiderError` type.
- Adjusted the channels and error handling in `write.rs`.


### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

- All existing tests passed successfully.
- `cargo fmt` and `cargo clippy` without warnings.


### Specifications & References

<!-- Provide any relevant references. -->

- #9730


### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

- Consider adding more targeted comments or clarifying documentation (as outlined in the issue). Maybe later in a cleanup PR when all paths are implemented.


### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The library crate changelogs are up to date.
- [x] The solution is tested.
- [ ] The documentation is up to date.
