### PR TITLE
Parse Zebra's config file as TOML

### DIFF
--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -132,7 +132,11 @@ impl ZebradConfig {
 
         // 2. Add TOML configuration file as a source if provided
         if let Some(path) = config_path {
-            builder = builder.add_source(config::File::from(path).required(true));
+            builder = builder.add_source(
+                config::File::from(path)
+                    .format(config::FileFormat::Toml)
+                    .required(true),
+            );
         }
 
         // 3. Load from environment variables (with a sensitive-leaf deny-list)


### PR DESCRIPTION
See #10221

Zebra's config file will always be in TOML format regardless of its file extension. Currently a config file with an extension like ".conf" causes Zebra to exit even if it contains valid TOML. This patch resolves that.