### PR TITLE
refactor(zebra-network): rename testnet_parameters in network config

### DIFF
--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -18,7 +18,7 @@ use zebra_chain::{
     parameters::{
         testnet::{
             self, ConfiguredActivationHeights, ConfiguredCheckpoints, ConfiguredFundingStreams,
-            ConfiguredLockboxDisbursement,
+            ConfiguredLockboxDisbursement, RegtestParameters,
         },
         Magic, Network, NetworkKind,
     },
@@ -609,11 +609,13 @@ struct DTestnetParameters {
     extend_funding_stream_addresses_as_required: Option<bool>,
 }
 
+/// Network configuration used during deserialization.
 #[derive(Serialize, Deserialize)]
 #[serde(untagged)]
 enum DNetwork {
     DefaultForKind(NetworkKind),
-    TestnetWithParams(Box<DTestnetParameters>),
+    ConfiguredTestnet(Box<DTestnetParameters>),
+    ConfiguredRegtest(Box<DTestnetParameters>),
 }
 
 impl Default for DNetwork {
@@ -716,9 +718,15 @@ impl From<Config> for DConfig {
                 .filter(|params| !params.is_default_testnet())
                 .map(Into::into)
             {
-                Some(params) => DNetwork::TestnetWithParams(Box::new(params)),
+                Some(params) => DNetwork::ConfiguredTestnet(Box::new(params)),
                 None => DNetwork::DefaultForKind(NetworkKind::Testnet),
             },
+
+            NetworkKind::Regtest => match network.parameters().map(Into::into) {
+                Some(params) => DNetwork::ConfiguredRegtest(Box::new(params)),
+                None => DNetwork::DefaultForKind(NetworkKind::Regtest),
+            },
+
             other_kind => DNetwork::DefaultForKind(other_kind),
         };
 
@@ -755,144 +763,25 @@ impl<'de> Deserialize<'de> for Config {
             max_connections_per_ip,
         } = DConfig::deserialize(deserializer)?;
 
-        /// Accepts an [`IndexSet`] of initial peers,
-        ///
-        /// Returns true if any of them are the default Testnet or Mainnet initial peers.
-        fn contains_default_initial_peers(initial_peers: &IndexSet<String>) -> bool {
-            let Config {
-                initial_mainnet_peers: mut default_initial_peers,
-                initial_testnet_peers: default_initial_testnet_peers,
-                ..
-            } = Config::default();
-            default_initial_peers.extend(default_initial_testnet_peers);
-
-            initial_peers
-                .intersection(&default_initial_peers)
-                .next()
-                .is_some()
-        }
-
-        let network = match dnetwork {
-            DNetwork::DefaultForKind(NetworkKind::Mainnet) => Network::Mainnet,
-            DNetwork::DefaultForKind(NetworkKind::Testnet) => Network::new_default_testnet(),
-            DNetwork::DefaultForKind(NetworkKind::Regtest) => {
-                Network::new_regtest(Default::default())
+        let network = match (dnetwork, testnet_parameters) {
+            (DNetwork::ConfiguredTestnet(params), _) => {
+                build_configured_testnet::<D>(*params, &initial_testnet_peers)?
             }
-            DNetwork::TestnetWithParams(params) => {
-                let DTestnetParameters {
-                    network_name,
-                    network_magic,
-                    slow_start_interval,
-                    target_difficulty_limit,
-                    disable_pow,
-                    genesis_hash,
-                    activation_heights,
-                    pre_nu6_funding_streams,
-                    post_nu6_funding_streams,
-                    funding_streams,
-                    pre_blossom_halving_interval,
-                    lockbox_disbursements,
-                    checkpoints,
-                    extend_funding_stream_addresses_as_required,
-                } = *params;
-
-                let mut params_builder = testnet::Parameters::build();
-
-                if let Some(network_name) = network_name.clone() {
-                    params_builder = params_builder
-                        .with_network_name(network_name)
-                        .map_err(de::Error::custom)?
-                }
-
-                if let Some(network_magic) = network_magic {
-                    params_builder = params_builder
-                        .with_network_magic(Magic(network_magic))
-                        .map_err(de::Error::custom)?;
-                }
-
-                if let Some(genesis_hash) = genesis_hash {
-                    params_builder = params_builder
-                        .with_genesis_hash(genesis_hash)
-                        .map_err(de::Error::custom)?;
-                }
-
-                if let Some(slow_start_interval) = slow_start_interval {
-                    params_builder = params_builder.with_slow_start_interval(
-                        slow_start_interval.try_into().map_err(de::Error::custom)?,
-                    );
-                }
-
-                if let Some(target_difficulty_limit) = target_difficulty_limit.clone() {
-                    params_builder = params_builder
-                        .with_target_difficulty_limit(
-                            target_difficulty_limit
-                                .parse::<U256>()
-                                .map_err(de::Error::custom)?,
-                        )
-                        .map_err(de::Error::custom)?;
-                }
-
-                if let Some(disable_pow) = disable_pow {
-                    params_builder = params_builder.with_disable_pow(disable_pow);
-                }
-
-                // Retain default Testnet activation heights unless there's an empty [testnet_parameters.activation_heights] section.
-                if let Some(activation_heights) = activation_heights {
-                    params_builder = params_builder
-                        .with_activation_heights(activation_heights)
-                        .map_err(de::Error::custom)?
-                }
-
-                if let Some(halving_interval) = pre_blossom_halving_interval {
-                    params_builder = params_builder
-                        .with_halving_interval(halving_interval.into())
-                        .map_err(de::Error::custom)?
-                }
-
-                // Set configured funding streams after setting any parameters that affect the funding stream address period.
-                let mut funding_streams_vec = funding_streams.unwrap_or_default();
-
-                if let Some(funding_streams) = post_nu6_funding_streams {
-                    funding_streams_vec.insert(0, funding_streams);
-                }
-
-                if let Some(funding_streams) = pre_nu6_funding_streams {
-                    funding_streams_vec.insert(0, funding_streams);
-                }
-
-                if !funding_streams_vec.is_empty() {
-                    params_builder = params_builder.with_funding_streams(funding_streams_vec);
-                }
-
-                if let Some(lockbox_disbursements) = lockbox_disbursements {
-                    params_builder =
-                        params_builder.with_lockbox_disbursements(lockbox_disbursements);
-                }
-
-                params_builder = params_builder
-                    .with_checkpoints(checkpoints)
-                    .map_err(de::Error::custom)?;
-
-                if let Some(true) = extend_funding_stream_addresses_as_required {
-                    params_builder = params_builder.extend_funding_streams();
-                }
-
-                // Return an error if the initial testnet peers includes any of the default initial Mainnet or Testnet
-                // peers and the configured network parameters are incompatible with the default public Testnet.
-                if !params_builder.is_compatible_with_default_parameters()
-                    && contains_default_initial_peers(&initial_testnet_peers)
-                {
-                    return Err(de::Error::custom(
-                        "cannot use default initials peers with incompatible testnet",
-                    ));
-                };
-
-                // Return the default Testnet if no network name was configured and all parameters match the default Testnet
-                if network_name.is_none() && params_builder == testnet::Parameters::build() {
-                    Network::new_default_testnet()
-                } else {
-                    params_builder.to_network().map_err(de::Error::custom)?
-                }
+            (DNetwork::ConfiguredRegtest(params), _) => {
+                Network::new_regtest(build_regtest_params(*params))
+            }
+            (DNetwork::DefaultForKind(NetworkKind::Mainnet), _) => Network::Mainnet,
+            (DNetwork::DefaultForKind(NetworkKind::Testnet), Some(params)) => {
+                build_configured_testnet::<D>(params, &initial_testnet_peers)?
+            }
+            (DNetwork::DefaultForKind(NetworkKind::Testnet), None) => {
+                Network::new_default_testnet()
+            }
+            (DNetwork::DefaultForKind(NetworkKind::Regtest), Some(params)) => {
+                Network::new_regtest(build_regtest_params(params))
+            }
+            (DNetwork::DefaultForKind(NetworkKind::Regtest), None) => {
+                Network::new_regtest(Default::default())
             }
         };
 
@@ -948,5 +837,174 @@ impl<'de> Deserialize<'de> for Config {
             crawl_new_peer_interval,
             max_connections_per_ip,
         })
+    }
+}
+
+/// Accepts an [`IndexSet`] of initial peers,
+///
+/// Returns true if any of them are the default Testnet or Mainnet initial peers.
+fn contains_default_initial_peers(initial_peers: &IndexSet<String>) -> bool {
+    let Config {
+        initial_mainnet_peers: mut default_initial_peers,
+        initial_testnet_peers: default_initial_testnet_peers,
+        ..
+    } = Config::default();
+    default_initial_peers.extend(default_initial_testnet_peers);
+
+    initial_peers
+        .intersection(&default_initial_peers)
+        .next()
+        .is_some()
+}
+
+fn build_configured_testnet<'de, D>(
+    params: DTestnetParameters,
+    initial_testnet_peers: &IndexSet<String>,
+) -> Result<Network, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let DTestnetParameters {
+        network_name,
+        network_magic,
+        slow_start_interval,
+        target_difficulty_limit,
+        disable_pow,
+        genesis_hash,
+        activation_heights,
+        pre_nu6_funding_streams,
+        post_nu6_funding_streams,
+        funding_streams,
+        pre_blossom_halving_interval,
+        lockbox_disbursements,
+        checkpoints,
+        extend_funding_stream_addresses_as_required,
+    } = params;
+
+    let mut params_builder = testnet::Parameters::build();
+
+    if let Some(network_name) = network_name.clone() {
+        params_builder = params_builder
+                        .with_network_name(network_name)
+                        .map_err(de::Error::custom)?
+    }
+
+    if let Some(network_magic) = network_magic {
+        params_builder = params_builder
+                        .with_network_magic(Magic(network_magic))
+                        .map_err(de::Error::custom)?;
+    }
+
+    if let Some(genesis_hash) = genesis_hash {
+        params_builder = params_builder
+                        .with_genesis_hash(genesis_hash)
+                        .map_err(de::Error::custom)?;
+    }
+
+    if let Some(slow_start_interval) = slow_start_interval {
+        params_builder = params_builder
+            .with_slow_start_interval(slow_start_interval.try_into().map_err(de::Error::custom)?);
+    }
+
+    if let Some(target_difficulty_limit) = target_difficulty_limit.clone() {
+        params_builder = params_builder
+                        .with_target_difficulty_limit(
+                target_difficulty_limit
+                    .parse::<U256>()
+                    .map_err(de::Error::custom)?,
+            )
+                        .map_err(de::Error::custom)?;
+    }
+
+    if let Some(disable_pow) = disable_pow {
+        params_builder = params_builder.with_disable_pow(disable_pow);
+    }
+
+    // Retain default Testnet activation heights unless there's an empty [testnet_parameters.activation_heights] section.
+    if let Some(activation_heights) = activation_heights {
+        params_builder = params_builder
+                        .with_activation_heights(activation_heights)
+                        .map_err(de::Error::custom)?
+    }
+
+    if let Some(halving_interval) = pre_blossom_halving_interval {
+        params_builder = params_builder
+                        .with_halving_interval(halving_interval.into())
+                        .map_err(de::Error::custom)?
+    }
+
+    // Set configured funding streams after setting any parameters that affect the funding stream address period.
+    let mut funding_streams_vec = funding_streams.unwrap_or_default();
+
+    if let Some(funding_streams) = post_nu6_funding_streams {
+        funding_streams_vec.insert(0, funding_streams);
+    }
+
+    if let Some(funding_streams) = pre_nu6_funding_streams {
+        funding_streams_vec.insert(0, funding_streams);
+    }
+
+    if !funding_streams_vec.is_empty() {
+        params_builder = params_builder.with_funding_streams(funding_streams_vec);
+    }
+
+    if let Some(lockbox_disbursements) = lockbox_disbursements {
+        params_builder = params_builder.with_lockbox_disbursements(lockbox_disbursements);
+    }
+
+    params_builder = params_builder
+                    .with_checkpoints(checkpoints)
+                    .map_err(de::Error::custom)?;
+
+    if let Some(true) = extend_funding_stream_addresses_as_required {
+        params_builder = params_builder.extend_funding_streams();
+    }
+
+    // Return an error if the initial testnet peers includes any of the default initial Mainnet or Testnet
+    // peers and the configured network parameters are incompatible with the default public Testnet.
+    if !params_builder.is_compatible_with_default_parameters()
+        && contains_default_initial_peers(&initial_testnet_peers)
+    {
+        return Err(de::Error::custom(
+            "cannot use default initials peers with incompatible testnet",
+        ));
+    };
+
+    // Return the default Testnet if no network name was configured and all parameters match the default Testnet
+    if network_name.is_none() && params_builder == testnet::Parameters::build() {
+        Ok(Network::new_default_testnet())
+    } else {
+        Ok(params_builder.to_network().map_err(de::Error::custom)?)
+    }
+}
+
+fn build_regtest_params(params: DTestnetParameters) -> RegtestParameters {
+    let DTestnetParameters {
+        activation_heights,
+        pre_nu6_funding_streams,
+        post_nu6_funding_streams,
+        funding_streams,
+        lockbox_disbursements,
+        checkpoints,
+        extend_funding_stream_addresses_as_required,
+        ..
+    } = params;
+
+    let mut funding_streams_vec = funding_streams.unwrap_or_default();
+
+    if let Some(funding_streams) = post_nu6_funding_streams {
+        funding_streams_vec.insert(0, funding_streams);
+    }
+
+    if let Some(funding_streams) = pre_nu6_funding_streams {
+        funding_streams_vec.insert(0, funding_streams);
+    }
+
+    RegtestParameters {
+        activation_heights: activation_heights.unwrap_or_default(),
+        funding_streams: Some(funding_streams_vec),
+        lockbox_disbursements,
+        checkpoints: Some(checkpoints),
+        extend_funding_stream_addresses_as_required,
     }
 }

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -18,7 +18,7 @@ use zebra_chain::{
     parameters::{
         testnet::{
             self, ConfiguredActivationHeights, ConfiguredCheckpoints, ConfiguredFundingStreams,
-            ConfiguredLockboxDisbursement, RegtestParameters,
+            ConfiguredLockboxDisbursement,
         },
         Magic, Network, NetworkKind,
     },
@@ -610,12 +610,24 @@ struct DTestnetParameters {
 }
 
 #[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+enum DNetwork {
+    DefaultForKind(NetworkKind),
+    TestnetWithParams(Box<DTestnetParameters>),
+}
+
+impl Default for DNetwork {
+    fn default() -> Self {
+        DNetwork::DefaultForKind(NetworkKind::Mainnet)
+    }
+}
+
+#[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields, default)]
 struct DConfig {
     listen_addr: String,
     external_addr: Option<String>,
-    network: NetworkKind,
-    testnet_parameters: Option<DTestnetParameters>,
+    network: DNetwork,
     initial_mainnet_peers: IndexSet<String>,
     initial_testnet_peers: IndexSet<String>,
     cache_dir: CacheDir,
@@ -632,7 +644,6 @@ impl Default for DConfig {
             listen_addr: "[::]".to_string(),
             external_addr: None,
             network: Default::default(),
-            testnet_parameters: None,
             initial_mainnet_peers: config.initial_mainnet_peers,
             initial_testnet_peers: config.initial_testnet_peers,
             cache_dir: config.cache_dir,
@@ -693,16 +704,22 @@ impl From<Config> for DConfig {
             max_connections_per_ip,
         }: Config,
     ) -> Self {
-        let testnet_parameters = network
-            .parameters()
-            .filter(|params| !params.is_default_testnet())
-            .map(Into::into);
+        let dnetwork = match network.kind() {
+            NetworkKind::Testnet => match network
+                .parameters()
+                .filter(|params| !params.is_default_testnet())
+                .map(Into::into)
+            {
+                Some(params) => DNetwork::TestnetWithParams(Box::new(params)),
+                None => DNetwork::DefaultForKind(NetworkKind::Testnet),
+            },
+            other_kind => DNetwork::DefaultForKind(other_kind),
+        };
 
         DConfig {
             listen_addr: listen_addr.to_string(),
             external_addr: external_addr.map(|addr| addr.to_string()),
-            network: network.into(),
-            testnet_parameters,
+            network: dnetwork,
             initial_mainnet_peers,
             initial_testnet_peers,
             cache_dir,
@@ -721,8 +738,7 @@ impl<'de> Deserialize<'de> for Config {
         let DConfig {
             listen_addr,
             external_addr,
-            network: network_kind,
-            testnet_parameters,
+            network: dnetwork,
             initial_mainnet_peers,
             initial_testnet_peers,
             cache_dir,
@@ -748,46 +764,14 @@ impl<'de> Deserialize<'de> for Config {
                 .is_some()
         }
 
-        let network = match (network_kind, testnet_parameters) {
-            (NetworkKind::Mainnet, _) => Network::Mainnet,
-            (NetworkKind::Testnet, None) => Network::new_default_testnet(),
-            (NetworkKind::Regtest, testnet_parameters) => {
-                let params = testnet_parameters
-                    .map(
-                        |DTestnetParameters {
-                             activation_heights,
-                             pre_nu6_funding_streams,
-                             post_nu6_funding_streams,
-                             funding_streams,
-                             lockbox_disbursements,
-                             checkpoints,
-                             extend_funding_stream_addresses_as_required,
-                             ..
-                         }| {
-                            let mut funding_streams_vec = funding_streams.unwrap_or_default();
-                            if let Some(funding_streams) = post_nu6_funding_streams {
-                                funding_streams_vec.insert(0, funding_streams);
-                            }
-                            if let Some(funding_streams) = pre_nu6_funding_streams {
-                                funding_streams_vec.insert(0, funding_streams);
-                            }
-
-                            RegtestParameters {
-                                activation_heights: activation_heights.unwrap_or_default(),
-                                funding_streams: Some(funding_streams_vec),
-                                lockbox_disbursements,
-                                checkpoints: Some(checkpoints),
-                                extend_funding_stream_addresses_as_required,
-                            }
-                        },
-                    )
-                    .unwrap_or_default();
-
-                Network::new_regtest(params)
+        let network = match dnetwork {
+            DNetwork::DefaultForKind(NetworkKind::Mainnet) => Network::Mainnet,
+            DNetwork::DefaultForKind(NetworkKind::Testnet) => Network::new_default_testnet(),
+            DNetwork::DefaultForKind(NetworkKind::Regtest) => {
+                Network::new_regtest(Default::default())
             }
-            (
-                NetworkKind::Testnet,
-                Some(DTestnetParameters {
+            DNetwork::TestnetWithParams(params) => {
+                let DTestnetParameters {
                     network_name,
                     network_magic,
                     slow_start_interval,
@@ -802,8 +786,8 @@ impl<'de> Deserialize<'de> for Config {
                     lockbox_disbursements,
                     checkpoints,
                     extend_funding_stream_addresses_as_required,
-                }),
-            ) => {
+                } = *params;
+
                 let mut params_builder = testnet::Parameters::build();
 
                 if let Some(network_name) = network_name.clone() {

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -614,8 +614,13 @@ struct DTestnetParameters {
 #[serde(untagged)]
 enum DNetwork {
     DefaultForKind(NetworkKind),
+    ConfiguredRegtest {
+        params: Box<DTestnetParameters>,
+
+        #[serde(default, skip_serializing)]
+        regtest: Option<bool>,
+    },
     ConfiguredTestnet(Box<DTestnetParameters>),
-    ConfiguredRegtest(Box<DTestnetParameters>),
 }
 
 impl Default for DNetwork {
@@ -723,7 +728,10 @@ impl From<Config> for DConfig {
             },
 
             NetworkKind::Regtest => match network.parameters().map(Into::into) {
-                Some(params) => DNetwork::ConfiguredRegtest(Box::new(params)),
+                Some(params) => DNetwork::ConfiguredRegtest {
+                    params: Box::new(params),
+                    regtest: Some(true),
+                },
                 None => DNetwork::DefaultForKind(NetworkKind::Regtest),
             },
 
@@ -767,7 +775,7 @@ impl<'de> Deserialize<'de> for Config {
             (DNetwork::ConfiguredTestnet(params), _) => {
                 build_configured_testnet::<D>(*params, &initial_testnet_peers)?
             }
-            (DNetwork::ConfiguredRegtest(params), _) => {
+            (DNetwork::ConfiguredRegtest { params, .. }, _) => {
                 Network::new_regtest(build_regtest_params(*params))
             }
             (DNetwork::DefaultForKind(NetworkKind::Mainnet), _) => Network::Mainnet,
@@ -885,20 +893,20 @@ where
 
     if let Some(network_name) = network_name.clone() {
         params_builder = params_builder
-                        .with_network_name(network_name)
-                        .map_err(de::Error::custom)?
+            .with_network_name(network_name)
+            .map_err(de::Error::custom)?
     }
 
     if let Some(network_magic) = network_magic {
         params_builder = params_builder
-                        .with_network_magic(Magic(network_magic))
-                        .map_err(de::Error::custom)?;
+            .with_network_magic(Magic(network_magic))
+            .map_err(de::Error::custom)?;
     }
 
     if let Some(genesis_hash) = genesis_hash {
         params_builder = params_builder
-                        .with_genesis_hash(genesis_hash)
-                        .map_err(de::Error::custom)?;
+            .with_genesis_hash(genesis_hash)
+            .map_err(de::Error::custom)?;
     }
 
     if let Some(slow_start_interval) = slow_start_interval {
@@ -908,12 +916,12 @@ where
 
     if let Some(target_difficulty_limit) = target_difficulty_limit.clone() {
         params_builder = params_builder
-                        .with_target_difficulty_limit(
+            .with_target_difficulty_limit(
                 target_difficulty_limit
                     .parse::<U256>()
                     .map_err(de::Error::custom)?,
             )
-                        .map_err(de::Error::custom)?;
+            .map_err(de::Error::custom)?;
     }
 
     if let Some(disable_pow) = disable_pow {
@@ -923,14 +931,14 @@ where
     // Retain default Testnet activation heights unless there's an empty [testnet_parameters.activation_heights] section.
     if let Some(activation_heights) = activation_heights {
         params_builder = params_builder
-                        .with_activation_heights(activation_heights)
-                        .map_err(de::Error::custom)?
+            .with_activation_heights(activation_heights)
+            .map_err(de::Error::custom)?
     }
 
     if let Some(halving_interval) = pre_blossom_halving_interval {
         params_builder = params_builder
-                        .with_halving_interval(halving_interval.into())
-                        .map_err(de::Error::custom)?
+            .with_halving_interval(halving_interval.into())
+            .map_err(de::Error::custom)?
     }
 
     // Set configured funding streams after setting any parameters that affect the funding stream address period.
@@ -953,8 +961,8 @@ where
     }
 
     params_builder = params_builder
-                    .with_checkpoints(checkpoints)
-                    .map_err(de::Error::custom)?;
+        .with_checkpoints(checkpoints)
+        .map_err(de::Error::custom)?;
 
     if let Some(true) = extend_funding_stream_addresses_as_required {
         params_builder = params_builder.extend_funding_streams();
@@ -963,7 +971,7 @@ where
     // Return an error if the initial testnet peers includes any of the default initial Mainnet or Testnet
     // peers and the configured network parameters are incompatible with the default public Testnet.
     if !params_builder.is_compatible_with_default_parameters()
-        && contains_default_initial_peers(&initial_testnet_peers)
+        && contains_default_initial_peers(initial_testnet_peers)
     {
         return Err(de::Error::custom(
             "cannot use default initials peers with incompatible testnet",

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -628,6 +628,11 @@ struct DConfig {
     listen_addr: String,
     external_addr: Option<String>,
     network: DNetwork,
+
+    /// Legacy testnet parameters, kept for backwards compatibility.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    testnet_parameters: Option<DTestnetParameters>,
+
     initial_mainnet_peers: IndexSet<String>,
     initial_testnet_peers: IndexSet<String>,
     cache_dir: CacheDir,
@@ -644,6 +649,7 @@ impl Default for DConfig {
             listen_addr: "[::]".to_string(),
             external_addr: None,
             network: Default::default(),
+            testnet_parameters: None,
             initial_mainnet_peers: config.initial_mainnet_peers,
             initial_testnet_peers: config.initial_testnet_peers,
             cache_dir: config.cache_dir,
@@ -720,6 +726,7 @@ impl From<Config> for DConfig {
             listen_addr: listen_addr.to_string(),
             external_addr: external_addr.map(|addr| addr.to_string()),
             network: dnetwork,
+            testnet_parameters: None,
             initial_mainnet_peers,
             initial_testnet_peers,
             cache_dir,
@@ -739,6 +746,7 @@ impl<'de> Deserialize<'de> for Config {
             listen_addr,
             external_addr,
             network: dnetwork,
+            testnet_parameters,
             initial_mainnet_peers,
             initial_testnet_peers,
             cache_dir,


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

<!--
- Describe the goals of the PR.
- If it closes any issues, enumerate them here.
-->

Fixes #9729 — The origin of the network parameters in the `Config` struct is not obvious without inspecting the details of `DConfig` and its deserialization.

This PR refactors `DConfig` by replacing `network` and `testnet_parameters` with an enum that has variants for default and custom configurations, and updates the deserialization logic to use this new enum structure.


## Solution

<!-- Describe the changes in the PR. -->

* Introduce `DNetwork` enum with variants for default networks and custom Testnet parameters.
* Update `Deserialize` implementation to handle the new enum structure.
* Preserve all fields from `DTestnetParameters` for Testnet.


### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

* Regtest currently always uses default parameters; custom Regtest parameters from the old `testnet_parameters` are not supported.
* Some acceptance tests fail (`zebrad --test acceptance`). This is likely because some config files still define `testnet_parameters`, which the current design no longer supports, or due to the mismatch described above (but it could also be the result of a bug in the deserialization).

```rust
failures: config_tests
          regtest_block_templates_are_valid_block_submissions
          restores_non_finalized_state_and_commits_new_blocks
          stored_configs_parsed_correctly
test result: FAILED. 41 passed; 4 failed; 13 ignored; 0 measured; 0 filtered out; finished in 164.68s
```

Guidance is requested on whether custom Regtest parameters should be supported in this PR. Also, removing `testnet_parameters` makes old config files incompatible—should this field be kept temporarily?

```rust
#[derive(Debug, Clone, Serialize, Deserialize)]
pub struct DConfig {
    ...
    pub network: DNetwork,

    #[serde(default)]
    #[serde(skip_serializing_if = "Option::is_none")]
    pub testnet_parameters: Option<serde_json::Value>, // <-- keep old test configs working

    // rest of fields...
}
```


### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [x] The solution is tested.
- [ ] The documentation is up to date.

