### PR TITLE
fix(ci): resolve Docker build failures and cargo deny duplicates

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -49,7 +49,7 @@ jobs:
     permissions:
       id-token: write
       statuses: write
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.DOCKER_BUILD_RUNNER_AMD64 || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
@@ -87,7 +87,7 @@ jobs:
       contents: read
       actions: read
       checks: read
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.DOCKER_BUILD_RUNNER_AMD64 || 'ubuntu-latest' }}
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/deny.toml
+++ b/deny.toml
@@ -100,6 +100,11 @@ skip-tree = [
     { name = "indexmap", version = "1.9" },
 
     { name = "hashbrown", version = "0.12" },
+    # hashbrown 0.15.x pulled by various deps; 0.16.x pulled by indexmap 2.x
+    { name = "hashbrown", version = "0.15" },
+
+    # itertools 0.13.x pulled by halo2 deps; 0.14.x pulled by other deps
+    { name = "itertools", version = "0.13" },
 
     { name = "getrandom", version = "0.2" },
 


### PR DESCRIPTION
## Motivation

Fix two CI issues that have been affecting the main branch:

1. **Docker test builds failing** (since Nov 13, 2025) - builds run out of disk space on standard GitHub-hosted runners
2. **Cargo deny duplicate errors** (since Jan 15, 2026) - dependency updates introduced duplicate crate versions

Closes #10126

## Solution

### Docker build failures
- Use configurable runner via `DOCKER_BUILD_RUNNER_AMD64` repository variable (already set to `ubuntu-latest-m`)
- ZcashFoundation org uses the larger runner; forks without the variable fallback to `ubuntu-latest`

### Cargo deny duplicates
- Add skip-tree entries for `hashbrown 0.15.x` (conflicts with 0.16.x from indexmap 2.x)
- Add skip-tree entry for `itertools 0.13.x` (conflicts with 0.14.x from other deps)

### Tests

- `cargo deny check bans` passes locally with these changes
- Docker build will be tested by CI on this PR

### Specifications & References

**Failed CI runs:**
- Docker build (main): https://github.com/ZcashFoundation/zebra/actions/runs/21049803117
- Cargo deny (main): https://github.com/ZcashFoundation/zebra/actions/runs/21049803137

### Follow-up Work

- Monitor CI to confirm Docker builds complete successfully
- GCP cleanup workflow still needs IAM permission fix (separate infrastructure task)

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [x] The solution is tested.
- [ ] The documentation is up to date.