### PR TITLE
fix(state): Avoid heap allocations in `expand_zero_be_bytes()`

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_format.rs
+++ b/zebra-state/src/service/finalized_state/disk_format.rs
@@ -5,7 +5,7 @@
 //! [`crate::constants::state_database_format_version_in_code()`] must be incremented
 //! each time the database format (column, serialization, etc) changes.
 
-use std::sync::Arc;
+use std::{io::Write, sync::Arc};
 
 pub mod block;
 pub mod chain;
@@ -182,25 +182,27 @@ pub fn truncate_zero_be_bytes(mem_bytes: &[u8], disk_len: usize) -> Option<&[u8]
     Some(truncated)
 }
 
-/// Expands `disk_bytes` to `mem_len`, by adding zero bytes at the start of the slice.
+/// Expands `disk_bytes` to `MEM_SIZE`, by adding zero bytes at the start of the slice.
 /// Used to zero-fill bytes that were discarded during serialization.
 ///
 /// # Panics
 ///
 /// - if `disk_bytes` is longer than `mem_len`
-pub fn expand_zero_be_bytes(disk_bytes: &[u8], mem_len: usize) -> Vec<u8> {
-    let extra_bytes = mem_len
-        .checked_sub(disk_bytes.len())
-        .expect("unexpected `disk_bytes` length: must not exceed `mem_len`");
-
-    if extra_bytes == 0 {
-        return disk_bytes.to_vec();
+#[inline]
+pub fn expand_zero_be_bytes<const MEM_SIZE: usize>(disk_bytes: &[u8]) -> [u8; MEM_SIZE] {
+    // Return early if disk_bytes is already the expected length
+    if let Ok(disk_bytes_array) = disk_bytes.try_into() {
+        return disk_bytes_array;
     }
 
-    let mut expanded = vec![0; extra_bytes];
-    expanded.extend(disk_bytes);
+    let extra_bytes = MEM_SIZE
+        .checked_sub(disk_bytes.len())
+        .expect("unexpected `disk_bytes` length: must not exceed `MEM_SIZE`");
 
-    assert_eq!(expanded.len(), mem_len);
+    let mut expanded = [0; MEM_SIZE];
+    (&mut expanded[extra_bytes..])
+        .write(disk_bytes)
+        .expect("should fit");
 
     expanded
 }

--- a/zebra-state/src/service/finalized_state/disk_format.rs
+++ b/zebra-state/src/service/finalized_state/disk_format.rs
@@ -200,7 +200,7 @@ pub fn expand_zero_be_bytes<const MEM_SIZE: usize>(disk_bytes: &[u8]) -> [u8; ME
         .expect("unexpected `disk_bytes` length: must not exceed `MEM_SIZE`");
 
     let mut expanded = [0; MEM_SIZE];
-    (&mut expanded[extra_bytes..])
+    let _ = (&mut expanded[extra_bytes..])
         .write(disk_bytes)
         .expect("should fit");
 

--- a/zebra-state/src/service/finalized_state/disk_format/block.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/block.rs
@@ -255,11 +255,9 @@ impl IntoDisk for Height {
 
 impl FromDisk for Height {
     fn from_bytes(disk_bytes: impl AsRef<[u8]>) -> Self {
-        let mem_len = u32::BITS / 8;
-        let mem_len = mem_len.try_into().unwrap();
+        const MEM_LEN: usize = size_of::<u32>();
 
-        let mem_bytes = expand_zero_be_bytes(disk_bytes.as_ref(), mem_len);
-        let mem_bytes = mem_bytes.try_into().unwrap();
+        let mem_bytes = expand_zero_be_bytes::<MEM_LEN>(disk_bytes.as_ref());
         Height(u32::from_be_bytes(mem_bytes))
     }
 }

--- a/zebra-state/src/service/finalized_state/disk_format/transparent.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/transparent.rs
@@ -682,11 +682,9 @@ impl IntoDisk for OutputIndex {
 
 impl FromDisk for OutputIndex {
     fn from_bytes(disk_bytes: impl AsRef<[u8]>) -> Self {
-        let mem_len = u32::BITS / 8;
-        let mem_len = mem_len.try_into().unwrap();
+        const MEM_LEN: usize = size_of::<u32>();
 
-        let mem_bytes = expand_zero_be_bytes(disk_bytes.as_ref(), mem_len);
-        let mem_bytes = mem_bytes.try_into().unwrap();
+        let mem_bytes = expand_zero_be_bytes::<MEM_LEN>(disk_bytes.as_ref());
         OutputIndex::from_index(u32::from_be_bytes(mem_bytes))
     }
 }


### PR DESCRIPTION
## Motivation

The logic for getting a value from the db generally avoids unnecessary allocations, this function showed up on a performance profile for reading an address balance.

Related to #9939.

## Solution

- Return an array from the function instead of allocating a vector, and
- Return early if `disk_bytes` is already the expected length.

### Tests

Should be covered by existing tests.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.
