### PR TITLE
cleanup(feature): Fully remove `getblocktemplate-rpcs` feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   `ZEBRA_COOKIE_DIR`, `NETWORK`, `ENABLE_COOKIE_AUTH`, or `MINER_ADDRESS` must switch to the
   config-rs equivalents shown above ([#9768](https://github.com/ZcashFoundation/zebra/pull/9768)).
 
+- Fully removed the `getblocktemplate-rpcs` feature flag from `zebrad/Cargo.toml`.
+  All functionality previously guarded by this flag has already been made the default.
+  As a result, the following build command is no longer supported:
+  ```
+  cargo build --features getblocktemplate-rpcs
+  ```
+  ([#9964](https://github.com/ZcashFoundation/zebra/pull/9964))
+
 ### Changed
 
 - `zebrad` now loads configuration from defaults, an optional TOML file, and environment variables,

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -64,9 +64,6 @@ default = ["default-release-binaries"]
 # Indexer support
 indexer = ["zebra-state/indexer"]
 
-# TODO: Remove this feature when releasing Zebra 3.0 (#9412).
-getblocktemplate-rpcs = []
-
 # Experimental internal miner support
 internal-miner = [
     "thread-priority",


### PR DESCRIPTION
## Motivation

We want to close https://github.com/ZcashFoundation/zebra/issues/9412 for the next release.


## Solution

- Remove pending feature flag.
- Add breaking change entry to CHANGELOG

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.
