### PR TITLE
test(lwd): ensure lwd full sync populates the cache disk

### DIFF
--- a/zebrad/tests/common/lightwalletd/sync.rs
+++ b/zebrad/tests/common/lightwalletd/sync.rs
@@ -214,6 +214,22 @@ pub fn are_zebrad_and_lightwalletd_tips_synced(
             .as_u64()
             .expect("unexpected block height: doesn't fit in u64");
 
+        if lightwalletd_tip_height != zebrad_tip_height {
+            tracing::info!(
+                lightwalletd_tip_height,
+                zebrad_tip_height,
+                zebra_rpc_address = ?zebra_rpc_address,
+                "lightwalletd tip is behind Zebra tip, waiting for sync",
+            );
+        } else {
+            tracing::debug!(
+                lightwalletd_tip_height,
+                zebrad_tip_height,
+                zebra_rpc_address = ?zebra_rpc_address,
+                "lightwalletd tip matches Zebra tip",
+            );
+        }
+
         Ok(lightwalletd_tip_height == zebrad_tip_height)
     })
 }

--- a/zebrad/tests/common/test_type.rs
+++ b/zebrad/tests/common/test_type.rs
@@ -313,6 +313,18 @@ impl TestType {
                 );
                 None
             }
+        } else if self.can_create_lightwalletd_cached_state() {
+            // Ensure the directory exists so FullSyncFromGenesis can populate it.
+            if let Err(error) = std::fs::create_dir_all(&default_path) {
+                tracing::warn!(
+                    ?default_path,
+                    ?error,
+                    "failed to create default lightwalletd cache directory; using an ephemeral temp dir instead",
+                );
+                None
+            } else {
+                Some(default_path)
+            }
         } else {
             None
         }


### PR DESCRIPTION
## Motivation

- CI lightwalletd update, gRPC wallet, and send-tx jobs are failing because the cached `lwd-cache` image no longer contains `db/main`.
- The last successful `lwd-sync-full` run wrote lightwalletd blocks into a temp directory instead of `/home/zebra/.cache/lwd`, so the snapshot only preserved Zebra state.

## Solution

- Update `TestType::lightwalletd_state_path` so tests that can build a lightwalletd cache (for example `FullSyncFromGenesis`) create and return the shared default directory even when they must start from an empty state.
- Emit info/debug logs in `wait_for_zebrad_and_lightwalletd_sync` that show both tip heights whenever they differ, giving us better diagnostics if sync drifts.

### Tests

- Rerun `lwd-sync-full` so the shared disk image is refreshed

### PR Checklist

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the contribution guidelines.
- [ ] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
