### PR TITLE
rpc: use specific error code for addnode; reuse message in response filter

### DIFF
--- a/zebra-rpc/qa/rpc-tests/test_framework/util.py
+++ b/zebra-rpc/qa/rpc-tests/test_framework/util.py
@@ -261,9 +261,7 @@ def wait_for_bitcoind_start(process, url, i):
     Wait for bitcoind to start. This means that RPC is accessible and fully initialized.
     Raise an exception if bitcoind exits during initialization.
     '''
-    # Zebra can do migration and other stuff at startup, even in regtest mode,
-    # giving 10 seconds for it to complete.
-    time.sleep(10)
+    time.sleep(1) # give the node a moment to start
     while True:
         if process.poll() is not None:
             raise Exception('%s node %d exited with status %i during initialization' % (zcashd_binary(), i, process.returncode))
@@ -639,7 +637,6 @@ def connect_nodes(from_connection, node_num):
 
 def connect_nodes_bi(nodes, a, b):
     connect_nodes(nodes[a], b)
-    connect_nodes(nodes[b], a)
 
 def find_output(node, txid, amount):
     """

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -2983,7 +2983,7 @@ where
                         Ok(())
                     } else {
                         return Err(ErrorObject::owned(
-                            ErrorCode::InvalidParams.code(),
+                            server::error::LegacyCode::ClientNodeAlreadyAdded.into(),
                             format!("peer address was already present in the address book: {addr}"),
                             None::<()>,
                         ));

--- a/zebra-rpc/src/server/rpc_call_compatibility.rs
+++ b/zebra-rpc/src/server/rpc_call_compatibility.rs
@@ -63,7 +63,14 @@ impl<'a> RpcServiceT<'a> for FixRpcResponseMiddleware {
 
                     return MethodResponse::error(
                         id,
-                        ErrorObject::borrowed(new_error_code, "Invalid params", None),
+                        ErrorObject::borrowed(
+                            new_error_code,
+                            json.get("error")
+                                .and_then(|v| v.get("message"))
+                                .and_then(|m| m.as_str())
+                                .unwrap_or("Invalid params"),
+                            None,
+                        ),
                     );
                 }
             }


### PR DESCRIPTION
## Motivation

Some small issues that came up during doing QA tests

## Solution

- Use a specific error code (same as zcashd) when addnode fails due to node already being in the address book
- In the error filtering middleware, reuse the returned message when possible instead of overwriting it

### Tests

I tested this manually in the `addnode.py` QA test, if you delete the sleep in `wait_for_bitcoind_start()` then the test fails, and with this PR, it shows the reason if you use `--tracerpc` to print the RPC response:

```
DEBUG:BitcoinRPC:-6310-> addnode ["127.0.0.1:13582", "add"]
2025-09-26T16:36:02.154332Z  INFO zebra_rpc::methods: adding peer address to the address book addr=v4redacted:13582
DEBUG:BitcoinRPC:<-- {"jsonrpc":"2.0","id":6310,"error":{"code":-23,"message":"peer address was already present in the address book: v4redacted:13582"}}
JSONRPC error: missing JSON-RPC result
  File "/home/conrado/zebra/zebra-rpc/qa/rpc-tests/test_framework/test_framework.py", line 144, in main
    self.setup_network()
  File "/home/conrado/zebra/zebra-rpc/./qa/rpc-tests/addnode.py", line 24, in setup_network
    connect_nodes_bi(self.nodes,1,2)
  File "/home/conrado/zebra/zebra-rpc/qa/rpc-tests/test_framework/util.py", line 640, in connect_nodes_bi
    connect_nodes(nodes[b], a)
  File "/home/conrado/zebra/zebra-rpc/qa/rpc-tests/test_framework/util.py", line 628, in connect_nodes
    from_connection.addnode(ip_port, "add")
  File "/home/conrado/zebra/zebra-rpc/qa/rpc-tests/test_framework/coverage.py", line 50, in __call__
    return_val = self.auth_service_proxy_instance.__call__(*args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/conrado/zebra/zebra-rpc/qa/rpc-tests/test_framework/proxy.py", line 130, in __call__
    raise JSONRPCException({
Stopping nodes
```

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
