### PR TITLE
fix(docker): replace gosu with setpriv for privilege dropping

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -93,6 +93,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Privilege drop verification - runs 'id' to verify non-root user
+          - id: privilege-drop
+            name: Privilege drop
+            env_vars: ""
+            test_cmd: id
+            grep_patterns: -e "uid=10001(zebra).*gid=10001(zebra)"
+
           # Basic network configurations
           - id: default-conf
             name: Default config
@@ -159,7 +166,23 @@ jobs:
       - name: Run ${{ matrix.name }} test
         # Only run custom-conf test if the config file exists in the built image
         if: ${{ matrix.id != 'custom-conf' || hashFiles('zebrad/tests/common/configs/custom-conf.toml') != '' }}
+        env:
+          TEST_CMD: ${{ matrix.test_cmd }}
         run: |
+          # For one-shot commands (like 'id'), run directly and check output
+          if [ -n "$TEST_CMD" ]; then
+            OUTPUT=$(docker run --rm ${{ matrix.env_vars }} zebrad-test:${{ github.sha }} $TEST_CMD)
+            echo "Output: $OUTPUT"
+            if echo "$OUTPUT" | grep --extended-regexp ${{ matrix.grep_patterns }}; then
+              echo "SUCCESS: Found expected pattern in output"
+              exit 0
+            else
+              echo "FAILURE: Expected pattern not found in output"
+              exit 1
+            fi
+          fi
+
+          # For long-running commands (zebrad start), run detached and follow logs
           docker run ${{ matrix.env_vars }} --detach --name ${{ matrix.id }} -t zebrad-test:${{ github.sha }} zebrad start
           # Use a subshell to handle the broken pipe error gracefully
           (

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -98,7 +98,7 @@ jobs:
             name: Privilege drop
             env_vars: ""
             test_cmd: id
-            grep_patterns: -e "uid=10001(zebra).*gid=10001(zebra)"
+            grep_patterns: -e "uid=10001\\(zebra\\).*gid=10001\\(zebra\\)"
 
           # Basic network configurations
           - id: default-conf

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-# check=skip=UndefinedVar,UserExist # We use gosu in the entrypoint instead of USER directive
+# check=skip=UndefinedVar,UserExist # We use setpriv in the entrypoint instead of USER directive
 
 # If you want to include a file in the Docker image, add it to .dockerignore.
 #
@@ -117,10 +117,6 @@ RUN [ -n "${SHORT_SHA}" ] && export SHORT_SHA="${SHORT_SHA}" || true; \
 # Copy the lightwalletd binary and source files to be able to run tests
 COPY --link --from=electriccoinco/lightwalletd:v0.4.17 /usr/local/bin/lightwalletd /usr/local/bin/
 
-# Copy the gosu binary to be able to run the entrypoint as non-root user
-# and allow to change permissions for mounted cache directories
-COPY --link --from=tianon/gosu:trixie /gosu /usr/local/bin/
-
 COPY --link --chown=${UID}:${GID} ./docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT [ "entrypoint.sh", "test" ]
@@ -207,13 +203,12 @@ WORKDIR ${HOME}
 RUN chown -R ${UID}:${GID} ${HOME}
 
 # We're explicitly NOT using the USER directive here.
-# Instead, we run as root initially and use gosu in the entrypoint.sh
+# Instead, we run as root initially and use setpriv in the entrypoint.sh
 # to step down to the non-privileged user. This allows us to change permissions
 # on mounted volumes before running the application as a non-root user.
-# User with UID=${UID} is created above and used via gosu in entrypoint.sh.
+# User with UID=${UID} is created above and used via setpriv in entrypoint.sh.
+# setpriv is part of util-linux, already included in debian:trixie-slim.
 
-# Copy the gosu binary to be able to run the entrypoint as non-root user
-COPY --link --from=tianon/gosu:trixie /gosu /usr/local/bin/
 COPY --link --from=release /usr/local/bin/zebrad /usr/local/bin/
 COPY --link --chown=${UID}:${GID} ./docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,11 +14,11 @@ set -eo pipefail
 : "${ZEBRA_STATE__CACHE_DIR:=${HOME}/.cache/zebra}"
 : "${ZEBRA_RPC__COOKIE_DIR:=${HOME}/.cache/zebra}"
 
-# Use gosu to drop privileges and execute the given command as the specified UID:GID
+# Use setpriv to drop privileges and execute the given command as the specified UID:GID
 exec_as_user() {
   user=$(id -u)
   if [[ ${user} == '0' ]]; then
-    exec gosu "${UID}:${GID}" "$@"
+    exec setpriv --reuid="${UID}" --regid="${GID}" --init-groups "$@"
   else
     exec "$@"
   fi

--- a/docs/decisions/devops/0002-docker-use-gosu.md
+++ b/docs/decisions/devops/0002-docker-use-gosu.md
@@ -1,5 +1,5 @@
 ---
-status: accepted
+status: superseded by [ADR-0004](0004-docker-use-setpriv.md)
 date: 2025-02-28
 story: Volumes permissions and privilege management in container entrypoint
 ---

--- a/docs/decisions/devops/0004-docker-use-setpriv.md
+++ b/docs/decisions/devops/0004-docker-use-setpriv.md
@@ -1,0 +1,60 @@
+---
+status: accepted
+date: 2026-02-04
+supersedes: "[ADR-0002](0002-docker-use-gosu.md)"
+story: Volumes permissions and privilege management in container entrypoint
+---
+
+# Use setpriv for Privilege Dropping in Entrypoint
+
+## Context & Problem Statement
+
+We previously used `gosu` for privilege dropping in our Docker entrypoint (see [ADR-0002](0002-docker-use-gosu.md)). In February 2026, `tianon/gosu:trixie` lost arm64 support, breaking our multi-architecture Docker builds.
+
+We need a privilege-dropping solution that:
+
+- Works on all target architectures (amd64, arm64)
+- Provides equivalent functionality to gosu
+- Minimizes external dependencies
+
+## Priorities & Constraints
+
+- Support multi-architecture builds (amd64, arm64)
+- Minimize external dependencies
+- Maintain equivalent privilege-dropping behavior
+- Avoid complex signal handling and TTY issues
+
+## Considered Options
+
+- Option 1: Pin `gosu` to version tag (`tianon/gosu:1.19`) instead of Debian tag
+- Option 2: Use `setpriv` from util-linux
+
+## Decision Outcome
+
+Chosen option: [Option 2: Use `setpriv` from util-linux]
+
+We chose `setpriv` because:
+
+1. **Zero additional dependencies**: `setpriv` is part of `util-linux`, already included in `debian:trixie-slim`.
+2. **Native multi-arch support**: Works on all architectures supported by the base image.
+3. **Equivalent functionality**: `setpriv --reuid --regid --init-groups` provides the same privilege-dropping behavior as `gosu`.
+4. **Reduced attack surface**: Eliminates an external dependency, reducing supply chain risks.
+
+### Why not pin gosu version?
+
+Pinning to `tianon/gosu:1.19` would restore arm64 support, but:
+
+- Still requires pulling an external image during build
+- Adds supply chain dependency we can eliminate
+- `setpriv` is already available at no cost
+
+### Expected Consequences
+
+- Reliable multi-architecture Docker builds
+- No external image dependencies for privilege dropping
+- Equivalent security posture to the previous gosu approach
+
+## More Information
+
+- [setpriv man page](https://man7.org/linux/man-pages/man1/setpriv.1.html)
+- Usage: `exec setpriv --reuid="${UID}" --regid="${GID}" --init-groups "$@"`


### PR DESCRIPTION
## Summary

The `tianon/gosu:trixie` image lost arm64 support on 2026-02-04, breaking multi-arch Docker builds.

Replace gosu with `setpriv` (part of util-linux, already in debian:trixie-slim).

## Changes

- Remove `COPY --from=tianon/gosu:trixie` from Dockerfile
- Update entrypoint.sh to use `setpriv --reuid --regid --init-groups`
- Add explicit privilege drop test to CI matrix

## Test Plan

- [x] Local Docker build succeeds
- [x] `docker run zebra id` returns `uid=10001(zebra) gid=10001(zebra)`
- [x] `zebrad start` works with dropped privileges
- [ ] CI privilege-drop test passes