### PR TITLE
cleanup: Apply suggestions for code cleanup from NU6.1 audit.

### DIFF
--- a/zebra-chain/src/parameters/constants.rs
+++ b/zebra-chain/src/parameters/constants.rs
@@ -28,10 +28,11 @@ pub mod magics {
     pub const REGTEST: Magic = Magic([0xaa, 0xe8, 0x3f, 0x5f]);
 }
 
+/// The block heights at which network upgrades activate.
 pub mod activation_heights {
+    /// Network upgrade activation heights for Testnet.
     pub mod testnet {
-        #[allow(unused_imports)]
-        use crate::{block::Height, parameters::NetworkUpgrade::*};
+        use crate::block::Height;
 
         /// The block height at which [`BeforeOverwinter`] activates on Testnet.
         pub const BEFORE_OVERWINTER: Height = Height(1);
@@ -53,9 +54,9 @@ pub mod activation_heights {
         pub const NU6_1: Height = Height(3_536_500);
     }
 
+    /// Network upgrade activation heights for Mainnet.
     pub mod mainnet {
-        #[allow(unused_imports)]
-        use crate::{block::Height, parameters::NetworkUpgrade::*};
+        use crate::block::Height;
 
         /// The block height at which [`BeforeOverwinter`] activates on Mainnet.
         pub const BEFORE_OVERWINTER: Height = Height(1);

--- a/zebra-chain/src/parameters/constants.rs
+++ b/zebra-chain/src/parameters/constants.rs
@@ -34,23 +34,23 @@ pub mod activation_heights {
     pub mod testnet {
         use crate::block::Height;
 
-        /// The block height at which [`BeforeOverwinter`] activates on Testnet.
+        /// The block height at which `BeforeOverwinter` activates on Testnet.
         pub const BEFORE_OVERWINTER: Height = Height(1);
-        /// The block height at which [`Overwinter`] activates on Testnet.
+        /// The block height at which `Overwinter` activates on Testnet.
         pub const OVERWINTER: Height = Height(207_500);
-        /// The block height at which [`Sapling`] activates on Testnet.
+        /// The block height at which `Sapling` activates on Testnet.
         pub const SAPLING: Height = Height(280_000);
-        /// The block height at which [`Blossom`] activates on Testnet.
+        /// The block height at which `Blossom` activates on Testnet.
         pub const BLOSSOM: Height = Height(584_000);
-        /// The block height at which [`Heartwood`] activates on Testnet.
+        /// The block height at which `Heartwood` activates on Testnet.
         pub const HEARTWOOD: Height = Height(903_800);
-        /// The block height at which [`Canopy`] activates on Testnet.
+        /// The block height at which `Canopy` activates on Testnet.
         pub const CANOPY: Height = Height(1_028_500);
-        /// The block height at which [`NU5`] activates on Testnet.
+        /// The block height at which `NU5` activates on Testnet.
         pub const NU5: Height = Height(1_842_420);
-        /// The block height at which [`NU6`] activates on Testnet.
+        /// The block height at which `NU6` activates on Testnet.
         pub const NU6: Height = Height(2_976_000);
-        /// The block height at which [`NU6.1`](NU6_1) activates on Testnet.
+        /// The block height at which `NU6.1` activates on Testnet.
         pub const NU6_1: Height = Height(3_536_500);
     }
 
@@ -58,23 +58,23 @@ pub mod activation_heights {
     pub mod mainnet {
         use crate::block::Height;
 
-        /// The block height at which [`BeforeOverwinter`] activates on Mainnet.
+        /// The block height at which `BeforeOverwinter` activates on Mainnet.
         pub const BEFORE_OVERWINTER: Height = Height(1);
-        /// The block height at which [`Overwinter`] activates on Mainnet.
+        /// The block height at which `Overwinter` activates on Mainnet.
         pub const OVERWINTER: Height = Height(347_500);
-        /// The block height at which [`Sapling`] activates on Mainnet.
+        /// The block height at which `Sapling` activates on Mainnet.
         pub const SAPLING: Height = Height(419_200);
-        /// The block height at which [`Blossom`] activates on Mainnet.
+        /// The block height at which `Blossom` activates on Mainnet.
         pub const BLOSSOM: Height = Height(653_600);
-        /// The block height at which [`Heartwood`] activates on Mainnet.
+        /// The block height at which `Heartwood` activates on Mainnet.
         pub const HEARTWOOD: Height = Height(903_000);
-        /// The block height at which [`Canopy`] activates on Mainnet.
+        /// The block height at which `Canopy` activates on Mainnet.
         pub const CANOPY: Height = Height(1_046_400);
-        /// The block height at which [`NU5`] activates on Mainnet.
+        /// The block height at which `NU5` activates on Mainnet.
         pub const NU5: Height = Height(1_687_104);
-        /// The block height at which [`NU6`] activates on Mainnet.
+        /// The block height at which `NU6` activates on Mainnet.
         pub const NU6: Height = Height(2_726_400);
-        // /// The block height at which [`NU6.1`](NU6_1) activates on Mainnet.
+        // /// The block height at which `NU6.1` activates on Mainnet.
         // pub const NU6_1: Height = Height(3_146_400);
     }
 }

--- a/zebra-chain/src/parameters/constants.rs
+++ b/zebra-chain/src/parameters/constants.rs
@@ -27,3 +27,53 @@ pub mod magics {
     /// The regtest, see <https://github.com/zcash/zcash/blob/master/src/chainparams.cpp#L716-L719>
     pub const REGTEST: Magic = Magic([0xaa, 0xe8, 0x3f, 0x5f]);
 }
+
+pub mod activation_heights {
+    pub mod testnet {
+        #[allow(unused_imports)]
+        use crate::{block::Height, parameters::NetworkUpgrade::*};
+
+        /// The block height at which [`BeforeOverwinter`] activates on Testnet.
+        pub const BEFORE_OVERWINTER: Height = Height(1);
+        /// The block height at which [`Overwinter`] activates on Testnet.
+        pub const OVERWINTER: Height = Height(207_500);
+        /// The block height at which [`Sapling`] activates on Testnet.
+        pub const SAPLING: Height = Height(280_000);
+        /// The block height at which [`Blossom`] activates on Testnet.
+        pub const BLOSSOM: Height = Height(584_000);
+        /// The block height at which [`Heartwood`] activates on Testnet.
+        pub const HEARTWOOD: Height = Height(903_800);
+        /// The block height at which [`Canopy`] activates on Testnet.
+        pub const CANOPY: Height = Height(1_028_500);
+        /// The block height at which [`NU5`] activates on Testnet.
+        pub const NU5: Height = Height(1_842_420);
+        /// The block height at which [`NU6`] activates on Testnet.
+        pub const NU6: Height = Height(2_976_000);
+        /// The block height at which [`NU6.1`](NU6_1) activates on Testnet.
+        pub const NU6_1: Height = Height(3_536_500);
+    }
+
+    pub mod mainnet {
+        #[allow(unused_imports)]
+        use crate::{block::Height, parameters::NetworkUpgrade::*};
+
+        /// The block height at which [`BeforeOverwinter`] activates on Mainnet.
+        pub const BEFORE_OVERWINTER: Height = Height(1);
+        /// The block height at which [`Overwinter`] activates on Mainnet.
+        pub const OVERWINTER: Height = Height(347_500);
+        /// The block height at which [`Sapling`] activates on Mainnet.
+        pub const SAPLING: Height = Height(419_200);
+        /// The block height at which [`Blossom`] activates on Mainnet.
+        pub const BLOSSOM: Height = Height(653_600);
+        /// The block height at which [`Heartwood`] activates on Mainnet.
+        pub const HEARTWOOD: Height = Height(903_000);
+        /// The block height at which [`Canopy`] activates on Mainnet.
+        pub const CANOPY: Height = Height(1_046_400);
+        /// The block height at which [`NU5`] activates on Mainnet.
+        pub const NU5: Height = Height(1_687_104);
+        /// The block height at which [`NU6`] activates on Mainnet.
+        pub const NU6: Height = Height(2_726_400);
+        // /// The block height at which [`NU6.1`](NU6_1) activates on Mainnet.
+        // pub const NU6_1: Height = Height(3_146_400);
+    }
+}

--- a/zebra-chain/src/parameters/network/subsidy.rs
+++ b/zebra-chain/src/parameters/network/subsidy.rs
@@ -19,7 +19,7 @@ use lazy_static::lazy_static;
 use crate::{
     amount::{self, Amount, NonNegative, COIN},
     block::{Height, HeightDiff},
-    parameters::{Network, NetworkUpgrade, NU6_1_ACTIVATION_HEIGHT_TESTNET},
+    parameters::{constants::activation_heights, Network, NetworkUpgrade},
     transparent,
 };
 
@@ -338,7 +338,7 @@ lazy_static! {
             .collect(),
         },
         FundingStreams {
-            height_range: NU6_1_ACTIVATION_HEIGHT_TESTNET..Height(4_476_000),
+            height_range: activation_heights::testnet::NU6_1..Height(4_476_000),
             recipients: [
                 (
                     FundingStreamReceiver::Deferred,
@@ -631,6 +631,9 @@ pub const POST_NU6_FUNDING_STREAMS_NUM_ADDRESSES_TESTNET: usize = 13;
 /// Number of addresses for each post-NU6 funding stream in the Testnet.
 /// In the spec ([protocol specification §7.10][7.10]) this is defined as: `fs.addressindex(fs.endheight - 1)`
 /// however we know this value beforehand so we prefer to make it a constant instead.
+///
+/// There are 27 funding stream periods across the 939,500 blocks for which the post-NU6.1 funding streams are
+/// active. See Testnet funding streams in revision 2 of <https://zips.z.cash/zip-0214#funding-streams>.
 ///
 /// [7.10]: https://zips.z.cash/protocol/protocol.pdf#fundingstreams
 pub const POST_NU6_1_FUNDING_STREAMS_NUM_ADDRESSES_TESTNET: usize = 27;

--- a/zebra-chain/src/parameters/network/tests/vectors.rs
+++ b/zebra-chain/src/parameters/network/tests/vectors.rs
@@ -400,7 +400,7 @@ fn check_configured_funding_stream_constraints() {
             assert_eq!(
                 network_funding_streams.recipients().clone(),
                 expected_recipients,
-                "should use default start height when unconfigured"
+                "should use default recipients when unconfigured"
             );
         }
     }
@@ -551,7 +551,7 @@ fn sum_of_one_time_lockbox_disbursements_is_correct() {
         assert_eq!(
             expected_total_lockbox_disbursement_value,
             network.lockbox_disbursement_total_amount(nu6_1_activation_height),
-            "sum of lockbox disbursement output values should match expected total"
+            "total lockbox disbursement value should match expected total"
         );
     }
 }

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -104,23 +104,20 @@ impl fmt::Display for NetworkUpgrade {
 /// Don't use this directly; use NetworkUpgrade::activation_list() so that
 /// we can switch to fake activation heights for some tests.
 #[allow(unused)]
-pub(super) const MAINNET_ACTIVATION_HEIGHTS: &[(block::Height, NetworkUpgrade)] = &[
-    (block::Height(0), Genesis),
-    (block::Height(1), BeforeOverwinter),
-    (block::Height(347_500), Overwinter),
-    (block::Height(419_200), Sapling),
-    (block::Height(653_600), Blossom),
-    (block::Height(903_000), Heartwood),
-    (block::Height(1_046_400), Canopy),
-    (block::Height(1_687_104), Nu5),
-    (block::Height(2_726_400), Nu6),
-];
-
-/// The block height at which NU6.1 activates on the default Testnet.
-// See NU6.1 Testnet activation height in zcashd:
-// <https://github.com/zcash/zcash/blob/b65b008a7b334a2f7c2eaae1b028e011f2e21dd1/src/chainparams.cpp#L472>
-pub const NU6_1_ACTIVATION_HEIGHT_TESTNET: block::Height = block::Height(3_536_500);
-
+pub(super) const MAINNET_ACTIVATION_HEIGHTS: &[(block::Height, NetworkUpgrade)] = {
+    use super::constants::activation_heights::mainnet::*;
+    &[
+        (block::Height(0), Genesis),
+        (BEFORE_OVERWINTER, BeforeOverwinter),
+        (OVERWINTER, Overwinter),
+        (SAPLING, Sapling),
+        (BLOSSOM, Blossom),
+        (HEARTWOOD, Heartwood),
+        (CANOPY, Canopy),
+        (NU5, Nu5),
+        (NU6, Nu6),
+    ]
+};
 /// Testnet network upgrade activation heights.
 ///
 /// This is actually a bijective map, but it is const, so we use a vector, and
@@ -131,18 +128,21 @@ pub const NU6_1_ACTIVATION_HEIGHT_TESTNET: block::Height = block::Height(3_536_5
 /// Don't use this directly; use NetworkUpgrade::activation_list() so that
 /// we can switch to fake activation heights for some tests.
 #[allow(unused)]
-pub(super) const TESTNET_ACTIVATION_HEIGHTS: &[(block::Height, NetworkUpgrade)] = &[
-    (block::Height(0), Genesis),
-    (block::Height(1), BeforeOverwinter),
-    (block::Height(207_500), Overwinter),
-    (block::Height(280_000), Sapling),
-    (block::Height(584_000), Blossom),
-    (block::Height(903_800), Heartwood),
-    (block::Height(1_028_500), Canopy),
-    (block::Height(1_842_420), Nu5),
-    (block::Height(2_976_000), Nu6),
-    (NU6_1_ACTIVATION_HEIGHT_TESTNET, Nu6_1),
-];
+pub(super) const TESTNET_ACTIVATION_HEIGHTS: &[(block::Height, NetworkUpgrade)] = {
+    use super::constants::activation_heights::testnet::*;
+    &[
+        (block::Height(0), Genesis),
+        (BEFORE_OVERWINTER, BeforeOverwinter),
+        (OVERWINTER, Overwinter),
+        (SAPLING, Sapling),
+        (BLOSSOM, Blossom),
+        (HEARTWOOD, Heartwood),
+        (CANOPY, Canopy),
+        (NU5, Nu5),
+        (NU6, Nu6),
+        (NU6_1, Nu6_1),
+    ]
+};
 
 /// The Consensus Branch Id, used to bind transactions and blocks to a
 /// particular network upgrade.


### PR DESCRIPTION
## Motivation

Closes #9915.

## Solution

- Moves all Testnet and Mainnet activation heights (except Genesis) to constants
- Fixes bad error messages in tests
- Improves documentation on `POST_NU6_1_FUNDING_STREAMS_NUM_ADDRESSES_TESTNET` constant

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.
