### PR TITLE
change(zebrad): always enable backtraces, add debug info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -285,7 +285,12 @@ panic = "abort"
 #     - add "-flto=thin" to all C/C++ code builds
 #     - see https://doc.rust-lang.org/rustc/linker-plugin-lto.html#cc-code-as-a-dependency-in-rust
 lto = "thin"
+# Enable line numbers in stack traces. Note that we re-disable it for dependencies below.
+debug = "line-tables-only"
 
+[profile.release.package."*"]
+# Disable debug info for dependencies to reduce binary size.
+debug = false
 
 [workspace.lints.rust]
 # The linter should ignore these expected config flags/values

--- a/zebrad/src/bin/zebrad/main.rs
+++ b/zebrad/src/bin/zebrad/main.rs
@@ -4,5 +4,11 @@ use zebrad::application::{boot, APPLICATION};
 
 /// Process entry point for `zebrad`
 fn main() {
+    std::env::set_var("RUST_BACKTRACE", "1");
+    // Disable library backtraces (i.e. eyre) to avoid performance hit for
+    // non-panic errors, but allow users to override it.
+    if std::env::var_os("RUST_LIB_BACKTRACE").is_none() {
+        std::env::set_var("RUST_LIB_BACKTRACE", "0");
+    }
     boot(&APPLICATION);
 }

