### PR TITLE
bump versions and update changelogs for 4.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ configuration. However, if you already have a config in place, you will need
 to add it manually; add `"mainnet.seeder.shieldedinfra.net:8233"` to
 `initial_mainnet_peers`.
 
+The new OpenTelemetry support must be enabled at compile time with the
+`opentelemetry` feature, e.g. `cargo build --features=opentelemetry --release`.
+
 ### Breaking Changes
 
 This release has the following breaking changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Zebra 4.0.0](https://github.com/ZcashFoundation/zebra/releases/tag/v4.0.0) - 2025-01-20
+
+This release fixes the type of a field in the `getinfo` RPC and adds support for
+the `pingtime` and `pingwait` fields of the `getpeerinfo` RPC.
+
+It also changes the Grafana dashboards to add auto-provisioning and AlertManager
+support.
+
+This release also adds a new mainnet DNS seeder from Shielded Labs to the default
+configuration. However, if you already have a config in place, you will need
+to add it manually; add `"mainnet.seeder.shieldedinfra.net:8233"` to
+`initial_mainnet_peers`.
+
+### Breaking Changes
+
+This release has the following breaking changes:
+
+- Changed the `getinfo` RPC `errorstimestamp` field from a string timestamp (ISO
+  UTC timestamp) to a i64 (seconds from Unix epoch) to match zcashd
+  ([#10079](https://github.com/ZcashFoundation/zebra/pull/10079)). If you rely
+  on this field, you will need to change your code to be able to interpret
+  the i64 result.
+- Always parse Zebra's config file as TOML (#10222). This allows using a config
+  file with an extension different than `.toml`. Previously, it would use the
+  format detected from the extension, so in the unlikely case you were using
+  a format different than TOML you will need to change your config to TOML.
+
+
+### Added
+
+- Added `pingtime` and `pingwait` to `getpeerinfo` RPC ([#9880](https://github.com/ZcashFoundation/zebra/pull/9880))
+- Added Grafana auto-provisioning and AlertManager ([#10171](https://github.com/ZcashFoundation/zebra/pull/10171))
+- Added OpenTelemetry distributed tracing support ([#10174](https://github.com/ZcashFoundation/zebra/pull/10174))
+- Added new Shielded Labs mainnet seeder ([#10228](https://github.com/ZcashFoundation/zebra/pull/10228))
+
+### Contributors
+
+Thank you to everyone who contributed to this release, we couldn't make Zebra without you:
+@conradoplg, @gustavovalverde and @syszery
+
 
 ## [Unreleased]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7087,7 +7087,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-network"
-version = "2.0.2"
+version = "3.0.0"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -7142,7 +7142,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7284,7 +7284,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-utils"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "color-eyre",
  "hex",
@@ -7312,7 +7312,7 @@ dependencies = [
 
 [[package]]
 name = "zebrad"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "abscissa_core",
  "atty",

--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.0.0] - 2026-01-20
+## [4.0.0] - 2026-01-21
 
 ### Breaking Changes
 

--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] - 2026-01-20
+
+### Breaking Changes
+
+All `ParametersBuilder` methods and `Parameters::new_regtest()` now return `Result` types instead of `Self`:
+
+- `Parameters::new_regtest()` - Returns `Result<Self, ParametersBuilderError>`
+- `ParametersBuilder::clear_checkpoints()` - Returns `Result<Self, ParametersBuilderError>`
+- `ParametersBuilder::to_network()` - Returns `Result<Network, ParametersBuilderError>`
+- `ParametersBuilder::with_activation_heights()` - Returns `Result<Self, ParametersBuilderError>`
+- `ParametersBuilder::with_checkpoints()` - Returns `Result<Self, ParametersBuilderError>`
+- `ParametersBuilder::with_genesis_hash()` - Returns `Result<Self, ParametersBuilderError>`
+- `ParametersBuilder::with_halving_interval()` - Returns `Result<Self, ParametersBuilderError>`
+- `ParametersBuilder::with_network_magic()` - Returns `Result<Self, ParametersBuilderError>`
+- `ParametersBuilder::with_network_name()` - Returns `Result<Self, ParametersBuilderError>`
+- `ParametersBuilder::with_target_difficulty_limit()` - Returns `Result<Self, ParametersBuilderError>`
+
+**Migration:**
+
+- Chain builder calls with `?` operator: `.with_network_name("test")?`
+- Or use `.expect()` if errors are unexpected: `.with_network_name("test").expect("valid name")`
+
+
+## [3.1.0] - 2025-11-28
+
+### Added
+
+- Added `Output::is_dust()`
+- Added `ONE_THIRD_DUST_THRESHOLD_RATE`
+
+## [3.0.1] - 2025-11-17
+
+### Added
+
+- Added `From<SerializationError>` implementation for `std::io::Error`
+- Added `InvalidMinFee` error variant to `zebra_chain::transaction::zip317::Error`
+- Added `Transaction::zip233_amount()` method
+
 ## [3.0.0] - 2025-10-15
 
 In this release we removed a significant amount of Sapling-related code in favor of upstream implementations.

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2025-11-28
+
+No API changes; internal dependencies updated.
+
 ## [3.1.0] - 2025-11-17
 
 ### Added

--- a/zebra-network/CHANGELOG.md
+++ b/zebra-network/CHANGELOG.md
@@ -8,9 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.0.0] - 2026-01-20
 
-Changes introduce to keep track of ping times for peers, for the `getpeerinfo`
-RPC.
-
 ### Breaking Changes
 
 - Added `rtt` argument to `MetaAddr::new_responded(addr, rtt)`

--- a/zebra-network/CHANGELOG.md
+++ b/zebra-network/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [3.0.0] - 2026-01-20
+## [3.0.0] - 2026-01-21
 
 ### Breaking Changes
 

--- a/zebra-network/CHANGELOG.md
+++ b/zebra-network/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [3.0.0] - 2026-01-20
+
+Changes introduce to keep track of ping times for peers, for the `getpeerinfo`
+RPC.
+
+### Breaking Changes
+
+- Added `rtt` argument to `MetaAddr::new_responded(addr, rtt)`
+
+### Added
+
+- Added `MetaAddr::new_ping_sent(addr, ping_sent_at)` - creates change with ping timestamp
+- Added `MetaAddr::ping_sent_at()` - returns optional ping sent timestamp
+- Added `MetaAddr::rtt()` - returns optional round-trip time duration
+- Added `Response::Pong(Duration)` - response variant with duration payload
+
+
+## [2.0.2] - 2025-11-28
+
+No API changes; internal dependencies updated.
+
+
+## [2.0.1] - 2025-11-17
+
+No API changes; internal dependencies updated.
+
+
 ## [2.0.0] - 2025-10-15
 
 Added a new `Request::AdvertiseBlockToAll` variant to support block advertisement

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-network"
-version = "2.0.2"
+version = "3.0.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Networking code for Zebra"
 # # Legal

--- a/zebra-node-services/CHANGELOG.md
+++ b/zebra-node-services/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [2.1.1] - 2025-11-28
+
+No API changes; internal dependencies updated.
+
 ## [2.1.0] - 2025-11-17
 
 ### Added

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -5,12 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.0.0] - 2026-01-20
+
+Most changes are related to a fix to `getinfo` RPC response which used a string
+for the `errors_timestamp` field, which was changed to `i64` to match `zcashd`.
 
 ### Breaking Changes
 
-- Changed `GetInfoResponse::errors_timestamp`from `String` to `i64` to match
-  `zcashd`.
+- Changed `FixRpcResponseMiddleware` from non-generic to generic struct `FixRpcResponseMiddleware<S>`
+- Changed `GetInfoResponse::errors_timestamp()` return type from `&String` to `i64`
+- Changed `GetInfoResponse::from_parts()` parameter `errors_timestamp` from `String` to `i64`
+- Changed `GetInfoResponse::into_parts()` return type for `errors_timestamp` from `String` to `i64`
+- Changed `GetInfoResponse::new()` parameter `errors_timestamp` from `String` to `i64`
+- Changed `PeerInfo::new()` to require `pingtime: Option<f64>` and `pingwait: Option<f64>` parameters
+- Added `Config::max_response_body_size` field of type `usize`
+
+### Added
+
+- Added `PeerInfo::pingtime()` method returning `&Option<f64>`
+- Added `PeerInfo::pingwait()` method returning `&Option<f64>`
+- Added `RpcImpl::ping()` async method
+- Added `RpcServer::ping()` async trait method
+- Added `zebra_rpc::server::rpc_tracing` module
+- Added `RpcTracingMiddleware<S>` with `new()`, `call()`, and `RpcServiceT` implementation
+
 
 ## [3.1.0] - 2025-11-17
 

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.0.0] - 2026-01-20
+## [4.0.0] - 2026-01-21
 
 Most changes are related to a fix to `getinfo` RPC response which used a string
 for the `errors_timestamp` field, which was changed to `i64` to match `zcashd`.

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-rpc"
-version = "3.1.0"
+version = "4.0.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Zebra JSON Remote Procedure Call (JSON-RPC) interface"
 license = "MIT OR Apache-2.0"
@@ -98,7 +98,7 @@ zebra-chain = { path = "../zebra-chain", version = "3.1.0", features = [
     "json-conversion",
 ] }
 zebra-consensus = { path = "../zebra-consensus", version = "3.1.1" }
-zebra-network = { path = "../zebra-network", version = "2.0.2" }
+zebra-network = { path = "../zebra-network", version = "3.0.0" }
 zebra-node-services = { path = "../zebra-node-services", version = "2.1.1", features = [
     "rpc-client",
 ] }
@@ -123,7 +123,7 @@ zebra-chain = { path = "../zebra-chain", version = "3.1.0", features = [
 zebra-consensus = { path = "../zebra-consensus", version = "3.1.1", features = [
     "proptest-impl",
 ] }
-zebra-network = { path = "../zebra-network", version = "2.0.2", features = [
+zebra-network = { path = "../zebra-network", version = "3.0.0", features = [
     "proptest-impl",
 ] }
 zebra-state = { path = "../zebra-state", version = "3.1.1", features = [

--- a/zebra-script/CHANGELOG.md
+++ b/zebra-script/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2025-11-28
+
+No API changes; internal dependencies updated.
+
 ## [3.0.0] - 2025-10-15
 
 ### Breaking changes

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.1.1] - 2025-11-28
+
+No API changes; internal dependencies updated.
+
+
 ## [3.1.0] - 2025-11-17
 
 ### Added

--- a/zebra-utils/CHANGELOG.md
+++ b/zebra-utils/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.2] - 2026-01-20
+## [3.0.2] - 2026-01-21
 
 No API changes; internal dependencies updated.
 

--- a/zebra-utils/CHANGELOG.md
+++ b/zebra-utils/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] - 2026-01-20
+
+No API changes; internal dependencies updated.
+
+
+## [3.0.1] - 2025-11-28
+
+No API changes; internal dependencies updated.
+
+
 ## [3.0.0] - 2025-10-15
 
 - Removed unused `jsonrpc` dependency.

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-utils"
-version = "3.0.1"
+version = "3.0.2"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Developer tools for Zebra maintenance and testing"
 license = "MIT OR Apache-2.0"
@@ -79,7 +79,7 @@ zebra-node-services = { path = "../zebra-node-services", version = "2.1.1" }
 zebra-chain = { path = "../zebra-chain", version = "3.1.0" }
 
 # These crates are needed for the block-template-to-proposal binary
-zebra-rpc = { path = "../zebra-rpc", version = "3.1.0" }
+zebra-rpc = { path = "../zebra-rpc", version = "4.0.0" }
 
 # These crates are needed for the zebra-checkpoints binary
 itertools = { workspace = true, optional = true }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate metadata
 name = "zebrad"
-version = "3.1.0"
+version = "4.0.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The Zcash Foundation's independent, consensus-compatible implementation of a Zcash node"
 license = "MIT OR Apache-2.0"
@@ -153,9 +153,9 @@ comparison-interpreter = ["zebra-script/comparison-interpreter"]
 [dependencies]
 zebra-chain = { path = "../zebra-chain", version = "3.1.0" }
 zebra-consensus = { path = "../zebra-consensus", version = "3.1.1" }
-zebra-network = { path = "../zebra-network", version = "2.0.2" }
+zebra-network = { path = "../zebra-network", version = "3.0.0" }
 zebra-node-services = { path = "../zebra-node-services", version = "2.1.1", features = ["rpc-client"] }
-zebra-rpc = { path = "../zebra-rpc", version = "3.1.0" }
+zebra-rpc = { path = "../zebra-rpc", version = "4.0.0" }
 zebra-state = { path = "../zebra-state", version = "3.1.1" }
 # zebra-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
@@ -163,7 +163,7 @@ zebra-state = { path = "../zebra-state", version = "3.1.1" }
 zebra-script = { path = "../zebra-script", version = "3.0.1" }
 
 # Required for crates.io publishing, but it's only used in tests
-zebra-utils = { path = "../zebra-utils", version = "3.0.1", optional = true }
+zebra-utils = { path = "../zebra-utils", version = "3.0.2", optional = true }
 
 abscissa_core = { workspace = true }
 clap = { workspace = true, features = ["cargo"] }
@@ -295,7 +295,7 @@ color-eyre = { workspace = true }
 
 zebra-chain = { path = "../zebra-chain", version = "3.1.0", features = ["proptest-impl"] }
 zebra-consensus = { path = "../zebra-consensus", version = "3.1.1", features = ["proptest-impl"] }
-zebra-network = { path = "../zebra-network", version = "2.0.2", features = ["proptest-impl"] }
+zebra-network = { path = "../zebra-network", version = "3.0.0", features = ["proptest-impl"] }
 zebra-state = { path = "../zebra-state", version = "3.1.1", features = ["proptest-impl"] }
 
 zebra-test = { path = "../zebra-test", version = "2.0.1" }
@@ -309,7 +309,7 @@ zebra-test = { path = "../zebra-test", version = "2.0.1" }
 # When `-Z bindeps` is stabilised, enable this binary dependency instead:
 # https://github.com/rust-lang/cargo/issues/9096
 # zebra-utils { path = "../zebra-utils", artifact = "bin:zebra-checkpoints" }
-zebra-utils = { path = "../zebra-utils", version = "3.0.1" }
+zebra-utils = { path = "../zebra-utils", version = "3.0.2" }
 
 [package.metadata.cargo-udeps.ignore]
 # These dependencies are false positives - they are actually used

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_150_000;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_212_000;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.


### PR DESCRIPTION
---
name: 'Release Checklist Template'
about: 'Checklist to create and publish a Zebra release'
title: 'Release Zebra (version)'
labels: 'A-release, C-exclude-from-changelog, P-Critical :ambulance:'
assignees: ''

---

# Prepare for the Release

- [x] Make sure there has been [at least one successful full sync test in the main branch](https://github.com/ZcashFoundation/zebra/actions/workflows/zfnd-ci-integration-tests-gcp.yml?query=branch%3Amain) since the last state change, or start a manual full sync.

# Checkpoints

For performance and security, we want to update the Zebra checkpoints in every release.
- [x] You can copy the latest checkpoints from CI by following [the zebra-checkpoints README](https://github.com/ZcashFoundation/zebra/blob/main/zebra-utils/README.md#zebra-checkpoints).

# Missed Dependency Updates

Sometimes `dependabot` misses some dependency updates, or we accidentally turned them off.

This step can be skipped if there is a large pending dependency upgrade. (For example, shared ECC crates.)

Here's how we make sure we got everything:
- [x] Run `cargo update` on the latest `main` branch, and keep the output
- [x] If needed, [add duplicate dependency exceptions to deny.toml](https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/continuous-integration.md#fixing-duplicate-dependencies-in-check-denytoml-bans)
- [x] If needed, remove resolved duplicate dependencies from `deny.toml`
- [x] Open a separate PR with the changes
- [x] Add the output of `cargo update` to that PR as a comment

# Summarise Release Changes

These steps can be done a few days before the release, in the same PR:

## Change Log

**Important**: Any merge into `main` deletes any edits to the draft changelog.
Once you are ready to tag a release, copy the draft changelog into `CHANGELOG.md`.

We use [the Release Drafter workflow](https://github.com/marketplace/actions/release-drafter) to automatically create a [draft changelog](https://github.com/ZcashFoundation/zebra/releases). We follow the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.

To create the final change log:
- [x] Copy the [**latest** draft
  changelog](https://github.com/ZcashFoundation/zebra/releases) into
  `CHANGELOG.md` (there can be multiple draft releases)
- [x] Delete any trivial changes
    - [x] Put the list of deleted changelog entries in a PR comment to make reviewing easier
- [x] Combine duplicate changes
- [x] Edit change descriptions so they will make sense to Zebra users
- [x] Check the category for each change
  - Prefer the "Fix" category if you're not sure

## README

README updates can be skipped for urgent releases.

Update the README to:
- [x] Remove any "Known Issues" that have been fixed since the last release.
- [x] Update the "Build and Run Instructions" with any new dependencies.
      Check for changes in the `Dockerfile` since the last tag: `git diff <previous-release-tag> docker/Dockerfile`.
- [x] If Zebra has started using newer Rust language features or standard library APIs, update the known working Rust version in the README, book, and `Cargo.toml`s

You can use a command like:
```sh
fastmod --fixed-strings '1.58' '1.65'
```

## Create the Release PR

- [x] Push the updated changelog and README into a new branch
      for example: `bump-v1.0.0` - this needs to be different to the tag name
- [x] Create a release PR by adding `&template=release-checklist.md` to the comparing url ([Example](https://github.com/ZcashFoundation/zebra/compare/bump-v1.0.0?expand=1&template=release-checklist.md)).
- [x] Freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [x] Mark all the release PRs as `Critical` priority, so they go in the `urgent` Mergify queue.
- [x] Mark all non-release PRs with `do-not-merge`, because Mergify checks approved PRs against every commit, even when a queue is frozen.
- [x] Add the `A-release` tag to the release pull request in order for the `check-no-git-dependencies` to run.

## Zebra git sources dependencies

- [x] Ensure the `check-no-git-dependencies` check passes.

This check runs automatically on pull requests with the `A-release` label. It must pass for crates to be published to crates.io. If the check fails, you should either halt the release process or proceed with the understanding that the crates will not be published on crates.io.

# Update Versions and End of Support

## Update Zebra Version

### Choose a Release Level

Zebra follows [semantic versioning](https://semver.org). Semantic versions look like: MAJOR.MINOR.PATCH[-TAG.PRE-RELEASE]

Choose a release level for `zebrad`. Release levels are based on user-visible changes from the changelog:
- Mainnet Network Upgrades are `major` releases
- significant new features or behaviour changes; changes to RPCs, command-line, or configs; and deprecations or removals are `minor` releases
- otherwise, it is a `patch` release

### Update Crate Versions and Crate Change Logs

If you're publishing crates for the first time, [log in to crates.io](https://zebra.zfnd.org/dev/crate-owners.html#logging-in-to-cratesio),
and make sure you're a member of owners group.

Check that the release will work:

- [x] Determine which crates require release. Run `git diff --stat <previous_tag>`
      and enumerate the crates that had changes.
- [x] Determine which type of release to make. Run `semver-checks` to list API
      changes: `cargo semver-checks -p <crate> --default-features`. If there are
      breaking API changes, do a major release, or try to revert the API change
      if it was accidental. Otherwise do a minor or patch release depending on
      whether a new API was added. Note that `semver-checks` won't work
      if the previous realase was yanked; you will have to determine the
      type of release manually.
- [x] Update the crate `CHANGELOG.md` listing the API changes or other
      relevant information for a crate consumer. It might make sense to copy
      entries from the `zebrad` changelog.
- [x] Update crate versions:

```sh
cargo release version --verbose --execute --allow-branch '*' -p <crate> patch # [ major | minor ]
cargo release replace --verbose --execute --allow-branch '*' -p <crate>
```

- [x] Update the crate `CHANGELOG.md`
- [x] Commit and push the above version changes to the release branch.

## Update End of Support

The end of support height is calculated from the current blockchain height:
- [x] Find where the Zcash blockchain tip is now by using a [Zcash Block Explorer](https://mainnet.zcashexplorer.app/) or other tool.
- [x] Replace `ESTIMATED_RELEASE_HEIGHT` in [`end_of_support.rs`](https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/sync/end_of_support.rs) with the height you estimate the release will be tagged.

<details>

<summary>Optional: calculate the release tagging height</summary>

- Add `1152` blocks for each day until the release
- For example, if the release is in 3 days, add `1152 * 3` to the current Mainnet block height

</details>

## Update the Release PR

- [x] Push the version increments and the release constants to the release branch.


# Publish the Zebra Release

## Create the GitHub Pre-Release

- [x] Wait for all the release PRs to be merged
- [x] Create a new release using the draft release as a base, by clicking the Edit icon in the [draft release](https://github.com/ZcashFoundation/zebra/releases)
- [x] Set the tag name to the version tag,
      for example: `v1.0.0`
- [x] Set the release to target the `main` branch
- [x] Set the release title to `Zebra ` followed by the version tag,
      for example: `Zebra 1.0.0`
- [x] Replace the prepopulated draft changelog in the release description with the final changelog you created;
      starting just _after_ the title `## [Zebra ...` of the current version being released,
      and ending just _before_ the title of the previous release.
- [x] Mark the release as 'pre-release', until it has been built and tested
- [x] Publish the pre-release to GitHub using "Publish Release"
- [x] Delete all the [draft releases from the list of releases](https://github.com/ZcashFoundation/zebra/releases)

## Test the Pre-Release

- [ ] Wait until the Docker binaries have been built on `main`, and the quick tests have passed:
    - [ ] [zfnd-ci-integration-tests-gcp.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/zfnd-ci-integration-tests-gcp.yml?query=branch%3Amain)
- [x] Wait until the [pre-release deployment machines have successfully launched](https://github.com/ZcashFoundation/zebra/actions/workflows/zfnd-deploy-nodes-gcp.yml?query=event%3Arelease)

## Publish Release

- [x] [Publish the release to GitHub](https://github.com/ZcashFoundation/zebra/releases) by disabling 'pre-release', then clicking "Set as the latest release"

## Publish Crates

- [x] [Run `cargo login`](https://zebra.zfnd.org/dev/crate-owners.html#logging-in-to-cratesio)
- [x] It is recommended that the following step be run from a fresh checkout of
      the repo, to avoid accidentally publishing files like e.g. logs that might
      be lingering around
- [x] Publish the crates to crates.io; edit the list to only include the crates that
      have been changed, but keep their overall order:

```
for c in zebra-test tower-fallback zebra-chain tower-batch-control zebra-node-services zebra-script zebra-state zebra-consensus zebra-network zebra-rpc zebra-utils zebrad; do cargo release publish --verbose --execute -p $c; done
```

- [x] Check that Zebra can be installed from `crates.io`:
      `cargo install --locked --force --version <version> zebrad && ~/.cargo/bin/zebrad`
      and put the output in a comment on the PR.

## Publish Docker Images

- [ ] Wait for the [the Docker images to be published successfully](https://github.com/ZcashFoundation/zebra/actions/workflows/release-binaries.yml?query=event%3Arelease).
- [ ] Wait for the new tag in the [dockerhub zebra space](https://hub.docker.com/r/zfnd/zebra/tags)
- [x] Un-freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [x] Remove `do-not-merge` from the PRs you added it to

## Release Failures

If building or running fails after tagging:

<details>

<summary>Tag a new release, following these instructions...</summary>

1. Fix the bug that caused the failure
2. Start a new `patch` release
3. Skip the **Release Preparation**, and start at the **Release Changes** step
4. Update `CHANGELOG.md` with details about the fix
5. Follow the release checklist for the new Zebra version

</details>
