### PR TITLE
Fix typos in multiple files

### DIFF
--- a/book/src/user/custom-testnets.md
+++ b/book/src/user/custom-testnets.md
@@ -85,7 +85,7 @@ network_magic = [0, 1, 0, 255]
 slow_start_interval = 20_000
 genesis_hash = "00040fe8ec8471911baa1db1266ea15dd06b4a8a5c453883c000b031973dce08"
 
-# Note that setting `disable_pow` to `false` with this target difficultly 
+# Note that setting `disable_pow` to `false` with this target difficulty 
 # limit will make it very difficult to mine valid blocks onto the chain and
 # is not recommended.
 target_difficulty_limit = "0008000000000000000000000000000000000000000000000000000000000000"

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -44,7 +44,7 @@ lazy_static::lazy_static! {
 
 /// Returns the `zebrad` version for this build, in SemVer 2.0 format.
 ///
-/// Includes `git describe` build metatata if available:
+/// Includes `git describe` build metadata if available:
 /// - the number of commits since the last version tag, and
 /// - the git commit.
 ///


### PR DESCRIPTION
Docs: Clean up spelling mistakes
Spotted some typos while browsing the codebase:
Changes:
Fixed "difficultly" → "difficulty" (custom-testnets config)
Fixed "metatata" → "metadata" (application.rs comment)