### PR TITLE
Cleanup: apply new service supertraits introduced in #10010

### DIFF
--- a/zebra-consensus/src/router/service_trait.rs
+++ b/zebra-consensus/src/router/service_trait.rs
@@ -3,13 +3,13 @@
 //! This trait provides a convenient alias for `tower::Service`
 //! implementations that operate on Zebra block verification request and response types.
 //!
-//! - [`BlockVerifierService`]: for services that handle semantic block verification requests.
+//! - [`BlockVerifierService`]: for services that handle block verification requests.
 
 use crate::router::Request;
 use zebra_chain::block::Hash;
 use zebra_node_services::service_traits::ZebraService;
 
-/// Trait alias for services handling semantic block verification requests.
+/// Trait alias for services handling block verification requests.
 pub trait BlockVerifierService: ZebraService<Request, Hash> {}
 
 impl<T> BlockVerifierService for T where T: ZebraService<Request, Hash> {}

--- a/zebra-rpc/src/indexer/methods.rs
+++ b/zebra-rpc/src/indexer/methods.rs
@@ -5,12 +5,12 @@ use std::pin::Pin;
 use futures::Stream;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Response, Status};
-use tower::{util::ServiceExt, BoxError};
+use tower::util::ServiceExt;
 
 use tracing::Span;
 use zebra_chain::{chain_tip::ChainTip, serialization::BytesInDisplayOrder};
 use zebra_node_services::mempool::MempoolChangeKind;
