### PR TITLE
chore: Fix `clippy` lints in Rust beta

### DIFF
--- a/tower-batch-control/tests/ed25519.rs
+++ b/tower-batch-control/tests/ed25519.rs
@@ -1,5 +1,7 @@
 //! Test batching using ed25519 verification.
 
+#![allow(clippy::unwrap_in_result)]
+
 use std::{
     mem,
     pin::Pin,

--- a/zebra-chain/src/amount/tests.rs
+++ b/zebra-chain/src/amount/tests.rs
@@ -1,4 +1,6 @@
 //! Tests for amounts
 
+#![allow(clippy::unwrap_in_result)]
+
 mod prop;
 mod vectors;

--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -602,9 +602,7 @@ where
                 input.set_outpoint(selected_outpoint);
                 new_inputs.push(input);
 
-                let spent_utxo = utxos
-                    .remove(&selected_outpoint)
-                    .expect("selected outpoint must have a UTXO");
+                let spent_utxo = utxos.remove(&selected_outpoint)?;
                 spent_outputs.insert(selected_outpoint, spent_utxo.utxo.output);
             }
             // otherwise, drop the invalid input, because it has no valid UTXOs to spend

--- a/zebra-chain/src/block/tests.rs
+++ b/zebra-chain/src/block/tests.rs
@@ -1,5 +1,7 @@
 //! Tests for Zebra blocks
 
+#![allow(clippy::unwrap_in_result)]
+
 // TODO: generate should be rewritten as strategies
 #[cfg(any(test, feature = "bench", feature = "proptest-impl"))]
 pub mod generate;

--- a/zebra-chain/src/chain_tip/tests.rs
+++ b/zebra-chain/src/chain_tip/tests.rs
@@ -1,1 +1,3 @@
+#![allow(clippy::unwrap_in_result)]
+
 mod prop;

--- a/zebra-chain/src/history_tree/tests.rs
+++ b/zebra-chain/src/history_tree/tests.rs
@@ -1,4 +1,6 @@
 //! Tests for history trees
 
+#![allow(clippy::unwrap_in_result)]
+
 #[cfg(test)]
 mod vectors;

--- a/zebra-chain/src/orchard/tests.rs
+++ b/zebra-chain/src/orchard/tests.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_in_result)]
+
 mod preallocate;
 mod prop;
 mod tree;

--- a/zebra-chain/src/parameters/checkpoint/list/tests.rs
+++ b/zebra-chain/src/parameters/checkpoint/list/tests.rs
@@ -1,5 +1,7 @@
 //! Tests for CheckpointList
 
+#![allow(clippy::unwrap_in_result)]
+
 use std::sync::Arc;
 
 use num_integer::div_ceil;

--- a/zebra-chain/src/parameters/network/subsidy.rs
+++ b/zebra-chain/src/parameters/network/subsidy.rs
@@ -712,34 +712,22 @@ pub fn height_for_halving(halving: u32, network: &Network) -> Option<Height> {
     }
 
     let slow_start_shift = i64::from(network.slow_start_shift().0);
-    let blossom_height = i64::from(
-        NetworkUpgrade::Blossom
-            .activation_height(network)
-            .expect("blossom activation height should be available")
-            .0,
-    );
+    let blossom_height = i64::from(NetworkUpgrade::Blossom.activation_height(network)?.0);
     let pre_blossom_halving_interval = network.pre_blossom_halving_interval();
     let halving_index = i64::from(halving);
 
-    let unscaled_height = halving_index
-        .checked_mul(pre_blossom_halving_interval)
-        .expect("Multiplication overflow: consider reducing the halving interval");
+    let unscaled_height = halving_index.checked_mul(pre_blossom_halving_interval)?;
 
     let pre_blossom_height = unscaled_height
         .min(blossom_height)
-        .checked_add(slow_start_shift)
-        .expect("Addition overflow: consider reducing the halving interval");
+        .checked_add(slow_start_shift)?;
 
     let post_blossom_height = 0
         .max(unscaled_height - blossom_height)
-        .checked_mul(i64::from(BLOSSOM_POW_TARGET_SPACING_RATIO))
-        .expect("Multiplication overflow: consider reducing the halving interval")
-        .checked_add(slow_start_shift)
-        .expect("Addition overflow: consider reducing the halving interval");
+        .checked_mul(i64::from(BLOSSOM_POW_TARGET_SPACING_RATIO))?
+        .checked_add(slow_start_shift)?;
 
-    let height = pre_blossom_height
-        .checked_add(post_blossom_height)
-        .expect("Addition overflow: consider reducing the halving interval");
+    let height = pre_blossom_height.checked_add(post_blossom_height)?;
 
     let height = u32::try_from(height).ok()?;
     height.try_into().ok()

--- a/zebra-chain/src/parameters/network/tests.rs
+++ b/zebra-chain/src/parameters/network/tests.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_in_result)]
+
 mod prop;
 mod vectors;
 

--- a/zebra-chain/src/parameters/tests.rs
+++ b/zebra-chain/src/parameters/tests.rs
@@ -1,5 +1,7 @@
 //! Consensus parameter tests for Zebra.
 
+#![allow(clippy::unwrap_in_result)]
+
 use std::collections::HashSet;
 
 use crate::block;

--- a/zebra-chain/src/primitives/zcash_history/tests.rs
+++ b/zebra-chain/src/primitives/zcash_history/tests.rs
@@ -1,4 +1,6 @@
 //! Tests for Zebra history trees
 
+#![allow(clippy::unwrap_in_result)]
+
 #[cfg(test)]
 mod vectors;

--- a/zebra-chain/src/sapling/tests.rs
+++ b/zebra-chain/src/sapling/tests.rs
@@ -1,2 +1,4 @@
+#![allow(clippy::unwrap_in_result)]
+
 mod preallocate;
 mod prop;

