### PR TITLE
feat(ci): Avoid compiling RocksDB

### DIFF
--- a/.github/actions/setup-zebra-build/action.yml
+++ b/.github/actions/setup-zebra-build/action.yml
@@ -1,20 +1,27 @@
 name: 'Setup Zebra Build Environment'
-description: 'Install protoc as system library'
+description: 'Install protoc and RocksDB as system libraries'
 runs:
   using: 'composite'
   steps:
-    - name: Install protoc on Ubuntu
+    - name: Install protoc and librocksdb-dev on Ubuntu
       if: runner.os == 'Linux'
       shell: bash
       run: |
         sudo apt-get -qq update
-        sudo apt-get -qq install -y --no-install-recommends protobuf-compiler
+        sudo apt-get -qq install -y --no-install-recommends protobuf-compiler librocksdb-dev
+        echo "ROCKSDB_LIB_DIR=/usr/lib/" >> $GITHUB_ENV
 
-    - name: Install protoc on macOS
+    - name: Install protoc and RocksDB on macOS
       if: runner.os == 'macOS'
       shell: bash
       run: |
-        brew install protobuf
+        brew install protobuf rocksdb
+        # Set ROCKSDB_LIB_DIR for both Intel and Apple Silicon Macs
+        if [ -d "/opt/homebrew/lib" ]; then
+          echo "ROCKSDB_LIB_DIR=/opt/homebrew/lib" >> $GITHUB_ENV
+        else
+          echo "ROCKSDB_LIB_DIR=/usr/local/lib" >> $GITHUB_ENV
+        fi
 
     - name: Install protoc on Windows
       if: runner.os == 'Windows'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,9 +34,13 @@ ARG BUILDPLATFORM
 # Install zebra build deps
 RUN apt-get -qq update && \
     apt-get -qq install -y --no-install-recommends \
+    librocksdb-dev \
     libclang-dev \
     protobuf-compiler \
     && rm -rf /var/lib/apt/lists/* /tmp/*
+
+# Link RocksDB dynamically for faster builds
+ENV ROCKSDB_LIB_DIR="/usr/lib/"
 
 # Build arguments and variables
 ARG CARGO_INCREMENTAL


### PR DESCRIPTION
## Motivation

- Close #10200.

## Solution

- In Docker:
  - Install the `librocksdb-dev` Debian package.
  - Point the `ROCKSDB_LIB_DIR` env var to the installed lib.
  - Setting the var enables the dynamic linking: https://github.com/rust-rocksdb/rust-rocksdb/issues/310.
- In CI:
  -	Add a new workflow named `setup-zebra-build` that enables the linking in GH runners the same way as in Docker.
  - Call the workflow from all jobs that build Zebra.
  - The workflow is generic, so we can use it to set up anything else in the future.
  - I didn't find a way to install RocksDB on Windows, so that's a TODO for now. 

## Notes

The PR is to be excluded from changelogs.
