### PR TITLE
fix(ci): Remove invalid `day` field from monthly dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
     # serde, clap, and other dependencies sometimes have multiple updates in a week
     schedule:
       interval: monthly
-      day: monday
       timezone: America/New_York
     # Limit dependabot to 1 PR per reviewer
     open-pull-requests-limit: 6


### PR DESCRIPTION
## Motivation

zizmor validation was failing with the following error:

```
ERROR collect_inputs: github_actions_models::common: msg="`schedule.day` is only valid when `schedule.interval` is `weekly`"
fatal: no audit was performed
failed to load file://./.github/dependabot.yml as dependabot config
```

## Solution

Removed the `day: monday` field from the cargo ecosystem's monthly schedule in `.github/dependabot.yml`.

### Tests

Validated against GitHub's dependabot configuration documentation and zizmor's validation requirements.

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.