### PR TITLE
feat(metrics): add value pool, RPC, and peer health metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-docs/
-!docs/**/*.md
 # Cargo files
 /coverage-target/
 # Legacy Zebra state (alpha versions only)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,6 @@ Thank you to everyone who contributed to this release, we couldn't make Zebra wi
 ### Added
 
 - Value pool metrics exposing transparent, sprout, sapling, orchard, and deferred pool balances plus total chain supply ([#10175](https://github.com/ZcashFoundation/zebra/pull/10175))
-- RPC metrics middleware tracking request counts, latencies, active requests, and errors per method ([#10175](https://github.com/ZcashFoundation/zebra/pull/10175))
 - Peer handshake metrics for duration histograms and failure tracking by reason ([#10175](https://github.com/ZcashFoundation/zebra/pull/10175))
 - Prometheus alert rules and Grafana dashboards for value pools and RPC monitoring ([#10175](https://github.com/ZcashFoundation/zebra/pull/10175))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,13 +53,10 @@ Thank you to everyone who contributed to this release, we couldn't make Zebra wi
 
 ### Added
 
-- OpenTelemetry tracing support behind the `opentelemetry` feature flag ([#10174](https://github.com/ZcashFoundation/zebra/pull/10174))
-- RPC tracing middleware with `SPAN_KIND_SERVER` spans for Jaeger Service Performance Monitoring ([#10174](https://github.com/ZcashFoundation/zebra/pull/10174))
-- Added Docker Compose observability stack with Jaeger, Prometheus, Grafana, and AlertManager for local development and testing
-- Added value pool metrics exposing transparent, sprout, sapling, orchard, and deferred pool balances plus total chain supply ([#10162](https://github.com/ZcashFoundation/zebra/issues/10162))
-- Added RPC metrics middleware tracking request counts, latencies, active requests, and errors per method ([#10163](https://github.com/ZcashFoundation/zebra/issues/10163))
-- Added peer handshake metrics for duration histograms and failure tracking by reason ([#10164](https://github.com/ZcashFoundation/zebra/issues/10164))
-- Added Prometheus alert rules and Grafana dashboards for value pools and RPC monitoring ([#10167](https://github.com/ZcashFoundation/zebra/issues/10167))
+- Value pool metrics exposing transparent, sprout, sapling, orchard, and deferred pool balances plus total chain supply ([#10175](https://github.com/ZcashFoundation/zebra/pull/10175))
+- RPC metrics middleware tracking request counts, latencies, active requests, and errors per method ([#10175](https://github.com/ZcashFoundation/zebra/pull/10175))
+- Peer handshake metrics for duration histograms and failure tracking by reason ([#10175](https://github.com/ZcashFoundation/zebra/pull/10175))
+- Prometheus alert rules and Grafana dashboards for value pools and RPC monitoring ([#10175](https://github.com/ZcashFoundation/zebra/pull/10175))
 
 
 ## [Zebra 3.1.0](https://github.com/ZcashFoundation/zebra/releases/tag/v3.1.0) - 2025-11-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ Thank you to everyone who contributed to this release, we couldn't make Zebra wi
 - OpenTelemetry tracing support behind the `opentelemetry` feature flag ([#10174](https://github.com/ZcashFoundation/zebra/pull/10174))
 - RPC tracing middleware with `SPAN_KIND_SERVER` spans for Jaeger Service Performance Monitoring ([#10174](https://github.com/ZcashFoundation/zebra/pull/10174))
 - Added Docker Compose observability stack with Jaeger, Prometheus, Grafana, and AlertManager for local development and testing
+- Added value pool metrics exposing transparent, sprout, sapling, orchard, and deferred pool balances plus total chain supply ([#10162](https://github.com/ZcashFoundation/zebra/issues/10162))
+- Added RPC metrics middleware tracking request counts, latencies, active requests, and errors per method ([#10163](https://github.com/ZcashFoundation/zebra/issues/10163))
+- Added peer handshake metrics for duration histograms and failure tracking by reason ([#10164](https://github.com/ZcashFoundation/zebra/issues/10164))
+- Added Prometheus alert rules and Grafana dashboards for value pools and RPC monitoring ([#10167](https://github.com/ZcashFoundation/zebra/issues/10167))
 
 
 ## [Zebra 3.1.0](https://github.com/ZcashFoundation/zebra/releases/tag/v3.1.0) - 2025-11-28

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7158,6 +7158,7 @@ dependencies = [
  "jsonrpsee",
  "jsonrpsee-proc-macros",
  "jsonrpsee-types",
+ "metrics",
  "nix",
  "proptest",
  "prost 0.14.3",

--- a/docker/observability/grafana/dashboards/rpc_metrics.json
+++ b/docker/observability/grafana/dashboards/rpc_metrics.json
@@ -1,0 +1,820 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "JSON-RPC endpoint metrics - request rates, latency, and errors",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zebra-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "rpc_active_requests",
+          "legendFormat": "Active Requests",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zebra-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "sum(rate(rpc_requests_total[5m]))",
+          "legendFormat": "Requests/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Rate (5m)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zebra-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "sum(rate(rpc_requests_total{status=\"error\"}[5m])) / sum(rate(rpc_requests_total[5m]))",
+          "legendFormat": "Error Rate",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Rate (5m)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zebra-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(rpc_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99 Latency",
+          "refId": "A"
+        }
+      ],
+      "title": "p99 Latency (5m)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zebra-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "req/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "sum(rate(rpc_requests_total[5m])) by (method)",
+          "legendFormat": "{{ method }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Rate by Method",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zebra-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "seconds",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(rpc_request_duration_seconds_bucket[5m])) by (le, method))",
+          "legendFormat": "{{ method }} p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(rpc_request_duration_seconds_bucket[5m])) by (le, method))",
+          "legendFormat": "{{ method }} p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(rpc_request_duration_seconds_bucket[5m])) by (le, method))",
+          "legendFormat": "{{ method }} p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Request Latency Percentiles by Method",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zebra-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "errors/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "sum(rate(rpc_errors_total[5m])) by (method, error_code)",
+          "legendFormat": "{{ method }} ({{ error_code }})",
+          "refId": "A"
+        }
+      ],
+      "title": "Errors by Method and Code",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zebra-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "rpc_active_requests",
+          "legendFormat": "Active Requests",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Requests Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zebra-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Rate"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "reqps"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 9,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Rate"
+          }
+        ]
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "sum(rate(rpc_requests_total[5m])) by (method)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "Rate"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(rpc_request_duration_seconds_bucket[5m])) by (le, method))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(rpc_request_duration_seconds_bucket[5m])) by (le, method))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "p99"
+        }
+      ],
+      "title": "Method Statistics",
+      "transformations": [
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "method"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value #Rate": "Rate",
+              "Value #p50": "p50",
+              "Value #p99": "p99",
+              "method": "Method"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": ["zebra", "zcash", "rpc", "json-rpc"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Zebra RPC Metrics",
+  "uid": "zebra-rpc-metrics",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docker/observability/grafana/dashboards/value_pools.json
+++ b/docker/observability/grafana/dashboards/value_pools.json
@@ -1,0 +1,725 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Value Pool Monitoring - Track shielded pool balances and total supply. Zebra enforces ZIP-209 internally.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zebra-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "ZEC",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": ["last"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "state_finalized_chain_supply_total / 100000000",
+          "legendFormat": "Total Supply (ZEC)",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Chain Supply",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zebra-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "ZEC",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Transparent"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#73BF69",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Sprout"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#F2CC0C",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Sapling"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5794F2",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Orchard"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#B877D9",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Deferred"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FF9830",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["last", "mean"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "state_finalized_value_pool_transparent / 100000000",
+          "legendFormat": "Transparent",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "state_finalized_value_pool_sprout / 100000000",
+          "legendFormat": "Sprout",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "state_finalized_value_pool_sapling / 100000000",
+          "legendFormat": "Sapling",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "state_finalized_value_pool_orchard / 100000000",
+          "legendFormat": "Orchard",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "state_finalized_value_pool_deferred / 100000000",
+          "legendFormat": "Deferred",
+          "refId": "E"
+        }
+      ],
+      "title": "Value Pools by Type (Stacked)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zebra-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 18
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "state_finalized_value_pool_transparent / 100000000",
+          "legendFormat": "Transparent ZEC",
+          "refId": "A"
+        }
+      ],
+      "title": "Transparent Pool",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zebra-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "#F2CC0C",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 18
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "state_finalized_value_pool_sprout / 100000000",
+          "legendFormat": "Sprout ZEC",
+          "refId": "A"
+        }
+      ],
+      "title": "Sprout Pool",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zebra-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "blue",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 18
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "state_finalized_value_pool_sapling / 100000000",
+          "legendFormat": "Sapling ZEC",
+          "refId": "A"
+        }
+      ],
+      "title": "Sapling Pool",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zebra-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "purple",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 18
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "state_finalized_value_pool_orchard / 100000000",
+          "legendFormat": "Orchard ZEC",
+          "refId": "A"
+        }
+      ],
+      "title": "Orchard Pool",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zebra-prometheus"
+      },
+      "description": "Pool Health Check: All pools should be non-negative (enforced internally by Zebra)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "HEALTHY"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "from": 1,
+                "result": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "VIOLATION"
+                },
+                "to": 999999
+              },
+              "type": "range"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "(state_finalized_value_pool_transparent < 0) + (state_finalized_value_pool_sprout < 0) + (state_finalized_value_pool_sapling < 0) + (state_finalized_value_pool_orchard < 0)",
+          "legendFormat": "Pool Health Status",
+          "refId": "A"
+        }
+      ],
+      "title": "Pool Health Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "zebra-prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "zebra-prometheus"
+          },
+          "expr": "state_finalized_block_height",
+          "legendFormat": "Block Height",
+          "refId": "A"
+        }
+      ],
+      "title": "Current Block Height",
+      "type": "stat"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": ["zebra", "zcash", "value-pools"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Zebra Value Pools",
+  "uid": "zebra-value-pools",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docker/observability/prometheus/rules/zebra_alerts.yml
+++ b/docker/observability/prometheus/rules/zebra_alerts.yml
@@ -58,3 +58,92 @@ groups:
         annotations:
           summary: "High error rate"
           description: "Zebra is experiencing elevated error rates (> 0.1/s for 5 minutes)."
+
+  # Value Pool Alerts (Monitoring)
+  - name: zebra-value-pools
+    rules:
+      # Critical: Negative value pool would indicate a bug (should never happen - Zebra rejects such blocks)
+      - alert: ValuePoolNegative
+        expr: state_finalized_value_pool_transparent < 0 or state_finalized_value_pool_sprout < 0 or state_finalized_value_pool_sapling < 0 or state_finalized_value_pool_orchard < 0
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Negative value pool detected"
+          description: "A pool has a negative balance in metrics. Zebra enforces ZIP-209 internally, so this should not occur in normal operation."
+
+      # Warning: Value pool not updating (may indicate sync issues)
+      - alert: ValuePoolStale
+        expr: changes(state_finalized_chain_supply_total[15m]) == 0 and state_finalized_block_height > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Value pool not updating"
+          description: "Chain supply has not changed in 15 minutes while blocks exist. Sync may be stalled."
+
+  # RPC Alerts
+  - name: zebra-rpc
+    rules:
+      # High RPC latency
+      - alert: RPCHighLatency
+        expr: histogram_quantile(0.99, sum(rate(rpc_request_duration_seconds_bucket[5m])) by (le, method)) > 2
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High RPC latency detected"
+          description: "RPC method {{ $labels.method }} has p99 latency > 2 seconds for 5 minutes."
+
+      # High RPC error rate
+      - alert: RPCHighErrorRate
+        expr: sum(rate(rpc_errors_total[5m])) by (method) / sum(rate(rpc_requests_total[5m])) by (method) > 0.1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High RPC error rate"
+          description: "RPC method {{ $labels.method }} has error rate > 10% for 5 minutes."
+
+      # RPC endpoint overloaded
+      - alert: RPCOverloaded
+        expr: rpc_active_requests > 100
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "RPC endpoint overloaded"
+          description: "More than 100 concurrent RPC requests for 2 minutes. Consider rate limiting."
+
+  # Peer Health Alerts
+  - name: zebra-peer-health
+    rules:
+      # High handshake failure rate
+      - alert: HandshakeFailureRateHigh
+        expr: sum(rate(zcash_net_peer_handshake_failures_total[5m])) / (sum(rate(zcash_net_peer_handshake_duration_seconds_count[5m])) + 0.001) > 0.5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High peer handshake failure rate"
+          description: "More than 50% of peer handshakes are failing for 5 minutes. Check network connectivity."
+
+      # Specific failure reason spike (e.g., obsolete version)
+      - alert: ObsoleteVersionHandshakes
+        expr: rate(zcash_net_peer_handshake_failures_total{reason="obsolete_version"}[5m]) > 0.1
+        for: 5m
+        labels:
+          severity: info
+        annotations:
+          summary: "Many obsolete version handshakes"
+          description: "Elevated rate of peer handshake failures due to obsolete protocol versions. May indicate network upgrade in progress."
+
+      # Slow handshakes
+      - alert: SlowHandshakes
+        expr: histogram_quantile(0.95, sum(rate(zcash_net_peer_handshake_duration_seconds_bucket{result="success"}[5m])) by (le)) > 10
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Slow peer handshakes"
+          description: "p95 handshake duration exceeds 10 seconds. Network latency may be high."

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -967,7 +967,7 @@ where
                         "reason" => reason
                     )
                     .increment(1);
-                    return Err(err.into());
+                    return Err(err);
                 }
             };
 

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `rpc_metrics` module for Prometheus metrics middleware tracking request counts, latencies, active requests, and errors ([#10175](https://github.com/ZcashFoundation/zebra/pull/10175))
+
 ## [4.0.0] - 2026-01-21
 
 Most changes are related to a fix to `getinfo` RPC response which used a string

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `rpc_metrics` module for Prometheus metrics middleware tracking request counts, latencies, active requests, and errors ([#10175](https://github.com/ZcashFoundation/zebra/pull/10175))
+- `server/rpc_metrics` module.
+- `server/rpc_tracing` module.
+- Dependency on the `metrics` crate.
 
 ## [4.0.0] - 2026-01-21
 

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -76,6 +76,9 @@ tokio-stream = { workspace = true }
 
 tracing = { workspace = true }
 
+# Metrics collection
+metrics = { workspace = true }
+
 hex = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["serde_derive"] }
 

--- a/zebra-rpc/src/server.rs
+++ b/zebra-rpc/src/server.rs
@@ -25,8 +25,7 @@ use crate::{
     methods::{RpcImpl, RpcServer as _},
     server::{
         http_request_compatibility::HttpRequestMiddlewareLayer,
-        rpc_call_compatibility::FixRpcResponseMiddleware,
-        rpc_metrics::RpcMetricsMiddleware,
+        rpc_call_compatibility::FixRpcResponseMiddleware, rpc_metrics::RpcMetricsMiddleware,
         rpc_tracing::RpcTracingMiddleware,
     },
 };

--- a/zebra-rpc/src/server.rs
+++ b/zebra-rpc/src/server.rs
@@ -25,7 +25,9 @@ use crate::{
     methods::{RpcImpl, RpcServer as _},
     server::{
         http_request_compatibility::HttpRequestMiddlewareLayer,
-        rpc_call_compatibility::FixRpcResponseMiddleware, rpc_tracing::RpcTracingMiddleware,
+        rpc_call_compatibility::FixRpcResponseMiddleware,
+        rpc_metrics::RpcMetricsMiddleware,
+        rpc_tracing::RpcTracingMiddleware,
     },
 };
 
@@ -33,6 +35,7 @@ pub mod cookie;
 pub mod error;
 pub mod http_request_compatibility;
 pub mod rpc_call_compatibility;
+pub mod rpc_metrics;
 pub mod rpc_tracing;
 
 #[cfg(test)]
@@ -129,6 +132,7 @@ impl RpcServer {
         let rpc_middleware = RpcServiceBuilder::new()
             .rpc_logger(1024)
             .layer_fn(FixRpcResponseMiddleware::new)
+            .layer_fn(RpcMetricsMiddleware::new)
             .layer_fn(RpcTracingMiddleware::new);
 
         let server = Server::builder()

--- a/zebra-rpc/src/server/rpc_metrics.rs
+++ b/zebra-rpc/src/server/rpc_metrics.rs
@@ -1,0 +1,87 @@
+//! RPC metrics middleware for Prometheus metrics collection.
+//!
+//! This middleware collects metrics for JSON-RPC requests, including:
+//! - Request count by method and status
+//! - Request duration by method
+//! - Active request count
+//! - Error count by method and error code
+//!
+//! These metrics complement the OpenTelemetry tracing in `rpc_tracing.rs`,
+//! providing aggregated data suitable for dashboards and alerting.
+
+use std::time::Instant;
+
+use jsonrpsee::{
+    server::middleware::rpc::{layer::ResponseFuture, RpcServiceT},
+    MethodResponse,
+};
+
+/// Middleware that collects Prometheus metrics for each RPC request.
+///
+/// This middleware records:
+/// - `rpc.requests.total{method, status}` - Counter of requests by method and status
+/// - `rpc.request.duration_seconds{method}` - Histogram of request durations
+/// - `rpc.active_requests` - Gauge of currently active requests
+/// - `rpc.errors.total{method, error_code}` - Counter of errors by method and code
+#[derive(Clone)]
+pub struct RpcMetricsMiddleware<S> {
+    service: S,
+}
+
+impl<S> RpcMetricsMiddleware<S> {
+    /// Create a new `RpcMetricsMiddleware` with the given `service`.
+    pub fn new(service: S) -> Self {
+        Self { service }
+    }
+}
+
+impl<'a, S> RpcServiceT<'a> for RpcMetricsMiddleware<S>
+where
+    S: RpcServiceT<'a> + Send + Sync + Clone + 'static,
+{
+    type Future = ResponseFuture<futures::future::BoxFuture<'a, MethodResponse>>;
+
+    fn call(&self, request: jsonrpsee::types::Request<'a>) -> Self::Future {
+        let service = self.service.clone();
+        let method = request.method_name().to_owned();
+        let start = Instant::now();
+
+        // Increment active requests gauge
+        metrics::gauge!("rpc.active_requests").increment(1.0);
+
+        ResponseFuture::future(Box::pin(async move {
+            let response = service.call(request).await;
+            let duration = start.elapsed().as_secs_f64();
+
+            // Determine status and record metrics
+            let status = if response.is_error() { "error" } else { "success" };
+
+            // Record request count
+            metrics::counter!("rpc.requests.total", "method" => method.clone(), "status" => status)
+                .increment(1);
+
+            // Record request duration
+            metrics::histogram!("rpc.request.duration_seconds", "method" => method.clone())
+                .record(duration);
+
+            // Record errors with error code
+            if response.is_error() {
+                let error_code = response
+                    .as_error_code()
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| "unknown".to_string());
+                metrics::counter!(
+                    "rpc.errors.total",
+                    "method" => method,
+                    "error_code" => error_code
+                )
+                .increment(1);
+            }
+
+            // Decrement active requests gauge
+            metrics::gauge!("rpc.active_requests").decrement(1.0);
+
+            response
+        }))
+    }
+}

--- a/zebra-rpc/src/server/rpc_metrics.rs
+++ b/zebra-rpc/src/server/rpc_metrics.rs
@@ -54,7 +54,11 @@ where
             let duration = start.elapsed().as_secs_f64();
 
             // Determine status and record metrics
-            let status = if response.is_error() { "error" } else { "success" };
+            let status = if response.is_error() {
+                "error"
+            } else {
+                "success"
+            };
 
             // Record request count
             metrics::counter!("rpc.requests.total", "method" => method.clone(), "status" => status)

--- a/zebra-state/src/service/finalized_state/zebra_db/chain.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/chain.rs
@@ -26,7 +26,7 @@ use crate::{
     service::finalized_state::{
         disk_db::DiskWriteBatch,
         disk_format::{chain::HistoryTreeParts, RawBytes},
-        zebra_db::ZebraDb,
+        zebra_db::{metrics::value_pool_metrics, ZebraDb},
         TypedColumnFamily,
     },
     BoxError, HashOrHeight,
@@ -258,6 +258,10 @@ impl DiskWriteBatch {
                 &utxos_spent_by_block,
                 finalized.deferred_pool_balance_change,
             )?)?;
+
+        // Update value pool metrics for observability (ZIP-209 compliance monitoring)
+        value_pool_metrics(&new_value_pool);
+
         let _ = db
             .chain_value_pools_cf()
             .with_batch_for_writing(self)


### PR DESCRIPTION
## Motivation

Operators lack visibility into Zebra's internal state. This PR adds Prometheus metrics for:
- Value pool balances (transparent, sprout, sapling, orchard, deferred)
- RPC request rates, latencies, and errors
- Peer handshake performance and failure reasons

Closes #10162 
Closes #10163
Closes #10164
Closes #10167

<img width="2574" height="1608" alt="image" src="https://github.com/user-attachments/assets/0322008e-7127-4fd2-a66c-cc9f0f63e25f" />

## Solution

### Value Pool Metrics (`zebra-state`)

New metrics in `zebra_db/metrics.rs`:
- `state.finalized.value_pool.{transparent,sprout,sapling,orchard,deferred}` - Pool balances in zatoshis
- `state.finalized.chain_supply.total` - Total chain supply

These are for monitoring/observability. Zebra already enforces ZIP-209 internally by rejecting blocks that would cause negative pools.

### RPC Metrics (`zebra-rpc`)

New middleware in `server/rpc_metrics.rs`:
- `rpc.requests.total{method,status}` - Request count by method and status
- `rpc.request.duration_seconds{method}` - Latency histogram
- `rpc.active_requests` - Concurrent requests gauge
- `rpc.errors.total{method,code}` - Error count by method and code

### Peer Health Metrics (`zebra-network`)

Added to `peer/handshake.rs`:
- `zcash.net.peer.handshake.duration_seconds{result}` - Handshake latency histogram
- `zcash.net.peer.handshake.failures.total{reason}` - Failure count by reason

### Dashboards & Alerts

- `docker/observability/grafana/dashboards/value_pools.json` - Value pool visualization
- `docker/observability/grafana/dashboards/rpc_metrics.json` - RPC performance dashboard
- `docker/observability/prometheus/rules/zebra_alerts.yml` - Alert rules for critical conditions

### Tests

Tested with the local observability stack (`docker compose -f docker/docker-compose.observability.yml up`):
- Verified all metrics appear at `/metrics` endpoint
- Confirmed dashboards render correctly in Grafana
- Validated alert rules load in Prometheus

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the contribution guidelines.
- [x] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.