### PR TITLE
Add(state): Adds a `MappedRequest` helper trait and refactors error types used by `CommitSemanticallyVerifiedBlock` requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6974,6 +6974,7 @@ dependencies = [
  "color-eyre",
  "crossbeam-channel",
  "derive-getters",
+ "derive-new",
  "dirs",
  "elasticsearch",
  "futures",

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2025-XX-XX
+
+### Breaking Changes
+
+- Updated error messages in response to failed `CommitSemanticallyVerifiedBlock` state requests ([#9923](https://github.com/ZcashFoundation/zebra/pull/9923))
+
+## Added
+
+- Added `MappedRequest` trait and `CommitSemanticallyVerifiedBlockRequest` for convenient state response and error type conversions ([#9923](https://github.com/ZcashFoundation/zebra/pull/9923))
+
+## Fixed
+
+- Replaced boxed-string errors in response to failed `CommitSemanticallyVerifiedBlock` and `ReconsiderBlock` state requests with concrete error type ([#9848](https://github.com/ZcashFoundation/zebra/pull/9848), [#9923](https://github.com/ZcashFoundation/zebra/pull/9923), [#9919](https://github.com/ZcashFoundation/zebra/pull/9919))
+
 ## [2.0.0] - 2025-08-07
 
 ### Breaking Changes

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -87,6 +87,7 @@ zebra-test = { path = "../zebra-test/", version = "1.0.1", optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 derive-getters.workspace = true
+derive-new.workspace = true
 
 [dev-dependencies]
 color-eyre = { workspace = true }

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -87,6 +87,23 @@ pub enum CommitSemanticallyVerifiedError {
     WriteTaskExited,
 }
 
+#[derive(Debug, Error)]
+pub enum LayeredStateError<E: std::error::Error + std::fmt::Display> {
+    #[error("{0}")]
+    State(E),
+    #[error("{0}")]
+    Layer(BoxError),
+}
+
+impl<E: std::error::Error + 'static> From<BoxError> for LayeredStateError<E> {
+    fn from(err: BoxError) -> Self {
+        match err.downcast::<E>() {
+            Ok(state_err) => Self::State(*state_err),
+            Err(layer_error) => Self::Layer(layer_error),
+        }
+    }
+}
+
 /// An error describing the reason a block or its descendants could not be reconsidered after
 /// potentially being invalidated from the chain_set.
 #[derive(Debug, Error)]

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -42,8 +42,8 @@ impl From<BoxError> for CloneError {
 /// A boxed [`std::error::Error`].
 pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
+/// An error describing why a block could not be queued to be committed to the state.
 #[derive(Debug, Error, Clone, PartialEq, Eq, new)]
-#[allow(missing_docs)]
 pub enum QueueAndCommitError {
     #[error("block hash {block_hash} has already been sent to be committed to the state")]
     #[non_exhaustive]
@@ -77,12 +77,14 @@ pub enum QueueAndCommitError {
 /// An error describing why a `CommitSemanticallyVerified` request failed.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 #[non_exhaustive]
-#[allow(missing_docs)]
 pub enum CommitSemanticallyVerifiedError {
+    /// Queuing/commit step failed.
     #[error("could not queue and commit semantically verified block")]
     QueueAndCommitError(#[from] QueueAndCommitError),
+    /// Contextual validation failed.
     #[error("could not contextually validate semantically verified block")]
     ValidateContextError(#[from] ValidateContextError),
+    /// The write task exited (likely during shutdown).
     #[error("block write task has exited. Is Zebra shutting down?")]
     WriteTaskExited,
 }

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -42,7 +42,8 @@ pub use error::{
     ValidateContextError,
 };
 pub use request::{
-    CheckpointVerifiedBlock, HashOrHeight, ReadRequest, Request, SemanticallyVerifiedBlock,
+    CheckpointVerifiedBlock, CommitSemanticallyVerifiedBlockRequest, HashOrHeight, MappedRequest,
+    ReadRequest, Request, SemanticallyVerifiedBlock,
 };
 
 #[cfg(feature = "indexer")]

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -633,7 +633,7 @@ impl DerefMut for CheckpointVerifiedBlock {
     }
 }
 
-/// Helper trait for using the state service with concrete request, response, and error types.
+/// Helper trait for convenient access to expected response and error types.
 pub trait MappedRequest: Sized + Send + 'static {
     /// Expected response type for this state request.
     type MappedResponse;

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -6,6 +6,7 @@ use std::{
     sync::Arc,
 };
 
+use tower::{BoxError, Service, ServiceExt};
 use zebra_chain::{
     amount::{DeferredPoolBalanceChange, NegativeAllowed},
     block::{self, Block, HeightDiff},
@@ -28,6 +29,7 @@ use crate::{
     constants::{MAX_FIND_BLOCK_HASHES_RESULTS, MAX_FIND_BLOCK_HEADERS_RESULTS},
     ReadResponse, Response,
 };
+use crate::{error::LayeredStateError, CommitSemanticallyVerifiedError};
 
 /// Identify a spend by a transparent outpoint or revealed nullifier.
 ///
@@ -327,7 +329,8 @@ pub struct Treestate {
 }
 
 impl Treestate {
-    pub fn new(
+    #[allow(missing_docs)]
+    pub(crate) fn new(
         sprout: Arc<sprout::tree::NoteCommitmentTree>,
         sapling: Arc<sapling::tree::NoteCommitmentTree>,
         orchard: Arc<orchard::tree::NoteCommitmentTree>,
@@ -352,6 +355,7 @@ impl Treestate {
 ///
 /// Zebra's state service passes this `enum` over to the finalized state
 /// when committing a block.
+#[allow(missing_docs)]
 pub enum FinalizableBlock {
     Checkpoint {
         checkpoint_verified: CheckpointVerifiedBlock,
@@ -629,6 +633,60 @@ impl DerefMut for CheckpointVerifiedBlock {
     }
 }
 
+/// Helper trait for using the state service with concrete request, response, and error types.
+pub trait MappedRequest: Sized + Send + 'static {
+    /// Expected response type for this state request.
+    type MappedResponse;
+    /// Expected error type for this state request.
+    type Error: std::error::Error + std::fmt::Display + 'static;
+
+    /// Maps the request type to a [`Request`].
+    fn map_request(self) -> Request;
+
+    /// Maps the expected [`Response`] variant for this request to the mapped response type.
+    fn map_response(response: Response) -> Self::MappedResponse;
+
+    /// Accepts a state service to call, maps this request to a [`Request`], waits for the state to be ready,
+    /// calls the state with the mapped request, then maps the success or error response to the expected response
+    /// or error type for this request.
+    ///
+    /// Returns a [`Result<MappedResponse, LayeredServicesError<RequestError>>`].
+    #[allow(async_fn_in_trait)]
+    async fn mapped_oneshot<State>(
+        self,
+        state: &mut State,
+    ) -> Result<Self::MappedResponse, LayeredStateError<Self::Error>>
+    where
+        State: Service<Request, Response = Response, Error = BoxError>,
+        State::Future: Send,
+    {
+        let response = state.ready().await?.call(self.map_request()).await?;
+        Ok(Self::map_response(response))
+    }
+}
+
+/// Performs contextual validation of the given semantically verified block,
+/// committing it to the state if successful.
+///
+/// See the [`crate`] documentation and [`Request::CommitSemanticallyVerifiedBlock`] for details.
+pub struct CommitSemanticallyVerifiedBlockRequest(pub SemanticallyVerifiedBlock);
+
+impl MappedRequest for CommitSemanticallyVerifiedBlockRequest {
+    type MappedResponse = block::Hash;
+    type Error = CommitSemanticallyVerifiedError;
+
+    fn map_request(self) -> Request {
+        Request::CommitSemanticallyVerifiedBlock(self.0)
+    }
+
+    fn map_response(response: Response) -> Self::MappedResponse {
+        match response {
+            Response::Committed(hash) => hash,
+            _ => unreachable!("wrong response variant for request"),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// A query about or modification to the chain state, via the
 /// [`StateService`](crate::service::StateService).
@@ -640,7 +698,7 @@ pub enum Request {
     /// until its parent is ready.
     ///
     /// Returns [`Response::Committed`] with the hash of the block when it is
-    /// committed to the state, or a [`CommitSemanticallyVerifiedBlockError`] if
+    /// committed to the state, or a [`CommitSemanticallyVerifiedBlockError`][0] if
     /// the block fails contextual validation or otherwise could not be committed.
     ///
     /// This request cannot be cancelled once submitted; dropping the response
@@ -653,6 +711,8 @@ pub enum Request {
     /// Block commit requests should be wrapped in a timeout, so that
     /// out-of-order and invalid requests do not hang indefinitely. See the [`crate`]
     /// documentation for details.
+    ///
+    /// [0]: (crate::error::CommitSemanticallyVerifiedBlockError)
     CommitSemanticallyVerifiedBlock(SemanticallyVerifiedBlock),
 
     /// Commit a checkpointed block to the state, skipping most but not all

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -640,8 +640,8 @@ pub enum Request {
     /// until its parent is ready.
     ///
     /// Returns [`Response::Committed`] with the hash of the block when it is
-    /// committed to the state, or an error if the block fails contextual
-    /// validation or has already been committed to the state.
+    /// committed to the state, or a [`CommitSemanticallyVerifiedBlockError`] if
+    /// the block fails contextual validation or otherwise could not be committed.
     ///
     /// This request cannot be cancelled once submitted; dropping the response
     /// future will have no effect on whether it is eventually processed. A

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -30,8 +30,8 @@ use crate::{service::read::AddressUtxos, NonFinalizedState, TransactionLocation,
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// A response to a [`StateService`](crate::service::StateService) [`Request`].
 pub enum Response {
-    /// Response to [`Request::CommitSemanticallyVerifiedBlock`] indicating that a block was
-    /// successfully committed to the state.
+    /// Response to [`Request::CommitSemanticallyVerifiedBlock`] and [`Request::CommitCheckpointVerifiedBlock`]
+    /// indicating that a block was successfully committed to the state.
     Committed(block::Hash),
 
     /// Response to [`Request::InvalidateBlock`] indicating that a block was found and

--- a/zebra-state/src/service/check/tests/nullifier.rs
+++ b/zebra-state/src/service/check/tests/nullifier.rs
@@ -165,11 +165,10 @@ proptest! {
         // we might need to just check `is_err()` here
         prop_assert_eq!(
             commit_result,
-            Err(Box::new(DuplicateSproutNullifier {
+            Err(DuplicateSproutNullifier {
                 nullifier: duplicate_nullifier,
                 in_finalized_state: false,
-            })
-            .into())
+            }.into())
         );
         // block was rejected
         prop_assert_eq!(Some((Height(0), genesis.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
@@ -224,11 +223,10 @@ proptest! {
 
         prop_assert_eq!(
             commit_result,
-            Err(Box::new(DuplicateSproutNullifier {
+            Err(DuplicateSproutNullifier {
                 nullifier: duplicate_nullifier,
                 in_finalized_state: false,
-            })
-            .into())
+            }.into())
         );
         prop_assert_eq!(Some((Height(0), genesis.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
         prop_assert!(non_finalized_state.eq_internal_state(&previous_mem));
@@ -285,11 +283,10 @@ proptest! {
 
         prop_assert_eq!(
             commit_result,
-            Err(Box::new(DuplicateSproutNullifier {
+            Err(DuplicateSproutNullifier {
                 nullifier: duplicate_nullifier,
                 in_finalized_state: false,
-            })
-            .into())
+            }.into())
         );
         prop_assert_eq!(Some((Height(0), genesis.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
         prop_assert!(non_finalized_state.eq_internal_state(&previous_mem));
@@ -392,11 +389,10 @@ proptest! {
 
         prop_assert_eq!(
             commit_result,
-            Err(Box::new(DuplicateSproutNullifier {
+            Err(DuplicateSproutNullifier {
                 nullifier: duplicate_nullifier,
                 in_finalized_state: duplicate_in_finalized_state,
-            })
-            .into())
+            }.into())
         );
 
         let check_tx_no_duplicates_in_chain =
@@ -517,11 +513,10 @@ proptest! {
 
         prop_assert_eq!(
             commit_result,
-            Err(Box::new(DuplicateSaplingNullifier {
+            Err(DuplicateSaplingNullifier {
                 nullifier: duplicate_nullifier,
                 in_finalized_state: false,
-            })
-            .into())
+            }.into())
         );
         prop_assert_eq!(Some((Height(0), genesis.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
         prop_assert!(non_finalized_state.eq_internal_state(&previous_mem));
@@ -573,11 +568,10 @@ proptest! {
 
         prop_assert_eq!(
             commit_result,
-            Err(Box::new(DuplicateSaplingNullifier {
+            Err(DuplicateSaplingNullifier {
                 nullifier: duplicate_nullifier,
                 in_finalized_state: false,
-            })
-            .into())
+            }.into())
         );
         prop_assert_eq!(Some((Height(0), genesis.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
         prop_assert!(non_finalized_state.eq_internal_state(&previous_mem));
@@ -670,11 +664,10 @@ proptest! {
 
         prop_assert_eq!(
             commit_result,
-            Err(Box::new(DuplicateSaplingNullifier {
+            Err(DuplicateSaplingNullifier {
                 nullifier: duplicate_nullifier,
                 in_finalized_state: duplicate_in_finalized_state,
-            })
-            .into())
+            }.into())
         );
 
         let check_tx_no_duplicates_in_chain =
@@ -798,11 +791,10 @@ proptest! {
 
         prop_assert_eq!(
             commit_result,
-            Err(Box::new(DuplicateOrchardNullifier {
+            Err(DuplicateOrchardNullifier {
                 nullifier: duplicate_nullifier,
                 in_finalized_state: false,
-            })
-            .into())
+            }.into())
         );
         prop_assert_eq!(Some((Height(0), genesis.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
         prop_assert!(non_finalized_state.eq_internal_state(&previous_mem));
@@ -858,11 +850,10 @@ proptest! {
 
         prop_assert_eq!(
             commit_result,
-            Err(Box::new(DuplicateOrchardNullifier {
+            Err(DuplicateOrchardNullifier {
                 nullifier: duplicate_nullifier,
                 in_finalized_state: false,
-            })
-            .into())
+            }.into())
         );
         prop_assert_eq!(Some((Height(0), genesis.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
         prop_assert!(non_finalized_state.eq_internal_state(&previous_mem));
@@ -958,11 +949,10 @@ proptest! {
 
         prop_assert_eq!(
             commit_result,
-            Err(Box::new(DuplicateOrchardNullifier {
+            Err(DuplicateOrchardNullifier {
                 nullifier: duplicate_nullifier,
                 in_finalized_state: duplicate_in_finalized_state,
-            })
-            .into())
+            }.into())
         );
 
         let check_tx_no_duplicates_in_chain =

--- a/zebra-state/src/service/check/tests/nullifier.rs
+++ b/zebra-state/src/service/check/tests/nullifier.rs
@@ -168,7 +168,7 @@ proptest! {
             Err(DuplicateSproutNullifier {
                 nullifier: duplicate_nullifier,
                 in_finalized_state: false,
-            }.into())
+            })
         );
         // block was rejected
         prop_assert_eq!(Some((Height(0), genesis.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
@@ -226,7 +226,7 @@ proptest! {
             Err(DuplicateSproutNullifier {
                 nullifier: duplicate_nullifier,
                 in_finalized_state: false,
-            }.into())
+            })
         );
         prop_assert_eq!(Some((Height(0), genesis.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
         prop_assert!(non_finalized_state.eq_internal_state(&previous_mem));
@@ -286,7 +286,7 @@ proptest! {
             Err(DuplicateSproutNullifier {
                 nullifier: duplicate_nullifier,
                 in_finalized_state: false,
-            }.into())
+            })
         );
         prop_assert_eq!(Some((Height(0), genesis.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
         prop_assert!(non_finalized_state.eq_internal_state(&previous_mem));
@@ -392,7 +392,7 @@ proptest! {
             Err(DuplicateSproutNullifier {
                 nullifier: duplicate_nullifier,
                 in_finalized_state: duplicate_in_finalized_state,
-            }.into())
+            })
         );
 
         let check_tx_no_duplicates_in_chain =
@@ -516,7 +516,7 @@ proptest! {
             Err(DuplicateSaplingNullifier {
                 nullifier: duplicate_nullifier,
                 in_finalized_state: false,
-            }.into())
+            })
         );
         prop_assert_eq!(Some((Height(0), genesis.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
         prop_assert!(non_finalized_state.eq_internal_state(&previous_mem));
@@ -571,7 +571,7 @@ proptest! {
             Err(DuplicateSaplingNullifier {
                 nullifier: duplicate_nullifier,
                 in_finalized_state: false,
-            }.into())
+            })
         );
         prop_assert_eq!(Some((Height(0), genesis.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
         prop_assert!(non_finalized_state.eq_internal_state(&previous_mem));
@@ -667,7 +667,7 @@ proptest! {
             Err(DuplicateSaplingNullifier {
                 nullifier: duplicate_nullifier,
                 in_finalized_state: duplicate_in_finalized_state,
-            }.into())
+            })
         );
 
         let check_tx_no_duplicates_in_chain =
@@ -794,7 +794,7 @@ proptest! {
             Err(DuplicateOrchardNullifier {
                 nullifier: duplicate_nullifier,
                 in_finalized_state: false,
-            }.into())
+            })
         );
         prop_assert_eq!(Some((Height(0), genesis.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
         prop_assert!(non_finalized_state.eq_internal_state(&previous_mem));
@@ -853,7 +853,7 @@ proptest! {
             Err(DuplicateOrchardNullifier {
                 nullifier: duplicate_nullifier,
                 in_finalized_state: false,
-            }.into())
+            })
         );
         prop_assert_eq!(Some((Height(0), genesis.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
         prop_assert!(non_finalized_state.eq_internal_state(&previous_mem));
@@ -952,7 +952,7 @@ proptest! {
             Err(DuplicateOrchardNullifier {
                 nullifier: duplicate_nullifier,
                 in_finalized_state: duplicate_in_finalized_state,
-            }.into())
+            })
         );
 
         let check_tx_no_duplicates_in_chain =

--- a/zebra-state/src/service/check/tests/utxo.rs
+++ b/zebra-state/src/service/check/tests/utxo.rs
@@ -374,10 +374,10 @@ proptest! {
         // the block was rejected
         prop_assert_eq!(
             commit_result,
-            Err(Box::new(DuplicateTransparentSpend {
+            Err(DuplicateTransparentSpend {
                 outpoint: expected_outpoint,
                 location: "the same block",
-            })
+            }
             .into())
         );
         prop_assert_eq!(Some((Height(0), genesis.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
@@ -438,11 +438,10 @@ proptest! {
         // the block was rejected
         prop_assert_eq!(
             commit_result,
-            Err(Box::new(DuplicateTransparentSpend {
+            Err(DuplicateTransparentSpend {
                 outpoint: expected_outpoint,
                 location: "the same block",
-            })
-            .into())
+            }.into())
         );
         prop_assert_eq!(Some((Height(1), block1.hash())), read::best_tip(&non_finalized_state, &finalized_state.db));
 
@@ -523,11 +522,10 @@ proptest! {
         // the block was rejected
         prop_assert_eq!(
             commit_result,
-            Err(Box::new(DuplicateTransparentSpend {
+            Err(DuplicateTransparentSpend {
                 outpoint: expected_outpoint,
                 location: "the same block",
-            })
-            .into())
+            }.into())
         );
         prop_assert_eq!(Some((Height(1), block1.hash())), read::best_tip(&non_finalized_state, &finalized_state.db));
 
@@ -674,20 +672,18 @@ proptest! {
         if use_finalized_state_spend {
             prop_assert_eq!(
                 commit_result,
-                Err(Box::new(MissingTransparentOutput {
+                Err(MissingTransparentOutput {
                     outpoint: expected_outpoint,
                     location: "the non-finalized and finalized chain",
-                })
-                .into())
+                }.into())
             );
         } else {
             prop_assert_eq!(
                 commit_result,
-                Err(Box::new(DuplicateTransparentSpend {
+                Err(DuplicateTransparentSpend {
                     outpoint: expected_outpoint,
                     location: "the non-finalized chain",
-                })
-                .into())
+                }.into())
             );
         }
         prop_assert_eq!(Some((Height(2), block2.hash())), read::best_tip(&non_finalized_state, &finalized_state.db));
@@ -749,11 +745,10 @@ proptest! {
         // the block was rejected
         prop_assert_eq!(
             commit_result,
-            Err(Box::new(MissingTransparentOutput {
+            Err(MissingTransparentOutput {
                 outpoint: expected_outpoint,
                 location: "the non-finalized and finalized chain",
-            })
-            .into())
+            }.into())
         );
         prop_assert_eq!(Some((Height(0), genesis.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
 
@@ -816,10 +811,9 @@ proptest! {
         // the block was rejected
         prop_assert_eq!(
             commit_result,
-            Err(Box::new(EarlyTransparentSpend {
+            Err(EarlyTransparentSpend {
                 outpoint: expected_outpoint,
-            })
-            .into())
+            }.into())
         );
         prop_assert_eq!(Some((Height(0), genesis.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
 

--- a/zebra-state/src/service/check/tests/utxo.rs
+++ b/zebra-state/src/service/check/tests/utxo.rs
@@ -377,8 +377,7 @@ proptest! {
             Err(DuplicateTransparentSpend {
                 outpoint: expected_outpoint,
                 location: "the same block",
-            }
-            .into())
+            })
         );
         prop_assert_eq!(Some((Height(0), genesis.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
 
@@ -441,7 +440,7 @@ proptest! {
             Err(DuplicateTransparentSpend {
                 outpoint: expected_outpoint,
                 location: "the same block",
-            }.into())
+            })
         );
         prop_assert_eq!(Some((Height(1), block1.hash())), read::best_tip(&non_finalized_state, &finalized_state.db));
 
@@ -525,7 +524,7 @@ proptest! {
             Err(DuplicateTransparentSpend {
                 outpoint: expected_outpoint,
                 location: "the same block",
-            }.into())
+            })
         );
         prop_assert_eq!(Some((Height(1), block1.hash())), read::best_tip(&non_finalized_state, &finalized_state.db));
 
@@ -675,7 +674,7 @@ proptest! {
                 Err(MissingTransparentOutput {
                     outpoint: expected_outpoint,
                     location: "the non-finalized and finalized chain",
-                }.into())
+                })
             );
         } else {
             prop_assert_eq!(
@@ -683,7 +682,7 @@ proptest! {
                 Err(DuplicateTransparentSpend {
                     outpoint: expected_outpoint,
                     location: "the non-finalized chain",
-                }.into())
+                })
             );
         }
         prop_assert_eq!(Some((Height(2), block2.hash())), read::best_tip(&non_finalized_state, &finalized_state.db));
@@ -748,7 +747,7 @@ proptest! {
             Err(MissingTransparentOutput {
                 outpoint: expected_outpoint,
                 location: "the non-finalized and finalized chain",
-            }.into())
+            })
         );
         prop_assert_eq!(Some((Height(0), genesis.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
 
@@ -813,7 +812,7 @@ proptest! {
             commit_result,
             Err(EarlyTransparentSpend {
                 outpoint: expected_outpoint,
-            }.into())
+            })
         );
         prop_assert_eq!(Some((Height(0), genesis.hash)), read::best_tip(&non_finalized_state, &finalized_state.db));
 

--- a/zebra-state/src/service/write.rs
+++ b/zebra-state/src/service/write.rs
@@ -23,7 +23,7 @@ use crate::{
         queued_blocks::{QueuedCheckpointVerified, QueuedSemanticallyVerified},
         BoxError, ChainTipBlock, ChainTipSender, ReconsiderError,
     },
-    CommitSemanticallyVerifiedError, SemanticallyVerifiedBlock,
+    SemanticallyVerifiedBlock, ValidateContextError,
 };
 
 // These types are used in doc links
@@ -53,19 +53,14 @@ pub(crate) fn validate_and_commit_non_finalized(
     finalized_state: &ZebraDb,
     non_finalized_state: &mut NonFinalizedState,
     prepared: SemanticallyVerifiedBlock,
-) -> Result<(), CommitSemanticallyVerifiedError> {
-    check::initial_contextual_validity(finalized_state, non_finalized_state, &prepared)
-        .map_err(Box::new)?;
+) -> Result<(), ValidateContextError> {
+    check::initial_contextual_validity(finalized_state, non_finalized_state, &prepared)?;
     let parent_hash = prepared.block.header.previous_block_hash;
 
     if finalized_state.finalized_tip_hash() == parent_hash {
-        non_finalized_state
-            .commit_new_chain(prepared, finalized_state)
-            .map_err(Box::new)?;
+        non_finalized_state.commit_new_chain(prepared, finalized_state)?;
     } else {
-        non_finalized_state
-            .commit_block(prepared, finalized_state)
-            .map_err(Box::new)?;
+        non_finalized_state.commit_block(prepared, finalized_state)?;
     }
 
     Ok(())
@@ -336,8 +331,7 @@ impl WriteBlockWorkerTask {
         }
 
         // Save any errors to propagate down to queued child blocks
-        let mut parent_error_map: IndexMap<block::Hash, CommitSemanticallyVerifiedError> =
-            IndexMap::new();
+        let mut parent_error_map: IndexMap<block::Hash, ValidateContextError> = IndexMap::new();
 
         while let Some(msg) = non_finalized_block_write_receiver.blocking_recv() {
             let queued_child_and_rsp_tx = match msg {
@@ -369,23 +363,21 @@ impl WriteBlockWorkerTask {
             let parent_hash = queued_child.block.header.previous_block_hash;
             let parent_error = parent_error_map.get(&parent_hash);
 
-            let result;
-
             // If the parent block was marked as rejected, also reject all its children.
             //
             // At this point, we know that all the block's descendants
             // are invalid, because we checked all the consensus rules before
             // committing the failing ancestor block to the non-finalized state.
-            if let Some(parent_error) = parent_error {
-                result = Err(parent_error.clone());
+            let result = if let Some(parent_error) = parent_error {
+                Err(parent_error.clone())
             } else {
                 tracing::trace!(?child_hash, "validating queued child");
-                result = validate_and_commit_non_finalized(
+                validate_and_commit_non_finalized(
                     &finalized_state.db,
                     non_finalized_state,
                     queued_child,
                 )
-            }
+            };
 
             // TODO: fix the test timing bugs that require the result to be sent
             //       after `update_latest_chain_channels()`,
@@ -393,7 +385,7 @@ impl WriteBlockWorkerTask {
 
             if let Err(ref error) = result {
                 // Update the caller with the error.
-                let _ = rsp_tx.send(result.clone().map(|()| child_hash));
+                let _ = rsp_tx.send(result.clone().map(|()| child_hash).map_err(Into::into));
 
                 // If the block is invalid, mark any descendant blocks as rejected.
                 parent_error_map.insert(child_hash, error.clone());
@@ -422,7 +414,7 @@ impl WriteBlockWorkerTask {
             );
 
             // Update the caller with the result.
-            let _ = rsp_tx.send(result.clone().map(|()| child_hash));
+            let _ = rsp_tx.send(result.clone().map(|()| child_hash).map_err(Into::into));
 
             while non_finalized_state
                 .best_chain_len()


### PR DESCRIPTION
## Motivation

This PR refactors the improved error types added in https://github.com/ZcashFoundation/zebra/pull/9848 into an enum.

## Solution

- Updates `CommitSemanticallyVerifiedError` to be an enum instead of a new type around a boxed `ValidateContextError`
- Moves new variants of `ValidateContextError` to a new `QueueAndCommitError` enum
- Updates documentation of `Request::CommitSemanticallyVerifiedBlock` to mention the expected error type
- Adds a code comment above the match arm for `CommitSemanticallyVerifiedBlock` to mention the expected error type
- Adds a `MappedRequest` helper trait and a new request type which implements it for convenient access to expected response/error types

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.
