### PR TITLE
fix: Make git details accessible in Docker builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -107,7 +107,8 @@ COPY --link --chown=${UID}:${GID} ./ ${HOME}
 
 # Build Zebra test binaries using nextest, but don't run them.
 # This also copies the necessary binaries to /usr/local/bin.
-RUN cargo nextest run --locked --release --no-run --features "${FEATURES}" && \
+RUN --mount=type=bind,source=.git,target=.git,readonly \
+    cargo nextest run --locked --release --no-run --features "${FEATURES}" && \
     # Copy binaries to standard location
     cp ${CARGO_TARGET_DIR}/release/zebrad /usr/local/bin && \
     # Only copy zebra-checkpoints if the feature is enabled
@@ -146,7 +147,8 @@ WORKDIR ${HOME}
 ARG CARGO_HOME
 ARG CARGO_TARGET_DIR
 
-RUN --mount=type=bind,source=tower-batch-control,target=tower-batch-control \
+RUN --mount=type=bind,source=.git,target=.git,readonly \
+    --mount=type=bind,source=tower-batch-control,target=tower-batch-control \
     --mount=type=bind,source=tower-fallback,target=tower-fallback \
     --mount=type=bind,source=zebra-chain,target=zebra-chain \
     --mount=type=bind,source=zebra-consensus,target=zebra-consensus \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,31 +28,12 @@ ARG CARGO_TARGET_DIR="${HOME}/target"
 FROM rust:${RUST_VERSION}-bookworm AS deps
 SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
-# Make the build platform available as a variable
-ARG BUILDPLATFORM
-
 # Install zebra build deps
 RUN apt-get -qq update && \
     apt-get -qq install -y --no-install-recommends \
     libclang-dev \
     protobuf-compiler \
     && rm -rf /var/lib/apt/lists/* /tmp/*
-
-# Build arguments and variables
-ARG CARGO_INCREMENTAL
-ENV CARGO_INCREMENTAL=${CARGO_INCREMENTAL:-0}
-
-ARG CARGO_HOME
-ENV CARGO_HOME=${CARGO_HOME}
-
-ARG CARGO_TARGET_DIR
-ENV CARGO_TARGET_DIR=${CARGO_TARGET_DIR}
-
-# If this is not set, it must be an empty string, so Zebra can try an
-# alternative git commit source:
-# https://github.com/ZcashFoundation/zebra/blob/9ebd56092bcdfc1a09062e15a0574c94af37f389/zebrad/src/application.rs#L179-L182
-ARG SHORT_SHA
-ENV SHORT_SHA=${SHORT_SHA:-}
 
 # This stage builds tests without running them.
 #
@@ -63,9 +44,21 @@ FROM deps AS tests
 ARG FEATURES
 ENV FEATURES=${FEATURES}
 
+ARG BUILDPLATFORM
+
 # Skip IPv6 tests by default, as some CI environment don't have IPv6 available
 ARG SKIP_IPV6_TESTS
 ENV SKIP_IPV6_TESTS=${SKIP_IPV6_TESTS:-1}
+
+# Build arguments and variables
+ARG CARGO_INCREMENTAL
+ENV CARGO_INCREMENTAL=${CARGO_INCREMENTAL:-0}
+
+# If this is not set, it must be an empty string, so Zebra can try an
+# alternative git commit source:
+# https://github.com/ZcashFoundation/zebra/blob/9ebd56092bcdfc1a09062e15a0574c94af37f389/zebrad/src/application.rs#L179-L182
+ARG SHORT_SHA
+ENV SHORT_SHA=${SHORT_SHA:-}
 
 # This environment setup is almost identical to the `runtime` target so that the
 # `tests` target differs minimally. In fact, a subset of this setup is used for
@@ -139,6 +132,9 @@ FROM deps AS release
 
 ARG FEATURES
 ENV FEATURES=${FEATURES}
+
+ARG SHORT_SHA
+ENV SHORT_SHA=${SHORT_SHA:-}
 
 # Set the working directory for the build.
 ARG HOME


### PR DESCRIPTION
## Motivation

- Close #10105.

## Solution

- [Include .git in Docker build context and mount in Dockerfile](https://github.com/ZcashFoundation/zebra/commit/27348cb09f202ff2015ad4360c178befd8e24e8f)
- [Fix dir ownership when building Zebra for tests](https://github.com/ZcashFoundation/zebra/pull/10109/commits/1d6216c8e00e932c44fe87d6ab6dab999c6cb40e)

### Tests


### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [x] The documentation is up to date.
