### PR TITLE
qa(suggestion): Remove one call to `connect_nodes`.

### DIFF
--- a/zebra-rpc/qa/rpc-tests/test_framework/util.py
+++ b/zebra-rpc/qa/rpc-tests/test_framework/util.py
@@ -261,9 +261,7 @@ def wait_for_bitcoind_start(process, url, i):
     Wait for bitcoind to start. This means that RPC is accessible and fully initialized.
     Raise an exception if bitcoind exits during initialization.
     '''
-    # Zebra can do migration and other stuff at startup, even in regtest mode,
-    # giving 10 seconds for it to complete.
-    time.sleep(10)
+    time.sleep(1) # give the node a moment to start
     while True:
         if process.poll() is not None:
             raise Exception('%s node %d exited with status %i during initialization' % (zcashd_binary(), i, process.returncode))
@@ -639,7 +637,6 @@ def connect_nodes(from_connection, node_num):
 
 def connect_nodes_bi(nodes, a, b):
     connect_nodes(nodes[a], b)
-    connect_nodes(nodes[b], a)
 
 def find_output(node, txid, amount):
     """


### PR DESCRIPTION
## Motivation

There is an extra call to `connect_nodes()` inside `connect_nodes_bi()`. Related to https://github.com/ZcashFoundation/zebra/pull/9931

## Solution

- Remove the redundant call, since Zebra already connects both sides with a single `addnode` request.
- Reduce the startup delay from 10 seconds to 1 second.

I tested this change multiple times locally, and it generally works well. However, I did observe a failure when running the addnode test repeatedly. This may be due to remaining `TIME_WAIT` connections after the test ends, and the extra 10-second delay might have been masking that issue.

We should wait for connections to be fully closed at shutdown if this becomes a problem.