### PR TITLE
Add(consensus): Set NU6.1 activation height, funding streams, lockbox disbursments, and current network protocol version

### DIFF
--- a/zebra-chain/src/parameters/constants.rs
+++ b/zebra-chain/src/parameters/constants.rs
@@ -74,7 +74,7 @@ pub mod activation_heights {
         pub const NU5: Height = Height(1_687_104);
         /// The block height at which `NU6` activates on Mainnet.
         pub const NU6: Height = Height(2_726_400);
-        // /// The block height at which `NU6.1` activates on Mainnet.
-        // pub const NU6_1: Height = Height(3_146_400);
+        /// The block height at which `NU6.1` activates on Mainnet.
+        pub const NU6_1: Height = Height(3_146_400);
     }
 }

--- a/zebra-chain/src/parameters/network/subsidy.rs
+++ b/zebra-chain/src/parameters/network/subsidy.rs
@@ -294,6 +294,22 @@ lazy_static! {
             .into_iter()
             .collect(),
         },
+
+        FundingStreams {
+            height_range: activation_heights::mainnet::NU6_1..Height(4_406_400),
+            recipients: [
+                (
+                    FundingStreamReceiver::Deferred,
+                    FundingStreamRecipient::new::<[&str; 0], &str>(12, []),
+                ),
+                (
+                    FundingStreamReceiver::MajorGrants,
+                    FundingStreamRecipient::new(8, POST_NU6_1_FUNDING_STREAM_FPF_ADDRESSES_MAINNET),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        },
     ];
 
     /// The funding streams for Testnet as described in:
@@ -366,7 +382,10 @@ const POST_NU6_FUNDING_STREAM_START_HEIGHT_TESTNET: u32 = 2_976_000;
 /// See:
 /// - <https://zips.z.cash/zip-0271#one-timelockboxdisbursement>
 /// - <https://zips.z.cash/zip-0214#mainnet-recipients-for-revision-2>
-pub const NU6_1_LOCKBOX_DISBURSEMENTS_MAINNET: [(&str, Amount<NonNegative>); 0] = [];
+pub const NU6_1_LOCKBOX_DISBURSEMENTS_MAINNET: [(&str, Amount<NonNegative>); 10] = [(
+    "t3ev37Q2uL1sfTsiJQJiWJoFzQpDhmnUwYo",
+    EXPECTED_NU6_1_LOCKBOX_DISBURSEMENTS_TOTAL_MAINNET.div_exact(10),
+); 10];
 
 /// The one-time lockbox disbursement output addresses and amounts expected in the NU6.1 activation block's
 /// coinbase transaction on Testnet.
@@ -550,6 +569,18 @@ pub const POST_NU6_FUNDING_STREAMS_NUM_ADDRESSES_MAINNET: usize = 12;
 pub const POST_NU6_FUNDING_STREAM_FPF_ADDRESSES_MAINNET: [&str;
     POST_NU6_FUNDING_STREAMS_NUM_ADDRESSES_MAINNET] =
     ["t3cFfPt1Bcvgez9ZbMBFWeZsskxTkPzGCow"; POST_NU6_FUNDING_STREAMS_NUM_ADDRESSES_MAINNET];
+
+/// Number of addresses for each post-NU6.1 funding stream on Mainnet.
+/// In the spec ([protocol specification §7.10][7.10]) this is defined as: `fs.addressindex(fs.endheight - 1)`
+/// however we know this value beforehand so we prefer to make it a constant instead.
+///
+/// [7.10]: https://zips.z.cash/protocol/protocol.pdf#fundingstreams
+pub const POST_NU6_1_FUNDING_STREAMS_NUM_ADDRESSES_MAINNET: usize = 36;
+
+/// List of addresses for the Major Grants post-NU6.1 funding stream on Mainnet administered by the Financial Privacy Fund (FPF).
+pub const POST_NU6_1_FUNDING_STREAM_FPF_ADDRESSES_MAINNET: [&str;
+    POST_NU6_1_FUNDING_STREAMS_NUM_ADDRESSES_MAINNET] =
+    ["t3cFfPt1Bcvgez9ZbMBFWeZsskxTkPzGCow"; POST_NU6_1_FUNDING_STREAMS_NUM_ADDRESSES_MAINNET];
 
 /// Number of addresses for each funding stream in the Testnet.
 /// In the spec ([protocol specification §7.10][7.10]) this is defined as: `fs.addressindex(fs.endheight - 1)`

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -117,6 +117,7 @@ pub(super) const MAINNET_ACTIVATION_HEIGHTS: &[(block::Height, NetworkUpgrade)] 
         (CANOPY, Canopy),
         (NU5, Nu5),
         (NU6, Nu6),
+        (NU6_1, Nu6_1),
     ]
 };
 /// Testnet network upgrade activation heights.

