### PR TITLE
fix(all): gate tx_v6 also under zcash_unstable=nu7

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -39,7 +39,7 @@ pub use unmined::{
 };
 use zcash_protocol::consensus;
 
-#[cfg(feature = "tx_v6")]
+#[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
 use crate::parameters::TX_V6_VERSION_GROUP_ID;
 use crate::{
     amount::{Amount, Error as AmountError, NegativeAllowed, NonNegative},
@@ -150,7 +150,7 @@ pub enum Transaction {
         orchard_shielded_data: Option<orchard::ShieldedData>,
     },
     /// A `version = 6` transaction, which is reserved for current development.
-    #[cfg(feature = "tx_v6")]
+    #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
     V6 {
         /// The Network Upgrade for this transaction.
         ///
@@ -191,7 +191,7 @@ impl fmt::Display for Transaction {
         if let Some(expiry_height) = self.expiry_height() {
             fmter.field("expiry_height", &expiry_height);
         }
-        #[cfg(feature = "tx_v6")]
+        #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
         fmter.field("zip233_amount", &self.zip233_amount());
 
         fmter.field("transparent_inputs", &self.inputs().len());
@@ -284,7 +284,7 @@ impl Transaction {
             | Transaction::V3 { .. }
             | Transaction::V4 { .. } => None,
             Transaction::V5 { .. } => Some(AuthDigest::from(self)),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { .. } => Some(AuthDigest::from(self)),
         }
     }
@@ -325,7 +325,7 @@ impl Transaction {
     }
 
     /// Does this transaction have zip233_amount output?
-    #[cfg(feature = "tx_v6")]
+    #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
     pub fn has_zip233_amount(&self) -> bool {
         self.zip233_amount() > Amount::<NonNegative>::zero()
     }
@@ -380,7 +380,7 @@ impl Transaction {
         match self {
             Transaction::V1 { .. } | Transaction::V2 { .. } => false,
             Transaction::V3 { .. } | Transaction::V4 { .. } | Transaction::V5 { .. } => true,
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { .. } => true,
         }
     }
@@ -403,7 +403,7 @@ impl Transaction {
             Transaction::V3 { .. } => 3,
             Transaction::V4 { .. } => 4,
             Transaction::V5 { .. } => 5,
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { .. } => 6,
         }
     }
@@ -416,7 +416,7 @@ impl Transaction {
             | Transaction::V3 { lock_time, .. }
             | Transaction::V4 { lock_time, .. }
             | Transaction::V5 { lock_time, .. } => *lock_time,
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { lock_time, .. } => *lock_time,
         };
 
@@ -465,7 +465,7 @@ impl Transaction {
             | Transaction::V3 { lock_time, .. }
             | Transaction::V4 { lock_time, .. }
             | Transaction::V5 { lock_time, .. } => *lock_time,
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { lock_time, .. } => *lock_time,
         };
         let mut lock_time_bytes = Vec::new();
@@ -503,7 +503,7 @@ impl Transaction {
                 block::Height(0) => None,
                 block::Height(expiry_height) => Some(block::Height(*expiry_height)),
             },
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { expiry_height, .. } => match expiry_height {
                 // # Consensus
                 //
@@ -528,7 +528,7 @@ impl Transaction {
             Transaction::V5 {
                 network_upgrade, ..
             } => Some(*network_upgrade),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 network_upgrade, ..
             } => Some(*network_upgrade),
@@ -545,7 +545,7 @@ impl Transaction {
             Transaction::V3 { ref inputs, .. } => inputs,
             Transaction::V4 { ref inputs, .. } => inputs,
             Transaction::V5 { ref inputs, .. } => inputs,
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { ref inputs, .. } => inputs,
         }
     }
@@ -565,7 +565,7 @@ impl Transaction {
             Transaction::V3 { ref outputs, .. } => outputs,
             Transaction::V4 { ref outputs, .. } => outputs,
             Transaction::V5 { ref outputs, .. } => outputs,
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { ref outputs, .. } => outputs,
         }
     }
