### PR TITLE
feat(DoS): Implement dust filter

### DIFF
--- a/zebra-chain/src/transparent.rs
+++ b/zebra-chain/src/transparent.rs
@@ -463,9 +463,7 @@ impl Output {
     /// Returns true if this output is considered dust.
     pub fn is_dust(&self) -> bool {
         let output_size: u32 = self
-            .zcash_serialize_to_vec()
-            .expect("serializing to vec should not fail")
-            .len()
+            .zcash_serialized_size()
             .try_into()
             .expect("output size should fit in u32");
 

--- a/zebra-chain/src/transparent.rs
+++ b/zebra-chain/src/transparent.rs
@@ -15,6 +15,7 @@ use crate::{
     amount::{Amount, NonNegative},
     block,
     parameters::Network,
+    serialization::ZcashSerialize,
     transaction,
 };
 
@@ -62,6 +63,11 @@ pub const MIN_TRANSPARENT_COINBASE_MATURITY: u32 = 100;
 // - https://github.com/emacs-lsp/lsp-mode/issues/2080
 // - https://github.com/rust-lang/rust-analyzer/issues/13709
 pub const EXTRA_ZEBRA_COINBASE_DATA: &str = "z\u{1F993}";
+
+/// The rate used to calculate the dust threshold, in zatoshis per 1000 bytes.
+///
+/// History: https://github.com/zcash/zcash/blob/v6.10.0/src/policy/policy.h#L43-L89
+pub const ONE_THIRD_DUST_THRESHOLD_RATE: u32 = 100;
 
 /// Arbitrary data inserted by miners into a coinbase transaction.
 //
@@ -453,6 +459,22 @@ impl Output {
                 Some(Address::from_script_hash(net.t_addr_kind(), sh))
             }
         }
+    }
+
+    /// Returns true if this output is considered dust.
+    pub fn is_dust(&self) -> bool {
+        let output_size: u32 = self
+            .zcash_serialize_to_vec()
+            .expect("serializing to vec should not fail")
+            .len()
+            .try_into()
+            .expect("output size should fit in u32");
+
+        // https://github.com/zcash/zcash/blob/v6.10.0/src/primitives/transaction.cpp#L75-L80
+        let threshold = 3 * (ONE_THIRD_DUST_THRESHOLD_RATE * (output_size + 148) / 1000);
+
+        // https://github.com/zcash/zcash/blob/v6.10.0/src/primitives/transaction.h#L396-L399
+        self.value.zatoshis() < threshold as i64
     }
 }
 

--- a/zebra-chain/src/transparent.rs
+++ b/zebra-chain/src/transparent.rs
@@ -66,7 +66,7 @@ pub const EXTRA_ZEBRA_COINBASE_DATA: &str = "z\u{1F993}";
 
 /// The rate used to calculate the dust threshold, in zatoshis per 1000 bytes.
 ///
-/// History: https://github.com/zcash/zcash/blob/v6.10.0/src/policy/policy.h#L43-L89
+/// History: <https://github.com/zcash/zcash/blob/v6.10.0/src/policy/policy.h#L43-L89>
 pub const ONE_THIRD_DUST_THRESHOLD_RATE: u32 = 100;
 
 /// Arbitrary data inserted by miners into a coinbase transaction.