--- a/zebra-chain/src/serialization/compact_size.rs
+++ b/zebra-chain/src/serialization/compact_size.rs
@@ -111,7 +111,7 @@ use proptest_derive::Arbitrary;
 /// let bytes = Cursor::new(b"\xff\xfd\xaa\xbb\xcc\x22\x00\x00\x00");
 /// assert!(CompactSizeMessage::zcash_deserialize(bytes).is_err());
 /// ```
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 pub struct CompactSizeMessage(
     /// The number of items in a Zcash message.
     ///

--- a/zebra-chain/src/serialization/compact_size.rs
+++ b/zebra-chain/src/serialization/compact_size.rs
@@ -241,7 +241,7 @@ impl TryFrom<usize> for CompactSizeMessage {
         let size: u32 = size.try_into()?;
 
         // # Security
-        // Defence-in-depth for memory DoS via preallocation.
+        // Defense-in-depth for memory DoS via preallocation.
         if size
             > MAX_PROTOCOL_MESSAGE_LEN
                 .try_into()

--- a/zebra-chain/src/serialization/tests.rs
+++ b/zebra-chain/src/serialization/tests.rs
@@ -1,4 +1,6 @@
 //! Serialization tests.
 
+#![allow(clippy::unwrap_in_result)]
+
 mod preallocate;
 mod prop;

--- a/zebra-chain/src/serialization/zcash_serialize.rs
+++ b/zebra-chain/src/serialization/zcash_serialize.rs
@@ -97,11 +97,7 @@ impl<T: ZcashSerialize> ZcashSerialize for AtLeastOne<T> {
 // we specifically want to serialize `Vec`s here, rather than generic slices
 #[allow(clippy::ptr_arg)]
 pub fn zcash_serialize_bytes<W: io::Write>(vec: &Vec<u8>, mut writer: W) -> Result<(), io::Error> {
-    let len: CompactSizeMessage = vec
-        .len()
-        .try_into()
-        .expect("len fits in MAX_PROTOCOL_MESSAGE_LEN");
-    len.zcash_serialize(&mut writer)?;
+    CompactSizeMessage::try_from(vec.len())?.zcash_serialize(&mut writer)?;
 
     zcash_serialize_bytes_external_count(vec, writer)
 }
@@ -109,8 +105,7 @@ pub fn zcash_serialize_bytes<W: io::Write>(vec: &Vec<u8>, mut writer: W) -> Resu
 /// Serialize an empty list of items, by writing a zero CompactSize length.
 /// (And no items.)
 pub fn zcash_serialize_empty_list<W: io::Write>(writer: W) -> Result<(), io::Error> {
-    let len: CompactSizeMessage = 0.try_into().expect("zero fits in MAX_PROTOCOL_MESSAGE_LEN");
-    len.zcash_serialize(writer)
+    CompactSizeMessage::default().zcash_serialize(writer)
 }
 
 /// Serialize a typed `Vec` **without** writing the number of items as a

--- a/zebra-chain/src/sprout/tests.rs
+++ b/zebra-chain/src/sprout/tests.rs
@@ -1,5 +1,7 @@
 //! Sprout tests.
 
+#![allow(clippy::unwrap_in_result)]
+
 mod preallocate;
 mod test_vectors;
 mod tree;

--- a/zebra-chain/src/sprout/tree.rs
+++ b/zebra-chain/src/sprout/tree.rs
@@ -259,10 +259,10 @@ impl NoteCommitmentTree {
     /// Appends a note commitment to the leafmost layer of the tree.
     ///
     /// Returns an error if the tree is full.
-    #[allow(clippy::unwrap_in_result)]
     pub fn append(&mut self, cm: NoteCommitment) -> Result<(), NoteCommitmentTreeError> {
         if self.inner.append(cm.into()) {
             // Invalidate cached root
+            #[allow(clippy::unwrap_in_result)]
             let cached_root = self
                 .cached_root
                 .get_mut()

--- a/zebra-chain/src/transaction/tests.rs
+++ b/zebra-chain/src/transaction/tests.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_in_result)]
+
 mod preallocate;
 mod prop;
 mod vectors;

--- a/zebra-chain/src/transparent/tests.rs
+++ b/zebra-chain/src/transparent/tests.rs
@@ -1,2 +1,4 @@
+#![allow(clippy::unwrap_in_result)]
+
 mod prop;
 mod vectors;

--- a/zebra-chain/src/value_balance/tests.rs
+++ b/zebra-chain/src/value_balance/tests.rs
@@ -1,3 +1,5 @@
 //! Tests for value balances.
 
+#![allow(clippy::unwrap_in_result)]
+
 mod prop;

--- a/zebra-chain/src/work/difficulty/tests.rs
+++ b/zebra-chain/src/work/difficulty/tests.rs
@@ -1,2 +1,4 @@
+#![allow(clippy::unwrap_in_result)]
+
 mod prop;
 mod vectors;

--- a/zebra-chain/src/work/difficulty/tests/vectors.rs
+++ b/zebra-chain/src/work/difficulty/tests/vectors.rs
@@ -181,7 +181,7 @@ fn compact_extremes() {
     // value. Therefore, a block can never pass with this threshold.
     //
     // zcashd rejects these blocks without comparing the hash.
-    let difficulty_max = CompactDifficulty(u32::MAX & !SIGN_BIT);
+    let difficulty_max = CompactDifficulty(!SIGN_BIT);
     assert_eq!(difficulty_max.to_expanded(), None);
     assert_eq!(difficulty_max.to_work(), None);
 

--- a/zebra-chain/src/work/tests.rs
+++ b/zebra-chain/src/work/tests.rs
@@ -1,2 +1,4 @@
+#![allow(clippy::unwrap_in_result)]
+
 mod prop;
 mod vectors;

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -212,7 +212,7 @@ pub fn subsidy_is_valid(
             .remove(&FundingStreamReceiver::Deferred)
             .unwrap_or_default()
             .constrain::<NegativeAllowed>()
-            .expect("should be valid Amount");
+            .map_err(|e| BlockError::Other(format!("invalid deferred pool amount: {e}")))?;
 
         // Checks the one-time lockbox disbursements in the NU6.1 activation block's coinbase transaction
         // See [ZIP-271](https://zips.z.cash/zip-0271) and [ZIP-1016](https://zips.z.cash/zip-1016) for more details.
@@ -275,7 +275,7 @@ pub fn miner_fees_are_valid(
         .sum::<Result<Amount<NonNegative>, AmountError>>()
         .map_err(|_| SubsidyError::SumOverflow)?
         .constrain()
-        .expect("positive value always fit in `NegativeAllowed`");
+        .map_err(|e| BlockError::Other(format!("invalid transparent value balance: {e}")))?;
     let sapling_value_balance = coinbase_tx.sapling_value_balance().sapling_amount();
     let orchard_value_balance = coinbase_tx.orchard_value_balance().orchard_amount();
 

--- a/zebra-consensus/src/block/subsidy/funding_streams.rs
+++ b/zebra-consensus/src/block/subsidy/funding_streams.rs
@@ -28,13 +28,11 @@ fn funding_stream_address_index(
     let num_addresses = funding_streams.recipient(receiver)?.addresses().len();
 
     let index = 1u32
-        .checked_add(funding_stream_address_period(height, network))
-        .expect("no overflow should happen in this sum")
+        .checked_add(funding_stream_address_period(height, network))?
         .checked_sub(funding_stream_address_period(
             funding_streams.height_range().start,
             network,
-        ))
-        .expect("no overflow should happen in this sub") as usize;
+        ))? as usize;
 
     assert!(index > 0 && index <= num_addresses);
     // spec formula will output an index starting at 1 but

--- a/zebra-consensus/src/block/subsidy/funding_streams/tests.rs
+++ b/zebra-consensus/src/block/subsidy/funding_streams/tests.rs
@@ -1,5 +1,7 @@
 //! Tests for funding streams.
 
+#![allow(clippy::unwrap_in_result)]
+
 use std::collections::HashMap;
 
 use color_eyre::Report;

--- a/zebra-consensus/src/block/tests.rs
+++ b/zebra-consensus/src/block/tests.rs
@@ -1,5 +1,7 @@
 //! Tests for block verification
 
+#![allow(clippy::unwrap_in_result)]
+
 use color_eyre::eyre::{eyre, Report};
 use once_cell::sync::Lazy;
 use tower::{buffer::Buffer, util::BoxService};

--- a/zebra-consensus/src/checkpoint/tests.rs
+++ b/zebra-consensus/src/checkpoint/tests.rs
@@ -1,5 +1,7 @@
 //! Tests for checkpoint-based block verification
 
+#![allow(clippy::unwrap_in_result)]
+
 use std::{cmp::min, time::Duration};
 
 use color_eyre::eyre::{eyre, Report};

--- a/zebra-consensus/src/primitives/ed25519/tests.rs
+++ b/zebra-consensus/src/primitives/ed25519/tests.rs
@@ -1,5 +1,7 @@
 //! Tests for Ed25519 signature verification
 
+#![allow(clippy::unwrap_in_result)]
+
 use std::time::Duration;
 
 use color_eyre::eyre::{eyre, Report, Result};

--- a/zebra-consensus/src/primitives/groth16/tests.rs
+++ b/zebra-consensus/src/primitives/groth16/tests.rs
@@ -1,5 +1,7 @@
 //! Tests for transaction verification
 
+#![allow(clippy::unwrap_in_result)]
+
 use futures::{
     future::ready,
     stream::{FuturesUnordered, StreamExt},

--- a/zebra-consensus/src/primitives/redjubjub/tests.rs
+++ b/zebra-consensus/src/primitives/redjubjub/tests.rs
@@ -1,5 +1,7 @@
 //! Tests for redjubjub signature verification
 
+#![allow(clippy::unwrap_in_result)]
+
 use super::*;
 
 use std::time::Duration;

--- a/zebra-consensus/src/primitives/redpallas/tests.rs
+++ b/zebra-consensus/src/primitives/redpallas/tests.rs
@@ -1,5 +1,7 @@
 //! Tests for redpallas signature verification
 
+#![allow(clippy::unwrap_in_result)]
+
 use super::*;
 
 use std::time::Duration;

--- a/zebra-consensus/src/router/tests.rs
+++ b/zebra-consensus/src/router/tests.rs
@@ -1,5 +1,7 @@
 //! Tests for chain verification
 
+#![allow(clippy::unwrap_in_result)]
+
 use std::{sync::Arc, time::Duration};
 
 use color_eyre::eyre::Report;

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -187,7 +187,7 @@ pub fn coinbase_tx_no_prevout_joinsplit_spend(tx: &Transaction) -> Result<(), Tr
 ///
 /// <https://zips.z.cash/protocol/protocol.pdf#joinsplitdesc>
 pub fn joinsplit_has_vpub_zero(tx: &Transaction) -> Result<(), TransactionError> {
-    let zero = Amount::<NonNegative>::try_from(0).expect("an amount of 0 is always valid");
+    let zero = Amount::<NonNegative>::zero();
 
     let vpub_pairs = tx
         .output_values_to_sprout()
@@ -226,7 +226,7 @@ pub fn disabled_add_to_sprout_pool(
     //
     // https://zips.z.cash/protocol/protocol.pdf#joinsplitdesc
     if height >= canopy_activation_height {
-        let zero = Amount::<NonNegative>::try_from(0).expect("an amount of 0 is always valid");
+        let zero = Amount::<NonNegative>::zero();
 
         let tx_sprout_pool = tx.output_values_to_sprout();
         for vpub_old in tx_sprout_pool {

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -1,4 +1,7 @@
 //! Tests for Zcash transaction consensus checks.
+
+#![allow(clippy::unwrap_in_result)]
+
 //
 // TODO: split fixed test vectors into a `vectors` module?
 

--- a/zebra-network/src/address_book/tests.rs
+++ b/zebra-network/src/address_book/tests.rs
@@ -1,4 +1,6 @@
 //! Tests for the address book.
 
+#![allow(clippy::unwrap_in_result)]
+
 mod prop;
 mod vectors;

--- a/zebra-network/src/config/tests.rs
+++ b/zebra-network/src/config/tests.rs
@@ -1,3 +1,5 @@
 //! Tests for zebra-network configs.
 
+#![allow(clippy::unwrap_in_result)]
+
 mod vectors;

--- a/zebra-network/src/isolated/tests.rs
+++ b/zebra-network/src/isolated/tests.rs
@@ -1,3 +1,5 @@
 //! Tests for isolated Zebra connections.
 
+#![allow(clippy::unwrap_in_result)]
+
 mod vectors;

--- a/zebra-network/src/isolated/tor/tests.rs
+++ b/zebra-network/src/isolated/tor/tests.rs
@@ -1,3 +1,5 @@
 //! Tests for isolated Tor connections.
 
+#![allow(clippy::unwrap_in_result)]
+
 mod vectors;

--- a/zebra-network/src/meta_addr/tests.rs
+++ b/zebra-network/src/meta_addr/tests.rs
@@ -1,5 +1,7 @@
 //! Tests for MetaAddrs
 
+#![allow(clippy::unwrap_in_result)]
+
 pub(crate) mod check;
 
 mod prop;

--- a/zebra-network/src/peer/client/tests.rs
+++ b/zebra-network/src/peer/client/tests.rs
@@ -2,7 +2,6 @@
 //! [`Client`] instances.
 
 #![allow(clippy::unwrap_in_result)]
-
 #![cfg_attr(feature = "proptest-impl", allow(dead_code))]
 
 use std::{

--- a/zebra-network/src/peer/client/tests.rs
+++ b/zebra-network/src/peer/client/tests.rs
@@ -1,6 +1,8 @@
 //! Tests for the [`Client`] part of peer connections, and some test utilities for mocking
 //! [`Client`] instances.
 
+#![allow(clippy::unwrap_in_result)]
+
 #![cfg_attr(feature = "proptest-impl", allow(dead_code))]
 
 use std::{

--- a/zebra-network/src/peer/connection/tests.rs
+++ b/zebra-network/src/peer/connection/tests.rs
@@ -1,5 +1,7 @@
 //! Tests for peer connections
 
+#![allow(clippy::unwrap_in_result)]
+
 use std::{
     io,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},

--- a/zebra-network/src/peer/handshake/tests.rs
+++ b/zebra-network/src/peer/handshake/tests.rs
@@ -1,5 +1,7 @@
 //! Implements methods for testing [`Handshake`]
 
+#![allow(clippy::unwrap_in_result)]
+
 use super::*;
 
 impl<S, C> Handshake<S, C>

--- a/zebra-network/src/peer/minimum_peer_version/tests.rs
+++ b/zebra-network/src/peer/minimum_peer_version/tests.rs
@@ -1,7 +1,6 @@
 //! Test utilities and tests for minimum network peer version requirements.
 
 #![allow(clippy::unwrap_in_result)]
-
 #![cfg_attr(feature = "proptest-impl", allow(dead_code))]
 
 use zebra_chain::{

--- a/zebra-network/src/peer/minimum_peer_version/tests.rs
+++ b/zebra-network/src/peer/minimum_peer_version/tests.rs
@@ -1,5 +1,7 @@
 //! Test utilities and tests for minimum network peer version requirements.
 
+#![allow(clippy::unwrap_in_result)]
+
 #![cfg_attr(feature = "proptest-impl", allow(dead_code))]
 
 use zebra_chain::{

--- a/zebra-network/src/peer_set/candidate_set/tests.rs
+++ b/zebra-network/src/peer_set/candidate_set/tests.rs
@@ -1,4 +1,6 @@
 //! [`CandidateSet`] tests.
 
+#![allow(clippy::unwrap_in_result)]
+
 mod prop;
 mod vectors;

--- a/zebra-network/src/peer_set/initialize/recent_by_ip/tests.rs
+++ b/zebra-network/src/peer_set/initialize/recent_by_ip/tests.rs
@@ -1,5 +1,7 @@
 //! Fixed test vectors for recent IP limits.
 
+#![allow(clippy::unwrap_in_result)]
+
 use std::time::Duration;
 
 use crate::peer_set::initialize::recent_by_ip::RecentByIp;

--- a/zebra-network/src/peer_set/initialize/tests.rs
+++ b/zebra-network/src/peer_set/initialize/tests.rs
@@ -1,3 +1,5 @@
 //! Tests for zebra-network initialization
 
+#![allow(clippy::unwrap_in_result)]
+
 mod vectors;

--- a/zebra-network/src/peer_set/inventory_registry/tests.rs
+++ b/zebra-network/src/peer_set/inventory_registry/tests.rs
@@ -1,5 +1,7 @@
 //! Tests for the inventory registry.
 
+#![allow(clippy::unwrap_in_result)]
+
 use tokio::sync::broadcast;
 
 use crate::peer_set::inventory_registry::{InventoryChange, InventoryRegistry};

--- a/zebra-network/src/peer_set/set/tests.rs
+++ b/zebra-network/src/peer_set/set/tests.rs
@@ -1,5 +1,7 @@
 //! Peer set unit tests, and test setup code.
 
+#![allow(clippy::unwrap_in_result)]
+
 use std::{net::SocketAddr, sync::Arc};
 
 use futures::{channel::mpsc, stream, Stream, StreamExt};

--- a/zebra-network/src/peer_set/unready_service/tests.rs
+++ b/zebra-network/src/peer_set/unready_service/tests.rs
@@ -1,3 +1,5 @@
 //! Tests for unready services.
 
+#![allow(clippy::unwrap_in_result)]
+
 mod vectors;

--- a/zebra-network/src/protocol/external/codec/tests.rs
+++ b/zebra-network/src/protocol/external/codec/tests.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_in_result)]
+
 use super::*;
 
 mod vectors;

--- a/zebra-network/src/protocol/external/tests.rs
+++ b/zebra-network/src/protocol/external/tests.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_in_result)]
+
 mod preallocate;
 mod prop;
 mod vectors;

--- a/zebra-rpc/build.rs
+++ b/zebra-rpc/build.rs
@@ -17,9 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn build_or_copy_proto() -> Result<(), Box<dyn std::error::Error>> {
     const PROTO_FILE_PATH: &str = "proto/indexer.proto";
 
-    let out_dir = env::var("OUT_DIR")
-        .map(PathBuf::from)
-        .expect("requires OUT_DIR environment variable definition");
+    let out_dir = env::var("OUT_DIR").map(PathBuf::from)?;
     let file_names = ["indexer_descriptor.bin", "zebra.indexer.rpc.rs"];
 
     let is_proto_file_available = Path::new(PROTO_FILE_PATH).exists();

--- a/zebra-rpc/src/indexer/tests.rs
+++ b/zebra-rpc/src/indexer/tests.rs
@@ -1,1 +1,3 @@
+#![allow(clippy::unwrap_in_result)]
+
 mod vectors;

--- a/zebra-rpc/src/methods/tests.rs
+++ b/zebra-rpc/src/methods/tests.rs
@@ -1,5 +1,7 @@
 //! Test code for RPC methods
 
+#![allow(clippy::unwrap_in_result)]
+
 mod prop;
 mod snapshot;
 pub mod utils;

--- a/zebra-rpc/src/methods/types/get_block_template/zip317/tests.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/zip317/tests.rs
@@ -1,5 +1,7 @@
 //! Tests for ZIP-317 transaction selection for block template production
 
+#![allow(clippy::unwrap_in_result)]
+
 use zcash_keys::address::Address;
 
 use zcash_transparent::address::TransparentAddress;

--- a/zebra-rpc/src/queue.rs
+++ b/zebra-rpc/src/queue.rs
@@ -203,7 +203,7 @@ impl Runner {
                     self.remove_committed(in_state);
 
                     // retry what is left in the queue
-                    let _retried = Self::retry(mempool.clone(), self.transactions_as_vec()).await;
+                    Self::retry(mempool.clone(), self.transactions_as_vec()).await;
                 }
             }
         }

--- a/zebra-rpc/src/queue/tests.rs
+++ b/zebra-rpc/src/queue/tests.rs
@@ -1,3 +1,5 @@
 //! Test code for the RPC queue
 
+#![allow(clippy::unwrap_in_result)]
+
 mod prop;

--- a/zebra-rpc/src/server/tests.rs
+++ b/zebra-rpc/src/server/tests.rs
@@ -1,3 +1,5 @@
 //! RPC server tests.
 
+#![allow(clippy::unwrap_in_result)]
+
 mod vectors;

--- a/zebra-rpc/src/tests.rs
+++ b/zebra-rpc/src/tests.rs
@@ -1,1 +1,3 @@
+#![allow(clippy::unwrap_in_result)]
+
 mod vectors;

--- a/zebra-rpc/tests/serialization_tests.rs
+++ b/zebra-rpc/tests/serialization_tests.rs
@@ -211,7 +211,6 @@ fn test_get_block_1() -> Result<(), Box<dyn std::error::Error>> {
     let tx = block
         .tx()
         .iter()
-        .cloned()
         .map(|tx| {
             let GetBlockTransaction::Hash(h) = tx else {
                 panic!("Expected GetBlockTransaction::Hash")

--- a/zebra-rpc/tests/serialization_tests.rs
+++ b/zebra-rpc/tests/serialization_tests.rs
@@ -4,6 +4,8 @@
 //! We want to ensure that users can use this crate to build RPC clients, so
 //! this is an integration test to ensure only the public API is accessed.
 
+#![allow(clippy::unwrap_in_result)]
+
 mod vectors;
 
 use std::{io::Cursor, ops::Deref};

--- a/zebra-script/src/tests.rs
+++ b/zebra-script/src/tests.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_in_result)]
+
 use hex::FromHex;
 use std::sync::Arc;
 use zebra_chain::{

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -380,6 +380,12 @@ pub enum ValidateContextError {
     },
 }
 
+impl From<sprout::tree::NoteCommitmentTreeError> for ValidateContextError {
+    fn from(value: sprout::tree::NoteCommitmentTreeError) -> Self {
+        ValidateContextError::NoteCommitmentTreeError(value.into())
+    }
+}
+
 /// Trait for creating the corresponding duplicate nullifier error from a nullifier.
 pub trait DuplicateNullifierError {
     /// Returns the corresponding duplicate nullifier error for `self`.

--- a/zebra-state/src/service/chain_tip/tests.rs
+++ b/zebra-state/src/service/chain_tip/tests.rs
@@ -1,4 +1,6 @@
 //! Tests for state ChainTip traits and types.
 
+#![allow(clippy::unwrap_in_result)]
+
 mod prop;
 mod vectors;

--- a/zebra-state/src/service/check/anchors.rs
+++ b/zebra-state/src/service/check/anchors.rs
@@ -293,9 +293,7 @@ fn sprout_anchors_refer_to_treestates(
 
         // Add new anchors to the interstitial note commitment tree.
         for cm in joinsplit.commitments {
-            input_tree_inner
-                .append(cm)
-                .expect("note commitment should be appendable to the tree");
+            input_tree_inner.append(cm)?;
         }
 
         interstitial_trees.insert(input_tree.root(), input_tree);

--- a/zebra-state/src/service/check/tests.rs
+++ b/zebra-state/src/service/check/tests.rs
@@ -1,5 +1,7 @@
 //! Tests for state contextual validation checks.
 
+#![allow(clippy::unwrap_in_result)]
+
 mod anchors;
 mod nullifier;
 mod utxo;

--- a/zebra-state/src/service/finalized_state/disk_db/tests.rs
+++ b/zebra-state/src/service/finalized_state/disk_db/tests.rs
@@ -1,7 +1,6 @@
 //! Tests and test methods for low-level RocksDB access.
 
 #![allow(clippy::unwrap_in_result)]
-
 #![allow(dead_code)]
 
 use std::ops::Deref;

--- a/zebra-state/src/service/finalized_state/disk_db/tests.rs
+++ b/zebra-state/src/service/finalized_state/disk_db/tests.rs
@@ -1,5 +1,7 @@
 //! Tests and test methods for low-level RocksDB access.
 
+#![allow(clippy::unwrap_in_result)]
+
 #![allow(dead_code)]
 
 use std::ops::Deref;

--- a/zebra-state/src/service/finalized_state/disk_format.rs
+++ b/zebra-state/src/service/finalized_state/disk_format.rs
@@ -162,7 +162,11 @@ impl FromDisk for RawBytes {
 ///
 /// - if `mem_bytes` is shorter than `disk_len`.
 pub fn truncate_zero_be_bytes(mem_bytes: &[u8], disk_len: usize) -> Option<&[u8]> {
-    let discarded_bytes = mem_bytes.len().checked_sub(disk_len)?;
+    #![allow(clippy::unwrap_in_result)]
+    let discarded_bytes = mem_bytes
+        .len()
+        .checked_sub(disk_len)
+        .expect("unexpected `mem_bytes` length: must be at least `disk_len`");
 
     if discarded_bytes == 0 {
         return Some(mem_bytes);

--- a/zebra-state/src/service/finalized_state/disk_format.rs
+++ b/zebra-state/src/service/finalized_state/disk_format.rs
@@ -162,10 +162,7 @@ impl FromDisk for RawBytes {
 ///
 /// - if `mem_bytes` is shorter than `disk_len`.
 pub fn truncate_zero_be_bytes(mem_bytes: &[u8], disk_len: usize) -> Option<&[u8]> {
-    let discarded_bytes = mem_bytes
-        .len()
-        .checked_sub(disk_len)
-        .expect("unexpected `mem_bytes` length: must be at least `disk_len`");
+    let discarded_bytes = mem_bytes.len().checked_sub(disk_len)?;
 
     if discarded_bytes == 0 {
         return Some(mem_bytes);

--- a/zebra-state/src/service/finalized_state/disk_format/tests.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/tests.rs
@@ -1,5 +1,7 @@
 //! Tests for the finalized disk format.
 
+#![allow(clippy::unwrap_in_result)]
+
 use serde::{Deserialize, Serialize};
 
 #[cfg(test)]

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/add_subtrees.rs
@@ -412,10 +412,11 @@ fn check_sapling_subtrees(
         }
         // Check that the final note has a greater subtree index if it didn't complete a subtree.
         else {
-            let prev_height = subtree
-                .end_height
-                .previous()
-                .expect("Note commitment subtrees should not end at the minimal height.");
+            let Ok(prev_height) = subtree.end_height.previous() else {
+                result = Err("Note commitment subtrees should not end at the minimal height");
+                error!(?result, ?subtree.end_height);
+                continue;
+            };
 
             let Some(prev_tree) = db.sapling_tree_by_height(&prev_height) else {
                 result = Err("missing note commitment tree below subtree completion height");
@@ -542,10 +543,11 @@ fn check_orchard_subtrees(
         }
         // Check that the final note has a greater subtree index if it didn't complete a subtree.
         else {
-            let prev_height = subtree
-                .end_height
-                .previous()
-                .expect("Note commitment subtrees should not end at the minimal height.");
+            let Ok(prev_height) = subtree.end_height.previous() else {
+                result = Err("Note commitment subtrees should not end at the minimal height");
+                error!(?result, ?subtree.end_height);
+                continue;
+            };
 
             let Some(prev_tree) = db.orchard_tree_by_height(&prev_height) else {
                 result = Err("missing note commitment tree below subtree completion height");

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/fix_tree_key_type.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/fix_tree_key_type.rs
@@ -87,14 +87,14 @@ pub fn quick_check(db: &ZebraDb) -> Result<(), String> {
         }
 
         // There should only be one tip tree in this column family.
-        if prev_tree.is_some() {
+        if let Some(prev_tree) = prev_tree {
             result = Err(format!(
                 "found duplicate sprout trees after running key format upgrade\n\
                  key: {key:?}, tree: {:?}\n\
                  prev key: {prev_key:?}, prev_tree: {:?}\n\
                  ",
                 tree.root(),
-                prev_tree.unwrap().root(),
+                prev_tree.root(),
             ));
             error!(?result);
         }
@@ -118,14 +118,14 @@ pub fn quick_check(db: &ZebraDb) -> Result<(), String> {
         }
 
         // There should only be one tip tree in this column family.
-        if prev_tree.is_some() {
+        if let Some(prev_tree) = prev_tree {
             result = Err(format!(
                 "found duplicate history trees after running key format upgrade\n\
                  key: {key:?}, tree: {:?}\n\
                  prev key: {prev_key:?}, prev_tree: {:?}\n\
                  ",
                 tree.hash(),
-                prev_tree.unwrap().hash(),
+                prev_tree.hash(),
             ));
             error!(?result);
         }

--- a/zebra-state/src/service/finalized_state/tests.rs
+++ b/zebra-state/src/service/finalized_state/tests.rs
@@ -1,4 +1,6 @@
 //! Finalized state tests.
 
+#![allow(clippy::unwrap_in_result)]
+
 mod prop;
 mod vectors;

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests.rs
@@ -1,4 +1,6 @@
 //! Tests for finalized database blocks and transactions.
 
+#![allow(clippy::unwrap_in_result)]
+
 mod snapshot;
 mod vectors;

--- a/zebra-state/src/service/non_finalized_state/tests.rs
+++ b/zebra-state/src/service/non_finalized_state/tests.rs
@@ -1,2 +1,4 @@
+#![allow(clippy::unwrap_in_result)]
+
 mod prop;
 mod vectors;

--- a/zebra-state/src/service/queued_blocks/tests.rs
+++ b/zebra-state/src/service/queued_blocks/tests.rs
@@ -1,3 +1,5 @@
 //! Tests for block queues.
 
+#![allow(clippy::unwrap_in_result)]
+
 mod vectors;

--- a/zebra-state/src/service/read/address/balance.rs
+++ b/zebra-state/src/service/read/address/balance.rs
@@ -54,9 +54,7 @@ pub fn transparent_balance(
         let chain_balance_change =
             chain_transparent_balance_change(chain, &addresses, finalized_tip);
 
-        balance = apply_balance_change(balance, chain_balance_change).expect(
-            "unexpected amount overflow: value balances are valid, so partial sum should be valid",
-        );
+        balance = apply_balance_change(balance, chain_balance_change)?;
     }
 
     Ok(balance)

--- a/zebra-state/src/service/read/block.rs
+++ b/zebra-state/src/service/read/block.rs
@@ -181,11 +181,7 @@ pub fn any_transaction<'a>(
         let confirmations = 1 + tip_height(best_chain, db)?.0 - height.0;
         Some(AnyTx::Mined(MinedTx::new(tx, height, confirmations, time)))
     } else {
-        let block_hash = containing_chain
-            .expect("if not in best chain, then it must be in a side chain")
-            .block(height.into())
-            .expect("must exist since tx is in chain")
-            .hash;
+        let block_hash = containing_chain?.block(height.into())?.hash;
         Some(AnyTx::Side((tx, block_hash)))
     }
 }

--- a/zebra-state/src/service/read/tests.rs
+++ b/zebra-state/src/service/read/tests.rs
@@ -1,3 +1,5 @@
 //! Tests for the ReadStateService.
 
+#![allow(clippy::unwrap_in_result)]
+
 mod vectors;

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -1,6 +1,8 @@
 //! StateService test vectors.
-//!
-//! TODO: move these tests into tests::vectors and tests::prop modules.
+
+#![allow(clippy::unwrap_in_result)]
+
+// TODO: move these tests into tests::vectors and tests::prop modules.
 
 use std::{env, sync::Arc, time::Duration};
 

--- a/zebra-state/src/tests.rs
+++ b/zebra-state/src/tests.rs
@@ -1,5 +1,7 @@
 //! Tests for the Zebra state service.
 
+#![allow(clippy::unwrap_in_result)]
+
 use std::{mem, sync::Arc};
 
 use zebra_chain::{

--- a/zebra-state/tests/basic.rs
+++ b/zebra-state/tests/basic.rs
@@ -1,5 +1,7 @@
 //! Basic integration tests for zebra-state
 
+#![allow(clippy::unwrap_in_result)]
+
 use std::sync::Arc;
 
 use color_eyre::eyre::Report;

--- a/zebra-utils/src/bin/block-template-to-proposal/main.rs
+++ b/zebra-utils/src/bin/block-template-to-proposal/main.rs
@@ -50,10 +50,7 @@ fn main() -> Result<()> {
 
     // parse string to generic json
     let mut template: Value = serde_json::from_str(&template)?;
-    eprintln!(
-        "{}",
-        serde_json::to_string_pretty(&template)?
-    );
+    eprintln!("{}", serde_json::to_string_pretty(&template)?);
 
     let template_obj = template
         .as_object_mut()
@@ -79,9 +76,7 @@ fn main() -> Result<()> {
 
     // the maxtime field is used by this tool
     // if it is missing, substitute a valid value
-    let current_time: DateTime32 = template_obj["curtime"]
-        .to_string()
-        .parse()?;
+    let current_time: DateTime32 = template_obj["curtime"].to_string().parse()?;
 
     template_obj.entry("maxtime").or_insert_with(|| {
         if time_source.uses_max_time() {

--- a/zebra-utils/src/bin/block-template-to-proposal/main.rs
+++ b/zebra-utils/src/bin/block-template-to-proposal/main.rs
@@ -52,7 +52,7 @@ fn main() -> Result<()> {
     let mut template: Value = serde_json::from_str(&template)?;
     eprintln!(
         "{}",
-        serde_json::to_string_pretty(&template).expect("re-serialization never fails")
+        serde_json::to_string_pretty(&template)?
     );
 
     let template_obj = template
@@ -81,8 +81,7 @@ fn main() -> Result<()> {
     // if it is missing, substitute a valid value
     let current_time: DateTime32 = template_obj["curtime"]
         .to_string()
-        .parse()
-        .expect("curtime is always a valid DateTime32");
+        .parse()?;
 
     template_obj.entry("maxtime").or_insert_with(|| {
         if time_source.uses_max_time() {
@@ -99,9 +98,7 @@ fn main() -> Result<()> {
     let proposal = proposal_block_from_template(&template, time_source, &args.net)?;
     eprintln!("{proposal:#?}");
 
-    let proposal = proposal
-        .zcash_serialize_to_vec()
-        .expect("serialization to Vec never fails");
+    let proposal = proposal.zcash_serialize_to_vec()?;
 
     println!("{}", hex::encode(proposal));
 

--- a/zebra-utils/src/bin/search-issue-refs/main.rs
+++ b/zebra-utils/src/bin/search-issue-refs/main.rs
@@ -139,7 +139,7 @@ impl PossibleIssueRef {
 type IssueId = String;
 
 /// Process entry point for `search-issue-refs`
-#[allow(clippy::print_stdout, clippy::print_stderr)]
+#[allow(clippy::print_stdout, clippy::print_stderr, clippy::unwrap_in_result)]
 #[tokio::main]
 async fn main() -> Result<()> {
     init_tracing();

--- a/zebra-utils/src/bin/search-issue-refs/main.rs
+++ b/zebra-utils/src/bin/search-issue-refs/main.rs
@@ -175,8 +175,9 @@ async fn main() -> Result<()> {
                         .start()
                         + 1;
 
-                    let potential_issue_ref =
-                        captures.get(2).ok_or_else(|| eyre!("matches should have 2 captures"))?;
+                    let potential_issue_ref = captures
+                        .get(2)
+                        .ok_or_else(|| eyre!("matches should have 2 captures"))?;
                     let matching_text = potential_issue_ref.as_str();
 
                     let id = matching_text[matching_text.len().checked_sub(4).unwrap_or(1)..]

--- a/zebra-utils/src/bin/zebra-checkpoints/main.rs
+++ b/zebra-utils/src/bin/zebra-checkpoints/main.rs
@@ -137,7 +137,7 @@ where
 
 /// Process entry point for `zebra-checkpoints`
 #[tokio::main]
-#[allow(clippy::print_stdout, clippy::print_stderr)]
+#[allow(clippy::print_stdout, clippy::print_stderr, clippy::unwrap_in_result)]
 async fn main() -> Result<()> {
     eprintln!("zebra-checkpoints launched");
 

--- a/zebra-utils/src/bin/zebra-checkpoints/main.rs
+++ b/zebra-utils/src/bin/zebra-checkpoints/main.rs
@@ -212,15 +212,15 @@ async fn main() -> Result<()> {
                 // get the values we are interested in
                 let hash: block::Hash = get_block["hash"]
                     .as_str()
-                    .expect("hash: unexpected missing field or field type")
+                    .ok_or_else(|| eyre!("hash: unexpected missing field or field type"))?
                     .parse()?;
                 let response_height: Height = get_block["height"]
                     .try_into_height()
-                    .expect("height: unexpected invalid value, missing field, or field type");
+                    .map_err(|_| eyre!("height: unexpected invalid value, missing field, or field type"))?;
 
                 let size = get_block["size"]
                     .as_u64()
-                    .expect("size: unexpected invalid value, missing field, or field type");
+                    .ok_or_else(|| eyre!("size: unexpected invalid value, missing field, or field type"))?;
 
                 (hash, response_height, size)
             }
@@ -234,7 +234,7 @@ async fn main() -> Result<()> {
                 .await?;
                 let block_bytes = block_bytes
                     .as_str()
-                    .expect("block bytes: unexpected missing field or field type");
+                    .ok_or_else(|| eyre!("block bytes: unexpected missing field or field type"))?;
 
                 let block_bytes: Vec<u8> = hex::decode(block_bytes)?;
 

--- a/zebra-utils/src/bin/zebra-checkpoints/main.rs
+++ b/zebra-utils/src/bin/zebra-checkpoints/main.rs
@@ -214,13 +214,14 @@ async fn main() -> Result<()> {
                     .as_str()
                     .ok_or_else(|| eyre!("hash: unexpected missing field or field type"))?
                     .parse()?;
-                let response_height: Height = get_block["height"]
-                    .try_into_height()
-                    .map_err(|_| eyre!("height: unexpected invalid value, missing field, or field type"))?;
+                let response_height: Height =
+                    get_block["height"].try_into_height().map_err(|_| {
+                        eyre!("height: unexpected invalid value, missing field, or field type")
+                    })?;
 
-                let size = get_block["size"]
-                    .as_u64()
-                    .ok_or_else(|| eyre!("size: unexpected invalid value, missing field, or field type"))?;
+                let size = get_block["size"].as_u64().ok_or_else(|| {
+                    eyre!("size: unexpected invalid value, missing field, or field type")
+                })?;
 
                 (hash, response_height, size)
             }

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -1,5 +1,7 @@
 //! Inbound service tests with a fake peer set.
 
+#![allow(clippy::unwrap_in_result)]
+
 use std::{collections::HashSet, iter, net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 
 use futures::FutureExt;

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -1,5 +1,7 @@
 //! Inbound service tests with a real peer set.
 
+#![allow(clippy::unwrap_in_result)]
+
 use std::{iter, net::SocketAddr};
 
 use futures::FutureExt;

--- a/zebrad/src/components/mempool/storage/tests/prop.rs
+++ b/zebrad/src/components/mempool/storage/tests/prop.rs
@@ -1,5 +1,7 @@
 //! Randomised property tests for mempool storage.
 
+#![allow(clippy::unwrap_in_result)]
+
 use std::{collections::HashSet, env, fmt::Debug, thread, time::Duration};
 
 use proptest::{collection::vec, prelude::*};

--- a/zebrad/src/components/mempool/storage/tests/vectors.rs
+++ b/zebrad/src/components/mempool/storage/tests/vectors.rs
@@ -1,5 +1,7 @@
 //! Fixed test vectors for mempool storage.
 
+#![allow(clippy::unwrap_in_result)]
+
 use std::iter;
 
 use color_eyre::eyre::Result;

--- a/zebrad/src/components/mempool/tests/prop.rs
+++ b/zebrad/src/components/mempool/tests/prop.rs
@@ -1,5 +1,7 @@
 //! Randomised property tests for the mempool.
 
+#![allow(clippy::unwrap_in_result)]
+
 use std::{env, fmt, sync::Arc};
 
 use proptest::{collection::vec, prelude::*};

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -1,5 +1,7 @@
 //! Fixed test vectors for the mempool.
 
+#![allow(clippy::unwrap_in_result)]
+
 use std::{sync::Arc, time::Duration};
 
 use color_eyre::Report;

--- a/zebrad/src/components/sync/tests/timing.rs
+++ b/zebrad/src/components/sync/tests/timing.rs
@@ -1,5 +1,7 @@
 //! Check the relationship between various sync timeouts and delays.
 
+#![allow(clippy::unwrap_in_result)]
+
 use std::sync::{
     atomic::{AtomicU8, Ordering},
     Arc,

--- a/zebrad/src/components/sync/tests/vectors.rs
+++ b/zebrad/src/components/sync/tests/vectors.rs
@@ -1,5 +1,7 @@
 //! Fixed test vectors for the syncer.
 
+#![allow(clippy::unwrap_in_result)]
+
 use std::{collections::HashMap, iter, sync::Arc, time::Duration};
 
 use color_eyre::Report;

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -412,7 +412,7 @@ async fn db_init_outside_future_executor() -> Result<()> {
         "futures executor was blocked longer than expected ({block_duration:?})",
     );
 
-    db_init_handle.await?;
+    db_init_handle.await.map_err(|e| eyre!(e))?;
 
     Ok(())
 }

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -132,6 +132,8 @@
 //! export TMPDIR=/path/to/disk/directory
 //! ```
 
+#![allow(clippy::unwrap_in_result)]
+
 mod common;
 
 use std::{

--- a/zebrad/tests/config.rs
+++ b/zebrad/tests/config.rs
@@ -4,6 +4,8 @@
 //! `ZEBRA_`-prefixed environment variable mappings used in Docker or
 //! other environments.
 
+#![allow(clippy::unwrap_in_result)]
+
 use std::{env, fs, io::Write, path::PathBuf, sync::Mutex};
 
 use tempfile::{Builder, TempDir};

--- a/zebrad/tests/end_of_support.rs
+++ b/zebrad/tests/end_of_support.rs
@@ -1,5 +1,7 @@
 //! Testing the end of support feature.
 
+#![allow(clippy::unwrap_in_result)]
+
 use std::time::Duration;
 
 use color_eyre::eyre::Result;


### PR DESCRIPTION
## Motivation

Clippy has new lints in Rust beta.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
