### PR TITLE
fix: Subtract Founders' Reward from block subsidy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ documentation with OpenRPC.
 - `AnyChainBlock` state request for querying blocks in side chains ([#10325](https://github.com/ZcashFoundation/zebra/pull/10325))
 - Remaining non-standard mempool transaction filters ([#10314](https://github.com/ZcashFoundation/zebra/pull/10314))
 
+### Fixed
+
+- Subtract Founders' Reward from block subsidy ([#10338](https://github.com/ZcashFoundation/zebra/pull/10338))
+
 ### Removed
 
 - Python QA RPC test framework (`zebra-rpc/qa/`) in favour of the new [integration-tests](https://github.com/zcash/integration-tests) project, which captures all previous work in [zcash/integration-tests#1](https://github.com/zcash/integration-tests/pull/1) ([#10363](https://github.com/ZcashFoundation/zebra/pull/10363))

--- a/zebra-chain/src/parameters/network/subsidy.rs
+++ b/zebra-chain/src/parameters/network/subsidy.rs
@@ -482,12 +482,13 @@ pub fn miner_subsidy(
     network: &Network,
     expected_block_subsidy: Amount<NonNegative>,
 ) -> Result<Amount<NonNegative>, amount::Error> {
-    let total_funding_stream_amount: Result<Amount<NonNegative>, _> =
-        funding_stream_values(height, network, expected_block_subsidy)?
-            .values()
-            .sum();
+    let founders_reward = founders_reward(network, height);
 
-    expected_block_subsidy - total_funding_stream_amount?
+    let funding_streams_sum = funding_stream_values(height, network, expected_block_subsidy)?
+        .values()
+        .sum::<Result<Amount<NonNegative>, _>>()?;
+
+    expected_block_subsidy - founders_reward - funding_streams_sum
 }
 
 /// Returns the founders reward address for a given height and network as described in [§7.9].
@@ -532,7 +533,12 @@ pub fn founders_reward_address(net: &Network, height: Height) -> Option<transpar
 ///
 /// [§7.8]: <https://zips.z.cash/protocol/protocol.pdf#subsidies>
 pub fn founders_reward(net: &Network, height: Height) -> Amount<NonNegative> {
-    if halving(height, net) < 1 {
+    // The founders reward is 20% of the block subsidy before the first halving, and 0 afterwards.
+    //
+    // On custom testnets, the first halving can occur later than Canopy, which causes an
+    // inconsistency in the definition of the founders reward, which should occur only before
+    // Canopy, so we check if Canopy is active as well.
+    if halving(height, net) < 1 && NetworkUpgrade::current(net, height) < NetworkUpgrade::Canopy {
         block_subsidy(height, net)
             .map(|subsidy| subsidy.div_exact(5))
             .expect("block subsidy must be valid for founders rewards")

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -67,7 +67,10 @@ use zebra_chain::{
     chain_sync_status::ChainSyncStatus,
     chain_tip::{ChainTip, NetworkChainTipHeightEstimator},
     parameters::{
-        subsidy::{block_subsidy, funding_stream_values, miner_subsidy, FundingStreamReceiver},
+        subsidy::{
+            block_subsidy, founders_reward, funding_stream_values, miner_subsidy,
+            FundingStreamReceiver,
+        },
         ConsensusBranchId, Network, NetworkUpgrade, POW_AVERAGING_WINDOW,
     },
     serialization::{BytesInDisplayOrder, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize},
@@ -2814,7 +2817,7 @@ where
             miner: miner_subsidy(height, &net, subsidy)
                 .map_misc_error()?
                 .into(),
-            founders: Amount::zero().into(),
+            founders: founders_reward(&net, height).into(),
             funding_streams,
             lockbox_streams,
             funding_streams_total: funding_streams_total?,

--- a/zebra-rpc/src/methods/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/types/get_block_template.rs
@@ -868,6 +868,12 @@ pub fn standard_coinbase_outputs(
     let funding_streams = funding_stream_values(height, network, expected_block_subsidy)
         .expect("funding stream value calculations are valid for reasonable chain heights");
 
+    let miner_reward = miner_subsidy(height, network, expected_block_subsidy)
+        .expect("reward calculations are valid for reasonable chain heights")
+        + miner_fee;
+    let miner_reward =
+        miner_reward.expect("reward calculations are valid for reasonable chain heights");
+
     // Optional TODO: move this into a zebra_consensus function?
     let funding_streams: HashMap<
         FundingStreamReceiver,
@@ -881,12 +887,6 @@ pub fn standard_coinbase_outputs(
             ))
         })
         .collect();
-
-    let miner_reward = miner_subsidy(height, network, expected_block_subsidy)
-        .expect("reward calculations are valid for reasonable chain heights")
-        + miner_fee;
-    let miner_reward =
-        miner_reward.expect("reward calculations are valid for reasonable chain heights");
 
     // Collect all the funding streams and convert them to outputs.
     let funding_streams_outputs: Vec<(transparent::Address, Amount<NonNegative>)> = funding_streams


### PR DESCRIPTION
## Motivation

- Close #10336.

## Solution

- Subtract the founders' reward from the block subsidy when calculating the miner subsidy.

### Tests

- No new tests.

### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [x] No AI tools were used in this PR
- [ ] AI tools were used: <!-- tool name and what it was used for, e.g., "Claude for test boilerplate" -->

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
