### PR TITLE
tests(qa): Update zallet to `0.1.0-alpha.2`

### DIFF
--- a/zebra-rpc/build.rs
+++ b/zebra-rpc/build.rs
@@ -5,7 +5,7 @@ use std::{
     process::Command,
 };
 
-const ZALLET_COMMIT: Option<&str> = Some("de70e46e37f903de4e182c5a823551b90a5bf80b");
+const ZALLET_COMMIT: Option<&str> = Some("baf860eb1160b0ab34f2c73b379e7bf7325003e2");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     build_or_copy_proto()?;

--- a/zebra-rpc/build.rs
+++ b/zebra-rpc/build.rs
@@ -5,7 +5,8 @@ use std::{
     process::Command,
 };
 
-const ZALLET_COMMIT: Option<&str> = Some("baf860eb1160b0ab34f2c73b379e7bf7325003e2");
+// 0.1.0-alpha.2
+const ZALLET_COMMIT: Option<&str> = Some("027e5e2139b2ca8f0317edb9d802b03a46e9aa4c");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     build_or_copy_proto()?;

--- a/zebra-rpc/qa/README.md
+++ b/zebra-rpc/qa/README.md
@@ -76,24 +76,16 @@ To get real-time output during a test you can run it using the
 python3 qa/rpc-tests/wallet.py
 ```
 
-A 200-block -regtest blockchain and wallets for four nodes
-is created the first time a regression test is run and
-is stored in the `qa/cache/` directory.  Each node has the miner
-subsidy from 25 mature blocks (25*10=250 ZEC) in its wallet.
-
-TODO: https://github.com/ZcashFoundation/zebra/issues/9726
-
-After the first run, the `qa/cache/` blockchain and wallets are
-copied into a temporary directory and used as the initial
-test state.
-
-If you get into a bad state, you should be able
-to recover with:
+If a test gets stuck, you can stop the underlying binaries with:
 
 ```bash
-rm -rf qa/cache
 killall zebrad
+killall zallet
 ```
+
+Zcashd's test framework includes a [cache mechanism](https://github.com/zcash/zcash/blob/v6.10.0/qa/README.md?plain=1#L73-L88)
+to speed up certain tests.
+This version of the framework currently has that functionality disabled.
 
 Writing tests
 =============

--- a/zebra-rpc/qa/pull-tester/rpc-tests.py
+++ b/zebra-rpc/qa/pull-tester/rpc-tests.py
@@ -206,9 +206,8 @@ def run_tests(test_handler, test_list, src_dir, build_dir, exeext, jobs=1, enabl
     else:
         coverage = None
 
-    if len(test_list) > 1 and jobs > 1:
-        # Populate cache
-        subprocess.check_output([tests_dir + 'create_cache.py'] + flags)
+    # TODO: Restore cache functionality if needed:
+    # https://github.com/ZcashFoundation/zebra/blob/v3.0.0-rc.0/zebra-rpc/qa/pull-tester/rpc-tests.py#L209-L211
 
     #Run Tests
     time_sum = 0

--- a/zebra-rpc/qa/rpc-tests/test_framework/authproxy.py
+++ b/zebra-rpc/qa/rpc-tests/test_framework/authproxy.py
@@ -153,7 +153,8 @@ class AuthServiceProxy():
                 'code': -342, 'message': 'missing HTTP response from server'})
         
         content_type = http_response.getheader('Content-Type')
-        if content_type != 'application/json':
+        # Zallet uses 'application/json; charset=utf-8'` while zcashd uses 'application/json'
+        if content_type != 'application/json; charset=utf-8':
             raise JSONRPCException({
                 'code': -342, 'message': 'non-JSON HTTP response with \'%i %s\' from server' % (http_response.status, http_response.reason)})
 

