### PR TITLE
perf: avoid extra clone in WtxId `TryFrom<&Vec<u8>>`

### DIFF
--- a/zebra-chain/src/transaction/hash.rs
+++ b/zebra-chain/src/transaction/hash.rs
@@ -299,7 +299,7 @@ impl TryFrom<&Vec<u8>> for WtxId {
     type Error = SerializationError;
 
     fn try_from(bytes: &Vec<u8>) -> Result<Self, Self::Error> {
-        bytes.clone().try_into()
+        bytes.as_slice().try_into()
     }
 }
 


### PR DESCRIPTION
## Motivation

TryFrom<&Vec<u8>> for WtxId implementation cloned the entire vector and then delegated to TryFrom<Vec<u8>>, causing an unnecessary allocation and copy even though WtxId already copies only the first 64 bytes into its own fixed-size array.

## Solution

Made TryFrom<&Vec<u8>> delegate directly to the &[u8] implementation via bytes.as_slice().try_into(), preserving behavior and
error handling while avoiding the redundant clone.