@@ -615,7 +615,7 @@ impl Transaction {
                 ..
             }
             | Transaction::V5 { .. } => Box::new(std::iter::empty()),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { .. } => Box::new(std::iter::empty()),
         }
     }
@@ -652,7 +652,7 @@ impl Transaction {
                 ..
             }
             | Transaction::V5 { .. } => Box::new(std::iter::empty()),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { .. } => Box::new(std::iter::empty()),
         }
     }
@@ -689,7 +689,7 @@ impl Transaction {
                 ..
             }
             | Transaction::V5 { .. } => 0,
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { .. } => 0,
         }
     }
@@ -730,7 +730,7 @@ impl Transaction {
                 ..
             }
             | Transaction::V5 { .. } => Box::new(std::iter::empty()),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { .. } => Box::new(std::iter::empty()),
         }
     }
@@ -768,7 +768,7 @@ impl Transaction {
                 ..
             }
             | Transaction::V5 { .. } => None,
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { .. } => None,
         }
     }
@@ -778,7 +778,7 @@ impl Transaction {
         match self {
             // No JoinSplits
             Transaction::V1 { .. } | Transaction::V5 { .. } => false,
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { .. } => false,
 
             // JoinSplits-on-BCTV14
@@ -827,7 +827,7 @@ impl Transaction {
             }
             | Transaction::V1 { .. }
             | Transaction::V5 { .. } => Box::new(std::iter::empty()),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { .. } => Box::new(std::iter::empty()),
         }
     }
@@ -850,7 +850,7 @@ impl Transaction {
                 ..
             } => Box::new(sapling_shielded_data.anchors()),
 
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
@@ -868,7 +868,7 @@ impl Transaction {
                 sapling_shielded_data: None,
                 ..
             } => Box::new(std::iter::empty()),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 sapling_shielded_data: None,
                 ..
@@ -898,7 +898,7 @@ impl Transaction {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
             } => Box::new(sapling_shielded_data.spends_per_anchor()),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
@@ -916,7 +916,7 @@ impl Transaction {
                 sapling_shielded_data: None,
                 ..
             } => Box::new(std::iter::empty()),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 sapling_shielded_data: None,
                 ..
@@ -936,7 +936,7 @@ impl Transaction {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
             } => Box::new(sapling_shielded_data.outputs()),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
@@ -954,7 +954,7 @@ impl Transaction {
                 sapling_shielded_data: None,
                 ..
             } => Box::new(std::iter::empty()),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 sapling_shielded_data: None,
                 ..
@@ -976,7 +976,7 @@ impl Transaction {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
             } => Box::new(sapling_shielded_data.nullifiers()),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
@@ -994,7 +994,7 @@ impl Transaction {
                 sapling_shielded_data: None,
                 ..
             } => Box::new(std::iter::empty()),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 sapling_shielded_data: None,
                 ..
@@ -1018,7 +1018,7 @@ impl Transaction {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
             } => Box::new(sapling_shielded_data.note_commitments()),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
@@ -1036,7 +1036,7 @@ impl Transaction {
                 sapling_shielded_data: None,
                 ..
             } => Box::new(std::iter::empty()),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 sapling_shielded_data: None,
                 ..
@@ -1056,7 +1056,7 @@ impl Transaction {
                 sapling_shielded_data,
                 ..
             } => sapling_shielded_data.is_some(),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 sapling_shielded_data,
                 ..
@@ -1075,7 +1075,7 @@ impl Transaction {
                 orchard_shielded_data,
                 ..
             } => orchard_shielded_data.as_ref(),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 orchard_shielded_data,
                 ..
@@ -1204,7 +1204,7 @@ impl Transaction {
                 ..
             }
             | Transaction::V5 { .. } => Box::new(std::iter::empty()),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { .. } => Box::new(std::iter::empty()),
         }
     }
