### PR TITLE
Suggestion for "refactor(state): improve error propagation for CommitCheckpointVerifiedBlock #9979"

### DIFF
--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -95,13 +95,9 @@ pub enum CommitCheckpointVerifiedError {
     #[error("could not queue and commit checkpoint-verified block")]
     CommitBlockError(#[from] CommitBlockError),
     /// RocksDB write failed
-    /// TODO: Wire it up in `finalized_state.rs`, `commit_finalized`
+    /// TODO: Decide whether to expect that writes will succeed (it's already expecting that there won't be a write error when finalizing non-finalized blocks)
     #[error("could not write checkpoint-verified block to RocksDB")]
     WriteError(#[from] rocksdb::Error),
-    /// Temporary workaround for boxed errors.
-    /// TODO: Replace with `ValidateContextError(#[from] ValidateContextError)`
-    #[error("{0}")]
-    CloneError(#[from] CloneError),
 }
 
 impl From<ValidateContextError> for CommitCheckpointVerifiedError {

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -46,7 +46,6 @@ pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 #[derive(Debug, Error, Clone, PartialEq, Eq, new)]
 pub enum CommitBlockError {
     #[error("block hash has already been sent to be committed to the state")]
-    #[non_exhaustive]
     Duplicate {
         hash_or_height: Option<HashOrHeight>,
         location: KnownBlock,
@@ -91,18 +90,12 @@ impl<E: std::error::Error + 'static> From<BoxError> for LayeredStateError<E> {
 
 /// An error describing why a `CommitCheckpointVerifiedBlock` request failed.
 #[derive(Debug, Error, Clone)]
-pub enum CommitCheckpointVerifiedError {
-    #[error("could not queue and commit checkpoint-verified block")]
-    CommitBlockError(#[from] CommitBlockError),
-    /// RocksDB write failed
-    /// TODO: Decide whether to expect that writes will succeed (it's already expecting that there won't be a write error when finalizing non-finalized blocks)
-    #[error("could not write checkpoint-verified block to RocksDB")]
-    WriteError(#[from] rocksdb::Error),
-}
+#[error("could not commit checkpoint-verified block")]
+pub struct CommitCheckpointVerifiedError(#[from] CommitBlockError);
 
 impl From<ValidateContextError> for CommitCheckpointVerifiedError {
     fn from(value: ValidateContextError) -> Self {
-        Self::CommitBlockError(value.into())
+        Self(value.into())
     }
 }
 

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -114,11 +114,17 @@ pub enum Response {
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// An enum of block stores in the state where a block hash could be found.
 pub enum KnownBlock {
+    /// Block is in the finalized portion of the best chain.
+    Finalized,
+
     /// Block is in the best chain.
     BestChain,
 
     /// Block is in a side chain.
     SideChain,
+
+    /// Block is in a block write channel
+    WriteChannel,
 
     /// Block is queued to be validated and committed, or rejected and dropped.
     Queue,

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -30,7 +30,7 @@ use crate::{
     error::CommitCheckpointVerifiedError,
     request::{FinalizableBlock, FinalizedBlock, Treestate},
     service::{check, QueuedCheckpointVerified},
-    BoxError, CheckpointVerifiedBlock, CloneError, Config,
+    CheckpointVerifiedBlock, Config, ValidateContextError,
 };
 
 pub mod column_family;
@@ -300,10 +300,6 @@ impl FinalizedState {
                 .set(checkpoint_verified.height.0 as f64);
         };
 
-        // Make the error cloneable, so we can send it to the block verify future,
-        // and the block write task.
-        let result = result.map_err(CloneError::from);
-
         let _ = rsp_tx.send(
             result
                 .clone()
@@ -335,7 +331,7 @@ impl FinalizedState {
         finalizable_block: FinalizableBlock,
         prev_note_commitment_trees: Option<NoteCommitmentTrees>,
         source: &str,
-    ) -> Result<(block::Hash, NoteCommitmentTrees), BoxError> {
+    ) -> Result<(block::Hash, NoteCommitmentTrees), CommitCheckpointVerifiedError> {
         let (height, hash, finalized, prev_note_commitment_trees) = match finalizable_block {
             FinalizableBlock::Checkpoint {
                 checkpoint_verified,
@@ -353,7 +349,9 @@ impl FinalizedState {
 
                 // Update the note commitment trees.
                 let mut note_commitment_trees = prev_note_commitment_trees.clone();
-                note_commitment_trees.update_trees_parallel(&block)?;
+                note_commitment_trees
+                    .update_trees_parallel(&block)
+                    .map_err(ValidateContextError::from)?;
 
                 // Check the block commitment if the history tree was not
                 // supplied by the non-finalized state. Note that we don't do
@@ -385,12 +383,11 @@ impl FinalizedState {
                 let history_tree_mut = Arc::make_mut(&mut history_tree);
                 let sapling_root = note_commitment_trees.sapling.root();
                 let orchard_root = note_commitment_trees.orchard.root();
-                history_tree_mut.push(
-                    &self.network(),
-                    block.clone(),
-                    &sapling_root,
-                    &orchard_root,
-                )?;
+                history_tree_mut
+                    .push(&self.network(), block.clone(), &sapling_root, &orchard_root)
+                    .map_err(Arc::new)
+                    .map_err(ValidateContextError::from)?;
+
                 let treestate = Treestate {
                     note_commitment_trees,
                     history_tree,

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/track_tx_locs_by_spends.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/track_tx_locs_by_spends.rs
@@ -87,9 +87,7 @@ pub fn run(
                         .zs_insert(&spent_output_location, &tx_loc);
                 }
 
-                batch
-                    .prepare_nullifier_batch(zebra_db, &tx, tx_loc)
-                    .expect("method should never return an error");
+                batch.prepare_nullifier_batch(zebra_db, &tx, tx_loc);
             }
 
             if !matches!(cancel_receiver.try_recv(), Err(TryRecvError::Empty)) {

--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -549,7 +549,9 @@ impl ZebraDb {
             prev_note_commitment_trees,
         )?;
 
-        self.db.write(batch)?;
+        self.db
+            .write(batch)
+            .expect("unexpected rocksdb error while writing block");
 
         tracing::trace!(?source, "committed block from");
 

--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -32,6 +32,7 @@ use zebra_chain::{
 };
 
 use crate::{
+    error::CommitCheckpointVerifiedError,
     request::FinalizedBlock,
     service::finalized_state::{
         disk_db::{DiskDb, DiskWriteBatch, ReadDisk, WriteDisk},
@@ -42,7 +43,7 @@ use crate::{
         zebra_db::{metrics::block_precommit_metrics, ZebraDb},
         FromDisk, RawBytes,
     },
-    BoxError, HashOrHeight,
+    HashOrHeight,
 };
 
 #[cfg(feature = "indexer")]
@@ -425,7 +426,8 @@ impl ZebraDb {
     /// # Errors
     ///
     /// - Propagates any errors from writing to the DB
-    /// - Propagates any errors from updating history and note commitment trees
+    /// - Propagates any errors from computing the block's chain value balance change or
+    ///   from applying the change to the chain value balance
     #[allow(clippy::unwrap_in_result)]
     pub(in super::super) fn write_block(
         &mut self,
@@ -433,7 +435,7 @@ impl ZebraDb {
         prev_note_commitment_trees: Option<NoteCommitmentTrees>,
         network: &Network,
         source: &str,
-    ) -> Result<block::Hash, BoxError> {
+    ) -> Result<block::Hash, CommitCheckpointVerifiedError> {
         let tx_hash_indexes: HashMap<transaction::Hash, usize> = finalized
             .transaction_hashes
             .iter()
@@ -588,7 +590,8 @@ impl DiskWriteBatch {
     ///
     /// # Errors
     ///
-    /// - Propagates any errors from updating history tree, note commitment trees, or value pools
+    /// - Propagates any errors from computing the block's chain value balance change or
+    ///   from applying the change to the chain value balance
     #[allow(clippy::too_many_arguments)]
     pub fn prepare_block_batch(
         &mut self,
@@ -605,11 +608,11 @@ impl DiskWriteBatch {
         address_balances: HashMap<transparent::Address, AddressBalanceLocationChange>,
         value_pool: ValueBalance<NonNegative>,
         prev_note_commitment_trees: Option<NoteCommitmentTrees>,
-    ) -> Result<(), BoxError> {
+    ) -> Result<(), CommitCheckpointVerifiedError> {
         let db = &zebra_db.db;
 
         // Commit block, transaction, and note commitment tree data.
-        self.prepare_block_header_and_transaction_data_batch(db, finalized)?;
+        self.prepare_block_header_and_transaction_data_batch(db, finalized);
 
         // The consensus rules are silent on shielded transactions in the genesis block,
         // because there aren't any in the mainnet or testnet genesis blocks.
@@ -617,8 +620,8 @@ impl DiskWriteBatch {
         // which is already present from height 1 to the first shielded transaction.
         //
         // In Zebra we include the nullifiers and note commitments in the genesis block because it simplifies our code.
-        self.prepare_shielded_transaction_batch(zebra_db, finalized)?;
-        self.prepare_trees_batch(zebra_db, finalized, prev_note_commitment_trees)?;
+        self.prepare_shielded_transaction_batch(zebra_db, finalized);
+        self.prepare_trees_batch(zebra_db, finalized, prev_note_commitment_trees);
 
         // # Consensus
         //
@@ -642,8 +645,9 @@ impl DiskWriteBatch {
                 #[cfg(feature = "indexer")]
                 &out_loc_by_outpoint,
                 address_balances,
-            )?;
+            );
         }
+
         // Commit UTXOs and value pools
         self.prepare_chain_value_pools_batch(
             zebra_db,
@@ -660,16 +664,12 @@ impl DiskWriteBatch {
 
     /// Prepare a database batch containing the block header and transaction data
     /// from `finalized.block`, and return it (without actually writing anything).
-    ///
-    /// # Errors
-    ///
-    /// - This method does not currently return any errors.
     #[allow(clippy::unwrap_in_result)]
     pub fn prepare_block_header_and_transaction_data_batch(
         &mut self,
         db: &DiskDb,
         finalized: &FinalizedBlock,
-    ) -> Result<(), BoxError> {
+    ) {
         // Blocks
         let block_header_by_height = db.cf_handle("block_header_by_height").unwrap();
         let hash_by_height = db.cf_handle("hash_by_height").unwrap();
@@ -710,7 +710,5 @@ impl DiskWriteBatch {
             self.zs_insert(&hash_by_tx_loc, transaction_location, transaction_hash);
             self.zs_insert(&tx_loc_by_hash, transaction_hash, transaction_location);
         }
-
-        Ok(())
     }
 }

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
@@ -146,9 +146,7 @@ fn test_block_db_round_trip_with(
 
         // Skip validation by writing the block directly to the database
         let mut batch = DiskWriteBatch::new();
-        batch
-            .prepare_block_header_and_transaction_data_batch(&state.db, &finalized)
-            .expect("block is valid for batch");
+        batch.prepare_block_header_and_transaction_data_batch(&state.db, &finalized);
         state.db.write(batch).expect("block is valid for writing");
 
         // Now read it back from the state

--- a/zebra-state/src/service/read/find.rs
+++ b/zebra-state/src/service/read/find.rs
@@ -159,7 +159,7 @@ pub fn non_finalized_state_contains_block_hash(
 /// Returns the location of the block if present in the finalized state.
 /// Returns None if the block hash is not found in the finalized state.
 pub fn finalized_state_contains_block_hash(db: &ZebraDb, hash: block::Hash) -> Option<KnownBlock> {
-    db.contains_hash(hash).then_some(KnownBlock::BestChain)
+    db.contains_hash(hash).then_some(KnownBlock::Finalized)
 }
 
 /// Return the height for the block at `hash`, if `hash` is in `chain` or `db`.


### PR DESCRIPTION
This is a suggestion PR for #9979 to:

- Update the `KnownBlock` struct and state request to indicate when blocks are found in the sent hashes recording what's been sent to a block write channel (fixing a bug where it's occasionally possible for Zebra to add a non-finalized chain to its chain set which is a duplicate portion of another non-finalized chain),
- Updates `write_block()` to return `CommitCheckpointVerifiedError`s instead of  `BoxError`s
- Condenses several error variants in `QueueAndCommitError` into a `Duplicate` variant
- Renames `QueueAndCommitError` to `BlockCommitError`
- Unifies `CommitSemanticallyVerifiedError` and `CommitCheckpointVerifiedError` types, making them both new types around `BlockCommitError`

These changes could close #9998.

#### TODO:
- The `Duplicate` error variant could likely be improved, I'm happy to try doing that here,
- Error messages should likely be adjusted to more closely match existing error messages, and
- `ChainSync::should_restart_sync()` will likely need some updates to continue working as expected

## Review

@syszery can review these changes and merge them if they look good. The base branch is a copy of `syszery:refactor/state-CommitCheckpointVerifiedBlock-error` so this PR shows a useful diff.