@@ -130,8 +130,7 @@ pub struct OutPoint {
     ///
     /// # Correctness
     ///
-    /// Consensus-critical serialization uses
-    /// [`ZcashSerialize`](crate::serialization::ZcashSerialize).
+    /// Consensus-critical serialization uses [`ZcashSerialize`].
     /// [`serde`]-based hex serialization must only be used for testing.
     #[cfg_attr(any(test, feature = "proptest-impl"), serde(with = "hex"))]
     pub hash: transaction::Hash,

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -1071,17 +1071,17 @@ fn add_some_stuff_to_mempool(
     mempool_service: &mut Mempool,
     network: Network,
 ) -> Vec<VerifiedUnminedTx> {
-    // get the genesis block coinbase transaction from the Zcash blockchain.
-    let genesis_transactions: Vec<_> = network
-        .unmined_transactions_in_blocks(..=0)
-        .take(1)
-        .collect();
-
-    // Insert the genesis block coinbase transaction into the mempool storage.
-    mempool_service
-        .storage()
-        .insert(genesis_transactions[0].clone(), Vec::new(), None)
+    // get the last transaction from the Zcash blockchain.
+    let last_transaction = network
+        .unmined_transactions_in_blocks(..=10)
+        .last()
         .unwrap();
 
-    genesis_transactions
+    // Insert the last transaction into the mempool storage.
+    mempool_service
+        .storage()
+        .insert(last_transaction.clone(), Vec::new(), None)
+        .unwrap();
+
+    vec![last_transaction]
 }

--- a/zebrad/src/components/mempool/error.rs
+++ b/zebrad/src/components/mempool/error.rs
@@ -9,7 +9,8 @@ use thiserror::Error;
 use proptest_derive::Arbitrary;
 
 use super::storage::{
-    ExactTipRejectionError, SameEffectsChainRejectionError, SameEffectsTipRejectionError,
+    ExactTipRejectionError, NonStandardTransactionError, SameEffectsChainRejectionError,
+    SameEffectsTipRejectionError,
 };
 
 /// Mempool errors.
@@ -74,4 +75,8 @@ pub enum MempoolError {
     /// Zebra enables the mempool when it is at the chain tip.
     #[error("mempool is disabled since synchronization is behind the chain tip")]
     Disabled,
+
+    /// The transaction is non-standard.
+    #[error("transaction is non-standard")]
+    NonStandardTransaction(#[from] NonStandardTransactionError),
 }

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -58,6 +58,8 @@ pub(crate) const MAX_EVICTION_MEMORY_ENTRIES: usize = 40_000;
 pub enum ExactTipRejectionError {
     #[error("transaction did not pass consensus validation: {0}")]
     FailedVerification(#[from] zebra_consensus::error::TransactionError),
+    #[error("transaction did not pass standard validation: {0}")]
+    FailedStandard(#[from] NonStandardTransactionError),
 }
 
 /// Transactions rejected based only on their effects (spends, outputs, transaction header).
@@ -121,6 +123,16 @@ pub enum RejectionError {
     SameEffectsTip(#[from] SameEffectsTipRejectionError),
     #[error(transparent)]
     SameEffectsChain(#[from] SameEffectsChainRejectionError),
+    #[error(transparent)]
+    NonStandardTransaction(#[from] NonStandardTransactionError),
+}
+
+/// Non-standard transaction error.
+#[derive(Error, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
+pub enum NonStandardTransactionError {
+    #[error("transaction is dust")]
+    IsDust,
 }
 
 /// Represents a set of transactions that have been removed from the mempool, either because
@@ -205,6 +217,33 @@ impl Storage {
         }
     }
 
+    /// Check whether a transaction is standard.
+    ///
+    /// Zcashd defines non-consensus standard transaction checks in
+    /// https://github.com/zcash/zcash/blob/v6.10.0/src/policy/policy.cpp#L58-L135
+    ///
+    /// This checks are applied before inserting a transaction in `AcceptToMemoryPool`:
+    /// https://github.com/zcash/zcash/blob/v6.10.0/src/main.cpp#L1819
+    ///
+    /// Currently, we only implement the dust output check.
+    fn is_standard_tx(&mut self, tx: &VerifiedUnminedTx) -> Result<(), MempoolError> {
+        // TODO: implement other standard transaction checks from zcashd.
+
+        if tx.height.unwrap_or_default() > Height::MIN {
+            // Check for dust outputs.
+            for output in tx.transaction.transaction.outputs() {
+                if output.is_dust() {
+                    let rejection_error = NonStandardTransactionError::IsDust;
+                    self.reject(tx.transaction.id, rejection_error.clone().into());
+
+                    return Err(MempoolError::NonStandardTransaction(rejection_error));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Insert a [`VerifiedUnminedTx`] into the mempool, caching any rejections.
     ///
     /// Accepts the [`VerifiedUnminedTx`] being inserted and `spent_mempool_outpoints`,
@@ -224,6 +263,9 @@ impl Storage {
         spent_mempool_outpoints: Vec<transparent::OutPoint>,
         height: Option<Height>,
     ) -> Result<UnminedTxId, MempoolError> {
+        // Check that the transaction is standard.
+        self.is_standard_tx(&tx)?;
+
         // # Security
         //
         // This method must call `reject`, rather than modifying the rejection lists directly.
@@ -596,6 +638,12 @@ impl Storage {
                         EvictionList::new(MAX_EVICTION_MEMORY_ENTRIES, eviction_memory_time)
                     })
                     .insert(tx_id.mined_id());
+            }
+            RejectionError::NonStandardTransaction(e) => {
+                // Non-standard transactions are rejected based on their exact
+                // transaction data.
+                self.tip_rejected_exact
+                    .insert(tx_id, ExactTipRejectionError::from(e));
             }
         }
         self.limit_rejection_list_memory();

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -229,15 +229,13 @@ impl Storage {
     fn is_standard_tx(&mut self, tx: &VerifiedUnminedTx) -> Result<(), MempoolError> {
         // TODO: implement other standard transaction checks from zcashd.
 
-        if tx.height.unwrap_or_default() > Height::MIN {
-            // Check for dust outputs.
-            for output in tx.transaction.transaction.outputs() {
-                if output.is_dust() {
-                    let rejection_error = NonStandardTransactionError::IsDust;
-                    self.reject(tx.transaction.id, rejection_error.clone().into());
+        // Check for dust outputs.
+        for output in tx.transaction.transaction.outputs() {
+            if output.is_dust() {
+                let rejection_error = NonStandardTransactionError::IsDust;
+                self.reject(tx.transaction.id, rejection_error.clone().into());
 
-                    return Err(MempoolError::NonStandardTransaction(rejection_error));
-                }
+                return Err(MempoolError::NonStandardTransaction(rejection_error));
             }
         }
 

--- a/zebrad/src/components/mempool/storage/tests/prop.rs
+++ b/zebrad/src/components/mempool/storage/tests/prop.rs
@@ -217,6 +217,7 @@ proptest! {
                 // used.
                 match rejection_error {
                     RejectionError::ExactTip(_) |
+                    RejectionError::NonStandardTransaction(_) |
                     RejectionError::SameEffectsTip(_) => {
                         prop_assert_eq!(storage.rejected_transaction_count(), 0);
                     },

--- a/zebrad/src/components/mempool/storage/tests/vectors.rs
+++ b/zebrad/src/components/mempool/storage/tests/vectors.rs
@@ -38,7 +38,7 @@ fn mempool_storage_crud_exact_mainnet() {
     // Get one (1) unmined transaction
     let unmined_tx = network
         .unmined_transactions_in_blocks(..)
-        .next()
+        .next_back()
         .expect("at least one unmined transaction");
 
     // Insert unmined tx into the mempool.
@@ -166,7 +166,7 @@ fn mempool_storage_crud_same_effects_mainnet() {
     // Get one (1) unmined transaction
     let unmined_tx_1 = network
         .unmined_transactions_in_blocks(..)
-        .next()
+        .next_back()
         .expect("at least one unmined transaction");
 
     // Insert unmined tx into the mempool.


### PR DESCRIPTION
## Motivation

We want to implement the non-consensus checks that `zcashd` performs for non-standard transactions. As a first step, this PR introduces the dust filter for transparent outputs.

Closes https://github.com/ZcashFoundation/zebra/issues/10094

## Solution

- Added an `is_standard_tx` function to check whether a transaction contains dust outputs.
- Added this check to `Mempool::Storage::insert`. At this stage, the transaction has already passed consensus and structural verification, but may still be rejected as non-standard. Transactions rejected due to dust (or any future non-standard reason) are added to the mempool’s rejected list and are not broadcast to peers.

### Tests

- Existing tests already cover successful insertion and rejection for other reasons.
- Added a new test specifically verifying that transactions are rejected due to dust.

### Follow-up Work

- [ ] Create an issue to implement the remaining non-standard transaction checks.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.
