### PR TITLE
fix(tests): don't fail on EoS warning

### DIFF
--- a/zebrad/tests/common/failure_messages.rs
+++ b/zebrad/tests/common/failure_messages.rs
@@ -42,7 +42,6 @@ pub const ZEBRA_FAILURE_MESSAGES: &[&str] = &[
     "Method not found",
     // Logs related to end of support halting feature.
     zebrad::components::sync::end_of_support::EOS_PANIC_MESSAGE_HEADER,
-    zebrad::components::sync::end_of_support::EOS_WARN_MESSAGE_HEADER,
 ];
 
 /// Failure log messages from lightwalletd.


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

Our tests fail if the end-of-support warning is found. This might be useful to raise awareness of the upcoming EoS but it also makes CI fail, which will get in the way of getting the release done.

## Solution

Remove the warning from the list of strings that are interpreted as test failures.

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
