### PR TITLE
docs: Add AI contribution policy and agent guidance files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,119 @@
+# Zebra — Copilot Review Instructions
+
+You are reviewing PRs for Zebra, a Zcash full node in Rust. Prioritize correctness, consensus safety, DoS resistance, and maintainability. Stay consistent with existing Zebra conventions. Avoid style-only feedback unless it clearly prevents bugs.
+
+If the diff or PR description is incomplete, ask questions before making strong claims.
+
+## Contribution Process Checks
+
+Before reviewing code quality, verify:
+
+- [ ] PR links to a pre-discussed issue
+- [ ] PR description includes Motivation, Solution, and Tests sections
+- [ ] PR title follows conventional commits
+- [ ] If AI tools were used, disclosure is present in the PR description
+
+If these are missing, note it in the review.
+
+## Architecture Constraints
+
+```text
+zebrad (CLI orchestration)
+  → zebra-consensus (verification)
+  → zebra-state (storage/service boundaries)
+  → zebra-chain (data types; sync-only)
+  → zebra-network (P2P)
+  → zebra-rpc (JSON-RPC)
+```
+
+- Dependencies flow **downward only** (lower crates must not depend on higher crates)
+- `zebra-chain` is **sync-only** (no async / tokio / Tower services)
+- State uses `ReadRequest` for queries, `Request` for mutations
+
+## High-Signal Checks
+
+### Tower Service Pattern
+
+If the PR touches a Tower `Service` implementation:
+
+- Bounds must include `Send + Clone + 'static` on services, `Send + 'static` on futures
+- `poll_ready` must call `poll_ready` on all inner services
+- Services must be cloned before moving into async blocks
+
+### Error Handling
+
+- Prefer `thiserror` with `#[from]` / `#[source]`
+- `expect()` messages must explain **why** the invariant holds:
+  ```rust
+  .expect("block hash exists because we just inserted it")  // good
+  .expect("failed to get block")                            // bad
+  ```
+- Don't turn invariant violations into misleading `None`/defaults
+
+### Numeric Safety
+
+- External/untrusted values: prefer `saturating_*` / `checked_*`
+- All `as` casts must have a comment justifying safety
+
+### Async & Concurrency
+
+- CPU-heavy crypto/proof work: must use `tokio::task::spawn_blocking`
+- All external waits need timeouts and must be cancellation-safe
+- Prefer `watch` channels over `Mutex` for shared async state
+- Progress tracking: prefer freshness ("time since last change") over static state
+
+### DoS / Resource Bounds
+
+- Anything from attacker-controlled data must be bounded
+- Use `TrustedPreallocate` for deserialization lists/collections
+- Avoid unbounded loops/allocations
+
+### Performance
+
+- Prefer existing indexed structures (maps/sets) over iteration
+- Avoid unnecessary clones (structs may grow over time)
+
+### Complexity (YAGNI)
+
+When the PR adds abstraction, flags, generics, or refactors:
+
+- Ask: "Is the difference important enough to complicate the code?"
+- Prefer minimal, reviewable changes; suggest splitting PRs when needed
+
+### Testing
+
+- New behavior needs tests
+- Async tests: `#[tokio::test]` with timeouts for long-running tests
+- Test configs must use realistic network parameters
+
+### Observability
+
+- Metrics use dot-separated hierarchical names with existing prefixes (`checkpoint.*`, `state.*`, `sync.*`, `rpc.*`, `peer.*`, `zcash.chain.*`)
+- Use `#[instrument(skip(large_arg))]` for tracing spans
+
+### Changelog & Release Process
+
+- User-visible changes need a `CHANGELOG.md` entry under `[Unreleased]`
+- Library-consumer-visible changes need the crate's `CHANGELOG.md` updated
+- PR labels must match the intended changelog category (`C-bug`, `C-feature`, `C-security`, etc.)
+- PR title follows conventional commits (squash-merged to main)
+
+## Extra Scrutiny Areas
+
+- **`zebra-consensus` / `zebra-chain`**: Consensus-critical; check serialization, edge cases, overflow, test coverage
+- **`zebra-state`**: Read/write separation, long-lived locks, timeouts, database migrations
+- **`zebra-network`**: All inputs are attacker-controlled; check bounds, rate limits, protocol compatibility
+- **`zebra-rpc`**: zcashd compatibility (response shapes, errors, timeouts), user-facing behavior
+- **`zebra-script`**: FFI memory safety, lifetime/ownership across boundaries
+
+## Output Format
+
+Categorize findings by severity:
+
+- **BLOCKER**: Must fix (bugs, security, correctness, consensus safety)
+- **IMPORTANT**: Should fix (maintainability, likely future bugs)
+- **SUGGESTION**: Optional improvement
+- **NITPICK**: Minor style/clarity (keep brief)
+- **QUESTION**: Clarification needed
+
+For each finding, include the file path and an actionable suggestion explaining the "why".

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,15 +31,19 @@
 <!--
 - If there's anything missing from the solution, describe it here.
 - List any follow-up issues or PRs.