-use zebra_state::{ReadRequest, ReadResponse};
+use zebra_state::{ReadRequest, ReadResponse, ReadState};
 
 use super::{
     indexer_server::Indexer, server::IndexerRPC, BlockAndHash, BlockHashAndHeight, Empty,
@@ -23,15 +23,7 @@ const RESPONSE_BUFFER_SIZE: usize = 4_000;
 #[tonic::async_trait]
 impl<ReadStateService, Tip> Indexer for IndexerRPC<ReadStateService, Tip>
 where
-    ReadStateService: tower::Service<
-            zebra_state::ReadRequest,
-            Response = zebra_state::ReadResponse,
-            Error = BoxError,
-        > + Clone
-        + Send
-        + Sync
-        + 'static,
-    <ReadStateService as tower::Service<zebra_state::ReadRequest>>::Future: Send,
+    ReadStateService: ReadState,
     Tip: ChainTip + Clone + Send + Sync + 'static,
 {
     type ChainTipChangeStream =

--- a/zebra-rpc/src/indexer/server.rs
+++ b/zebra-rpc/src/indexer/server.rs
@@ -7,6 +7,7 @@ use tonic::transport::{server::TcpIncoming, Server};
 use tower::BoxError;
 use zebra_chain::chain_tip::ChainTip;
 use zebra_node_services::mempool::MempoolTxSubscriber;
+use zebra_state::ReadState;
 
 use crate::{indexer::indexer_server::IndexerServer, server::OPENED_RPC_ENDPOINT_MSG};
 
@@ -15,15 +16,7 @@ type ServerTask = JoinHandle<Result<(), BoxError>>;
 /// Indexer RPC service.
 pub struct IndexerRPC<ReadStateService, Tip>
 where
-    ReadStateService: tower::Service<
-            zebra_state::ReadRequest,
-            Response = zebra_state::ReadResponse,
-            Error = BoxError,
-        > + Clone
-        + Send
-        + Sync
-        + 'static,
-    <ReadStateService as tower::Service<zebra_state::ReadRequest>>::Future: Send,
+    ReadStateService: ReadState,
     Tip: ChainTip + Clone + Send + Sync + 'static,
 {
     pub(super) read_state: ReadStateService,
@@ -40,15 +33,7 @@ pub async fn init<ReadStateService, Tip>(
     mempool_change: MempoolTxSubscriber,
 ) -> Result<(ServerTask, SocketAddr), BoxError>
 where
-    ReadStateService: tower::Service<
-            zebra_state::ReadRequest,
-            Response = zebra_state::ReadResponse,
-            Error = BoxError,
-        > + Clone
-        + Send
-        + Sync
-        + 'static,
-    <ReadStateService as tower::Service<zebra_state::ReadRequest>>::Future: Send,
+    ReadStateService: ReadState,
     Tip: ChainTip + Clone + Send + Sync + 'static,
 {
     let indexer_service = IndexerRPC {

--- a/zebra-rpc/src/methods/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/types/get_block_template.rs
@@ -43,7 +43,9 @@ use zebra_chain::{
 #[allow(unused_imports)]
 use zebra_chain::serialization::BytesInDisplayOrder;
 
-use zebra_consensus::{funding_stream_address, MAX_BLOCK_SIGOPS};
+use zebra_consensus::{
+    funding_stream_address, router::service_trait::BlockVerifierService, MAX_BLOCK_SIGOPS,
+};
 use zebra_node_services::mempool::{self, TransactionDependencies};
 use zebra_state::GetBlockTemplateChainInfo;
 
@@ -425,12 +427,7 @@ impl GetBlockTemplateResponse {
 #[derive(Clone)]
 pub struct GetBlockTemplateHandler<BlockVerifierRouter, SyncStatus>
 where
-    BlockVerifierRouter: Service<zebra_consensus::Request, Response = block::Hash, Error = zebra_consensus::BoxError>
-        + Clone
-        + Send
-        + Sync
-        + 'static,
-    <BlockVerifierRouter as Service<zebra_consensus::Request>>::Future: Send,
+    BlockVerifierRouter: BlockVerifierService,
     SyncStatus: ChainSyncStatus + Clone + Send + Sync + 'static,
 {
     /// Address for receiving miner subsidy and tx fees.
@@ -457,12 +454,7 @@ const EXTRA_COINBASE_DATA_LIMIT: usize = MAX_COINBASE_DATA_LEN - MAX_COINBASE_HE
 
 impl<BlockVerifierRouter, SyncStatus> GetBlockTemplateHandler<BlockVerifierRouter, SyncStatus>
 where
-    BlockVerifierRouter: Service<zebra_consensus::Request, Response = block::Hash, Error = zebra_consensus::BoxError>
-        + Clone
-        + Send
-        + Sync
-        + 'static,
-    <BlockVerifierRouter as Service<zebra_consensus::Request>>::Future: Send,
+    BlockVerifierRouter: BlockVerifierService,
     SyncStatus: ChainSyncStatus + Clone + Send + Sync + 'static,
 {
     /// Creates a new [`GetBlockTemplateHandler`].
@@ -561,12 +553,7 @@ where
 impl<BlockVerifierRouter, SyncStatus> fmt::Debug
     for GetBlockTemplateHandler<BlockVerifierRouter, SyncStatus>
 where
-    BlockVerifierRouter: Service<zebra_consensus::Request, Response = block::Hash, Error = zebra_consensus::BoxError>
-        + Clone
-        + Send
-        + Sync
-        + 'static,
-    <BlockVerifierRouter as Service<zebra_consensus::Request>>::Future: Send,
+    BlockVerifierRouter: BlockVerifierService,
     SyncStatus: ChainSyncStatus + Clone + Send + Sync + 'static,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
## Motivation

This PR is part of #9665. In PR #10010, new service traits were introduced. This PR applies the new traits in the `zebra-rpc`.

While reviewing the modules, it was observed that some bounds like `Future: Send + 'static` or `Sync` are not always required (for example, in `zebra-rpc/src/queue.rs`). This PR only replaces cases that **exactly match** the new trait bounds.

### Solution

* Applied the unmerged review feedback from PR #10010.
* Replaced explicit `Service<...> + Clone + Send + Sync + 'static` bounds with the new `Service` trait aliases where the bounds match exactly.
* Verified that the changes do not remove any required trait bounds or functionality.
* Left cases where `Future: Send` or `Sync` are not used untouched to avoid introducing unnecessary constraints.

### Reviewer Question

Are these current trait restrictions acceptable, and should I proceed to clean up the codebase? Or should they be revisited to be made more flexible before wider adoption?

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.
