### PR TITLE
ci: make test-docker more robust by adjusting grep pattern

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -104,12 +104,12 @@ jobs:
           - id: default-conf
             name: Default config
             env_vars: ""
-            grep_patterns: -e "resolved seed peer IP addresses.*mainnet.seeder"
+            grep_patterns: -e "resolved seed peer IP addresses.*mainnet"
 
           - id: testnet-conf
             name: Testnet config
             env_vars: -e ZEBRA_NETWORK__NETWORK=Testnet
-            grep_patterns: -e "resolved seed peer IP addresses.*testnet.seeder"
+            grep_patterns: -e "resolved seed peer IP addresses.*testnet"
 
           # Only runs when using the image is built with the `tests` target, because the `runtime` target
           # doesn't have the custom config file available in the tests/common/configs directory


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

test-docker.yml tests configurations by starting zebra and grepping for a pattern when it connects to the ZF DNS seeder.
However if that lookup fails, Zebra still starts if another seeders works, but [the test timeouts](https://github.com/ZcashFoundation/zebra/actions/runs/21765626854/job/62804386452).

## Solution

Change the pattern to match any seeder with `mainnet` (works for ZF and SL) or `testnet` (works for ZF and z.cash)

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

We could make it even more robust by using a pattern that matches any of the known seeders, or matching on something else that also makes sense in the context.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
