### PR TITLE
fix(ci): update Docker test grep patterns for current log format

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -97,12 +97,12 @@ jobs:
           - id: default-conf
             name: Default config
             env_vars: ""
-            grep_patterns: -e "net.*=.*Main.*estimated progress to chain tip.*BeforeOverwinter"
+            grep_patterns: -e "resolved seed peer IP addresses.*mainnet.seeder"
 
           - id: testnet-conf
             name: Testnet config
             env_vars: -e ZEBRA_NETWORK__NETWORK=Testnet
-            grep_patterns: -e "net.*=.*Test.*estimated progress to chain tip.*BeforeOverwinter"
+            grep_patterns: -e "resolved seed peer IP addresses.*testnet.seeder"
 
           # Only runs when using the image is built with the `tests` target, because the `runtime` target
           # doesn't have the custom config file available in the tests/common/configs directory


### PR DESCRIPTION
## Motivation

Follow-up to #10219. The Docker config tests for Default and Testnet were timing out because the grep patterns no longer match the current log format.

**Failed run:** https://github.com/ZcashFoundation/zebra/actions/runs/21075361987

## Solution

Update grep patterns to match the seed peer resolution log line:
```
resolved seed peer IP addresses seed="mainnet.seeder.zfnd.org:8233"
```

This verifies both:
1. Correct network is configured (mainnet vs testnet seeder)
2. Node is actually starting (peer resolution happens during startup)

## Test plan

- CI will validate the fix