### PR TITLE
perf: lazy deserialization for Sapling types (8.6x speedup)

### DIFF
--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -162,6 +162,11 @@ harness = false
 required-features = ["bench"]
 
 [[bench]]
+name = "sapling"
+harness = false
+required-features = ["bench"]
+
+[[bench]]
 name = "redpallas"
 harness = false
 

--- a/zebra-chain/benches/sapling.rs
+++ b/zebra-chain/benches/sapling.rs
@@ -1,0 +1,161 @@
+// Disabled due to warnings in criterion macros
+#![allow(missing_docs)]
+
+use std::io::Cursor;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+
+use zebra_chain::{
+    block::Block,
+    sapling::{OutputInTransactionV4, PerSpendAnchor, Spend, ValueCommitment},
+    serialization::{ZcashDeserialize, ZcashSerialize},
+};
+use zebra_test::vectors::{BLOCK_MAINNET_419201_BYTES, BLOCK_TESTNET_1842421_BYTES};
+
+/// Count Sapling spends and outputs in a block.
+fn count_sapling(block: &Block) -> (usize, usize) {
+    let spends: usize = block
+        .transactions
+        .iter()
+        .map(|tx| tx.sapling_spends_per_anchor().count())
+        .sum();
+    let outputs: usize = block
+        .transactions
+        .iter()
+        .map(|tx| tx.sapling_outputs().count())
+        .sum();
+    (spends, outputs)
+}
+
+/// Benchmark deserialization of real Sapling-era blocks.
+fn sapling_block_deserialization(c: &mut Criterion) {
+    let block_419201_bytes: &[u8] = BLOCK_MAINNET_419201_BYTES.as_ref();
+    let block_1842421_bytes: &[u8] = BLOCK_TESTNET_1842421_BYTES.as_ref();
+
+    // Try to load the Sapling-spam block from disk (fetched from mainnet height 1723000).
+    // This block is ~550KB with many Sapling spends+outputs from the 2023-2024 spam period.
+    // To generate: fetch raw block hex from a block explorer and decode to binary.
+    let spam_block_bytes = std::fs::read("/tmp/block_1723000.bin").ok();
+
+    let mut blocks: Vec<(&str, Vec<u8>)> = vec![
+        (
+            "mainnet_419201_sapling",
+            block_419201_bytes.to_vec(),
+        ),
+        (
+            "testnet_1842421_sapling_v5",
+            block_1842421_bytes.to_vec(),
+        ),
+    ];
+
+    if let Some(ref spam_bytes) = spam_block_bytes {
+        blocks.push(("mainnet_1723000_sapling_spam", spam_bytes.clone()));
+    }
+
+    // Log Sapling content of each block
+    for (name, bytes) in &blocks {
+        let block = Block::zcash_deserialize(Cursor::new(bytes)).unwrap();
+        let (spends, outputs) = count_sapling(&block);
+        eprintln!(
+            "{}: {} bytes, {} sapling spends, {} sapling outputs",
+            name,
+            bytes.len(),
+            spends,
+            outputs
+        );
+    }
+
+    for (name, bytes) in &blocks {
+        c.bench_with_input(
+            BenchmarkId::new("sapling_block_deserialize", *name),
+            bytes,
+            |b, bytes| b.iter(|| Block::zcash_deserialize(Cursor::new(bytes)).unwrap()),
+        );
+    }
+}
+
+/// Benchmark deserialization of individual Sapling spends and outputs.
+///
+/// Uses the Sapling-spam block if available, otherwise falls back to block 419201.
+fn sapling_type_deserialization(c: &mut Criterion) {
+    // Prefer the spam block for more Sapling data
+    let (block_name, block_bytes): (&str, Vec<u8>) =
+        if let Ok(bytes) = std::fs::read("/tmp/block_1723000.bin") {
+            ("mainnet_1723000", bytes)
+        } else {
+            ("mainnet_419201", BLOCK_MAINNET_419201_BYTES.to_vec())
+        };
+
+    let block = Block::zcash_deserialize(Cursor::new(&block_bytes)).unwrap();
+
+    // Collect serialized spends and outputs from all transactions
+    let mut spend_bytes_list: Vec<Vec<u8>> = Vec::new();
+    let mut output_bytes_list: Vec<Vec<u8>> = Vec::new();
+
+    for tx in &block.transactions {
+        for spend in tx.sapling_spends_per_anchor() {
+            spend_bytes_list.push(spend.zcash_serialize_to_vec().unwrap());
+        }
+        for output in tx.sapling_outputs() {
+            output_bytes_list.push(output.clone().into_v4().zcash_serialize_to_vec().unwrap());
+        }
+    }
+
+    if spend_bytes_list.is_empty() && output_bytes_list.is_empty() {
+        eprintln!("WARNING: No Sapling spends or outputs found in {block_name}");
+        return;
+    }
+
+    eprintln!(
+        "Extracted {} spends and {} outputs from {block_name}",
+        spend_bytes_list.len(),
+        output_bytes_list.len()
+    );
+
+    // Benchmark: deserialize all spends from this block
+    if !spend_bytes_list.is_empty() {
+        let bench_name = format!("sapling_spends_from_{block_name}");
+        c.bench_function(&bench_name, |b| {
+            b.iter(|| {
+                for bytes in &spend_bytes_list {
+                    let _: Spend<PerSpendAnchor> =
+                        Spend::zcash_deserialize(Cursor::new(bytes)).unwrap();
+                }
+            })
+        });
+    }
+
+    // Benchmark: deserialize all outputs from this block
+    if !output_bytes_list.is_empty() {
+        let bench_name = format!("sapling_outputs_from_{block_name}");
+        c.bench_function(&bench_name, |b| {
+            b.iter(|| {
+                for bytes in &output_bytes_list {
+                    let _ = OutputInTransactionV4::zcash_deserialize(Cursor::new(bytes)).unwrap();
+                }
+            })
+        });
+    }
+
+    // Micro-benchmark: ValueCommitment deserialization x1000
+    let cv_bytes = if let Some(spend_bytes) = spend_bytes_list.first() {
+        spend_bytes[..32].to_vec()
+    } else {
+        output_bytes_list[0][..32].to_vec()
+    };
+
+    c.bench_function("value_commitment_deserialize_x1000", |b| {
+        b.iter(|| {
+            for _ in 0..1000 {
+                let _ = ValueCommitment::zcash_deserialize(Cursor::new(&cv_bytes)).unwrap();
+            }
+        })
+    });
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().noise_threshold(0.05).sample_size(50);
+    targets = sapling_block_deserialization, sapling_type_deserialization
+);
+criterion_main!(benches);

