### PR TITLE
release(changelog): Add changelogs for OpenRPC changes

### DIFF
--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   renamed to `Overflow`.
 - `parameters::network::subsidy::num_halvings` was renamed to `halving`.
 - `transparent::Output::new_coinbase` was renamed to `new`.
+- `NoteCommitmentSubtreeIndex` now derives `schemars::JsonSchema` (#10201)
 
 ## [5.0.0] - 2026-02-05
 

--- a/zebra-network/CHANGELOG.md
+++ b/zebra-network/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `PeerSocketAddr` now derives `schemars::JsonSchema` (#10201)
+
 ## [4.0.0] - 2026-02-05
 
 ### Breaking Changes

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `get_tx_out` method and `OutputObject` response. ([#10235](https://github.com/ZcashFoundation/zebra/pull/10235))
+- OpenRPC support (#10201):
+  - `openrpsee` dependency
+  - Added `build_rpc_schema()` to generate a map of the node's supported RPC interface at build time
+  - Use the generated OpenRPC schema to serve the `rpc.discover` RPC method.
+
+### Changed
+
+- `GetBlockTemplateRequestMode`, `GetBlockTemplateCapability`, `GetBlockTemplateParameters`, `LongPollId`,
+  `SubmitBlockParameters`, `GetAddressBalanceRequest`, `DGetAddressBalanceRequest`, `GetAddressUtxosRequest`,
+  `DGetAddressUtxosRequest`, `DGetAddressTxIdsRequest` and `AddNodeCommand` now derives `schemars::JsonSchema` (#10201)
 
 ## [5.0.0] - 2026-02-05
 


### PR DESCRIPTION
## Motivation

In https://github.com/ZcashFoundation/zebra/pull/10201, I forgot to add the corresponding changelog entries to the affected crates.

## Solution

Add the missing changelog entries.
