### PR TITLE
fix(ci): Use configurable runners for Docker builds to fix disk space failures

### DIFF
--- a/.github/workflows/zfnd-build-docker-image.yml
+++ b/.github/workflows/zfnd-build-docker-image.yml
@@ -82,14 +82,20 @@ jobs:
       - name: Set build matrix
         id: set-matrix
         run: |
+          # Runners are configurable via repository variables to allow larger runners
+          # for ZcashFoundation (more disk space) while forks use default runners.
+          AMD64_RUNNER="${{ vars.DOCKER_BUILD_RUNNER_AMD64 || 'ubuntu-latest' }}"
+          ARM64_RUNNER="${{ vars.DOCKER_BUILD_RUNNER_ARM64 || 'ubuntu-24.04-arm' }}"
+
           # Runtime builds: AMD64 + ARM64 (multi-arch)
           # Other targets: AMD64 only (lightwalletd dependency)
           if [[ "${{ inputs.dockerfile_target }}" == "runtime" ]]; then
-            MATRIX='{"include":[{"platform":"linux/amd64","runner":"ubuntu-latest"},{"platform":"linux/arm64","runner":"ubuntu-24.04-arm"}]}'
+            MATRIX='{"include":[{"platform":"linux/amd64","runner":"'"$AMD64_RUNNER"'"},{"platform":"linux/arm64","runner":"'"$ARM64_RUNNER"'"}]}'
           else
-            MATRIX='{"include":[{"platform":"linux/amd64","runner":"ubuntu-latest"}]}'
+            MATRIX='{"include":[{"platform":"linux/amd64","runner":"'"$AMD64_RUNNER"'"}]}'
           fi
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
+          echo "Runners: AMD64=$AMD64_RUNNER, ARM64=$ARM64_RUNNER"
           echo "Platforms: $(echo $MATRIX | jq -r '.include[].platform' | paste -sd ',' -)"
 
   build:


### PR DESCRIPTION
## Motivation

Docker builds are failing with `No space left on device` after PR #10097 added `debug = "line-tables-only"` to release builds, which increases compilation artifact sizes beyond the ~14GB available on standard GitHub runners.

Closes #10126

## Solution

Add repository variables `DOCKER_BUILD_RUNNER_AMD64` and `DOCKER_BUILD_RUNNER_ARM64` to allow configurable runner types:

- **Forks**: Use default `ubuntu-latest` and `ubuntu-24.04-arm` (no configuration needed)
- **ZcashFoundation**: Configure larger runners with more disk space

This follows the existing pattern used for `vars.DOCKER_BUILDER`, `vars.RUST_LOG`, etc.

### Changes

- Updated `prepare-matrix` job to use `vars.DOCKER_BUILD_RUNNER_AMD64` with `ubuntu-latest` fallback
- Updated `prepare-matrix` job to use `vars.DOCKER_BUILD_RUNNER_ARM64` with `ubuntu-24.04-arm` fallback
- Added runner info to build matrix output for debugging

### Tests

- Forks will continue working with default runners (no configuration required)
- ZcashFoundation works by setting`DOCKER_BUILD_RUNNER_AMD64` to a larger runner.

### Follow-up Work

- Set repository variable `DOCKER_BUILD_RUNNER_AMD64` to `ubuntu-latest-m` (or similar larger runner)
- `DOCKER_BUILD_RUNNER_ARM64` can remain unset unless ARM builds also need more resources

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.