### PR TITLE
fix(qa): close wallets on test exit

### DIFF
--- a/zebra-rpc/qa/rpc-tests/test_framework/test_framework.py
+++ b/zebra-rpc/qa/rpc-tests/test_framework/test_framework.py
@@ -16,6 +16,7 @@ import traceback
 
 from .proxy import JSONRPCException
 from .util import (
+    stop_wallets,
     zcashd_binary,
     initialize_chain,
     start_nodes,
@@ -36,6 +37,7 @@ class BitcoinTestFramework(object):
         self.num_nodes = 4
         self.cache_behavior = 'current'
         self.nodes = None
+        self.wallets = None
 
     def run_test(self):
         raise NotImplementedError
@@ -158,6 +160,13 @@ class BitcoinTestFramework(object):
             traceback.print_tb(sys.exc_info()[2])
         except KeyboardInterrupt as e:
             print("Exiting after " + repr(e))
+
+        print("Stopping wallets")
+        try:
+            if self.wallets:
+                stop_wallets(self.wallets)
+        except Exception as e:
+            print("Ignoring error while stopping wallets: ", repr(e))
 
         if not self.options.noshutdown:
             print("Stopping nodes")


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

Small improvement that came up while reviewing #10045. When running the test directly, the wallet would keep running in the background.

## Solution

Stop the wallets at the end of the tests.

### Tests

Run a test directly, e.g. `PYTHON_DEBUG=1 CARGO_BIN_EXE_zebrad=~/zebra/target/debug/zebrad ./qa/rpc-tests/wallet.py` and check that the wallet does not keep running.

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
