### PR TITLE
fix(mempool): Avoid panicking when a transaction is unexpectedly missing in the mempool

### DIFF
--- a/zebra-node-services/src/mempool/transaction_dependencies.rs
+++ b/zebra-node-services/src/mempool/transaction_dependencies.rs
@@ -73,7 +73,7 @@ impl TransactionDependencies {
                 };
 
                 // TODO: Move this struct to zebra-chain and log a warning here if the dependency was not found.
-                dependencies.remove(&mined_tx_id);
+                dependencies.remove(mined_tx_id);
             }
         }
     }

--- a/zebra-node-services/src/mempool/transaction_dependencies.rs
+++ b/zebra-node-services/src/mempool/transaction_dependencies.rs
@@ -73,7 +73,7 @@ impl TransactionDependencies {
                 };
 
                 // TODO: Move this struct to zebra-chain and log a warning here if the dependency was not found.
-                let _ = dependencies.remove(&dependent_id);
+                dependencies.remove(&mined_tx_id);
             }
         }
     }

--- a/zebrad/src/components/mempool/storage/verified_set.rs
+++ b/zebrad/src/components/mempool/storage/verified_set.rs
@@ -256,6 +256,11 @@ impl VerifiedSet {
         let mut removed_transactions = HashSet::new();
 
         for key_to_remove in keys_to_remove {
+            if !self.transactions.contains_key(&key_to_remove) {
+                // Skip any keys that may have already been removed as their dependencies were removed.
+                continue;
+            }
+
             removed_transactions.extend(
                 self.remove(&key_to_remove)
                     .into_iter()


### PR DESCRIPTION
## Motivation

Closes #10038.

## Solution

- Logs a warning instead of panicking when a transaction that should be removed from the mempool is missing in the mempool's verified set, and
- Avoids calling `remove()` with tx ids that are not in the mempool.

Related:
- Fixes a bug where mined transactions were not being removed as dependencies of transactions in the mempool.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
