### PR TITLE
cleanup: Simplify `ReadStateService::call()` method

### DIFF
--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `parameters::network::testnet::founder_address_list`
 - `parameters::network::subsidy::founders_reward`
 - `parameters::network::subsidy::founders_reward_address`
+- `diagnostics::CodeTimer::{start_desc, finish_desc, finish_inner}`
 
 ### Changed
 

--- a/zebra-chain/src/diagnostic.rs
+++ b/zebra-chain/src/diagnostic.rs
@@ -56,7 +56,7 @@ impl CodeTimer {
     /// Start timing the execution of a function, method, or other code region.
     ///
     /// Returns a guard that finishes timing the code when dropped,
-    /// or when [`CodeTimer::finish()`] is called.
+    /// or when [`CodeTimer::finish_inner()`] is called with an empty description.
     #[track_caller]
     pub fn start_desc(description: &'static str) -> Self {
         let start = Instant::now();

--- a/zebra-chain/src/diagnostic.rs
+++ b/zebra-chain/src/diagnostic.rs
@@ -37,6 +37,9 @@ pub struct CodeTimer {
     /// The minimum duration for warning messages.
     min_warn_time: Duration,
 
+    /// The description configured when the timer is started.
+    description: &'static str,
+
     /// `true` if this timer has finished.
     has_finished: bool,
 }
@@ -44,10 +47,18 @@ pub struct CodeTimer {
 impl CodeTimer {
     /// Start timing the execution of a function, method, or other code region.
     ///
+    /// See [`CodeTimer::start_desc`] for more details.
+    #[track_caller]
+    pub fn start() -> Self {
+        Self::start_desc("")
+    }
+
+    /// Start timing the execution of a function, method, or other code region.
+    ///
     /// Returns a guard that finishes timing the code when dropped,
     /// or when [`CodeTimer::finish()`] is called.
     #[track_caller]
-    pub fn start() -> Self {
+    pub fn start_desc(description: &'static str) -> Self {
         let start = Instant::now();
         trace!(
             target: "run time",
@@ -57,6 +68,7 @@ impl CodeTimer {
 
         Self {
             start,
+            description,
             min_info_time: DEFAULT_MIN_INFO_TIME,
             min_warn_time: DEFAULT_MIN_WARN_TIME,
             has_finished: false,
@@ -64,15 +76,10 @@ impl CodeTimer {
     }
 
     /// Finish timing the execution of a function, method, or other code region.
-    pub fn finish<S>(
-        mut self,
-        module_path: &'static str,
-        line: u32,
-        description: impl Into<Option<S>>,
-    ) where
-        S: ToString,
-    {
-        self.finish_inner(Some(module_path), Some(line), description);
+    #[track_caller]
+    pub fn finish_desc(mut self, description: &'static str) {
+        let location = std::panic::Location::caller();
+        self.finish_inner(Some(location.file()), Some(location.line()), description);
     }
 
     /// Ignore this timer: it will not check the elapsed time or log any warnings.
@@ -81,19 +88,21 @@ impl CodeTimer {
     }
 
     /// Finish timing the execution of a function, method, or other code region.
-    ///
-    /// This private method can be called from [`CodeTimer::finish()`] or `drop()`.
-    fn finish_inner<S>(
+    pub fn finish_inner(
         &mut self,
-        module_path: impl Into<Option<&'static str>>,
+        file: impl Into<Option<&'static str>>,
         line: impl Into<Option<u32>>,
-        description: impl Into<Option<S>>,
-    ) where
-        S: ToString,
-    {
+        description: &'static str,
+    ) {
         if self.has_finished {
             return;
         }
+
+        let description = if description.is_empty() {
+            self.description
+        } else {
+            description
+        };
 
         self.has_finished = true;
 
@@ -101,21 +110,16 @@ impl CodeTimer {
         let time = duration_short(execution);
         let time = time.as_str();
 
-        let module = module_path.into().unwrap_or_default();
+        let file = file.into().unwrap_or_default();
 
         let line = line.into().map(|line| line.to_string()).unwrap_or_default();
         let line = line.as_str();
-
-        let description = description
-            .into()
-            .map(|desc| desc.to_string())
-            .unwrap_or_default();
 
         if execution >= self.min_warn_time {
             warn!(
                 target: "run time",
                 %time,
-                %module,
+                %file,
                 %line,
                 "very long {description}",
             );
@@ -123,7 +127,7 @@ impl CodeTimer {
             info!(
                 target: "run time",
                 %time,
-                %module,
+                %file,
                 %line,
                 "long {description}",
             );
@@ -131,7 +135,7 @@ impl CodeTimer {
             trace!(
                 target: "run time",
                 %time,
-                %module,
+                %file,
                 %line,
                 "finished {description} code timer",
             );

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -1413,6 +1413,7 @@ pub enum ReadRequest {
 }
 
 impl ReadRequest {
+    /// Returns a [`&'static str`](str) name of the variant representing this value.
     pub fn variant_name(&self) -> &'static str {
         match self {
             ReadRequest::UsageInfo => "usage_info",

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -1538,7 +1538,7 @@ impl TimedSpan {
 
     /// Spawns a blocking tokio task in scope of the `span` field.
     #[track_caller]
-    pub fn spawn_blocking_in_scope<T: Send + 'static>(
+    pub fn spawn_blocking<T: Send + 'static>(
         mut self,
         f: impl FnOnce() -> Result<T, BoxError> + Send + 'static,
     ) -> Pin<Box<dyn futures::Future<Output = Result<T, BoxError>> + Send>> {

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -3,6 +3,7 @@
 use std::{
     collections::{HashMap, HashSet},
     ops::{Add, Deref, DerefMut, RangeInclusive},
+    pin::Pin,
     sync::Arc,
 };
 
@@ -10,6 +11,7 @@ use tower::{BoxError, Service, ServiceExt};
 use zebra_chain::{
     amount::{DeferredPoolBalanceChange, NegativeAllowed},
     block::{self, Block, HeightDiff},
+    diagnostic::{task::WaitForPanics, CodeTimer},
     history_tree::HistoryTree,
     orchard,
     parallel::tree::NoteCommitmentTrees,
@@ -1040,7 +1042,8 @@ pub enum Request {
 }
 
 impl Request {
-    fn variant_name(&self) -> &'static str {
+    /// Returns a [`&'static str`](str) name of the variant representing this value.
+    pub fn variant_name(&self) -> &'static str {
         match self {
             Request::CommitSemanticallyVerifiedBlock(_) => "commit_semantically_verified_block",
             Request::CommitCheckpointVerifiedBlock(_) => "commit_checkpoint_verified_block",
@@ -1410,7 +1413,7 @@ pub enum ReadRequest {
 }
 
 impl ReadRequest {
-    fn variant_name(&self) -> &'static str {
+    pub fn variant_name(&self) -> &'static str {
         match self {
             ReadRequest::UsageInfo => "usage_info",
             ReadRequest::Tip => "tip",
@@ -1516,5 +1519,43 @@ impl TryFrom<Request> for ReadRequest {
                 ReadRequest::CheckBlockProposalValidity(semantically_verified),
             ),
         }
+    }
+}
+
+#[derive(Debug)]
+/// A convenience type for spawning blocking tokio tasks with
+/// a timer in the scope of a provided span.
+pub struct TimedSpan {
+    timer: CodeTimer,
+    span: tracing::Span,
+}
+
+impl TimedSpan {
+    /// Creates a new [`TimedSpan`].
+    pub fn new(timer: CodeTimer, span: tracing::Span) -> Self {
+        Self { timer, span }
+    }
+
+    /// Spawns a blocking tokio task in scope of the `span` field.
+    #[track_caller]
+    pub fn spawn_blocking_in_scope<T: Send + 'static>(
+        mut self,
+        f: impl FnOnce() -> Result<T, BoxError> + Send + 'static,
+    ) -> Pin<Box<dyn futures::Future<Output = Result<T, BoxError>> + Send>> {
+        let location = std::panic::Location::caller();
+        // # Performance
+        //
+        // Allow other async tasks to make progress while concurrently reading blocks from disk.
+
+        // The work is done in the future.
+        tokio::task::spawn_blocking(move || {
+            self.span.in_scope(move || {
+                let result = f();
+                self.timer
+                    .finish_inner(Some(location.file()), Some(location.line()), "");
+                result
+            })
+        })
+        .wait_for_panics()
     }
 }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -33,18 +33,18 @@ use tower::buffer::Buffer;
 
 use zebra_chain::{
     block::{self, CountedHeader, HeightDiff},
-    diagnostic::{task::WaitForPanics, CodeTimer},
+    diagnostic::CodeTimer,
     parameters::{Network, NetworkUpgrade},
+    serialization::ZcashSerialize,
     subtree::NoteCommitmentSubtreeIndex,
 };
-
-use zebra_chain::{block::Height, serialization::ZcashSerialize};
 
 use crate::{
     constants::{
         MAX_FIND_BLOCK_HASHES_RESULTS, MAX_FIND_BLOCK_HEADERS_RESULTS, MAX_LEGACY_CHAIN_BLOCKS,
     },
     error::{CommitBlockError, CommitCheckpointVerifiedError, InvalidateError, ReconsiderError},
+    request::TimedSpan,
     response::NonFinalizedBlocksListener,
     service::{
         block_iter::any_ancestor_blocks,
@@ -53,6 +53,7 @@ use crate::{
         non_finalized_state::{Chain, NonFinalizedState},
         pending_utxos::PendingUtxos,
         queued_blocks::QueuedBlocks,
+        read::find,
         watch_receiver::WatchReceiver,
     },
     BoxError, CheckpointVerifiedBlock, CommitSemanticallyVerifiedError, Config, KnownBlock,
@@ -312,7 +313,7 @@ impl StateService {
                     #[cfg(feature = "elasticsearch")]
                     true,
                 );
-                timer.finish(module_path!(), line!(), "opening finalized state database");
+                timer.finish_desc("opening finalized state database");
 
                 let timer = CodeTimer::start();
                 let finalized_tip = finalized_state.db.tip_block();
@@ -405,7 +406,7 @@ impl StateService {
             read_service: read_service.clone(),
             max_finalized_queue_height: f64::NAN,
         };
-        timer.finish(module_path!(), line!(), "initializing state service");
+        timer.finish_desc("initializing state service");
 
         tracing::info!("starting legacy chain check");
         let timer = CodeTimer::start();
@@ -442,7 +443,7 @@ impl StateService {
         }
 
         tracing::info!("cached state consensus branch is valid: no legacy chain found");
-        timer.finish(module_path!(), line!(), "legacy chain check");
+        timer.finish_desc("legacy chain check");
 
         // Spawn a background task to periodically export RocksDB metrics to Prometheus
         let db_for_metrics = read_service.db.clone();
@@ -981,7 +982,6 @@ impl Service<Request> for StateService {
     #[instrument(name = "state", skip(self, req))]
     fn call(&mut self, req: Request) -> Self::Future {
         req.count_metric();
-        let timer = CodeTimer::start();
         let span = Span::current();
 
         match req {
@@ -990,6 +990,7 @@ impl Service<Request> for StateService {
             //
             // The expected error type for this request is `CommitSemanticallyVerifiedError`.
             Request::CommitSemanticallyVerifiedBlock(semantically_verified) => {
+                let timer = CodeTimer::start();
                 self.assert_block_can_be_validated(&semantically_verified);
 
                 self.pending_utxos
@@ -1017,7 +1018,7 @@ impl Service<Request> for StateService {
                 //     as well as in poll_ready()
 
                 // The work is all done, the future just waits on a channel for the result
-                timer.finish(module_path!(), line!(), "CommitSemanticallyVerifiedBlock");
+                timer.finish_desc("CommitSemanticallyVerifiedBlock");
 
                 // Await the channel response, flatten the result, map receive errors to
                 // `CommitSemanticallyVerifiedError::WriteTaskExited`.
@@ -1040,6 +1041,7 @@ impl Service<Request> for StateService {
             //
             // The expected error type for this request is `CommitCheckpointVerifiedError`.
             Request::CommitCheckpointVerifiedBlock(finalized) => {
+                let timer = CodeTimer::start();
                 // # Consensus
                 //
                 // A semantic block verification could have called AwaitUtxo
@@ -1067,7 +1069,7 @@ impl Service<Request> for StateService {
                 //     as well as in poll_ready()
 
                 // The work is all done, the future just waits on a channel for the result
-                timer.finish(module_path!(), line!(), "CommitCheckpointVerifiedBlock");
+                timer.finish_desc("CommitCheckpointVerifiedBlock");
 
                 // Await the channel response, flatten the result, map receive errors to
                 // `CommitCheckpointVerifiedError::WriteTaskExited`.
@@ -1087,6 +1089,7 @@ impl Service<Request> for StateService {
             // Uses pending_utxos and non_finalized_state_queued_blocks in the StateService.
             // If the UTXO isn't in the queued blocks, runs concurrently using the ReadStateService.
             Request::AwaitUtxo(outpoint) => {
+                let timer = CodeTimer::start();
                 // Prepare the AwaitUtxo future from PendingUxtos.
                 let response_fut = self.pending_utxos.queue(outpoint);
                 // Only instrument `response_fut`, the ReadStateService already
@@ -1100,7 +1103,7 @@ impl Service<Request> for StateService {
                     self.pending_utxos.respond(&outpoint, utxo);
 
                     // We're finished, the returned future gets the UTXO from the respond() channel.
-                    timer.finish(module_path!(), line!(), "AwaitUtxo/queued-non-finalized");
+                    timer.finish_desc("AwaitUtxo/queued-non-finalized");
 
                     return response_fut;
                 }
@@ -1110,7 +1113,7 @@ impl Service<Request> for StateService {
                     self.pending_utxos.respond(&outpoint, utxo);
 
                     // We're finished, the returned future gets the UTXO from the respond() channel.
-                    timer.finish(module_path!(), line!(), "AwaitUtxo/sent-non-finalized");
+                    timer.finish_desc("AwaitUtxo/sent-non-finalized");
 
                     return response_fut;
                 }
@@ -1145,13 +1148,13 @@ impl Service<Request> for StateService {
                     // that's rare enough that a retry is ok.
                     if let ReadResponse::AnyChainUtxo(Some(utxo)) = rsp {
                         // We got a UTXO, so we replace the response future with the result own.
-                        timer.finish(module_path!(), line!(), "AwaitUtxo/any-chain");
+                        timer.finish_desc("AwaitUtxo/any-chain");
 
                         return Ok(Response::Utxo(utxo));
                     }
 
                     // We're finished, but the returned future is waiting on the respond() channel.
-                    timer.finish(module_path!(), line!(), "AwaitUtxo/waiting");
+                    timer.finish_desc("AwaitUtxo/waiting");
 
                     response_fut.await
                 }
@@ -1162,7 +1165,6 @@ impl Service<Request> for StateService {
             // before downloading or validating it.
             Request::KnownBlock(hash) => {
                 let timer = CodeTimer::start();
-
                 let sent_hash_response = self.known_sent_hash(&hash);
                 let read_service = self.read_service.clone();
 
@@ -1178,8 +1180,7 @@ impl Service<Request> for StateService {
                     // TODO: Move this to a blocking task, perhaps by moving some of this logic to the ReadStateService.
                     .or_else(|| read::finalized_state_contains_block_hash(&read_service.db, hash));
 
-                    // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "Request::KnownBlock");
+                    timer.finish_desc("Request::KnownBlock");
 
                     Ok(Response::KnownBlock(response))
                 }
@@ -1245,24 +1246,8 @@ impl Service<Request> for StateService {
             | Request::BlockHeader(_)
             | Request::FindBlockHashes { .. }
             | Request::FindBlockHeaders { .. }
-            | Request::CheckBestChainTipNullifiersAndAnchors(_) => {
-                // Redirect the request to the concurrent ReadStateService
-                let read_service = self.read_service.clone();
-
-                async move {
-                    let req = req
-                        .try_into()
-                        .expect("ReadRequest conversion should not fail");
-
-                    let rsp = read_service.oneshot(req).await?;
-                    let rsp = rsp.try_into().expect("Response conversion should not fail");
-
-                    Ok(rsp)
-                }
-                .boxed()
-            }
-
-            Request::CheckBlockProposalValidity(_) => {
+            | Request::CheckBestChainTipNullifiersAndAnchors(_)
+            | Request::CheckBlockProposalValidity(_) => {
                 // Redirect the request to the concurrent ReadStateService
                 let read_service = self.read_service.clone();
 
@@ -1316,155 +1301,102 @@ impl Service<ReadRequest> for ReadStateService {
     #[instrument(name = "read_state", skip(self, req))]
     fn call(&mut self, req: ReadRequest) -> Self::Future {
         req.count_metric();
-        let timer = CodeTimer::start();
+        let timer = CodeTimer::start_desc(req.variant_name());
         let span = Span::current();
+        let timed_span = TimedSpan::new(timer, span);
+        let state = self.clone();
 
         match req {
             // Used by the `getblockchaininfo` RPC.
-            ReadRequest::UsageInfo => {
-                let db = self.db.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let db_size = db.size();
-
-                    timer.finish(module_path!(), line!(), "ReadRequest::UsageInfo");
-
-                    Ok(ReadResponse::UsageInfo(db_size))
-                })
-            }
+            ReadRequest::UsageInfo => timed_span
+                .spawn_blocking_in_scope(move || Ok(ReadResponse::UsageInfo(state.db.size()))),
 
             // Used by the StateService.
-            ReadRequest::Tip => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let tip = read::tip(state.latest_best_chain(), &state.db);
-
-                    timer.finish(module_path!(), line!(), "ReadRequest::Tip");
-
-                    Ok(ReadResponse::Tip(tip))
-                })
-            }
+            ReadRequest::Tip => timed_span.spawn_blocking_in_scope(move || {
+                Ok(ReadResponse::Tip(read::tip(
+                    state.latest_best_chain(),
+                    &state.db,
+                )))
+            }),
 
             // Used by `getblockchaininfo` RPC method.
-            ReadRequest::TipPoolValues => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let tip_with_value_balance =
-                        read::tip_with_value_balance(state.latest_best_chain(), &state.db);
-
-                    timer.finish(module_path!(), line!(), "ReadRequest::TipPoolValues");
-
-                    let (tip_height, tip_hash, value_balance) = tip_with_value_balance?
+            ReadRequest::TipPoolValues => timed_span.spawn_blocking_in_scope(move || {
+                let (tip_height, tip_hash, value_balance) =
+                    read::tip_with_value_balance(state.latest_best_chain(), &state.db)?
                         .ok_or(BoxError::from("no chain tip available yet"))?;
 
-                    Ok(ReadResponse::TipPoolValues {
-                        tip_height,
-                        tip_hash,
-                        value_balance,
-                    })
+                Ok(ReadResponse::TipPoolValues {
+                    tip_height,
+                    tip_hash,
+                    value_balance,
                 })
-            }
+            }),
 
             // Used by getblock
             ReadRequest::BlockInfo(hash_or_height) => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let value_balance =
-                        read::block_info(state.latest_best_chain(), &state.db, hash_or_height);
-
-                    timer.finish(module_path!(), line!(), "ReadRequest::BlockInfo");
-
-                    Ok(ReadResponse::BlockInfo(value_balance))
+                timed_span.spawn_blocking_in_scope(move || {
+                    Ok(ReadResponse::BlockInfo(read::block_info(
+                        state.latest_best_chain(),
+                        &state.db,
+                        hash_or_height,
+                    )))
                 })
             }
 
             // Used by the StateService.
-            ReadRequest::Depth(hash) => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let depth = read::depth(state.latest_best_chain(), &state.db, hash);
-
-                    timer.finish(module_path!(), line!(), "ReadRequest::Depth");
-
-                    Ok(ReadResponse::Depth(depth))
-                })
-            }
+            ReadRequest::Depth(hash) => timed_span.spawn_blocking_in_scope(move || {
+                Ok(ReadResponse::Depth(read::depth(
+                    state.latest_best_chain(),
+                    &state.db,
+                    hash,
+                )))
+            }),
 
             // Used by the StateService.
             ReadRequest::BestChainNextMedianTimePast => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let non_finalized_state = state.latest_non_finalized_state();
-                    let median_time_past =
-                        read::next_median_time_past(&non_finalized_state, &state.db);
-
-                    // The work is done in the future.
-                    timer.finish(
-                        module_path!(),
-                        line!(),
-                        "ReadRequest::BestChainNextMedianTimePast",
-                    );
-
-                    Ok(ReadResponse::BestChainNextMedianTimePast(median_time_past?))
+                timed_span.spawn_blocking_in_scope(move || {
+                    Ok(ReadResponse::BestChainNextMedianTimePast(
+                        read::next_median_time_past(
+                            &state.latest_non_finalized_state(),
+                            &state.db,
+                        )?,
+                    ))
                 })
             }
 
             // Used by the get_block (raw) RPC and the StateService.
-            ReadRequest::Block(hash_or_height) => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let block = read::block(state.latest_best_chain(), &state.db, hash_or_height);
-
-                    // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "ReadRequest::Block");
-
-                    Ok(ReadResponse::Block(block))
-                })
-            }
+            ReadRequest::Block(hash_or_height) => timed_span.spawn_blocking_in_scope(move || {
+                Ok(ReadResponse::Block(read::block(
+                    state.latest_best_chain(),
+                    &state.db,
+                    hash_or_height,
+                )))
+            }),
 
             ReadRequest::AnyChainBlock(hash_or_height) => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let block = read::any_block(
+                timed_span.spawn_blocking_in_scope(move || {
+                    Ok(ReadResponse::Block(read::any_block(
                         state.latest_non_finalized_state().chain_iter(),
                         &state.db,
                         hash_or_height,
-                    );
-
-                    // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "ReadRequest::AnyChainBlock");
-
-                    Ok(ReadResponse::Block(block))
+                    )))
                 })
             }
 
             // Used by the get_block (raw) RPC and the StateService.
             ReadRequest::BlockAndSize(hash_or_height) => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let block_and_size =
-                        read::block_and_size(state.latest_best_chain(), &state.db, hash_or_height);
-
-                    // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "ReadRequest::BlockAndSize");
-
-                    Ok(ReadResponse::BlockAndSize(block_and_size))
+                timed_span.spawn_blocking_in_scope(move || {
+                    Ok(ReadResponse::BlockAndSize(read::block_and_size(
+                        state.latest_best_chain(),
+                        &state.db,
+                        hash_or_height,
+                    )))
                 })
             }
 
             // Used by the get_block (verbose) RPC and the StateService.
             ReadRequest::BlockHeader(hash_or_height) => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
+                timed_span.spawn_blocking_in_scope(move || {
                     let best_chain = state.latest_best_chain();
 
                     let height = hash_or_height
@@ -1486,9 +1418,6 @@ impl Service<ReadRequest> for ReadStateService {
                     let header = read::block_header(best_chain, &state.db, height.into())
                         .ok_or_else(|| BoxError::from("block hash or height not found"))?;
 
-                    // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "ReadRequest::Block");
-
                     Ok(ReadResponse::BlockHeader {
                         header,
                         hash,
@@ -1499,225 +1428,137 @@ impl Service<ReadRequest> for ReadStateService {
             }
 
             // For the get_raw_transaction RPC and the StateService.
-            ReadRequest::Transaction(hash) => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let response =
-                        read::mined_transaction(state.latest_best_chain(), &state.db, hash);
-
-                    // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "ReadRequest::Transaction");
-
-                    Ok(ReadResponse::Transaction(response))
-                })
-            }
+            ReadRequest::Transaction(hash) => timed_span.spawn_blocking_in_scope(move || {
+                Ok(ReadResponse::Transaction(read::mined_transaction(
+                    state.latest_best_chain(),
+                    &state.db,
+                    hash,
+                )))
+            }),
 
             ReadRequest::AnyChainTransaction(hash) => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let tx = read::any_transaction(
+                timed_span.spawn_blocking_in_scope(move || {
+                    Ok(ReadResponse::AnyChainTransaction(read::any_transaction(
                         state.latest_non_finalized_state().chain_iter(),
                         &state.db,
                         hash,
-                    );
-
-                    // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "ReadRequest::AnyChainTransaction");
-
-                    Ok(ReadResponse::AnyChainTransaction(tx))
+                    )))
                 })
             }
 
             // Used by the getblock (verbose) RPC.
-            ReadRequest::TransactionIdsForBlock(hash_or_height) => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let transaction_ids = read::transaction_hashes_for_block(
-                        state.latest_best_chain(),
-                        &state.db,
-                        hash_or_height,
-                    );
-
-                    // The work is done in the future.
-                    timer.finish(
-                        module_path!(),
-                        line!(),
-                        "ReadRequest::TransactionIdsForBlock",
-                    );
-
-                    Ok(ReadResponse::TransactionIdsForBlock(transaction_ids))
-                })
-            }
-
-            ReadRequest::AnyChainTransactionIdsForBlock(hash_or_height) => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let transaction_ids = read::transaction_hashes_for_any_block(
-                        state.latest_non_finalized_state().chain_iter(),
-                        &state.db,
-                        hash_or_height,
-                    );
-
-                    // The work is done in the future.
-                    timer.finish(
-                        module_path!(),
-                        line!(),
-                        "ReadRequest::AnyChainTransactionIdsForBlock",
-                    );
-
-                    Ok(ReadResponse::AnyChainTransactionIdsForBlock(
-                        transaction_ids,
+            ReadRequest::TransactionIdsForBlock(hash_or_height) => timed_span
+                .spawn_blocking_in_scope(move || {
+                    Ok(ReadResponse::TransactionIdsForBlock(
+                        read::transaction_hashes_for_block(
+                            state.latest_best_chain(),
+                            &state.db,
+                            hash_or_height,
+                        ),
                     ))
-                })
-            }
+                }),
+
+            ReadRequest::AnyChainTransactionIdsForBlock(hash_or_height) => timed_span
+                .spawn_blocking_in_scope(move || {
+                    Ok(ReadResponse::AnyChainTransactionIdsForBlock(
+                        read::transaction_hashes_for_any_block(
+                            state.latest_non_finalized_state().chain_iter(),
+                            &state.db,
+                            hash_or_height,
+                        ),
+                    ))
+                }),
 
             #[cfg(feature = "indexer")]
             ReadRequest::SpendingTransactionId(spend) => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let spending_transaction_id = read::spending_transaction_hash(
-                        state.latest_best_chain(),
-                        &state.db,
-                        spend,
-                    );
-
-                    // The work is done in the future.
-                    timer.finish(
-                        module_path!(),
-                        line!(),
-                        "ReadRequest::TransactionIdForSpentOutPoint",
-                    );
-
-                    Ok(ReadResponse::TransactionId(spending_transaction_id))
+                timed_span.spawn_blocking_in_scope(move || {
+                    Ok(ReadResponse::TransactionId(
+                        read::spending_transaction_hash(
+                            state.latest_best_chain(),
+                            &state.db,
+                            spend,
+                        ),
+                    ))
                 })
             }
 
             ReadRequest::UnspentBestChainUtxo(outpoint) => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let utxo = read::unspent_utxo(state.latest_best_chain(), &state.db, outpoint);
-
-                    // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "ReadRequest::UnspentBestChainUtxo");
-
-                    Ok(ReadResponse::UnspentBestChainUtxo(utxo))
+                timed_span.spawn_blocking_in_scope(move || {
+                    Ok(ReadResponse::UnspentBestChainUtxo(read::unspent_utxo(
+                        state.latest_best_chain(),
+                        &state.db,
+                        outpoint,
+                    )))
                 })
             }
 
             // Manually used by the StateService to implement part of AwaitUtxo.
-            ReadRequest::AnyChainUtxo(outpoint) => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let utxo =
-                        read::any_utxo(state.latest_non_finalized_state(), &state.db, outpoint);
-
-                    // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "ReadRequest::AnyChainUtxo");
-
-                    Ok(ReadResponse::AnyChainUtxo(utxo))
-                })
-            }
+            ReadRequest::AnyChainUtxo(outpoint) => timed_span.spawn_blocking_in_scope(move || {
+                Ok(ReadResponse::AnyChainUtxo(read::any_utxo(
+                    state.latest_non_finalized_state(),
+                    &state.db,
+                    outpoint,
+                )))
+            }),
 
             // Used by the StateService.
-            ReadRequest::BlockLocator => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let block_locator = read::block_locator(state.latest_best_chain(), &state.db);
-
-                    // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "ReadRequest::BlockLocator");
-
-                    Ok(ReadResponse::BlockLocator(
-                        block_locator.unwrap_or_default(),
-                    ))
-                })
-            }
+            ReadRequest::BlockLocator => timed_span.spawn_blocking_in_scope(move || {
+                Ok(ReadResponse::BlockLocator(
+                    read::block_locator(state.latest_best_chain(), &state.db).unwrap_or_default(),
+                ))
+            }),
 
             // Used by the StateService.
-            ReadRequest::FindBlockHashes { known_blocks, stop } => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let block_hashes = read::find_chain_hashes(
+            ReadRequest::FindBlockHashes { known_blocks, stop } => timed_span
+                .spawn_blocking_in_scope(move || {
+                    Ok(ReadResponse::BlockHashes(read::find_chain_hashes(
                         state.latest_best_chain(),
                         &state.db,
                         known_blocks,
                         stop,
                         MAX_FIND_BLOCK_HASHES_RESULTS,
-                    );
-
-                    // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "ReadRequest::FindBlockHashes");
-
-                    Ok(ReadResponse::BlockHashes(block_hashes))
-                })
-            }
+                    )))
+                }),
 
             // Used by the StateService.
-            ReadRequest::FindBlockHeaders { known_blocks, stop } => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let block_headers = read::find_chain_headers(
-                        state.latest_best_chain(),
-                        &state.db,
-                        known_blocks,
-                        stop,
-                        MAX_FIND_BLOCK_HEADERS_RESULTS,
-                    );
-
-                    let block_headers = block_headers
+            ReadRequest::FindBlockHeaders { known_blocks, stop } => timed_span
+                .spawn_blocking_in_scope(move || {
+                    Ok(ReadResponse::BlockHeaders(
+                        read::find_chain_headers(
+                            state.latest_best_chain(),
+                            &state.db,
+                            known_blocks,
+                            stop,
+                            MAX_FIND_BLOCK_HEADERS_RESULTS,
+                        )
                         .into_iter()
                         .map(|header| CountedHeader { header })
-                        .collect();
-
-                    // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "ReadRequest::FindBlockHeaders");
-
-                    Ok(ReadResponse::BlockHeaders(block_headers))
-                })
-            }
+                        .collect(),
+                    ))
+                }),
 
             ReadRequest::SaplingTree(hash_or_height) => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let sapling_tree =
-                        read::sapling_tree(state.latest_best_chain(), &state.db, hash_or_height);
-
-                    // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "ReadRequest::SaplingTree");
-
-                    Ok(ReadResponse::SaplingTree(sapling_tree))
+                timed_span.spawn_blocking_in_scope(move || {
+                    Ok(ReadResponse::SaplingTree(read::sapling_tree(
+                        state.latest_best_chain(),
+                        &state.db,
+                        hash_or_height,
+                    )))
                 })
             }
 
             ReadRequest::OrchardTree(hash_or_height) => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let orchard_tree =
-                        read::orchard_tree(state.latest_best_chain(), &state.db, hash_or_height);
-
-                    // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "ReadRequest::OrchardTree");
-
-                    Ok(ReadResponse::OrchardTree(orchard_tree))
+                timed_span.spawn_blocking_in_scope(move || {
+                    Ok(ReadResponse::OrchardTree(read::orchard_tree(
+                        state.latest_best_chain(),
+                        &state.db,
+                        hash_or_height,
+                    )))
                 })
             }
 
             ReadRequest::SaplingSubtrees { start_index, limit } => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
+                timed_span.spawn_blocking_in_scope(move || {
                     let end_index = limit
                         .and_then(|limit| start_index.0.checked_add(limit.0))
                         .map(NoteCommitmentSubtreeIndex);
@@ -1745,17 +1586,12 @@ impl Service<ReadRequest> for ReadStateService {
                                 }
                             });
 
-                    // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "ReadRequest::SaplingSubtrees");
-
                     Ok(ReadResponse::SaplingSubtrees(sapling_subtrees))
                 })
             }
 
             ReadRequest::OrchardSubtrees { start_index, limit } => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
+                timed_span.spawn_blocking_in_scope(move || {
                     let end_index = limit
                         .and_then(|limit| start_index.0.checked_add(limit.0))
                         .map(NoteCommitmentSubtreeIndex);
@@ -1783,31 +1619,15 @@ impl Service<ReadRequest> for ReadStateService {
                                 }
                             });
 
-                    // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "ReadRequest::OrchardSubtrees");
-
                     Ok(ReadResponse::OrchardSubtrees(orchard_subtrees))
                 })
             }
 
             // For the get_address_balance RPC.
             ReadRequest::AddressBalance(addresses) => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let (balance, received) = state.non_finalized_state_receiver.with_watch_data(
-                        |non_finalized_state| {
-                            read::transparent_balance(
-                                non_finalized_state.best_chain().cloned(),
-                                &state.db,
-                                addresses,
-                            )
-                        },
-                    )?;
-
-                    // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "ReadRequest::AddressBalance");
-
+                timed_span.spawn_blocking_in_scope(move || {
+                    let (balance, received) =
+                        read::transparent_balance(state.latest_best_chain(), &state.db, addresses)?;
                     Ok(ReadResponse::AddressBalance { balance, received })
                 })
             }