@@ -1253,7 +1253,7 @@ impl Transaction {
                 ..
             }
             | Transaction::V5 { .. } => Box::new(std::iter::empty()),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { .. } => Box::new(std::iter::empty()),
         }
     }
@@ -1296,7 +1296,7 @@ impl Transaction {
                 ..
             }
             | Transaction::V5 { .. } => Box::new(iter::empty()),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { .. } => Box::new(iter::empty()),
         };
 
@@ -1339,7 +1339,7 @@ impl Transaction {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
             } => sapling_shielded_data.value_balance,
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
@@ -1356,7 +1356,7 @@ impl Transaction {
                 sapling_shielded_data: None,
                 ..
             } => Amount::zero(),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 sapling_shielded_data: None,
                 ..
@@ -1380,7 +1380,7 @@ impl Transaction {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
             } => Some(sapling_shielded_data.binding_sig),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
@@ -1541,7 +1541,7 @@ impl Transaction {
             Transaction::V3 { .. } => Some(OVERWINTER_VERSION_GROUP_ID),
             Transaction::V4 { .. } => Some(SAPLING_VERSION_GROUP_ID),
             Transaction::V5 { .. } => Some(TX_V5_VERSION_GROUP_ID),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { .. } => Some(TX_V6_VERSION_GROUP_ID),
         }
     }
@@ -1554,7 +1554,7 @@ impl Transaction {
             | Transaction::V3 { .. }
             | Transaction::V4 { .. }
             | Transaction::V5 { .. } => Amount::zero(),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { zip233_amount, .. } => *zip233_amount,
         }
     }
@@ -1582,7 +1582,7 @@ impl Transaction {
                 *network_upgrade = nu;
                 Ok(())
             }
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 ref mut network_upgrade,
                 ..
@@ -1615,7 +1615,7 @@ impl Transaction {
                 ref mut expiry_height,
                 ..
             } => expiry_height,
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 ref mut expiry_height,
                 ..
@@ -1631,7 +1631,7 @@ impl Transaction {
             Transaction::V3 { ref mut inputs, .. } => inputs,
             Transaction::V4 { ref mut inputs, .. } => inputs,
             Transaction::V5 { ref mut inputs, .. } => inputs,
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { ref mut inputs, .. } => inputs,
         }
     }
@@ -1659,7 +1659,7 @@ impl Transaction {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
             } => Some(&mut sapling_shielded_data.value_balance),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
@@ -1675,7 +1675,7 @@ impl Transaction {
                 sapling_shielded_data: None,
                 ..
             } => None,
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 sapling_shielded_data: None,
                 ..
@@ -1728,7 +1728,7 @@ impl Transaction {
                 ..
             }
             | Transaction::V5 { .. } => Box::new(std::iter::empty()),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { .. } => Box::new(std::iter::empty()),
         }
     }
@@ -1778,7 +1778,7 @@ impl Transaction {
                 ..
             }
             | Transaction::V5 { .. } => Box::new(std::iter::empty()),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { .. } => Box::new(std::iter::empty()),
         }
     }
@@ -1798,7 +1798,7 @@ impl Transaction {
                 orchard_shielded_data: Some(orchard_shielded_data),
                 ..
             } => Some(orchard_shielded_data),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 orchard_shielded_data: Some(orchard_shielded_data),
                 ..
@@ -1812,7 +1812,7 @@ impl Transaction {
                 orchard_shielded_data: None,
                 ..
             } => None,
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 orchard_shielded_data: None,
                 ..
@@ -1838,7 +1838,7 @@ impl Transaction {
             Transaction::V5 {
                 ref mut outputs, ..
             } => outputs,
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 ref mut outputs, ..
             } => outputs,

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -934,7 +934,7 @@ pub fn transaction_to_fake_v5(
             orchard_shielded_data: None,
         },
         v5 @ V5 { .. } => v5.clone(),
