### PR TITLE
cleanup(network): remove unused `ping_sent_at` parameter from `UpdateResponded`

### DIFF
--- a/zebra-network/src/address_book/tests/vectors.rs
+++ b/zebra-network/src/address_book/tests/vectors.rs
@@ -129,7 +129,7 @@ fn reconnection_peers_skips_recently_updated_ip() {
     // tests that reconnection_peers() skips addresses where there's a connection at that IP with a recent:
     // - `last_response`
     test_reconnection_peers_skips_recently_updated_ip(true, |addr| {
-        MetaAddr::new_responded(addr, None, None)
+        MetaAddr::new_responded(addr, None)
     });
 
     // tests that reconnection_peers() *does not* skip addresses where there's a connection at that IP with a recent:

--- a/zebra-network/src/address_book_peers/mock.rs
+++ b/zebra-network/src/address_book_peers/mock.rs
@@ -27,7 +27,7 @@ impl MockAddressBookPeers {
         // The real add peer will use `MetaAddr::new_initial_peer` but we just want to get a `MetaAddr` for the mock.
         let rtt = Duration::from_millis(100);
         self.recently_live_peers.push(
-            MetaAddr::new_responded(peer, Some(rtt), None).into_new_meta_addr(
+            MetaAddr::new_responded(peer, Some(rtt)).into_new_meta_addr(
                 Instant::now(),
                 chrono::Utc::now()
                     .try_into()

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -300,7 +300,6 @@ pub enum MetaAddrChange {
         )]
         addr: PeerSocketAddr,
         rtt: Option<Duration>,
-        ping_sent_at: Option<Instant>,
     },
 
     /// Updates an existing `MetaAddr` when a peer fails.
@@ -413,15 +412,10 @@ impl MetaAddr {
     /// - malicious peers could interfere with other peers' [`AddressBook`](crate::AddressBook)
     ///   state, or
     /// - Zebra could advertise unreachable addresses to its own peers.
-    pub fn new_responded(
-        addr: PeerSocketAddr,
-        rtt: Option<Duration>,
-        ping_sent_at: Option<Instant>,
-    ) -> MetaAddrChange {
+    pub fn new_responded(addr: PeerSocketAddr, rtt: Option<Duration>) -> MetaAddrChange {
         UpdateResponded {
             addr: canonical_peer_addr(*addr),
             rtt,
-            ping_sent_at,
         }
     }
 

--- a/zebra-network/src/meta_addr/tests/vectors.rs
+++ b/zebra-network/src/meta_addr/tests/vectors.rs
@@ -158,7 +158,7 @@ fn recently_responded_peer_is_gossipable() {
     let peer_seed = MetaAddr::new_initial_peer(address).into_new_meta_addr(instant_now, local_now);
 
     // Create a peer that has responded
-    let peer = MetaAddr::new_responded(address, None, None)
+    let peer = MetaAddr::new_responded(address, None)
         .apply_to_meta_addr(peer_seed, instant_now, chrono_now)
         .expect("Failed to create MetaAddr for responded peer");
 
@@ -178,7 +178,7 @@ fn not_so_recently_responded_peer_is_still_gossipable() {
     let peer_seed = MetaAddr::new_initial_peer(address).into_new_meta_addr(instant_now, local_now);
 
     // Create a peer that has responded
-    let mut peer = MetaAddr::new_responded(address, None, None)
+    let mut peer = MetaAddr::new_responded(address, None)
         .apply_to_meta_addr(peer_seed, instant_now, chrono_now)
         .expect("Failed to create MetaAddr for responded peer");
 
@@ -208,7 +208,7 @@ fn responded_long_ago_peer_is_not_gossipable() {
     let peer_seed = MetaAddr::new_initial_peer(address).into_new_meta_addr(instant_now, local_now);
 
     // Create a peer that has responded
-    let mut peer = MetaAddr::new_responded(address, None, None)
+    let mut peer = MetaAddr::new_responded(address, None)
         .apply_to_meta_addr(peer_seed, instant_now, chrono_now)
         .expect("Failed to create MetaAddr for responded peer");
 
@@ -238,7 +238,7 @@ fn long_delayed_change_is_not_applied() {
     let peer_seed = MetaAddr::new_initial_peer(address).into_new_meta_addr(instant_now, local_now);
 
     // Create a peer that has responded
-    let peer = MetaAddr::new_responded(address, None, None)
+    let peer = MetaAddr::new_responded(address, None)
         .apply_to_meta_addr(peer_seed, instant_now, chrono_now)
         .expect("Failed to create MetaAddr for responded peer");
 
@@ -281,7 +281,7 @@ fn later_revert_change_is_applied() {
     let peer_seed = MetaAddr::new_initial_peer(address).into_new_meta_addr(instant_now, local_now);
 
     // Create a peer that has responded
-    let peer = MetaAddr::new_responded(address, None, None)
+    let peer = MetaAddr::new_responded(address, None)
         .apply_to_meta_addr(peer_seed, instant_now, chrono_now)
         .expect("Failed to create MetaAddr for responded peer");
 
@@ -323,7 +323,7 @@ fn concurrent_state_revert_change_is_not_applied() {
     let peer_seed = MetaAddr::new_initial_peer(address).into_new_meta_addr(instant_now, local_now);
 
     // Create a peer that has responded
-    let peer = MetaAddr::new_responded(address, None, None)
+    let peer = MetaAddr::new_responded(address, None)
         .apply_to_meta_addr(peer_seed, instant_now, chrono_now)
         .expect("Failed to create MetaAddr for responded peer");
 
@@ -382,7 +382,7 @@ fn concurrent_state_progress_change_is_applied() {
     let peer_seed = MetaAddr::new_initial_peer(address).into_new_meta_addr(instant_now, local_now);
 
     // Create a peer that has responded
-    let peer = MetaAddr::new_responded(address, None, None)
+    let peer = MetaAddr::new_responded(address, None)
         .apply_to_meta_addr(peer_seed, instant_now, chrono_now)
         .expect("Failed to create MetaAddr for responded peer");
 
@@ -442,7 +442,7 @@ fn rtt_is_stored_correctly_in_meta_addr() {
     let rtt = Duration::from_millis(128);
 
     // Create a peer that has responded
-    let peer = MetaAddr::new_responded(address, Some(rtt), Some(instant_now))
+    let peer = MetaAddr::new_responded(address, Some(rtt))
         .apply_to_meta_addr(peer_seed, instant_now, chrono_now)
         .expect("Failed to create MetaAddr for responded peer");
 

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -1334,7 +1334,7 @@ async fn send_periodic_heartbeats_run_loop(
                 // the collector doesn't depend on network activity,
                 // so this await should not hang
                 let _ = heartbeat_ts_collector
-                    .send(MetaAddr::new_responded(book_addr, Some(rtt), None))
+                    .send(MetaAddr::new_responded(book_addr, Some(rtt)))
                     .await;
             }
         }


### PR DESCRIPTION

<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

<!--
- Describe the goals of the PR.
- If it closes any issues, enumerate them here.
-->

This PR implements an unmerged review suggestion from #9880 to remove the unused `ping_sent_at` parameter from `UpdateResponded` and its constructor. After the latest changes made in #9880, the `ping_sent_at` field is now always cleared when a peer responds, making the parameter obsolete. Thus, this cleanup simplifies the update logic without changing behavior.

## Solution

<!-- Describe the changes in the PR. -->
* Removed the `ping_sent_at` parameter from `UpdateResponded` and related methods.
* Updated all method calls  in tests.


### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
