### PR TITLE
fix(build): Fix issue around copying generated files to output directory when `protoc` or `.proto` files are unavailable

### DIFF
--- a/zebra-rpc/build.rs
+++ b/zebra-rpc/build.rs
@@ -45,7 +45,7 @@ fn build_or_copy_proto() -> Result<(), Box<dyn std::error::Error>> {
         for file_name in file_names {
             let out_path = out_dir.join(file_name);
             let generated_path = format!("proto/__generated__/{file_name}");
-            if fs::read_to_string(&out_path).ok() != fs::read_to_string(&generated_path).ok() {
+            if fs::read(&out_path).ok() != Some(fs::read(&generated_path)?) {
                 fs::copy(generated_path, out_path)?;
             }
         }


### PR DESCRIPTION
## Motivation

This PR fixes a bug in `zebra-rpc`'s `build.rs` where it skipped copying generated files to the output directory if it failed to read the file at a relative path in both the output directory and the `__generated__` directory as a string. This was causing it to always skip copying the generated `indexer_descriptor.bin` file.

This issue did not affect the hotfix `zebra-rpc v2.0.1` release which included [a simpler `build.rs` without the comparison](https://github.com/ZcashFoundation/zebra/pull/9823/files#diff-fbcfcc82da44a5b035fe5d406dc988c3afcec513b7ce132e459c924588ab66e4R37-R41).

## Solution

- Calls `fs::read()` instead of `fs::read_to_string()`
- Returns an error from the build script if it cannot read the generated file
- Always copies generated file to the output file path if it cannot read the output file
- Skips copying generated files if it successfully reads the output file and the output file matches the generated file

### Tests

Tested manually by running:
- `cargo release publish --verbose -p zebra-rpc` (in dry-run mode) where the if condition in build.rs should resolve to false, and
- `cargo b` with the if condition in `build.rs` set to false.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.
