### PR TITLE
feat(ci): Enable RPC on GCP instances deployed from main and releases

### DIFF
--- a/.github/workflows/zfnd-deploy-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-nodes-gcp.yml
@@ -325,6 +325,13 @@ jobs:
             LOG_FILE="${{ vars.CD_LOG_FILE }}"
           fi
 
+          # Set RPC port based on network
+          if [ "${{ matrix.network }}" = "Mainnet" ]; then
+            RPC_PORT="8232"
+          else
+            RPC_PORT="18232"
+          fi
+
           gcloud compute instance-templates create-with-container "${TEMPLATE_NAME}" \
           --machine-type ${{ vars.GCP_SMALL_MACHINE }} \
           --provisioning-model=SPOT \
@@ -338,7 +345,7 @@ jobs:
           --container-stdin \
           --container-tty \
           --container-image ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }} \
-          --container-env "ZEBRA_NETWORK__NETWORK=${{ matrix.network }},LOG_FILE=${LOG_FILE},SENTRY_DSN=${{ vars.SENTRY_DSN }},ZEBRA_HEALTH__LISTEN_ADDR=0.0.0.0:8080,ZEBRA_HEALTH__MIN_CONNECTED_PEERS=1" \
+          --container-env "ZEBRA_NETWORK__NETWORK=${{ matrix.network }},LOG_FILE=${LOG_FILE},SENTRY_DSN=${{ vars.SENTRY_DSN }},ZEBRA_HEALTH__LISTEN_ADDR=0.0.0.0:8080,ZEBRA_HEALTH__MIN_CONNECTED_PEERS=1,ZEBRA_RPC__LISTEN_ADDR=0.0.0.0:${RPC_PORT}" \
           --service-account ${{ vars.GCP_DEPLOYMENTS_SA }} \
           --scopes cloud-platform \
           --metadata google-logging-enabled=true,google-logging-use-fluentbit=true,google-monitoring-enabled=true \


### PR DESCRIPTION
## Motivation

GCP instances deployed through our pipelines don't have RPC enabled, making them unavailable for external integrations or queries. We need RPC endpoints on instances deployed from main and releases.

## Solution

- Set `ZEBRA_RPC__LISTEN_ADDR` based on network type in the deployment workflow
- Mainnet instances bind to `0.0.0.0:8232`
- Testnet instances bind to `0.0.0.0:18232`
- Cookie authentication remains enabled by default (via `ZEBRA_RPC__COOKIE_DIR`)
- Manual deployments via `workflow_dispatch` are unchanged

### Implementation

Changed `.github/workflows/zfnd-deploy-nodes-gcp.yml`:
- Added RPC port selection logic (lines 328-333)
- Added `ZEBRA_RPC__LISTEN_ADDR` to container environment variables (line 348)

### Security Considerations

RPC endpoints are publicly bound (0.0.0.0) but protected by cookie authentication. Firewall rules must be configured separately:

```bash
# Allow RPC access (adjust source-ranges as needed)
gcloud compute firewall-rules create zebra-rpc-mainnet \
  --target-tags=zebrad \
  --allow=tcp:8232 \
  --source-ranges=<your-allowed-ips>

gcloud compute firewall-rules create zebra-rpc-testnet \
  --target-tags=zebrad \
  --allow=tcp:18232 \
  --source-ranges=<your-allowed-ips>
```

### Testing

Verify RPC is accessible after deployment:

```bash
# Get instance external IP
INSTANCE_IP=$(gcloud compute instances list --filter="labels.app=zebrad AND labels.network=mainnet" --format="value(EXTERNAL_IP)" --limit=1)

# Test RPC endpoint (requires cookie from instance)
curl --data-binary '{"jsonrpc": "1.0", "id":"test", "method": "getinfo", "params": [] }' \
  -H 'Content-type: application/json' \
  http://$INSTANCE_IP:8232/
```

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.

Closes #10119