--- a/zebra-consensus/src/block/subsidy/funding_streams/tests.rs
+++ b/zebra-consensus/src/block/subsidy/funding_streams/tests.rs
@@ -19,20 +19,27 @@ fn test_funding_stream_values() -> Result<(), Report> {
 
     let canopy_activation_height = Canopy.activation_height(network).unwrap();
     let nu6_activation_height = Nu6.activation_height(network).unwrap();
+    let nu6_1_activation_height = Nu6_1.activation_height(network).unwrap();
 
     let dev_fund_height_range = network.all_funding_streams()[0].height_range();
     let nu6_fund_height_range = network.all_funding_streams()[1].height_range();
+    let nu6_1_fund_height_range = network.all_funding_streams()[2].height_range();
 
     let nu6_fund_end = Height(3_146_400);
+    let nu6_1_fund_end = Height(4_406_400);
 
     assert_eq!(canopy_activation_height, Height(1_046_400));
     assert_eq!(nu6_activation_height, Height(2_726_400));
+    assert_eq!(nu6_1_activation_height, Height(3_146_400));
 
     assert_eq!(dev_fund_height_range.start, canopy_activation_height);
     assert_eq!(dev_fund_height_range.end, nu6_activation_height);
 
     assert_eq!(nu6_fund_height_range.start, nu6_activation_height);
     assert_eq!(nu6_fund_height_range.end, nu6_fund_end);
+
+    assert_eq!(nu6_1_fund_height_range.start, nu6_1_activation_height);
+    assert_eq!(nu6_1_fund_height_range.end, nu6_1_fund_end);
 
     assert_eq!(dev_fund_height_range.end, nu6_fund_height_range.start);
 
@@ -73,6 +80,12 @@ fn test_funding_stream_values() -> Result<(), Report> {
         nu6_fund_height_range.end.previous().unwrap(),
         nu6_fund_height_range.end,
         nu6_fund_height_range.end.next().unwrap(),
+        nu6_1_fund_height_range.start.previous().unwrap(),
+        nu6_1_fund_height_range.start,
+        nu6_1_fund_height_range.start.next().unwrap(),
+        nu6_1_fund_height_range.end.previous().unwrap(),
+        nu6_1_fund_height_range.end,
+        nu6_1_fund_height_range.end.next().unwrap(),
     ] {
         let fsv = funding_stream_values(height, network, block_subsidy(height, network)?).unwrap();
 
@@ -80,7 +93,8 @@ fn test_funding_stream_values() -> Result<(), Report> {
             assert!(fsv.is_empty());
         } else if height < nu6_activation_height {
             assert_eq!(fsv, expected_dev_fund);
-        } else if height < nu6_fund_end {
+        } else if height < nu6_1_fund_end {
+            // NU6 and NU6.1 funding streams are in the same halving and expected to have the same values
             assert_eq!(fsv, expected_nu6_fund);
         } else {
             assert!(fsv.is_empty());

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -2249,7 +2249,7 @@ async fn v5_transaction_with_exceeding_expiry_height() {
         expiry_height,
         sapling_shielded_data: None,
         orchard_shielded_data: None,
-        network_upgrade: NetworkUpgrade::Nu6,
+        network_upgrade: NetworkUpgrade::Nu6_1,
     };
 
     let transaction_hash = transaction.hash();

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -339,12 +339,11 @@ pub const TIMESTAMP_TRUNCATION_SECONDS: u32 = 30 * 60;
 /// network upgrades.
 ///
 /// This version of Zebra draws the current network protocol version from
-/// [ZIP-253](https://zips.z.cash/zip-0253).
-// TODO: Update this constant to the correct value after NU6.1 & NU7 activation (see NU deployment ZIPs),
-// pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_140); // NU6.1 Mainnet
+/// [ZIP-255](https://zips.z.cash/zip-0255).
+// TODO: Update this constant to the correct value after NU7 activation (see NU deployment ZIPs),
+pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_140);
 // pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_150); // NU7 Testnet.
 // pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_160); // NU7 Mainnet.
-pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_130);
 
 /// The default RTT estimate for peer responses.
 ///

--- a/zebra-rpc/src/methods/tests/snapshots/get_blockchain_info@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_blockchain_info@mainnet_10.snap
@@ -86,6 +86,11 @@ expression: info
       "name": "NU6",
       "activationheight": 2726400,
       "status": "pending"
+    },
+    "4dec4df0": {
+      "name": "NU6.1",
+      "activationheight": 3146400,
+      "status": "pending"
     }
   },
   "consensus": {

--- a/zebra-rpc/src/methods/tests/snapshots/get_info@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_info@mainnet_10.snap
@@ -6,7 +6,7 @@ expression: info
   "version": 100,
   "build": "v0.0.1",
   "subversion": "[SubVersion]",
-  "protocolversion": 170130,
+  "protocolversion": 170140,
   "blocks": 10,
   "connections": 0,
   "difficulty": 1.0,

--- a/zebra-rpc/src/methods/tests/snapshots/get_info@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_info@testnet_10.snap
@@ -6,7 +6,7 @@ expression: info
   "version": 100,
   "build": "v0.0.1",
   "subversion": "[SubVersion]",
-  "protocolversion": 170130,
+  "protocolversion": 170140,
   "blocks": 10,
   "connections": 0,
   "difficulty": 1.0,

--- a/zebra-rpc/src/methods/tests/snapshots/get_network_info@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_network_info@mainnet_10.snap
@@ -5,7 +5,7 @@ expression: get_network_info
 {
   "version": 100,
   "subversion": "RPC test",
-  "protocolversion": 170130,
+  "protocolversion": 170140,
   "localservices": "0000000000000001",
   "timeoffset": 0,
   "connections": 1,

--- a/zebra-rpc/src/methods/tests/snapshots/get_network_info@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_network_info@testnet_10.snap
@@ -5,7 +5,7 @@ expression: get_network_info
 {
   "version": 100,
   "subversion": "RPC test",
-  "protocolversion": 170130,
+  "protocolversion": 170140,
   "localservices": "0000000000000001",
   "timeoffset": 0,
   "connections": 1,


### PR DESCRIPTION
## Motivation

We want to prepare for tagging a release of Zebra which deploys NU6.1 on Mainnet.

## Solution

- Set an NU6.1 activation height on Mainnet,
- Extends the NU6 funding streams by 1_260_000 blocks,
- Adds the NU6.1 one-time lockbox disbursements on Mainnet (split into 10 disbursements, [matching zcashd](https://github.com/zcash/zcash/pull/7059/files#diff-ff53e63501a5e89fd650b378c9708274df8ad5d38fcffa6c64be417c4d438b6dR290-R303)), and 
- Bumps Zebra's current network protocol version to [170_140 as specified in ZIP 255](https://zips.z.cash/zip-0255).

### Specifications & References

https://zips.z.cash/zip-0255
https://github.com/zcash/zcash/pull/7059
https://github.com/zcash/zips/pull/1099

### Follow-up Work

Tag a release

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [x] The documentation is up to date.
