### PR TITLE
refactor(state): improve error propagation for InvalidateBlock

### DIFF
--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -110,21 +110,20 @@ impl<E: std::error::Error + 'static> From<BoxError> for LayeredStateError<E> {
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum InvalidateError {
-    #[error("cannot invalidate blocks while still committing checkpointed blocks")]
     /// The state is currently checkpointing blocks and cannot accept invalidation requests.
-    CannotInvalidateWhileCheckpointing,
+    #[error("cannot invalidate blocks while still committing checkpointed blocks")]
+    ProcessingCheckpointedBlocks,
 
-    #[error("failed to send invalidate block request to block write task")]
     /// Sending the invalidate request to the block write task failed.
+    #[error("failed to send invalidate block request to block write task")]
     SendInvalidateRequestFailed,
 
-    #[error("invalidate block request was unexpectedly dropped")]
     /// The invalidate request was dropped before processing.
+    #[error("invalidate block request was unexpectedly dropped")]
     InvalidateRequestDropped,
 
-    #[error("contextual validation of the block failed")]
-    /// The block failed contextual validation during invalidation.
-    ValidationError(#[from] ValidateContextError),
+    #[error("block hash {0} not found in any non-finalized chain")]
+    BlockNotFound(block::Hash),
 }
 
 /// An error describing why a `ReconsiderBlock` request failed.

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -127,30 +127,37 @@ pub enum InvalidateError {
     ValidationError(#[from] ValidateContextError),
 }
 
-/// An error describing the reason a block or its descendants could not be reconsidered after
-/// potentially being invalidated from the chain_set.
+/// An error describing why a `ReconsiderBlock` request failed.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ReconsiderError {
     #[error("Block with hash {0} was not previously invalidated")]
+    /// The block is not found in the list of invalidated blocks.
     MissingInvalidatedBlock(block::Hash),
 
     #[error("Parent chain not found for block {0}")]
+    /// The block's parent is missing from the non-finalized state.
     ParentChainNotFound(block::Hash),
 
     #[error("Invalidated blocks list is empty when it should contain at least one block")]
+    /// There were no invalidated blocks when at least one was expected.
     InvalidatedBlocksEmpty,
 
     #[error("cannot reconsider blocks while still committing checkpointed blocks")]
+    /// The state is currently checkpointing blocks and cannot accept reconsider requests.
     CheckpointCommitInProgress,
 
     #[error("failed to send reconsider block request to block write task")]
+    /// Sending the reconsider request to the block write task failed.
     ReconsiderSendFailed,
 
     #[error("reconsider block request was unexpectedly dropped")]
+    /// The reconsider request was dropped before processing.
     ReconsiderResponseDropped,
 
-    #[error("{0}")]
-    ValidationError(#[from] Box<ValidateContextError>),
+    #[error("contextual validation of the block failed")]
+    /// The block failed contextual validation during reconsideration.
+    ValidationError(#[from] ValidateContextError),
 }
 
 /// An error describing why a block failed contextual validation.

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -122,6 +122,7 @@ pub enum InvalidateError {
     #[error("invalidate block request was unexpectedly dropped")]
     InvalidateRequestDropped,
 
+    /// The block hash was not found in any non-finalized chain.
     #[error("block hash {0} not found in any non-finalized chain")]
     BlockNotFound(block::Hash),
 }
@@ -130,30 +131,29 @@ pub enum InvalidateError {
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum ReconsiderError {
-    #[error("Block with hash {0} was not previously invalidated")]
     /// The block is not found in the list of invalidated blocks.
+    #[error("Block with hash {0} was not previously invalidated")]
     MissingInvalidatedBlock(block::Hash),
 
-    #[error("Parent chain not found for block {0}")]
     /// The block's parent is missing from the non-finalized state.
+    #[error("Parent chain not found for block {0}")]
     ParentChainNotFound(block::Hash),
 
-    #[error("Invalidated blocks list is empty when it should contain at least one block")]
     /// There were no invalidated blocks when at least one was expected.
+    #[error("Invalidated blocks list is empty when it should contain at least one block")]
     InvalidatedBlocksEmpty,
 
-    #[error("cannot reconsider blocks while still committing checkpointed blocks")]
     /// The state is currently checkpointing blocks and cannot accept reconsider requests.
+    #[error("cannot reconsider blocks while still committing checkpointed blocks")]
     CheckpointCommitInProgress,
 
-    #[error("failed to send reconsider block request to block write task")]
     /// Sending the reconsider request to the block write task failed.
+    #[error("failed to send reconsider block request to block write task")]
     ReconsiderSendFailed,
 
-    #[error("reconsider block request was unexpectedly dropped")]
     /// The reconsider request was dropped before processing.
+    #[error("reconsider block request was unexpectedly dropped")]
     ReconsiderResponseDropped,
-
 }
 
 /// An error describing why a block failed contextual validation.

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -378,10 +378,6 @@ pub enum ValidateContextError {
         tx_index_in_block: Option<usize>,
         transaction_hash: transaction::Hash,
     },
-
-    #[error("block hash {block_hash} not found in any non-finalized chain")]
-    #[non_exhaustive]
-    BlockNotFound { block_hash: block::Hash },
 }
 
 /// Trait for creating the corresponding duplicate nullifier error from a nullifier.

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -154,9 +154,6 @@ pub enum ReconsiderError {
     /// The reconsider request was dropped before processing.
     ReconsiderResponseDropped,
 
-    #[error("contextual validation of the block failed")]
-    /// The block failed contextual validation during reconsideration.
-    ValidationError(#[from] ValidateContextError),
 }
 
 /// An error describing why a block failed contextual validation.

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -106,6 +106,22 @@ impl<E: std::error::Error + 'static> From<BoxError> for LayeredStateError<E> {
     }
 }
 
+/// An error describing the reason a block could not be invalidated.
+#[derive(Debug, Error)]
+pub enum InvalidateError {
+    #[error("cannot invalidate blocks while still committing checkpointed blocks")]
+    CannotInvalidateWhileCheckpointing,
+
+    #[error("failed to send invalidate block request to block write task")]
+    SendInvalidateRequestFailed,
+
+    #[error("invalidate block request was unexpectedly dropped")]
+    InvalidateRequestDropped,
+
+    #[error("{0}")]
+    ValidationError(#[from] Box<ValidateContextError>),
+}
+
 /// An error describing the reason a block or its descendants could not be reconsidered after
 /// potentially being invalidated from the chain_set.
 #[derive(Debug, Error)]
@@ -354,6 +370,10 @@ pub enum ValidateContextError {
         tx_index_in_block: Option<usize>,
         transaction_hash: transaction::Hash,
     },
+
+    #[error("block hash {block_hash} not found in any non-finalized chain")]
+    #[non_exhaustive]
+    BlockNotFound { block_hash: block::Hash },
 }
 
 /// Trait for creating the corresponding duplicate nullifier error from a nullifier.

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -106,20 +106,25 @@ impl<E: std::error::Error + 'static> From<BoxError> for LayeredStateError<E> {
     }
 }
 
