### PR TITLE
fix(ci): remove unsupported `continue-on-error` from reusable workflow calls

### DIFF
--- a/.github/workflows/zfnd-ci-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-ci-integration-tests-gcp.yml
@@ -356,7 +356,6 @@ jobs:
   sync-full-testnet:
     name: Zebra tip on testnet
     needs: [build, get-available-disks-testnet]
-    continue-on-error: true
     permissions:
       contents: read
       id-token: write
@@ -380,6 +379,7 @@ jobs:
       saves_to_disk: true
       force_save_to_disk: ${{ inputs.force_save_to_disk || false }}
       height_grep_text: current_height.*=.*Height.*\(
+      allow_failure: true
 
   # Test that Zebra can generate testnet checkpoints after syncing to the chain tip,
   # using a cached Zebra tip state.
@@ -395,7 +395,6 @@ jobs:
   generate-checkpoints-testnet:
     name: Generate checkpoints testnet
     needs: [sync-full-testnet, get-available-disks-testnet]
-    continue-on-error: true
     permissions:
       contents: read
       id-token: write
@@ -415,6 +414,7 @@ jobs:
       saves_to_disk: true
       force_save_to_disk: ${{ inputs.force_save_to_disk || false }}
       height_grep_text: zebra_tip_height.*=.*Height.*\(
+      allow_failure: true
 
   # lightwalletd cached tip state tests
 

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -78,6 +78,11 @@ on:
         type: string
         default: zebra
         description: Application name, used to work out when a job is an update job
+      allow_failure:
+        required: false
+        type: boolean
+        default: false
+        description: If true, test failures won't fail the workflow (shows check mark instead of X)
     secrets:
       GCP_SSH_PRIVATE_KEY:
         required: true
@@ -138,6 +143,7 @@ jobs:
     runs-on: zfnd-runners
     needs: [ get-disk-name ]
     if: ${{ !cancelled() && !failure() && (needs.get-disk-name.result == 'success' || needs.get-disk-name.result == 'skipped') }}
+    continue-on-error: ${{ inputs.allow_failure }}
     timeout-minutes: ${{ inputs.is_long_test && 7200 || 180 }}
     outputs:
       cached_disk_name: ${{ (inputs.needs_zebra_state || inputs.needs_lwd_state) && needs.get-disk-name.outputs.cached_disk_name || '' }}

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -164,6 +164,9 @@ jobs:
         uses: rlespinasse/github-slug-action@6f7a8d2348e2a4aa5defafcdaafe5aef3f83bd4b #v5.4.0
         with:
           short-length: 7
+          # GCP instance names are limited to 63 chars. With test_id (max ~31) + sha (7) + hyphens (2),
+          # we need to limit the slug to 23 chars to stay under the limit.
+          slug-maxlength: 23
 
       - name: Downcase network name for disks and labels
         run: |
@@ -221,13 +224,18 @@ jobs:
 
           # Create disk separately if using cached image, or prepare params for --create-disk if new
           if [ -n "${{ env.CACHED_DISK_NAME }}" ]; then
-            # Create disk from cached image separately (allows partition mounting)
-            echo "Creating disk ${NAME} from cached image ${{ env.CACHED_DISK_NAME }}"
-            gcloud compute disks create "${NAME}" \
-              --size=400GB \
-              --type=pd-balanced \
-              --image="${{ env.CACHED_DISK_NAME }}" \
-              --zone=${{ vars.GCP_ZONE }}
+            # Check if disk already exists (from a previous failed run)
+            if gcloud compute disks describe "${NAME}" --zone=${{ vars.GCP_ZONE }} &>/dev/null; then
+              echo "Disk ${NAME} already exists, reusing it"
+            else
+              # Create disk from cached image separately (allows partition mounting)
+              echo "Creating disk ${NAME} from cached image ${{ env.CACHED_DISK_NAME }}"
+              gcloud compute disks create "${NAME}" \
+                --size=400GB \
+                --type=pd-balanced \
+                --image="${{ env.CACHED_DISK_NAME }}" \
+                --zone=${{ vars.GCP_ZONE }}
+            fi
             DISK_ATTACH_PARAMS="--disk=name=${NAME},device-name=${NAME}"
           else
             # Use --create-disk for new disks (no partition support)
@@ -378,6 +386,7 @@ jobs:
         uses: rlespinasse/github-slug-action@6f7a8d2348e2a4aa5defafcdaafe5aef3f83bd4b #v5.4.0
         with:
           short-length: 7
+          slug-maxlength: 23
 
       # Performs formatting on disk name components.
       #
@@ -708,6 +717,7 @@ jobs:
         uses: rlespinasse/github-slug-action@6f7a8d2348e2a4aa5defafcdaafe5aef3f83bd4b #v5.4.0
         with:
           short-length: 7
+          slug-maxlength: 23
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud


### PR DESCRIPTION
## Motivation

Fix issues with the `zfnd-ci-integration-tests-gcp` workflow:

1. **Workflow parsing errors** since #10251 - `continue-on-error` is not supported at the caller job level for reusable workflows
2. **GCP instance name too long** - Instance names exceed GCP's 63-character limit when branch names are long

## Solution

### Fix 1: Move continue-on-error inside reusable workflow

`continue-on-error` is not supported at the caller job level for jobs that use reusable workflows (`uses:`). The fix moves it inside the reusable workflow where it's valid.

- Add `allow_failure` input to `zfnd-deploy-integration-tests-gcp.yml`
- Use `continue-on-error: ${{ inputs.allow_failure }}` on the `test-result` job
- Pass `allow_failure: true` from testnet jobs

### Fix 2: Truncate branch name for GCP instance names

GCP instance names are limited to 63 characters. The pattern `{test_id}-{branch}-{sha}` exceeds this when both test_id and branch are long.

- Add `slug-maxlength: 23` to all uses of `github-slug-action` to limit branch slug length
- This keeps instance names under the 63-character limit

### Fix 3: Make disk creation idempotent

Defensive fix for edge cases where a workflow run fails after creating the disk but before the instance is created (e.g., due to name length errors). Without this, re-running the failed workflow would fail with "disk already exists".

- Check if disk exists before creating
- Reuse existing disk if present

### Tests

- Verified the workflow can be triggered manually via `gh workflow run`
- Workflow successfully creates instances with truncated names

### Specifications & References

- [GitHub Community Discussion: Cannot use continue-on-error with reusable workflows](https://github.com/orgs/community/discussions/77915)
- [GCP resource naming](https://cloud.google.com/compute/docs/naming-resources#resource-name-format)
- Caused by #10251

### Follow-up Work

- Clean up orphaned GCP disks from old failed runs (manual maintenance task)

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The library crate changelogs are up to date.
- [x] The solution is tested.
- [x] The documentation is up to date.