### PR TITLE
fix(ci): Prevent race condition in GCP static IP assignment

### DIFF
--- a/.github/workflows/zfnd-deploy-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-nodes-gcp.yml
@@ -340,6 +340,7 @@ jobs:
           --image-project=cos-cloud \
           --image-family=cos-stable \
           --subnet=${{ vars.GCP_SUBNETWORK }} \
+          --no-address `# Static IPs are assigned after MIG creation; avoids race conditions` \
           --create-disk="${DISK_PARAMS}" \
           --container-mount-disk=mount-path='/home/zebra/.cache/zebra',name=${DISK_NAME},mode=rw \
           --container-stdin \
@@ -454,6 +455,8 @@ jobs:
           IFS=$'\n' read -rd '' -a INSTANCE_ROWS <<<"$INSTANCE_DATA" || true
 
           # Loop to assign all IPs
+          # Note: Instance template uses --no-address, so instances start without external IP.
+          # This avoids race conditions with MIG trying to restore ephemeral IPs.
           for i in "${!INSTANCE_ROWS[@]}"; do
             [ -z "${IP_ADDRESSES[$i]}" ] && continue
 
@@ -462,19 +465,17 @@ jobs:
 
             echo "Assigning ${IP_ADDRESS} to ${INSTANCE_NAME} in zone ${ZONE}"
 
-            gcloud compute instances delete-access-config "${INSTANCE_NAME}" \
-              --access-config-name="external-nat" \
-              --zone="${ZONE}" || true
-
-            gcloud compute instances add-access-config "${INSTANCE_NAME}" \
-              --access-config-name="external-nat" \
-              --address="${IP_ADDRESS}" \
-              --zone="${ZONE}"
-
+            # First: Configure stateful IP policy (tells MIG to preserve this IP)
             gcloud compute instance-groups managed update-instances "${MIG_NAME}" \
               --instances="${INSTANCE_NAME}" \
               --stateful-external-ip "interface-name=nic0,address=${IP_ADDRESS},auto-delete=never" \
               --region "${{ vars.GCP_REGION }}"
+
+            # Then: Add the static IP access config to the instance
+            gcloud compute instances add-access-config "${INSTANCE_NAME}" \
+              --access-config-name="external-nat" \
+              --address="${IP_ADDRESS}" \
+              --zone="${ZONE}"
           done
 
       # Detect how many zones the MIG spans (needed for max-unavailable constraint)


### PR DESCRIPTION
## Motivation

Fixes a race condition in GCP MIG deployments where static IP assignment fails intermittently with "At most one access config currently supported".

Closes #10158

## Solution

1. Add `--no-address` to the instance template so instances start without external IPs
2. Remove `delete-access-config` call (no longer needed)
3. Reorder operations: set stateful IP policy before adding access config

The root cause was the MIG controller restoring ephemeral IPs after deletion, racing with the script trying to add static IPs.

### Tests

- Cannot be tested locally; requires a full GCP deployment
- The fix was derived from GCP documentation on stateful MIGs
- Existing MIGs with stateful IPs will continue to work (stateful per-instance config overrides template)

### Specifications & References

- [Configuring stateful IP addresses in MIGs](https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-ip-addresses-in-migs)
- Failed run: https://github.com/ZcashFoundation/zebra/actions/runs/19770436851/job/56653235554

### Follow-up Work

None

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [x] The documentation is up to date.
