### PR TITLE
hotfix: do major bumps for every crate that depends on zebra-chain

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md
@@ -17,36 +17,27 @@ A hotfix release should only be created when a bug or critical issue is discover
 - [ ] Create a hotfix release PR by adding `&template=hotfix-release-checklist.md` to the comparing url ([Example](https://github.com/ZcashFoundation/zebra/compare/bump-v1.0.0?expand=1&template=hotfix-release-checklist.md)).
 - [ ] Add the `C-exclude-from-changelog` label so that the PR is omitted from the next release changelog
 - [ ] Add the `A-release` tag to the release pull request in order for the `check_no_git_refs_in_cargo_lock` to run.
+- [ ] Add the `do-not-merge` tag to prevent Mergify from merging, since after PR approval the
+      release is done from the branch itself.
 - [ ] Ensure the `check_no_git_refs_in_cargo_lock` check passes.
 - [ ] Add a changelog entry for the release summarizing user-visible changes.
 
 ## Update Versions
 
-The release level for a hotfix should always follow semantic versioning as a `patch` release.
+If it is a Zebra hotfix, the release level for should always follow semantic
+versioning as a `patch` release. If is is a crate hotfix, it should simply
+follow semver, depending on thing being fixed.
 
-<details>
-<summary>Update crate versions, commit the changes to the release branch, and do a release dry-run:</summary>
-
-```sh
-# Update everything except for alpha crates and zebrad:
-cargo release version --verbose --execute --allow-branch '*' --workspace --exclude zebrad beta
-# Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
-# Update zebrad:
-cargo release version --verbose --execute --allow-branch '*' --package zebrad patch
-# Continue with the release process:
-cargo release replace --verbose --execute --allow-branch '*' --package zebrad
-cargo release commit --verbose --execute --allow-branch '*'
-```
-
-</details>
+- [ ] Follow the "Update Zebra Version" section in the regular checklist for
+  instructions
 
 ## Update the Release PR
 
 - [ ] Push the version increments and the release constants to the hotfix release branch.
 
-# Publish the Zebra Release
+# Publish the Release
 
-## Create the GitHub Pre-Release
+## Create the GitHub Pre-Release (if Zebra hotfix)
 
 - [ ] Wait for the hotfix release PR to be reviewed, approved, and merged into main.
 - [ ] Create a new release
@@ -61,13 +52,13 @@ cargo release commit --verbose --execute --allow-branch '*'
 - [ ] Mark the release as 'pre-release', until it has been built and tested
 - [ ] Publish the pre-release to GitHub using "Publish Release"
 
-## Test the Pre-Release
+## Test the Pre-Release (if Zebra hotfix)
 
 - [ ] Wait until the Docker binaries have been built on the hotfix release branch, and the quick tests have passed:
     - [ ] [ci-tests.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-tests.yml)
 - [ ] Wait until the [pre-release deployment machines have successfully launched](https://github.com/ZcashFoundation/zebra/actions/workflows/zfnd-deploy-nodes-gcp.yml?query=event%3Arelease)
 
-## Publish Release
+## Publish Release (if Zebra hotfix)
 
 - [ ] [Publish the release to GitHub](https://github.com/ZcashFoundation/zebra/releases) by disabling 'pre-release', then clicking "Set as the latest release"
 
@@ -81,15 +72,19 @@ cargo release commit --verbose --execute --allow-branch '*'
       `cargo install --locked --force --version 2.minor.patch zebrad && ~/.cargo/bin/zebrad`
       and put the output in a comment on the PR.
 
-## Publish Docker Images
+## Publish Docker Images (if Zebra hotfix)
 
 - [ ] Wait for the [the Docker images to be published successfully](https://github.com/ZcashFoundation/zebra/actions/workflows/release-binaries.yml?query=event%3Arelease).
 - [ ] Wait for the new tag in the [dockerhub zebra space](https://hub.docker.com/r/zfnd/zebra/tags)
 
 ## Merge hotfix into main
 
-- [ ] Review and merge the hotfix branch into the main branch. The changes and the update to the changelog must be included in the next release from main as well.
-- [ ] If there are conflicts between the hotfix branch and main, the conflicts should be resolved after the hotfix release is tagged and published.
+- [ ] Solve any conflicts between the hotfix branch and main. Do not force-push
+      into the branch! We need to include the commit that was released into `main`.
+- [ ] Get the PR reviewed again if changes were made
+- [ ] Admin-merge the PR with a merge commit (if by the time you are following
+      this we have switched to merge commits by default, then just remove
+      the `do-not-merge` label)
 
 ## Release Failures
 

--- a/.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md
@@ -24,12 +24,12 @@ A hotfix release should only be created when a bug or critical issue is discover
 
 ## Update Versions
 
-If it is a Zebra hotfix, the release level for should always follow semantic
+If it is a Zebra hotfix, the release level should always follow semantic
 versioning as a `patch` release. If it is a crate hotfix, it should simply
 follow semver, depending on the thing being fixed.
 
 - [ ] Follow the "Update Zebra Version" section in the regular checklist for
-  instructions
+  instructions.
 
 ## Update the Release PR
 

--- a/.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md
@@ -25,8 +25,8 @@ A hotfix release should only be created when a bug or critical issue is discover
 ## Update Versions
 
 If it is a Zebra hotfix, the release level for should always follow semantic
-versioning as a `patch` release. If is is a crate hotfix, it should simply
-follow semver, depending on thing being fixed.
+versioning as a `patch` release. If it is a crate hotfix, it should simply
+follow semver, depending on the thing being fixed.
 
 - [ ] Follow the "Update Zebra Version" section in the regular checklist for
   instructions

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -86,8 +86,6 @@ This check runs automatically on pull requests with the `A-release` label. It mu
 
 ## Update Zebra Version
 
-### Choose a Release Level
-
 Zebra follows [semantic versioning](https://semver.org). Semantic versions look like: MAJOR.MINOR.PATCH[-TAG.PRE-RELEASE]
 
 Choose a release level for `zebrad`. Release levels are based on user-visible changes:
@@ -105,7 +103,7 @@ Update the version using:
 cargo release version --verbose --execute --allow-branch '*' -p zebrad patch # [ major | minor ]
 ```
 
-### Update Crate Versions and Crate Change Logs
+## Update Crate Versions and Crate Change Logs
 
 If you're publishing crates for the first time, [log in to crates.io](https://zebra.zfnd.org/dev/crate-owners.html#logging-in-to-cratesio),
 and make sure you're a member of owners group.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7043,7 +7043,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-consensus"
-version = "3.1.2"
+version = "4.0.0"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7131,7 +7131,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-node-services"
-version = "2.1.2"
+version = "3.0.0"
 dependencies = [
  "color-eyre",
  "jsonrpsee-types",
@@ -7145,7 +7145,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7198,7 +7198,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-script"
-version = "3.0.2"
+version = "4.0.0"
 dependencies = [
  "hex",
  "lazy_static",
@@ -7212,7 +7212,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "3.1.2"
+version = "4.0.0"
 dependencies = [
  "bincode",
  "chrono",
@@ -7288,7 +7288,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-utils"
-version = "3.0.2"
+version = "4.0.0"
 dependencies = [
  "color-eyre",
  "hex",

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -5,9 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.1.2] - 2026-01-21
+## [4.0.0] - 2026-02-04
 
-No API changes; internal dependencies updated.
+- `zebra-chain` and `zebra-state` were bumped to `4.0.0`, requiring a major release
+
+## [3.1.2] - 2026-01-21 - Yanked
+
+This should have been a major release, see 4.0.0.
 
 ## [3.1.1] - 2025-11-28
 

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This should have been a major release, see 4.0.0.
 
+Dependencies updated. 
+
 ## [3.1.1] - 2025-11-28
 
 No API changes; internal dependencies updated.

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-consensus"
-version = "3.1.2"
+version = "4.0.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Implementation of Zcash consensus checks"
 license = "MIT OR Apache-2.0"
@@ -61,9 +61,9 @@ zcash_proofs = { workspace = true, features = ["multicore", "bundled-prover"] }
 tower-fallback = { path = "../tower-fallback/", version = "0.2.41" }
 tower-batch-control = { path = "../tower-batch-control/", version = "1.0.1" }
 
-zebra-script = { path = "../zebra-script", version = "3.0.2" }
-zebra-state = { path = "../zebra-state", version = "3.1.2" }
-zebra-node-services = { path = "../zebra-node-services", version = "2.1.2" }
+zebra-script = { path = "../zebra-script", version = "4.0.0" }
+zebra-state = { path = "../zebra-state", version = "4.0.0" }
+zebra-node-services = { path = "../zebra-node-services", version = "3.0.0" }
 zebra-chain = { path = "../zebra-chain", version = "4.0.0" }
 
 zcash_protocol.workspace = true
@@ -88,7 +88,7 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zebra-state = { path = "../zebra-state", version = "3.1.2", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", version = "4.0.0", features = ["proptest-impl"] }
 zebra-chain = { path = "../zebra-chain", version = "4.0.0", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/", version = "2.0.1" }
 

--- a/zebra-node-services/CHANGELOG.md
+++ b/zebra-node-services/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.2] - 2026-01-21
+## [3.0.0] - 2026-02-04
+
+- `zebra-chain` was bumped to `4.0.0`, requiring a major release
+
+## [2.1.2] - 2026-01-21 - Yanked
+
+This should have been a major release, see 4.0.0.
 
 No API changes; internal dependencies updated.
 

--- a/zebra-node-services/CHANGELOG.md
+++ b/zebra-node-services/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This should have been a major release, see 4.0.0.
 
-No API changes; internal dependencies updated.
+Dependencies updated.
 
 ## [2.1.1] - 2025-11-28
 

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-node-services"
-version = "2.1.2"
+version = "3.0.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The interfaces of some Zebra node services"
 license = "MIT OR Apache-2.0"

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -7,13 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0] - 2026-02-04
+
+### Breaking Changes
+
+- `zebra-state` bumped to `4.0.0`
+- `zebra-chain` bumped to `4.0.0`
+
 ### Added
 
 - `server/rpc_metrics` module.
 - `server/rpc_tracing` module.
 - Dependency on the `metrics` crate.
 
-## [4.0.0] - 2026-01-21
+## [4.0.0] - 2026-01-21 - Yanked
 
 Most changes are related to a fix to `getinfo` RPC response which used a string
 for the `errors_timestamp` field, which was changed to `i64` to match `zcashd`.

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-rpc"
-version = "4.0.0"
+version = "5.0.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Zebra JSON Remote Procedure Call (JSON-RPC) interface"
 license = "MIT OR Apache-2.0"
@@ -100,13 +100,13 @@ proptest = { workspace = true, optional = true }
 zebra-chain = { path = "../zebra-chain", version = "4.0.0", features = [
     "json-conversion",
 ] }
-zebra-consensus = { path = "../zebra-consensus", version = "3.1.2" }
+zebra-consensus = { path = "../zebra-consensus", version = "4.0.0" }
 zebra-network = { path = "../zebra-network", version = "3.0.0" }
-zebra-node-services = { path = "../zebra-node-services", version = "2.1.2", features = [
+zebra-node-services = { path = "../zebra-node-services", version = "3.0.0", features = [
     "rpc-client",
 ] }
-zebra-script = { path = "../zebra-script", version = "3.0.2" }
-zebra-state = { path = "../zebra-state", version = "3.1.2" }
+zebra-script = { path = "../zebra-script", version = "4.0.0" }
+zebra-state = { path = "../zebra-state", version = "4.0.0" }
 
 [build-dependencies]
 tonic-prost-build = { workspace = true }
@@ -123,13 +123,13 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 zebra-chain = { path = "../zebra-chain", version = "4.0.0", features = [
     "proptest-impl",
 ] }
-zebra-consensus = { path = "../zebra-consensus", version = "3.1.2", features = [
+zebra-consensus = { path = "../zebra-consensus", version = "4.0.0", features = [
     "proptest-impl",
 ] }
 zebra-network = { path = "../zebra-network", version = "3.0.0", features = [
     "proptest-impl",
 ] }
-zebra-state = { path = "../zebra-state", version = "3.1.2", features = [
+zebra-state = { path = "../zebra-state", version = "4.0.0", features = [
     "proptest-impl",
 ] }
 

--- a/zebra-script/CHANGELOG.md
+++ b/zebra-script/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This should have been a major release, see 4.0.0.
 
-No API changes; internal dependencies updated.
+Dependencies updated.
 
 ## [3.0.1] - 2025-11-28
 

--- a/zebra-script/CHANGELOG.md
+++ b/zebra-script/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.2] - 2026-01-21
+## [4.0.0] - 2026-02-04
+
+- `zebra-chain` was bumped to `4.0.0`, requiring a major release
+
+## [3.0.2] - 2026-01-21 - Yanked
+
+This should have been a major release, see 4.0.0.
 
 No API changes; internal dependencies updated.
 

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-script"
-version = "3.0.2"
+version = "4.0.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Zebra script verification wrapping zcashd's zcash_script library"
 license = "MIT OR Apache-2.0"

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This should have been a major release, see 4.0.0.
 
+Dependencies updated.
 
 ## [3.1.1] - 2025-11-28
 

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -6,9 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [3.1.2] - 2026-01-21
+## [4.0.0] - 2026-02-04
 
-No API changes; internal dependencies updated.
+- `zebra-chain` was bumped to `4.0.0`, requiring a major release
+
+
+## [3.1.2] - 2026-01-21 - Yanked
+
+This should have been a major release, see 4.0.0.
 
 
 ## [3.1.1] - 2025-11-28

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-state"
-version = "3.1.2"
+version = "4.0.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "State contextual verification and storage code for Zebra"
 license = "MIT OR Apache-2.0"
@@ -77,7 +77,7 @@ sapling-crypto = { workspace = true }
 elasticsearch = { workspace = true, features = ["rustls-tls"], optional = true }
 serde_json = { workspace = true, optional = true }
 
-zebra-node-services = { path = "../zebra-node-services", version = "2.1.2" }
+zebra-node-services = { path = "../zebra-node-services", version = "3.0.0" }
 zebra-chain = { path = "../zebra-chain", version = "4.0.0", features = ["async-error"] }
 
 # prod feature progress-bar

--- a/zebra-utils/CHANGELOG.md
+++ b/zebra-utils/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This should have been a major release, see 4.0.0.
 
-No API changes; internal dependencies updated.
+Dependencies updated.
 
 
 ## [3.0.1] - 2025-11-28

--- a/zebra-utils/CHANGELOG.md
+++ b/zebra-utils/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] - 2026-02-04
+
+- `zebra-chain` was bumped to `4.0.0`, requiring a major release
+
+
 ## [3.0.2] - 2026-01-21
+
+This should have been a major release, see 4.0.0.
 
 No API changes; internal dependencies updated.
 

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-utils"
-version = "3.0.2"
+version = "4.0.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Developer tools for Zebra maintenance and testing"
 license = "MIT OR Apache-2.0"
@@ -75,11 +75,11 @@ tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 
-zebra-node-services = { path = "../zebra-node-services", version = "2.1.2" }
+zebra-node-services = { path = "../zebra-node-services", version = "3.0.0" }
 zebra-chain = { path = "../zebra-chain", version = "4.0.0" }
 
 # These crates are needed for the block-template-to-proposal binary
-zebra-rpc = { path = "../zebra-rpc", version = "4.0.0" }
+zebra-rpc = { path = "../zebra-rpc", version = "5.0.0" }
 
 # These crates are needed for the zebra-checkpoints binary
 itertools = { workspace = true, optional = true }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -152,19 +152,19 @@ comparison-interpreter = ["zebra-script/comparison-interpreter"]
 
 [dependencies]
 zebra-chain = { path = "../zebra-chain", version = "4.0.0" }
-zebra-consensus = { path = "../zebra-consensus", version = "3.1.2" }
+zebra-consensus = { path = "../zebra-consensus", version = "4.0.0" }
 zebra-network = { path = "../zebra-network", version = "3.0.0" }
-zebra-node-services = { path = "../zebra-node-services", version = "2.1.2", features = ["rpc-client"] }
-zebra-rpc = { path = "../zebra-rpc", version = "4.0.0" }
-zebra-state = { path = "../zebra-state", version = "3.1.2" }
+zebra-node-services = { path = "../zebra-node-services", version = "3.0.0", features = ["rpc-client"] }
+zebra-rpc = { path = "../zebra-rpc", version = "5.0.0" }
+zebra-state = { path = "../zebra-state", version = "4.0.0" }
 # zebra-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
 # enabling it in the other imports of zcash-script.)
-zebra-script = { path = "../zebra-script", version = "3.0.2" }
+zebra-script = { path = "../zebra-script", version = "4.0.0" }
 zcash_script = { workspace = true }
 
 # Required for crates.io publishing, but it's only used in tests
-zebra-utils = { path = "../zebra-utils", version = "3.0.2", optional = true }
+zebra-utils = { path = "../zebra-utils", version = "4.0.0", optional = true }
 
 abscissa_core = { workspace = true }
 clap = { workspace = true, features = ["cargo"] }
@@ -295,9 +295,9 @@ proptest-derive = { workspace = true }
 color-eyre = { workspace = true }
 
 zebra-chain = { path = "../zebra-chain", version = "4.0.0", features = ["proptest-impl"] }
-zebra-consensus = { path = "../zebra-consensus", version = "3.1.2", features = ["proptest-impl"] }
+zebra-consensus = { path = "../zebra-consensus", version = "4.0.0", features = ["proptest-impl"] }
 zebra-network = { path = "../zebra-network", version = "3.0.0", features = ["proptest-impl"] }
-zebra-state = { path = "../zebra-state", version = "3.1.2", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", version = "4.0.0", features = ["proptest-impl"] }
 
 zebra-test = { path = "../zebra-test", version = "2.0.1" }
 
@@ -310,7 +310,7 @@ zebra-test = { path = "../zebra-test", version = "2.0.1" }
 # When `-Z bindeps` is stabilised, enable this binary dependency instead:
 # https://github.com/rust-lang/cargo/issues/9096
 # zebra-utils { path = "../zebra-utils", artifact = "bin:zebra-checkpoints" }
-zebra-utils = { path = "../zebra-utils", version = "3.0.2" }
+zebra-utils = { path = "../zebra-utils", version = "4.0.0" }
 
 [package.metadata.cargo-udeps.ignore]
 # These dependencies are false positives - they are actually used


### PR DESCRIPTION
---
name: 'Hotfix Release Checklist Template'
about: 'Checklist to create and publish a hotfix Zebra release'
title: 'Release Zebra (version)'
labels: 'A-release, C-exclude-from-changelog, P-Critical :ambulance:'
assignees: ''

---

Closes https://github.com/ZcashFoundation/zebra/issues/10253

Our hotfix checklist does not work very well for the only-crates scenario, I updated it a little bit but it needs more work, which we can do separately.

I did not bump:

- `tower-batch-control` and `tower-fallback`, since they do not depend on `zebra-chain`
- `zebra-network` because it already had a major bump and does not depend on the other crates that were bumped here
- `zebrad` itself since it is a binary, we can simply bump it in the next release (and it does not require a major bump because of zebra-chain since it is not a library)


---


A hotfix release should only be created when a bug or critical issue is discovered in an existing release, and waiting for the next scheduled release is impractical or unacceptable.

## Create the Release PR

- [x] Create a branch to fix the issue based on the tag of the release being fixed (not the main branch).
      for example: `hotfix-v2.3.1` - this needs to be different to the tag name
- [x] Make the required changes
- [x] Create a hotfix release PR by adding `&template=hotfix-release-checklist.md` to the comparing url ([Example](https://github.com/ZcashFoundation/zebra/compare/bump-v1.0.0?expand=1&template=hotfix-release-checklist.md)).
- [x] Add the `C-exclude-from-changelog` label so that the PR is omitted from the next release changelog
- [x] Add the `A-release` tag to the release pull request in order for the `check_no_git_refs_in_cargo_lock` to run.
- [ ] Ensure the `check_no_git_refs_in_cargo_lock` check passes.
- [x] Add a changelog entry for the release summarizing user-visible changes.

## Update Versions

The release level for a hotfix should always follow semantic versioning as a `patch` release.

<details>
<summary>Update crate versions, commit the changes to the release branch, and do a release dry-run:</summary>

```sh
# Update everything except for alpha crates and zebrad:
cargo release version --verbose --execute --allow-branch '*' --workspace --exclude zebrad beta
# Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
# Update zebrad:
cargo release version --verbose --execute --allow-branch '*' --package zebrad patch
# Continue with the release process:
cargo release replace --verbose --execute --allow-branch '*' --package zebrad
cargo release commit --verbose --execute --allow-branch '*'
```

</details>

## Update the Release PR

- [x] Push the version increments and the release constants to the hotfix release branch.

# Publish the Zebra Release

## Create the GitHub Pre-Release

- [ ] Wait for the hotfix release PR to be reviewed, approved, and merged into main.
- [ ] Create a new release
- [ ] Set the tag name to the version tag,
      for example: `v2.3.1`
- [ ] Set the release to target the hotfix release branch
- [ ] Set the release title to `Zebra ` followed by the version tag,
      for example: `Zebra 2.3.1`
- [ ] Populate the release description with the final changelog you created;
      starting just _after_ the title `## [Zebra ...` of the current version being released,
      and ending just _before_ the title of the previous release.
- [ ] Mark the release as 'pre-release', until it has been built and tested
- [ ] Publish the pre-release to GitHub using "Publish Release"

## Test the Pre-Release

- [ ] Wait until the Docker binaries have been built on the hotfix release branch, and the quick tests have passed:
    - [ ] [ci-tests.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-tests.yml)
- [ ] Wait until the [pre-release deployment machines have successfully launched](https://github.com/ZcashFoundation/zebra/actions/workflows/zfnd-deploy-nodes-gcp.yml?query=event%3Arelease)

## Publish Release

- [ ] [Publish the release to GitHub](https://github.com/ZcashFoundation/zebra/releases) by disabling 'pre-release', then clicking "Set as the latest release"

## Publish Crates

- [ ] Checkout the hotfix release branch
- [ ] [Run `cargo login`](https://zebra.zfnd.org/dev/crate-owners.html#logging-in-to-cratesio)
- [ ] Run `cargo clean` in the zebra repo
- [ ] Publish the crates to crates.io: `cargo release publish --verbose --workspace --execute --allow-branch {hotfix-release-branch}`
- [ ] Check that the published version of Zebra can be installed from `crates.io`:
      `cargo install --locked --force --version 2.minor.patch zebrad && ~/.cargo/bin/zebrad`
      and put the output in a comment on the PR.

## Publish Docker Images

- [ ] Wait for the [the Docker images to be published successfully](https://github.com/ZcashFoundation/zebra/actions/workflows/release-binaries.yml?query=event%3Arelease).
- [ ] Wait for the new tag in the [dockerhub zebra space](https://hub.docker.com/r/zfnd/zebra/tags)

## Merge hotfix into main

- [ ] Review and merge the hotfix branch into the main branch. The changes and the update to the changelog must be included in the next release from main as well.
- [ ] If there are conflicts between the hotfix branch and main, the conflicts should be resolved after the hotfix release is tagged and published.

## Release Failures

If building or running fails after tagging:

<details>
1. Create a new hotfix release, starting from the top of this document.
</details>
