### PR TITLE
fix(clippy): Change `println!` to `tracing::info!` in test

### DIFF
--- a/zebrad/src/components/health/tests.rs
+++ b/zebrad/src/components/health/tests.rs
@@ -204,7 +204,7 @@ async fn rate_limiting_drops_bursts() {
     for i in 0..(MAX_RECENT_REQUESTS + 10) {
         if http_get(addr, "/healthy").await.is_none() {
             was_request_dropped = true;
-            println!("got expected status after some reqs: {i}");
+            tracing::info!("got expected status after some reqs: {i}");
             break;
         }
     }


### PR DESCRIPTION
## Motivation

Clippy is complaining 

```
warning: use of `println!`
```

## Solution

Change `println` to `tracing::info`

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