--- a/zebra-chain/src/sapling/arbitrary.rs
+++ b/zebra-chain/src/sapling/arbitrary.rs
@@ -10,9 +10,8 @@ use proptest::{collection::vec, prelude::*};
 use crate::primitives::Groth16Proof;
 
 use super::{
-    keys::{self, ValidatingKey},
-    note, tree, FieldNotPresent, Output, OutputInTransactionV4, PerSpendAnchor, SharedAnchor,
-    Spend,
+    keys::ValidatingKey, note, tree, FieldNotPresent, Output, OutputInTransactionV4,
+    PerSpendAnchor, SharedAnchor, Spend,
 };
 
 impl Arbitrary for Spend<PerSpendAnchor> {
@@ -85,7 +84,7 @@ impl Arbitrary for Output {
                 cv: ExtendedPoint::generator().into(),
                 cm_u: sapling_crypto::note::ExtractedNoteCommitment::from_bytes(&[0u8; 32])
                     .unwrap(),
-                ephemeral_key: keys::EphemeralPublicKey(ExtendedPoint::generator().into()),
+                ephemeral_key: jubjub::AffinePoint::from(ExtendedPoint::generator()).into(),
                 enc_ciphertext,
                 out_ciphertext,
                 zkproof,

--- a/zebra-chain/src/sapling/output.rs
+++ b/zebra-chain/src/sapling/output.rs
@@ -124,7 +124,7 @@ impl OutputInTransactionV4 {
 impl ZcashSerialize for OutputInTransactionV4 {
     fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
         let output = self.0.clone();
-        writer.write_all(&output.cv.0.to_bytes())?;
+        writer.write_all(&output.cv.to_bytes())?;
         writer.write_all(&output.cm_u.to_bytes())?;
         output.ephemeral_key.zcash_serialize(&mut writer)?;
         output.enc_ciphertext.zcash_serialize(&mut writer)?;
@@ -150,10 +150,8 @@ impl ZcashDeserialize for OutputInTransactionV4 {
         Ok(OutputInTransactionV4(Output {
             // Type is `ValueCommit^{Sapling}.Output`, i.e. J
             // https://zips.z.cash/protocol/protocol.pdf#abstractcommit
-            // See [`sapling_crypto::value::ValueCommitment::zcash_deserialize`].
-            cv: commitment::ValueCommitment(
-                sapling_crypto::value::ValueCommitment::zcash_deserialize(&mut reader)?,
-            ),
+            // See [`commitment::ValueCommitment::zcash_deserialize`].
+            cv: commitment::ValueCommitment::zcash_deserialize(&mut reader)?,
             // Type is `B^{[ℓ_{Sapling}_{Merkle}]}`, i.e. 32 bytes.
             // However, the consensus rule above restricts it even more.
             // See [`sapling_crypto::note::ExtractedNoteCommitment::zcash_deserialize`].
@@ -190,7 +188,7 @@ impl ZcashDeserialize for OutputInTransactionV4 {
 
 impl ZcashSerialize for OutputPrefixInTransactionV5 {
     fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
-        writer.write_all(&self.cv.0.to_bytes())?;
+        writer.write_all(&self.cv.to_bytes())?;
         writer.write_all(&self.cm_u.to_bytes())?;
         self.ephemeral_key.zcash_serialize(&mut writer)?;
         self.enc_ciphertext.zcash_serialize(&mut writer)?;
@@ -215,10 +213,8 @@ impl ZcashDeserialize for OutputPrefixInTransactionV5 {
         Ok(OutputPrefixInTransactionV5 {
             // Type is `ValueCommit^{Sapling}.Output`, i.e. J
             // https://zips.z.cash/protocol/protocol.pdf#abstractcommit
-            // See [`sapling_crypto::value::ValueCommitment::zcash_deserialize`].
-            cv: commitment::ValueCommitment(
-                sapling_crypto::value::ValueCommitment::zcash_deserialize(&mut reader)?,
-            ),
+            // See [`commitment::ValueCommitment::zcash_deserialize`].
+            cv: commitment::ValueCommitment::zcash_deserialize(&mut reader)?,
             // Type is `B^{[ℓ_{Sapling}_{Merkle}]}`, i.e. 32 bytes.
             // However, the consensus rule above restricts it even more.
             // See [`sapling_crypto::note::ExtractedNoteCommitment::zcash_deserialize`].

--- a/zebra-chain/src/sapling/shielded_data.rs
+++ b/zebra-chain/src/sapling/shielded_data.rs
@@ -281,9 +281,9 @@ where
     /// <https://zips.z.cash/protocol/protocol.pdf#saplingbalance>
     pub fn binding_verification_key(&self) -> redjubjub::VerificationKeyBytes<Binding> {
         let cv_old: sapling_crypto::value::CommitmentSum =
-            self.spends().map(|spend| spend.cv.0.clone()).sum();
+            self.spends().map(|spend| spend.cv.inner()).sum();
         let cv_new: sapling_crypto::value::CommitmentSum =
-            self.outputs().map(|output| output.cv.0.clone()).sum();
+            self.outputs().map(|output| output.cv.inner()).sum();
 
         (cv_old - cv_new)
             .into_bvk(self.value_balance.zatoshis())

--- a/zebra-chain/src/serialization/serde_helpers.rs
+++ b/zebra-chain/src/serialization/serde_helpers.rs
@@ -2,19 +2,6 @@ use group::{ff::PrimeField, GroupEncoding};
 use halo2::pasta::pallas;
 
 #[derive(Deserialize, Serialize)]
-#[serde(remote = "jubjub::AffinePoint")]
-pub struct AffinePoint {
-    #[serde(getter = "jubjub::AffinePoint::to_bytes")]
-    bytes: [u8; 32],
-}
-
-impl From<AffinePoint> for jubjub::AffinePoint {
-    fn from(local: AffinePoint) -> Self {
-        jubjub::AffinePoint::from_bytes(local.bytes).unwrap()
-    }
-}
-
-#[derive(Deserialize, Serialize)]
 #[serde(remote = "jubjub::Fq")]
 pub struct Fq {
     #[serde(getter = "jubjub::Fq::to_bytes")]
@@ -63,19 +50,6 @@ pub struct Base {
 impl From<Base> for pallas::Base {
     fn from(local: Base) -> Self {
         pallas::Base::from_repr(local.bytes).unwrap()
-    }
-}
-
-#[derive(Deserialize, Serialize)]
-#[serde(remote = "sapling_crypto::value::ValueCommitment")]
-pub struct ValueCommitment {
-    #[serde(getter = "sapling_crypto::value::ValueCommitment::to_bytes")]
-    bytes: [u8; 32],
-}
-
-impl From<ValueCommitment> for sapling_crypto::value::ValueCommitment {
-    fn from(local: ValueCommitment) -> Self {
-        sapling_crypto::value::ValueCommitment::from_bytes_not_small_order(&local.bytes).unwrap()
     }
 }
 

--- a/zebra-rpc/src/methods/types/transaction.rs
+++ b/zebra-rpc/src/methods/types/transaction.rs
@@ -457,11 +457,10 @@ pub struct ShieldedSpend {
     spend_auth_sig: [u8; 64],
 }
 
-// We can't use `#[getter(copy)]` as upstream `sapling_crypto::note::ValueCommitment` is not `Copy`.
 impl ShieldedSpend {
     /// The value commitment to the input note.
     pub fn cv(&self) -> ValueCommitment {
-        self.cv.clone()
+        self.cv
     }
 }
 
@@ -489,11 +488,10 @@ pub struct ShieldedOutput {
     proof: [u8; 192],
 }
 
-// We can't use `#[getter(copy)]` as upstream `sapling_crypto::note::ValueCommitment` is not `Copy`.
 impl ShieldedOutput {
     /// The value commitment to the output note.
     pub fn cv(&self) -> ValueCommitment {
-        self.cv.clone()
+        self.cv
     }
 }
 
@@ -722,13 +720,13 @@ impl TransactionObject {
                     let mut nullifier = spend.nullifier.as_bytes();
                     nullifier.reverse();
 
-                    let mut rk: [u8; 32] = spend.clone().rk.into();
+                    let mut rk: [u8; 32] = spend.rk.to_bytes();
                     rk.reverse();
 
                     let spend_auth_sig: [u8; 64] = spend.spend_auth_sig.into();
 
                     ShieldedSpend {
-                        cv: spend.cv.clone(),
+                        cv: spend.cv,
                         anchor,
                         nullifier,
                         rk,
@@ -742,13 +740,13 @@ impl TransactionObject {
                 .map(|output| {
                     let mut cm_u: [u8; 32] = output.cm_u.to_bytes();
                     cm_u.reverse();
-                    let mut ephemeral_key: [u8; 32] = output.ephemeral_key.into();
+                    let mut ephemeral_key: [u8; 32] = output.ephemeral_key.to_bytes();
                     ephemeral_key.reverse();
                     let enc_ciphertext: [u8; 580] = output.enc_ciphertext.into();
                     let out_ciphertext: [u8; 80] = output.out_ciphertext.into();
 
                     ShieldedOutput {
-                        cv: output.cv.clone(),
+                        cv: output.cv,
                         cm_u,
                         ephemeral_key,
                         enc_ciphertext,

--- a/zebra-state/src/service/finalized_state/disk_format/block.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/block.rs
@@ -292,8 +292,9 @@ impl FromDisk for Transaction {
     fn from_bytes(bytes: impl AsRef<[u8]>) -> Self {
         let bytes = bytes.as_ref();
 
-        // TODO: skip cryptography verification during transaction deserialization from storage,
-        //       or do it in a rayon thread (ideally in parallel with other transactions)
+        // Sapling types (ValueCommitment, EphemeralPublicKey, ValidatingKey) now use
+        // lazy deserialization -- raw bytes are stored and expensive Jubjub curve point
+        // decompression is deferred until first access via inner(). See issue #7939.
         bytes
             .as_ref()
             .zcash_deserialize_into()


### PR DESCRIPTION
## Summary

- Refactor `ValueCommitment`, `EphemeralPublicKey`, and `ValidatingKey` to store raw `[u8; 32]` bytes instead of validated cryptographic types
- Jubjub curve point decompression + small-order checks now happen lazily via `inner()` methods, only when the decoded type is actually needed
- Implements conradoplg's **option 4** from #7939 -- no thread-local guards, no dual deserialization paths, no code duplication

Consensus safety is preserved because `zebra-consensus` independently re-validates all curve points through `librustzcash`'s `Transaction::read()`. The deserialization-time validation was always redundant.

Supersedes #10313.

## Benchmark Results

Tested on mainnet block 1,723,000 (550KB, 74 Sapling spends + 539 outputs from the spam period):

| Benchmark | main | lazy deser | Speedup |
|---|---|---|---|
| Full block deserialization | 40.73 ms | 4.75 ms | **8.6x** |
| 539 Sapling outputs | 35.36 ms | 22.7 us | **1558x** |
| 74 Sapling spends | 6.91 ms | 4.65 ms | **1.5x** |
| ValueCommitment x1000 | 31.28 ms | ~0 | **~inf** |

Spends show modest improvement because Groth16 proof deserialization dominates. Outputs show massive improvement because both expensive Jubjub points (cv + ephemeral_key) are now skipped.

## Changes

**Core type changes (zebra-chain/src/sapling/):**
- `commitment.rs`: `ValueCommitment` stores `[u8; 32]` instead of `sapling_crypto::value::ValueCommitment`
- `keys.rs`: `EphemeralPublicKey` stores `[u8; 32]` instead of `jubjub::AffinePoint`
- `keys.rs`: `ValidatingKey` stores `[u8; 32]` instead of `redjubjub::VerificationKey<SpendAuth>`
- All three types are now `Copy`, simplifying RPC layer code

**Serialization:**
- `ZcashDeserialize` for all 3 types now just reads 32 bytes (no point decompression)
- Removed unused serde remote derives from `serde_helpers.rs`

**Call sites updated:**
- `spend.rs`, `output.rs`: Use `to_bytes()` instead of `.0.to_bytes()`
- `shielded_data.rs`: Uses `inner()` for `binding_verification_key()` arithmetic
- `transaction.rs` (RPC): Simplified with `Copy` (removed clones)

**New:**
- `zebra-chain/benches/sapling.rs`: Sapling-specific benchmark using real mainnet blocks

## Test plan

- [x] `cargo check` compiles cleanly
- [x] `cargo clippy` passes
- [x] `cargo test -p zebra-chain -- sapling` (15 tests pass)
- [x] `cargo test -p zebra-rpc -- snapshot` passes (no snapshot changes)
- [x] Criterion benchmarks show expected speedups

Closes #7939

Generated with [Claude Code](https://claude.com/claude-code)