### PR TITLE
change(build): Remove duplicate dependency on `zcash_script`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2841,7 +2841,7 @@ dependencies = [
  "cc",
  "thiserror 2.0.17",
  "tracing",
- "zcash_script 0.4.0",
+ "zcash_script",
 ]
 
 [[package]]
@@ -6654,7 +6654,7 @@ dependencies = [
  "zcash_encoding",
  "zcash_note_encryption",
  "zcash_protocol",
- "zcash_script 0.4.0",
+ "zcash_script",
  "zcash_spec",
  "zcash_transparent",
  "zip32",
@@ -6698,24 +6698,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_script"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c1d06ec5990ad2c51c3052fd41f87aa5ccab92d02d1ab5173712c2e37c24658"
-dependencies = [
- "bitflags 2.9.4",
- "bounded-vec",
- "ripemd 0.1.3",
- "secp256k1",
- "sha1",
- "sha2 0.10.9",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "zcash_script"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f57cbcd4fc01af086e349f7baae2b64dc702233b0cd1c20685a9c4d0bcf359"
+checksum = "9bed6cf5b2b4361105d4ea06b2752f0c8af4641756c7fbc9858a80af186c234f"
 dependencies = [
  "bitflags 2.9.4",
  "bounded-vec",
@@ -6755,7 +6740,7 @@ dependencies = [
  "zcash_address",
  "zcash_encoding",
  "zcash_protocol",
- "zcash_script 0.4.0",
+ "zcash_script",
  "zcash_spec",
  "zip32",
 ]
@@ -6822,7 +6807,7 @@ dependencies = [
  "zcash_note_encryption",
  "zcash_primitives",
  "zcash_protocol",
- "zcash_script 0.4.0",
+ "zcash_script",
  "zcash_transparent",
  "zebra-test",
 ]
@@ -6969,8 +6954,7 @@ dependencies = [
  "zcash_keys",
  "zcash_primitives",
  "zcash_protocol",
- "zcash_script 0.4.0",
- "zcash_script 0.5.0",
+ "zcash_script",
  "zcash_transparent",
  "zebra-chain",
  "zebra-consensus",
@@ -6990,7 +6974,7 @@ dependencies = [
  "libzcash_script",
  "thiserror 2.0.17",
  "zcash_primitives",
- "zcash_script 0.4.0",
+ "zcash_script",
  "zebra-chain",
  "zebra-test",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ uint = "0.10"
 vergen-git2 = { version = "1.0", default-features = false }
 x25519-dalek = "2.0.1"
 zcash_note_encryption = "0.4.1"
-zcash_script = "0.4"
+zcash_script = "0.4.2"
 config = { version = "0.15.14", features = ["toml"] }
 which = "8.0.0"
 

--- a/deny.toml
+++ b/deny.toml
@@ -125,9 +125,6 @@ skip-tree = [
 
     # wait for derive_builder to update
     { name = "darling", version = "0.20.11" },
-
-    # wait until zcash_primitives, zcash_transparent, etc upgrades
-    { name = "zcash_script", version = "0.4.0" },
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -85,8 +85,6 @@ zcash_keys = { workspace = true }
 zcash_primitives = { workspace = true, features = ["transparent-inputs"] }
 zcash_protocol = { workspace = true }
 zcash_script = { workspace = true }
-# TODO: Remove `zcash_script05` when `zcash_script` get's updated to 0.5 everywhere.
-zcash_script05 = { package = "zcash_script", version =  "0.5.0" }
 zcash_transparent = { workspace = true }
 
 sapling-crypto = { workspace = true }

--- a/zebra-rpc/src/methods/types/transaction.rs
+++ b/zebra-rpc/src/methods/types/transaction.rs
@@ -8,7 +8,7 @@ use derive_getters::Getters;
 use derive_new::new;
 use hex::ToHex;
 
-use zcash_script05::script::Asm;
+use zcash_script::script::Asm;
 use zebra_chain::{
     amount::{self, Amount, NegativeOrZero, NonNegative},
     block::{self, merkle::AUTH_DIGEST_PLACEHOLDER, Height},
@@ -659,11 +659,8 @@ impl TransactionObject {
                         txid: outpoint.hash.encode_hex(),
                         vout: outpoint.index,
                         script_sig: ScriptSig {
-                            // TODO: Remove `zcash_script05` when `zcash_script` get's updated to 0.5 everywhere.
-                            asm: zcash_script05::script::Code(
-                                unlock_script.as_raw_bytes().to_vec(),
-                            )
-                            .to_asm(false),
+                            asm: zcash_script::script::Code(unlock_script.as_raw_bytes().to_vec())
+                                .to_asm(false),
                             hex: unlock_script.clone(),
                         },
                         sequence: *sequence,
@@ -690,30 +687,25 @@ impl TransactionObject {
                         value_zat: output.1.value.zatoshis(),
                         n: output.0 as u32,
                         script_pub_key: ScriptPubKey {
-                            // TODO: Remove `zcash_script05` when `zcash_script` get's updated to 0.5 everywhere.
-                            asm: zcash_script05::script::Code(
+                            asm: zcash_script::script::Code(
                                 output.1.lock_script.as_raw_bytes().to_vec(),
                             )
                             .to_asm(false),
                             hex: output.1.lock_script.clone(),
                             req_sigs,
-                            r#type: zcash_script05::script::Code(
+                            r#type: zcash_script::script::Code(
                                 output.1.lock_script.as_raw_bytes().to_vec(),
                             )
                             .to_component()
                             .ok()
                             .and_then(|c| c.refine().ok())
-                            .and_then(|component| zcash_script05::solver::standard(&component))
+                            .and_then(|component| zcash_script::solver::standard(&component))
                             .map(|kind| match kind {
-                                zcash_script05::solver::ScriptKind::PubKeyHash { .. } => {
-                                    "pubkeyhash"
-                                }
-                                zcash_script05::solver::ScriptKind::ScriptHash { .. } => {
-                                    "scripthash"
-                                }
-                                zcash_script05::solver::ScriptKind::MultiSig { .. } => "multisig",
-                                zcash_script05::solver::ScriptKind::NullData { .. } => "nulldata",
-                                zcash_script05::solver::ScriptKind::PubKey { .. } => "pubkey",
+                                zcash_script::solver::ScriptKind::PubKeyHash { .. } => "pubkeyhash",
+                                zcash_script::solver::ScriptKind::ScriptHash { .. } => "scripthash",
+                                zcash_script::solver::ScriptKind::MultiSig { .. } => "multisig",
+                                zcash_script::solver::ScriptKind::NullData { .. } => "nulldata",
+                                zcash_script::solver::ScriptKind::PubKey { .. } => "pubkey",
                             })
                             .unwrap_or("nonstandard")
                             .to_string(),


### PR DESCRIPTION
~This is a suggestion for #10019 to remove the duplicate dependency on different versions of `zcash_script`.~

This PR removes the duplicate dependency on `zcash_script`. It was originally a suggestion PR, but the base branch somehow merged with unresolved comments.