### PR TITLE
fix(ci): merge ARM64 and AMD64 images into multi-arch Docker manifest

### DIFF
--- a/.github/workflows/zfnd-build-docker-image.yml
+++ b/.github/workflows/zfnd-build-docker-image.yml
@@ -326,13 +326,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
-        with:
-          version: lab:latest
-          driver: ${{ vars.DOCKER_BUILDER || 'docker' }}
-          endpoint: zfnd/zebra
-
       # Create multi-arch manifest and push to registries
       - name: Create manifest and push
         id: create

--- a/.github/workflows/zfnd-build-docker-image.yml
+++ b/.github/workflows/zfnd-build-docker-image.yml
@@ -62,7 +62,7 @@ on:
     outputs:
       image_digest:
         description: The image digest to be used on a caller workflow
-        value: ${{ jobs.build.outputs.image_digest }}
+        value: ${{ jobs.merge.outputs.image_digest }}
 
 permissions:
   contents: read
@@ -111,7 +111,7 @@ jobs:
     env:
       DOCKER_BUILD_SUMMARY: ${{ vars.DOCKER_BUILD_SUMMARY }}
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v4.2.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd #v5.0.1
         with:
           persist-credentials: false
 
@@ -189,7 +189,8 @@ jobs:
           driver: ${{ vars.DOCKER_BUILDER || 'docker' }}
           endpoint: zfnd/zebra
 
-      # Build and push image to Google Artifact Registry, and possibly DockerHub
+      # Build and push image by digest to Google Artifact Registry
+      # Images are pushed by digest only and will be merged into multi-arch manifest in the merge job
       # With provenance and SBOM (ZcashFoundation repository only)
       - name: Build & push (with attestations)
         id: docker_build
@@ -200,14 +201,13 @@ jobs:
           target: ${{ inputs.dockerfile_target }}
           context: .
           file: ${{ inputs.dockerfile_path }}
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             SHORT_SHA=${{ inputs.short_sha == 'auto' && env.GITHUB_SHA_SHORT || inputs.short_sha }}
             RUST_LOG=${{ env.RUST_LOG }}
             CARGO_INCREMENTAL=${{ env.CARGO_INCREMENTAL }}
             FEATURES=${{ env.FEATURES }}
-          push: true
+          outputs: type=image,name=us-docker.pkg.dev/${{ vars.GCP_PROJECT }}/zebra/${{ inputs.image_name }},push-by-digest=true,name-canonical=true,push=true
           # It's recommended to build images with max-level provenance attestations
           # https://docs.docker.com/build/ci/github-actions/attestations/
           provenance: mode=max
@@ -216,7 +216,8 @@ jobs:
           # https://docs.docker.com/engine/reference/commandline/buildx_build/#options
           no-cache: ${{ inputs.no_cache }}
 
-      # Build and push image without attestations (contributor forks)
+      # Build and push image by digest without attestations (contributor forks)
+      # Images are pushed by digest only and will be merged into multi-arch manifest in the merge job
       - name: Build & push (without attestations)
         id: docker_build_no_attestations
         if: github.repository_owner != 'ZcashFoundation'
@@ -226,36 +227,145 @@ jobs:
           target: ${{ inputs.dockerfile_target }}
           context: .
           file: ${{ inputs.dockerfile_path }}
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             SHORT_SHA=${{ inputs.short_sha == 'auto' && env.GITHUB_SHA_SHORT || inputs.short_sha }}
             RUST_LOG=${{ env.RUST_LOG }}
             CARGO_INCREMENTAL=${{ env.CARGO_INCREMENTAL }}
             FEATURES=${{ env.FEATURES }}
-          push: true
+          outputs: type=image,name=us-docker.pkg.dev/${{ vars.GCP_PROJECT }}/zebra/${{ inputs.image_name }},push-by-digest=true,name-canonical=true,push=true
           # Don't read from the cache if the caller disabled it.
           # https://docs.docker.com/engine/reference/commandline/buildx_build/#options
           no-cache: ${{ inputs.no_cache }}
 
