### PR TITLE
WIP: Improve initial sync performance by committing checkpoint-verified blocks to the non-finalized state first

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7069,6 +7069,7 @@ dependencies = [
  "indicatif",
  "inferno",
  "insta",
+ "itertools 0.14.0",
  "jsonrpsee-types",
  "lazy_static",
  "log",

--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -216,6 +216,8 @@ impl TrustedChainSync {
         &mut self,
         block: SemanticallyVerifiedBlock,
     ) -> Result<(), ValidateContextError> {
+        // TODO: Update this function or this module to work with the latest changes in the non-finalized state.
+
         self.try_catch_up_with_primary().await;
 
         if self.db.finalized_tip_hash() == block.block.header.previous_block_hash {

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -426,6 +426,19 @@ impl FinalizableBlock {
         }
     }
 
+    /// Returns the hash and height of the inner block.
+    pub fn hash_and_height(&self) -> (block::Hash, block::Height) {
+        match self {
+            FinalizableBlock::Checkpoint {
+                checkpoint_verified,
+            } => (checkpoint_verified.hash, checkpoint_verified.height),
+            FinalizableBlock::Contextual {
+                contextually_verified,
+                ..
+            } => (contextually_verified.hash, contextually_verified.height),
+        }
+    }
+
     #[cfg(test)]
     /// Extract a [`Block`] from a [`FinalizableBlock`] variant.
     pub fn inner_block(&self) -> Arc<Block> {

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -330,7 +330,7 @@ impl FinalizedState {
         prev_note_commitment_trees: Option<NoteCommitmentTrees>,
         source: &str,
     ) -> Result<(block::Hash, NoteCommitmentTrees), BoxError> {
-        let (height, hash, finalized, prev_note_commitment_trees) = match finalizable_block {
+        let (height, finalized, prev_note_commitment_trees) = match finalizable_block {
             FinalizableBlock::Checkpoint {
                 checkpoint_verified,
             } => {
@@ -392,7 +392,6 @@ impl FinalizedState {
 
                 (
                     checkpoint_verified.height,
-                    checkpoint_verified.hash,
                     FinalizedBlock::from_checkpoint_verified(checkpoint_verified, treestate),
                     Some(prev_note_commitment_trees),
                 )
@@ -402,7 +401,6 @@ impl FinalizedState {
                 treestate,
             } => (
                 contextually_verified.height,
-                contextually_verified.hash,
                 FinalizedBlock::from_contextually_verified(contextually_verified, treestate),
                 prev_note_commitment_trees,
             ),
@@ -446,7 +444,7 @@ impl FinalizedState {
             source,
         );
 
-        if result.is_ok() {
+        if let Ok(hash) = result {
             // Save blocks to elasticsearch if the feature is enabled.
             #[cfg(feature = "elasticsearch")]
             self.elasticsearch(&finalized_inner_block);

--- a/zebra-state/src/service/finalized_state/disk_format/transparent.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/transparent.rs
@@ -334,6 +334,38 @@ impl AddressBalanceLocation {
     pub fn into_new_change(self) -> AddressBalanceLocationChange {
         AddressBalanceLocationChange::new(self.location)
     }
+
+    /// Updates the current balance by adding the supplied output's value.
+    #[allow(clippy::unwrap_in_result)]
+    pub fn receive_output(
+        &mut self,
+        unspent_output: &transparent::Output,
+    ) -> Result<(), amount::Error> {
+        self.balance = (self
+            .balance
+            .zatoshis()
+            .checked_add(unspent_output.value().zatoshis()))
+        .expect("adding two Amounts is always within an i64")
+        .try_into()?;
+        self.received = self.received.saturating_add(unspent_output.value().into());
+        Ok(())
+    }
+
+    /// Updates the current balance by subtracting the supplied output's value.
+    #[allow(clippy::unwrap_in_result)]
+    pub fn spend_output(
+        &mut self,
+        spent_output: &transparent::Output,
+    ) -> Result<(), amount::Error> {
+        self.balance = (self
+            .balance
+            .zatoshis()
+            .checked_sub(spent_output.value().zatoshis()))
+        .expect("subtracting two Amounts is always within an i64")
+        .try_into()?;
+
+        Ok(())
+    }
 }
 
 impl std::ops::Deref for AddressBalanceLocation {

--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -457,6 +457,14 @@ impl ZebraDb {
             })
             .collect();
 
+        // TODO:
+        // - Look up spent UTXOs `OutputLocation`s in advance, after getting the treestate from the non-finalized state
+        //   and before calling `commit_finalized_direct()`, i.e. add another thread to process finalizable blocks and
+        //   query the database for the output locations of spent UTXOs and any other data needed to write blocks.
+        //   processing contextually
+        //   (check the non-finalized state for the UTXOs too).
+        // - Re-use the `OrderedUtxo`s from the `spent_outputs` field on `ContextuallyVerifiedBlock`
+
         // Get a list of the spent UTXOs, before we delete any from the database
         let spent_utxos: Vec<(transparent::OutPoint, OutputLocation, transparent::Utxo)> =
             finalized

--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -459,10 +459,8 @@ impl ZebraDb {
 
         // TODO:
         // - Look up spent UTXOs `OutputLocation`s in advance, after getting the treestate from the non-finalized state
-        //   and before calling `commit_finalized_direct()`, i.e. add another thread to process finalizable blocks and
-        //   query the database for the output locations of spent UTXOs and any other data needed to write blocks.
-        //   processing contextually
-        //   (check the non-finalized state for the UTXOs too).
+        //   and before calling `commit_finalized_direct()`, i.e. add another thread to process finalizable blocks by
+        //   querying the database for the output locations of spent UTXOs and any other data needed to write blocks.
         // - Re-use the `OrderedUtxo`s from the `spent_outputs` field on `ContextuallyVerifiedBlock`
 
         // Get a list of the spent UTXOs, before we delete any from the database

--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -37,7 +37,7 @@ use crate::{
         disk_db::{DiskDb, DiskWriteBatch, ReadDisk, WriteDisk},
         disk_format::{
             block::TransactionLocation,
-            transparent::{AddressBalanceLocationChange, OutputLocation},
+            transparent::{AddressBalanceLocation, OutputLocation},
         },
         zebra_db::{metrics::block_precommit_metrics, ZebraDb},
         FromDisk, RawBytes,
@@ -517,7 +517,7 @@ impl ZebraDb {
             .collect();
 
         // Get the current address balances, before the transactions in this block
-        let address_balances: HashMap<transparent::Address, AddressBalanceLocationChange> =
+        let address_balances: HashMap<transparent::Address, AddressBalanceLocation> =
             changed_addresses
                 .into_iter()
                 .filter_map(|address| {
@@ -525,7 +525,7 @@ impl ZebraDb {
                     //
                     // Address balances are updated with the `fetch_add_balance_and_received` merge operator, so
                     // the values must represent the changes to the balance, not the final balance.
-                    let addr_loc = self.address_balance_location(&address)?.into_new_change();
+                    let addr_loc = self.address_balance_location(&address)?;
                     Some((address.clone(), addr_loc))
                 })
                 .collect();
@@ -602,7 +602,7 @@ impl DiskWriteBatch {
             transparent::OutPoint,
             OutputLocation,
         >,
-        address_balances: HashMap<transparent::Address, AddressBalanceLocationChange>,
+        address_balances: HashMap<transparent::Address, AddressBalanceLocation>,
         value_pool: ValueBalance<NonNegative>,
         prev_note_commitment_trees: Option<NoteCommitmentTrees>,
     ) -> Result<(), BoxError> {

--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -431,7 +431,7 @@ impl DiskWriteBatch {
             transparent::OutPoint,
             OutputLocation,
         >,
-        mut address_balances: HashMap<transparent::Address, AddressBalanceLocationChange>,
+        mut address_balances: HashMap<transparent::Address, AddressBalanceLocation>,
     ) -> Result<(), BoxError> {
         let db = &zebra_db.db;
         let FinalizedBlock { block, height, .. } = finalized;
@@ -489,7 +489,7 @@ impl DiskWriteBatch {
         db: &DiskDb,
         network: &Network,
         new_outputs_by_out_loc: &BTreeMap<OutputLocation, transparent::Utxo>,
-        address_balances: &mut HashMap<transparent::Address, AddressBalanceLocationChange>,
+        address_balances: &mut HashMap<transparent::Address, AddressBalanceLocation>,
     ) -> Result<(), BoxError> {
         let utxo_by_out_loc = db.cf_handle("utxo_by_out_loc").unwrap();
         let utxo_loc_by_transparent_addr_loc =
@@ -513,7 +513,7 @@ impl DiskWriteBatch {
                 //   (the first location of the address in the chain).
                 let address_balance_location = address_balances
                     .entry(receiving_address)
-                    .or_insert_with(|| AddressBalanceLocationChange::new(*new_output_location));
+                    .or_insert_with(|| AddressBalanceLocation::new(*new_output_location));
                 let receiving_address_location = address_balance_location.address_location();
 
                 // Update the balance for the address in memory.
@@ -567,7 +567,7 @@ impl DiskWriteBatch {
         db: &DiskDb,
         network: &Network,
         spent_utxos_by_out_loc: &BTreeMap<OutputLocation, transparent::Utxo>,
-        address_balances: &mut HashMap<transparent::Address, AddressBalanceLocationChange>,
+        address_balances: &mut HashMap<transparent::Address, AddressBalanceLocation>,
     ) -> Result<(), BoxError> {
         let utxo_by_out_loc = db.cf_handle("utxo_by_out_loc").unwrap();
         let utxo_loc_by_transparent_addr_loc =
@@ -629,7 +629,7 @@ impl DiskWriteBatch {
             transparent::OutPoint,
             OutputLocation,
         >,
-        address_balances: &HashMap<transparent::Address, AddressBalanceLocationChange>,
+        address_balances: &HashMap<transparent::Address, AddressBalanceLocation>,
     ) -> Result<(), BoxError> {
         let db = &zebra_db.db;
         let tx_loc_by_transparent_addr_loc =
@@ -689,17 +689,17 @@ impl DiskWriteBatch {
     pub fn prepare_transparent_balances_batch(
         &mut self,
         db: &DiskDb,
-        address_balances: HashMap<transparent::Address, AddressBalanceLocationChange>,
+        address_balances: HashMap<transparent::Address, AddressBalanceLocation>,
     ) -> Result<(), BoxError> {
         let balance_by_transparent_addr = db.cf_handle(BALANCE_BY_TRANSPARENT_ADDR).unwrap();
 
         // Update all the changed address balances in the database.
-        for (address, address_balance_location_change) in address_balances.into_iter() {
+        for (address, address_balance_location) in address_balances.into_iter() {
             // Some of these balances are new, and some are updates
-            self.zs_merge(
+            self.zs_insert(
                 &balance_by_transparent_addr,
                 address,
-                address_balance_location_change,
+                address_balance_location,
             );
         }
 

--- a/zebra-state/src/service/non_finalized_state/backup.rs
+++ b/zebra-state/src/service/non_finalized_state/backup.rs
@@ -200,6 +200,8 @@ fn read_non_finalized_blocks_from_backup<'a>(
     backup_dir_path: &PathBuf,
     finalized_state: &'a ZebraDb,
 ) -> impl Iterator<Item = SemanticallyVerifiedBlock> + 'a {
+    // TODO: Update this function or this module to work with the latest changes in the non-finalized state.
+
     list_backup_dir_entries(backup_dir_path)
         // It's okay to leave the file here, the backup task will delete it as long as
         // the block is not added to the non-finalized state.

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -516,7 +516,7 @@ proptest! {
             let result_receiver = state_service.queue_and_commit_to_finalized_state(block);
             let result = result_receiver.blocking_recv();
 
-            prop_assert!(result.is_ok(), "unexpected failed finalized block commit: {:?}", result);
+            prop_assert!(result.as_ref().is_ok_and(|result| result.is_ok()), "unexpected failed finalized block commit: {:?}", result);
 
             // Wait for the channels to be updated by the block commit task.
             // TODO: add a blocking method on ChainTipChange
@@ -539,7 +539,7 @@ proptest! {
             let result_receiver = state_service.queue_and_commit_to_non_finalized_state(block);
             let result = result_receiver.blocking_recv();
 
-            prop_assert!(result.is_ok(), "unexpected failed non-finalized block commit: {:?}", result);
+            prop_assert!(result.as_ref().is_ok_and(|result| result.is_ok()), "unexpected failed non-finalized block commit: {:?}", result);
 
             // Wait for the channels to be updated by the block commit task.
             // TODO: add a blocking method on ChainTipChange

--- a/zebra-state/src/service/write.rs
+++ b/zebra-state/src/service/write.rs
@@ -269,6 +269,9 @@ impl BlockWriteSender {
                         )
                         .unwrap();
 
+                    // TODO: The success response could be sent when the latest chain tip channel is updated instead of here.
+                    //       It could improve sync time as it could respond to requests originating from the `ChainSync` component
+                    //       more quickly to free up slots for the syncer to request more blocks from the network.
                     if let Some(rsp_tx) = rsp_tx {
                         let _ = rsp_tx.send(Ok(hash));
                     }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -166,6 +166,8 @@ zebra-script = { path = "../zebra-script", version = "2.0.0" }
 # Required for crates.io publishing, but it's only used in tests
 zebra-utils = { path = "../zebra-utils", version = "2.0.0", optional = true }
 
+itertools.workspace = true
+
 abscissa_core = { workspace = true }
 clap = { workspace = true, features = ["cargo"] }
 chrono = { workspace = true, features = ["clock", "std"] }


### PR DESCRIPTION
### This PR requires some significant additions, documentation, and cleanup/refactoring. It may be difficult to review in its current state.

This is a draft PR to improve Zebra's initial sync performance by doing the basic contextual validity checks for contextually-verified blocks with the non-finalized state, committing them first to the non-finalized state first, and queuing them to be written to the finalized state instead of waiting on them to be written before trying to validate the next block.

*Zebra finished its full initial sync on Mainnet in 7 hours and 20 minutes* for me locally with these changes. 🎉 We may be able to improve initial sync time a little more through this approach by also [splitting out read operations into their own task](https://github.com/ZcashFoundation/zebra/pull/9958/files#diff-9781032518c3c6d10a656ef34d8b7a85325f9c55c5fd65856b2257786459fd50R460-R464).

Will close #9939.