-        #[cfg(feature = "tx_v6")]
+        #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
         v6 @ V6 { .. } => v6.clone(),
     }
 }
@@ -1020,7 +1020,7 @@ pub fn v5_transactions<'b>(
         | Transaction::V3 { .. }
         | Transaction::V4 { .. } => None,
         ref tx @ Transaction::V5 { .. } => Some(tx.clone()),
-        #[cfg(feature = "tx_v6")]
+        #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
         ref tx @ Transaction::V6 { .. } => Some(tx.clone()),
     })
 }

--- a/zebra-chain/src/transaction/builder.rs
+++ b/zebra-chain/src/transaction/builder.rs
@@ -11,7 +11,7 @@ use crate::{
 impl Transaction {
     /// Returns a new version 6 coinbase transaction for `network` and `height`,
     /// which contains the specified `outputs`.
-    #[cfg(feature = "tx_v6")]
+    #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
     pub fn new_v6_coinbase(
         network: &Network,
         height: Height,

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -20,7 +20,7 @@ use crate::{
     },
 };
 
-#[cfg(feature = "tx_v6")]
+#[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
 use crate::parameters::TX_V6_VERSION_GROUP_ID;
 
 use super::*;
@@ -676,7 +676,7 @@ impl ZcashSerialize for Transaction {
                 orchard_shielded_data.zcash_serialize(&mut writer)?;
             }
 
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 {
                 network_upgrade,
                 lock_time,
@@ -977,7 +977,7 @@ impl ZcashDeserialize for Transaction {
                     orchard_shielded_data,
                 })
             }
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             (6, true) => {
                 // Denoted as `nVersionGroupId` in the spec.
                 let id = limited_reader.read_u32::<LittleEndian>()?;

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -974,7 +974,7 @@ fn binding_signatures() {
                             at_least_one_v5_checked = true;
                         }
                     }
-                    #[cfg(feature = "tx_v6")]
+                    #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
                     Transaction::V6 {
                         sapling_shielded_data,
                         ..

--- a/zebra-chain/src/transaction/txid.rs
+++ b/zebra-chain/src/transaction/txid.rs
@@ -28,7 +28,7 @@ impl<'a> TxIdBuilder<'a> {
             | Transaction::V3 { .. }
             | Transaction::V4 { .. } => self.txid_v1_to_v4(),
             Transaction::V5 { .. } => self.txid_v5(),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { .. } => self.txid_v6(),
         }
     }
@@ -52,7 +52,7 @@ impl<'a> TxIdBuilder<'a> {
     }
 
     /// Passthrough to txid_v5 for V6 transactions.
-    #[cfg(feature = "tx_v6")]
+    #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
     fn txid_v6(self) -> Option<Hash> {
         self.txid_v5()
     }

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -142,7 +142,7 @@ impl From<&Transaction> for UnminedTxId {
         match transaction {
             V1 { .. } | V2 { .. } | V3 { .. } | V4 { .. } => Legacy(transaction.into()),
             V5 { .. } => Witnessed(transaction.into()),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             V6 { .. } => Witnessed(transaction.into()),
         }
     }

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -517,7 +517,7 @@ where
                     script_verifier,
                     cached_ffi_transaction.clone(),
                 )?,
-                #[cfg(feature="tx_v6")]
+                #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
                 Transaction::V6 {
                     ..
                 } => Self::verify_v6_transaction(
@@ -556,7 +556,7 @@ where
             let value_balance = tx.value_balance(&spent_utxos);
 
             let zip233_amount = match *tx {
-            	#[cfg(feature="tx_v6")]
+            	#[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
                 Transaction::V6{ .. } => tx.zip233_amount(),
                 _ => Amount::zero()
             };
@@ -1031,7 +1031,7 @@ where
     }
 
     /// Passthrough to verify_v5_transaction, but for V6 transactions.
