### PR TITLE
fix(consensus): Avoid panicking when validation result channel is closed

### DIFF
--- a/tower-batch-control/src/worker.rs
+++ b/tower-batch-control/src/worker.rs
@@ -291,7 +291,7 @@ where
 
     /// Register an inner service failure.
     ///
-    /// The underlying service failed when we called `poll_ready` on it with the given `error`. We
+    /// The underlying service failed with the given `error` when we called `poll_ready` or `call` on it. We
     /// need to communicate this to all the `Batch` handles. To do so, we wrap up the error in
     /// an `Arc`, send that `Arc<E>` to all pending requests, and store it so that subsequent
     /// requests will also fail with the same error.

--- a/zebra-consensus/src/primitives/sapling.rs
+++ b/zebra-consensus/src/primitives/sapling.rs
@@ -136,9 +136,9 @@ impl Service<BatchControl<Item>> for Verifier {
                         let (spend_vk, output_vk) = SAPLING.verifying_keys();
 
                         let res = batch.validate(&spend_vk, &output_vk, thread_rng());
-                        tx.send(Some(res))
+                        let _ = tx.send(Some(res));
                     })
-                    .await?
+                    .await
                     .map_err(Self::Error::from)
                 }
                 .boxed()


### PR DESCRIPTION
## Motivation

Closes #10044

The worker task is returning [here](https://github.com/ZcashFoundation/zebra/blob/main/tower-batch-control/src/worker.rs#L285) after its [channel receiver is closed here](https://github.com/ZcashFoundation/zebra/blob/main/tower-batch-control/src/worker.rs#L324) in the `failed()` method, which is only called if `poll_ready()` or `call()` on the inner service returns an error.

Both the Sapling and Orchard verifiers always return `Poll::Ready(Ok(())` from their `poll_ready()` methods, so `failed()` is [likely being called here](https://github.com/ZcashFoundation/zebra/blob/main/tower-batch-control/src/worker.rs#L219) where it's awaiting a response to a `BatchControl::Flush` request but getting a [`SendError`](https://github.com/ZcashFoundation/zebra/actions/runs/18563585081/job/52921668116#step:12:248).

The [`BatchControl::Flush` match arm in the Orchard verifier's `call()` method is infallible](https://github.com/ZcashFoundation/zebra/blob/main/zebra-consensus/src/primitives/halo2.rs#L302), and there are no layers added when [instantiating the `Batch` service around it](https://github.com/ZcashFoundation/zebra/blob/main/zebra-consensus/src/primitives/halo2.rs#L141). The [arm was infallible in the Sapling verifier too prior to #9737](https://github.com/ZcashFoundation/zebra/pull/9737/files#diff-49d789823381c8e99c79885d1f62574f0808ad439a348fd11488b1aed14a5a65L522), but now, in rare cases, I think the transaction verifier could do some checks concurrently then drop the `FuturesUnordered`/`AsyncChecks` struct that owns the only receiver for that watch channel `Sender` when one of them fails such that the Sapling verifier has nowhere to send the validation result and returns a `SendError` causing the batch worker to return. 

## Solution

- Always returns `Ok(())` from `BatchControl::Flush` match arm of Sapling verifier's `call()` method rather than potentially returning a `SendError` if there the validation result channel is closed.
- ~Avoids polling the `tower_batch_control::Batch` worker task from the service's `poll_ready()` method when the worker task has already finished, instead logging a warning and returning an error early (so that the request goes to the fallback service instead).~
- Adds a correctness comment in `Batch::poll_ready()` noting that the inner service should not return recoverable errors in some cases.

Related:
- Minor fix to `failed()` method docs.

### Tests



### Follow-up Work

Release v3.0.0

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [x] The documentation is up to date.
