### PR TITLE
feat(state): Add a `AnyChainBlock` state request for querying blocks in side chains

### DIFF
--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `ReadRequest::IsTransparentOutputSpent` and `ReadResponse::IsTransparentOutputSpent` to the read state service ([#10235](https://github.com/ZcashFoundation/zebra/pull/10235))
+- Added `{ReadRequest, Request}::AnyChainBlock` to the read state service ([#10325](https://github.com/ZcashFoundation/zebra/pull/10325))
 
 
 ## [4.0.0] - 2026-02-05

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -1126,7 +1126,8 @@ pub enum ReadRequest {
     /// Returns
     ///
     /// * [`ReadResponse::Block(Some(Arc<Block>))`](ReadResponse::Block) if the block hash is in any chain, or
-    ///   if the block height is in the best chain;
+    ///   if the block height is in any chain, checking the best chain first
+    ///   followed by side chains in order from most to least work.
     /// * [`ReadResponse::Block(None)`](ReadResponse::Block) otherwise.
     ///
     /// Note: the [`HashOrHeight`] can be constructed from a [`block::Hash`] or

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -896,7 +896,7 @@ pub enum Request {
     ///
     /// Returns
     ///
-    /// * [`Response::Block(Some(Arc<Block>))`](Response::Block) if the block hash is in any chain, or
+    /// * [`Response::Block(Some(Arc<Block>))`](Response::Block) if the block hash is in any chain, or,
     ///   if the block height is in the best chain;
     /// * [`Response::Block(None)`](Response::Block) otherwise.
     ///

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -892,6 +892,17 @@ pub enum Request {
     /// [`block::Height`] using `.into()`.
     Block(HashOrHeight),
 
+    /// Looks up a block by hash in any current chain or by height in the current best chain.
+    ///
+    /// Returns
+    ///
+    /// * [`Response::Block(Some(Arc<Block>))`](Response::Block) if the block is in the best chain;
+    /// * [`Response::Block(None)`](Response::Block) otherwise.
+    ///
+    /// Note: the [`HashOrHeight`] can be constructed from a [`block::Hash`] or
+    /// [`block::Height`] using `.into()`.
+    AnyChainBlock(HashOrHeight),
+
     //// Same as Block, but also returns serialized block size.
     ////
     /// Returns
@@ -1032,7 +1043,6 @@ impl Request {
         match self {
             Request::CommitSemanticallyVerifiedBlock(_) => "commit_semantically_verified_block",
             Request::CommitCheckpointVerifiedBlock(_) => "commit_checkpoint_verified_block",
-
             Request::AwaitUtxo(_) => "await_utxo",
             Request::Depth(_) => "depth",
             Request::Tip => "tip",
@@ -1041,6 +1051,7 @@ impl Request {
             Request::AnyChainTransaction(_) => "any_chain_transaction",
             Request::UnspentBestChainUtxo { .. } => "unspent_best_chain_utxo",
             Request::Block(_) => "block",
+            Request::AnyChainBlock(_) => "any_chain_block",
             Request::BlockAndSize(_) => "block_and_size",
             Request::BlockHeader(_) => "block_header",
             Request::FindBlockHashes { .. } => "find_block_hashes",
@@ -1108,6 +1119,17 @@ pub enum ReadRequest {
     /// Note: the [`HashOrHeight`] can be constructed from a [`block::Hash`] or
     /// [`block::Height`] using `.into()`.
     Block(HashOrHeight),
+
+    /// Looks up a block by hash in any current chain or by height in the current best chain.
+    ///
+    /// Returns
+    ///
+    /// * [`ReadResponse::Block(Some(Arc<Block>))`](ReadResponse::Block) if the block is in the best chain;
+    /// * [`ReadResponse::Block(None)`](ReadResponse::Block) otherwise.
+    ///
+    /// Note: the [`HashOrHeight`] can be constructed from a [`block::Hash`] or
+    /// [`block::Height`] using `.into()`.
+    AnyChainBlock(HashOrHeight),
 
     //// Same as Block, but also returns serialized block size.
     ////
@@ -1393,6 +1415,7 @@ impl ReadRequest {
             ReadRequest::BlockInfo(_) => "block_info",
             ReadRequest::Depth(_) => "depth",
             ReadRequest::Block(_) => "block",
+            ReadRequest::AnyChainBlock(_) => "any_chain_block",
             ReadRequest::BlockAndSize(_) => "block_and_size",
             ReadRequest::BlockHeader(_) => "block_header",
             ReadRequest::Transaction(_) => "transaction",
@@ -1452,6 +1475,9 @@ impl TryFrom<Request> for ReadRequest {
             Request::BestChainBlockHash(hash) => Ok(ReadRequest::BestChainBlockHash(hash)),
 
             Request::Block(hash_or_height) => Ok(ReadRequest::Block(hash_or_height)),
+            Request::AnyChainBlock(hash_or_height) => {
+                Ok(ReadRequest::AnyChainBlock(hash_or_height))
+            }
             Request::BlockAndSize(hash_or_height) => Ok(ReadRequest::BlockAndSize(hash_or_height)),
             Request::BlockHeader(hash_or_height) => Ok(ReadRequest::BlockHeader(hash_or_height)),
             Request::Transaction(tx_hash) => Ok(ReadRequest::Transaction(tx_hash)),

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -896,7 +896,8 @@ pub enum Request {
     ///
     /// Returns
     ///
-    /// * [`Response::Block(Some(Arc<Block>))`](Response::Block) if the block is in the best chain;
+    /// * [`Response::Block(Some(Arc<Block>))`](Response::Block) if the block hash is in any chain, or
+    ///   if the block height is in the best chain;
     /// * [`Response::Block(None)`](Response::Block) otherwise.
     ///
     /// Note: the [`HashOrHeight`] can be constructed from a [`block::Hash`] or
@@ -1124,7 +1125,8 @@ pub enum ReadRequest {
     ///
     /// Returns
     ///
-    /// * [`ReadResponse::Block(Some(Arc<Block>))`](ReadResponse::Block) if the block is in the best chain;
+    /// * [`ReadResponse::Block(Some(Arc<Block>))`](ReadResponse::Block) if the block hash is in any chain, or
+    ///   if the block height is in the best chain;
     /// * [`ReadResponse::Block(None)`](ReadResponse::Block) otherwise.
     ///
     /// Note: the [`HashOrHeight`] can be constructed from a [`block::Hash`] or

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -922,9 +922,7 @@ impl ReadStateService {
     /// Gets a clone of the latest, best non-finalized chain from the `non_finalized_state_receiver`
     fn latest_best_chain(&self) -> Option<Arc<Chain>> {
         self.non_finalized_state_receiver
-            .cloned_mapped_watch_data(|non_finalized_state| {
-                non_finalized_state.best_chain().cloned()
-            })
+            .borrow_mapped(|non_finalized_state| non_finalized_state.best_chain().cloned())
     }
 
     /// Test-only access to the inner database.
@@ -1464,8 +1462,8 @@ impl Service<ReadRequest> for ReadStateService {
 
                 tokio::task::spawn_blocking(move || {
                     span.in_scope(move || {
-                        let block = read::any_chain_block(
-                            state.latest_non_finalized_state(),
+                        let block = read::any_block(
+                            state.latest_non_finalized_state().chain_iter(),
                             &state.db,
                             hash_or_height,
                         );

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -29,7 +29,7 @@ pub use address::{
     utxo::{address_utxos, AddressUtxos},
 };
 pub use block::{
-    any_chain_block, any_transaction, any_utxo, block, block_and_size, block_header, block_info,
+    any_block, any_transaction, any_utxo, block, block_and_size, block_header, block_info,
     mined_transaction, transaction_hashes_for_any_block, transaction_hashes_for_block,
     unspent_utxo,
 };

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -29,8 +29,9 @@ pub use address::{
     utxo::{address_utxos, AddressUtxos},
 };
 pub use block::{
-    any_transaction, any_utxo, block, block_and_size, block_header, block_info, mined_transaction,
-    transaction_hashes_for_any_block, transaction_hashes_for_block, unspent_utxo,
+    any_chain_block, any_transaction, any_utxo, block, block_and_size, block_header, block_info,
+    mined_transaction, transaction_hashes_for_any_block, transaction_hashes_for_block,
+    unspent_utxo,
 };
 
 #[cfg(feature = "indexer")]

--- a/zebra-state/src/service/read/block.rs
+++ b/zebra-state/src/service/read/block.rs
@@ -38,6 +38,28 @@ use crate::{
 use crate::request::Spend;
 
 /// Returns the [`Block`] with [`block::Hash`] or
+/// [`Height`], if it exists in the non-finalized state or finalized `db`.
+///
+/// Checks all non-finalized chain for block hashes or the best chain for heights.
+pub fn any_chain_block(
+    non_finalized: NonFinalizedState,
+    db: &ZebraDb,
+    hash_or_height: HashOrHeight,
+) -> Option<Arc<Block>> {
+    let unchecked_best_chain = if let HashOrHeight::Hash(hash) = hash_or_height {
+        if let Some(block) = non_finalized.any_block_by_hash(hash) {
+            return Some(block);
+        }
+
+        None
+    } else {
+        non_finalized.best_chain()
+    };
+
+    block(unchecked_best_chain, db, hash_or_height)
+}
+
+/// Returns the [`Block`] with [`block::Hash`] or
 /// [`Height`], if it exists in the non-finalized `chain` or finalized `db`.
 pub fn block<C>(chain: Option<C>, db: &ZebraDb, hash_or_height: HashOrHeight) -> Option<Arc<Block>>
 where

--- a/zebra-state/src/service/watch_receiver.rs
+++ b/zebra-state/src/service/watch_receiver.rs
@@ -89,6 +89,21 @@ where
         f(cloned_data)
     }
 
+    /// Returns a clone of the output of the provided closure when
+    /// called with the watch data in the channel.
+    /// Cloning the watched data helps avoid deadlocks.
+    ///
+    /// Does not mark the watched data as seen.
+    ///
+    /// This method is meant to be used with quick accessor closures
+    /// and should not be called with computationally expensive closures.
+    pub fn cloned_mapped_watch_data<U: 'static, F>(&self, f: F) -> U
+    where
+        F: FnOnce(watch::Ref<T>) -> U,
+    {
+        f(self.receiver.borrow())
+    }
+
     /// Returns a clone of the watch data in the channel.
     /// Cloning the watched data helps avoid deadlocks.
     ///

--- a/zebra-state/src/service/watch_receiver.rs
+++ b/zebra-state/src/service/watch_receiver.rs
@@ -89,15 +89,15 @@ where
         f(cloned_data)
     }
 
-    /// Returns a clone of the output of the provided closure when
-    /// called with the watch data in the channel.
-    /// Cloning the watched data helps avoid deadlocks.
+    /// Calls the provided closure with the watch data in the channel
+    /// and returns the output.
     ///
     /// Does not mark the watched data as seen.
     ///
-    /// This method is meant to be used with quick accessor closures
-    /// and should not be called with computationally expensive closures.
-    pub fn cloned_mapped_watch_data<U: 'static, F>(&self, f: F) -> U
+    /// The closure provided to this method will hold a read lock,
+    /// callers are expected to ensure any closures they provide
+    /// will promptly drop the read lock.
+    pub fn borrow_mapped<U: 'static, F>(&self, f: F) -> U
     where
         F: FnOnce(watch::Ref<T>) -> U,
     {


### PR DESCRIPTION
## Motivation

Closes #10305.

## Solution

- Adds a new request variant for querying block hashes in any chain
- Adds a new read fn in zebra-state for reading blocks from any chain

Related changes:
- Replaces some calls to `with_watched_data()` with calls to `latest_best_chain()`
- Adds a new method on `WatchReciever` to map the borrowed data to an owned value
- Updates `latest_best_chain()` to clone only the best chain and not the rest of the non-finalized state

### Tests

Currently unused in Zebra and a trivial addition.

### AI Disclosure

- [x] No AI tools were used in this PR
- [ ] AI tools were used: <!-- tool name and what it was used for, e.g., "Claude for test boilerplate" -->

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [ ] The solution is tested.
- [x] The documentation and changelogs are up to date.
