### PR TITLE
fix(ci): add issues write permission to release-binaries workflow

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -83,6 +83,8 @@ jobs:
     # Open tickets for any failed build in this workflow.
     if: failure() || cancelled()
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: jayqi/failed-build-issue-action@1a893bbf43ef1c2a8705e2b115cd4f0fe3c5649b #v1.2.0
         with:


### PR DESCRIPTION
## Motivation

The `failure-issue` job in the release-binaries workflow has been failing with:
```
Resource not accessible by integration
```

This occurs because the job uses `jayqi/failed-build-issue-action` to automatically create or update GitHub issues when releases fail, but lacks the necessary permissions.

## Solution

Adds `permissions: issues: write` to the `failure-issue` job, allowing it to create and comment on issues as intended.

### Tests

- Manual verification that the workflow file is valid YAML
- This same pattern is used in other workflows that need to create issues

### Specifications & References

- [GitHub Actions permissions documentation](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)
- Related error from workflow run: `Resource not accessible by integration`

### Follow-up Work

Additional CI fixes identified during investigation that require separate PRs:
- DockerHub authentication needs updated PAT (secret update required)

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date. (N/A - CI only)
- [x] The solution is tested.
- [ ] The documentation is up to date. (N/A - CI only)