### PR TITLE
refactor(state): improve error propagation for CommitCheckpointVerifiedBlock

### DIFF
--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -75,9 +75,9 @@ pub enum VerifyBlockError {
     #[error(transparent)]
     Time(zebra_chain::block::BlockTimeError),
 
+    /// Error when attempting to commit a block after semantic verification.
     #[error("unable to commit block after semantic verification: {0}")]
-    // TODO: make this into a concrete type, and add it to is_duplicate_request() (#2908)
-    Commit(#[source] BoxError),
+    Commit(#[from] zs::CommitBlockError),
 
     #[error("unable to validate block proposal: failed semantic verification (proof of work is not checked for proposals): {0}")]
     // TODO: make this into a concrete type (see #5732)
@@ -88,6 +88,11 @@ pub enum VerifyBlockError {
 
     #[error("invalid block subsidy: {0}")]
     Subsidy(#[from] SubsidyError),
+
+    /// Errors originating from the state service, which may arise from general failures in interacting with the state.
+    /// This is for errors that are not specifically related to block depth or commit failures.
+    #[error("state service error for block {hash}: {source}")]
+    StateService { source: BoxError, hash: block::Hash },
 }
 
 impl VerifyBlockError {
@@ -96,6 +101,7 @@ impl VerifyBlockError {
     pub fn is_duplicate_request(&self) -> bool {
         match self {
             VerifyBlockError::Block { source, .. } => source.is_duplicate_request(),
+            VerifyBlockError::Commit(commit_err) => commit_err.is_duplicate_request(),
             _ => false,
         }
     }
@@ -353,15 +359,23 @@ where
             match state_service
                 .ready()
                 .await
-                .map_err(VerifyBlockError::Commit)?
+                .map_err(|source| VerifyBlockError::StateService { source, hash })?
                 .call(zs::Request::CommitSemanticallyVerifiedBlock(prepared_block))
                 .await
-                .map_err(VerifyBlockError::Commit)?
             {
-                zs::Response::Committed(committed_hash) => {
+                Ok(zs::Response::Committed(committed_hash)) => {
                     assert_eq!(committed_hash, hash, "state must commit correct hash");
                     Ok(hash)
                 }
+
+                Err(source) => {
+                    if let Some(commit_err) = source.downcast_ref::<zs::CommitBlockError>() {
+                        return Err(VerifyBlockError::Commit(commit_err.clone()));
+                    }
+
+                    Err(VerifyBlockError::StateService { source, hash })
+                }
+
                 _ => unreachable!("wrong response for CommitSemanticallyVerifiedBlock"),
             }
         }

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -106,6 +106,34 @@ impl<E: std::error::Error + 'static> From<BoxError> for LayeredStateError<E> {
     }
 }
 
+/// An error describing why a `CommitCheckpointVerifiedBlock` request failed.
+#[derive(Debug, Error, Clone)]
+#[non_exhaustive]
+pub enum CommitCheckpointVerifiedError {
+    /// An older checkpoint block was dropped because of a newer duplicate block.
+    #[error("dropping older checkpoint verified block: got newer duplicate block")]
+    ReplacedByNewer,
+
+    /// A checkpoint block was dropped because it was already committed to the finalized state.
+    #[error("already finished committing checkpoint verified blocks: dropped duplicate block, block is already committed to the state")]
+    DroppedAlreadyCommitted,
+
+    /// The block was dropped from the queue of finalized blocks.
+    #[error("block was dropped from the queue of finalized blocks")]
+    DroppedFromFinalizedQueue,
+
+    /// The commit task exited (likely during shutdown).
+    #[error("block commit task exited. Is Zebra shutting down?")]
+    CommitTaskExited,
+
+    /// The write task exited (likely during shutdown).
+    #[error("block write task has exited. Is Zebra shutting down?")]
+    WriteTaskExited,
+
+    #[error("clone error: {0}")]
+    CloneError(#[from] CloneError),
+}
+
 /// An error describing why a `InvalidateBlock` request failed.
 #[derive(Debug, Error)]
 #[non_exhaustive]

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -46,8 +46,11 @@ pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 #[derive(Debug, Error, Clone, PartialEq, Eq, new)]
 pub enum CommitBlockError {
     #[error("block hash is a duplicate: already in {location}")]
+    /// The block is a duplicate: it is already queued or committed in the state.
     Duplicate {
+        /// Hash or height of the duplicated block.
         hash_or_height: Option<HashOrHeight>,
+        /// Location in the state where the block can be found.
         location: KnownBlock,
     },
 
@@ -55,6 +58,7 @@ pub enum CommitBlockError {
     #[error("could not contextually validate semantically verified block")]
     ValidateContextError(#[from] ValidateContextError),
 
+    /// The write task exited (likely during shutdown).
     #[error("block commit task exited. Is Zebra shutting down?")]
     #[non_exhaustive]
     WriteTaskExited,

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -130,7 +130,7 @@ pub enum CommitCheckpointVerifiedError {
     #[error("block write task has exited. Is Zebra shutting down?")]
     WriteTaskExited,
 
-    #[error("clone error: {0}")]
+    #[error("{0}")]
     CloneError(#[from] CloneError),
 }
 

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -64,6 +64,14 @@ pub enum CommitBlockError {
     WriteTaskExited,
 }
 
+impl CommitBlockError {
+    /// Returns `true` if this is definitely a duplicate commit request.
+    /// Some duplicate requests might not be detected, and therefore return `false`.
+    pub fn is_duplicate_request(&self) -> bool {
+        matches!(self, CommitBlockError::Duplicate { .. })
+    }
+}
+
 /// An error describing why a `CommitSemanticallyVerified` request failed.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 #[error("could not commit semantically-verified block")]

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -45,7 +45,7 @@ pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 /// An error describing why a block could not be queued to be committed to the state.
 #[derive(Debug, Error, Clone, PartialEq, Eq, new)]
 pub enum CommitBlockError {
-    #[error("block hash has already been sent to be committed to the state")]
+    #[error("block hash is a duplicate: already in {location}")]
     Duplicate {
         hash_or_height: Option<HashOrHeight>,
         location: KnownBlock,

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -95,13 +95,9 @@ pub enum CommitCheckpointVerifiedError {
     #[error("could not queue and commit checkpoint-verified block")]
     CommitBlockError(#[from] CommitBlockError),
     /// RocksDB write failed
-    /// TODO: Wire it up in `finalized_state.rs`, `commit_finalized`
+    /// TODO: Decide whether to expect that writes will succeed (it's already expecting that there won't be a write error when finalizing non-finalized blocks)
     #[error("could not write checkpoint-verified block to RocksDB")]
     WriteError(#[from] rocksdb::Error),
-    /// Temporary workaround for boxed errors.
-    /// TODO: Replace with `ValidateContextError(#[from] ValidateContextError)`
-    #[error("{0}")]
-    CloneError(#[from] CloneError),
 }
 
 impl From<ValidateContextError> for CommitCheckpointVerifiedError {

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -46,7 +46,6 @@ pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 #[derive(Debug, Error, Clone, PartialEq, Eq, new)]
 pub enum CommitBlockError {
     #[error("block hash has already been sent to be committed to the state")]
-    #[non_exhaustive]
     Duplicate {
         hash_or_height: Option<HashOrHeight>,
         location: KnownBlock,
@@ -91,18 +90,12 @@ impl<E: std::error::Error + 'static> From<BoxError> for LayeredStateError<E> {
 
 /// An error describing why a `CommitCheckpointVerifiedBlock` request failed.
 #[derive(Debug, Error, Clone)]
-pub enum CommitCheckpointVerifiedError {
-    #[error("could not queue and commit checkpoint-verified block")]
-    CommitBlockError(#[from] CommitBlockError),
-    /// RocksDB write failed
-    /// TODO: Decide whether to expect that writes will succeed (it's already expecting that there won't be a write error when finalizing non-finalized blocks)
-    #[error("could not write checkpoint-verified block to RocksDB")]
-    WriteError(#[from] rocksdb::Error),
-}
+#[error("could not commit checkpoint-verified block")]
+pub struct CommitCheckpointVerifiedError(#[from] CommitBlockError);
 
 impl From<ValidateContextError> for CommitCheckpointVerifiedError {
     fn from(value: ValidateContextError) -> Self {
-        Self::CommitBlockError(value.into())
+        Self(value.into())
     }
 }
 

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -56,7 +56,7 @@ pub enum CommitBlockError {
 
     /// Contextual validation failed.
     #[error("could not contextually validate semantically verified block")]
-    ValidateContextError(#[from] ValidateContextError),
+    ValidateContextError(#[from] Box<ValidateContextError>),
 
     /// The write task exited (likely during shutdown).
     #[error("block commit task exited. Is Zebra shutting down?")]
@@ -79,7 +79,7 @@ pub struct CommitSemanticallyVerifiedError(#[from] CommitBlockError);
 
 impl From<ValidateContextError> for CommitSemanticallyVerifiedError {
     fn from(value: ValidateContextError) -> Self {
-        Self(value.into())
+        Self(CommitBlockError::ValidateContextError(Box::new(value)))
     }
 }
 
@@ -107,7 +107,7 @@ pub struct CommitCheckpointVerifiedError(#[from] CommitBlockError);
 
 impl From<ValidateContextError> for CommitCheckpointVerifiedError {
     fn from(value: ValidateContextError) -> Self {
-        Self(value.into())
+        Self(CommitBlockError::ValidateContextError(Box::new(value)))
     }
 }
 

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -38,8 +38,8 @@ pub use config::{
 };
 pub use constants::{state_database_format_version_in_code, MAX_BLOCK_REORG_HEIGHT};
 pub use error::{
-    BoxError, CloneError, CommitSemanticallyVerifiedError, DuplicateNullifierError,
-    ValidateContextError,
+    BoxError, CloneError, CommitBlockError, CommitSemanticallyVerifiedError,
+    DuplicateNullifierError, ValidateContextError,
 };
 pub use request::{
     CheckpointVerifiedBlock, CommitSemanticallyVerifiedBlockRequest, HashOrHeight, MappedRequest,

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -830,7 +830,7 @@ pub enum Request {
     /// Block commit requests should be wrapped in a timeout, so that
     /// out-of-order and invalid requests do not hang indefinitely. See the [`crate`]
     /// documentation for details.
-    /// 
+    ///
     /// [0]: (crate::error::CommitCheckpointVerifiedError)
     CommitCheckpointVerifiedBlock(CheckpointVerifiedBlock),
 
@@ -1003,20 +1003,20 @@ pub enum Request {
 
     /// Invalidates a block in the non-finalized state with the provided hash if one is present, removing it and
     /// its child blocks, and rejecting it during contextual validation if it's resubmitted to the state.
-    /// 
+    ///
     /// Returns [`Response::Invalidated`] with the hash of the invalidated block,
     /// or a [`InvalidateError`][0] if the block was not found, the state is still
     /// committing checkpointed blocks, or the request could not be processed.
-    /// 
+    ///
     /// [0]: (crate::error::InvalidateError)
     InvalidateBlock(block::Hash),
 
     /// Reconsiders a previously invalidated block in the non-finalized state with the provided hash if one is present.
-    /// 
+    ///
     /// Returns [`Response::Reconsidered`] with the hash of the reconsidered block,
     /// or a [`ReconsiderError`][0] if the block was not previously invalidated,
     /// its parent chain is missing, or the state is not ready to process the request.
-    /// 
+    ///
     /// [0]: (crate::error::ReconsiderError)
     ReconsiderBlock(block::Hash),
 

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -767,7 +767,7 @@ pub enum Request {
     /// until its parent is ready.
     ///
     /// Returns [`Response::Committed`] with the hash of the block when it is
-    /// committed to the state, or a [`CommitSemanticallyVerifiedBlockError`][0] if
+    /// committed to the state, or a [`CommitSemanticallyVerifiedError`][0] if
     /// the block fails contextual validation or otherwise could not be committed.
     ///
     /// This request cannot be cancelled once submitted; dropping the response
@@ -781,7 +781,7 @@ pub enum Request {
     /// out-of-order and invalid requests do not hang indefinitely. See the [`crate`]
     /// documentation for details.
     ///
-    /// [0]: (crate::error::CommitSemanticallyVerifiedBlockError)
+    /// [0]: (crate::error::CommitSemanticallyVerifiedError)
     CommitSemanticallyVerifiedBlock(SemanticallyVerifiedBlock),
 
     /// Commit a checkpointed block to the state, skipping most but not all
@@ -792,7 +792,7 @@ pub enum Request {
     /// it until its parent is ready.
     ///
     /// Returns [`Response::Committed`] with the hash of the newly committed
-    /// block, or a [`CommitCheckpointVerifiedError`] if the block could not be
+    /// block, or a [`CommitCheckpointVerifiedError`][0] if the block could not be
     /// committed to the state.
     ///
     /// This request cannot be cancelled once submitted; dropping the response
@@ -830,6 +830,8 @@ pub enum Request {
     /// Block commit requests should be wrapped in a timeout, so that
     /// out-of-order and invalid requests do not hang indefinitely. See the [`crate`]
     /// documentation for details.
+    /// 
+    /// [0]: (crate::error::CommitCheckpointVerifiedError)
     CommitCheckpointVerifiedBlock(CheckpointVerifiedBlock),
 
     /// Computes the depth in the current best chain of the block identified by the given hash.
@@ -1001,9 +1003,21 @@ pub enum Request {
 
     /// Invalidates a block in the non-finalized state with the provided hash if one is present, removing it and
     /// its child blocks, and rejecting it during contextual validation if it's resubmitted to the state.
+    /// 
+    /// Returns [`Response::Invalidated`] with the hash of the invalidated block,
+    /// or a [`InvalidateError`][0] if the block was not found, the state is still
+    /// committing checkpointed blocks, or the request could not be processed.
+    /// 
+    /// [0]: (crate::error::InvalidateError)
     InvalidateBlock(block::Hash),
 
     /// Reconsiders a previously invalidated block in the non-finalized state with the provided hash if one is present.
+    /// 
+    /// Returns [`Response::Reconsidered`] with the hash of the reconsidered block,
+    /// or a [`ReconsiderError`][0] if the block was not previously invalidated,
+    /// its parent chain is missing, or the state is not ready to process the request.
+    /// 
+    /// [0]: (crate::error::ReconsiderError)
     ReconsiderBlock(block::Hash),
 
     /// Performs contextual validation of the given block, but does not commit it to the state.

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -130,6 +130,18 @@ pub enum KnownBlock {
     Queue,
 }
 
+impl std::fmt::Display for KnownBlock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            KnownBlock::Finalized => write!(f, "finalized state"),
+            KnownBlock::BestChain => write!(f, "best chain"),
+            KnownBlock::SideChain => write!(f, "side chain"),
+            KnownBlock::WriteChannel => write!(f, "block write channel"),
+            KnownBlock::Queue => write!(f, "validation/commit queue"),
+        }
+    }
+}
+
 /// Information about a transaction in any chain.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AnyTx {

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -114,11 +114,17 @@ pub enum Response {
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// An enum of block stores in the state where a block hash could be found.
 pub enum KnownBlock {
+    /// Block is in the finalized portion of the best chain.
+    Finalized,
+
     /// Block is in the best chain.
     BestChain,
 
     /// Block is in a side chain.
     SideChain,
+
+    /// Block is in a block write channel
+    WriteChannel,
 
     /// Block is queued to be validated and committed, or rejected and dropped.
     Queue,

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -44,7 +44,7 @@ use crate::{
     constants::{
         MAX_FIND_BLOCK_HASHES_RESULTS, MAX_FIND_BLOCK_HEADERS_RESULTS, MAX_LEGACY_CHAIN_BLOCKS,
     },
-    error::{CommitCheckpointVerifiedError, InvalidateError, QueueAndCommitError, ReconsiderError},
+    error::{CommitBlockError, CommitCheckpointVerifiedError, InvalidateError, ReconsiderError},
     response::NonFinalizedBlocksListener,
     service::{
         block_iter::any_ancestor_blocks,
@@ -55,8 +55,8 @@ use crate::{
         queued_blocks::QueuedBlocks,
         watch_receiver::WatchReceiver,
     },
-    BoxError, CheckpointVerifiedBlock, CommitSemanticallyVerifiedError, Config, ReadRequest,
-    ReadResponse, Request, Response, SemanticallyVerifiedBlock,
+    BoxError, CheckpointVerifiedBlock, CommitSemanticallyVerifiedError, Config, KnownBlock,
+    ReadRequest, ReadResponse, Request, Response, SemanticallyVerifiedBlock,
 };
 
 pub mod block_iter;
@@ -234,8 +234,8 @@ impl Drop for StateService {
         std::mem::drop(self.block_write_sender.finalized.take());
         std::mem::drop(self.block_write_sender.non_finalized.take());
 
-        self.clear_finalized_block_queue(CommitCheckpointVerifiedError::WriteTaskExited);
-        self.clear_non_finalized_block_queue(CommitSemanticallyVerifiedError::WriteTaskExited);
+        self.clear_finalized_block_queue(CommitBlockError::WriteTaskExited);
+        self.clear_non_finalized_block_queue(CommitBlockError::WriteTaskExited);
 
         // Log database metrics before shutting down
         info!("dropping the state: logging database metrics");
@@ -495,10 +495,10 @@ impl StateService {
             {
                 Self::send_checkpoint_verified_block_error(
                     duplicate_queued,
-                    QueueAndCommitError::ReplacedByNewer {
-                        block_hash: queued_prev_hash,
-                    }
-                    .into(),
+                    CommitBlockError::new_duplicate(
+                        Some(queued_prev_hash.into()),
+                        KnownBlock::Queue,
+                    ),
                 );
             }
 
@@ -511,10 +511,13 @@ impl StateService {
             //       every time we send some blocks (like QueuedSemanticallyVerifiedBlocks)
             Self::send_checkpoint_verified_block_error(
                 queued,
-                QueueAndCommitError::AlreadyCommitted.into(),
+                CommitBlockError::new_duplicate(None, KnownBlock::Finalized),
             );
 
-            self.clear_finalized_block_queue(QueueAndCommitError::AlreadyCommitted.into());
+            self.clear_finalized_block_queue(CommitBlockError::new_duplicate(
+                None,
+                KnownBlock::Finalized,
+            ));
         }
 
         if self.finalized_state_queued_blocks.is_empty() {
@@ -581,10 +584,10 @@ impl StateService {
                     // If Zebra is shutting down, drop blocks and return an error.
                     Self::send_checkpoint_verified_block_error(
                         queued,
-                        QueueAndCommitError::CommitTaskExited.into(),
+                        CommitBlockError::WriteTaskExited,
                     );
 
-                    self.clear_finalized_block_queue(QueueAndCommitError::CommitTaskExited.into());
+                    self.clear_finalized_block_queue(CommitBlockError::WriteTaskExited);
                 } else {
                     metrics::gauge!("state.checkpoint.sent.block.height")
                         .set(last_sent_finalized_block_height.0 as f64);
@@ -594,7 +597,10 @@ impl StateService {
     }
 
     /// Drops all finalized state queue blocks, and sends an error on their result channels.
-    fn clear_finalized_block_queue(&mut self, error: CommitCheckpointVerifiedError) {
+    fn clear_finalized_block_queue(
+        &mut self,
+        error: impl Into<CommitCheckpointVerifiedError> + Clone,
+    ) {
         for (_hash, queued) in self.finalized_state_queued_blocks.drain() {
             Self::send_checkpoint_verified_block_error(queued, error.clone());
         }
@@ -603,18 +609,21 @@ impl StateService {
     /// Send an error on a `QueuedCheckpointVerified` block's result channel, and drop the block
     fn send_checkpoint_verified_block_error(
         queued: QueuedCheckpointVerified,
-        error: CommitCheckpointVerifiedError,
+        error: impl Into<CommitCheckpointVerifiedError>,
     ) {
         let (finalized, rsp_tx) = queued;
 
         // The block sender might have already given up on this block,
         // so ignore any channel send errors.
-        let _ = rsp_tx.send(Err(error));
+        let _ = rsp_tx.send(Err(error.into()));
         std::mem::drop(finalized);
     }
 
     /// Drops all non-finalized state queue blocks, and sends an error on their result channels.
-    fn clear_non_finalized_block_queue(&mut self, error: CommitSemanticallyVerifiedError) {
+    fn clear_non_finalized_block_queue(
+        &mut self,
+        error: impl Into<CommitSemanticallyVerifiedError> + Clone,
+    ) {
         for (_hash, queued) in self.non_finalized_state_queued_blocks.drain() {
             Self::send_semantically_verified_block_error(queued, error.clone());
         }
@@ -623,13 +632,13 @@ impl StateService {
     /// Send an error on a `QueuedSemanticallyVerified` block's result channel, and drop the block
     fn send_semantically_verified_block_error(
         queued: QueuedSemanticallyVerified,
-        error: CommitSemanticallyVerifiedError,
+        error: impl Into<CommitSemanticallyVerifiedError>,
     ) {
         let (finalized, rsp_tx) = queued;
 
         // The block sender might have already given up on this block,
         // so ignore any channel send errors.
-        let _ = rsp_tx.send(Err(error));
+        let _ = rsp_tx.send(Err(error.into()));
         std::mem::drop(finalized);
     }
 
@@ -653,8 +662,9 @@ impl StateService {
             .contains(&semantically_verified.hash)
         {
             let (rsp_tx, rsp_rx) = oneshot::channel();
-            let _ = rsp_tx.send(Err(QueueAndCommitError::new_duplicate(
-                semantically_verified.hash,
+            let _ = rsp_tx.send(Err(CommitBlockError::new_duplicate(
+                Some(semantically_verified.hash.into()),
+                KnownBlock::WriteChannel,
             )
             .into()));
             return rsp_rx;
@@ -666,8 +676,9 @@ impl StateService {
             .contains_height(semantically_verified.height)
         {
             let (rsp_tx, rsp_rx) = oneshot::channel();
-            let _ = rsp_tx.send(Err(QueueAndCommitError::new_already_finalized(
-                semantically_verified.height,
+            let _ = rsp_tx.send(Err(CommitBlockError::new_duplicate(
+                Some(semantically_verified.height.into()),
+                KnownBlock::Finalized,
             )
             .into()));
             return rsp_rx;
@@ -683,8 +694,9 @@ impl StateService {
             tracing::debug!("replacing older queued request with new request");
             let (mut rsp_tx, rsp_rx) = oneshot::channel();
             std::mem::swap(old_rsp_tx, &mut rsp_tx);
-            let _ = rsp_tx.send(Err(QueueAndCommitError::new_replaced(
-                semantically_verified.hash,
+            let _ = rsp_tx.send(Err(CommitBlockError::new_duplicate(
+                Some(semantically_verified.hash.into()),
+                KnownBlock::Queue,
             )
             .into()));
             rsp_rx
@@ -721,7 +733,10 @@ impl StateService {
             // Send blocks from non-finalized queue
             self.send_ready_non_finalized_queued(self.finalized_block_write_last_sent_hash);
             // We've finished committing checkpoint verified blocks to finalized state, so drop any repeated queued blocks.
-            self.clear_finalized_block_queue(QueueAndCommitError::AlreadyCommitted.into());
+            self.clear_finalized_block_queue(CommitBlockError::new_duplicate(
+                None,
+                KnownBlock::Finalized,
+            ));
         } else if !self.can_fork_chain_at(&parent_hash) {
             tracing::trace!("unready to verify, returning early");
         } else if self.block_write_sender.finalized.is_none() {
@@ -784,12 +799,10 @@ impl StateService {
                         // If Zebra is shutting down, drop blocks and return an error.
                         Self::send_semantically_verified_block_error(
                             queued,
-                            CommitSemanticallyVerifiedError::WriteTaskExited,
+                            CommitBlockError::WriteTaskExited,
                         );
 
-                        self.clear_non_finalized_block_queue(
-                            CommitSemanticallyVerifiedError::WriteTaskExited,
-                        );
+                        self.clear_non_finalized_block_queue(CommitBlockError::WriteTaskExited);
 
                         return;
                     };
@@ -864,6 +877,12 @@ impl StateService {
             blocks, and the canopy activation block, must be committed to the state as finalized \
             blocks"
         );
+    }
+
+    fn known_sent_hash(&self, hash: &block::Hash) -> Option<KnownBlock> {
+        self.non_finalized_block_write_sent_hashes
+            .contains(hash)
+            .then_some(KnownBlock::WriteChannel)
     }
 }
 
@@ -1007,7 +1026,7 @@ impl Service<Request> for StateService {
                 async move {
                     rsp_rx
                         .await
-                        .map_err(|_recv_error| CommitSemanticallyVerifiedError::WriteTaskExited)
+                        .map_err(|_recv_error| CommitBlockError::WriteTaskExited.into())
                         .flatten()
                         .map_err(BoxError::from)
                         .map(Response::Committed)
@@ -1056,7 +1075,7 @@ impl Service<Request> for StateService {
                 async move {
                     rsp_rx
                         .await
-                        .map_err(|_recv_error| CommitCheckpointVerifiedError::WriteTaskExited)
+                        .map_err(|_recv_error| CommitBlockError::WriteTaskExited.into())
                         .flatten()
                         .map_err(BoxError::from)
                         .map(Response::Committed)
@@ -1144,9 +1163,14 @@ impl Service<Request> for StateService {
             Request::KnownBlock(hash) => {
                 let timer = CodeTimer::start();
 
+                let sent_hash_response = self.known_sent_hash(&hash);
                 let read_service = self.read_service.clone();
 
                 async move {
+                    if sent_hash_response.is_some() {
+                        return Ok(Response::KnownBlock(sent_hash_response));
+                    };
+
                     let response = read::non_finalized_state_contains_block_hash(
                         &read_service.latest_non_finalized_state(),
                         hash,

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -16,7 +16,6 @@
 
 use std::{
     collections::HashMap,
-    convert,
     future::Future,
     pin::Pin,
     sync::Arc,
@@ -45,7 +44,7 @@ use crate::{
     constants::{
         MAX_FIND_BLOCK_HASHES_RESULTS, MAX_FIND_BLOCK_HEADERS_RESULTS, MAX_LEGACY_CHAIN_BLOCKS,
     },
-    error::{InvalidateError, QueueAndCommitError, ReconsiderError},
+    error::{CommitCheckpointVerifiedError, InvalidateError, QueueAndCommitError, ReconsiderError},
     response::NonFinalizedBlocksListener,
     service::{
         block_iter::any_ancestor_blocks,
@@ -235,9 +234,7 @@ impl Drop for StateService {
         std::mem::drop(self.block_write_sender.finalized.take());
         std::mem::drop(self.block_write_sender.non_finalized.take());
 
-        self.clear_finalized_block_queue(
-            "dropping the state: dropped unused finalized state queue block",
-        );
+        self.clear_finalized_block_queue(CommitCheckpointVerifiedError::WriteTaskExited);
         self.clear_non_finalized_block_queue(CommitSemanticallyVerifiedError::WriteTaskExited);
 
         // Log database metrics before shutting down
@@ -471,7 +468,7 @@ impl StateService {
     fn queue_and_commit_to_finalized_state(
         &mut self,
         checkpoint_verified: CheckpointVerifiedBlock,
-    ) -> oneshot::Receiver<Result<block::Hash, BoxError>> {
+    ) -> oneshot::Receiver<Result<block::Hash, CommitCheckpointVerifiedError>> {
         // # Correctness & Performance
         //
         // This method must not block, access the database, or perform CPU-intensive tasks,
@@ -498,7 +495,7 @@ impl StateService {
             {
                 Self::send_checkpoint_verified_block_error(
                     duplicate_queued,
-                    "dropping older checkpoint verified block: got newer duplicate block",
+                    CommitCheckpointVerifiedError::ReplacedByNewer,
                 );
             }
 
@@ -511,13 +508,11 @@ impl StateService {
             //       every time we send some blocks (like QueuedSemanticallyVerifiedBlocks)
             Self::send_checkpoint_verified_block_error(
                 queued,
-                "already finished committing checkpoint verified blocks: dropped duplicate block, \
-                 block is already committed to the state",
+                CommitCheckpointVerifiedError::DroppedAlreadyCommitted,
             );
 
             self.clear_finalized_block_queue(
-                "already finished committing checkpoint verified blocks: dropped duplicate block, \
-                 block is already committed to the state",
+                CommitCheckpointVerifiedError::DroppedAlreadyCommitted,
             );
         }
 
@@ -585,11 +580,11 @@ impl StateService {
                     // If Zebra is shutting down, drop blocks and return an error.
                     Self::send_checkpoint_verified_block_error(
                         queued,
-                        "block commit task exited. Is Zebra shutting down?",
+                        CommitCheckpointVerifiedError::CommitTaskExited,
                     );
 
                     self.clear_finalized_block_queue(
-                        "block commit task exited. Is Zebra shutting down?",
+                        CommitCheckpointVerifiedError::CommitTaskExited,
                     );
                 } else {
                     metrics::gauge!("state.checkpoint.sent.block.height")
@@ -600,7 +595,7 @@ impl StateService {
     }
 
     /// Drops all finalized state queue blocks, and sends an error on their result channels.
-    fn clear_finalized_block_queue(&mut self, error: impl Into<BoxError> + Clone) {
+    fn clear_finalized_block_queue(&mut self, error: CommitCheckpointVerifiedError) {
         for (_hash, queued) in self.finalized_state_queued_blocks.drain() {
             Self::send_checkpoint_verified_block_error(queued, error.clone());
         }
@@ -609,13 +604,13 @@ impl StateService {
     /// Send an error on a `QueuedCheckpointVerified` block's result channel, and drop the block
     fn send_checkpoint_verified_block_error(
         queued: QueuedCheckpointVerified,
-        error: impl Into<BoxError>,
+        error: CommitCheckpointVerifiedError,
     ) {
         let (finalized, rsp_tx) = queued;
 
         // The block sender might have already given up on this block,
         // so ignore any channel send errors.
-        let _ = rsp_tx.send(Err(error.into()));
+        let _ = rsp_tx.send(Err(error));
         std::mem::drop(finalized);
     }
 
@@ -728,8 +723,7 @@ impl StateService {
             self.send_ready_non_finalized_queued(self.finalized_block_write_last_sent_hash);
             // We've finished committing checkpoint verified blocks to finalized state, so drop any repeated queued blocks.
             self.clear_finalized_block_queue(
-                "already finished committing checkpoint verified blocks: dropped duplicate block, \
-                 block is already committed to the state",
+                CommitCheckpointVerifiedError::DroppedAlreadyCommitted,
             );
         } else if !self.can_fork_chain_at(&parent_hash) {
             tracing::trace!("unready to verify, returning early");
@@ -1027,6 +1021,8 @@ impl Service<Request> for StateService {
 
             // Uses finalized_state_queued_blocks and pending_utxos in the StateService.
             // Accesses shared writeable state in the StateService.
+            //
+            // The expected error type for this request is `CommitCheckpointVerifiedError`.
             Request::CommitCheckpointVerifiedBlock(finalized) => {
                 // # Consensus
                 //
@@ -1057,15 +1053,17 @@ impl Service<Request> for StateService {
                 // The work is all done, the future just waits on a channel for the result
                 timer.finish(module_path!(), line!(), "CommitCheckpointVerifiedBlock");
 
+                // Await the channel response, flatten the result, map receive errors to
+                // `CommitCheckpointVerifiedError::DroppedFromFinalizedQueue`.
+                // Then flatten the nested Result and convert any errors to a BoxError.
                 async move {
                     rsp_rx
                         .await
                         .map_err(|_recv_error| {
-                            BoxError::from("block was dropped from the queue of finalized blocks")
+                            CommitCheckpointVerifiedError::DroppedFromFinalizedQueue
                         })
-                        // TODO: replace with Result::flatten once it stabilises
-                        // https://github.com/rust-lang/rust/issues/70142
-                        .and_then(convert::identity)
+                        .flatten()
+                        .map_err(BoxError::from)
                         .map(Response::Committed)
                 }
                 .instrument(span)

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -495,7 +495,10 @@ impl StateService {
             {
                 Self::send_checkpoint_verified_block_error(
                     duplicate_queued,
-                    CommitCheckpointVerifiedError::ReplacedByNewer,
+                    QueueAndCommitError::ReplacedByNewer {
+                        block_hash: queued_prev_hash,
+                    }
+                    .into(),
                 );
             }
 
@@ -508,12 +511,10 @@ impl StateService {
             //       every time we send some blocks (like QueuedSemanticallyVerifiedBlocks)
             Self::send_checkpoint_verified_block_error(
                 queued,
-                CommitCheckpointVerifiedError::DroppedAlreadyCommitted,
+                QueueAndCommitError::AlreadyCommitted.into(),
             );
 
-            self.clear_finalized_block_queue(
-                CommitCheckpointVerifiedError::DroppedAlreadyCommitted,
-            );
+            self.clear_finalized_block_queue(QueueAndCommitError::AlreadyCommitted.into());
         }
 
         if self.finalized_state_queued_blocks.is_empty() {
@@ -580,12 +581,10 @@ impl StateService {
                     // If Zebra is shutting down, drop blocks and return an error.
                     Self::send_checkpoint_verified_block_error(
                         queued,
-                        CommitCheckpointVerifiedError::CommitTaskExited,
+                        QueueAndCommitError::CommitTaskExited.into(),
                     );
 
-                    self.clear_finalized_block_queue(
-                        CommitCheckpointVerifiedError::CommitTaskExited,
-                    );
+                    self.clear_finalized_block_queue(QueueAndCommitError::CommitTaskExited.into());
                 } else {
                     metrics::gauge!("state.checkpoint.sent.block.height")
                         .set(last_sent_finalized_block_height.0 as f64);
@@ -722,9 +721,7 @@ impl StateService {
             // Send blocks from non-finalized queue
             self.send_ready_non_finalized_queued(self.finalized_block_write_last_sent_hash);
             // We've finished committing checkpoint verified blocks to finalized state, so drop any repeated queued blocks.
-            self.clear_finalized_block_queue(
-                CommitCheckpointVerifiedError::DroppedAlreadyCommitted,
-            );
+            self.clear_finalized_block_queue(QueueAndCommitError::AlreadyCommitted.into());
         } else if !self.can_fork_chain_at(&parent_hash) {
             tracing::trace!("unready to verify, returning early");
         } else if self.block_write_sender.finalized.is_none() {
@@ -1054,14 +1051,12 @@ impl Service<Request> for StateService {
                 timer.finish(module_path!(), line!(), "CommitCheckpointVerifiedBlock");
 
                 // Await the channel response, flatten the result, map receive errors to
-                // `CommitCheckpointVerifiedError::DroppedFromFinalizedQueue`.
+                // `CommitCheckpointVerifiedError::WriteTaskExited`.
                 // Then flatten the nested Result and convert any errors to a BoxError.
                 async move {
                     rsp_rx
                         .await
-                        .map_err(|_recv_error| {
-                            CommitCheckpointVerifiedError::DroppedFromFinalizedQueue
-                        })
+                        .map_err(|_recv_error| CommitCheckpointVerifiedError::WriteTaskExited)
                         .flatten()
                         .map_err(BoxError::from)
                         .map(Response::Committed)

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -300,16 +300,9 @@ impl FinalizedState {
                 .set(checkpoint_verified.height.0 as f64);
         };
 
-        let _ = rsp_tx.send(
-            result
-                .clone()
-                .map(|(hash, _)| hash)
-                .map_err(CommitCheckpointVerifiedError::from),
-        );
+        let _ = rsp_tx.send(result.clone().map(|(hash, _)| hash));
 
-        result
-            .map(|(_hash, note_commitment_trees)| (checkpoint_verified, note_commitment_trees))
-            .map_err(CommitCheckpointVerifiedError::from)
+        result.map(|(_hash, note_commitment_trees)| (checkpoint_verified, note_commitment_trees))
     }
 
     /// Immediately commit a `finalized` block to the finalized state.

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -30,7 +30,7 @@ use crate::{
     error::CommitCheckpointVerifiedError,
     request::{FinalizableBlock, FinalizedBlock, Treestate},
     service::{check, QueuedCheckpointVerified},
-    BoxError, CheckpointVerifiedBlock, CloneError, Config,
+    CheckpointVerifiedBlock, Config, ValidateContextError,
 };
 
 pub mod column_family;
@@ -300,10 +300,6 @@ impl FinalizedState {
                 .set(checkpoint_verified.height.0 as f64);
         };
 
-        // Make the error cloneable, so we can send it to the block verify future,
-        // and the block write task.
-        let result = result.map_err(CloneError::from);
-
         let _ = rsp_tx.send(
             result
                 .clone()
@@ -335,7 +331,7 @@ impl FinalizedState {
         finalizable_block: FinalizableBlock,
         prev_note_commitment_trees: Option<NoteCommitmentTrees>,
         source: &str,
-    ) -> Result<(block::Hash, NoteCommitmentTrees), BoxError> {
+    ) -> Result<(block::Hash, NoteCommitmentTrees), CommitCheckpointVerifiedError> {
         let (height, hash, finalized, prev_note_commitment_trees) = match finalizable_block {
             FinalizableBlock::Checkpoint {
                 checkpoint_verified,
@@ -353,7 +349,9 @@ impl FinalizedState {
 
                 // Update the note commitment trees.
                 let mut note_commitment_trees = prev_note_commitment_trees.clone();
-                note_commitment_trees.update_trees_parallel(&block)?;
+                note_commitment_trees
+                    .update_trees_parallel(&block)
+                    .map_err(ValidateContextError::from)?;
 
                 // Check the block commitment if the history tree was not
                 // supplied by the non-finalized state. Note that we don't do
@@ -385,12 +383,11 @@ impl FinalizedState {
                 let history_tree_mut = Arc::make_mut(&mut history_tree);
                 let sapling_root = note_commitment_trees.sapling.root();
                 let orchard_root = note_commitment_trees.orchard.root();
-                history_tree_mut.push(
-                    &self.network(),
-                    block.clone(),
-                    &sapling_root,
-                    &orchard_root,
-                )?;
+                history_tree_mut
+                    .push(&self.network(), block.clone(), &sapling_root, &orchard_root)
+                    .map_err(Arc::new)
+                    .map_err(ValidateContextError::from)?;
+
                 let treestate = Treestate {
                     note_commitment_trees,
                     history_tree,

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/drop_tx_locs_by_spends.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/drop_tx_locs_by_spends.rs
@@ -52,9 +52,7 @@ pub fn run(
                     continue;
                 }
 
-                batch
-                    .prepare_nullifier_batch(zebra_db, &tx)
-                    .expect("method should never return an error");
+                batch.prepare_nullifier_batch(zebra_db, &tx);
             }
 
             if !matches!(cancel_receiver.try_recv(), Err(TryRecvError::Empty)) {

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/track_tx_locs_by_spends.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/track_tx_locs_by_spends.rs
@@ -87,9 +87,7 @@ pub fn run(
                         .zs_insert(&spent_output_location, &tx_loc);
                 }
 
-                batch
-                    .prepare_nullifier_batch(zebra_db, &tx, tx_loc)
-                    .expect("method should never return an error");
+                batch.prepare_nullifier_batch(zebra_db, &tx, tx_loc);
             }
 
             if !matches!(cancel_receiver.try_recv(), Err(TryRecvError::Empty)) {

--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -569,7 +569,9 @@ impl ZebraDb {
 
         // Track batch commit latency for observability
         let batch_start = std::time::Instant::now();
-        self.db.write(batch)?;
+        self.db
+            .write(batch)
+            .expect("unexpected rocksdb error while writing block");
         metrics::histogram!("zebra.state.rocksdb.batch_commit.duration_seconds")
             .record(batch_start.elapsed().as_secs_f64());
 

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
@@ -146,9 +146,7 @@ fn test_block_db_round_trip_with(
 
         // Skip validation by writing the block directly to the database
         let mut batch = DiskWriteBatch::new();
-        batch
-            .prepare_block_header_and_transaction_data_batch(&state.db, &finalized)
-            .expect("block is valid for batch");
+        batch.prepare_block_header_and_transaction_data_batch(&state.db, &finalized);
         state.db.write(batch).expect("block is valid for writing");
 
         // Now read it back from the state

--- a/zebra-state/src/service/finalized_state/zebra_db/chain.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/chain.rs
@@ -29,7 +29,7 @@ use crate::{
         zebra_db::{metrics::value_pool_metrics, ZebraDb},
         TypedColumnFamily,
     },
-    BoxError, HashOrHeight,
+    HashOrHeight, ValidateContextError,
 };
 
 /// The name of the History Tree column family.
@@ -252,12 +252,32 @@ impl DiskWriteBatch {
         finalized: &FinalizedBlock,
         utxos_spent_by_block: HashMap<transparent::OutPoint, transparent::Utxo>,
         value_pool: ValueBalance<NonNegative>,
-    ) -> Result<(), BoxError> {
-        let new_value_pool =
-            value_pool.add_chain_value_pool_change(finalized.block.chain_value_pool_change(
+    ) -> Result<(), ValidateContextError> {
+        let block_value_pool_change = finalized
+            .block
+            .chain_value_pool_change(
                 &utxos_spent_by_block,
                 finalized.deferred_pool_balance_change,
-            )?)?;
+            )
+            .map_err(|value_balance_error| {
+                ValidateContextError::CalculateBlockChainValueChange {
+                    value_balance_error,
+                    height: finalized.height,
+                    block_hash: finalized.hash,
+                    transaction_count: finalized.transaction_hashes.len(),
+                    spent_utxo_count: utxos_spent_by_block.len(),
+                }
+            })?;
+
+        let new_value_pool = value_pool
+            .add_chain_value_pool_change(block_value_pool_change)
+            .map_err(|value_balance_error| ValidateContextError::AddValuePool {
+                value_balance_error,
+                chain_value_pools: Box::new(value_pool),
+                block_value_pool_change: Box::new(block_value_pool_change),
+                height: Some(finalized.height),
+            })?;
+
 
         // Update value pool metrics for observability (ZIP-209 compliance monitoring)
         value_pool_metrics(&new_value_pool);

--- a/zebra-state/src/service/finalized_state/zebra_db/chain.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/chain.rs
@@ -278,7 +278,6 @@ impl DiskWriteBatch {
                 height: Some(finalized.height),
             })?;
 
-
         // Update value pool metrics for observability (ZIP-209 compliance monitoring)
         value_pool_metrics(&new_value_pool);
 

--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -40,7 +40,7 @@ use crate::{
         },
         zebra_db::ZebraDb,
     },
-    BoxError, FromDisk, IntoDisk,
+    FromDisk, IntoDisk,
 };
 
 use super::super::TypedColumnFamily;
@@ -415,10 +415,6 @@ impl DiskWriteBatch {
     ///
     /// If this method returns an error, it will be propagated,
     /// and the batch should not be written to the database.
-    ///
-    /// # Errors
-    ///
-    /// - Propagates any errors from updating note commitment trees
     #[allow(clippy::too_many_arguments)]
     pub fn prepare_transparent_transaction_batch(
         &mut self,
@@ -433,7 +429,7 @@ impl DiskWriteBatch {
             OutputLocation,
         >,
         mut address_balances: AddressBalanceLocationUpdates,
-    ) -> Result<(), BoxError> {
+    ) {
         let db = &zebra_db.db;
         let FinalizedBlock { block, height, .. } = finalized;
 
@@ -443,13 +439,13 @@ impl DiskWriteBatch {
             network,
             new_outputs_by_out_loc,
             &mut address_balances,
-        )?;
+        );
         self.prepare_spent_transparent_outputs_batch(
             db,
             network,
             spent_utxos_by_out_loc,
             &mut address_balances,
-        )?;
+        );
 
         // Index the transparent addresses that spent in each transaction
         for (tx_index, transaction) in block.transactions.iter().enumerate() {
@@ -464,10 +460,10 @@ impl DiskWriteBatch {
                 #[cfg(feature = "indexer")]
                 out_loc_by_outpoint,
                 &address_balances,
-            )?;
+            );
         }
 
-        self.prepare_transparent_balances_batch(db, address_balances)
+        self.prepare_transparent_balances_batch(db, address_balances);
     }
 
     /// Prepare a database batch for the new UTXOs in `new_outputs_by_out_loc`.
@@ -491,7 +487,7 @@ impl DiskWriteBatch {
         network: &Network,
         new_outputs_by_out_loc: &BTreeMap<OutputLocation, transparent::Utxo>,
         address_balances: &mut AddressBalanceLocationUpdates,
-    ) -> Result<(), BoxError> {
+    ) {
         let utxo_by_out_loc = db.cf_handle("utxo_by_out_loc").unwrap();
         let utxo_loc_by_transparent_addr_loc =
             db.cf_handle("utxo_loc_by_transparent_addr_loc").unwrap();
@@ -574,8 +570,6 @@ impl DiskWriteBatch {
             // to get an output.)
             self.zs_insert(&utxo_by_out_loc, new_output_location, unspent_output);
         }
-
-        Ok(())
     }
 
     /// Prepare a database batch for the spent outputs in `spent_utxos_by_out_loc`.
@@ -598,7 +592,7 @@ impl DiskWriteBatch {
         network: &Network,
         spent_utxos_by_out_loc: &BTreeMap<OutputLocation, transparent::Utxo>,
         address_balances: &mut AddressBalanceLocationUpdates,
-    ) -> Result<(), BoxError> {
+    ) {
         let utxo_by_out_loc = db.cf_handle("utxo_by_out_loc").unwrap();
         let utxo_loc_by_transparent_addr_loc =
             db.cf_handle("utxo_loc_by_transparent_addr_loc").unwrap();
@@ -652,8 +646,6 @@ impl DiskWriteBatch {
             // Delete the OutputLocation, and the copy of the spent Output in the database.
             self.zs_delete(&utxo_by_out_loc, spent_output_location);
         }
-
-        Ok(())
     }
 
     /// Prepare a database batch indexing the transparent addresses that spent in this transaction.
@@ -680,7 +672,7 @@ impl DiskWriteBatch {
             OutputLocation,
         >,
         address_balances: &AddressBalanceLocationUpdates,
-    ) -> Result<(), BoxError> {
+    ) {
         let db = &zebra_db.db;
         let tx_loc_by_transparent_addr_loc =
             db.cf_handle("tx_loc_by_transparent_addr_loc").unwrap();
@@ -729,8 +721,6 @@ impl DiskWriteBatch {
                     .zs_insert(spent_output_location, &spending_tx_location);
             }
         }
-
-        Ok(())
     }
 
     /// Prepare a database batch containing `finalized.block`'s:
@@ -746,7 +736,7 @@ impl DiskWriteBatch {
         &mut self,
         db: &DiskDb,
         address_balances: AddressBalanceLocationUpdates,
-    ) -> Result<(), BoxError> {
+    ) {
         let balance_by_transparent_addr = db.cf_handle(BALANCE_BY_TRANSPARENT_ADDR).unwrap();
 
         // Update all the changed address balances in the database.
@@ -772,7 +762,5 @@ impl DiskWriteBatch {
                 }
             }
         };
-
-        Ok(())
     }
 }

--- a/zebra-state/src/service/queued_blocks.rs
+++ b/zebra-state/src/service/queued_blocks.rs
@@ -11,8 +11,9 @@ use tracing::instrument;
 use zebra_chain::{block, transparent};
 
 use crate::{
-    error::QueueAndCommitError, BoxError, CheckpointVerifiedBlock, CommitSemanticallyVerifiedError,
-    NonFinalizedState, SemanticallyVerifiedBlock,
+    error::{CommitCheckpointVerifiedError, QueueAndCommitError},
+    CheckpointVerifiedBlock, CommitSemanticallyVerifiedError, NonFinalizedState,
+    SemanticallyVerifiedBlock,
 };
 
 #[cfg(test)]
@@ -21,7 +22,7 @@ mod tests;
 /// A queued checkpoint verified block, and its corresponding [`Result`] channel.
 pub type QueuedCheckpointVerified = (
     CheckpointVerifiedBlock,
-    oneshot::Sender<Result<block::Hash, BoxError>>,
+    oneshot::Sender<Result<block::Hash, CommitCheckpointVerifiedError>>,
 );
 
 /// A queued semantically verified block, and its corresponding [`Result`] channel.

--- a/zebra-state/src/service/read/find.rs
+++ b/zebra-state/src/service/read/find.rs
@@ -159,7 +159,7 @@ pub fn non_finalized_state_contains_block_hash(
 /// Returns the location of the block if present in the finalized state.
 /// Returns None if the block hash is not found in the finalized state.
 pub fn finalized_state_contains_block_hash(db: &ZebraDb, hash: block::Hash) -> Option<KnownBlock> {
-    db.contains_hash(hash).then_some(KnownBlock::BestChain)
+    db.contains_hash(hash).then_some(KnownBlock::Finalized)
 }
 
 /// Return the height for the block at `hash`, if `hash` is in `chain` or `db`.

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -1191,7 +1191,7 @@ where
         match e {
             // Structural matches: downcasts
             BlockDownloadVerifyError::Invalid { error, .. } if error.is_duplicate_request() => {
-                debug!(error = ?e, "block was already verified, possibly from a previous sync run, continuing");
+                debug!(error = ?e, "block was already verified or committed, possibly from a previous sync run, continuing");
                 false
             }
 
@@ -1218,21 +1218,6 @@ where
                 false
             }
 
-            // String matches
-            //
-            // We want to match VerifyChainError::Block(VerifyBlockError::Commit(ref source)),
-            // but that type is boxed.
-            // TODO:
-            // - turn this check into a function on VerifyChainError, like is_duplicate_request()
-            BlockDownloadVerifyError::Invalid { error, .. }
-                if format!("{error:?}").contains("block is already committed to the state")
-                    || format!("{error:?}")
-                        .contains("block has already been sent to be committed to the state") =>
-            {
-                // TODO: improve this by checking the type (#2908)
-                debug!(error = ?e, "block is already committed or pending a commit, possibly from a previous sync run, continuing");
-                false
-            }
             BlockDownloadVerifyError::DownloadFailed { ref error, .. }
                 if format!("{error:?}").contains("NotFound") =>
             {
@@ -1257,12 +1242,7 @@ where
                 // TODO: add a proper test and remove this
                 // https://github.com/ZcashFoundation/zebra/issues/2909
                 let err_str = format!("{e:?}");
-                if err_str.contains("AlreadyVerified")
-                    || err_str.contains("AlreadyInState")
-                    || err_str.contains("block is already committed to the state")
-                    || err_str.contains("block has already been sent to be committed to the state")
-                    || err_str.contains("NotFound")
-                {
+                if err_str.contains("NotFound") {
                     error!(?e,
                         "a BlockDownloadVerifyError that should have been filtered out was detected, \
                         which possibly indicates a programming error in the downcast inside \


### PR DESCRIPTION
## Motivation

This PR addresses #9730 and focuses on the `CommitCheckpointVerifiedBlock` path.


## Solution

<!-- Describe the changes in the PR. -->

* Refactors the errors in `CommitCheckpointVerifiedBlock` following the example from #9848 and #9923.
* Introduces the new error enum `CommitCheckpointVerifiedError` in `error.rs`.
* Implements `MappedRequest` for `CommitCheckpointVerifiedBlock`.
* Adds documentation for the new error type and its usage across relevant modules.


### Follow-up Work

* **Should `CloneError` be replaced?**
  `CloneError` was introduced due to [`commit_finalized_direct`](https://github.com/ZcashFoundation/zebra/blob/d1ce5e59b40ac09ca951b9d2c1a71f8037f11594/zebra-state/src/service/finalized_state.rs#L327) returning a `BoxError`. Replacing it will require additional changes to the error like implementing `From<zebra_chain::parallel::tree::NoteCommitmentTreeError>`. 
* **Should `CommitCheckpointVerifiedError` wrap `QueueAndCommitError`?**
  There is some overlap between these error types, particularly with regard to the error messages. Adopting `QueueAndCommitError` would simplify error handling, but this would require modifying some of the existing error messages to match.

Happy to adjust based on feedback.


### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.
