### PR TITLE
fix(Docker): Fix logging of commit IDs

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -30,6 +30,7 @@ jobs:
       dockerfile_path: ./docker/Dockerfile
       dockerfile_target: runtime
       image_name: zebra
+      short_sha: ''
       features: ${{ vars.RUST_PROD_FEATURES }}
       rust_log: ${{ vars.RUST_LOG }}
       # Enable Docker Hub publishing for official releases (this is the single source of truth for production images)

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -55,6 +55,10 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
           persist-credentials: false
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@c33ff65466c58d57e4d796f88bb1ae0ff26ee453 #v5.2.0
+        with:
+          short-length: 7
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
       - name: Build & push
@@ -66,7 +70,7 @@ jobs:
           file: docker/Dockerfile
           tags: zebrad-test:${{ github.sha }}
           build-args: |
-            SHORT_SHA=${{ github.sha }}
+            SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}
             CARGO_INCREMENTAL=1
           outputs: type=docker,dest=${{ runner.temp }}/zebrad-test.tar
 
@@ -151,11 +155,6 @@ jobs:
         run: |
           docker load --input ${{ runner.temp }}/zebrad-test.tar
           docker image ls -a
-
-      - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@c33ff65466c58d57e4d796f88bb1ae0ff26ee453 #v5.2.0
-        with:
-          short-length: 7
 
       - name: Run ${{ matrix.name }} test
         # Only run custom-conf test if the config file exists in the built image

--- a/.github/workflows/zfnd-build-docker-image.yml
+++ b/.github/workflows/zfnd-build-docker-image.yml
@@ -20,8 +20,10 @@ on:
         required: true
         type: string
       short_sha:
+        description: "Git short SHA to embed in the build. Defaults to GITHUB_SHA_SHORT. Pass empty string to disable."
         required: false
         type: string
+        default: auto
       rust_backtrace:
         required: false
         type: string
@@ -201,7 +203,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}
+            SHORT_SHA=${{ inputs.short_sha == 'auto' && env.GITHUB_SHA_SHORT || inputs.short_sha }}
             RUST_LOG=${{ env.RUST_LOG }}
             CARGO_INCREMENTAL=${{ env.CARGO_INCREMENTAL }}
             FEATURES=${{ env.FEATURES }}
@@ -227,7 +229,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            SHORT_SHA=${{ env.GITHUB_SHA_SHORT }}
+            SHORT_SHA=${{ inputs.short_sha == 'auto' && env.GITHUB_SHA_SHORT || inputs.short_sha }}
             RUST_LOG=${{ env.RUST_LOG }}
             CARGO_INCREMENTAL=${{ env.CARGO_INCREMENTAL }}
             FEATURES=${{ env.FEATURES }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,18 +48,13 @@ ENV CARGO_HOME=${CARGO_HOME}
 ARG CARGO_TARGET_DIR
 ENV CARGO_TARGET_DIR=${CARGO_TARGET_DIR}
 
-# If this is not set, it must be an empty string, so Zebra can try an
-# alternative git commit source:
-# https://github.com/ZcashFoundation/zebra/blob/9ebd56092bcdfc1a09062e15a0574c94af37f389/zebrad/src/application.rs#L179-L182
-ARG SHORT_SHA
-ENV SHORT_SHA=${SHORT_SHA:-}
-
 # This stage builds tests without running them.
 #
 # We also download needed dependencies for tests to work, from other images.
 # An entrypoint.sh is only available in this step for easier test handling with variables.
 FROM deps AS tests
 
+ARG SHORT_SHA
 ARG FEATURES
 ENV FEATURES=${FEATURES}
 
@@ -107,7 +102,8 @@ COPY --link --chown=${UID}:${GID} ./ ${HOME}
 
 # Build Zebra test binaries using nextest, but don't run them.
 # This also copies the necessary binaries to /usr/local/bin.
-RUN cargo nextest run --locked --release --no-run --features "${FEATURES}" && \
+RUN [ -n "${SHORT_SHA}" ] && export SHORT_SHA="${SHORT_SHA}" || true; \
+    cargo nextest run --locked --release --no-run --features "${FEATURES}" && \
     # Copy binaries to standard location
     cp ${CARGO_TARGET_DIR}/release/zebrad /usr/local/bin && \
     # Only copy zebra-checkpoints if the feature is enabled
@@ -136,6 +132,7 @@ CMD [ "cargo", "test" ]
 # `test` stage. The resulting zebrad binary is used in the `runtime` stage.
 FROM deps AS release
 
+ARG SHORT_SHA
 ARG FEATURES
 ENV FEATURES=${FEATURES}
 
@@ -162,6 +159,7 @@ RUN --mount=type=bind,source=tower-batch-control,target=tower-batch-control \
     --mount=type=bind,source=Cargo.lock,target=Cargo.lock \
     --mount=type=cache,target=${CARGO_TARGET_DIR} \
     --mount=type=cache,target=${CARGO_HOME} \
+    [ -n "${SHORT_SHA}" ] && export SHORT_SHA="${SHORT_SHA}" || true; \
     cargo build --locked --release --features "${FEATURES}" --package zebrad --bin zebrad && \
     cp ${CARGO_TARGET_DIR}/release/zebrad /usr/local/bin
 


### PR DESCRIPTION
## Motivation

- Close #10130.

## Solution

- [Do not pass short SHA to production images](https://github.com/ZcashFoundation/zebra/commit/55702ebf3ac8cbfa6d3a43f1d0d99cfc67ff62f3).
- [Use short SHA only if it is set in Docker](https://github.com/ZcashFoundation/zebra/commit/f3427f646515c12a85f8e6fddb10ec19938204a1).

### Tests

- Manually checked that the `zebrad` field is not present in logs in a container running from a locally built image:
  
  ```
  2025-11-27T09:14:15.363752Z  INFO {net="Main"}: zebrad::commands::start: Starting zebrad
  ```

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.