-    #[cfg(feature = "tx_v6")]
+    #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
     fn verify_v6_transaction(
         request: &Request,
         network: &Network,

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -122,10 +122,10 @@ pub fn lock_time_has_passed(
 ///
 /// This check counts both `Coinbase` and `PrevOut` transparent inputs.
 pub fn has_inputs_and_outputs(tx: &Transaction) -> Result<(), TransactionError> {
-    #[cfg(feature = "tx_v6")]
+    #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
     let has_other_circulation_effects = tx.has_zip233_amount();
 
-    #[cfg(not(feature = "tx_v6"))]
+    #[cfg(not(all(zcash_unstable = "nu7", feature = "tx_v6")))]
     let has_other_circulation_effects = false;
 
     if !tx.has_transparent_or_shielded_inputs() {

--- a/zebra-consensus/src/transaction/tests/prop.rs
+++ b/zebra-consensus/src/transaction/tests/prop.rs
@@ -303,7 +303,7 @@ fn mock_transparent_transaction(
     // Create the mock transaction
     let expiry_height = block_height;
 
-    #[cfg(feature = "tx_v6")]
+    #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
     let zip233_amount = Amount::zero();
 
     let transaction = match transaction_version {
@@ -324,7 +324,7 @@ fn mock_transparent_transaction(
             orchard_shielded_data: None,
             network_upgrade,
         },
-        #[cfg(feature = "tx_v6")]
+        #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
         6 => Transaction::V6 {
             inputs,
             outputs,

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -2413,7 +2413,7 @@ where
             mempool_txs,
             mempool_tx_deps,
             extra_coinbase_data.clone(),
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             None,
         );
 
@@ -2435,7 +2435,7 @@ where
             mempool_txs,
             submit_old,
             extra_coinbase_data,
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             None,
         );
 

--- a/zebra-rpc/src/methods/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/types/get_block_template.rs
@@ -278,7 +278,9 @@ impl BlockTemplateResponse {
         #[cfg(test)] mempool_txs: Vec<(InBlockTxDependenciesDepth, VerifiedUnminedTx)>,
         submit_old: Option<bool>,
         extra_coinbase_data: Vec<u8>,
-        #[cfg(feature = "tx_v6")] zip233_amount: Option<Amount<NonNegative>>,
+        #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))] zip233_amount: Option<
+            Amount<NonNegative>,
+        >,
     ) -> Self {
         // Calculate the next block height.
         let next_block_height =
@@ -330,7 +332,7 @@ impl BlockTemplateResponse {
             &mempool_txs,
             chain_tip_and_local_time.chain_history_root,
             extra_coinbase_data,
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             zip233_amount,
         )
         .expect("coinbase should be valid under the given parameters");
@@ -815,7 +817,9 @@ pub fn generate_coinbase_and_roots(
     mempool_txs: &[VerifiedUnminedTx],
     chain_history_root: Option<ChainHistoryMmrRootHash>,
     miner_data: Vec<u8>,
-    #[cfg(feature = "tx_v6")] zip233_amount: Option<Amount<NonNegative>>,
+    #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))] zip233_amount: Option<
+        Amount<NonNegative>,
+    >,
 ) -> Result<(TransactionTemplate<NegativeOrZero>, DefaultRoots), &'static str> {
     let miner_fee = calculate_miner_fee(mempool_txs);
     let outputs = standard_coinbase_outputs(network, height, miner_address, miner_fee);
@@ -826,9 +830,9 @@ pub fn generate_coinbase_and_roots(
         NetworkUpgrade::Nu5 | NetworkUpgrade::Nu6 | NetworkUpgrade::Nu6_1 => {
             Transaction::new_v5_coinbase(network, height, outputs, miner_data)
         }
-        #[cfg(not(feature = "tx_v6"))]
+        #[cfg(not(all(zcash_unstable = "nu7", feature = "tx_v6")))]
         NetworkUpgrade::Nu7 => Transaction::new_v5_coinbase(network, height, outputs, miner_data),
-        #[cfg(feature = "tx_v6")]
+        #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
         NetworkUpgrade::Nu7 => {
             Transaction::new_v6_coinbase(network, height, outputs, miner_data, zip233_amount)
         }

--- a/zebra-rpc/src/methods/types/get_block_template/zip317.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/zip317.rs
@@ -26,10 +26,10 @@ use zebra_node_services::mempool::TransactionDependencies;
 
 use crate::methods::types::transaction::TransactionTemplate;
 
-#[cfg(feature = "tx_v6")]
+#[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
 use crate::methods::{Amount, NonNegative};
 
-#[cfg(feature = "tx_v6")]
+#[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
 use zebra_chain::parameters::NetworkUpgrade;
 
 #[cfg(test)]
@@ -66,7 +66,9 @@ pub fn select_mempool_transactions(
     mempool_txs: Vec<VerifiedUnminedTx>,
     mempool_tx_deps: TransactionDependencies,
     extra_coinbase_data: Vec<u8>,
-    #[cfg(feature = "tx_v6")] zip233_amount: Option<Amount<NonNegative>>,
+    #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))] zip233_amount: Option<
+        Amount<NonNegative>,
+    >,
 ) -> Vec<SelectedMempoolTx> {
     // Use a fake coinbase transaction to break the dependency between transaction
     // selection, the miner fee, and the fee payment in the coinbase transaction.
@@ -75,7 +77,7 @@ pub fn select_mempool_transactions(
         next_block_height,
         miner_address,
         extra_coinbase_data,
-        #[cfg(feature = "tx_v6")]
+        #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
         zip233_amount,
     );
 
@@ -152,7 +154,9 @@ pub fn fake_coinbase_transaction(
     height: Height,
     miner_address: &Address,
     extra_coinbase_data: Vec<u8>,
-    #[cfg(feature = "tx_v6")] zip233_amount: Option<Amount<NonNegative>>,
+    #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))] zip233_amount: Option<
+        Amount<NonNegative>,
+    >,
 ) -> TransactionTemplate<NegativeOrZero> {
     // Block heights are encoded as variable-length (script) and `u32` (lock time, expiry height).
     // They can also change the `u32` consensus branch id.
@@ -166,10 +170,10 @@ pub fn fake_coinbase_transaction(
     let miner_fee = 1.try_into().expect("amount is valid and non-negative");
     let outputs = standard_coinbase_outputs(net, height, miner_address, miner_fee);
 
-    #[cfg(not(feature = "tx_v6"))]
+    #[cfg(not(all(zcash_unstable = "nu7", feature = "tx_v6")))]
     let coinbase = Transaction::new_v5_coinbase(net, height, outputs, extra_coinbase_data).into();
 
-    #[cfg(feature = "tx_v6")]
+    #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
     let coinbase = {
         let network_upgrade = NetworkUpgrade::current(net, height);
         if network_upgrade < NetworkUpgrade::Nu7 {

--- a/zebra-rpc/src/methods/types/get_block_template/zip317/tests.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/zip317/tests.rs
@@ -36,7 +36,7 @@ fn excludes_tx_with_unselected_dependencies() {
             vec![unmined_tx],
             mempool_tx_deps,
             extra_coinbase_data,
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             None,
         ),
         vec![],
@@ -82,7 +82,7 @@ fn includes_tx_with_selected_dependencies() {
         unmined_txs.clone(),
         mempool_tx_deps.clone(),
         extra_coinbase_data,
-        #[cfg(feature = "tx_v6")]
+        #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
         None,
     );
 

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -1584,7 +1584,7 @@ impl Chain {
                     sapling_shielded_data,
                     orchard_shielded_data,
                 ),
-                #[cfg(feature="tx_v6")]
+                #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
                 V6 {
                     inputs,
                     outputs,
@@ -1769,7 +1769,7 @@ impl UpdateWith<ContextuallyVerifiedBlock> for Chain {
                     sapling_shielded_data,
                     orchard_shielded_data,
                 ),
-                #[cfg(feature="tx_v6")]
+                #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
                 V6 {
                     inputs,
                     outputs,

--- a/zebra-state/src/tests.rs
+++ b/zebra-state/src/tests.rs
@@ -36,7 +36,7 @@ impl FakeChainHelper for Arc<Block> {
             Transaction::V3 { inputs, .. } => &mut inputs[0],
             Transaction::V4 { inputs, .. } => &mut inputs[0],
             Transaction::V5 { inputs, .. } => &mut inputs[0],
-            #[cfg(feature = "tx_v6")]
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             Transaction::V6 { inputs, .. } => &mut inputs[0],
         };
 

--- a/zebrad/src/components/mempool/storage/tests/prop.rs
+++ b/zebrad/src/components/mempool/storage/tests/prop.rs
@@ -570,7 +570,7 @@ impl SpendConflictTestInput {
 
                 // No JoinSplits
                 Transaction::V1 { .. } | Transaction::V5 { .. } => {}
-                #[cfg(feature = "tx_v6")]
+                #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
                 Transaction::V6 { .. } => {}
             }
         }
@@ -642,7 +642,7 @@ impl SpendConflictTestInput {
                     Self::remove_sapling_transfers_with_conflicts(sapling_shielded_data, &conflicts)
                 }
 
-                #[cfg(feature = "tx_v6")]
+                #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
                 Transaction::V6 {
                     sapling_shielded_data,
                     ..
@@ -721,7 +721,7 @@ impl SpendConflictTestInput {
                     ..
                 } => Self::remove_orchard_actions_with_conflicts(orchard_shielded_data, &conflicts),
 
-                #[cfg(feature = "tx_v6")]
+                #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
                 Transaction::V6 {
                     orchard_shielded_data,
                     ..

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -3521,7 +3521,7 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
         &[],
         chain_history_root,
         vec![],
-        #[cfg(feature = "tx_v6")]
+        #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
         None,
     )
     .expect("coinbase transaction should be valid under the given parameters");
@@ -3581,7 +3581,7 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
         &[],
         chain_history_root,
         vec![],
-        #[cfg(feature = "tx_v6")]
+        #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
         None,
     )
     .expect("coinbase transaction should be valid under the given parameters");
@@ -3645,9 +3645,9 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
 /// Test successful block template submission as a block proposal.
 ///
 /// This test can be run locally with:
-/// `cargo test --package zebrad --test acceptance --features tx_v6 -- nu7_nsm_transactions --exact --show-output`
+/// `RUSTFLAGS='--cfg zcash_unstable="nu7"' cargo test --package zebrad --test acceptance --features tx_v6 -- nu7_nsm_transactions --exact --show-output`
 #[tokio::test(flavor = "multi_thread")]
-#[cfg(feature = "tx_v6")]
+#[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
 async fn nu7_nsm_transactions() -> Result<()> {
     use zebra_chain::{
         chain_sync_status::MockSyncStatus,


### PR DESCRIPTION
## Motivation

This is a follow up to #8930.

Gating experimental/incomplete stuff behind features is dangerous because they can easily be turned on by accident via e.g. feature unification or `--all-features`. This PR also gates it behind `zcash_unstable` in the exact same way as `librustzcash` already does. Note that `zcash_unstable` is already required for the feature precisely because of `librustzcash`.


## Solution

Also gate behind `zcash_unstable = "nu7"`

### Tests

`RUSTFLAGS='--cfg zcash_unstable="nu7"' cargo test --package zebrad --test acceptance --features tx_v6 -- nu7_nsm_transactions --exact --show-output` (the test from the NSM PR) should work.

Everything else should work as normal without the feature (or with the feature but without the flag)

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
