### PR TITLE
tests(qa): Add zaino to the qa rpc framework

### DIFF
--- a/zebra-rpc/build.rs
+++ b/zebra-rpc/build.rs
@@ -5,8 +5,13 @@ use std::{
     process::Command,
 };
 
-// 0.1.0-alpha.2
+// 0.1.0-alpha.2 - https://github.com/zcash/wallet/commit/027e5e2139b2ca8f0317edb9d802b03a46e9aa4c
 const ZALLET_COMMIT: Option<&str> = Some("027e5e2139b2ca8f0317edb9d802b03a46e9aa4c");
+
+// Zaino last tested commit - https://github.com/zingolabs/zaino/commit/559510ffcc62a5a6e7bb20db5e3329654542c8b1
+// TODO: Zaino is not currently built by this build script.
+#[allow(dead_code)]
+const ZAINO_COMMIT: Option<&str> = Some("559510ffcc62a5a6e7bb20db5e3329654542c8b1");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     build_or_copy_proto()?;

--- a/zebra-rpc/qa/base_config.toml
+++ b/zebra-rpc/qa/base_config.toml
@@ -13,6 +13,7 @@ initial_testnet_peers = []
 [rpc]
 listen_addr = "127.0.0.1:0"
 enable_cookie_auth = false
+indexer_listen_addr = "127.0.0.1:0"
 
 [state]
 cache_dir = ""

--- a/zebra-rpc/qa/pull-tester/rpc-tests.py
+++ b/zebra-rpc/qa/pull-tester/rpc-tests.py
@@ -45,7 +45,8 @@ BASE_SCRIPTS= [
     'feature_nu6_1.py',
     'feature_backup_non_finalized_state.py',
     'getrawtransaction_sidechain.py',
-    'fix_block_commitments.py']
+    'fix_block_commitments.py',
+    'indexer.py']
 
 ZMQ_SCRIPTS = [
     # ZMQ test can only be run if bitcoin was built with zmq-enabled.

--- a/zebra-rpc/qa/rpc-tests/indexer.py
+++ b/zebra-rpc/qa/rpc-tests/indexer.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 The Zcash developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, start_nodes, start_zainos
+
+# Test that we can call the indexer RPCs.
+class IndexerTest (BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.cache_behavior = 'clean'
+        self.num_nodes = 1
+
+    def setup_network(self, split=False):
+        args = [None]
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, args)
+
+        # Zaino need at least 100 blocks to start
+        self.nodes[0].generate(100)
+
+        args = [None]
+        self.zainos = start_zainos(1, self.options.tmpdir)
+
+    def run_test(self):
+        assert_equal(self.zainos[0].getblockcount(), 100)
+        assert_equal(self.nodes[0].getblockcount(), 100)
+
+if __name__ == '__main__':
+    IndexerTest ().main ()

--- a/zebra-rpc/qa/rpc-tests/test_framework/config.py
+++ b/zebra-rpc/qa/rpc-tests/test_framework/config.py
@@ -20,6 +20,7 @@ class ZebraConfig:
         "network_listen_address": "127.0.0.1:0",
         "rpc_listen_address": "127.0.0.1:0",
         "data_dir": None,
+        "indexer_listen_address": "127.0.0.1:0",
         "extra_args": ZebraExtraArgs,
     }
 
@@ -30,6 +31,7 @@ class ZebraConfig:
     def update(self, config_file):
         # Base config updates
         config_file['rpc']['listen_addr'] = self.rpc_listen_address
+        config_file['rpc']['indexer_listen_addr'] = self.indexer_listen_address
         config_file['network']['listen_addr'] = self.network_listen_address
         config_file['state']['cache_dir'] = self.data_dir
 
@@ -38,5 +40,26 @@ class ZebraConfig:
         config_file['network']['testnet_parameters']['funding_streams'] = self.extra_args.funding_streams
         config_file['network']['testnet_parameters']['activation_heights'] = self.extra_args.activation_heights
         config_file['network']['testnet_parameters']['lockbox_disbursements'] = self.extra_args.lockbox_disbursements
+
+        return config_file
+
+class ZainoConfig:
+    defaults = {
+        "json_rpc_listen_address": "127.0.0.1:0",
+        "grpc_listen_address": "127.0.0.1:0",
+        "validator_grpc_listen_address": "127.0.0.1:0",
+        "validator_jsonrpc_listen_address": "127.0.0.1:0",
+    }
+
+    def __init__(self, **kwargs):
+        for key, default in self.defaults.items():
+            setattr(self, key, kwargs.get(key, default))
+
+    def update(self, config_file):
+        # Base config updates
+        config_file['json_server_settings']['json_rpc_listen_address'] = self.json_rpc_listen_address
+        config_file['grpc_settings']['grpc_listen_address'] = self.grpc_listen_address
+        config_file['validator_settings']['validator_grpc_listen_address'] = self.validator_grpc_listen_address
+        config_file['validator_settings']['validator_jsonrpc_listen_address'] = self.validator_jsonrpc_listen_address
 
         return config_file

--- a/zebra-rpc/qa/rpc-tests/test_framework/test_framework.py
+++ b/zebra-rpc/qa/rpc-tests/test_framework/test_framework.py
@@ -17,6 +17,7 @@ import traceback
 from .proxy import JSONRPCException
 from .util import (
     stop_wallets,
+    stop_zainos,
     zcashd_binary,
     initialize_chain,
     start_nodes,
@@ -167,6 +168,13 @@ class BitcoinTestFramework(object):
                 stop_wallets(self.wallets)
         except Exception as e:
             print("Ignoring error while stopping wallets: ", repr(e))
+
+        print("Stopping indexers")
+        try:
+            if self.zainos:
+                stop_zainos(self.zainos)
+        except Exception as e:
+            print("Ignoring error while stopping zainos: ", repr(e))
 
         if not self.options.noshutdown:
             print("Stopping nodes")

--- a/zebra-rpc/qa/zindexer.toml
+++ b/zebra-rpc/qa/zindexer.toml
@@ -1,0 +1,12 @@
+backend = "fetch"
+network = "Regtest"
+
+[json_server_settings]
+json_rpc_listen_address = "127.0.0.1:0"
+
+[grpc_settings]
+grpc_listen_address = "127.0.0.1:0"
+
+[validator_settings]
+validator_grpc_listen_address =  "127.0.0.1:0"
+validator_jsonrpc_listen_address = "127.0.0.1:0"


### PR DESCRIPTION
## Motivation

We want to add `zainod` to the python QA framework in Zebra so we can cover the full Z3 stack.

## Solution

Follow the same logic as we did for Zallet and Zebra itself, add Zaino to the framework.

### Tests

```bash
$ ./qa/pull-tester/rpc-tests.py indexer.py
Running individually selected tests: 
	indexer.py
..............................
indexer.py:
Pass: True, Duration: 15 s
TEST       | PASSED | DURATION

indexer.py | True   | 15 s
ALL        | True   | 15 s (accumulated)
Runtime: 15 s
$ 
```

### PR Checklist

<!-- Check as many boxes as possible. -->

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.
