### PR TITLE
chore: fix typos in docs

### DIFF
--- a/book/src/dev/state-db-upgrades.md
+++ b/book/src/dev/state-db-upgrades.md
@@ -281,7 +281,7 @@ So it is better to test with a full sync, and an older cached state.
 [current]: #current
 
 rocksdb provides a persistent, thread-safe `BTreeMap<&[u8], &[u8]>`. Each map is
-a distinct "tree". Keys are sorted using lexographic order (`[u8].sorted()`) on byte strings, so
+a distinct "tree". Keys are sorted using lexicographic order (`[u8].sorted()`) on byte strings, so
 integer values should be stored using big-endian encoding (so that the lex
 order on byte strings is the numeric ordering).
 

--- a/zebra-chain/src/history_tree/tests/vectors.rs
+++ b/zebra-chain/src/history_tree/tests/vectors.rs
@@ -94,7 +94,7 @@ fn push_and_prune_for_network_upgrade(
     tree.push(second_block, &second_sapling_root, &Default::default())
         .unwrap();
 
-    // Adding a second block will produce a 3-node tree (one parent and two leafs).
+    // Adding a second block will produce a 3-node tree (one parent and two leaves).
     assert_eq!(tree.size(), 3);
     // The tree must have been pruned, resulting in a single peak (the parent).
     assert_eq!(tree.peaks().len(), 1);

--- a/zebra-chain/src/primitives/zcash_history/tests/vectors.rs
+++ b/zebra-chain/src/primitives/zcash_history/tests/vectors.rs
@@ -73,7 +73,7 @@ fn tree_for_network_upgrade(network: &Network, network_upgrade: NetworkUpgrade) 
         .append_leaf(block1, &sapling_root1, &Default::default())
         .unwrap();
 
-    // Tree how has 3 nodes: two leafs for each block, and one parent node
+    // Tree how has 3 nodes: two leaves for each block, and one parent node
     // which is the new root
     assert_eq!(tree.inner.len(), 3);
     // Two nodes were appended: the new leaf and the parent node


### PR DESCRIPTION
## Description

Corrected misspellings:

- `lexographic` → `lexicographic`
- `leafs` → `leaves`