### PR TITLE
fix(docs): update release checklist to reference correct CI workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -9,7 +9,7 @@ assignees: ''
 
 # Prepare for the Release
 
-- [ ] Make sure there has been [at least one successful full sync test in the main branch](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-tests.yml?query=branch%3Amain) since the last state change, or start a manual full sync.
+- [ ] Make sure there has been [at least one successful full sync test in the main branch](https://github.com/ZcashFoundation/zebra/actions/workflows/zfnd-ci-integration-tests-gcp.yml?query=branch%3Amain) since the last state change, or start a manual full sync.
 
 # Checkpoints
 
@@ -165,7 +165,7 @@ The end of support height is calculated from the current blockchain height:
 ## Test the Pre-Release
 
 - [ ] Wait until the Docker binaries have been built on `main`, and the quick tests have passed:
-    - [ ] [ci-tests.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-tests.yml?query=branch%3Amain)
+    - [ ] [zfnd-ci-integration-tests-gcp.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/zfnd-ci-integration-tests-gcp.yml?query=branch%3Amain)
 - [ ] Wait until the [pre-release deployment machines have successfully launched](https://github.com/ZcashFoundation/zebra/actions/workflows/zfnd-deploy-nodes-gcp.yml?query=event%3Arelease)
 
 ## Publish Release


### PR DESCRIPTION
## Motivation

The release checklist contains broken links to `ci-tests.yml`, which was deleted during the CI refactor in PR #9883. This prevents release managers from verifying that full sync tests have passed on the main branch.

## Solution

Updated two references in `.github/PULL_REQUEST_TEMPLATE/release-checklist.md`:
- Line 12: Changed link from `ci-tests.yml` to `zfnd-ci-integration-tests-gcp.yml`
- Line 168: Changed link from `ci-tests.yml` to `zfnd-ci-integration-tests-gcp.yml`

The new workflow file contains all the full sync and integration tests that run on the main branch.

### Tests

Verified that:
- `zfnd-ci-integration-tests-gcp.yml` exists and is active
- The workflow contains the full sync jobs (`sync-full-mainnet`, `sync-full-testnet`, `lwd-sync-full`)
- The workflow runs on pushes to the main branch
- Links are accessible and correctly filtered with `?query=branch%3Amain`

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.
