### PR TITLE
fix(ci): enable manual re-deployment of instances from release tags

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -32,6 +32,9 @@ jobs:
       image_name: zebra
       features: ${{ vars.RUST_PROD_FEATURES }}
       rust_log: ${{ vars.RUST_LOG }}
+      # Enable Docker Hub publishing for official releases (this is the single source of truth for production images)
+      # The deploy-nodes workflow also builds for releases but doesn't publish to Docker Hub (defaults to false)
+      publish_to_dockerhub: true
     # This step needs access to Docker Hub secrets to run successfully
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/zfnd-build-docker-image.yml
+++ b/.github/workflows/zfnd-build-docker-image.yml
@@ -40,6 +40,11 @@ on:
         required: false
         type: boolean
         default: false
+      publish_to_dockerhub:
+        description: "Whether to publish to Docker Hub. Set to true only in release-binaries.yml to create official production images. Defaults to false to prevent duplicate publishing from deploy-nodes.yml."
+        required: false
+        type: boolean
+        default: false
 
     secrets:
       DOCKERHUB_USERNAME:
@@ -92,11 +97,14 @@ jobs:
         uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f #v5.8.0
         with:
           # list of Docker images to use as base name for tags
-          # We only publish images to DockerHub if a release is not a pre-release
+          # Docker Hub publishing requires ALL conditions to be true:
+          # - inputs.publish_to_dockerhub must be explicitly set to true (defaults to false)
+          # - Event must be a release (not a pre-release)
+          # This prevents duplicate publishing when both release-binaries.yml and deploy-nodes.yml run
           # Ref: https://github.com/orgs/community/discussions/26281#discussioncomment-3251177
           images: |
             us-docker.pkg.dev/${{ vars.GCP_PROJECT }}/zebra/${{ inputs.image_name }}
-            zfnd/${{ inputs.image_name }},enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            zfnd/${{ inputs.image_name }},enable=${{ inputs.publish_to_dockerhub && github.event_name == 'release' && !github.event.release.prerelease }}
           # generate Docker tags based on the following events/attributes
           tags: |
             # These DockerHub release tags support the following use cases:

--- a/.github/workflows/zfnd-deploy-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-nodes-gcp.yml
@@ -57,6 +57,14 @@ on:
       log_file:
         default: ""
         description: Log to a file path rather than standard output
+      environment:
+        default: dev
+        description: "Environment to deploy to (commonly dev)"
+        required: true
+        type: choice
+        options:
+          - dev
+          - prod
 
   push:
     # Skip main branch updates where Rust code and dependencies aren't modified.
@@ -140,6 +148,7 @@ jobs:
   #
   # For push events, this job always runs.
   # For workflow_dispatch events, it runs only if inputs.need_cached_disk is true.
+  # For release events, this job is skipped (releases use fixed disk names, not cached images).
   # PRs from forked repositories are skipped.
   get-disk-name:
     name: Get disk name
@@ -147,7 +156,9 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/zfnd-find-cached-disks.yml
-    if: ${{ !(github.event.pull_request.head.repo.fork) && (github.event_name != 'workflow_dispatch' || inputs.need_cached_disk) }}
+    # Skip for releases (they use fixed disk names like 'zebrad-cache-mainnet-tip')
+    # For workflow_dispatch: only run if need_cached_disk is true
+    if: ${{ github.event_name != 'release' && !(github.event.pull_request.head.repo.fork) && (github.event_name != 'workflow_dispatch' || inputs.need_cached_disk) }}
     with:
       network: ${{ inputs.network || vars.ZCASH_NETWORK }}
       disk_prefix: zebrad-cache
@@ -164,7 +175,12 @@ jobs:
       id-token: write
       pull-requests: write
     uses: ./.github/workflows/zfnd-build-docker-image.yml
-    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+    # Build for:
+    # - Pull requests
+    # - Manual workflow_dispatch
+    # - Push to main branch
+    # - Releases
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'release' }}
     with:
       dockerfile_path: ./docker/Dockerfile
       dockerfile_target: runtime
@@ -225,10 +241,16 @@ jobs:
     timeout-minutes: 60
     env:
       CACHED_DISK_NAME: ${{ needs.get-disk-name.outputs.cached_disk_name }}
-    environment: ${{ github.event_name == 'release' && 'prod' || 'dev' }}
+    # Use prod environment for releases, allow manual selection for workflow_dispatch, default to dev for others
+    environment: ${{ github.event_name == 'release' && 'prod' || (github.event_name == 'workflow_dispatch' && inputs.environment || 'dev') }}
     permissions:
       contents: read
       id-token: write
+    # Deploy when:
+    # - Build job succeeded (needs.build.result == 'success')
+    # - Running in ZcashFoundation repo (not a fork)
+    # - Event is one of: push to main, release, or workflow_dispatch
+    # - Workflow not cancelled or failed
     if: ${{ !cancelled() && !failure() && needs.build.result == 'success' && github.repository_owner == 'ZcashFoundation' && ((github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'release' || github.event_name == 'workflow_dispatch') }}
 
     steps:
@@ -393,7 +415,7 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe #v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: versioning
+          allowed-skips: versioning, get-disk-name, build
 
   failure-issue:
     name: Open or update issues for release failures


### PR DESCRIPTION
## Motivation

Release deployments were being skipped because the build job only ran for pull requests. This meant we couldn't manually re-deploy release tags to our environments (dev or prod).

Fixes the v3.0.0-rc.0 deployment skip and enables manual re-deployments from release tags.

## Solution

- Enable build job for release, workflow_dispatch, and push-to-main events in deploy-nodes workflow
- Add environment selector to workflow_dispatch inputs (dev/prod) to control which variables are loaded
- Add `publish_to_dockerhub` parameter to `zfnd-build-docker-image.yml` (defaults to false)
- Enable `publish_to_dockerhub` only in `release-binaries.yml` to prevent duplicate publishes
- Skip `get-disk-name` job for releases (they use fixed disk names)
- Update `allowed-skips` to handle legitimately skipped jobs

### Tests

Testing will occur on the next:
- Manual workflow_dispatch run (we need to merge to fully test this)
- Release event (verify build runs and no duplicate Docker Hub publish)
- Push to main (verify deployment continues to work)

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the contribution guidelines.
- [ ] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [x] The documentation is up to date.