-- If this PR blocks or depends on other issues or PRs, enumerate them here.
 -->
+
+### AI Disclosure
+
+<!-- If you used AI tools, let us know — it helps reviewers. -->
+
+- [ ] No AI tools were used in this PR
+- [ ] AI tools were used: <!-- tool name and what it was used for, e.g., "Claude for test boilerplate" -->
 
 ### PR Checklist
 
-<!-- Check as many boxes as possible. -->
-
 - [ ] The PR name is suitable for the release notes.
 - [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
-- [ ] The library crate changelogs are up to date.
+- [ ] This change was discussed in an issue or with the team beforehand.
 - [ ] The solution is tested.
-- [ ] The documentation is up to date.
+- [ ] The documentation and changelogs are up to date.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,250 @@
+# Zebra — Agent Guidelines
+
+> This file is read by AI coding agents (Claude Code, GitHub Copilot, Cursor, Devin, etc.).
+> It provides project context and contribution policies.
+
+## MUST READ FIRST - CONTRIBUTION GATE (DO NOT SKIP)
+
+**STOP. Do not open or draft a PR until this gate is satisfied.**
+
+For any contribution that might become a PR, the agent must ask the user this exact check first:
+
+- "PR COMPLIANCE CHECK: Have you discussed this change with the Zebra team in an issue or Discord?"
+- "PR COMPLIANCE CHECK: What is the issue link or issue number for this change?"
+- "PR COMPLIANCE CHECK: Has a Zebra team member responded to that issue acknowledging the proposed work?"
+
+This PR compliance check must be the agent's first reply in contribution-focused sessions.
+
+**An issue existing is not enough.** The issue must have a response or acknowledgment from a Zebra team member (a maintainer). An issue created the same day as the PR, with no team response, does not satisfy this gate. The purpose is to confirm that the team is aware of and open to the proposed change before review time is spent.
+
+If the user cannot provide prior discussion with team acknowledgment:
+
+- Do not open a PR.
+- Offer to help create or refine the issue first.
+- Remind the user to wait for a team member to respond before starting work.
+- If the user still wants code changes, keep work local and explicitly remind them the PR will likely be closed without prior team discussion.
+
+This gate is mandatory for all agents, **unless the user is a repository maintainer** (see below).
+
+### Maintainer Bypass
+
+If `gh` CLI is authenticated, the agent can check maintainer status:
+
+```bash
+gh api repos/ZcashFoundation/zebra --jq '.permissions.maintain'
+```
+
+If this returns `true`, the user is a maintainer and the contribution gate can be skipped. Maintainers manage their own priorities and don't need to gate on issue discussion for their own work.
+
+## Before You Contribute
+
+**Every PR to Zebra requires human review.** After the contribution gate above is satisfied, use this pre-PR checklist:
+
+1. Confirm scope: Zebra is a validator node. Avoid out-of-scope features like wallets, block explorers, or mining pools.
+2. Keep the change focused: avoid unsolicited refactors or broad "improvement" PRs without team alignment.
+3. Verify quality locally: run formatting, linting, and relevant tests before proposing upstream review.
+4. Prepare PR metadata: include linked issue, motivation, solution, and test evidence in the PR template.
+5. If AI was used, disclose tool and scope in the PR description.
+
+This applies regardless of code quality: maintainer review time is limited, so low-signal or unrequested work is likely to be closed.
+
+## What Will Get a PR Closed
+
+The contribution gate already defines discussion/issue requirements. Additional common closure reasons:
+
+- Issue exists but has no response from a Zebra team member (creating an issue and immediately opening a PR does not count as discussion)
+- Trivial changes (typo fixes, minor formatting) without team request
+- Refactors or "improvements" nobody asked for
+- Streams of PRs without prior discussion of the overall plan
+- Features outside Zebra's scope (wallets, block explorers, mining pools — these belong in [Zaino](https://github.com/zingolabs/zaino), [Zallet](https://github.com/zcash/wallet), or [librustzcash](https://github.com/zcash/librustzcash))
+- Missing test evidence for behavior changes
+- Inability to explain the logic or design tradeoffs of the changes when asked
+
+## AI Disclosure
+
+If AI tools were used to write code, tests, or PR descriptions, disclose this in the PR description. Specify the tool and scope (e.g., "Used Claude for test boilerplate"). The contributor is the sole responsible author — "the AI generated it" is not a justification during review.
+
+## Project Structure & Module Organization
+
+Zebra is a Rust workspace. Main crates include:
+
+- `zebrad/` (node CLI/orchestration),
+- core libraries like `zebra-chain/`, `zebra-consensus/`, `zebra-network/`, `zebra-state/`, `zebra-rpc/`,
+- support crates like `zebra-node-services/`, `zebra-test/`, `zebra-utils/`, `tower-batch-control/`, and `tower-fallback/`.
+
+Code is primarily in each crate's `src/`; integration tests are in `*/tests/`; many unit/property tests are colocated in `src/**/tests/` (for example `prop.rs`, `vectors.rs`, `preallocate.rs`). Documentation is in `book/` and `docs/decisions/`. CI and policy automation live in `.github/workflows/`.
+
+## Build, Test, and Development Commands
+
+All of these must pass before submitting a PR:
+
+```bash
+# Optional full build check
+cargo build --workspace --locked
+
+# All three must pass before any PR
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+
+# Run a single crate's tests
+cargo test -p zebra-chain
+cargo test -p zebra-state
+
+# Run a single test by name
+cargo test -p zebra-chain -- test_name
+
+# CI-like nextest profile for broad coverage
+cargo nextest run --profile all-tests --locked --release --features default-release-binaries --run-ignored=all
+
+# Run with nextest (integration profiles)
+cargo nextest run --profile sync-large-checkpoints-empty
+```
+
+## Commit & Pull Request Guidelines
+
+- PR titles must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) (PRs are squash-merged — the PR title becomes the commit message)
+- Do not add `Co-Authored-By` tags for AI tools
+- Do not add "Generated with [tool]" footers
+- Use `.github/pull_request_template.md` and include: motivation, solution summary, test evidence, issue link (`Closes #...`), and AI disclosure.
+- For user-visible changes, update `CHANGELOG.md` per `CHANGELOG_GUIDELINES.md`.
+
+## Project Overview
+
+Zebra is a Zcash full node implementation in Rust. It is a validator node — it excludes features not strictly needed for block validation and chain sync.
+
+- **Rust edition**: 2021
+- **MSRV**: 1.85
+- **Database format version**: defined in `zebra-state/src/constants.rs`
+
+## Crate Architecture
+
+```text
+zebrad (CLI orchestration)
+  ├── zebra-consensus (block/transaction verification)
+  │     └── zebra-script (script validation via FFI)
+  ├── zebra-state (finalized + non-finalized storage)
+  ├── zebra-network (P2P, peer management)
+  └── zebra-rpc (JSON-RPC + gRPC)
+        └── zebra-node-services (service trait aliases)
+              └── zebra-chain (core data types, no async)
+```
+
+**Dependency rules**:
+
+- Dependencies flow **downward only** — lower crates must not depend on higher ones
+- `zebra-chain` is **sync-only**: no async, no tokio, no Tower services
+- `zebra-node-services` defines service trait aliases used across crates
+- `zebrad` orchestrates all components but contains minimal logic
+- Utility crates: `tower-batch-control`, `tower-fallback`, `zebra-test`
+
+### Per-Crate Concerns
+
+| Crate | Key Concerns |
+| --- | --- |
+| `zebra-chain` | Serialization correctness, no async, consensus-critical data structures |
+| `zebra-network` | Protocol correctness, peer handling, rate limiting, DoS resistance |
+| `zebra-consensus` | Verification completeness, error handling, checkpoint vs semantic paths |
+| `zebra-state` | Read/write separation (`ReadRequest` vs `Request`), database migrations |
+| `zebra-rpc` | zcashd compatibility, error responses, timeout handling |
+| `zebra-script` | FFI safety, memory management, lifetime/ownership across boundaries |
+
+## Coding Style & Naming Conventions
+
+- Rust 2021 conventions and `rustfmt` defaults apply across the workspace (4-space indentation).
+- Naming: `snake_case` for functions/modules/files, `CamelCase` for types/traits, `SCREAMING_SNAKE_CASE` for constants.
+- Respect workspace lint policy in `.cargo/config.toml` and crate-specific lint config in `clippy.toml`.
+- Keep dependencies flowing downward across crates; maintain `zebra-chain` as sync-only.
+
+## Code Patterns
+
+### Tower Services
+
+All services must include these bounds:
+
+```rust
+S: Service<Req, Response = Resp, Error = BoxError> + Send + Clone + 'static,
+S::Future: Send + 'static,
+```
+
+- `poll_ready` must check all inner services
+- Clone services before moving into async blocks
+
+### Error Handling
+
+- Use `thiserror` with `#[from]` / `#[source]` for error chaining
+- `expect()` messages must explain **why** the invariant holds, not what happens if it fails:
+  ```rust
+  .expect("block hash exists because we just inserted it")  // good
+  .expect("failed to get block")                            // bad
+  ```
+- Don't turn invariant violations into misleading `None`/default values
+
+### Numeric Safety
+
+- External/untrusted values: use `saturating_*` / `checked_*` arithmetic
+- All `as` casts must have a comment explaining why the cast is safe
+
+### Async & Concurrency
+
+- CPU-heavy work (crypto, proofs): use `tokio::task::spawn_blocking`
+- All external waits need timeouts (network, state, channels)
+- Prefer `tokio::sync::watch` over `Mutex` for shared async state
+- Prefer freshness tracking ("time since last change") to detect stalls
+
+### Security
+
+- Use `TrustedPreallocate` for deserializing collections from untrusted sources
+- Bound all loops/allocations over attacker-controlled data
+- Validate at system boundaries (network, RPC, disk)
+
+### Performance
+
+- Prefer existing indexed structures (maps/sets) over scanning/iterating
+- Avoid unnecessary clones — structs may grow in size over time
+- Use `impl Into<T>` to reduce verbose `.into()` at call sites
+- Don't add unnecessary comments, docstrings, or type annotations to code you didn't change
+
+## Testing Guidelines
+
+- Unit/property tests: `src/*/tests/` within each crate (`prop.rs`, `vectors.rs`, `preallocate.rs`)
+- Integration tests: `crate/tests/` (standard Rust layout)
+- Async tests: `#[tokio::test]` with timeouts for long-running tests
+- Test configs must match real network parameters (don't rely on defaults)
+
+```bash
+# Unit tests
+cargo test --workspace
+
+# Integration tests with nextest
+cargo nextest run --profile sync-large-checkpoints-empty
+```
+
+## Metrics & Observability
+
+- Metrics use dot-separated hierarchical names with existing prefixes: `checkpoint.*`, `state.*`, `sync.*`, `rpc.*`, `peer.*`, `zcash.chain.*`
+- Use `#[instrument(skip(large_arg))]` for tracing spans on important operations
+- Errors must be logged with context
+
+## Changelog
+
+- Update `CHANGELOG.md` under `[Unreleased]` for user-visible changes
+- Update crate `CHANGELOG.md` for library-consumer-visible changes
+- Apply the appropriate PR label (`C-feature`, `C-bug`, `C-security`, etc.)
+- See `CHANGELOG_GUIDELINES.md` for detailed formatting rules
+
+## Configuration
+
+```rust
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct Config {
+    /// Documentation for field
+    pub field: Type,
+}
+```
+
+- Use `#[serde(deny_unknown_fields)]` for strict validation
+- Use `#[serde(default)]` for backward compatibility
+- All fields must have documentation
+- Defaults must be sensible for production

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,39 +1,69 @@
 # Contributing
 
-* [Running and Debugging](#running-and-debugging)
-* [Bug Reports](#bug-reports)
-* [Pull Requests](#pull-requests)
-* [Coverage Reports](#coverage-reports)
+- [Contributing](#contributing)
+  - [Running and Debugging](#running-and-debugging)
+  - [Bug Reports](#bug-reports)
+  - [Pull Requests](#pull-requests)
+  - [AI-Assisted Contributions](#ai-assisted-contributions)
+  - [When We Close PRs](#when-we-close-prs)
+  - [Code Standards](#code-standards)
 
 ## Running and Debugging
-[running-and-debugging]: #running-and-debugging
 
 See the [user documentation](https://zebra.zfnd.org/user.html) for details on
 how to build, run, and instrument Zebra.
 
 ## Bug Reports
-[bug-reports]: #bug-reports
 
 Please [create an issue](https://github.com/ZcashFoundation/zebra/issues/new?assignees=&labels=C-bug%2C+S-needs-triage&projects=&template=bug_report.yml&title=) on the Zebra issue tracker.
 
 ## Pull Requests
-[pull-requests]: #pull-requests
 
-PRs are welcome for small and large changes, but please don't make large PRs
-without coordinating with us via the [issue tracker](https://github.com/ZcashFoundation/zebra/issues) or [Discord](https://discord.gg/yVNhQwQE68). This helps
-increase development coordination and makes PRs easier to merge. Low-effort PRs, including but not limited to fixing typos and grammatical corrections, will generally be redone or closed by us to dissuade metric farming.
+PRs are welcome, but every PR requires human review time. To make that time count:
 
-Issues in this repository may not need to be addressed here, Zebra is meant to exclude any new features that are not strictly needed by the validator node. It may be desirable to implement features that support wallets, 
-block explorers, and other clients, particularly features that require database format changes, in [Zaino](https://github.com/zingolabs/zaino), [Zallet](https://github.com/zcash/wallet), or [librustzcash](https://github.com/zcash/librustzcash/). 
+1. **Start with an issue.** Check the [issue tracker](https://github.com/ZcashFoundation/zebra/issues) for existing issues or create a new one describing what you want to change and why. **Wait for a team member to respond before writing code** — an issue with no team acknowledgment does not count as prior discussion.
+2. **Coordinate large changes.** For anything beyond a small bug fix, discuss your approach with us via [issue tracker](https://github.com/ZcashFoundation/zebra/issues) or [Discord](https://discord.gg/yVNhQwQE68) before opening a PR.
+3. **Keep PRs focused.** One logical change per PR. If you're planning multiple related PRs, discuss the overall plan with the team first.
+4. **Follow conventional commits.** PRs are squash-merged to main, so the PR title becomes the commit message. Follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) standard.
 
-Check out the [help wanted][hw] or [good first issue][gfi] labels if you're
-looking for a place to get started!
+Zebra is a validator node — it excludes features not strictly needed for block validation and chain sync. Features like wallets, block explorers, and mining pools belong in [Zaino](https://github.com/zingolabs/zaino), [Zallet](https://github.com/zcash/wallet), or [librustzcash](https://github.com/zcash/librustzcash).
 
-Zebra follows the [conventional commits][conventional] standard for the commits
-merged to main. Since PRs are squashed before merging to main, the PR titles
-should follow the conventional commits standard so that the merged commits
-are conformant.
+Check out the [help wanted][hw] or [good first issue][gfi] labels if you're looking for a place to get started.
 
 [hw]: https://github.com/ZcashFoundation/zebra/labels/E-help-wanted
 [gfi]: https://github.com/ZcashFoundation/zebra/labels/good%20first%20issue
-[conventional]: https://www.conventionalcommits.org/en/v1.0.0/#specification
+
+## AI-Assisted Contributions
+
+We welcome contributions that use AI tools. What matters is the quality of the result and the contributor's understanding of it, not whether AI was involved.
+
+**What we ask:**
+
+- **Disclose AI usage** in your PR description: Specify the tool and what it was used for (e.g., "Used Claude for test boilerplate"). This helps reviewers calibrate their review.
+- **Understand your code:** You are the sole responsible author. If asked during review, you must be able to explain the logic and design trade-offs of every change.
+- **Don't submit without reviewing:** Run the full test suite locally and review every line before opening a PR.
+
+Tab-completion, spell checking, and syntax highlighting don't need disclosure.
+
+## When We Close PRs
+
+Any team member may close a PR. We'll leave a comment explaining why and invite you to create an issue if you believe the change has value. Common reasons for closure:
+
+- No linked issue, or issue exists but no team member has responded to it
+- Feature or refactor nobody requested
+- Low-effort changes (typo fixes, minor formatting) not requested by the team
+- Missing test evidence or inability to explain the changes
+- Out of scope for Zebra (see above)
+
+This is not personal; it's about managing review capacity. We encourage you to reach out first so your effort counts.
+
+## Code Standards
+
+Zebra enforces code quality through review. For the full list of architecture rules, code patterns, testing requirements, and security considerations, see [`AGENTS.md`](AGENTS.md). The key points:
+
+- **Build requirements**: `cargo fmt`, `cargo clippy`, and `cargo test` must all pass
+- **Architecture**: Dependencies flow downward only; `zebra-chain` is sync-only
+- **Error handling**: Use `thiserror`; `expect()` messages explain why the invariant holds
+- **Async**: CPU-heavy work in `spawn_blocking`; all waits need timeouts
+- **Security**: Bound allocations from untrusted data; validate at system boundaries
+- **Changelog**: Update `CHANGELOG.md` for user-visible changes (see [`CHANGELOG_GUIDELINES.md`](CHANGELOG_GUIDELINES.md))


### PR DESCRIPTION
## Motivation

As AI coding agents become more prevalent, Zebra (like many open source projects) is seeing an increase in external PRs that lack context, prior discussion, or evidence of understanding. These PRs require significant reviewer time regardless of whether they're ultimately useful.

This isn't about discouraging AI use; AI is a legitimate tool. The issue is that **opening a PR is not a free action**: every PR requires human review time. Contributors need to be conscious of this cost and coordinate with the team before submitting work.

This PR establishes clear guidelines that:
- Help contributors (human or AI-assisted) understand what's expected **before** they invest time writing code
- Give AI agents project-specific context so they produce better contributions and warn users when a PR would likely be closed
- Reduce review burden by filtering out uncoordinated, unsolicited, or out-of-scope PRs early
- Make closure criteria transparent so contributors aren't surprised

## Solution

### New files

- **`AGENTS.md`** — Universal agent guidance file ([AGENTS.md standard](https://agents.md/), Linux Foundation). Read by Codex, GitHub Copilot, Cursor, Devin, and 20+ other AI tools. Contains:
  - Contribution gate requiring issue discussion with team acknowledgment before PRs
  - Maintainer bypass via `gh` CLI permission check
  - Build/test commands, crate architecture, code patterns, testing guidelines
  - Explicit closure criteria

- **`CLAUDE.md`** — Symlink to `AGENTS.md`. Claude Code reads `CLAUDE.md` from the repo root; this ensures it gets the same content without duplication.

- **`.github/copilot-instructions.md`** — GitHub Copilot Code Review instructions. Provides Zebra-specific review checks (Tower service bounds, error handling, numeric safety, DoS resistance, async patterns, YAGNI) so Copilot reviews flag project-relevant issues. Adapted from review analysis of 18,876 historical review comments.

### Updated files

- **`CONTRIBUTING.md`** — Restructured for clarity. New sections:
  - *AI-Assisted Contributions*: Disclosure expectations, sole-author responsibility
  - *When We Close PRs*: Transparent closure criteria including "issue exists but no team response"
  - *Code Standards*: Brief summary linking to `AGENTS.md` for full details

- **`.github/pull_request_template.md`** — Added:
  - AI Disclosure section (soft request, not hard gate)
  - "This change was discussed in an issue or with the team" checklist item
  - `Closes #` prompt for issue linking

### Tests

Tested locally by verifying AI agents (Claude Code) respect the AGENTS.md contribution gate and compliance checks when working in the repository.

### Specifications & References

Approach informed by policies from other projects facing similar challenges:

- [Reth CLAUDE.md](https://github.com/paradigmxyz/reth/blob/main/CLAUDE.md) — Agent guidance for an Ethereum execution client
- [Lodestar CONTRIBUTING.md](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md) — Mandatory AI disclosure with scope specification
- [Ghostty AI Disclosure](https://github.com/ghostty-org/ghostty/pull/8289) — PR template with mandatory AI checkbox
- [AGENTS.md specification](https://agents.md/) — Universal agent guidance standard (Linux Foundation / Agentic AI Foundation)
- [GitHub Copilot Code Review docs](https://docs.github.com/en/copilot/using-github-copilot/code-review/using-copilot-code-review)
- [GitHub Custom Instructions for Copilot](https://docs.github.com/copilot/customizing-copilot/adding-custom-instructions-for-github-copilot)

### Follow-up Work

- Enable GitHub Copilot Code Review on the repository with the custom instructions
- Review and update branch protection rules
- Monitor effectiveness over a 2-4 week experiment period
- Iterate on policies based on team feedback and contributor responses