### PR TITLE
feat: implement gettxout RPC method

### DIFF
--- a/zebra-rpc/src/methods/tests/snapshots/gettxout_invalid_txid@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/gettxout_invalid_txid@mainnet_10.snap
@@ -1,0 +1,11 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+assertion_line: 603
+expression: rsp
+---
+{
+  "Err": {
+    "code": -5,
+    "message": "Invalid string length"
+  }
+}

--- a/zebra-rpc/src/methods/tests/snapshots/gettxout_invalid_txid@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/gettxout_invalid_txid@testnet_10.snap
@@ -1,0 +1,11 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+assertion_line: 603
+expression: rsp
+---
+{
+  "Err": {
+    "code": -5,
+    "message": "Invalid string length"
+  }
+}

--- a/zebra-rpc/src/methods/tests/snapshots/gettxout_nonexistent_index@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/gettxout_nonexistent_index@mainnet_10.snap
@@ -1,0 +1,8 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+assertion_line: 580
+expression: rsp
+---
+{
+  "Ok": null
+}

--- a/zebra-rpc/src/methods/tests/snapshots/gettxout_nonexistent_index@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/gettxout_nonexistent_index@testnet_10.snap
@@ -1,0 +1,8 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+assertion_line: 580
+expression: rsp
+---
+{
+  "Ok": null
+}

--- a/zebra-rpc/src/methods/tests/snapshots/gettxout_unknown_txid@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/gettxout_unknown_txid@mainnet_10.snap
@@ -1,0 +1,8 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+assertion_line: 598
+expression: rsp
+---
+{
+  "Ok": null
+}

--- a/zebra-rpc/src/methods/tests/snapshots/gettxout_unknown_txid@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/gettxout_unknown_txid@testnet_10.snap
@@ -1,0 +1,8 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+assertion_line: 598
+expression: rsp
+---
+{
+  "Ok": null
+}

--- a/zebra-rpc/src/methods/tests/snapshots/gettxout_valid@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/gettxout_valid@mainnet_10.snap
@@ -1,0 +1,23 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+assertion_line: 566
+expression: rsp
+---
+{
+  "Ok": {
+    "bestblock": "00074c46a4aa8172df8ae2ad1848a2e084e1b6989b7d9e6132adc938bf835b36",
+    "confirmations": 10,
+    "value": 0.000125,
+    "scriptPubKey": {
+      "asm": "OP_HASH160 7d46a730d31f97b1930d3368a967c309bd4d136a OP_EQUAL",
+      "hex": "a9147d46a730d31f97b1930d3368a967c309bd4d136a87",
+      "reqSigs": 1,
+      "type": "scripthash",
+      "addresses": [
+        "t3Vz22vK5z2LcKEdg16Yv4FFneEL1zg9ojd"
+      ]
+    },
+    "version": 1,
+    "coinbase": true
+  }
+}

--- a/zebra-rpc/src/methods/tests/snapshots/gettxout_valid@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/gettxout_valid@testnet_10.snap
@@ -1,0 +1,23 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+assertion_line: 566
+expression: rsp
+---
+{
+  "Ok": {
+    "bestblock": "079f4c752729be63e6341ee9bce42fbbe37236aba22e3deb82405f3c2805c112",
+    "confirmations": 10,
+    "value": 0.000125,
+    "scriptPubKey": {
+      "asm": "OP_HASH160 ef775f1f997f122a062fff1a2d7443abd1f9c642 OP_EQUAL",
+      "hex": "a914ef775f1f997f122a062fff1a2d7443abd1f9c64287",
+      "reqSigs": 1,
+      "type": "scripthash",
+      "addresses": [
+        "t2UNzUUx8mWBCRYPRezvA363EYXyEpHokyi"
+      ]
+    },
+    "version": 1,
+    "coinbase": true
+  }
+}


### PR DESCRIPTION
## Summary
- Implement the `gettxout` RPC method matching the [zcashd API](https://zcash.github.io/rpc/gettxout.html)
- Returns details about an unspent transaction output (UTXO), or null for spent/nonexistent outputs
- Supports optional `include_mempool` parameter (default true)
- Extracts `ScriptPubKey::from_output()` helper to deduplicate script analysis logic previously inlined in `TransactionObject`

## Known issues / future improvements

1. **Extra state roundtrip for tx version**: The chain state path fetches the full transaction via `AnyChainTransaction` just to extract `tx.version()`, since `Utxo` doesn't store the transaction version. A lighter-weight query or storing the version in the UTXO would reduce overhead.

2. **TOCTOU between sequential state queries**: The chain path makes 4 sequential state queries (`UnspentBestChainUtxo`, `BestChainBlockHash`, `Depth`, `AnyChainTransaction`). A reorg between queries could produce inconsistent results. Currently handled gracefully by returning `null` when intermediate queries fail, but an atomic read path would be more robust.

3. **Unnecessary state query on mempool fallthrough**: If a transaction is found in the mempool but the requested output index doesn't exist, the code falls through to the chain state check (which will also return `None`). This is functionally correct but performs an unnecessary state query in that narrow case.

## Test plan
- [ ] Valid UTXO lookup with mempool enabled (default)
- [ ] Valid UTXO lookup with mempool disabled
- [ ] Nonexistent output index returns null
- [ ] Unknown txid returns null
- [ ] Invalid txid returns error (code -5)
- [ ] Snapshot tests for mainnet and testnet

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>