### PR TITLE
feat(rpc): Display `asm` code in script outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,7 +1582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2272,7 +2272,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -2561,7 +2561,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2841,7 +2841,7 @@ dependencies = [
  "cc",
  "thiserror 2.0.17",
  "tracing",
- "zcash_script",
+ "zcash_script 0.4.0",
 ]
 
 [[package]]
@@ -3831,7 +3831,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -3868,9 +3868,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4325,7 +4325,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5031,7 +5031,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6224,7 +6224,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6654,7 +6654,7 @@ dependencies = [
  "zcash_encoding",
  "zcash_note_encryption",
  "zcash_protocol",
- "zcash_script",
+ "zcash_script 0.4.0",
  "zcash_spec",
  "zcash_transparent",
  "zip32",
@@ -6712,6 +6712,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_script"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28f57cbcd4fc01af086e349f7baae2b64dc702233b0cd1c20685a9c4d0bcf359"
+dependencies = [
+ "bitflags 2.9.4",
+ "bounded-vec",
+ "ripemd 0.1.3",
+ "secp256k1",
+ "sha1",
+ "sha2 0.10.9",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "zcash_spec"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6740,7 +6755,7 @@ dependencies = [
  "zcash_address",
  "zcash_encoding",
  "zcash_protocol",
- "zcash_script",
+ "zcash_script 0.4.0",
  "zcash_spec",
  "zip32",
 ]
@@ -6807,7 +6822,7 @@ dependencies = [
  "zcash_note_encryption",
  "zcash_primitives",
  "zcash_protocol",
- "zcash_script",
+ "zcash_script 0.4.0",
  "zcash_transparent",
  "zebra-test",
 ]
@@ -6954,7 +6969,8 @@ dependencies = [
  "zcash_keys",
  "zcash_primitives",
  "zcash_protocol",
- "zcash_script",
+ "zcash_script 0.4.0",
+ "zcash_script 0.5.0",
  "zcash_transparent",
  "zebra-chain",
  "zebra-consensus",
@@ -6974,7 +6990,7 @@ dependencies = [
  "libzcash_script",
  "thiserror 2.0.17",
  "zcash_primitives",
- "zcash_script",
+ "zcash_script 0.4.0",
  "zebra-chain",
  "zebra-test",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -125,6 +125,9 @@ skip-tree = [
 
     # wait for derive_builder to update
     { name = "darling", version = "0.20.11" },
+
+    # wait until zcash_primitives, zcash_transparent, etc upgrades
+    { name = "zcash_script", version = "0.4.0" },
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -85,6 +85,8 @@ zcash_keys = { workspace = true }
 zcash_primitives = { workspace = true, features = ["transparent-inputs"] }
 zcash_protocol = { workspace = true }
 zcash_script = { workspace = true }
+# TODO: Remove `zcash_script05` when `zcash_script` get's updated to 0.5 everywhere.
+zcash_script05 = { package = "zcash_script", version =  "0.5.0" }
 zcash_transparent = { workspace = true }
 
 sapling-crypto = { workspace = true }

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@mainnet_10.snap
@@ -29,9 +29,9 @@ expression: block
           "valueZat": 50000,
           "n": 0,
           "scriptPubKey": {
-            "asm": "",
+            "asm": "027a46eb513588b01b37ea24303f4b628afd12cc20df789fede0921e43cad3e875 OP_CHECKSIG",
             "hex": "21027a46eb513588b01b37ea24303f4b628afd12cc20df789fede0921e43cad3e875ac",
-            "type": ""
+            "type": "pubkey"
           }
         },
         {
@@ -39,10 +39,10 @@ expression: block
           "valueZat": 12500,
           "n": 1,
           "scriptPubKey": {
-            "asm": "",
+            "asm": "OP_HASH160 7d46a730d31f97b1930d3368a967c309bd4d136a OP_EQUAL",
             "hex": "a9147d46a730d31f97b1930d3368a967c309bd4d136a87",
             "reqSigs": 1,
-            "type": "",
+            "type": "scripthash",
             "addresses": [
               "t3Vz22vK5z2LcKEdg16Yv4FFneEL1zg9ojd"
             ]

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_hash_verbosity_2@testnet_10.snap
@@ -29,9 +29,9 @@ expression: block
           "valueZat": 50000,
           "n": 0,
           "scriptPubKey": {
-            "asm": "",
+            "asm": "025229e1240a21004cf8338db05679fa34753706e84f6aebba086ba04317fd8f99 OP_CHECKSIG",
             "hex": "21025229e1240a21004cf8338db05679fa34753706e84f6aebba086ba04317fd8f99ac",
-            "type": ""
+            "type": "pubkey"
           }
         },
         {
@@ -39,10 +39,10 @@ expression: block
           "valueZat": 12500,
           "n": 1,
           "scriptPubKey": {
-            "asm": "",
+            "asm": "OP_HASH160 ef775f1f997f122a062fff1a2d7443abd1f9c642 OP_EQUAL",
             "hex": "a914ef775f1f997f122a062fff1a2d7443abd1f9c64287",
             "reqSigs": 1,
-            "type": "",
+            "type": "scripthash",
             "addresses": [
               "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi"
             ]

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@mainnet_10.snap
@@ -29,9 +29,9 @@ expression: block
           "valueZat": 50000,
           "n": 0,
           "scriptPubKey": {
-            "asm": "",
+            "asm": "027a46eb513588b01b37ea24303f4b628afd12cc20df789fede0921e43cad3e875 OP_CHECKSIG",
             "hex": "21027a46eb513588b01b37ea24303f4b628afd12cc20df789fede0921e43cad3e875ac",
-            "type": ""
+            "type": "pubkey"
           }
         },
         {
@@ -39,10 +39,10 @@ expression: block
           "valueZat": 12500,
           "n": 1,
           "scriptPubKey": {
-            "asm": "",
+            "asm": "OP_HASH160 7d46a730d31f97b1930d3368a967c309bd4d136a OP_EQUAL",
             "hex": "a9147d46a730d31f97b1930d3368a967c309bd4d136a87",
             "reqSigs": 1,
-            "type": "",
+            "type": "scripthash",
             "addresses": [
               "t3Vz22vK5z2LcKEdg16Yv4FFneEL1zg9ojd"
             ]

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_verbose_height_verbosity_2@testnet_10.snap
@@ -29,9 +29,9 @@ expression: block
           "valueZat": 50000,
           "n": 0,
           "scriptPubKey": {
-            "asm": "",
+            "asm": "025229e1240a21004cf8338db05679fa34753706e84f6aebba086ba04317fd8f99 OP_CHECKSIG",
             "hex": "21025229e1240a21004cf8338db05679fa34753706e84f6aebba086ba04317fd8f99ac",
-            "type": ""
+            "type": "pubkey"
           }
         },
         {
@@ -39,10 +39,10 @@ expression: block
           "valueZat": 12500,
           "n": 1,
           "scriptPubKey": {
-            "asm": "",
+            "asm": "OP_HASH160 ef775f1f997f122a062fff1a2d7443abd1f9c642 OP_EQUAL",
             "hex": "a914ef775f1f997f122a062fff1a2d7443abd1f9c64287",
             "reqSigs": 1,
-            "type": "",
+            "type": "scripthash",
             "addresses": [
               "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi"
             ]

--- a/zebra-rpc/src/methods/tests/snapshots/getrawtransaction_verbosity=1@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/getrawtransaction_verbosity=1@mainnet_10.snap
@@ -20,9 +20,9 @@ expression: rsp
         "valueZat": 50000,
         "n": 0,
         "scriptPubKey": {
-          "asm": "",
+          "asm": "027a46eb513588b01b37ea24303f4b628afd12cc20df789fede0921e43cad3e875 OP_CHECKSIG",
           "hex": "21027a46eb513588b01b37ea24303f4b628afd12cc20df789fede0921e43cad3e875ac",
-          "type": ""
+          "type": "pubkey"
         }
       },
       {
@@ -30,10 +30,10 @@ expression: rsp
         "valueZat": 12500,
         "n": 1,
         "scriptPubKey": {
-          "asm": "",
+          "asm": "OP_HASH160 7d46a730d31f97b1930d3368a967c309bd4d136a OP_EQUAL",
           "hex": "a9147d46a730d31f97b1930d3368a967c309bd4d136a87",
           "reqSigs": 1,
-          "type": "",
+          "type": "scripthash",
           "addresses": [
             "t3Vz22vK5z2LcKEdg16Yv4FFneEL1zg9ojd"
           ]

--- a/zebra-rpc/src/methods/tests/snapshots/getrawtransaction_verbosity=1@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/getrawtransaction_verbosity=1@testnet_10.snap
@@ -20,9 +20,9 @@ expression: rsp
         "valueZat": 50000,
         "n": 0,
         "scriptPubKey": {
-          "asm": "",
+          "asm": "025229e1240a21004cf8338db05679fa34753706e84f6aebba086ba04317fd8f99 OP_CHECKSIG",
           "hex": "21025229e1240a21004cf8338db05679fa34753706e84f6aebba086ba04317fd8f99ac",
-          "type": ""
+          "type": "pubkey"
         }
       },
       {
@@ -30,10 +30,10 @@ expression: rsp
         "valueZat": 12500,
         "n": 1,
         "scriptPubKey": {
-          "asm": "",
+          "asm": "OP_HASH160 ef775f1f997f122a062fff1a2d7443abd1f9c642 OP_EQUAL",
           "hex": "a914ef775f1f997f122a062fff1a2d7443abd1f9c64287",
           "reqSigs": 1,
-          "type": "",
+          "type": "scripthash",
           "addresses": [
             "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi"
           ]


### PR DESCRIPTION
## Motivation

We want to display the assembly (`asm`) representation of scripts in Zebra RPC's and the script type.

Close https://github.com/ZcashFoundation/zebra/issues/9330

## Solution

A new version of `zcash_script` ([v0.5.0](https://github.com/ZcashFoundation/zcash_script/releases/tag/v0.5.0)) was released, which introduces support for displaying scripts in assembly form ([#256](https://github.com/ZcashFoundation/zcash_script/pull/256)).

However, upgrading Zebra’s existing zcash_script dependency directly would cause version conflicts with other crates (`zcash_transparent`, `zcash_primitives`, etc.) that still depend on the older version.

To work around this, we added a separate dependency, `zcash_script05`, specifically in `zebra-rpc`, and use it only where the new assembly functionality is required.

### Tests

Snapshot tests were updated.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
