### PR TITLE
perf(state): avoid cloning UTXO maps and Arc<Block> in contextual validation

### DIFF
--- a/zebra-state/src/service/check/utxo.rs
+++ b/zebra-state/src/service/check/utxo.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use zebra_chain::{
     amount,
-    transparent::{self, utxos_from_ordered_utxos, CoinbaseSpendRestriction::*},
+    transparent::{self, CoinbaseSpendRestriction::*},
 };
 
 use crate::{
@@ -239,8 +239,12 @@ pub fn remaining_transaction_value(
             continue;
         }
 
+        // Build a temporary UTXO map (OutPoint -> Utxo) from the provided
+        // OrderedUtxo references, avoiding cloning the entire map.
+        let utxos_map: HashMap<_, _> = utxos.iter().map(|(k, v)| (*k, v.utxo.clone())).collect();
+
         // Check the remaining transparent value pool for this transaction
-        let value_balance = transaction.value_balance(&utxos_from_ordered_utxos(utxos.clone()));
+        let value_balance = transaction.value_balance(&utxos_map);
         match value_balance {
             Ok(vb) => match vb.remaining_transaction_value() {
                 Ok(_) => Ok(()),


### PR DESCRIPTION
Optimize ContextuallyVerifiedBlock::with_block_and_spent_utxos() by removing redundant new_outputs extension and spent_outputs cloning. Build a temporary HashMap<OutPoint, Utxo> from references to compute block.chain_value_pool_change(...), and compute before moving block to avoid Arc::clone().
Similarly, in remaining_transaction_value(), replace cloning the entire HashMap<OutPoint, OrderedUtxo> and utxos_from_ordered_utxos(...) with a local Utxo map derived from references.
These changes reduce allocations and copies without altering behavior: the value-balance computations still receive all required UTXOs (including intra-block new outputs), and stored fields remain unchanged.