### PR TITLE
fix(health): Avoid repeated warnings about the chain metrics channel being closed when the healthcheck server is disabled

### DIFF
--- a/zebrad/src/components/sync/progress.rs
+++ b/zebrad/src/components/sync/progress.rs
@@ -129,6 +129,7 @@ pub async fn show_block_chain_progress(
 
     #[cfg(feature = "progress-bar")]
     let block_bar = howudoin::new().label("Blocks");
+    let mut is_chain_metrics_chan_closed = false;
 
     loop {
         let now = Utc::now();
@@ -173,12 +174,15 @@ pub async fn show_block_chain_progress(
                 last_state_change_instant = instant_now;
             }
 
-            if let Err(err) = chain_tip_metrics_sender.send(ChainTipMetrics::new(
-                last_state_change_instant,
-                Some(remaining_sync_blocks),
-            )) {
-                tracing::warn!(?err, "chain tip metrics channel closed");
-            };
+            if !is_chain_metrics_chan_closed {
+                if let Err(err) = chain_tip_metrics_sender.send(ChainTipMetrics::new(
+                    last_state_change_instant,
+                    Some(remaining_sync_blocks),
+                )) {
+                    tracing::warn!(?err, "chain tip metrics channel closed");
+                    is_chain_metrics_chan_closed = true
+                };
+            }
 
             // Skip logging and status updates if it isn't time for them yet.
             let elapsed_since_log = instant_now.saturating_duration_since(last_log_time);


### PR DESCRIPTION
## Motivation

This PR updates the progress task to avoid repeatedly logging warnings when there is no healthcheck server.

## Solution

- Adds a `is_chain_metrics_chan_closed` flag and sets it to true if sending to the chain metrics channel fails
- Avoids sending to the chain metrics channel when the flag is set to true

### Tests

This has been manually tested to check that it avoids repeated warnings.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.
