### PR TITLE
feat: Precompute coinbase tx and respond quickly on tip change

### DIFF
--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `client::TransactionTemplate::from_coinbase()`; replaced by `new_coinbase()`
 - `server::http_request_compatibility::With` trait and its impls on `HttpRequestMiddleware`
-- `generate_coinbase_and_roots()`; replaced by `new_coinbase_with_roots()`
+- `fetch_state_tip_and_local_time()`; replaced by `fetch_chain_info()`
+- `generate_coinbase_and_roots()`; replaced by `TransactionTemplate::new_coinbase()` and `DefaultRoots::from_coinbase()`
+
+### Changed
+
+- `client::DefaultRoots::from_coinbase()` return type changed from `Result<Self, Box<dyn Error>>` to `Self`
+- `client::TransactionTemplate::new_coinbase()` parameter changed from `mempool_txs` to `txs_fee: Amount<NonNegative>`
 
 ### Added
 
@@ -27,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `MinerAddressTypeIter` struct (strum-derived iterator for `MinerAddressType`)
   - `Config::miner_memo` field
   - `default_miner_address()` function
-- `new_coinbase_with_roots()`; replacement for removed `generate_coinbase_and_roots()`
+- `fetch_chain_info()`; replacement for removed `fetch_state_tip_and_local_time()`
 
 ## [7.0.0] - 2026-05-01
 

--- a/zebra-rpc/src/lib.rs
+++ b/zebra-rpc/src/lib.rs
@@ -16,9 +16,6 @@ pub mod sync;
 mod tests;
 
 pub use methods::types::{
-    get_block_template::{
-        fetch_state_tip_and_local_time, new_coinbase_with_roots,
-        proposal::proposal_block_from_template, MinerParams,
-    },
+    get_block_template::{fetch_chain_info, proposal::proposal_block_from_template, MinerParams},
     submit_block::SubmitBlockChannel,
 };

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -2360,6 +2360,8 @@ where
             // The clone preserves the seen status of the chain tip.
             let mut wait_for_new_tip = latest_chain_tip.clone();
             let wait_for_new_tip = wait_for_new_tip.best_tip_changed();