-        # For the latest built image, display:
-        # - the vulnerabilities (ignoring the base image, and only displaying vulnerabilities with a critical or high security severity)
-        # - the available recommendations
-        # - compare it to the latest image indexed in Docker Hub (only displaying changed packages and vulnerabilities that already have a fix)
-        #
-        # Record the image to Scout environment based on the event type, for example:
-        # - `prod` for a release event
-        # - `stage` for a push event to the main branch
-        # - `dev` for a pull request event
+      # Export digest for multi-arch manifest merge
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.docker_build.outputs.digest || steps.docker_build_no_attestations.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      # Upload digest as artifact for merge job
+      - name: Upload digest
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 #v5.0.0
+        with:
+          name: digests-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Merge multi-platform manifests and apply tags
+  # This job creates a multi-arch manifest from all platform-specific images built in parallel
+  # and applies all necessary tags to both GCP Artifact Registry and DockerHub
+  merge:
+    name: Create multi-arch manifest
+    runs-on: ubuntu-latest
+    needs: [prepare-matrix, build]
+    environment: ${{ github.event_name == 'release' && 'prod' || inputs.environment || 'dev' }}
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    outputs:
+      image_digest: ${{ steps.create.outputs.digest }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd #v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@c33ff65466c58d57e4d796f88bb1ae0ff26ee453 #v5.2.0
+        with:
+          short-length: 7
+
+      # Download all platform digests
+      - name: Download digests
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      # Docker meta for tag generation
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f #v5.8.0
+        with:
+          images: |
+            us-docker.pkg.dev/${{ vars.GCP_PROJECT }}/zebra/${{ inputs.image_name }}
+            zfnd/${{ inputs.image_name }},enable=${{ inputs.publish_to_dockerhub && github.event_name == 'release' && !github.event.release.prerelease }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=ref,event=pr
+            type=ref,event=branch
+            type=edge,enable={{is_default_branch}}
+            type=schedule
+            type=sha,event=pr
+            type=sha,event=branch
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 #v3.0.0
+        with:
+          workload_identity_provider: "${{ vars.GCP_WIF }}"
+          service_account: "${{ vars.GCP_ARTIFACTS_SA }}"
+          token_format: access_token
+          access_token_lifetime: 3600s
+
+      - name: Login to Google Artifact Registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef #v3.6.0
+        with:
+          registry: us-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+
+      - name: Login to DockerHub
+        if: inputs.publish_to_dockerhub && github.event_name == 'release' && !github.event.release.prerelease
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef #v3.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
+        with:
+          version: lab:latest
+          driver: ${{ vars.DOCKER_BUILDER || 'docker' }}
+          endpoint: zfnd/zebra
+
+      # Create multi-arch manifest and push to registries
+      - name: Create manifest and push
+        id: create
+        working-directory: /tmp/digests
+        run: |
+          # Create array of image references from digests
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf 'us-docker.pkg.dev/${{ vars.GCP_PROJECT }}/zebra/${{ inputs.image_name }}@sha256:%s ' *)
+
+          # Get digest of the merged manifest
+          docker buildx imagetools inspect us-docker.pkg.dev/${{ vars.GCP_PROJECT }}/zebra/${{ inputs.image_name }}:${{ steps.meta.outputs.version }} \
+            --format '{{json .Manifest}}' | jq -r '.digest' | tee /tmp/digest.txt
+          echo "digest=$(cat /tmp/digest.txt)" >> $GITHUB_OUTPUT
+        env:
+          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
+
+      # For the merged multi-arch manifest, display:
+      # - the vulnerabilities (ignoring the base image, and only displaying vulnerabilities with a critical or high security severity)
+      # - the available recommendations
+      # - compare it to the latest image indexed in Docker Hub (only displaying changed packages and vulnerabilities that already have a fix)
+      #
+      # Record the image to Scout environment based on the event type, for example:
+      # - `prod` for a release event
+      # - `stage` for a push event to the main branch
+      # - `dev` for a pull request event
       - name: Docker Scout
         id: docker-scout
         uses: docker/scout-action@f8c776824083494ab0d56b8105ba2ca85c86e4de #v1.18.2
         # We only run Docker Scout on the `runtime` target, as the other targets are not meant to be released
         # and are commonly used for testing, and thus are ephemeral.
-        # Run only on AMD64 to avoid running twice in matrix builds
         # TODO: Remove the `contains` check once we have a better way to determine if just new vulnerabilities are present.
         # See: https://github.com/docker/scout-action/issues/56
-        if: ${{ matrix.platform == 'linux/amd64' && inputs.dockerfile_target == 'runtime' && contains(github.event.pull_request.title, 'Release v') }}
+        if: ${{ inputs.dockerfile_target == 'runtime' && contains(github.event.pull_request.title, 'Release v') }}
         with:
           command: cves,recommendations,compare,environment
           image: us-docker.pkg.dev/${{ vars.GCP_PROJECT }}/zebra/${{ inputs.image_name }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## Motivation

PR #10072 added ARM64 platform support to Docker builds, but the multi-arch manifest was not being created properly. Both AMD64 and ARM64 builds succeeded but pushed separately, causing the last build to overwrite the first instead of merging into a single multi-arch manifest.

Evidence from v3.0.0 release (https://github.com/ZcashFoundation/zebra/actions/runs/19471553691):
- Both builds succeeded
- DockerHub shows incomplete multi-arch support (only AMD64 + unknown platform)
- ARM64 users cannot reliably pull the correct image

## Solution

Implement the proper multi-platform build workflow as documented in Docker's official guide: https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners

**Changes to `.github/workflows/zfnd-build-docker-image.yml`:**

1. **Build step modifications**:
   - Changed from pushing with tags to pushing by digest only
   - Added `outputs: type=image,name=...,push-by-digest=true,name-canonical=true,push=true`
   - Removed `tags` parameter from build action

2. **Digest handling**:
   - Export digest to file after each platform build
   - Upload digest as artifact (separate artifacts for AMD64 and ARM64)

3. **New merge job**:
   - Downloads all platform digest artifacts
   - Uses `docker buildx imagetools create` to combine digests into multi-arch manifest
   - Applies all tags to the merged manifest
   - Pushes to both GCP Artifact Registry and DockerHub (when applicable)
   - Outputs the final manifest digest

4. **Docker Scout update**:
   - Moved from build job to merge job
   - Now scans the merged multi-arch manifest instead of individual platforms
   - Removed platform-specific condition

5. **Workflow output**:
   - Changed from `jobs.build.outputs.image_digest` to `jobs.merge.outputs.image_digest`
   - Callers now receive the multi-arch manifest digest

## Testing

Verify that future releases create proper multi-arch manifests:
- Check DockerHub tags show both AMD64 and ARM64 architectures
- Test `docker pull zfnd/zebra:latest` on both AMD64 and ARM64 machines
- Confirm both platforms pull without errors and get the correct architecture

## Related Issues

- Fixes #10124
- Related to #10072 (ARM64 support PR)

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.