-/// An error describing the reason a block could not be invalidated.
+/// An error describing why a `InvalidateBlock` request failed.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum InvalidateError {
     #[error("cannot invalidate blocks while still committing checkpointed blocks")]
+    /// The state is currently checkpointing blocks and cannot accept invalidation requests.
     CannotInvalidateWhileCheckpointing,
 
     #[error("failed to send invalidate block request to block write task")]
+    /// Sending the invalidate request to the block write task failed.
     SendInvalidateRequestFailed,
 
     #[error("invalidate block request was unexpectedly dropped")]
+    /// The invalidate request was dropped before processing.
     InvalidateRequestDropped,
 
-    #[error("{0}")]
-    ValidationError(#[from] Box<ValidateContextError>),
+    #[error("contextual validation of the block failed")]
+    /// The block failed contextual validation during invalidation.
+    ValidationError(#[from] ValidateContextError),
 }
 
 /// An error describing the reason a block or its descendants could not be reconsidered after

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1164,12 +1164,9 @@ impl Service<Request> for StateService {
                 async move {
                     rsp_rx
                         .await
-                        .map_err(|_recv_error| {
-                            BoxError::from(InvalidateError::InvalidateRequestDropped)
-                        })
-                        // TODO: replace with Result::flatten once it stabilises
-                        // https://github.com/rust-lang/rust/issues/70142
-                        .and_then(|res| res.map_err(BoxError::from))
+                        .map_err(|_recv_error| InvalidateError::InvalidateRequestDropped)
+                        .flatten()
+                        .map_err(BoxError::from)
                         .map(Response::Invalidated)
                 }
                 .instrument(span)

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1182,12 +1182,9 @@ impl Service<Request> for StateService {
                 async move {
                     rsp_rx
                         .await
-                        .map_err(|_recv_error| {
-                            BoxError::from(ReconsiderError::ReconsiderResponseDropped)
-                        })
-                        // TODO: replace with Result::flatten once it stabilises
-                        // https://github.com/rust-lang/rust/issues/70142
-                        .and_then(|res| res.map_err(BoxError::from))
+                        .map_err(|_recv_error| ReconsiderError::ReconsiderResponseDropped)
+                        .flatten()
+                        .map_err(BoxError::from)
                         .map(Response::Reconsidered)
                 }
                 .instrument(span)

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1155,11 +1155,15 @@ impl Service<Request> for StateService {
                 .boxed()
             }
 
+            // The expected error type for this request is `InvalidateError`
             Request::InvalidateBlock(block_hash) => {
                 let rsp_rx = tokio::task::block_in_place(move || {
                     span.in_scope(|| self.send_invalidate_block(block_hash))
                 });
 
+                // Await the channel response, flatten the result, map receive errors to
+                // `InvalidateError::InvalidateRequestDropped`.
+                // Then flatten the nested Result and convert any errors to a BoxError.
                 let span = Span::current();
                 async move {
                     rsp_rx
@@ -1173,11 +1177,15 @@ impl Service<Request> for StateService {
                 .boxed()
             }
 
+            // The expected error type for this request is `ReconsiderError`
             Request::ReconsiderBlock(block_hash) => {
                 let rsp_rx = tokio::task::block_in_place(move || {
                     span.in_scope(|| self.send_reconsider_block(block_hash))
                 });
 
+                // Await the channel response, flatten the result, map receive errors to
+                // `ReconsiderError::ReconsiderResponseDropped`.
+                // Then flatten the nested Result and convert any errors to a BoxError.
                 let span = Span::current();
                 async move {
                     rsp_rx

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -45,7 +45,7 @@ use crate::{
     constants::{
         MAX_FIND_BLOCK_HASHES_RESULTS, MAX_FIND_BLOCK_HEADERS_RESULTS, MAX_LEGACY_CHAIN_BLOCKS,
     },
-    error::{QueueAndCommitError, ReconsiderError},
+    error::{InvalidateError, QueueAndCommitError, ReconsiderError},
     response::NonFinalizedBlocksListener,
     service::{
         block_iter::any_ancestor_blocks,
@@ -806,13 +806,11 @@ impl StateService {
     fn send_invalidate_block(
         &self,
         hash: block::Hash,
-    ) -> oneshot::Receiver<Result<block::Hash, BoxError>> {
+    ) -> oneshot::Receiver<Result<block::Hash, InvalidateError>> {
         let (rsp_tx, rsp_rx) = oneshot::channel();
 
         let Some(sender) = &self.block_write_sender.non_finalized else {
-            let _ = rsp_tx.send(Err(
-                "cannot invalidate blocks while still committing checkpointed blocks".into(),
-            ));
+            let _ = rsp_tx.send(Err(InvalidateError::CannotInvalidateWhileCheckpointing));
             return rsp_rx;
         };
 
@@ -823,9 +821,7 @@ impl StateService {
                 unreachable!("should return the same Invalidate message could not be sent");
             };
 
-            let _ = rsp_tx.send(Err(
-                "failed to send invalidate block request to block write task".into(),
-            ));
+            let _ = rsp_tx.send(Err(InvalidateError::SendInvalidateRequestFailed));
         }
 
         rsp_rx
@@ -1169,11 +1165,11 @@ impl Service<Request> for StateService {
                     rsp_rx
                         .await
                         .map_err(|_recv_error| {
-                            BoxError::from("invalidate block request was unexpectedly dropped")
+                            BoxError::from(InvalidateError::InvalidateRequestDropped)
                         })
                         // TODO: replace with Result::flatten once it stabilises
                         // https://github.com/rust-lang/rust/issues/70142
-                        .and_then(convert::identity)
+                        .and_then(|res| res.map_err(BoxError::from))
                         .map(Response::Invalidated)
                 }
                 .instrument(span)

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -810,7 +810,7 @@ impl StateService {
         let (rsp_tx, rsp_rx) = oneshot::channel();
 
         let Some(sender) = &self.block_write_sender.non_finalized else {
-            let _ = rsp_tx.send(Err(InvalidateError::CannotInvalidateWhileCheckpointing));
+            let _ = rsp_tx.send(Err(InvalidateError::ProcessingCheckpointedBlocks));
             return rsp_rx;
         };
 

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -456,7 +456,9 @@ impl NonFinalizedState {
 
         let mut modified_chain = Arc::unwrap_or_clone(chain_result);
         for block in invalidated_blocks {
-            modified_chain = modified_chain.push(block)?;
+            modified_chain = modified_chain
+                .push(block)
+                .expect("previously invalidated block should be valid for chain");
         }
 
         let (height, hash) = modified_chain.non_finalized_tip();

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -351,9 +351,7 @@ impl NonFinalizedState {
     #[allow(clippy::unwrap_in_result)]
     pub fn invalidate_block(&mut self, block_hash: Hash) -> Result<block::Hash, InvalidateError> {
         let Some(chain) = self.find_chain(|chain| chain.contains_block_hash(block_hash)) else {
-            return Err(InvalidateError::ValidationError(
-                ValidateContextError::BlockNotFound { block_hash },
-            ));
+            return Err(InvalidateError::BlockNotFound(block_hash));
         };
 
         let invalidated_blocks = if chain.non_finalized_root_hash() == block_hash {

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -351,9 +351,9 @@ impl NonFinalizedState {
     #[allow(clippy::unwrap_in_result)]
     pub fn invalidate_block(&mut self, block_hash: Hash) -> Result<block::Hash, InvalidateError> {
         let Some(chain) = self.find_chain(|chain| chain.contains_block_hash(block_hash)) else {
-            return Err(InvalidateError::ValidationError(Box::new(
+            return Err(InvalidateError::ValidationError(
                 ValidateContextError::BlockNotFound { block_hash },
-            )));
+            ));
         };
 
         let invalidated_blocks = if chain.non_finalized_root_hash() == block_hash {

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -458,7 +458,7 @@ impl NonFinalizedState {
 
         let mut modified_chain = Arc::unwrap_or_clone(chain_result);
         for block in invalidated_blocks {
-            modified_chain = modified_chain.push(block).map_err(Box::new)?;
+            modified_chain = modified_chain.push(block)?;
         }
 
         let (height, hash) = modified_chain.non_finalized_tip();

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -394,6 +394,7 @@ impl NonFinalizedState {
     /// Reconsiders a previously invalidated block and its descendants into the non-finalized state
     /// based on a block_hash. Reconsidered blocks are inserted into the previous chain and re-inserted
     /// into the chain_set.
+    #[allow(clippy::unwrap_in_result)]
     pub fn reconsider_block(
         &mut self,
         block_hash: block::Hash,

--- a/zebra-state/src/service/write.rs
+++ b/zebra-state/src/service/write.rs
@@ -21,7 +21,7 @@ use crate::{
         finalized_state::{FinalizedState, ZebraDb},
         non_finalized_state::NonFinalizedState,
         queued_blocks::{QueuedCheckpointVerified, QueuedSemanticallyVerified},
-        BoxError, ChainTipBlock, ChainTipSender, ReconsiderError,
+        ChainTipBlock, ChainTipSender, InvalidateError, ReconsiderError,
     },
     SemanticallyVerifiedBlock, ValidateContextError,
 };
@@ -134,7 +134,7 @@ pub enum NonFinalizedWriteMessage {
     /// the non-finalized state, if present.
     Invalidate {
         hash: block::Hash,
-        rsp_tx: oneshot::Sender<Result<block::Hash, BoxError>>,
+        rsp_tx: oneshot::Sender<Result<block::Hash, InvalidateError>>,
     },
     /// The hash of a block that was previously invalidated but should be
     /// reconsidered and reinserted into the non-finalized state.


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

<!--
- Describe the goals of the PR.
- If it closes any issues, enumerate them here.
-->

This PR addresses #9730 and focuses on the `InvalidateBlock` path.


## Solution

<!-- Describe the changes in the PR. -->

- Introduce the `InvalidateError` in `error.rs` following the example of the existing `ReconsiderError`.
- Adjusted `Request::InvalidateBlock` in `Service::call()` and related methods to propagate the newly introduced `InvalidateError`.

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

- All existing tests passed successfully.
- `cargo fmt` and `cargo clippy` without warnings.


### Specifications & References

<!-- Provide any relevant references. -->

- #9730 

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

- Consider adding more targeted comments or clarifying documentation (as outlined in the issue). Maybe later in a cleanup PR when all paths are implemented.
- Consider changing unwrapping to return `InvalidateError` in the `invalidate_block` method within `zebra_state::service::non_finalized_state::NonFinalizedState`.


### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The library crate changelogs are up to date.
- [x] The solution is tested.
- [ ] The documentation is up to date.
