### PR TITLE
tests(qa): remove cache functionality

### DIFF
--- a/zebra-rpc/qa/README.md
+++ b/zebra-rpc/qa/README.md
@@ -76,24 +76,16 @@ To get real-time output during a test you can run it using the
 python3 qa/rpc-tests/wallet.py
 ```
 
-A 200-block -regtest blockchain and wallets for four nodes
-is created the first time a regression test is run and
-is stored in the `qa/cache/` directory.  Each node has the miner
-subsidy from 25 mature blocks (25*10=250 ZEC) in its wallet.
-
-TODO: https://github.com/ZcashFoundation/zebra/issues/9726
-
-After the first run, the `qa/cache/` blockchain and wallets are
-copied into a temporary directory and used as the initial
-test state.
-
-If you get into a bad state, you should be able
-to recover with:
+If a test gets stuck, you can stop the underlying binaries with:
 
 ```bash
-rm -rf qa/cache
 killall zebrad
+killall zallet
 ```
+
+Zcashd's test framework includes a [cache mechanism](https://github.com/zcash/zcash/blob/v6.10.0/qa/README.md?plain=1#L73-L88)
+to speed up certain tests.
+This version of the framework currently has that functionality disabled.
 
 Writing tests
 =============

--- a/zebra-rpc/qa/pull-tester/rpc-tests.py
+++ b/zebra-rpc/qa/pull-tester/rpc-tests.py
@@ -206,9 +206,8 @@ def run_tests(test_handler, test_list, src_dir, build_dir, exeext, jobs=1, enabl
     else:
         coverage = None
 
-    if len(test_list) > 1 and jobs > 1:
-        # Populate cache
-        subprocess.check_output([tests_dir + 'create_cache.py'] + flags)
+    # TODO: Restore cache functionality if needed:
+    # https://github.com/ZcashFoundation/zebra/blob/v3.0.0-rc.0/zebra-rpc/qa/pull-tester/rpc-tests.py#L209-L211
 
     #Run Tests
     time_sum = 0


### PR DESCRIPTION
## Motivation

We want to temporarily disable the cache functionality in the test framework, as it is currently unused and incompatible with the Z3 stack.

Closes https://github.com/ZcashFoundation/zebra/issues/9726

## Solution

The cache code itself is not being removed, only the default behavior of populating the cache when running the full test suite is disabled.

### Tests

```bash
$ ./qa/pull-tester/rpc-tests.py
..
getmininginfo.py:
Pass: True, Duration: 1 s
...................
wallet.py:
Pass: True, Duration: 11 s
......
feature_nu6_1.py:
Pass: True, Duration: 3 s
..........................................................
nuparams.py:
Pass: True, Duration: 44 s
...
getrawtransaction_sidechain.py:
Pass: True, Duration: 2 s
.
feature_nu6.py:
Pass: True, Duration: 46 s
...
fix_block_commitments.py:
Pass: True, Duration: 3 s
.................
addnode.py:
Pass: True, Duration: 58 s

feature_backup_non_finalized_state.py:
Pass: True, Duration: 44 s
TEST                                  | PASSED | DURATION

addnode.py                            | True   | 58 s
feature_backup_non_finalized_state.py | True   | 44 s
feature_nu6.py                        | True   | 46 s
feature_nu6_1.py                      | True   | 3 s
fix_block_commitments.py              | True   | 3 s
getmininginfo.py                      | True   | 1 s
getrawtransaction_sidechain.py        | True   | 2 s
nuparams.py                           | True   | 44 s
wallet.py                             | True   | 11 s
ALL                                   | True   | 212 s (accumulated)
Runtime: 59 s
$
```

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
