### PR TITLE
fix: clarify TransparentInputNotFound error message

### DIFF
--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -174,7 +174,7 @@ pub enum TransactionError {
     #[error("must have at least one active orchard flag")]
     NotEnoughFlags,
 
-    #[error("could not find transparent input UTXO in the chain or mempool")]
+    #[error("could not find transparent input UTXO in the best chain or mempool")]
     TransparentInputNotFound,
 
     #[error("could not contextually validate transaction on best chain: {0}")]

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -174,7 +174,7 @@ pub enum TransactionError {
     #[error("must have at least one active orchard flag")]
     NotEnoughFlags,
 
-    #[error("could not find a mempool transaction input UTXO in the best chain")]
+    #[error("could not find transparent input UTXO in the chain or mempool")]
     TransparentInputNotFound,
 
     #[error("could not contextually validate transaction on best chain: {0}")]


### PR DESCRIPTION
## Summary

- Corrects the `TransparentInputNotFound` error message from "could not find a mempool transaction input UTXO in the best chain" to "could not find transparent input UTXO in the chain or mempool"
- The old message was misleading: the error can occur when looking up UTXOs in either the chain state or the mempool, not just the best chain
- No logic changes, only the user-facing error string

## Test plan

- [ ] Existing test `mempool_request_with_missing_input_is_rejected` validates the error variant is returned correctly
- [ ] No string-based assertions on the error message exist, so no test updates needed
- [ ] CI passes

Close https://github.com/ZcashFoundation/zebra/issues/10214