@@ -1816,61 +1636,31 @@ impl Service<ReadRequest> for ReadStateService {
             ReadRequest::TransactionIdsByAddresses {
                 addresses,
                 height_range,
-            } => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let tx_ids =
-                        state
-                            .non_finalized_state_receiver
-                            .with_watch_data(|non_finalized_state| {
-                                read::transparent_tx_ids(
-                                    non_finalized_state.best_chain(),
-                                    &state.db,
-                                    addresses,
-                                    height_range,
-                                )
-                            });
-
-                    // The work is done in the future.
-                    timer.finish(
-                        module_path!(),
-                        line!(),
-                        "ReadRequest::TransactionIdsByAddresses",
-                    );
-
-                    tx_ids.map(ReadResponse::AddressesTransactionIds)
-                })
-            }
+            } => timed_span.spawn_blocking_in_scope(move || {
+                read::transparent_tx_ids(
+                    state.latest_best_chain(),
+                    &state.db,
+                    addresses,
+                    height_range,
+                )
+                .map(ReadResponse::AddressesTransactionIds)
+            }),
 
             // For the get_address_utxos RPC.
             ReadRequest::UtxosByAddresses(addresses) => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    let utxos =
-                        state
-                            .non_finalized_state_receiver
-                            .with_watch_data(|non_finalized_state| {
-                                read::address_utxos(
-                                    &state.network,
-                                    non_finalized_state.best_chain(),
-                                    &state.db,
-                                    addresses,
-                                )
-                            });
-
-                    // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "ReadRequest::UtxosByAddresses");
-
-                    utxos.map(ReadResponse::AddressUtxos)
+                timed_span.spawn_blocking_in_scope(move || {
+                    read::address_utxos(
+                        &state.network,
+                        state.latest_best_chain(),
+                        &state.db,
+                        addresses,
+                    )
+                    .map(ReadResponse::AddressUtxos)
                 })
             }
 
