### PR TITLE
chore: bump license year to 2026

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,4 +1,4 @@
-Copyright (c) 2019-2025 Zcash Foundation
+Copyright (c) 2019-2026 Zcash Foundation
 
                               Apache License
                         Version 2.0, January 2004

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2019-2025 Zcash Foundation
+Copyright (c) 2019-2026 Zcash Foundation
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
Updates the copyright year from 2025 to 2026.

Keeping license files current for the new year.