### PR TITLE
Update Zebra Docker configuration to use IPv6 listen address [::]:8233

### DIFF
--- a/docker/default-zebra-config.toml
+++ b/docker/default-zebra-config.toml
@@ -13,7 +13,7 @@
 
 [network]
 network = "Mainnet"
-listen_addr = "0.0.0.0"
+listen_addr = "[::]:8233"
 cache_dir = "/home/zebra/.cache/zebra"
 
 [rpc]


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

The default value for `listen_address` was updated in #9591 to listen on IPv6 by default.  That change wasn't reflected in the docker image. This PR updates the default `listen_address` for the docker image.

## Solution

Change the network `listen_addr` from `listen_addr = "0.0.0.0"` to `listen_addr = "[::]:8233"` in `docker/default-zebra-config.toml`

### Tests

I built the image locally and ran it successfully on a Docker instance that did NOT have IPv6 connectivity enabled. I was concerned that setting `listen_addr = "[::]:8233"` could potentially cause problems when the Docker daemon is not configured for IPv6 but this concern was unwarranted.

e.g. This value was NOT present in `/etc/docker/daemon.json`
```
{
  "ipv6": true,
}
```

### PR Checklist


- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [x] The solution is tested.
- [ ] The documentation is up to date.
