### PR TITLE
fix(ci): Login to DockerHub for Docker Scout on release PRs

### DIFF
--- a/.github/workflows/zfnd-build-docker-image.yml
+++ b/.github/workflows/zfnd-build-docker-image.yml
@@ -325,8 +325,11 @@ jobs:
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 
+      # Login to DockerHub when:
+      # 1. Publishing images for a release (not prerelease), OR
+      # 2. Running Docker Scout on release PRs (requires DockerHub authentication)
       - name: Login to DockerHub
-        if: inputs.publish_to_dockerhub && github.event_name == 'release' && !github.event.release.prerelease
+        if: (inputs.publish_to_dockerhub && github.event_name == 'release' && !github.event.release.prerelease) || (inputs.dockerfile_target == 'runtime' && contains(github.event.pull_request.title, 'Release v'))
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef #v3.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## Motivation

Fix Docker Scout authentication failure on release PRs.

The error was: `could not authenticate: user githubactions not entitled to use Docker Scout`

See: https://github.com/ZcashFoundation/zebra/actions/runs/19766249660/job/56639855916?pr=10145

## Solution

Docker Scout requires DockerHub authentication to run. The DockerHub login step in the `merge` job was only configured for release events:

```yaml
if: inputs.publish_to_dockerhub && github.event_name == 'release' && !github.event.release.prerelease
```

However, Docker Scout also runs on PRs with "Release v" in the title:

```yaml
if: inputs.dockerfile_target == 'runtime' && contains(github.event.pull_request.title, 'Release v')
```

This mismatch caused the login to be skipped on release PRs while Docker Scout still attempted to run.

The fix extends the DockerHub login condition to also run when Docker Scout will execute.

### Tests

- This will be validated when the CI runs on this PR or when PR #10145 is rebased on main after this merges.

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The solution is tested.