### PR TITLE
fix(auth): Use `STANDARD` Base64 for RPC auth encoding/decoding

### DIFF
--- a/zebra-rpc/src/server/cookie.rs
+++ b/zebra-rpc/src/server/cookie.rs
@@ -1,6 +1,6 @@
 //! Cookie-based authentication for the RPC server.
 
-use base64::{engine::general_purpose::URL_SAFE, Engine as _};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use color_eyre::Result;
 use rand::RngCore;
 
@@ -29,7 +29,7 @@ impl Default for Cookie {
         let mut bytes = [0u8; 32];
         rand::thread_rng().fill_bytes(&mut bytes);
 
-        Self(URL_SAFE.encode(bytes))
+        Self(STANDARD.encode(bytes))
     }
 }
 

--- a/zebra-rpc/src/server/http_request_compatibility.rs
+++ b/zebra-rpc/src/server/http_request_compatibility.rs
@@ -19,7 +19,7 @@ use tower::Service;
 
 use super::cookie::Cookie;
 
-use base64::{engine::general_purpose::URL_SAFE, Engine as _};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 
 /// HTTP [`HttpRequestMiddleware`] with compatibility workarounds.
 ///
@@ -71,7 +71,7 @@ impl<S> HttpRequestMiddleware<S> {
                 .get(header::AUTHORIZATION)
                 .and_then(|auth_header| auth_header.to_str().ok())
                 .and_then(|auth_header| auth_header.split_whitespace().nth(1))
-                .and_then(|encoded| URL_SAFE.decode(encoded).ok())
+                .and_then(|encoded| STANDARD.decode(encoded).ok())
                 .and_then(|decoded| String::from_utf8(decoded).ok())
                 .and_then(|request_cookie| request_cookie.split(':').nth(1).map(String::from))
                 .is_some_and(|passwd| internal_cookie.authenticate(passwd))


### PR DESCRIPTION
## Motivation

According to [RFC 7617 §2](https://datatracker.ietf.org/doc/html/rfc7617#section-2), HTTP Basic Authentication uses Base64 as defined in [RFC 4648 §4](https://datatracker.ietf.org/doc/html/rfc4648#section-4), which specifies the standard Base64 alphabet. Previously, Zebra used the `URL_SAFE` variant, which differs in character set and padding rules.

Closes [#9966](https://github.com/ZcashFoundation/zebra/issues/9966).

## Solution

Switched RPC auth encoding/decoding to use `STANDARD` instead of `URL_SAFE`.

Note that with this change, some commands that previously worked may no longer decode correctly. For example:

```bash
curl -X POST -H "Content-Type: application/json" \
  -d '{"jsonrpc": "2.0", "method": "getinfo", "params": [], "id":123 }' \
  __cookie__:kpMRGXxEBy/riUrSkIb2LMTAMR4mRYcMdIswpFuYLz8=@127.0.0.1:6666 | jq
```

should now be written as:

```bash
curl -u "__cookie__:kpMRGXxEBy/riUrSkIb2LMTAMR4mRYcMdIswpFuYLz8=" \
  -X POST -H "Content-Type: application/json" \
  -d '{"jsonrpc": "2.0", "method": "getinfo", "params": [], "id":123 }' \
  127.0.0.1:6666 | jq
 ```

It’s unclear to me whether this should be considered a breaking change, but users relying on the old behavior may need to update their commands.

### Tests

Manually.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
