### PR TITLE
fix(clippy): address clippy beta lints

### DIFF
--- a/zebra-chain/src/parameters/network/tests/vectors.rs
+++ b/zebra-chain/src/parameters/network/tests/vectors.rs
@@ -614,8 +614,7 @@ fn lockbox_input_value(network: &Network, height: Height) -> Amount<NonNegative>
     // Funding stream height range end bound is not incremented since it's an exclusive end bound
     let num_blocks_with_lockbox_output = (height.0 + 1)
         .min(post_nu6_funding_stream_height_range.end.0)
-        .checked_sub(post_nu6_funding_stream_height_range.start.0)
-        .unwrap_or_default();
+        .saturating_sub(post_nu6_funding_stream_height_range.start.0);
 
     (deferred_amount_per_block * num_blocks_with_lockbox_output.into())
         .expect("lockbox input value should fit in Amount")

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -636,7 +636,8 @@ impl Service<Request> for Mempool {
                                 .download_if_needed_and_verify(tx.transaction.into(), rsp_tx);
                         }
                     }
-                    Ok(Err((tx_id, error))) => {
+                    Ok(Err(boxed_err)) => {
+                        let (tx_id, error) = *boxed_err;
                         if let TransactionDownloadVerifyError::Invalid {
                             error,
                             advertiser_addr: Some(advertiser_addr),


### PR DESCRIPTION
## Summary
- Box large error tuple `(TransactionDownloadVerifyError, UnminedTxId)` in mempool downloads (208 bytes → pointer)
- Replace `.checked_sub().unwrap_or_default()` with `.saturating_sub()`

## Motivation
Fixes lints flagged by clippy beta (`result_large_err`, `manual_saturating_arithmetic`) to prevent CI failures when these lints reach stable.

This is also making new PRs fail in CI

## Test plan
- [x] `cargo clippy --all-features --all-targets -- -D warnings` passes