### PR TITLE
release(bump): tower-batch-control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5491,7 +5491,7 @@ dependencies = [
 
 [[package]]
 name = "tower-batch-control"
-version = "0.2.41"
+version = "1.0.0"
 dependencies = [
  "color-eyre",
  "ed25519-zebra",

--- a/tower-batch-control/CHANGELOG.md
+++ b/tower-batch-control/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.42] - 2025-10-15
+
+### Added
+
+- Added `RequestWeight` trait and changed to a `max_items_weight_in_batch` field in the
+  `BatchLayer` struct ([#9308](https://github.com/ZcashFoundation/zebra/pull/9308))
+
+
 ## [0.2.41] - 2025-07-11
 
 First "stable" release. However, be advised that the API may still greatly

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-batch-control"
-version = "0.2.41"
+version = "1.0.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Tower middleware for batch request processing"
 # # Legal

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -59,7 +59,7 @@ orchard.workspace = true
 zcash_proofs = { workspace = true, features = ["multicore", "bundled-prover"] }
 
 tower-fallback = { path = "../tower-fallback/", version = "0.2.41" }
-tower-batch-control = { path = "../tower-batch-control/", version = "0.2.41" }
+tower-batch-control = { path = "../tower-batch-control/", version = "1.0.0" }
 
 zebra-script = { path = "../zebra-script", version = "2.0.0" }
 zebra-state = { path = "../zebra-state", version = "3.0.0" }


### PR DESCRIPTION
## Motivation

I made a mistake in the previous release (https://github.com/ZcashFoundation/zebra/pull/10000)

The `tower-batch-control` crate was not bumped, even though it has changes.

This caused issues when publishing the `zebra-consensus` crate to crates.io, since cargo publish resolves the version from crates.io rather than using the local path dependency.

Fortunately, this does not affect the tagged release, as local builds use the path dependency (cargo build), so I think no patch release is required.

## Solution

Bump the `tower-batch-control` crate version to include the latest changes should fix the publishing issue.