--- a/zebrad/src/bin/zebrad/main.rs
+++ b/zebrad/src/bin/zebrad/main.rs
@@ -4,11 +4,14 @@ use zebrad::application::{boot, APPLICATION};
 
 /// Process entry point for `zebrad`
 fn main() {
-    std::env::set_var("RUST_BACKTRACE", "1");
-    // Disable library backtraces (i.e. eyre) to avoid performance hit for
-    // non-panic errors, but allow users to override it.
-    if std::env::var_os("RUST_LIB_BACKTRACE").is_none() {
-        std::env::set_var("RUST_LIB_BACKTRACE", "0");
+    // Enable backtraces by default for zebrad, but allow users to override it.
+    if std::env::var_os("RUST_BACKTRACE").is_none() {
+        std::env::set_var("RUST_BACKTRACE", "1");
+        // Disable library backtraces (i.e. eyre) to avoid performance hit for
+        // non-panic errors, but allow users to override it.
+        if std::env::var_os("RUST_LIB_BACKTRACE").is_none() {
+            std::env::set_var("RUST_LIB_BACKTRACE", "0");
+        }
     }
     boot(&APPLICATION);
 }


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

We want to enable backtraces in production to help debugging crash reports.

Closes https://github.com/ZcashFoundation/zebra/issues/10084

## Solution

Set [RUST_BACKTRACE=1 inside Zebra itself](https://internals.rust-lang.org/t/rust-backtrace-in-production-use/5609/3). However, this enables backtraces for regular errors, so this also [sets RUST_LIB_BACKTRACE=0](https://docs.rs/eyre/latest/eyre/)

Additionally, enable line number debug info. I tried different options. Currently the zebrad binary has 90 MB. 
With `debug = "line-tables-only"` it is over 400 MB big. With that flag enable just for workspace members (and not dependencies), it then takes 150 MB. I think 400 MB is a bit too much but 150 MB seems more reasonable, so I went with that option.

This is a random backtrace I created by manually adding a panic:

<details>

<summary>Backtrace without debug info</summary>

```
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                ⋮ 6 frames hidden ⋮                               
   7: zebrad::components::mempool::storage::Storage::insert::h56bb45487b6a47db
      at <unknown source file>:<unknown line>
   8: <zebrad::components::mempool::Mempool as tower_service::Service<zebra_node_services::mempool::Request>>::poll_ready::h72a85e6f817bfcb8
      at <unknown source file>:<unknown line>
   9: <tower::util::map_future::MapFuture<S,F> as tower_service::Service<R>>::poll_ready::h24f95834db03ea55
      at <unknown source file>:<unknown line>
  10: <tower::buffer::worker::Worker<T,Request> as core::future::future::Future>::poll::h7ed5cb2e94b65b21
      at <unknown source file>:<unknown line>
  11: tokio::runtime::task::core::Core<T,S>::poll::h71b4b7ad9aff8d83
      at <unknown source file>:<unknown line>
  12: tokio::runtime::task::harness::Harness<T,S>::poll::hd2b4146f8a8734aa
      at <unknown source file>:<unknown line>
  13: tokio::runtime::scheduler::multi_thread::worker::Context::run_task::h9631c0e884c1f3d7
      at <unknown source file>:<unknown line>
  14: tokio::runtime::scheduler::multi_thread::worker::Context::run::hec947b44374ac921
      at <unknown source file>:<unknown line>
  15: tokio::runtime::context::runtime::enter_runtime::h9e066fa2785fbcff
      at <unknown source file>:<unknown line>
  16: tokio::runtime::scheduler::multi_thread::worker::run::hefce4a520c412105
      at <unknown source file>:<unknown line>
  17: tokio::runtime::task::raw::poll::h479d566b028eed41
      at <unknown source file>:<unknown line>
  18: tokio::runtime::blocking::pool::Inner::run::h68d1350b784f3e10
      at <unknown source file>:<unknown line>
  19: std::sys::backtrace::__rust_begin_short_backtrace::hfd209799d2b749d8
      at <unknown source file>:<unknown line>
  20: core::ops::function::FnOnce::call_once{{vtable.shim}}::hd3016fce2676d0af
      at <unknown source file>:<unknown line>
  21: std::sys::thread::unix::Thread::new::thread_start::h38da0f633f090ce2
      at <unknown source file>:<unknown line>
  22: start_thread<unknown>
      at ./nptl/pthread_create.c:447
  23: clone3<unknown>
      at ./misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:78
```
</details>

<details>

<summary>With debuginfo just for workspace members</summary>

```
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
                                ⋮ 7 frames hidden ⋮                               
   8: insert<unknown>
      at /home/conrado/zebra/zebrad/src/components/mempool/storage.rs:227
   9: poll_ready<unknown>
      at /home/conrado/zebra/zebrad/src/components/mempool.rs:612
  10: poll_ready<zebra_node_services::mempool::Request, zebrad::components::mempool::Mempool, tower::util::boxed::sync::{impl#0}::new::{closure_env#0}<zebra_node_services::mempool::Request, zebra_node_services::mempool::Response, alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>, zebrad::components::mempool::Mempool>, zebra_node_services::mempool::Response, alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>, core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output=core::result::Result<zebra_node_services::mempool::Response, alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>> + core::marker::Send), alloc::alloc::Global>>><unknown>
      at /home/conrado/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-0.4.13/src/util/map_future.rs:61
  11: poll_ready<(dyn tower_service::Service<zebra_node_services::mempool::Request, Response=zebra_node_services::mempool::Response, Future=core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output=core::result::Result<zebra_node_services::mempool::Response, alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>> + core::marker::Send), alloc::alloc::Global>>, Error=alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>> + core::marker::Send), zebra_node_services::mempool::Request><unknown>
      at /home/conrado/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-service-0.3.3/src/lib.rs:384
  12: poll_ready<zebra_node_services::mempool::Request, zebra_node_services::mempool::Response, alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>><unknown>
      at /home/conrado/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-0.4.13/src/util/boxed/sync.rs:62
  13: poll<tower::util::boxed::sync::BoxService<zebra_node_services::mempool::Request, zebra_node_services::mempool::Response, alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, zebra_node_services::mempool::Request><unknown>
      at /home/conrado/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-0.4.13/src/buffer/worker.rs:195
  14: {closure#0}<tower::buffer::worker::Worker<tower::util::boxed::sync::BoxService<zebra_node_services::mempool::Request, zebra_node_services::mempool::Response, alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, zebra_node_services::mempool::Request>, alloc::sync::Arc<tokio::runtime::scheduler::current_thread::Handle, alloc::alloc::Global>><unknown>
      at /home/conrado/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/core.rs:365
  15: with_mut<tokio::runtime::task::core::Stage<tower::buffer::worker::Worker<tower::util::boxed::sync::BoxService<zebra_node_services::mempool::Request, zebra_node_services::mempool::Response, alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, zebra_node_services::mempool::Request>>, core::task::poll::Poll<()>, tokio::runtime::task::core::{impl#6}::poll::{closure_env#0}<tower::buffer::worker::Worker<tower::util::boxed::sync::BoxService<zebra_node_services::mempool::Request, zebra_node_services::mempool::Response, alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, zebra_node_services::mempool::Request>, alloc::sync::Arc<tokio::runtime::scheduler::current_thread::Handle, alloc::alloc::Global>>><unknown>
      at /home/conrado/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/loom/std/unsafe_cell.rs:16
  16: poll<tower::buffer::worker::Worker<tower::util::boxed::sync::BoxService<zebra_node_services::mempool::Request, zebra_node_services::mempool::Response, alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, zebra_node_services::mempool::Request>, alloc::sync::Arc<tokio::runtime::scheduler::current_thread::Handle, alloc::alloc::Global>><unknown>
      at /home/conrado/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/core.rs:354
  17: {closure#0}<tower::buffer::worker::Worker<tower::util::boxed::sync::BoxService<zebra_node_services::mempool::Request, zebra_node_services::mempool::Response, alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, zebra_node_services::mempool::Request>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>><unknown>
      at /home/conrado/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/harness.rs:535
  18: call_once<core::task::poll::Poll<()>, tokio::runtime::task::harness::poll_future::{closure_env#0}<tower::buffer::worker::Worker<tower::util::boxed::sync::BoxService<zebra_node_services::mempool::Request, zebra_node_services::mempool::Response, alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, zebra_node_services::mempool::Request>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>>><unknown>
      at /home/conrado/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:274
  19: do_call<core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::{closure_env#0}<tower::buffer::worker::Worker<tower::util::boxed::sync::BoxService<zebra_node_services::mempool::Request, zebra_node_services::mempool::Response, alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, zebra_node_services::mempool::Request>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>>>, core::task::poll::Poll<()>><unknown>
      at /home/conrado/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:590
  20: catch_unwind<core::task::poll::Poll<()>, core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::{closure_env#0}<tower::buffer::worker::Worker<tower::util::boxed::sync::BoxService<zebra_node_services::mempool::Request, zebra_node_services::mempool::Response, alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, zebra_node_services::mempool::Request>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>>>><unknown>
      at /home/conrado/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:553
  21: catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::{closure_env#0}<tower::buffer::worker::Worker<tower::util::boxed::sync::BoxService<zebra_node_services::mempool::Request, zebra_node_services::mempool::Response, alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, zebra_node_services::mempool::Request>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>>>, core::task::poll::Poll<()>><unknown>
      at /home/conrado/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:359
  22: poll_future<tower::buffer::worker::Worker<tower::util::boxed::sync::BoxService<zebra_node_services::mempool::Request, zebra_node_services::mempool::Response, alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, zebra_node_services::mempool::Request>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>><unknown>
      at /home/conrado/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/harness.rs:523
  23: poll_inner<tower::buffer::worker::Worker<tower::util::boxed::sync::BoxService<zebra_node_services::mempool::Request, zebra_node_services::mempool::Response, alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, zebra_node_services::mempool::Request>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>><unknown>
      at /home/conrado/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/harness.rs:210
  24: poll<tower::buffer::worker::Worker<tower::util::boxed::sync::BoxService<zebra_node_services::mempool::Request, zebra_node_services::mempool::Response, alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync), alloc::alloc::Global>>, zebra_node_services::mempool::Request>, alloc::sync::Arc<tokio::runtime::scheduler::multi_thread::handle::Handle, alloc::alloc::Global>><unknown>
      at /home/conrado/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/harness.rs:155
  25: tokio::runtime::scheduler::multi_thread::worker::Context::run_task::h9631c0e884c1f3d7
      at <unknown source file>:<unknown line>
  26: tokio::runtime::scheduler::multi_thread::worker::Context::run::hec947b44374ac921
      at <unknown source file>:<unknown line>
  27: tokio::runtime::context::runtime::enter_runtime::h9e066fa2785fbcff
      at <unknown source file>:<unknown line>
  28: tokio::runtime::scheduler::multi_thread::worker::run::hefce4a520c412105
      at <unknown source file>:<unknown line>
  29: {closure#0}<zebra_network::protocol::external::codec::{impl#6}::deserialize_transaction_spawning::{closure_env#0}<&mut std::io::cursor::Cursor<&bytes::bytes_mut::BytesMut>>, ()><unknown>
      at /home/conrado/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/multi_thread/worker.rs:432
  30: poll<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zebra_network::protocol::external::codec::{impl#6}::deserialize_transaction_spawning::{closure_env#0}<&mut std::io::cursor::Cursor<&bytes::bytes_mut::BytesMut>>, ()>, ()><unknown>
      at /home/conrado/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/blocking/task.rs:42
  31: {closure#0}<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zebra_network::protocol::external::codec::{impl#6}::deserialize_transaction_spawning::{closure_env#0}<&mut std::io::cursor::Cursor<&bytes::bytes_mut::BytesMut>>, ()>>, tokio::runtime::blocking::schedule::BlockingSchedule><unknown>
      at /home/conrado/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/core.rs:365
  32: with_mut<tokio::runtime::task::core::Stage<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zebra_network::protocol::external::codec::{impl#6}::deserialize_transaction_spawning::{closure_env#0}<&mut std::io::cursor::Cursor<&bytes::bytes_mut::BytesMut>>, ()>>>, core::task::poll::Poll<()>, tokio::runtime::task::core::{impl#6}::poll::{closure_env#0}<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zebra_network::protocol::external::codec::{impl#6}::deserialize_transaction_spawning::{closure_env#0}<&mut std::io::cursor::Cursor<&bytes::bytes_mut::BytesMut>>, ()>>, tokio::runtime::blocking::schedule::BlockingSchedule>><unknown>
      at /home/conrado/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/loom/std/unsafe_cell.rs:16
  33: poll<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zebra_network::protocol::external::codec::{impl#6}::deserialize_transaction_spawning::{closure_env#0}<&mut std::io::cursor::Cursor<&bytes::bytes_mut::BytesMut>>, ()>>, tokio::runtime::blocking::schedule::BlockingSchedule><unknown>
      at /home/conrado/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/core.rs:354
  34: {closure#0}<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zebra_network::protocol::external::codec::{impl#6}::deserialize_transaction_spawning::{closure_env#0}<&mut std::io::cursor::Cursor<&bytes::bytes_mut::BytesMut>>, ()>>, tokio::runtime::blocking::schedule::BlockingSchedule><unknown>
      at /home/conrado/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/harness.rs:535
  35: call_once<core::task::poll::Poll<()>, tokio::runtime::task::harness::poll_future::{closure_env#0}<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zebra_network::protocol::external::codec::{impl#6}::deserialize_transaction_spawning::{closure_env#0}<&mut std::io::cursor::Cursor<&bytes::bytes_mut::BytesMut>>, ()>>, tokio::runtime::blocking::schedule::BlockingSchedule>><unknown>
      at /home/conrado/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:274
  36: do_call<core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::{closure_env#0}<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zebra_network::protocol::external::codec::{impl#6}::deserialize_transaction_spawning::{closure_env#0}<&mut std::io::cursor::Cursor<&bytes::bytes_mut::BytesMut>>, ()>>, tokio::runtime::blocking::schedule::BlockingSchedule>>, core::task::poll::Poll<()>><unknown>
      at /home/conrado/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:590
  37: catch_unwind<core::task::poll::Poll<()>, core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::{closure_env#0}<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zebra_network::protocol::external::codec::{impl#6}::deserialize_transaction_spawning::{closure_env#0}<&mut std::io::cursor::Cursor<&bytes::bytes_mut::BytesMut>>, ()>>, tokio::runtime::blocking::schedule::BlockingSchedule>>><unknown>
      at /home/conrado/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:553
  38: catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<tokio::runtime::task::harness::poll_future::{closure_env#0}<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zebra_network::protocol::external::codec::{impl#6}::deserialize_transaction_spawning::{closure_env#0}<&mut std::io::cursor::Cursor<&bytes::bytes_mut::BytesMut>>, ()>>, tokio::runtime::blocking::schedule::BlockingSchedule>>, core::task::poll::Poll<()>><unknown>
      at /home/conrado/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:359
  39: poll_future<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zebra_network::protocol::external::codec::{impl#6}::deserialize_transaction_spawning::{closure_env#0}<&mut std::io::cursor::Cursor<&bytes::bytes_mut::BytesMut>>, ()>>, tokio::runtime::blocking::schedule::BlockingSchedule><unknown>
      at /home/conrado/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/harness.rs:523
  40: poll_inner<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zebra_network::protocol::external::codec::{impl#6}::deserialize_transaction_spawning::{closure_env#0}<&mut std::io::cursor::Cursor<&bytes::bytes_mut::BytesMut>>, ()>>, tokio::runtime::blocking::schedule::BlockingSchedule><unknown>
      at /home/conrado/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/harness.rs:210
  41: poll<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zebra_network::protocol::external::codec::{impl#6}::deserialize_transaction_spawning::{closure_env#0}<&mut std::io::cursor::Cursor<&bytes::bytes_mut::BytesMut>>, ()>>, tokio::runtime::blocking::schedule::BlockingSchedule><unknown>
      at /home/conrado/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/harness.rs:155
  42: poll<tokio::runtime::blocking::task::BlockingTask<tokio::runtime::scheduler::multi_thread::worker::block_in_place::{closure#0}::{closure_env#0}<zebra_network::protocol::external::codec::{impl#6}::deserialize_transaction_spawning::{closure_env#0}<&mut std::io::cursor::Cursor<&bytes::bytes_mut::BytesMut>>, ()>>, tokio::runtime::blocking::schedule::BlockingSchedule><unknown>
      at /home/conrado/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/task/raw.rs:325
  43: tokio::runtime::blocking::pool::Inner::run::h68d1350b784f3e10
      at <unknown source file>:<unknown line>
  44: std::sys::backtrace::__rust_begin_short_backtrace::hfd209799d2b749d8
      at <unknown source file>:<unknown line>
  45: core::ops::function::FnOnce::call_once{{vtable.shim}}::hd3016fce2676d0af
      at <unknown source file>:<unknown line>
  46: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h43642ed9c40e0ab2
      at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/alloc/src/boxed.rs:1985
  47: std::sys::thread::unix::Thread::new::thread_start::h38da0f633f090ce2
      at /rustc/f8297e351a40c1439a467bbbb6879088047f50b3/library/std/src/sys/thread/unix.rs:126
  48: start_thread<unknown>
      at ./nptl/pthread_create.c:447
  49: clone3<unknown>
      at ./misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:78

```
</details>

### Tests

I tested this manually by adding a `panic` somewhere in the code that is reached soon after start (in my case, when adding a tx to the mempool) and seeing the results.

Note that if you use `cargo run` to test this, then cargo picks up `RUST_BACKTRACE` from `.cargo/config.toml` so if you want to really test it you need to `cargo install` it.

I'm deploying a node from this branch to see if it affects performance.

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
- If this PR blocks or depends on other issues or PRs, enumerate them here.
-->

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
