### PR TITLE
chore: Release v4.1.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md
@@ -17,36 +17,27 @@ A hotfix release should only be created when a bug or critical issue is discover
 - [ ] Create a hotfix release PR by adding `&template=hotfix-release-checklist.md` to the comparing url ([Example](https://github.com/ZcashFoundation/zebra/compare/bump-v1.0.0?expand=1&template=hotfix-release-checklist.md)).
 - [ ] Add the `C-exclude-from-changelog` label so that the PR is omitted from the next release changelog
 - [ ] Add the `A-release` tag to the release pull request in order for the `check_no_git_refs_in_cargo_lock` to run.
+- [ ] Add the `do-not-merge` tag to prevent Mergify from merging, since after PR approval the
+      release is done from the branch itself.
 - [ ] Ensure the `check_no_git_refs_in_cargo_lock` check passes.
 - [ ] Add a changelog entry for the release summarizing user-visible changes.
 
 ## Update Versions
 
-The release level for a hotfix should always follow semantic versioning as a `patch` release.
+If it is a Zebra hotfix, the release level should always follow semantic
+versioning as a `patch` release. If it is a crate hotfix, it should simply
+follow semver, depending on the thing being fixed.
 
-<details>
-<summary>Update crate versions, commit the changes to the release branch, and do a release dry-run:</summary>
-
-```sh
-# Update everything except for alpha crates and zebrad:
-cargo release version --verbose --execute --allow-branch '*' --workspace --exclude zebrad beta
-# Due to a bug in cargo-release, we need to pass exact versions for alpha crates:
-# Update zebrad:
-cargo release version --verbose --execute --allow-branch '*' --package zebrad patch
-# Continue with the release process:
-cargo release replace --verbose --execute --allow-branch '*' --package zebrad
-cargo release commit --verbose --execute --allow-branch '*'
-```
-
-</details>
+- [ ] Follow the "Update Zebra Version" section in the regular checklist for
+  instructions.
 
 ## Update the Release PR
 
 - [ ] Push the version increments and the release constants to the hotfix release branch.
 
-# Publish the Zebra Release
+# Publish the Release
 
-## Create the GitHub Pre-Release
+## Create the GitHub Pre-Release (if Zebra hotfix)
 
 - [ ] Wait for the hotfix release PR to be reviewed, approved, and merged into main.
 - [ ] Create a new release
@@ -61,13 +52,13 @@ cargo release commit --verbose --execute --allow-branch '*'
 - [ ] Mark the release as 'pre-release', until it has been built and tested
 - [ ] Publish the pre-release to GitHub using "Publish Release"
 
-## Test the Pre-Release
+## Test the Pre-Release (if Zebra hotfix)
 
 - [ ] Wait until the Docker binaries have been built on the hotfix release branch, and the quick tests have passed:
     - [ ] [ci-tests.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/ci-tests.yml)
 - [ ] Wait until the [pre-release deployment machines have successfully launched](https://github.com/ZcashFoundation/zebra/actions/workflows/zfnd-deploy-nodes-gcp.yml?query=event%3Arelease)
 
-## Publish Release
+## Publish Release (if Zebra hotfix)
 
 - [ ] [Publish the release to GitHub](https://github.com/ZcashFoundation/zebra/releases) by disabling 'pre-release', then clicking "Set as the latest release"
 
@@ -81,15 +72,19 @@ cargo release commit --verbose --execute --allow-branch '*'
       `cargo install --locked --force --version 2.minor.patch zebrad && ~/.cargo/bin/zebrad`
       and put the output in a comment on the PR.
 
-## Publish Docker Images
+## Publish Docker Images (if Zebra hotfix)
 
 - [ ] Wait for the [the Docker images to be published successfully](https://github.com/ZcashFoundation/zebra/actions/workflows/release-binaries.yml?query=event%3Arelease).
 - [ ] Wait for the new tag in the [dockerhub zebra space](https://hub.docker.com/r/zfnd/zebra/tags)
 
 ## Merge hotfix into main
 
-- [ ] Review and merge the hotfix branch into the main branch. The changes and the update to the changelog must be included in the next release from main as well.
-- [ ] If there are conflicts between the hotfix branch and main, the conflicts should be resolved after the hotfix release is tagged and published.
+- [ ] Solve any conflicts between the hotfix branch and main. Do not force-push
+      into the branch! We need to include the commit that was released into `main`.
+- [ ] Get the PR reviewed again if changes were made
+- [ ] Admin-merge the PR with a merge commit (if by the time you are following
+      this we have switched to merge commits by default, then just remove
+      the `do-not-merge` label)
 
 ## Release Failures
 

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -86,8 +86,6 @@ This check runs automatically on pull requests with the `A-release` label. It mu
 
 ## Update Zebra Version
 
-### Choose a Release Level
-
 Zebra follows [semantic versioning](https://semver.org). Semantic versions look like: MAJOR.MINOR.PATCH[-TAG.PRE-RELEASE]
 
 Choose a release level for `zebrad`. Release levels are based on user-visible changes:
@@ -105,7 +103,7 @@ Update the version using:
 cargo release version --verbose --execute --allow-branch '*' -p zebrad patch # [ major | minor ]
 ```
 
-### Update Crate Versions and Crate Change Logs
+## Update Crate Versions and Crate Change Logs
 
 If you're publishing crates for the first time, [log in to crates.io](https://zebra.zfnd.org/dev/crate-owners.html#logging-in-to-cratesio),
 and make sure you're a member of owners group.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,36 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Zebra 4.0.0](https://github.com/ZcashFoundation/zebra/releases/tag/v4.0.0) - 2025-01-20
+## [Zebra 4.1.0](https://github.com/ZcashFoundation/zebra/releases/tag/v4.1.0) - 2026-02-05
+
+This release has no breaking changes for node operators. It expands Zebra's
+observability with new Prometheus metrics and Grafana dashboards. It also adds
+mempool checks for standard transparent scripts to match zcashd.
+
+Listed below are all user-visible changes.
+
+### Changed
+
+- Split subsidy constants into submodules ([#10185](https://github.com/ZcashFoundation/zebra/pull/10185))
+- Check that `SENTRY_DSN` env variable is present before initializing sentry ([#10256](https://github.com/ZcashFoundation/zebra/pull/10256))
+- Report connection task exits as ConnectionTaskExited ([#10231](https://github.com/ZcashFoundation/zebra/pull/10231))
+- Improve error propagation for `CommitCheckpointVerifiedBlock` ([#9979](https://github.com/ZcashFoundation/zebra/pull/9979))
+
+### Added
+
+- Add RocksDB I/O latency and sync distance metrics ([#10181](https://github.com/ZcashFoundation/zebra/pull/10181))
+- Add performance histograms for bottleneck identification ([#10179](https://github.com/ZcashFoundation/zebra/pull/10179))
+- Add value pool, RPC, and peer health metrics ([#10175](https://github.com/ZcashFoundation/zebra/pull/10175))
+- Add new `Bounded` vec type and apply it in `AdjustDifficulty` ([#10056](https://github.com/ZcashFoundation/zebra/pull/10056))
+- Add standardness checks and configurable `OP_RETURN` policy ([#10224](https://github.com/ZcashFoundation/zebra/pull/10224))
+- Add zaino to the qa rpc framework ([#10199](https://github.com/ZcashFoundation/zebra/pull/10199))
+
+### Contributors
+
+Thank you to everyone who contributed to this release, we couldn't make Zebra without you:
+@Bashmunta, @MozirDmitriy, @gustavovalverde, @mpguerra, @oxarbitrage, @syszery, @upbqdn and @zlyzol
+
+## [Zebra 4.0.0](https://github.com/ZcashFoundation/zebra/releases/tag/v4.0.0) - 2026-01-20
 
 This release fixes the type of a field in the `getinfo` RPC and adds support for
 the `pingtime` and `pingwait` fields of the `getpeerinfo` RPC.
@@ -47,9 +76,6 @@ This release has the following breaking changes:
 
 Thank you to everyone who contributed to this release, we couldn't make Zebra without you:
 @conradoplg, @gustavovalverde and @syszery
-
-
-## [Unreleased]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,17 +15,13 @@ Listed below are all user-visible changes.
 
 ### Changed
 
-- Split subsidy constants into submodules ([#10185](https://github.com/ZcashFoundation/zebra/pull/10185))
 - Check that `SENTRY_DSN` env variable is present before initializing sentry ([#10256](https://github.com/ZcashFoundation/zebra/pull/10256))
-- Report connection task exits as ConnectionTaskExited ([#10231](https://github.com/ZcashFoundation/zebra/pull/10231))
-- Improve error propagation for `CommitCheckpointVerifiedBlock` ([#9979](https://github.com/ZcashFoundation/zebra/pull/9979))
 
 ### Added
 
 - Add RocksDB I/O latency and sync distance metrics ([#10181](https://github.com/ZcashFoundation/zebra/pull/10181))
 - Add performance histograms for bottleneck identification ([#10179](https://github.com/ZcashFoundation/zebra/pull/10179))
 - Add value pool, RPC, and peer health metrics ([#10175](https://github.com/ZcashFoundation/zebra/pull/10175))
-- Add new `Bounded` vec type and apply it in `AdjustDifficulty` ([#10056](https://github.com/ZcashFoundation/zebra/pull/10056))
 - Add standardness checks and configurable `OP_RETURN` policy ([#10224](https://github.com/ZcashFoundation/zebra/pull/10224))
 - Add zaino to the qa rpc framework ([#10199](https://github.com/ZcashFoundation/zebra/pull/10199))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7043,7 +7043,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-consensus"
-version = "3.1.2"
+version = "4.0.0"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7131,7 +7131,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-node-services"
-version = "2.1.2"
+version = "3.0.0"
 dependencies = [
  "color-eyre",
  "jsonrpsee-types",
@@ -7145,7 +7145,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7198,7 +7198,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-script"
-version = "3.0.2"
+version = "4.0.0"
 dependencies = [
  "hex",
  "lazy_static",
@@ -7212,7 +7212,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "3.1.2"
+version = "4.0.0"
 dependencies = [
  "bincode",
  "chrono",
@@ -7288,7 +7288,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-utils"
-version = "3.0.2"
+version = "4.0.0"
 dependencies = [
  "color-eyre",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6975,7 +6975,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "bech32",
  "bitflags 2.10.0",
@@ -7090,7 +7090,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-network"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -7316,7 +7316,7 @@ dependencies = [
 
 [[package]]
 name = "zebrad"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "abscissa_core",
  "atty",

--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -5,15 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [5.0.0] - 2026-02-05
+
+### Breaking Changes
+
+- `AtLeastOne<T>` is now a type alias for `BoundedVec<T, 1, { usize::MAX }>`.
 
 ### Added
 
 - `parameters::network::subsidy::constants` module.
+- `BoundedVec` re-export.
+- `OrchardActions` trait with `actions()` method.
+- `ConfiguredFundingStreamRecipient::new_for()` method.
 
 ### Removed
 
 - All constants from `parameters::network::subsidy`.
+- `AtLeastOne<T>` struct (replaced with type alias to `BoundedVec`).
 
 ## [4.0.0] - 2026-01-21
 

--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `parameters::network::subsidy::constants` module.
 - `BoundedVec` re-export.
 - `OrchardActions` trait with `actions()` method.
 - `ConfiguredFundingStreamRecipient::new_for()` method.

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-chain"
-version = "4.0.0"
+version = "5.0.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Core Zcash data structures"
 license = "MIT OR Apache-2.0"

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `zebra-state` bumped to 4.0.0
 - `zebra-chain` bumped to 5.0.0
+- `zebra-script` bumped to 4.0.0
+- `zebra-node-services` bumped to 3.0.0
 - `VerifyBlockError::Commit` now contains `CommitBlockError` instead of `BoxError`.
 
 ### Added

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.1.2] - 2026-01-21
+## [4.0.0] - 2026-02-04
 
-No API changes; internal dependencies updated.
+- `zebra-chain` and `zebra-state` were bumped to `4.0.0`, requiring a major release
+
+## [3.1.2] - 2026-01-21 - Yanked
+
+This should have been a major release, see 4.0.0.
+
+Dependencies updated. 
 
 ## [3.1.1] - 2025-11-28
 

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -5,9 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.0.0] - 2026-02-04
+## [4.0.0] - 2026-02-05
 
-- `zebra-chain` and `zebra-state` were bumped to `4.0.0`, requiring a major release
+### Breaking Changes
+
+- `zebra-state` bumped to 4.0.0
+- `zebra-chain` bumped to 5.0.0
+- `VerifyBlockError::Commit` now contains `CommitBlockError` instead of `BoxError`.
+
+### Added
+
+- `VerifyBlockError::StateService` variant with `hash` and `source` fields.
 
 ## [3.1.2] - 2026-01-21 - Yanked
 

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -64,7 +64,7 @@ tower-batch-control = { path = "../tower-batch-control/", version = "1.0.1" }
 zebra-script = { path = "../zebra-script", version = "4.0.0" }
 zebra-state = { path = "../zebra-state", version = "4.0.0" }
 zebra-node-services = { path = "../zebra-node-services", version = "3.0.0" }
-zebra-chain = { path = "../zebra-chain", version = "4.0.0" }
+zebra-chain = { path = "../zebra-chain", version = "5.0.0" }
 
 zcash_protocol.workspace = true
 
@@ -89,7 +89,7 @@ tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 zebra-state = { path = "../zebra-state", version = "4.0.0", features = ["proptest-impl"] }
-zebra-chain = { path = "../zebra-chain", version = "4.0.0", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "5.0.0", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/", version = "2.0.1" }
 
 [lints]

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-consensus"
-version = "3.1.2"
+version = "4.0.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Implementation of Zcash consensus checks"
 license = "MIT OR Apache-2.0"
@@ -61,9 +61,9 @@ zcash_proofs = { workspace = true, features = ["multicore", "bundled-prover"] }
 tower-fallback = { path = "../tower-fallback/", version = "0.2.41" }
 tower-batch-control = { path = "../tower-batch-control/", version = "1.0.1" }
 
-zebra-script = { path = "../zebra-script", version = "3.0.2" }
-zebra-state = { path = "../zebra-state", version = "3.1.2" }
-zebra-node-services = { path = "../zebra-node-services", version = "2.1.2" }
+zebra-script = { path = "../zebra-script", version = "4.0.0" }
+zebra-state = { path = "../zebra-state", version = "4.0.0" }
+zebra-node-services = { path = "../zebra-node-services", version = "3.0.0" }
 zebra-chain = { path = "../zebra-chain", version = "4.0.0" }
 
 zcash_protocol.workspace = true
@@ -88,7 +88,7 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zebra-state = { path = "../zebra-state", version = "3.1.2", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", version = "4.0.0", features = ["proptest-impl"] }
 zebra-chain = { path = "../zebra-chain", version = "4.0.0", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/", version = "2.0.1" }
 

--- a/zebra-network/CHANGELOG.md
+++ b/zebra-network/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] - 2026-02-05
+
+### Breaking Changes
+
+- `zebra-chain` dependency bumped to `5.0.0`.
 
 ## [3.0.0] - 2026-01-21
 

--- a/zebra-network/CHANGELOG.md
+++ b/zebra-network/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `zebra-chain` dependency bumped to `5.0.0`.
 
-## [3.0.0] - 2026-01-21
+## [3.0.0] - 2026-01-21 - Yanked
 
 ### Breaking Changes
 

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-network"
-version = "3.0.0"
+version = "4.0.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Networking code for Zebra"
 # # Legal
@@ -83,7 +83,7 @@ howudoin = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "4.0.0", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "5.0.0", features = ["async-error"] }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/zebra-node-services/CHANGELOG.md
+++ b/zebra-node-services/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.0] - 2026-02-04
+## [3.0.0] - 2026-02-05
 
-- `zebra-chain` was bumped to `4.0.0`, requiring a major release
+### Breaking Changes
+
+- `zebra-chain` dependency bumped to `5.0.0`.
 
 ## [2.1.2] - 2026-01-21 - Yanked
 

--- a/zebra-node-services/CHANGELOG.md
+++ b/zebra-node-services/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.2] - 2026-01-21
+## [3.0.0] - 2026-02-04
 
-No API changes; internal dependencies updated.
+- `zebra-chain` was bumped to `4.0.0`, requiring a major release
+
+## [2.1.2] - 2026-01-21 - Yanked
+
+This should have been a major release, see 4.0.0.
+
+Dependencies updated.
 
 ## [2.1.1] - 2025-11-28
 

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -30,7 +30,7 @@ rpc-client = [
 ]
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain" , version = "4.0.0" }
+zebra-chain = { path = "../zebra-chain" , version = "5.0.0" }
 tower = { workspace = true }
 
 # Optional dependencies

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-node-services"
-version = "2.1.2"
+version = "3.0.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The interfaces of some Zebra node services"
 license = "MIT OR Apache-2.0"

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [5.0.0] - 2026-02-04
+## [5.0.0] - 2026-02-05
 
 ### Breaking Changes
 
+- `zebra-chain` bumped to `5.0.0`
+- `zebra-script` bumped to `4.0.0`
 - `zebra-state` bumped to `4.0.0`
-- `zebra-chain` bumped to `4.0.0`
+- `zebra-node-services` bumped to `3.0.0`
+- `zebra-consensus` bumped to `4.0.0`
+- `zebra-network` bumped to `4.0.0`
 
 ### Added
 

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -7,13 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0] - 2026-02-04
+
+### Breaking Changes
+
+- `zebra-state` bumped to `4.0.0`
+- `zebra-chain` bumped to `4.0.0`
+
 ### Added
 
 - `server/rpc_metrics` module.
 - `server/rpc_tracing` module.
 - Dependency on the `metrics` crate.
 
-## [4.0.0] - 2026-01-21
+## [4.0.0] - 2026-01-21 - Yanked
 
 Most changes are related to a fix to `getinfo` RPC response which used a string
 for the `errors_timestamp` field, which was changed to `i64` to match `zcashd`.

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-rpc"
-version = "4.0.0"
+version = "5.0.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "A Zebra JSON Remote Procedure Call (JSON-RPC) interface"
 license = "MIT OR Apache-2.0"
@@ -100,13 +100,13 @@ proptest = { workspace = true, optional = true }
 zebra-chain = { path = "../zebra-chain", version = "4.0.0", features = [
     "json-conversion",
 ] }
-zebra-consensus = { path = "../zebra-consensus", version = "3.1.2" }
+zebra-consensus = { path = "../zebra-consensus", version = "4.0.0" }
 zebra-network = { path = "../zebra-network", version = "3.0.0" }
-zebra-node-services = { path = "../zebra-node-services", version = "2.1.2", features = [
+zebra-node-services = { path = "../zebra-node-services", version = "3.0.0", features = [
     "rpc-client",
 ] }
-zebra-script = { path = "../zebra-script", version = "3.0.2" }
-zebra-state = { path = "../zebra-state", version = "3.1.2" }
+zebra-script = { path = "../zebra-script", version = "4.0.0" }
+zebra-state = { path = "../zebra-state", version = "4.0.0" }
 
 [build-dependencies]
 tonic-prost-build = { workspace = true }
@@ -123,13 +123,13 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 zebra-chain = { path = "../zebra-chain", version = "4.0.0", features = [
     "proptest-impl",
 ] }
-zebra-consensus = { path = "../zebra-consensus", version = "3.1.2", features = [
+zebra-consensus = { path = "../zebra-consensus", version = "4.0.0", features = [
     "proptest-impl",
 ] }
 zebra-network = { path = "../zebra-network", version = "3.0.0", features = [
     "proptest-impl",
 ] }
-zebra-state = { path = "../zebra-state", version = "3.1.2", features = [
+zebra-state = { path = "../zebra-state", version = "4.0.0", features = [
     "proptest-impl",
 ] }
 

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -97,11 +97,11 @@ sapling-crypto = { workspace = true }
 # Test-only feature proptest-impl
 proptest = { workspace = true, optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "4.0.0", features = [
+zebra-chain = { path = "../zebra-chain", version = "5.0.0", features = [
     "json-conversion",
 ] }
 zebra-consensus = { path = "../zebra-consensus", version = "4.0.0" }
-zebra-network = { path = "../zebra-network", version = "3.0.0" }
+zebra-network = { path = "../zebra-network", version = "4.0.0" }
 zebra-node-services = { path = "../zebra-node-services", version = "3.0.0", features = [
     "rpc-client",
 ] }
@@ -120,13 +120,13 @@ proptest = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zebra-chain = { path = "../zebra-chain", version = "4.0.0", features = [
+zebra-chain = { path = "../zebra-chain", version = "5.0.0", features = [
     "proptest-impl",
 ] }
 zebra-consensus = { path = "../zebra-consensus", version = "4.0.0", features = [
     "proptest-impl",
 ] }
-zebra-network = { path = "../zebra-network", version = "3.0.0", features = [
+zebra-network = { path = "../zebra-network", version = "4.0.0", features = [
     "proptest-impl",
 ] }
 zebra-state = { path = "../zebra-state", version = "4.0.0", features = [

--- a/zebra-script/CHANGELOG.md
+++ b/zebra-script/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.2] - 2026-01-21
+## [4.0.0] - 2026-02-04
 
-No API changes; internal dependencies updated.
+- `zebra-chain` was bumped to `4.0.0`, requiring a major release
+
+## [3.0.2] - 2026-01-21 - Yanked
+
+This should have been a major release, see 4.0.0.
+
+Dependencies updated.
 
 ## [3.0.1] - 2025-11-28
 

--- a/zebra-script/CHANGELOG.md
+++ b/zebra-script/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.0.0] - 2026-02-04
 
-- `zebra-chain` was bumped to `4.0.0`, requiring a major release
+- `zebra-chain` was bumped to 5.0.0, requiring a major release
 
 ## [3.0.2] - 2026-01-21 - Yanked
 

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -25,7 +25,7 @@ comparison-interpreter = []
 libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
-zebra-chain = { path = "../zebra-chain", version = "4.0.0" }
+zebra-chain = { path = "../zebra-chain", version = "5.0.0" }
 
 thiserror = { workspace = true }
 

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-script"
-version = "3.0.2"
+version = "4.0.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Zebra script verification wrapping zcashd's zcash_script library"
 license = "MIT OR Apache-2.0"

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -6,9 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [4.0.0] - 2026-02-04
+## [4.0.0] - 2026-02-05
 
-- `zebra-chain` was bumped to `4.0.0`, requiring a major release
+### Breaking Changes
+
+- `zebra-chain` bumped to 5.0.0.
+- `CommitSemanticallyVerifiedError` changed from enum to struct.
+- `DiskWriteBatch::prepare_*` methods now return `()` or specific error types instead of `Result<(), BoxError>`.
+- `FinalizedState::commit_finalized*` methods now return `CommitCheckpointVerifiedError`.
+
+### Added
+
+- `CommitBlockError` enum with `Duplicate`, `ValidateContextError`, `WriteTaskExited` variants.
+- `KnownBlock::Finalized` and `KnownBlock::WriteChannel` variants.
+- `impl From<ValidateContextError> for CommitSemanticallyVerifiedError`.
 
 
 ## [3.1.2] - 2026-01-21 - Yanked

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -6,10 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [3.1.2] - 2026-01-21
+## [4.0.0] - 2026-02-04
 
-No API changes; internal dependencies updated.
+- `zebra-chain` was bumped to `4.0.0`, requiring a major release
 
+
+## [3.1.2] - 2026-01-21 - Yanked
+
+This should have been a major release, see 4.0.0.
+
+Dependencies updated.
 
 ## [3.1.1] - 2025-11-28
 

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-state"
-version = "3.1.2"
+version = "4.0.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "State contextual verification and storage code for Zebra"
 license = "MIT OR Apache-2.0"
@@ -77,7 +77,7 @@ sapling-crypto = { workspace = true }
 elasticsearch = { workspace = true, features = ["rustls-tls"], optional = true }
 serde_json = { workspace = true, optional = true }
 
-zebra-node-services = { path = "../zebra-node-services", version = "2.1.2" }
+zebra-node-services = { path = "../zebra-node-services", version = "3.0.0" }
 zebra-chain = { path = "../zebra-chain", version = "4.0.0", features = ["async-error"] }
 
 # prod feature progress-bar

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -78,7 +78,7 @@ elasticsearch = { workspace = true, features = ["rustls-tls"], optional = true }
 serde_json = { workspace = true, optional = true }
 
 zebra-node-services = { path = "../zebra-node-services", version = "3.0.0" }
-zebra-chain = { path = "../zebra-chain", version = "4.0.0", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "5.0.0", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { workspace = true, optional = true }
@@ -108,7 +108,7 @@ jubjub = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zebra-chain = { path = "../zebra-chain", version = "4.0.0", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "5.0.0", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/", version = "2.0.1" }
 
 [lints]

--- a/zebra-utils/CHANGELOG.md
+++ b/zebra-utils/CHANGELOG.md
@@ -5,9 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] - 2026-02-04
+
+- `zebra-chain` was bumped to `4.0.0`, requiring a major release
+
+
 ## [3.0.2] - 2026-01-21
 
-No API changes; internal dependencies updated.
+This should have been a major release, see 4.0.0.
+
+Dependencies updated.
 
 
 ## [3.0.1] - 2025-11-28

--- a/zebra-utils/CHANGELOG.md
+++ b/zebra-utils/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.0.0] - 2026-02-04
+## [4.0.0] - 2026-02-05
 
-- `zebra-chain` was bumped to `4.0.0`, requiring a major release
+- `zebra-chain` was bumped to 5.0.0
+- `zebra-rpc` was bumped to 5.0.0
+- `zebra-node-services` bumped to 3.0.0
 
 
 ## [3.0.2] - 2026-01-21

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -76,7 +76,7 @@ tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 
 zebra-node-services = { path = "../zebra-node-services", version = "3.0.0" }
-zebra-chain = { path = "../zebra-chain", version = "4.0.0" }
+zebra-chain = { path = "../zebra-chain", version = "5.0.0" }
 
 # These crates are needed for the block-template-to-proposal binary
 zebra-rpc = { path = "../zebra-rpc", version = "5.0.0" }

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-utils"
-version = "3.0.2"
+version = "4.0.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "Developer tools for Zebra maintenance and testing"
 license = "MIT OR Apache-2.0"
@@ -75,11 +75,11 @@ tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 
-zebra-node-services = { path = "../zebra-node-services", version = "2.1.2" }
+zebra-node-services = { path = "../zebra-node-services", version = "3.0.0" }
 zebra-chain = { path = "../zebra-chain", version = "4.0.0" }
 
 # These crates are needed for the block-template-to-proposal binary
-zebra-rpc = { path = "../zebra-rpc", version = "4.0.0" }
+zebra-rpc = { path = "../zebra-rpc", version = "5.0.0" }
 
 # These crates are needed for the zebra-checkpoints binary
 itertools = { workspace = true, optional = true }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate metadata
 name = "zebrad"
-version = "4.0.0"
+version = "4.1.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>"]
 description = "The Zcash Foundation's independent, consensus-compatible implementation of a Zcash node"
 license = "MIT OR Apache-2.0"
@@ -151,9 +151,9 @@ tx_v6 = ["zebra-chain/tx_v6", "zebra-state/tx_v6", "zebra-consensus/tx_v6", "zeb
 comparison-interpreter = ["zebra-script/comparison-interpreter"]
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain", version = "4.0.0" }
+zebra-chain = { path = "../zebra-chain", version = "5.0.0" }
 zebra-consensus = { path = "../zebra-consensus", version = "4.0.0" }
-zebra-network = { path = "../zebra-network", version = "3.0.0" }
+zebra-network = { path = "../zebra-network", version = "4.0.0" }
 zebra-node-services = { path = "../zebra-node-services", version = "3.0.0", features = ["rpc-client"] }
 zebra-rpc = { path = "../zebra-rpc", version = "5.0.0" }
 zebra-state = { path = "../zebra-state", version = "4.0.0" }
@@ -294,9 +294,9 @@ proptest-derive = { workspace = true }
 # enable span traces and track caller in tests
 color-eyre = { workspace = true }
 
-zebra-chain = { path = "../zebra-chain", version = "4.0.0", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "5.0.0", features = ["proptest-impl"] }
 zebra-consensus = { path = "../zebra-consensus", version = "4.0.0", features = ["proptest-impl"] }
-zebra-network = { path = "../zebra-network", version = "3.0.0", features = ["proptest-impl"] }
+zebra-network = { path = "../zebra-network", version = "4.0.0", features = ["proptest-impl"] }
 zebra-state = { path = "../zebra-state", version = "4.0.0", features = ["proptest-impl"] }
 
 zebra-test = { path = "../zebra-test", version = "2.0.1" }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -152,19 +152,19 @@ comparison-interpreter = ["zebra-script/comparison-interpreter"]
 
 [dependencies]
 zebra-chain = { path = "../zebra-chain", version = "4.0.0" }
-zebra-consensus = { path = "../zebra-consensus", version = "3.1.2" }
+zebra-consensus = { path = "../zebra-consensus", version = "4.0.0" }
 zebra-network = { path = "../zebra-network", version = "3.0.0" }
-zebra-node-services = { path = "../zebra-node-services", version = "2.1.2", features = ["rpc-client"] }
-zebra-rpc = { path = "../zebra-rpc", version = "4.0.0" }
-zebra-state = { path = "../zebra-state", version = "3.1.2" }
+zebra-node-services = { path = "../zebra-node-services", version = "3.0.0", features = ["rpc-client"] }
+zebra-rpc = { path = "../zebra-rpc", version = "5.0.0" }
+zebra-state = { path = "../zebra-state", version = "4.0.0" }
 # zebra-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
 # enabling it in the other imports of zcash-script.)
-zebra-script = { path = "../zebra-script", version = "3.0.2" }
+zebra-script = { path = "../zebra-script", version = "4.0.0" }
 zcash_script = { workspace = true }
 
 # Required for crates.io publishing, but it's only used in tests
-zebra-utils = { path = "../zebra-utils", version = "3.0.2", optional = true }
+zebra-utils = { path = "../zebra-utils", version = "4.0.0", optional = true }
 
 abscissa_core = { workspace = true }
 clap = { workspace = true, features = ["cargo"] }
@@ -295,9 +295,9 @@ proptest-derive = { workspace = true }
 color-eyre = { workspace = true }
 
 zebra-chain = { path = "../zebra-chain", version = "4.0.0", features = ["proptest-impl"] }
-zebra-consensus = { path = "../zebra-consensus", version = "3.1.2", features = ["proptest-impl"] }
+zebra-consensus = { path = "../zebra-consensus", version = "4.0.0", features = ["proptest-impl"] }
 zebra-network = { path = "../zebra-network", version = "3.0.0", features = ["proptest-impl"] }
-zebra-state = { path = "../zebra-state", version = "3.1.2", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", version = "4.0.0", features = ["proptest-impl"] }
 
 zebra-test = { path = "../zebra-test", version = "2.0.1" }
 
@@ -310,7 +310,7 @@ zebra-test = { path = "../zebra-test", version = "2.0.1" }
 # When `-Z bindeps` is stabilised, enable this binary dependency instead:
 # https://github.com/rust-lang/cargo/issues/9096
 # zebra-utils { path = "../zebra-utils", artifact = "bin:zebra-checkpoints" }
-zebra-utils = { path = "../zebra-utils", version = "3.0.2" }
+zebra-utils = { path = "../zebra-utils", version = "4.0.0" }
 
 [package.metadata.cargo-udeps.ignore]
 # These dependencies are false positives - they are actually used

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_212_000;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_231_000;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.


### PR DESCRIPTION
---
name: 'Release Checklist Template'
about: 'Checklist to create and publish a Zebra release'
title: 'Release Zebra (version)'
labels: 'A-release, C-exclude-from-changelog, P-Critical :ambulance:'
assignees: ''

---

# Prepare for the Release

- [x] Make sure there has been [at least one successful full sync test in the main branch](https://github.com/ZcashFoundation/zebra/actions/workflows/zfnd-ci-integration-tests-gcp.yml?query=branch%3Amain) since the last state change, or start a manual full sync.

# Checkpoints

For performance and security, we want to update the Zebra checkpoints in every release.
- [x] You can copy the latest checkpoints from CI by following [the zebra-checkpoints README](https://github.com/ZcashFoundation/zebra/blob/main/zebra-utils/README.md#zebra-checkpoints).

# Missed Dependency Updates

Sometimes `dependabot` misses some dependency updates, or we accidentally turned them off.

This step can be skipped if there is a large pending dependency upgrade. (For example, shared ECC crates.)

Here's how we make sure we got everything:
- [x] Run `cargo update` on the latest `main` branch, and keep the output
- [x] If needed, [add duplicate dependency exceptions to deny.toml](https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/continuous-integration.md#fixing-duplicate-dependencies-in-check-denytoml-bans)
- [x] If needed, remove resolved duplicate dependencies from `deny.toml`
- [x] Open a separate PR with the changes
- [x] Add the output of `cargo update` to that PR as a comment

# Summarise Release Changes

These steps can be done a few days before the release, in the same PR:

## Change Log

**Important**: Any merge into `main` deletes any edits to the draft changelog.
Once you are ready to tag a release, copy the draft changelog into `CHANGELOG.md`.

We use [the Release Drafter workflow](https://github.com/marketplace/actions/release-drafter) to automatically create a [draft changelog](https://github.com/ZcashFoundation/zebra/releases). We follow the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.

To create the final change log:
- [x] Copy the [**latest** draft
  changelog](https://github.com/ZcashFoundation/zebra/releases) into
  `CHANGELOG.md` (there can be multiple draft releases)
- [x] Delete any trivial changes
    - [x] Put the list of deleted changelog entries in a PR comment to make reviewing easier
- [x] Combine duplicate changes
- [x] Edit change descriptions so they will make sense to Zebra users
- [x] Check the category for each change
  - Prefer the "Fix" category if you're not sure

## README

README updates can be skipped for urgent releases.

Update the README to:
- [x] Remove any "Known Issues" that have been fixed since the last release.
- [x] Update the "Build and Run Instructions" with any new dependencies.
      Check for changes in the `Dockerfile` since the last tag: `git diff <previous-release-tag> docker/Dockerfile`.
- [x] If Zebra has started using newer Rust language features or standard library APIs, update the known working Rust version in the README, book, and `Cargo.toml`s

You can use a command like:
```sh
fastmod --fixed-strings '1.58' '1.65'
```

## Create the Release PR

- [x] Push the updated changelog and README into a new branch
      for example: `bump-v1.0.0` - this needs to be different to the tag name
- [x] Create a release PR by adding `&template=release-checklist.md` to the comparing url ([Example](https://github.com/ZcashFoundation/zebra/compare/bump-v1.0.0?expand=1&template=release-checklist.md)).
- [x] Freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [ ] Mark all the release PRs as `Critical` priority, so they go in the `urgent` Mergify queue.
- [ ] Mark all non-release PRs with `do-not-merge`, because Mergify checks approved PRs against every commit, even when a queue is frozen.
- [x] Add the `A-release` tag to the release pull request in order for the `check-no-git-dependencies` to run.

## Zebra git sources dependencies

- [ ] Ensure the `check-no-git-dependencies` check passes.

This check runs automatically on pull requests with the `A-release` label. It must pass for crates to be published to crates.io. If the check fails, you should either halt the release process or proceed with the understanding that the crates will not be published on crates.io.

# Update Versions and End of Support

## Update Zebra Version

### Choose a Release Level

Zebra follows [semantic versioning](https://semver.org). Semantic versions look like: MAJOR.MINOR.PATCH[-TAG.PRE-RELEASE]

Choose a release level for `zebrad`. Release levels are based on user-visible changes:

- Major release: breaking changes to RPCs (fields changed or removed), config files (fields
  changed or removed), command line (arguments changed or removed), features
  (features changed or removed), environment variables (changed or removed)
  or any other external interface of Zebra
- Minor release: new features are `minor` releases
- Patch release: otherwise

Update the version using:

```
cargo release version --verbose --execute --allow-branch '*' -p zebrad patch # [ major | minor ]
```

### Update Crate Versions and Crate Change Logs

If you're publishing crates for the first time, [log in to crates.io](https://zebra.zfnd.org/dev/crate-owners.html#logging-in-to-cratesio),
and make sure you're a member of owners group.

Check that the release will work:

- [x] Determine which crates require release. Run `git diff --stat <previous_tag>`
      and enumerate the crates that had changes.
- [x] Update (or install) `semver-checks`: `cargo +stable install cargo-semver-checks --locked`
- [x] Update (or install) `public-api`: `cargo +stable install cargo-public-api --locked`
- [x] For each crate that requires a release:
  - [x] Determine which type of release to make. Run `semver-checks` to list API
        changes: `cargo semver-checks -p <crate> --default-features`. If there are
        breaking API changes, do a major release, or try to revert the API change
        if it was accidental. Otherwise do a minor or patch release depending on
        whether a new API was added. Note that `semver-checks` won't work
        if the previous realase was yanked; you will have to determine the
        type of release manually.
  - [x] Update the crate `CHANGELOG.md` listing the API changes or other
        relevant information for a crate consumer. Use `public-api` to list all
        API changes: `cargo public-api diff latest -p <crate> -sss`. You can use
        e.g. copilot to turn it into a human-readable list, e.g. (write the output
        to `api.txt` beforehand):
        ```
        copilot -p "Transform @api.txt which is a API diff into a human-readable description of the API changes. Be terse. Write output api-readable.txt. Use backtick quotes for identifiers. Use '### Breaking Changes' header for changes and removals, and '### Added' for additions. Make each item start with a verb e.g, Added, Changed" --allow-tool write
        ```
        It might also make sense to copy entries from the `zebrad` changelog.
  - [x] Update crate versions:

```sh
cargo release version --verbose --execute --allow-branch '*' -p <crate> patch # [ major | minor ]
cargo release replace --verbose --execute --allow-branch '*' -p <crate>
```

- [x] Commit and push the above version changes to the release branch.

## Update End of Support

The end of support height is calculated from the current blockchain height:

- [x] Replace `ESTIMATED_RELEASE_HEIGHT` in [`end_of_support.rs`](https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/sync/end_of_support.rs) with the height you estimate the release will be tagged.

<details>

<summary>Optional: calculate the release tagging height</summary>

- Find where the Zcash blockchain tip is now by using a [Zcash Block Explorer](https://mainnet.zcashexplorer.app/) or other tool.
- Add `1152` blocks for each day until the release
- For example, if the release is in 3 days, add `1152 * 3` to the current Mainnet block height

</details>

## Update the Release PR

- [x] Push the version increments and the release constants to the release branch.


# Publish the Zebra Release

## Create the GitHub Pre-Release

- [x] Wait for all the release PRs to be merged
- [x] Create a new release using the draft release as a base, by clicking the Edit icon in the [draft release](https://github.com/ZcashFoundation/zebra/releases)
- [x] Set the tag name to the version tag,
      for example: `v1.0.0`
- [x] Set the release to target the `main` branch
- [x] Set the release title to `Zebra ` followed by the version tag,
      for example: `Zebra 1.0.0`
- [x] Replace the prepopulated draft changelog in the release description with the final changelog you created;
      starting just _after_ the title `## [Zebra ...` of the current version being released,
      and ending just _before_ the title of the previous release.
- [x] Mark the release as 'pre-release', until it has been built and tested
- [x] Publish the pre-release to GitHub using "Publish Release"
- [x] Delete all the [draft releases from the list of releases](https://github.com/ZcashFoundation/zebra/releases)

## Test the Pre-Release

- [x] Wait until the Docker binaries have been built on `main`, and the quick tests have passed:
    - [ ] [zfnd-ci-integration-tests-gcp.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/zfnd-ci-integration-tests-gcp.yml?query=branch%3Amain)
- [ ] Wait until the [pre-release deployment machines have successfully launched](https://github.com/ZcashFoundation/zebra/actions/workflows/zfnd-deploy-nodes-gcp.yml?query=event%3Arelease)

## Publish Release

- [x] [Publish the release to GitHub](https://github.com/ZcashFoundation/zebra/releases) by disabling 'pre-release', then clicking "Set as the latest release"

## Publish Crates

- [x] [Run `cargo login`](https://zebra.zfnd.org/dev/crate-owners.html#logging-in-to-cratesio)
- [x] It is recommended that the following step be run from a fresh checkout of
      the repo, to avoid accidentally publishing files like e.g. logs that might
      be lingering around
- [x] Publish the crates to crates.io; edit the list to only include the crates that
      have been changed, but keep their overall order:

```
for c in zebra-test tower-fallback zebra-chain tower-batch-control zebra-node-services zebra-script zebra-state zebra-consensus zebra-network zebra-rpc zebra-utils zebrad; do cargo release publish --verbose --execute -p $c; done
```

- [x] Check that Zebra can be installed from `crates.io`:
      `cargo install --locked --force --version <version> zebrad && ~/.cargo/bin/zebrad`
      and put the output in a comment on the PR.

## Publish Docker Images

- [x] Wait for the [the Docker images to be published successfully](https://github.com/ZcashFoundation/zebra/actions/workflows/release-binaries.yml?query=event%3Arelease).
- [x] Wait for the new tag in the [dockerhub zebra space](https://hub.docker.com/r/zfnd/zebra/tags)
- [ ] Un-freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [x] Remove `do-not-merge` from the PRs you added it to

## Release Failures

If building or running fails after tagging:

<details>

<summary>Tag a new release, following these instructions...</summary>

1. Fix the bug that caused the failure
2. Start a new `patch` release
3. Skip the **Release Preparation**, and start at the **Release Changes** step
4. Update `CHANGELOG.md` with details about the fix
5. Follow the release checklist for the new Zebra version

</details>
