### PR TITLE
fix(ci): Prevent static IP assignment step from failing on read command

### DIFF
--- a/.github/workflows/zfnd-deploy-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-nodes-gcp.yml
@@ -444,7 +444,7 @@ jobs:
             --region "${{ vars.GCP_REGION }}" \
             --format="table[no-heading](instance.basename(),instance.scope().segment(0))" | sort)
 
-          IFS=$'\n' read -rd '' -a INSTANCE_ROWS <<<"$INSTANCE_DATA"
+          IFS=$'\n' read -rd '' -a INSTANCE_ROWS <<<"$INSTANCE_DATA" || true
 
           # Loop to assign all IPs
           for i in "${!INSTANCE_ROWS[@]}"; do


### PR DESCRIPTION
## Motivation

The deployment workflow fails during the "Assign static IPs to instances" step when executing `read -rd ''`. This command populates the array but returns exit code 1 at EOF. GitHub Actions runs bash with `set -e`, causing the workflow to fail despite successful array population.

## Solution

Add `|| true` to the read command at line 447 to allow the script to continue:

```bash
IFS=$'\n' read -rd '' -a INSTANCE_ROWS <<<"$INSTANCE_DATA" || true
```

This is standard handling for `read -d ''` which always returns non-zero when hitting the delimiter.

## Testing

The fix allows the workflow to proceed past the array population step and successfully assign static IPs to instances. Verify by checking that deployments from main complete the "Assign static IPs to instances" step without error.

## Related Issues

- Failed deployment: https://github.com/ZcashFoundation/zebra/actions/runs/19448245778/job/55716322494
- Error occurred at: 2025-11-18T14:59:54Z

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.

Fixes #10122