### PR TITLE
fix(mempool): prevent stale dependency references in transaction graph

### DIFF
--- a/zebra-node-services/src/mempool/transaction_dependencies.rs
+++ b/zebra-node-services/src/mempool/transaction_dependencies.rs
@@ -49,7 +49,7 @@ impl TransactionDependencies {
                 .insert(dependent);
         }
 
-        // Only add an entries to `dependencies` for transactions that spend unmined outputs so it
+        // Only add entries to `dependencies` for transactions that spend unmined outputs so it
         // can be used to handle transactions with dependencies differently during block production.
         if !spent_mempool_outpoints.is_empty() {
             self.dependencies.insert(
@@ -87,10 +87,9 @@ impl TransactionDependencies {
     ///
     /// # Invariant
     ///
-    /// Every hash in the returned set is guaranteed to have been present in
-    /// [`Self::dependents`] at the time of removal. Removing a child transaction
-    /// also erases it from each parent's dependents list, so callers can safely
-    /// assume the IDs are still present in their own transaction maps.
+    /// Every hash in the returned set was present in [`Self::dependents`] at the time of removal.
+    /// Removing a child transaction also removes it from each parent's dependents list, so callers
+    /// can safely assume the IDs are still present in their own transaction maps.
     pub fn remove_all(&mut self, &tx_hash: &transaction::Hash) -> HashSet<transaction::Hash> {
         let mut all_dependents = HashSet::new();
         let mut queue: VecDeque<_> = VecDeque::from([tx_hash]);
@@ -147,4 +146,122 @@ impl TransactionDependencies {
 }
 
 #[cfg(test)]
-mod tests;
+mod tests {
+    use super::*;
+
+    fn hash(byte: u8) -> transaction::Hash {
+        let mut bytes = [0u8; 32];
+        bytes[0] = byte;
+        transaction::Hash::from(bytes)
+    }
+
+    fn outpoint(hash: transaction::Hash) -> transparent::OutPoint {
+        transparent::OutPoint::from_usize(hash, 0)
+    }
+
+    #[test]
+    fn remove_all_drops_stale_dependents() {
+        let mut deps = TransactionDependencies::default();
+        let parent = hash(1);
+        let child = hash(2);
+
+        deps.add(child, vec![outpoint(parent)]);
+        assert!(deps.direct_dependents(&parent).contains(&child));
+
+        let removed = deps.remove_all(&child);
+        assert!(removed.is_empty());
+        assert!(deps.direct_dependents(&parent).is_empty());
+
+        let removed_parent = deps.remove_all(&parent);
+        assert!(removed_parent.is_empty());
+        assert!(deps.direct_dependents(&parent).is_empty());
+    }
+
+    #[test]
+    fn remove_all_returns_transitive_dependents() {
+        let mut deps = TransactionDependencies::default();
+        let parent = hash(10);
+        let child = hash(11);
+        let grandchild = hash(12);
+
+        deps.add(child, vec![outpoint(parent)]);
+        deps.add(grandchild, vec![outpoint(child)]);
+
+        let removed = deps.remove_all(&parent);
+        let expected: HashSet<_> = [child, grandchild].into_iter().collect();
+        assert_eq!(removed, expected);
+        assert!(deps.direct_dependents(&parent).is_empty());
+        assert!(deps.direct_dependents(&child).is_empty());
+        assert!(deps.direct_dependencies(&grandchild).is_empty());
+    }
+
+    #[test]
+    fn remove_parent_with_multiple_children() {
+        let mut deps = TransactionDependencies::default();
+        let parent = hash(30);
+        let children = [hash(31), hash(32), hash(33)];
+
+        for child in children {
+            deps.add(child, vec![outpoint(parent)]);
+        }
+
+        let removed = deps.remove_all(&parent);
+        let expected: HashSet<_> = children.into_iter().collect();
+        assert_eq!(removed, expected);
+        assert!(deps.direct_dependents(&parent).is_empty());
+    }
+
+    #[test]
+    fn remove_child_with_multiple_parents() {
+        let mut deps = TransactionDependencies::default();
+        let parents = [hash(40), hash(41)];
+        let child = hash(42);
+
+        deps.add(
+            child,
+            parents.iter().copied().map(outpoint).collect::<Vec<_>>(),
+        );
+
+        let removed = deps.remove_all(&child);
+        assert!(removed.is_empty());
+        for parent in parents {
+            assert!(deps.direct_dependents(&parent).is_empty());
+        }
+    }
+
+    #[test]
+    fn remove_from_complex_graph() {
+        let mut deps = TransactionDependencies::default();
+        let a = hash(50);
+        let b = hash(51);
+        let c = hash(52);
+        let d = hash(53);
+
+        deps.add(b, vec![outpoint(a)]);
+        deps.add(c, vec![outpoint(a)]);
+        deps.add(d, vec![outpoint(b), outpoint(c)]);
+
+        let removed = deps.remove_all(&a);
+        let expected: HashSet<_> = [b, c, d].into_iter().collect();
+        assert_eq!(removed, expected);
+        assert!(deps.dependents().is_empty());
+        assert!(deps.dependencies().is_empty());
+    }
+
+    #[test]
+    fn clear_mined_dependencies_removes_correct_hash() {
+        let mut deps = TransactionDependencies::default();
+        let parent = hash(20);
+        let child = hash(21);
+
+        deps.add(child, vec![outpoint(parent)]);
+        assert!(deps.direct_dependencies(&child).contains(&parent));
+
+        let mined_ids: HashSet<_> = [parent].into_iter().collect();
+        deps.clear_mined_dependencies(&mined_ids);
+
+        assert!(deps.direct_dependents(&parent).is_empty());
+        assert!(deps.direct_dependencies(&child).is_empty());
+        assert!(deps.dependents().get(&parent).is_none());
+    }
+}

--- a/zebra-node-services/src/mempool/transaction_dependencies/tests.rs
+++ b/zebra-node-services/src/mempool/transaction_dependencies/tests.rs
@@ -1,0 +1,121 @@
+use super::*;
+use std::collections::HashSet;
+
+fn hash(byte: u8) -> transaction::Hash {
+    let mut bytes = [0u8; 32];
+    bytes[0] = byte;
+    transaction::Hash::from(bytes)
+}
+
+fn outpoint(hash: transaction::Hash) -> transparent::OutPoint {
+    transparent::OutPoint::from_usize(hash, 0)
+}
+
+#[test]
+fn remove_all_drops_stale_dependents() {
+    let mut deps = TransactionDependencies::default();
+    let parent = hash(1);
+    let child = hash(2);
+
+    deps.add(child, vec![outpoint(parent)]);
+    assert!(deps.direct_dependents(&parent).contains(&child));
+
+    // Removing the child first should also erase it from the parent's dependents list.
+    let removed = deps.remove_all(&child);
+    assert!(removed.is_empty());
+    assert!(deps.direct_dependents(&parent).is_empty());
+
+    // Removing the parent afterwards should not re-discover the child.
+    let removed_parent = deps.remove_all(&parent);
+    assert!(removed_parent.is_empty());
+    assert!(deps.direct_dependents(&parent).is_empty());
+}
+
+#[test]
+fn remove_all_returns_transitive_dependents() {
+    let mut deps = TransactionDependencies::default();
+    let parent = hash(10);
+    let child = hash(11);
+    let grandchild = hash(12);
+
+    deps.add(child, vec![outpoint(parent)]);
+    deps.add(grandchild, vec![outpoint(child)]);
+
+    let removed = deps.remove_all(&parent);
+    let expected: HashSet<_> = [child, grandchild].into_iter().collect();
+    assert_eq!(removed, expected);
+    assert!(deps.direct_dependents(&parent).is_empty());
+    assert!(deps.direct_dependents(&child).is_empty());
+    assert!(deps.direct_dependencies(&grandchild).is_empty());
+}
+
+#[test]
+fn remove_parent_with_multiple_children() {
+    let mut deps = TransactionDependencies::default();
+    let parent = hash(30);
+    let children = [hash(31), hash(32), hash(33)];
+
+    for child in children {
+        deps.add(child, vec![outpoint(parent)]);
+    }
+
+    let removed = deps.remove_all(&parent);
+    let expected: HashSet<_> = children.into_iter().collect();
+    assert_eq!(removed, expected);
+    assert!(deps.direct_dependents(&parent).is_empty());
+}
+
+#[test]
+fn remove_child_with_multiple_parents() {
+    let mut deps = TransactionDependencies::default();
+    let parents = [hash(40), hash(41)];
+    let child = hash(42);
+
+    deps.add(
+        child,
+        parents.iter().copied().map(outpoint).collect::<Vec<_>>(),
+    );
+
+    let removed = deps.remove_all(&child);
+    assert!(removed.is_empty());
+    for parent in parents {
+        assert!(deps.direct_dependents(&parent).is_empty());
+    }
+}
+
+#[test]
+fn remove_from_complex_graph() {
+    let mut deps = TransactionDependencies::default();
+    let a = hash(50);
+    let b = hash(51);
+    let c = hash(52);
+    let d = hash(53);
+
+    // A -> B, A -> C, and B -> D, C -> D
+    deps.add(b, vec![outpoint(a)]);
+    deps.add(c, vec![outpoint(a)]);
+    deps.add(d, vec![outpoint(b), outpoint(c)]);
+
+    let removed = deps.remove_all(&a);
+    let expected: HashSet<_> = [b, c, d].into_iter().collect();
+    assert_eq!(removed, expected);
+    assert!(deps.dependents().is_empty());
+    assert!(deps.dependencies().is_empty());
+}
+
+#[test]
+fn clear_mined_dependencies_removes_correct_hash() {
+    let mut deps = TransactionDependencies::default();
+    let parent = hash(20);
+    let child = hash(21);
+
+    deps.add(child, vec![outpoint(parent)]);
+    assert!(deps.direct_dependencies(&child).contains(&parent));
+
+    let mined_ids: HashSet<_> = [parent].into_iter().collect();
+    deps.clear_mined_dependencies(&mined_ids);
+
+    assert!(deps.direct_dependents(&parent).is_empty());
+    assert!(deps.direct_dependencies(&child).is_empty());
+    assert!(deps.dependents().get(&parent).is_none());
+}

--- a/zebrad/src/components/mempool/storage/tests.rs
+++ b/zebrad/src/components/mempool/storage/tests.rs
@@ -2,3 +2,4 @@
 
 mod prop;
 mod vectors;
+mod verified_set;

--- a/zebrad/src/components/mempool/storage/tests/verified_set.rs
+++ b/zebrad/src/components/mempool/storage/tests/verified_set.rs
@@ -1,0 +1,83 @@
+use super::super::verified_set::VerifiedSet;
+use crate::components::mempool::pending_outputs::PendingOutputs;
+use std::collections::HashSet;
+use zebra_chain::{
+    amount::Amount,
+    transaction::{LockTime, Transaction, UnminedTx, UnminedTxId, VerifiedUnminedTx},
+    transparent,
+};
+
+fn dummy_output(tag: u8) -> transparent::Output {
+    transparent::Output {
+        value: Amount::try_from(1_000_000).expect("valid amount"),
+        lock_script: transparent::Script::new(&[tag]),
+    }
+}
+
+fn dummy_transaction(tag: u8) -> Transaction {
+    Transaction::V1 {
+        inputs: Vec::new(),
+        outputs: vec![dummy_output(tag)],
+        lock_time: LockTime::unlocked(),
+    }
+}
+
+fn dummy_verified_unmined_tx(tag: u8) -> VerifiedUnminedTx {
+    let unmined = UnminedTx::from(dummy_transaction(tag));
+
+    VerifiedUnminedTx {
+        transaction: unmined,
+        miner_fee: Amount::try_from(1_000).expect("valid amount"),
+        sigops: 0,
+        conventional_actions: 0,
+        unpaid_actions: 0,
+        fee_weight_ratio: 0.0,
+        time: None,
+        height: None,
+    }
+}
+
+fn insert_dummy_tx(
+    set: &mut VerifiedSet,
+    tx: VerifiedUnminedTx,
+    spent_outpoints: Vec<transparent::OutPoint>,
+    pending_outputs: &mut PendingOutputs,
+) -> UnminedTxId {
+    let tx_id = tx.transaction.id;
+    set.insert(tx, spent_outpoints, pending_outputs, None)
+        .expect("insert should succeed");
+    tx_id
+}
+
+#[test]
+fn verified_set_remove_all_that_with_dependencies() {
+    let _init_guard = zebra_test::init();
+    let mut set = VerifiedSet::default();
+    let mut pending_outputs = PendingOutputs::default();
+
+    let parent_id = insert_dummy_tx(
+        &mut set,
+        dummy_verified_unmined_tx(0x01),
+        Vec::new(),
+        &mut pending_outputs,
+    );
+    let parent_hash = parent_id.mined_id();
+
+    let child_id = insert_dummy_tx(
+        &mut set,
+        dummy_verified_unmined_tx(0x02),
+        vec![transparent::OutPoint::from_usize(parent_hash, 0)],
+        &mut pending_outputs,
+    );
+
+    let expected: HashSet<_> = [parent_id, child_id].into_iter().collect();
+
+    let removed = set.remove_all_that(|tx| {
+        let mined_id = tx.transaction.id.mined_id();
+        mined_id == parent_hash || mined_id == child_id.mined_id()
+    });
+
+    assert_eq!(removed, expected);
+    assert!(set.transactions().is_empty());
+    assert!(set.transaction_dependencies().dependents().is_empty());
+}

--- a/zebrad/src/components/mempool/storage/verified_set.rs
+++ b/zebrad/src/components/mempool/storage/verified_set.rs
@@ -463,3 +463,6 @@ impl VerifiedSet {
         metrics::gauge!("zcash.mempool.cost.bytes").set(self.total_cost as f64);
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/zebrad/src/components/mempool/storage/verified_set.rs
+++ b/zebrad/src/components/mempool/storage/verified_set.rs
@@ -256,6 +256,10 @@ impl VerifiedSet {
         let mut removed_transactions = HashSet::new();
 
         for key_to_remove in keys_to_remove {
+            if !self.transactions.contains_key(&key_to_remove) {
+                // Skip keys that were already removed as dependents while processing earlier keys.
+                continue;
+            }
             removed_transactions.extend(
                 self.remove(&key_to_remove)
                     .into_iter()

--- a/zebrad/src/components/mempool/storage/verified_set/tests.rs
+++ b/zebrad/src/components/mempool/storage/verified_set/tests.rs
@@ -1,0 +1,78 @@
+use super::*;
+use std::collections::HashSet;
+use zebra_chain::{
+    amount::Amount,
+    transaction::{self, LockTime, Transaction, UnminedTx, UnminedTxId, VerifiedUnminedTx},
+    transparent,
+};
+
+fn dummy_output(tag: u8) -> transparent::Output {
+    transparent::Output {
+        value: Amount::try_from(1_000_000).expect("valid amount"),
+        lock_script: transparent::Script::new(&[tag]),
+    }
+}
+
+fn dummy_transaction(tag: u8) -> Transaction {
+    Transaction::V1 {
+        inputs: Vec::new(),
+        outputs: vec![dummy_output(tag)],
+        lock_time: LockTime::unlocked(),
+    }
+}
+
+fn dummy_verified_unmined_tx(tag: u8) -> VerifiedUnminedTx {
+    let unmined = UnminedTx::from(dummy_transaction(tag));
+
+    VerifiedUnminedTx {
+        transaction: unmined,
+        miner_fee: Amount::try_from(1_000).expect("valid amount"),
+        sigops: 0,
+        conventional_actions: 0,
+        unpaid_actions: 0,
+        fee_weight_ratio: 0.0,
+        time: None,
+        height: None,
+    }
+}
+
+fn insert_dummy_tx(
+    set: &mut VerifiedSet,
+    tx: VerifiedUnminedTx,
+) -> (transaction::Hash, UnminedTxId) {
+    let unmined_id = tx.transaction.id;
+    let tx_hash = unmined_id.mined_id();
+
+    set.transactions_serialized_size += tx.transaction.size;
+    set.total_cost += tx.cost();
+    set.transactions.insert(tx_hash, tx);
+
+    (tx_hash, unmined_id)
+}
+
+#[test]
+fn verified_set_remove_all_that_with_dependencies() {
+    let _init_guard = zebra_test::init();
+    let mut set = VerifiedSet::default();
+
+    let (parent_hash, parent_id) = insert_dummy_tx(&mut set, dummy_verified_unmined_tx(0x01));
+    let (child_hash, child_id) = insert_dummy_tx(&mut set, dummy_verified_unmined_tx(0x02));
+
+    set.transaction_dependencies.add(
+        child_hash,
+        vec![transparent::OutPoint::from_usize(parent_hash, 0)],
+    );
+
+    let expected: HashSet<_> = [parent_id, child_id].into_iter().collect();
+
+    let removed = set.remove_all_that(|tx| {
+        let mined_id = tx.transaction.id.mined_id();
+        mined_id == parent_hash || mined_id == child_hash
+    });
+
+    assert_eq!(removed, expected);
+    assert!(set.transactions.is_empty());
+    assert!(set.transaction_dependencies.dependents().is_empty());
+    assert_eq!(set.transactions_serialized_size, 0);
+    assert_eq!(set.total_cost, 0);
+}


### PR DESCRIPTION
## Motivation

Zebra nodes have been crashing with "invalid transaction key" panics at `zebrad/src/components/mempool/storage/verified_set.rs:288`. The panic occurs when `VerifiedSet::remove` receives transaction IDs that have already been evicted from the mempool.

This happens because the `TransactionDependencies::remove_all` removes a transaction from the dependencies and dependents maps but fails to remove it from its parent transactions' dependents sets. This leaves stale references in the dependency graph. When a parent transaction is later removed, it tries to remove already-evicted child transactions, causing the panic.

**Bug**
When `TransactionDependencies::remove_all(tx_hash)` removes a transaction, it:

1. Removes the transaction from `dependencies` map
2. Removes the transaction from `dependents` map
3. Recursively removes all dependent transactions
4. **NEVER removes the transaction from its parents' `dependents` sets**

**Scenario**
```
Initial state:
- transactions: {A, B}
- dependencies[B] = {A}
- dependents[A] = {B}

After remove_all(B):
- transactions: {A}         // B removed from verified set
- dependencies[B] = ø       // B's entry removed
- dependents[A] = {B}       // ← STALE! B no longer exists but A still references it
```

This panic can occur in multiple scenarios:
1. **A parent transaction is removed after its child** (child removed earlier, stale ref remains)
2. **Block mining removes multiple related transactions** (some removed as dependents, then accessed again)
3. **Expiration removes dependent before parent** (child expires first, parent expires later)
4. **Any operation that processes parent transactions** after children have been removed


### Tertiary Issue: Typo in `clear_mined_dependencies()`

In the specific case of clearing mined dependencies, there was also a typo:

```rust
// Before fix:
dependencies.remove(&dependent_id);  // Removing wrong ID!

// After fix:
dependencies.remove(&mined_tx_id);   // Remove the mined tx from dependencies
```

This compounded the stale edge problem specifically for mined transactions, but is a separate issue from the core invariant violation in `remove_all`.

## Solution

- Rework `TransactionDependencies::remove_all` to walk the graph with a queue and remove every visited child from its parents' dependents sets before cascading, guaranteeing that only live IDs are returned.
- Fix `clear_mined_dependencies` to delete the mined hash (not the dependent ID) from each dependency set and document the invariant that callers can rely on.
- Add regression coverage:
  - Unit tests for stale-child removal, transitive chains, multi-child, multi-parent, and diamond-shaped graphs
  - `VerifiedSet::remove_all_that` integration test that exercises the mempool path without going through `insert`

### Tests

```bash
cargo test -p zebra-node-services transaction_dependencies
cargo test -p zebrad verified_set_remove_all_that_with_dependencies
```

### Specifications & References

- Original feature PR: #8857

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date. (not required for this internal fix)
- [x] The solution is tested.
- [x] The documentation is up to date.