-            ReadRequest::CheckBestChainTipNullifiersAndAnchors(unmined_tx) => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
+            ReadRequest::CheckBestChainTipNullifiersAndAnchors(unmined_tx) => timed_span
+                .spawn_blocking_in_scope(move || {
                     let latest_non_finalized_best_chain = state.latest_best_chain();
 
                     check::nullifier::tx_no_duplicates_in_chain(
@@ -1885,54 +1675,23 @@ impl Service<ReadRequest> for ReadStateService {
                         &unmined_tx,
                     )?;
 
-                    // The work is done in the future.
-                    timer.finish(
-                        module_path!(),
-                        line!(),
-                        "ReadRequest::CheckBestChainTipNullifiersAndAnchors",
-                    );
-
                     Ok(ReadResponse::ValidBestChainTipNullifiersAndAnchors)
-                })
-            }
+                }),
 
             // Used by the get_block and get_block_hash RPCs.
             ReadRequest::BestChainBlockHash(height) => {
-                let state = self.clone();
-
-                // # Performance
-                //
-                // Allow other async tasks to make progress while concurrently reading blocks from disk.
-
-                span.spawn_blocking_in_scope(move || {
-                    let hash =
-                        state
-                            .non_finalized_state_receiver
-                            .with_watch_data(|non_finalized_state| {
-                                read::hash_by_height(
-                                    non_finalized_state.best_chain(),
-                                    &state.db,
-                                    height,
-                                )
-                            });
-
-                    // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "ReadRequest::BestChainBlockHash");
-
-                    Ok(ReadResponse::BlockHash(hash))
+                timed_span.spawn_blocking_in_scope(move || {
+                    Ok(ReadResponse::BlockHash(read::hash_by_height(
+                        state.latest_best_chain(),
+                        &state.db,
+                        height,
+                    )))
                 })
             }
 
             // Used by get_block_template and getblockchaininfo RPCs.
             ReadRequest::ChainInfo => {
-                let state = self.clone();
-                let latest_non_finalized_state = self.latest_non_finalized_state();
-
-                // # Performance
-                //
-                // Allow other async tasks to make progress while concurrently reading blocks from disk.
-
-                span.spawn_blocking_in_scope(move || {
+                timed_span.spawn_blocking_in_scope(move || {
                     // # Correctness
                     //
                     // It is ok to do these lookups using multiple database calls. Finalized state updates
@@ -1944,28 +1703,18 @@ impl Service<ReadRequest> for ReadStateService {
                     //
                     // In that case, the `getblocktemplate` RPC will return an error because Zebra
                     // is not synced to the tip. That check happens before the RPC makes this request.
-                    let get_block_template_info = read::difficulty::get_block_template_chain_info(
-                        &latest_non_finalized_state,
+                    read::difficulty::get_block_template_chain_info(
+                        &state.latest_non_finalized_state(),
                         &state.db,
                         &state.network,
-                    );
-
-                    // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "ReadRequest::ChainInfo");
-
-                    get_block_template_info.map(ReadResponse::ChainInfo)
+                    )
+                    .map(ReadResponse::ChainInfo)
                 })
             }
 
             // Used by getmininginfo, getnetworksolps, and getnetworkhashps RPCs.
             ReadRequest::SolutionRate { num_blocks, height } => {
-                let state = self.clone();
-
-                // # Performance
-                //
-                // Allow other async tasks to make progress while concurrently reading blocks from disk.
-
-                span.spawn_blocking_in_scope(move || {
+                timed_span.spawn_blocking_in_scope(move || {
                     let latest_non_finalized_state = state.latest_non_finalized_state();
                     // # Correctness
                     //
@@ -1999,21 +1748,12 @@ impl Service<ReadRequest> for ReadStateService {
                         )
                     });
 
-                    // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "ReadRequest::SolutionRate");
-
                     Ok(ReadResponse::SolutionRate(solution_rate))
                 })
             }
 
             ReadRequest::CheckBlockProposalValidity(semantically_verified) => {
-                let state = self.clone();
-
-                // # Performance
-                //
-                // Allow other async tasks to make progress while concurrently reading blocks from disk.
-
-                span.spawn_blocking_in_scope(move || {
+                timed_span.spawn_blocking_in_scope(move || {
                     tracing::debug!(
                         "attempting to validate and commit block proposal \
                          onto a cloned non-finalized state"
@@ -2049,51 +1789,17 @@ impl Service<ReadRequest> for ReadStateService {
                         semantically_verified,
                     )?;
 
-                    // The work is done in the future.
-                    timer.finish(
-                        module_path!(),
-                        line!(),
-                        "ReadRequest::CheckBlockProposalValidity",
-                    );
-
                     Ok(ReadResponse::ValidBlockProposal)
                 })
             }
 
             ReadRequest::TipBlockSize => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
-                    // Get the best chain tip height.
-                    let tip_height = state
-                        .non_finalized_state_receiver
-                        .with_watch_data(|non_finalized_state| {
-                            read::tip_height(non_finalized_state.best_chain(), &state.db)
-                        })
-                        .unwrap_or(Height(0));
-
-                    // Get the block at the best chain tip height.
-                    let block =
-                        state
-                            .non_finalized_state_receiver
-                            .with_watch_data(|non_finalized_state| {
-                                read::block(
-                                    non_finalized_state.best_chain(),
-                                    &state.db,
-                                    tip_height.into(),
-                                )
-                            });
-
-                    // The work is done in the future.
-                    timer.finish(module_path!(), line!(), "ReadRequest::TipBlockSize");
-
+                timed_span.spawn_blocking_in_scope(move || {
                     // Respond with the length of the obtained block if any.
-                    match block {
-                        Some(b) => Ok(ReadResponse::TipBlockSize(Some(
-                            b.zcash_serialize_to_vec()?.len(),
-                        ))),
-                        None => Ok(ReadResponse::TipBlockSize(None)),
-                    }
+                    Ok(ReadResponse::TipBlockSize(
+                        find::tip_block(state.latest_best_chain(), &state.db)
+                            .map(|b| b.zcash_serialize_to_vec().unwrap().len()),
+                    ))
                 })
             }
 
@@ -2106,12 +1812,6 @@ impl Service<ReadRequest> for ReadStateService {
                 );
 
                 async move {
-                    timer.finish(
-                        module_path!(),
-                        line!(),
-                        "ReadRequest::NonFinalizedBlocksListener",
-                    );
-
                     Ok(ReadResponse::NonFinalizedBlocksListener(
                         non_finalized_blocks_listener,
                     ))
@@ -2121,47 +1821,13 @@ impl Service<ReadRequest> for ReadStateService {
 
             // Used by `gettxout` RPC method.
             ReadRequest::IsTransparentOutputSpent(outpoint) => {
-                let state = self.clone();
-
-                span.spawn_blocking_in_scope(move || {
+                timed_span.spawn_blocking_in_scope(move || {
                     let is_spent =
-                        state
-                            .non_finalized_state_receiver
-                            .with_watch_data(|non_finalized_state| {
-                                read::block::unspent_utxo(
-                                    non_finalized_state.best_chain(),
-                                    &state.db,
-                                    outpoint,
-                                )
-                            });
-
-                    timer.finish(
-                        module_path!(),
-                        line!(),
-                        "ReadRequest::IsTransparentOutputSpent",
-                    );
-
+                        read::block::unspent_utxo(state.latest_best_chain(), &state.db, outpoint);
                     Ok(ReadResponse::IsTransparentOutputSpent(is_spent.is_none()))
                 })
             }
         }
-    }
-}
-
-trait SpanExt {
-    fn spawn_blocking_in_scope<T: Send + 'static>(
-        self,
-        f: impl FnOnce() -> Result<T, BoxError> + Send + 'static,
-    ) -> Pin<Box<dyn futures::Future<Output = Result<T, BoxError>> + Send>>;
-}
-
-impl SpanExt for Span {
-    fn spawn_blocking_in_scope<T: Send + 'static>(
-        self,
-        f: impl FnOnce() -> Result<T, BoxError> + Send + 'static,
-    ) -> Pin<Box<dyn futures::Future<Output = Result<T, BoxError>> + Send>> {
-        // The work is done in the future.
-        tokio::task::spawn_blocking(move || self.in_scope(f)).wait_for_panics()
     }
 }
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1504,28 +1504,16 @@ impl Service<ReadRequest> for ReadStateService {
                     .and_then(|limit| start_index.0.checked_add(limit.0))
                     .map(NoteCommitmentSubtreeIndex);
 
-                let sapling_subtrees =
-                    state
-                        .non_finalized_state_receiver
-                        .with_watch_data(|non_finalized_state| {
-                            if let Some(end_index) = end_index {
-                                read::sapling_subtrees(
-                                    non_finalized_state.best_chain(),
-                                    &state.db,
-                                    start_index..end_index,
-                                )
-                            } else {
-                                // If there is no end bound, just return all the trees.
-                                // If the end bound would overflow, just returns all the trees, because that's what
-                                // `zcashd` does. (It never calculates an end bound, so it just keeps iterating until
-                                // the trees run out.)
-                                read::sapling_subtrees(
-                                    non_finalized_state.best_chain(),
-                                    &state.db,
-                                    start_index..,
-                                )
-                            }
-                        });
+                let best_chain = state.latest_best_chain();
+                let sapling_subtrees = if let Some(end_index) = end_index {
+                    read::sapling_subtrees(best_chain, &state.db, start_index..end_index)
+                } else {
+                    // If there is no end bound, just return all the trees.
+                    // If the end bound would overflow, just returns all the trees, because that's what
+                    // `zcashd` does. (It never calculates an end bound, so it just keeps iterating until
+                    // the trees run out.)
+                    read::sapling_subtrees(best_chain, &state.db, start_index..)
+                };
 
                 Ok(ReadResponse::SaplingSubtrees(sapling_subtrees))
             }
@@ -1535,28 +1523,16 @@ impl Service<ReadRequest> for ReadStateService {
                     .and_then(|limit| start_index.0.checked_add(limit.0))
                     .map(NoteCommitmentSubtreeIndex);
 
-                let orchard_subtrees =
-                    state
-                        .non_finalized_state_receiver
-                        .with_watch_data(|non_finalized_state| {
-                            if let Some(end_index) = end_index {
-                                read::orchard_subtrees(
-                                    non_finalized_state.best_chain(),
-                                    &state.db,
-                                    start_index..end_index,
-                                )
-                            } else {
-                                // If there is no end bound, just return all the trees.
-                                // If the end bound would overflow, just returns all the trees, because that's what
-                                // `zcashd` does. (It never calculates an end bound, so it just keeps iterating until
-                                // the trees run out.)
-                                read::orchard_subtrees(
-                                    non_finalized_state.best_chain(),
-                                    &state.db,
-                                    start_index..,
-                                )
-                            }
-                        });
+                let best_chain = state.latest_best_chain();
+                let orchard_subtrees = if let Some(end_index) = end_index {
+                    read::orchard_subtrees(best_chain, &state.db, start_index..end_index)
+                } else {
+                    // If there is no end bound, just return all the trees.
+                    // If the end bound would overflow, just returns all the trees, because that's what
+                    // `zcashd` does. (It never calculates an end bound, so it just keeps iterating until
+                    // the trees run out.)
+                    read::orchard_subtrees(best_chain, &state.db, start_index..)
+                };
 
                 Ok(ReadResponse::OrchardSubtrees(orchard_subtrees))
             }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1690,7 +1690,7 @@ impl Service<ReadRequest> for ReadStateService {
                 // Respond with the length of the obtained block if any.
                 Ok(ReadResponse::TipBlockSize(
                     find::tip_block(state.latest_best_chain(), &state.db)
-                        .map(|b| b.zcash_serialize_to_vec().unwrap().len()),
+                        .map(|b| b.zcash_serialized_size()),
                 ))
             }
 

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -460,7 +460,7 @@ impl DbFormatChange {
             track_tx_locs_by_spends::run(initial_tip_height, db, cancel_receiver)?;
             info!("finished checking/adding indexes for spending tx ids");
 
-            timer.finish(module_path!(), line!(), "indexing spending transaction ids");
+            timer.finish_desc("indexing spending transaction ids");
         };
 
         #[cfg(not(feature = "indexer"))]
@@ -487,7 +487,7 @@ impl DbFormatChange {
                 db.update_format_version_on_disk(&version)
                     .expect("unable to write database format version file to disk");
 
-                timer.finish(module_path!(), line!(), "removing spending transaction ids");
+                timer.finish_desc("removing spending transaction ids");
             }
         };
 
@@ -580,7 +580,7 @@ impl DbFormatChange {
                     .validate(db, cancel_receiver)?
                     .expect("db should be valid after upgrade");
 
-                timer.finish(module_path!(), line!(), upgrade.description());
+                timer.finish_desc(upgrade.description());
             }
 
             // Mark the database as upgraded. Zebra won't repeat the upgrade anymore once the
@@ -613,7 +613,7 @@ impl DbFormatChange {
         results.push(fix_tree_key_type::quick_check(db));
 
         // The work is done in the functions we just called.
-        timer.finish(module_path!(), line!(), "format_validity_checks_quick()");
+        timer.finish_desc("format_validity_checks_quick()");
 
         if results.iter().any(Result::is_err) {
             let err = Err(format!("invalid quick check: {results:?}"));
@@ -643,7 +643,7 @@ impl DbFormatChange {
         }
 
         // The work is done in the functions we just called.
-        timer.finish(module_path!(), line!(), "format_validity_checks_detailed()");
+        timer.finish_desc("format_validity_checks_detailed()");
 
         if results.iter().any(Result::is_err) {
             let err = Err(format!("invalid detailed check: {results:?}"));

--- a/zebra-state/src/service/read/find.rs
+++ b/zebra-state/src/service/read/find.rs
@@ -65,6 +65,23 @@ where
         .or_else(|| db.tip())
 }
 
+/// Returns the tip block of `chain`.
+/// If there is no chain, returns the tip of `db`.
+pub fn tip_block<C>(chain: Option<C>, db: &ZebraDb) -> Option<Arc<Block>>
+where
+    C: AsRef<Chain>,
+{
+    // # Correctness
+    //
+    // If there is an overlap between the non-finalized and finalized states,
+    // where the finalized tip is above the non-finalized tip,
+    // Zebra is receiving a lot of blocks, or this request has been delayed for a long time,
+    // so it is acceptable to return either tip.
+    chain
+        .and_then(|chain| chain.as_ref().tip_block().map(|b| b.block.clone()))
+        .or_else(|| db.tip_block())
+}
+
 /// Returns the tip [`Height`] of `chain`.
 /// If there is no chain, returns the tip of `db`.
 pub fn tip_height<C>(chain: Option<C>, db: &ZebraDb) -> Option<Height>


### PR DESCRIPTION
## Motivation

This PR de-duplicates some code across match arms in the `ReadStateService::call()` method for simplicity.


## Solution

- Use `#[track_caller]` and `std::panic::Location::caller()` to get caller file names and line numbers in a common fn
- Factor out common logic to a new method on a new `TimedSpan` helper type
- Re-use `variant_name()` method to remove repetitive descriptions indicating the request variant

Reduces the length of the `call()` method by about half.

## Testing

Manually tested that `#[track_caller]` and `std::panic::Location::caller()` work as expected, the rest is a trivial refactor.

### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [x] No AI tools were used in this PR
- [ ] AI tools were used: <!-- tool name and what it was used for, e.g., "Claude for test boilerplate" -->

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
