### PR TITLE
Fix/peerset banned cancel handles

### DIFF
--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -524,6 +524,11 @@ where
                     if self.bans_receiver.borrow().contains_key(&key.ip()) {
                         warn!(?key, "service is banned, dropping service");
                         std::mem::drop(svc);
+                        let cancel = self.cancel_handles.remove(&key);
+                        debug_assert!(
+                            cancel.is_some(),
+                            "missing cancel handle for banned unready peer"
+                        );
                         continue;
                     }
 
@@ -1087,6 +1092,9 @@ where
         let Some((req, sender, mut remaining_peers)) = self.queued_broadcast_all.take() else {
             return;
         };
+
+        let bans = self.bans_receiver.borrow().clone();
+        remaining_peers.retain(|addr| !bans.contains_key(&addr.ip()));
 
         let Ok(reserved_send_slot) = sender.try_reserve() else {
             self.queued_broadcast_all = Some((req, sender, remaining_peers));


### PR DESCRIPTION


## Motivation

Previously, when an unready peer became ready and was already banned, the service was dropped but its cancel handle remained in the PeerSet. This left stale entries in cancel_handles, inflated per-IP connection counts, and caused banned peers to be treated as still-unready in queued broadcasts, which could prevent AdvertiseBlockToAll from ever fully completing.

## Solution

This change removes the cancel handle for banned peers as soon as their unready service is dropped, and filters banned peers out of the remaining_peers set used for queued broadcasts. Together, these updates keep PeerSet’s internal state consistent and prevent queued broadcasts from being held open by permanently banned peers.

### Tests

- Added the `broadcast_all_queued_removes_banned_peers` unit test for `PeerSet`
- Ran `cargo test -p zebra-network` to execute the updated peer_set test suite.

