### PR TITLE
Cleanup(zebra-consensus): remove unused groth16 code

### DIFF
--- a/zebra-rpc/src/methods/types/transaction.rs
+++ b/zebra-rpc/src/methods/types/transaction.rs
@@ -20,7 +20,6 @@ use zebra_chain::{
     transaction::{self, SerializedTransaction, Transaction, UnminedTx, VerifiedUnminedTx},
     transparent::Script,
 };
-use zebra_consensus::groth16::Description;
 use zebra_script::Sigops;
 use zebra_state::IntoDisk;
 
@@ -733,7 +732,7 @@ impl TransactionObject {
                         anchor,
                         nullifier,
                         rk,
-                        proof: spend.proof().0,
+                        proof: spend.zkproof.0,
                         spend_auth_sig,
                     }
                 })
@@ -754,7 +753,7 @@ impl TransactionObject {
                         ephemeral_key,
                         enc_ciphertext,
                         out_ciphertext,
-                        proof: output.proof().0,
+                        proof: output.zkproof.0,
                     }
                 })
                 .collect(),


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

<!--
- Describe the goals of the PR.
- If it closes any issues, enumerate them here.
-->

This PR addresses #9891. After switching to the `sapling_crypto` verifier, the `Description` trait for Sapling types is no longer needed. This change cleans up dead code and reduces maintenance overhead.


## Solution

<!-- Describe the changes in the PR. -->

* Deleted the impl `Description for Spend<PerSpendAnchor>` and impl `Description for Output`.
* Updated all usages to access the `zkproof` field directly instead of calling `proof()`.
* Verified that tests still pass after these changes.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
