### PR TITLE
cleanup: remove serde Serialize/Deserialize from Block, Transaction

### DIFF
--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -47,10 +47,6 @@ pub use arbitrary::LedgerState;
 
 /// A Zcash block, containing a header and a list of transactions.
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(
-    any(test, feature = "proptest-impl", feature = "elasticsearch"),
-    derive(Serialize)
-)]
 pub struct Block {
     /// The block header, containing block metadata.
     pub header: Arc<Header>,

--- a/zebra-chain/src/orchard/action.rs
+++ b/zebra-chain/src/orchard/action.rs
@@ -3,9 +3,7 @@ use std::io;
 use halo2::pasta::pallas;
 use reddsa::orchard::SpendAuth;
 
-use crate::serialization::{
-    serde_helpers, ReadZcashExt, SerializationError, ZcashDeserialize, ZcashSerialize,
-};
+use crate::serialization::{ReadZcashExt, SerializationError, ZcashDeserialize, ZcashSerialize};
 
 use super::{
     commitment::{self, ValueCommitment},
@@ -20,7 +18,7 @@ use super::{
 /// describe Action transfers.
 ///
 /// [actiondesc]: https://zips.z.cash/protocol/nu5.pdf#actiondesc
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Action {
     /// A value commitment to net value of the input note minus the output note
     pub cv: commitment::ValueCommitment,
@@ -29,7 +27,6 @@ pub struct Action {
     /// The randomized validating key for spendAuthSig,
     pub rk: reddsa::VerificationKeyBytes<SpendAuth>,
     /// The x-coordinate of the note commitment for the output note.
-    #[serde(with = "serde_helpers::Base")]
     pub cm_x: pallas::Base,
     /// An encoding of an ephemeral Pallas public key corresponding to the
     /// encrypted private key in `out_ciphertext`.

--- a/zebra-chain/src/orchard/commitment.rs
+++ b/zebra-chain/src/orchard/commitment.rs
@@ -103,8 +103,8 @@ impl NoteCommitment {
 /// Action descriptions.
 ///
 /// <https://zips.z.cash/protocol/nu5.pdf#concretehomomorphiccommit>
-#[derive(Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
-pub struct ValueCommitment(#[serde(with = "serde_helpers::Affine")] pub pallas::Affine);
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ValueCommitment(pub pallas::Affine);
 
 impl<'a> std::ops::Add<&'a ValueCommitment> for ValueCommitment {
     type Output = Self;

--- a/zebra-chain/src/orchard/shielded_data.rs
+++ b/zebra-chain/src/orchard/shielded_data.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 /// A bundle of [`Action`] descriptions and signature data.
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ShieldedData {
     /// The orchard flags for this transaction.
     /// Denoted as `flagsOrchard` in the spec.
@@ -130,7 +130,7 @@ impl AtLeastOne<AuthorizedAction> {
 /// An authorized action description.
 ///
 /// Every authorized Orchard `Action` must have a corresponding `SpendAuth` signature.
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AuthorizedAction {
     /// The action description of this Action.
     pub action: Action,

--- a/zebra-chain/src/sapling/output.rs
+++ b/zebra-chain/src/sapling/output.rs
@@ -9,9 +9,7 @@ use derive_getters::Getters;
 use crate::{
     block::MAX_BLOCK_BYTES,
     primitives::Groth16Proof,
-    serialization::{
-        serde_helpers, SerializationError, TrustedPreallocate, ZcashDeserialize, ZcashSerialize,
-    },
+    serialization::{SerializationError, TrustedPreallocate, ZcashDeserialize, ZcashSerialize},
 };
 
 use super::{commitment, keys, note};
@@ -24,12 +22,11 @@ use super::{commitment, keys, note};
 /// `V5` transactions split them into multiple arrays.
 ///
 /// [ps]: https://zips.z.cash/protocol/protocol.pdf#outputencoding
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Getters)]
+#[derive(Clone, Debug, PartialEq, Eq, Getters)]
 pub struct Output {
     /// A value commitment to the value of the input note.
     pub cv: commitment::ValueCommitment,
     /// The u-coordinate of the note commitment for the output note.
-    #[serde(with = "serde_helpers::SaplingExtractedNoteCommitment")]
     pub cm_u: sapling_crypto::note::ExtractedNoteCommitment,
     /// An encoding of an ephemeral Jubjub public key.
     pub ephemeral_key: keys::EphemeralPublicKey,
@@ -44,7 +41,7 @@ pub struct Output {
 /// Wrapper for `Output` serialization in a `V4` transaction.
 ///
 /// <https://zips.z.cash/protocol/protocol.pdf#outputencoding>
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OutputInTransactionV4(pub Output);
 
 /// The serialization prefix fields of an `Output` in Transaction V5.
@@ -55,12 +52,11 @@ pub struct OutputInTransactionV4(pub Output);
 /// Serialized as `OutputDescriptionV5` in [protocol specification §7.3][ps].
 ///
 /// [ps]: https://zips.z.cash/protocol/protocol.pdf#outputencoding
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OutputPrefixInTransactionV5 {
     /// A value commitment to the value of the input note.
     pub cv: commitment::ValueCommitment,
     /// The u-coordinate of the note commitment for the output note.
-    #[serde(with = "serde_helpers::SaplingExtractedNoteCommitment")]
     pub cm_u: sapling_crypto::note::ExtractedNoteCommitment,
     /// An encoding of an ephemeral Jubjub public key.
     pub ephemeral_key: keys::EphemeralPublicKey,

--- a/zebra-chain/src/sapling/shielded_data.rs
+++ b/zebra-chain/src/sapling/shielded_data.rs
@@ -85,7 +85,7 @@ pub trait AnchorVariant {
 /// there is a single `shared_anchor` for the entire transaction, which is only
 /// present when there is at least one spend. These structural differences are
 /// modeled using the `AnchorVariant` type trait and `TransferData` enum.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Getters)]
+#[derive(Clone, Debug, PartialEq, Eq, Getters)]
 pub struct ShieldedData<AnchorV>
 where
     AnchorV: AnchorVariant + Clone,
@@ -116,7 +116,7 @@ where
 /// Specifically, TransferData ensures that:
 /// * there is at least one spend or output, and
 /// * the shared anchor is only present when there are spends.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TransferData<AnchorV>
 where
     AnchorV: AnchorVariant + Clone,

--- a/zebra-chain/src/sapling/spend.rs
+++ b/zebra-chain/src/sapling/spend.rs
@@ -33,7 +33,7 @@ use super::{
 /// `V5` transactions split them into multiple arrays.
 ///
 /// [ps]: https://zips.z.cash/protocol/protocol.pdf#spendencoding
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Getters)]
+#[derive(Clone, Debug, PartialEq, Getters)]
 pub struct Spend<AnchorV: AnchorVariant> {
     /// A value commitment to the value of the input note.
     pub cv: commitment::ValueCommitment,
@@ -65,7 +65,7 @@ pub struct Spend<AnchorV: AnchorVariant> {
 /// Serialized as `SpendDescriptionV5` in [protocol specification §7.3][ps].
 ///
 /// [ps]: https://zips.z.cash/protocol/protocol.pdf#spendencoding
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SpendPrefixInTransactionV5 {
     /// A value commitment to the value of the input note.
     pub cv: commitment::ValueCommitment,

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -72,10 +72,6 @@ use crate::{
 /// internally by different enum variants. Because we checkpoint on Canopy
 /// activation, we do not validate any pre-Sapling transaction types.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    any(test, feature = "proptest-impl", feature = "elasticsearch"),
-    derive(Serialize)
-)]
 pub enum Transaction {
     /// A fully transparent transaction (`version = 1`).
     V1 {

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -38,6 +38,9 @@ mod disk_db;
 mod disk_format;
 mod zebra_db;
 
+#[cfg(feature = "elasticsearch")]
+mod elastic;
+
 #[cfg(any(test, feature = "proptest-impl"))]
 mod arbitrary;
 
@@ -54,6 +57,9 @@ pub use disk_format::{
     MAX_ON_DISK_HEIGHT,
 };
 pub use zebra_db::ZebraDb;
+
+#[cfg(feature = "elasticsearch")]
+use elastic::ElasticBlockObject;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 pub use disk_format::KV;
@@ -519,8 +525,9 @@ impl FinalizedState {
             );
 
             // Insert the block itself.
+            let elastic_obj = ElasticBlockObject::from(block.as_ref());
             self.elastic_blocks
-                .push(serde_json::json!(block).to_string());
+                .push(serde_json::to_string(&elastic_obj).unwrap());
 
             // We are in bulk time, insert to ES all we have.
             if self.elastic_blocks.len() >= blocks_size_to_dump {

--- a/zebra-state/src/service/finalized_state/elastic.rs
+++ b/zebra-state/src/service/finalized_state/elastic.rs
@@ -1,0 +1,86 @@
+//! Elasticsearch representations of Zebra blocks and transactions.
+//!
+//! This module provides serializable structs for indexing Zcash blocks and transactions
+//! in Elasticsearch. It extracts minimal information useful for search and analytics,
+//! including block height, hash, timestamp, and basic transaction data.
+
+use serde::Serialize;
+use zebra_chain::{block::Block, transaction::Transaction};
+
+/// A Zcash block for Elasticsearch indexing.
+#[derive(Debug, Serialize)]
+pub struct ElasticBlockObject {
+    pub height: u32,
+    pub hash: String,
+    pub time: i64,
+    pub tx_count: usize,
+    pub transactions: Vec<ElasticTxObject>,
+}
+
+/// A Zcash transaction for Elasticsearch indexing.
+#[derive(Debug, Serialize)]
+pub struct ElasticTxObject {
+    pub txid: String,
+    pub version: u32,
+    pub inputs: usize,
+    pub outputs: usize,
+}
+
+impl ElasticBlockObject {
+    /// Convert a Zebra `Block` into an `ElasticBlockObject`.
+    pub fn from(block: &Block) -> Self {
+        let height = block.coinbase_height().map(|h| h.0).unwrap_or(0);
+        let hash = block.hash().to_string();
+        let time = block.header.time.timestamp();
+
+        let transactions = block
+            .transactions
+            .iter()
+            .map(|tx| ElasticTxObject::from(tx.as_ref()))
+            .collect();
+
+        Self {
+            height,
+            hash,
+            time,
+            tx_count: block.transactions.len(),
+            transactions,
+        }
+    }
+}
+
+impl ElasticTxObject {
+    /// Convert a Zebra `Transaction` into an `ElasticTxObject`.
+    pub fn from(tx: &Transaction) -> Self {
+        let txid = tx.hash().to_string();
+
+        let (version, inputs, outputs) = match tx {
+            Transaction::V1 {
+                inputs, outputs, ..
+            } => (1, inputs.len(), outputs.len()),
+            Transaction::V2 {
+                inputs, outputs, ..
+            } => (2, inputs.len(), outputs.len()),
+            Transaction::V3 {
+                inputs, outputs, ..
+            } => (3, inputs.len(), outputs.len()),
+            Transaction::V4 {
+                inputs, outputs, ..
+            } => (4, inputs.len(), outputs.len()),
+            Transaction::V5 {
+                inputs, outputs, ..
+            } => (5, inputs.len(), outputs.len()),
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+            Transaction::V6 {
+                inputs, outputs, ..
+            } => (6, inputs.len(), outputs.len()),
+        };
+
+        Self {
+            txid,
+            version,
+            inputs,
+            outputs,
+        }
+    }
+}


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

<!--
- Describe the goals of the PR.
- If it closes any issues, enumerate them here.
-->

As noted in #9892, `Block` and `Transaction` include `serde` serialization only needed for the optional Elasticsearch feature (and one test). This PR removes those derives and adds dedicated structs for Elasticsearch indexing, reducing unnecessary serialization code.


## Solution

<!-- Describe the changes in the PR. -->

* Removes `Serialize`/`Deserialize` derives from various types in `zebra-chain`:
  * `ValueCommitment`
  * `Action`, `AuthorizedAction`, `ShieldedData`
  * `Output`, `OutputInTransactionV4`, `OutputPrefixInTransactionV5`
  * `Spend`, `SpendPrefixInTransactionV5`
  * `Transaction`, `Block`
* Added a new module `zebra_state::service::finalized_state::elastic` containing dedicated `struct`s for serializing `Block` and `Transaction` data for Elasticsearch indexing.
* Updated the `elasticsearch` method to use the new structs.
* **Note:** The snapshot test in `zebra-rpc` still depends on `serde`, so `cargo test -p zebra-rpc` will fail until that test is updated or removed.


Feedback is welcome on whether the included fields are sufficient for Elasticsearch, and whether this approach aligns with what was envisioned in #9892.


### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