--- a/zebra-rpc/qa/rpc-tests/test_framework/util.py
+++ b/zebra-rpc/qa/rpc-tests/test_framework/util.py
@@ -837,7 +837,7 @@ def start_wallets(num_wallets, dirname, extra_args=None, rpchost=None, binary=No
     try:
         for i in range(num_wallets):
             rpcs.append(start_wallet(i, dirname, extra_args[i], rpchost, binary=binary[i]))
-    except: # If one node failed to start, stop the others
+    except: # If one wallet failed to start, stop the others
         stop_wallets(rpcs)
         raise
     return rpcs

--- a/zebra-rpc/qa/rpc-tests/test_framework/util.py
+++ b/zebra-rpc/qa/rpc-tests/test_framework/util.py
@@ -29,6 +29,7 @@ import errno
 
 from . import coverage
 from .proxy import ServiceProxy, JSONRPCException
+from .authproxy import AuthServiceProxy
 
 from test_framework.config import ZebraConfig, ZebraExtraArgs
 
@@ -86,7 +87,7 @@ def get_rpc_proxy(url, node_number, timeout=None):
         timeout (int): HTTP timeout in seconds
 
     Returns:
-        AuthServiceProxy. convenience object for making RPC calls.
+        ServiceProxy. convenience object for making RPC calls.
 
     """
     proxy_kwargs = {}
@@ -827,6 +828,34 @@ def tarfile_extractall(tarfile, path):
 
 zallet_processes = {}
 
+ZALLET_RPC_DEFAULT_USERNAME = "zebra"
+ZALLET_RPC_DEFAULT_PASSWORD = "zebra"
+
+def get_rpc_auth_proxy(url, node_number, timeout=None):
+    """
+    Args:
+        url (str): URL of the RPC server to call
+        node_number (int): the node number (or id) that this calls to
+
+    Kwargs:
+        timeout (int): HTTP timeout in seconds
+
+    Returns:
+        AuthServiceProxy. convenience object for making RPC calls.
+
+    """
+    proxy_kwargs = {}
+    if timeout is not None:
+        proxy_kwargs['timeout'] = timeout
+
+    proxy = AuthServiceProxy(url, **proxy_kwargs)
+    proxy.url = url  # store URL on proxy for info
+
+    coverage_logfile = coverage.get_filename(
+        COVERAGE_DIR, node_number) if COVERAGE_DIR else None
+
+    return coverage.AuthServiceProxyWrapper(proxy, coverage_logfile)
+
 def start_wallets(num_wallets, dirname, extra_args=None, rpchost=None, binary=None):
     """
     Start multiple wallets, return RPC connections to them
@@ -883,7 +912,7 @@ def start_wallet(i, dirname, extra_args=None, rpchost=None, timewait=None, binar
     wait_for_wallet_start(zallet_processes[i], url, i)
     if os.getenv("PYTHON_DEBUG", ""):
         print("start_wallet: RPC successfully started for wallet {} with pid {}".format(i, zallet_processes[i].pid))
-    proxy = get_rpc_proxy(url, i, timeout=timewait)
+    proxy = get_rpc_auth_proxy(url, i, timeout=timewait)
     if COVERAGE_DIR:
         coverage.write_all_rpc_commands(COVERAGE_DIR, proxy)
 
@@ -933,7 +962,7 @@ def wait_for_wallet_start(process, url, i):
         if process.poll() is not None:
             raise Exception('%s wallet %d exited with status %i during initialization' % (zallet_binary(), i, process.returncode))
         try:
-            rpc = get_rpc_proxy(url, i)
+            rpc = get_rpc_auth_proxy(url, i)
             rpc.getwalletinfo()
             break # break out of loop on success
         except IOError as e:
@@ -953,5 +982,4 @@ def rpc_url_wallet(i, rpchost=None):
             host, port = parts
         else:
             host = rpchost
-    # For zallet, we just use a non-authenticated endpoint.
-    return "http://%s:%d" % (host, int(port))
+    return "http://%s:%s@%s:%d" % (ZALLET_RPC_DEFAULT_USERNAME, ZALLET_RPC_DEFAULT_PASSWORD, host, int(port))

--- a/zebra-rpc/qa/rpc-tests/wallet.py
+++ b/zebra-rpc/qa/rpc-tests/wallet.py
@@ -26,11 +26,11 @@ class WalletTest (BitcoinTestFramework):
         # Zallet needs a block to start
         self.nodes[0].generate(1)
 
-        # Wait for the non-finalized state to be populated in the node
-        # before starting the wallet
-        time.sleep(2)
-
         self.wallets = start_wallets(self.num_nodes, self.options.tmpdir)
+
+        # TODO: Use `getwalletstatus` in all sync issues
+        # https://github.com/zcash/wallet/issues/316
+        time.sleep(2)
 
     def run_test(self):
         # Generate a new account

--- a/zebra-rpc/qa/zallet-datadir/zallet.toml
+++ b/zebra-rpc/qa/zallet-datadir/zallet.toml
@@ -38,3 +38,7 @@ encryption_identity = "identity.txt"
 
 [rpc]
 bind = ["127.0.0.1:0"]
+
+[[rpc.auth]]
+user = "zebra"
+pwhash = "eaa27c81df81f655e69bbe84026e733a$bb9f70d53decfeca863cb114f7b0fd5ae050c7ef885c3d5fa73d5bace6c14fea"


### PR DESCRIPTION
## Motivation

We want to run the wallet test using a newer version of Zallet. Close https://github.com/ZcashFoundation/zebra/issues/10046

## Solution

Tested up to the `0.1.0-alpha.2` Zallet commit: https://github.com/zcash/wallet/commit/027e5e2139b2ca8f0317edb9d802b03a46e9aa4c

I added this commit hash to the build file (even though it’s not used directly for building Zallet) so we can track which version was last tested.

With that version, the first error encountered was:

```
MissingData("Non-finalised state is empty.")
```

This was fixed in: https://github.com/ZcashFoundation/zebra/blob/abfe850dcc1bfc0982223287dcb5285cb1a3d00d/zebra-rpc/qa/rpc-tests/wallet.py#L29-L31

After that, I noticed an intermittent failure in the wallet’s reported balance. It seems related to block confirmations, sometimes the wallet reports the balance from the last mined block, and other times from the previous one:
https://github.com/ZcashFoundation/zebra/blob/abfe850dcc1bfc0982223287dcb5285cb1a3d00d/zebra-rpc/qa/rpc-tests/wallet.py#L100-L104

Reporting the previous block’s value makes sense, since `z_gettotalbalance` requires at least one confirmation, but it’s unclear why the latest block’s value sometimes appears given the same test conditions.

I’m not certain whether this behavior comes from Zallet, zcash_client_backend, or the test setup itself. However, switching to `assert_true` is sufficient for this test. Our goal is just to verify that the wallet balance increases as new blocks are mined to the configured wallet address.

### Tests

This is test code.

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
