### PR TITLE
fix(state): Restore initial sync performance by avoiding RocksDB merge operations when the on-disk database format is up-to-date

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -16,7 +16,10 @@ use std::{
     fs,
     ops::RangeBounds,
     path::Path,
-    sync::Arc,
+    sync::{
+        atomic::{self, AtomicBool},
+        Arc,
+    },
 };
 
 use itertools::Itertools;
@@ -89,6 +92,10 @@ pub struct DiskDb {
     ///
     /// If true, the database files are deleted on drop.
     ephemeral: bool,
+
+    /// A boolean flag indicating whether the db format change task has finished
+    /// applying any format changes that may have been required.
+    finished_format_upgrades: Arc<AtomicBool>,
 
     // Owned State
     //
@@ -623,6 +630,19 @@ impl DiskDb {
         total_size_on_disk
     }
 
+    /// Sets `finished_format_upgrades` to true to indicate that Zebra has
+    /// finished applying any required db format upgrades.
+    pub fn mark_finished_format_upgrades(&self) {
+        self.finished_format_upgrades
+            .store(true, atomic::Ordering::SeqCst);
+    }
+
+    /// Returns true if the `finished_format_upgrades` flag has been set to true to
+    /// indicate that Zebra has finished applying any required db format upgrades.
+    pub fn finished_format_upgrades(&self) -> bool {
+        self.finished_format_upgrades.load(atomic::Ordering::SeqCst)
+    }
+
     /// When called with a secondary DB instance, tries to catch up with the primary DB instance
     pub fn try_catch_up_with_primary(&self) -> Result<(), rocksdb::Error> {
         self.db.try_catch_up_with_primary()
@@ -932,6 +952,7 @@ impl DiskDb {
                     network: network.clone(),
                     ephemeral: config.ephemeral,
                     db: Arc::new(db),
+                    finished_format_upgrades: Arc::new(AtomicBool::new(false)),
                 };
 
                 db.assert_default_cf_is_empty();

--- a/zebra-state/src/service/finalized_state/disk_format/transparent.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/transparent.rs
@@ -223,7 +223,7 @@ impl<C: Constraint + Copy + std::fmt::Debug> AddressBalanceLocationInner<C> {
             .balance
             .zatoshis()
             .checked_add(unspent_output.value().zatoshis()))
-        .expect("adding two Amounts is always within an i64")
+        .expect("ops handling taddr balances must not overflow")
         .try_into()?;
         self.received = self.received.saturating_add(unspent_output.value().into());
         Ok(())
@@ -239,7 +239,7 @@ impl<C: Constraint + Copy + std::fmt::Debug> AddressBalanceLocationInner<C> {
             .balance
             .zatoshis()
             .checked_sub(spent_output.value().zatoshis()))
-        .expect("subtracting two Amounts is always within an i64")
+        .expect("ops handling taddr balances must not underflow")
         .try_into()?;
 
         Ok(())

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -381,9 +381,18 @@ impl DbFormatChange {
         initial_tip_height: Option<Height>,
         cancel_receiver: &Receiver<CancelFormatChange>,
     ) -> Result<(), CancelFormatChange> {
+        // Mark the database as having finished applying any format upgrades if there are no
+        // format upgrades that need to be applied.
+        if !self.is_upgrade() {
+            db.mark_finished_format_upgrades();
+        }
+
         match self {
             // Perform any required upgrades, then mark the state as upgraded.
-            Upgrade { .. } => self.apply_format_upgrade(db, initial_tip_height, cancel_receiver)?,
+            Upgrade { .. } => {
+                self.apply_format_upgrade(db, initial_tip_height, cancel_receiver)?;
+                db.mark_finished_format_upgrades();
+            }
 
             NewlyCreated { .. } => {
                 Self::mark_as_newly_created(db);

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -179,6 +179,18 @@ impl ZebraDb {
         self.format_change_handle = Some(format_change_handle);
     }
 
+    /// Sets `finished_format_upgrades` to true on the inner [`DiskDb`] to indicate that Zebra has
+    /// finished applying any required db format upgrades.
+    pub fn mark_finished_format_upgrades(&self) {
+        self.db.mark_finished_format_upgrades();
+    }
+
+    /// Returns true if the `finished_format_upgrades` flag has been set to true on the inner [`DiskDb`] to
+    /// indicate that Zebra has finished applying any required db format upgrades.
+    pub fn finished_format_upgrades(&self) -> bool {
+        self.db.finished_format_upgrades()
+    }
+
     /// Returns config for this database.
     pub fn config(&self) -> &Config {
         &self.config

--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -37,7 +37,7 @@ use crate::{
         disk_db::{DiskDb, DiskWriteBatch, ReadDisk, WriteDisk},
         disk_format::{
             block::TransactionLocation,
-            transparent::{AddressBalanceLocationChange, OutputLocation},
+            transparent::{AddressBalanceLocationUpdates, OutputLocation},
         },
         zebra_db::{metrics::block_precommit_metrics, ZebraDb},
         FromDisk, RawBytes,
@@ -517,18 +517,26 @@ impl ZebraDb {
             .collect();
 
         // Get the current address balances, before the transactions in this block
-        let address_balances: HashMap<transparent::Address, AddressBalanceLocationChange> =
+
+        fn read_addr_locs<T, F: Fn(&transparent::Address) -> Option<T>>(
+            changed_addresses: HashSet<transparent::Address>,
+            f: F,
+        ) -> HashMap<transparent::Address, T> {
             changed_addresses
                 .into_iter()
-                .filter_map(|address| {
-                    // # Correctness
-                    //
-                    // Address balances are updated with the `fetch_add_balance_and_received` merge operator, so
-                    // the values must represent the changes to the balance, not the final balance.
-                    let addr_loc = self.address_balance_location(&address)?.into_new_change();
-                    Some((address.clone(), addr_loc))
-                })
-                .collect();
+                .filter_map(|address| Some((address.clone(), f(&address)?)))
+                .collect()
+        }
+
+        let address_balances: AddressBalanceLocationUpdates = if self.finished_format_upgrades() {
+            AddressBalanceLocationUpdates::Insert(read_addr_locs(changed_addresses, |addr| {
+                self.address_balance_location(addr)
+            }))
+        } else {
+            AddressBalanceLocationUpdates::Merge(read_addr_locs(changed_addresses, |addr| {
+                Some(self.address_balance_location(addr)?.into_new_change())
+            }))
+        };
 
         let mut batch = DiskWriteBatch::new();
 
@@ -602,7 +610,7 @@ impl DiskWriteBatch {
             transparent::OutPoint,
             OutputLocation,
         >,
-        address_balances: HashMap<transparent::Address, AddressBalanceLocationChange>,
+        address_balances: AddressBalanceLocationUpdates,
         value_pool: ValueBalance<NonNegative>,
         prev_note_commitment_trees: Option<NoteCommitmentTrees>,
     ) -> Result<(), BoxError> {

--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -513,7 +513,6 @@ impl DiskWriteBatch {
                 // - create or fetch the link from the address to the AddressLocation
                 //   (the first location of the address in the chain).
 
-                #[inline]
                 fn update_addr_loc<
                     C: Constraint + Copy + std::fmt::Debug,
                     T: std::ops::DerefMut<Target = AddressBalanceLocationInner<C>>
@@ -613,7 +612,6 @@ impl DiskWriteBatch {
 
             // Fetch the balance, and the link from the address to the AddressLocation, from memory.
             if let Some(sending_address) = sending_address {
-                #[inline]
                 fn update_addr_loc<
                     C: Constraint + Copy + std::fmt::Debug,
                     T: std::ops::DerefMut<Target = AddressBalanceLocationInner<C>>


### PR DESCRIPTION
## Motivation

We want to fix a recently introduced regression in Zebra's initial sync performance.

Close https://github.com/ZcashFoundation/zebra/issues/9939.

## Solution

- Adds a `finished_format_upgrades` field on `DiskDb` to mark when there are no db format upgrades that are being applied or which need to be applied, and
- Updates `ZebraDb::write_block()` to insert updated address balances instead of merging address balance updates into database values

### Tests

These changes need manual testing to check that:
- [x] Zebra behaves as expected when syncing blocks during a db format upgrade, and
- [x] Zebra's initial sync performance has been restored to what it was before it started using merge operations

### Follow-up Work

We can further improve Zebra's initial sync performance by updating note commitment trees in parallel to writing blocks to the database, see https://github.com/ZcashFoundation/zebra/pull/9958 for more details.

We can also improve the `copy-state` command's performance by copying blocks in batches (or otherwise committing more blocks before verifying that their parents have been committed). See https://github.com/ZcashFoundation/zebra/pull/9958 for more details.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.