+            // `+2`: we expect the tip to advance by one block before waking us up.
+            let precomputed_height = Height(chain_info.tip_height.0 + 2);
             let wait_for_new_tip = async {
                 // Precompute the coinbase tx for an empty block that will sit on the new tip. We
                 // will return this provisional block upon a chain tip change so that miners can
@@ -2377,7 +2379,7 @@ where
 
                 let precomputed_coinbase = precompute_coinbase(
                     self.network.clone(),
-                    Height(chain_info.tip_height.0 + 2),
+                    precomputed_height,
                     miner_params.clone(),
                 )
                 .await
@@ -2445,12 +2447,19 @@ where
                         .as_ref()
                         .map(|old_long_poll_id| server_long_poll_id.submit_old(old_long_poll_id));
 
+                    // Discard the precomputed coinbase if our `+2` guess was wrong
+                    // (multi-block advance, reorg, or spurious notification) — its
+                    // BIP-34 height and subsidies wouldn't match the block.
+                    let next_height = chain_info.tip_height.next().map_misc_error()?;
+                    let precomputed_coinbase = (next_height == precomputed_height)
+                        .then_some(precomputed_coinbase);
+
                     // Respond instantly with an empty block upon a chain tip change so that
                     // the miner doesn't waste their effort trying to extend a shorter
                     // chain.
                     return Ok(BlockTemplateResponse::new_internal(
                         &self.network,
-                        Some(precomputed_coinbase),
+                        precomputed_coinbase,
                         miner_params,
                         &chain_info,
                         server_long_poll_id,

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -92,6 +92,7 @@ use zebra_state::{
 };
 
 use crate::{
+    client::TransactionTemplate,
     client::Treestate,
     config,
     methods::types::{
@@ -2218,9 +2219,8 @@ where
         parameters: Option<GetBlockTemplateParameters>,
     ) -> Result<GetBlockTemplateResponse> {
         use types::get_block_template::{
-            check_parameters, check_synced_to_tip, fetch_mempool_transactions,
-            fetch_state_tip_and_local_time, validate_block_proposal,
-            zip317::select_mempool_transactions,
+            check_parameters, check_synced_to_tip, fetch_chain_info, fetch_mempool_transactions,
+            validate_block_proposal, zip317::select_mempool_transactions,
         };
 
         // Clone Services
@@ -2248,20 +2248,18 @@ where
 
         let client_long_poll_id = parameters.as_ref().and_then(|params| params.long_poll_id);
 
+        let miner_params = self
+            .gbt
+            .miner_params()
+            .ok_or_error(0, "miner parameters are required for get_block_template")?;
+
         // - Checks and fetches that can change during long polling
         //
         // Set up the loop.
         let mut max_time_reached = false;
 
-        // The loop returns the server long poll ID,
-        // which should be different to the client long poll ID.
-        let (
-            server_long_poll_id,
-            chain_tip_and_local_time,
-            mempool_txs,
-            mempool_tx_deps,
-            submit_old,
-        ) = loop {
+        // The loop returns the server long poll ID, which should be different to the client one.
+        let (server_long_poll_id, chain_info, mempool_txs, mempool_tx_deps, submit_old) = loop {
             // Check if we are synced to the tip.
             // The result of this check can change during long polling.
             //
@@ -2283,13 +2281,13 @@ where
             //
             // We always return after 90 minutes on mainnet, even if we have the same response,
             // because the max time has been reached.
-            let chain_tip_and_local_time @ zebra_state::GetBlockTemplateChainInfo {
+            let chain_info @ zebra_state::GetBlockTemplateChainInfo {
                 tip_hash,
                 tip_height,
                 max_time,
                 cur_time,
                 ..
-            } = fetch_state_tip_and_local_time(read_state.clone()).await?;
+            } = fetch_chain_info(read_state.clone()).await?;
 
             // Fetch the mempool data for the block template:
             // - if the mempool transactions change, we might return from long polling.
@@ -2326,21 +2324,20 @@ where
             // - the server long poll ID is different to the client long poll ID, or
             // - the previous loop iteration waited until the max time.
             if Some(&server_long_poll_id) != client_long_poll_id.as_ref() || max_time_reached {
-                let mut submit_old = client_long_poll_id
-                    .as_ref()
-                    .map(|old_long_poll_id| server_long_poll_id.submit_old(old_long_poll_id));
-
-                // On testnet, the max time changes the block difficulty, so old shares are
-                // invalid. On mainnet, this means there has been 90 minutes without a new
-                // block or mempool transaction, which is very unlikely. So the miner should
-                // probably reset anyway.
-                if max_time_reached {
-                    submit_old = Some(false);
-                }
+                // On testnet, the max time changes the block difficulty, so old shares are invalid.
+                // On mainnet, this means there has been 90 minutes without a new block or mempool
+                // transaction, which is very unlikely. So the miner should probably reset anyway.
+                let submit_old = if max_time_reached {
+                    Some(false)
+                } else {
+                    client_long_poll_id
+                        .as_ref()
+                        .map(|old_long_poll_id| server_long_poll_id.submit_old(old_long_poll_id))
+                };
 
                 break (
                     server_long_poll_id,
-                    chain_tip_and_local_time,
+                    chain_info,
                     mempool_txs,
                     mempool_tx_deps,
                     submit_old,
@@ -2361,8 +2358,35 @@ where
 
             // Return immediately if the chain tip has changed.
             // The clone preserves the seen status of the chain tip.
-            let mut wait_for_best_tip_change = latest_chain_tip.clone();
-            let wait_for_best_tip_change = wait_for_best_tip_change.best_tip_changed();
+            let mut wait_for_new_tip = latest_chain_tip.clone();
+            let wait_for_new_tip = wait_for_new_tip.best_tip_changed();
+            let wait_for_new_tip = async {
+                // Precompute the coinbase tx for an empty block that will sit on the new tip. We
+                // will return this provisional block upon a chain tip change so that miners can
+                // mine on the newest tip, and don't waste their effort on a shorter chain while we
+                // compute a new template for a properly filled block. We do this precomputation
+                // before we start waiting for a new tip since computing the coinbase tx takes a few
+                // seconds if the miner mines to a shielded address, and we want to return fast
+                // when the tip changes.
+                let precompute_coinbase = |network, height, params| {
+                    tokio::task::spawn_blocking(move || {
+                        TransactionTemplate::new_coinbase(&network, height, &params, Amount::zero())
+                            .expect("valid coinbase tx")
+                    })
+                };
+
+                let precomputed_coinbase = precompute_coinbase(
+                    self.network.clone(),
+                    Height(chain_info.tip_height.0 + 2),
+                    miner_params.clone(),
+                )
+                .await
+                .expect("valid coinbase tx");
+
+                let _ = wait_for_new_tip.await;
+
+                precomputed_coinbase
+            };
 
             // Wait for the maximum block time to elapse. This can change the block header
             // on testnet. (On mainnet it can happen due to a network disconnection, or a
@@ -2406,59 +2430,34 @@ where
                     );
                 }
 
-                // The state changes after around a target block interval (75s)
-                tip_changed_result = wait_for_best_tip_change => {
-                    match tip_changed_result {
-                        Ok(()) => {
-                            // Spurious updates shouldn't happen in the state, because the
-                            // difficulty and hash ordering is a stable total order. But
-                            // since they could cause a busy-loop, guard against them here.
-                            latest_chain_tip.mark_best_tip_seen();
+                precomputed_coinbase = wait_for_new_tip => {
+                    let chain_info = fetch_chain_info(read_state.clone()).await?;
 
-                            let new_tip_hash = latest_chain_tip.best_tip_hash();
-                            if new_tip_hash == Some(tip_hash) {
-                                tracing::debug!(
-                                    ?max_time,
-                                    ?cur_time,
-                                    ?server_long_poll_id,
-                                    ?client_long_poll_id,
-                                    ?tip_hash,
-                                    ?tip_height,
-                                    "ignoring spurious state change notification"
-                                );
+                    let server_long_poll_id = LongPollInput::new(
+                        chain_info.tip_height,
+                        chain_info.tip_hash,
+                        chain_info.max_time,
+                        vec![]
+                    )
+                    .generate_id();
 
-                                // Wait for the mempool interval, then check for any changes.
-                                tokio::time::sleep(Duration::from_secs(
-                                    MEMPOOL_LONG_POLL_INTERVAL,
-                                )).await;
+                    let submit_old = client_long_poll_id
+                        .as_ref()
+                        .map(|old_long_poll_id| server_long_poll_id.submit_old(old_long_poll_id));
 
-                                continue;
-                            }
-
-                            tracing::debug!(
-                                ?max_time,
-                                ?cur_time,
-                                ?server_long_poll_id,
-                                ?client_long_poll_id,
-                                "returning from long poll because state has changed"
-                            );
-                        }
-
-                        Err(recv_error) => {
-                            // This log is rare and helps with debugging, so it's ok to be info.
-                            tracing::info!(
-                                ?recv_error,
-                                ?max_time,
-                                ?cur_time,
-                                ?server_long_poll_id,
-                                ?client_long_poll_id,
-                                "returning from long poll due to a state error.\
-                                Is Zebra shutting down?"
-                            );
-
-                            return Err(recv_error).map_error(server::error::LegacyCode::default());
-                        }
-                    }
+                    // Respond instantly with an empty block upon a chain tip change so that
+                    // the miner doesn't waste their effort trying to extend a shorter
+                    // chain.
+                    return Ok(BlockTemplateResponse::new_internal(
+                        &self.network,
+                        Some(precomputed_coinbase),
+                        miner_params,
+                        &chain_info,
+                        server_long_poll_id,
+                        vec![],
+                        submit_old,
+                    )
+                    .into())
                 }
 
                 // The max time does not elapse during normal operation on mainnet,
@@ -2492,16 +2491,7 @@ where
             "selecting transactions for the template from the mempool"
         );
 
-        let miner_params = self.gbt.miner_params().ok_or_error(
-            0,
-            "miner parameters must be present to generate a coinbase transaction",
-        )?;
-
-        // Determine the next block height.
-        let height = chain_tip_and_local_time
-            .tip_height
-            .next()
-            .expect("chain tip must be below Height::MAX");
+        let height = chain_info.tip_height.next().map_misc_error()?;
 
         // Randomly select some mempool transactions.
         let mempool_txs = select_mempool_transactions(
@@ -2524,18 +2514,18 @@ where
 
         // - After this point, the template only depends on the previously fetched data.
 
-        let response = BlockTemplateResponse::new_internal(
+        Ok(BlockTemplateResponse::new_internal(
             &self.network,
+            None,
             miner_params,
-            &chain_tip_and_local_time,
+            &chain_info,
             server_long_poll_id,
             mempool_txs,
             submit_old,
             #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             None,
-        );
-
-        Ok(response.into())
+        )
+        .into())
     }
 
     async fn submit_block(

--- a/zebra-rpc/src/methods/types/default_roots.rs
+++ b/zebra-rpc/src/methods/types/default_roots.rs
@@ -61,13 +61,13 @@ impl DefaultRoots {
         coinbase: &TransactionTemplate<NegativeOrZero>,
         chain_history_root: Option<ChainHistoryMmrRootHash>,
         mempool_txs: &[VerifiedUnminedTx],
-    ) -> Result<Self, Box<dyn std::error::Error>> {
+    ) -> Self {
         let chain_history_root = chain_history_root
             .or_else(|| {
                 (NetworkUpgrade::Heartwood.activation_height(net) == Some(height))
                     .then_some(block::CHAIN_HISTORY_ACTIVATION_RESERVED.into())
             })
-            .ok_or("chain history root is required")?;
+            .expect("history root is required for block templates");
 
         // TODO:
         // Computing `auth_data_root` and `merkle_root` gets more expensive as `mempool_txs` grows.
@@ -82,7 +82,7 @@ impl DefaultRoots {
             }))
             .collect();
 
-        Ok(Self {
+        Self {
             merkle_root: iter::once(coinbase.hash)
                 .chain(mempool_txs.iter().map(|tx| tx.transaction.id.mined_id()))
                 .collect(),
@@ -99,6 +99,6 @@ impl DefaultRoots {
                     &auth_data_root,
                 )
             },
-        })
+        }
     }
 }

--- a/zebra-rpc/src/methods/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/types/get_block_template.rs
@@ -30,10 +30,9 @@ use zcash_script::{
 #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
 use zebra_chain::amount::{Amount, NonNegative};
 use zebra_chain::{
-    amount::{self, NegativeOrZero},
+    amount::{self, Amount, NonNegative},
     block::{
-        self, Block, ChainHistoryBlockTxAuthCommitmentHash, ChainHistoryMmrRootHash, Height,
-        MAX_BLOCK_BYTES, ZCASH_BLOCK_VERSION,
+        self, Block, ChainHistoryBlockTxAuthCommitmentHash, MAX_BLOCK_BYTES, ZCASH_BLOCK_VERSION,
     },
     chain_sync_status::ChainSyncStatus,
     chain_tip::ChainTip,
@@ -274,9 +273,10 @@ impl BlockTemplateResponse {
     /// The result of this method only depends on the supplied arguments and constants.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_internal(
-        network: &Network,
+        net: &Network,
+        precomputed_coinbase: Option<TransactionTemplate<amount::NegativeOrZero>>,
         miner_params: &MinerParams,
-        chain_tip_and_local_time: &GetBlockTemplateChainInfo,
+        chain_info: &GetBlockTemplateChainInfo,
         long_poll_id: LongPollId,
         #[cfg(not(test))] mempool_txs: Vec<VerifiedUnminedTx>,
         #[cfg(test)] mempool_txs: Vec<(InBlockTxDependenciesDepth, VerifiedUnminedTx)>,
@@ -286,7 +286,7 @@ impl BlockTemplateResponse {
         >,
     ) -> Self {
         // Determine the next block height.
-        let height = chain_tip_and_local_time
+        let height = chain_info
             .tip_height
             .next()
             .expect("chain tip must be below Height::MAX");
@@ -327,22 +327,34 @@ impl BlockTemplateResponse {
                 .unzip()
         };
 
-        // Generate the coinbase transaction and default roots
-        //
-        // TODO: move expensive root, hash, and tree cryptography to a rayon thread?
-        let (coinbase_txn, default_roots) = new_coinbase_with_roots(
-            network,
+        let txs_fee = mempool_txs
+            .iter()
+            .map(|tx| tx.miner_fee)
+            .sum::<amount::Result<Amount<NonNegative>>>()
+            .expect("mempool tx fees must be non-negative");
+
+        let coinbase_txn = precomputed_coinbase.unwrap_or(
+            TransactionTemplate::new_coinbase(
+                net,
+                height,
+                miner_params,
+                txs_fee,
+                #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+                zip233_amount,
+            )
+            .expect("valid coinbase tx"),
+        );
+
+        let default_roots = DefaultRoots::from_coinbase(
+            net,
             height,
-            miner_params,
+            &coinbase_txn,
+            chain_info.chain_history_root,
             &mempool_txs,
-            chain_tip_and_local_time.chain_history_root,
-            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
-            zip233_amount,
-        )
-        .expect("coinbase should be valid under the given parameters");
+        );
 
         // Convert difficulty
-        let target = chain_tip_and_local_time
+        let target = chain_info
             .expected_difficulty
             .to_expanded()
             .expect("state always returns a valid difficulty value");
@@ -364,7 +376,7 @@ impl BlockTemplateResponse {
 
             version: ZCASH_BLOCK_VERSION,
 
-            previous_block_hash: chain_tip_and_local_time.tip_hash,
+            previous_block_hash: chain_info.tip_hash,
             block_commitments_hash: default_roots.block_commitments_hash,
             light_client_root_hash: default_roots.block_commitments_hash,
             final_sapling_root_hash: default_roots.block_commitments_hash,
@@ -378,7 +390,7 @@ impl BlockTemplateResponse {
 
             target,
 
-            min_time: chain_tip_and_local_time.min_time,
+            min_time: chain_info.min_time,
 
             mutable,
 
@@ -388,13 +400,13 @@ impl BlockTemplateResponse {
 
             size_limit: MAX_BLOCK_BYTES,
 
-            cur_time: chain_tip_and_local_time.cur_time,
+            cur_time: chain_info.cur_time,
 
-            bits: chain_tip_and_local_time.expected_difficulty,
+            bits: chain_info.expected_difficulty,
 
             height: height.0,
 
-            max_time: chain_tip_and_local_time.max_time,
+            max_time: chain_info.max_time,
 
             submit_old,
         }
@@ -780,9 +792,7 @@ where
 ///
 /// You should call `check_synced_to_tip()` before calling this function.
 /// If the state does not have enough blocks, returns an error.
-pub async fn fetch_state_tip_and_local_time<State>(
-    state: State,
-) -> RpcResult<GetBlockTemplateChainInfo>
+pub async fn fetch_chain_info<State>(state: State) -> RpcResult<GetBlockTemplateChainInfo>
 where
     State: Service<
             zebra_state::ReadRequest,
@@ -842,30 +852,4 @@ where
 
     // Check that the mempool and state were in sync when we made the requests
     Ok((last_seen_tip_hash == chain_tip_hash).then_some((transactions, transaction_dependencies)))
-}
-
-// - Response processing
-
-/// Generates and returns the coinbase transaction and default roots.
-pub fn new_coinbase_with_roots(
-    net: &Network,
-    height: Height,
-    miner_params: &MinerParams,
-    mempool_txs: &[VerifiedUnminedTx],
-    chain_history_root: Option<ChainHistoryMmrRootHash>,
-    #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))] zip233_amount: Option<
-        Amount<NonNegative>,
-    >,
-) -> Result<(TransactionTemplate<NegativeOrZero>, DefaultRoots), Box<dyn std::error::Error>> {
-    let tx = TransactionTemplate::new_coinbase(
-        net,
-        height,
-        miner_params,
-        mempool_txs,
-        #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
-        zip233_amount,
-    )?;
-    let roots = DefaultRoots::from_coinbase(net, height, &tx, chain_history_root, mempool_txs)?;
-
-    Ok((tx, roots))
 }

--- a/zebra-rpc/src/methods/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/types/get_block_template.rs
@@ -333,7 +333,7 @@ impl BlockTemplateResponse {
             .sum::<amount::Result<Amount<NonNegative>>>()
             .expect("mempool tx fees must be non-negative");
 
-        let coinbase_txn = precomputed_coinbase.unwrap_or(
+        let coinbase_txn = precomputed_coinbase.unwrap_or_else(|| {
             TransactionTemplate::new_coinbase(
                 net,
                 height,
@@ -342,8 +342,8 @@ impl BlockTemplateResponse {
                 #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
                 zip233_amount,
             )
-            .expect("valid coinbase tx"),
-        );
+            .expect("valid coinbase tx")
+        });
 
         let default_roots = DefaultRoots::from_coinbase(
             net,

--- a/zebra-rpc/src/methods/types/get_block_template/tests.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/tests.rs
@@ -2,6 +2,7 @@
 
 use anyhow::anyhow;
 use std::iter;
+use zebra_chain::amount::Amount;
 
 use strum::IntoEnumIterator;
 use zcash_keys::address::Address;
@@ -79,7 +80,7 @@ fn coinbase() -> anyhow::Result<()> {
                             Address::decode(&net, default_miner_address(net.kind(), &addr_type))
                                 .ok_or(anyhow!("hard-coded addr must be valid"))?,
                         ),
-                        &[],
+                        Amount::zero(),
                         #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
                         None,
                     )?

--- a/zebra-rpc/src/methods/types/get_block_template/zip317.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/zip317.rs
@@ -14,6 +14,7 @@ use rand::{
 };
 
 use zebra_chain::{
+    amount::Amount,
     block::{Height, MAX_BLOCK_BYTES},
     parameters::Network,
     transaction::{self, zip317::BLOCK_UNPAID_ACTION_LIMIT, VerifiedUnminedTx},
@@ -72,7 +73,7 @@ pub fn select_mempool_transactions(
         net,
         height,
         miner_params,
-        &[],
+        Amount::zero(),
         #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
         zip233_amount,
     )

--- a/zebra-rpc/src/methods/types/transaction.rs
+++ b/zebra-rpc/src/methods/types/transaction.rs
@@ -129,19 +129,13 @@ impl TransactionTemplate<NegativeOrZero> {
         net: &Network,
         height: Height,
         miner_params: &MinerParams,
-        mempool_txs: &[VerifiedUnminedTx],
+        txs_fee: Amount<NonNegative>,
         #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))] zip233_amount: Option<
             Amount<NonNegative>,
         >,
     ) -> Result<Self, TransactionError> {
         let block_subsidy = block_subsidy(height, net)?;
-
-        let miner_fee = mempool_txs
-            .iter()
-            .map(|tx| tx.miner_fee)
-            .sum::<amount::Result<Amount<NonNegative>>>()?;
-
-        let miner_reward = miner_subsidy(height, net, block_subsidy)? + miner_fee;
+        let miner_reward = miner_subsidy(height, net, block_subsidy)? + txs_fee;
         let miner_reward = Zatoshis::try_from(miner_reward?)?;
 
         let mut builder = Builder::new(
@@ -152,8 +146,8 @@ impl TransactionTemplate<NegativeOrZero> {
             },
         );
 
-        let empty_memo = MemoBytes::empty();
-        let memo = miner_params.memo().unwrap_or(&empty_memo);
+        let default_memo = MemoBytes::empty();
+        let memo = miner_params.memo().unwrap_or(&default_memo);
 
         #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
         {
@@ -266,7 +260,7 @@ impl TransactionTemplate<NegativeOrZero> {
             hash: tx.txid().as_ref().into(),
             auth_digest: tx.auth_commitment().as_ref().try_into()?,
             depends: Vec::new(),
-            fee: (-miner_fee).constrain()?,
+            fee: (-txs_fee).constrain()?,
             sigops: tx.sigops()?,
             required: true,
         })

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -155,6 +155,7 @@ use serde_json::Value;
 use tower::ServiceExt;
 
 use zebra_chain::{
+    amount::Amount,
     block::{self, genesis::regtest_genesis_block, ChainHistoryBlockTxAuthCommitmentHash, Height},
     parameters::{
         testnet::{ConfiguredActivationHeights, ConfiguredCheckpoints, RegtestParameters},
@@ -166,12 +167,13 @@ use zebra_chain::{
 use zebra_node_services::rpc_client::RpcRequestClient;
 use zebra_rpc::{
     client::{
-        BlockTemplateResponse, GetBlockTemplateParameters, GetBlockTemplateRequestMode,
-        GetBlockTemplateResponse, SubmitBlockErrorResponse, SubmitBlockResponse,
+        BlockTemplateResponse, DefaultRoots, GetBlockTemplateParameters,
+        GetBlockTemplateRequestMode, GetBlockTemplateResponse, SubmitBlockErrorResponse,
+        SubmitBlockResponse, TransactionTemplate,
     },
-    fetch_state_tip_and_local_time,
+    fetch_chain_info,
     methods::{RpcImpl, RpcServer},
-    new_coinbase_with_roots, proposal_block_from_template,
+    proposal_block_from_template,
     server::OPENED_RPC_ENDPOINT_MSG,
     MinerParams, SubmitBlockChannel,
 };
@@ -3581,9 +3583,9 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
 
     let zebra_state::GetBlockTemplateChainInfo {
         chain_history_root, ..
-    } = fetch_state_tip_and_local_time(read_state.clone()).await?;
+    } = fetch_chain_info(read_state.clone()).await?;
 
-    let network = base_network_params
+    let net = base_network_params
         .clone()
         .with_funding_streams(vec![ConfiguredFundingStreams {
             height_range: Some(Height(1)..Height(100)),
@@ -3592,16 +3594,23 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
         .to_network()
         .expect("failed to build configured network");
 
-    let (coinbase_txn, default_roots) = new_coinbase_with_roots(
-        &network,
+    let coinbase_txn = TransactionTemplate::new_coinbase(
+        &net,
         Height(block_template.height()),
         &miner_params,
-        &[],
-        chain_history_root,
+        Amount::zero(),
         #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
         None,
     )
     .expect("coinbase transaction should be valid under the given parameters");
+
+    let default_roots = DefaultRoots::from_coinbase(
+        &net,
+        Height(block_template.height()),
+        &coinbase_txn,
+        chain_history_root,
+        &[],
+    );
 
     let block_template = BlockTemplateResponse::new(
         block_template.capabilities().clone(),
@@ -3627,7 +3636,7 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
         block_template.submit_old(),
     );
 
-    let proposal_block = proposal_block_from_template(&block_template, None, &network)?;
+    let proposal_block = proposal_block_from_template(&block_template, None, &net)?;
 
     // Submit the invalid block with an excessive coinbase output value
     let submit_block_response = rpc
@@ -3643,7 +3652,7 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
     );
 
     // Use an invalid coinbase transaction (with an output value less than the `block_subsidy + miner_fees - expected_lockbox_funding_stream`)
-    let network = base_network_params
+    let net = base_network_params
         .clone()
         .with_funding_streams(vec![ConfiguredFundingStreams {
             height_range: Some(Height(1)..Height(100)),
@@ -3652,16 +3661,23 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
         .to_network()
         .expect("failed to build configured network");
 
-    let (coinbase_txn, default_roots) = new_coinbase_with_roots(
-        &network,
+    let coinbase_txn = TransactionTemplate::new_coinbase(
+        &net,
         Height(block_template.height()),
         &miner_params,
-        &[],
-        chain_history_root,
+        Amount::zero(),
         #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
         None,
     )
     .expect("coinbase transaction should be valid under the given parameters");
+
+    let default_roots = DefaultRoots::from_coinbase(
+        &net,
+        Height(block_template.height()),
+        &coinbase_txn,
+        chain_history_root,
+        &[],
+    );
 
     let block_template = BlockTemplateResponse::new(
         block_template.capabilities().clone(),
@@ -3687,7 +3703,7 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
         block_template.submit_old(),
     );
 
-    let proposal_block = proposal_block_from_template(&block_template, None, &network)?;
+    let proposal_block = proposal_block_from_template(&block_template, None, &net)?;
 
     // Submit the invalid block with an excessive coinbase input value
     let submit_block_response = rpc
@@ -3703,8 +3719,7 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
     );
 
     // Check that the original block template can be submitted successfully
-    let proposal_block =
-        proposal_block_from_template(&valid_original_block_template, None, &network)?;
+    let proposal_block = proposal_block_from_template(&valid_original_block_template, None, &net)?;
 
     let submit_block_response = rpc
         .submit_block(HexData(proposal_block.zcash_serialize_to_vec()?), None)


### PR DESCRIPTION
## Motivation

- Close #9727.

## Solution

Precompute the coinbase tx for an empty block that will sit on the new tip. We will return this provisional block upon a chain tip change so that miners can mine on the newest tip, and don't waste their effort on a shorter chain while we compute a new template for a properly filled block. We do this precomputation before we start waiting for a new tip since computing the coinbase tx takes a few seconds if the miner mines to a shielded address, and we want to return fast when the tip changes.

### Tests

No new tests.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.
