### PR TITLE
fix: report connection task exits as ConnectionTaskExited

### DIFF
--- a/zebra-network/src/peer/client.rs
+++ b/zebra-network/src/peer/client.rs
@@ -509,23 +509,11 @@ impl Client {
                 self.set_task_exited_error("connection", PeerError::ConnectionTaskExited)
             }
             Err(error) => {
-                // Connection task panicked.
-                let error = error.panic_if_task_has_panicked();
+                // Connection task panicked or was cancelled.
+                let _ = error.panic_if_task_has_panicked();
 
-                // Connection task was cancelled.
-                if error.is_cancelled() {
-                    self.set_task_exited_error(
-                        "connection",
-                        PeerError::HeartbeatTaskExited("Task was cancelled".to_string()),
-                    )
-                }
-                // Connection task stopped with another kind of task error.
-                else {
-                    self.set_task_exited_error(
-                        "connection",
-                        PeerError::HeartbeatTaskExited(error.to_string()),
-                    )
-                }
+                // Any unexpected termination of the connection task is reported as ConnectionTaskExited.
+                self.set_task_exited_error("connection", PeerError::ConnectionTaskExited)
             }
         };
 


### PR DESCRIPTION
Reason:
Previously, Client::poll_connection used the HeartbeatTaskExited error variant when the connection background task finished with a JoinError (panic or cancel).
This mixed up the semantics between heartbeat and connection tasks: some connection failures were reported as HeartbeatTaskExited, while other paths used ConnectionTaskExited. As a result, diagnostics and metrics that rely on
PeerError::kind() could not reliably distinguish between heartbeat and connection task exits.

Changes:
- Updated Client::poll_connection to always report unexpected termination of the connection task as PeerError::ConnectionTaskExited, both for the normal Ok(()) completion case and for JoinError cases.
- Simplified the JoinError handling by removing the is_cancelled() branch, since all connection task exits are now consistently surfaced as ConnectionTaskExited.