### PR TITLE
fix(consensus): Updates block validation and block template generation to use `hashBlockCommitments` when NU5 is active at the Heartwood activation height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   cargo build --features getblocktemplate-rpcs
   ```
   ([#9964](https://github.com/ZcashFoundation/zebra/pull/9964))
+- Expects the block commitment bytes of Heartwood activation blocks to be the `hashBlockCommitments` after NU5 activation
 
 ### Changed
 

--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `{sapling,orchard}::Root::bytes_in_display_order()`
 - Added `bytes_in_display_order()` for multiple `sprout` types,
   as well for `orchard::tree::Root` and `Halo2Proof`.
+- Added `CHAIN_HISTORY_ACTIVATION_RESERVED` as an export from the `block` module.
 
 ## [2.0.0] - 2025-08-07
 

--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -35,6 +35,7 @@ pub mod tests;
 
 pub use commitment::{
     ChainHistoryBlockTxAuthCommitmentHash, ChainHistoryMmrRootHash, Commitment, CommitmentError,
+    CHAIN_HISTORY_ACTIVATION_RESERVED,
 };
 pub use hash::Hash;
 pub use header::{BlockTimeError, CountedHeader, Header, ZCASH_BLOCK_VERSION};

--- a/zebra-rpc/qa/pull-tester/rpc-tests.py
+++ b/zebra-rpc/qa/pull-tester/rpc-tests.py
@@ -45,7 +45,8 @@ BASE_SCRIPTS= [
     'feature_nu6.py',
     'feature_nu6_1.py',
     'feature_backup_non_finalized_state.py',
-    'getrawtransaction_sidechain.py']
+    'getrawtransaction_sidechain.py',
+    'fix_block_commitments.py']
 
 ZMQ_SCRIPTS = [
     # ZMQ test can only be run if bitcoin was built with zmq-enabled.

--- a/zebra-rpc/qa/rpc-tests/fix_block_commitments.py
+++ b/zebra-rpc/qa/rpc-tests/fix_block_commitments.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 The Zcash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+from decimal import Decimal
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.config import ZebraExtraArgs
+from test_framework.util import (
+    assert_true,
+    assert_equal,
+    start_node,
+)
+
+# Test if the fix at https://github.com/ZcashFoundation/zebra/pull/9982
+# fixes the regtest bug reported in https://github.com/ZcashFoundation/zebra/issues/9978
+#
+# We start 2 nodes and activate Heartwood and NU5 in the same block at node 0,
+# and in different blocks at node 1. We then check that the blockcommitments
+# field in the block header is non-zero only when NU5 activates.
+#
+# Previous to the fix, the blockcommitments field was zero when both
+# Heartwood and NU5 activated in the same block.
+class BlockCommitmentsTest(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.num_nodes = 2
+        self.cache_behavior = 'clean'
+
+    def start_node_with(self, index, args):
+        return start_node(index, self.options.tmpdir, args)
+
+    def setup_network(self, split=False):
+        self.nodes = []
+
+        # At node 0, Heartwood and NU5 activate in the same block.
+        args = ZebraExtraArgs(
+            activation_heights={"Heartwood": 1, "NU5": 1}
+        )
+        self.nodes.append(self.start_node_with(0, args))
+
+        # At node 1, Heartwood and NU5 activate in different blocks.
+        args = ZebraExtraArgs(
+            activation_heights={"Heartwood": 1, "NU5": 2}
+        )
+        self.nodes.append(self.start_node_with(1, args))
+
+    def run_test(self):
+        print("Activating Heartwood and NU5 in one block at node 0")
+        self.nodes[0].generate(1)
+
+        # When both Heartwood and NU5 activate in the same block, the blockcommitments should be non-zero.
+        assert_true(self.nodes[0].getblock('1')['blockcommitments'] != "0000000000000000000000000000000000000000000000000000000000000000")
+
+        print("Activating just Heartwood at node 1")
+        self.nodes[1].generate(1)
+
+        # When only Heartwood activates, the blockcommitments should be zero.
+        assert_equal(self.nodes[1].getblock('1')['blockcommitments'], "0000000000000000000000000000000000000000000000000000000000000000")
+
+        print("Activating NU5 at node 1")
+        self.nodes[1].generate(1)
+
+        # When NU5 activates, the blockcommitments for block 2 should be non-zero.
+        assert_equal(self.nodes[1].getblock('1')['blockcommitments'], "0000000000000000000000000000000000000000000000000000000000000000")
+        assert_true(self.nodes[1].getblock('2')['blockcommitments'] != "0000000000000000000000000000000000000000000000000000000000000000")
+
+if __name__ == '__main__':
+    BlockCommitmentsTest().main()

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -110,15 +110,15 @@ async fn test_z_get_treestate() {
         .with_activation_heights(ConfiguredActivationHeights {
             sapling: Some(SAPLING_ACTIVATION_HEIGHT),
             // We need to set the NU5 activation height higher than the height of the last block for
-            // this test because we currently have only the first 10 blocks from the public Testnet,
+            // this test because we currently have only the first 11 blocks from the public Testnet,
             // none of which are compatible with NU5 due to the following consensus rule:
             //
             // > [NU5 onward] hashBlockCommitments MUST be set to the value of
             // > hashBlockCommitments for this block, as specified in [ZIP-244].
             //
-            // Activating NU5 at a lower height and using the 10 blocks causes a failure in
+            // Activating NU5 at a lower height and using the 11 blocks causes a failure in
             // [`zebra_state::populated_state`].
-            nu5: Some(10),
+            nu5: Some(11),
             ..Default::default()
         })
         .clear_funding_streams()

--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -191,7 +191,15 @@ pub(crate) fn block_commitment_is_valid_for_chain_history(
             // return the block commitments if it's NU5 onward.
             let history_tree_root = history_tree
                 .hash()
-                .expect("the history tree of the previous block must exist since the current block has a ChainHistoryBlockTxAuthCommitment");
+                .or_else(|| {
+                    (NetworkUpgrade::Heartwood.activation_height(network)
+                        == block.coinbase_height())
+                    .then_some(block::CHAIN_HISTORY_ACTIVATION_RESERVED.into())
+                })
+                .expect(
+                    "the history tree of the previous block must exist \
+                 since the current block has a ChainHistoryBlockTxAuthCommitment",
+                );
             let auth_data_root = block.auth_data_root();
 
             let hash_block_commitments = ChainHistoryBlockTxAuthCommitmentHash::from_commitments(


### PR DESCRIPTION
## Motivation

This PR fixes a bug in Zebra's block validation and block template generation on Regtest and test networks where NU5 is active at the Heartwood activation height.

Close #9978.

## Solution

- Only check that Heartwood activation block commitment bytes are `CHAIN_HISTORY_ACTIVATION_RESERVED` pre-NU5 (for Heartwood and Canopy)
- Use `CHAIN_HISTORY_ACTIVATION_RESERVED` as the history tree root when computing the expected block commitment for the Heartwood activation block
- Generate post-NU5 Heartwood activation block templates with the `hashBlockCommitments` as the commitment bytes instead of `CHAIN_HISTORY_ACTIVATION_RESERVED`

Related:
- Exports `CHAIN_HISTORY_ACTIVATION_RESERVED` from `zebra-chain` and uses it instead of magic values in `get_block_template` module.

### Tests

This is covered by existing tests, notably the `nu6_funding_streams_and_coinbase_balance()` test which generates and validates blocks on a network where NU5 is active at the Heartwood activation height.

### Specifications & References

The `hashReserved/hashFinalSaplingRoot/hashLightClientRoot/hashBlockCommitmentsSection` field in section 7.6 of https://zips.z.cash/protocol/protocol.pdf

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.
