### PR TITLE
fix(ci): re-enable Docker provenance and SBOM attestations

### DIFF
--- a/.github/workflows/zfnd-build-docker-image.yml
+++ b/.github/workflows/zfnd-build-docker-image.yml
@@ -78,8 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ github.event_name == 'release' && 'prod' || inputs.environment || 'dev' }}
     outputs:
-      image_digest: ${{ steps.docker_build.outputs.digest }}
-      image_name: ${{ fromJSON(steps.docker_build.outputs.metadata)['image.name'] }}
+      image_digest: ${{ steps.docker_build.outputs.digest || steps.docker_build_no_attestations.outputs.digest }}
+      image_name: ${{ fromJSON(steps.docker_build.outputs.metadata || steps.docker_build_no_attestations.outputs.metadata)['image.name'] }}
     permissions:
       contents: read
       id-token: write
@@ -166,8 +166,10 @@ jobs:
           endpoint: zfnd/zebra
 
       # Build and push image to Google Artifact Registry, and possibly DockerHub
-      - name: Build & push
+      # With provenance and SBOM (ZcashFoundation repository only)
+      - name: Build & push (with attestations)
         id: docker_build
+        if: github.repository_owner == 'ZcashFoundation'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
         with:
           target: ${{ inputs.dockerfile_target }}
@@ -183,9 +185,29 @@ jobs:
           push: true
           # It's recommended to build images with max-level provenance attestations
           # https://docs.docker.com/build/ci/github-actions/attestations/
-          # TODO: Uncomment this once we have a better way to turn on/off provenance
-          # provenance: mode=max
-          # sbom: true
+          provenance: mode=max
+          sbom: true
+          # Don't read from the cache if the caller disabled it.
+          # https://docs.docker.com/engine/reference/commandline/buildx_build/#options
+          no-cache: ${{ inputs.no_cache }}
+
+      # Build and push image without attestations (contributor forks)
+      - name: Build & push (without attestations)
+        id: docker_build_no_attestations
+        if: github.repository_owner != 'ZcashFoundation'
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
+        with:
+          target: ${{ inputs.dockerfile_target }}
+          context: .
+          file: ${{ inputs.dockerfile_path }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}
+            RUST_LOG=${{ env.RUST_LOG }}
+            CARGO_INCREMENTAL=${{ env.CARGO_INCREMENTAL }}
+            FEATURES=${{ env.FEATURES }}
+          push: true
           # Don't read from the cache if the caller disabled it.
           # https://docs.docker.com/engine/reference/commandline/buildx_build/#options
           no-cache: ${{ inputs.no_cache }}


### PR DESCRIPTION
## Motivation

Docker images built in CI, after the CI refactor, lacked provenance attestations and SBOM (Software Bill of Materials). The recommended `provenance: mode=max` and `sbom: true` settings were commented out because:

1. GitHub Actions YAML doesn't support conditionally including/excluding keys
2. When `provenance: false`, the `sbom` key causes workflow failures
3. Contributor forks may not support these features

This PR enables these security features in the ZcashFoundation repository while maintaining compatibility with contributor forks.

## Solution

### Docker Build Security

- Split the docker/build-push-action step into two conditional steps:
- Update job outputs to use `||` operator to get digest/metadata from whichever step ran
- Both steps maintain identical configuration except for attestations

### Tests

- This configuration was working before the CI refactor, it's just being re-enabled here for our repository.

### Specifications & References

- [Docker Build Attestations Documentation](https://docs.docker.com/build/ci/github-actions/attestations/)
- [Docker SBOM Documentation](https://docs.docker.com/build/attestations/sbom/)
- [GitHub Actions Expressions Documentation](https://docs.github.com/en/actions/learn-github-actions/expressions)

### PR Checklist

- [X] The PR name is suitable for the release notes.
- [X] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [X] The solution is tested.
- [X] The documentation is up to date.
