### PR TITLE
fix(ci): run ignored test in `check-no-git-dependencies`

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -121,7 +121,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check no git dependencies
-        run: cargo nextest run --profile check-no-git-dependencies
+        run: cargo nextest run --profile check-no-git-dependencies --locked --run-ignored=only
 
   test-success:
     name: test success


### PR DESCRIPTION
## Motivation

The `check-no-git-dependencies` job was failing when the `A-release` label was present, preventing release PRs from passing CI. The failure was reported in https://github.com/ZcashFoundation/zebra/pull/10000#issuecomment-3408161299.

The job exited with code 4 and the message "no tests to run" despite the test existing in the codebase.

## Solution

The `check_no_git_dependencies` test in `zebrad/tests/acceptance.rs` is marked with `#[ignore]`, but the workflow command didn't include the `--run-ignored` flag.

This change:
- Runs only ignored tests (`--run-ignored=only`) filtered by the nextest profile
- Prevents Cargo.lock modifications during test execution (`--locked`)

### Tests

The fix can be verified by adding the `A-release` label to this PR

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.
