### PR TITLE
fix(network): rebroadcast blocks beyond a single hop in regtest

### DIFF
--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -80,6 +80,12 @@ pub const OUTBOUND_PEER_LIMIT_MULTIPLIER: usize = 3;
 ///       connections to an IP.
 pub const DEFAULT_MAX_CONNS_PER_IP: usize = 1;
 
+/// The default maximum number of peer connections per IP on regtest.
+///
+/// On regtest, multiple nodes typically run on localhost, so the per-IP
+/// connection limit is effectively disabled.
+pub const REGTEST_MAX_CONNS_PER_IP: usize = usize::MAX;
+
 /// The default peerset target size.
 ///
 /// This will be used as `Config.peerset_initial_target_size` if no valid value is provided.

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -891,7 +891,7 @@ async fn setup(
         Span::none(),
     );
     let address_book = Arc::new(std::sync::Mutex::new(address_book));
-    let (sync_status, mut recent_syncs) = SyncStatus::new();
+    let (sync_status, mut recent_syncs) = SyncStatus::new(&Network::Mainnet);
 
     // UTXO verification doesn't matter for these tests.
     let (state, _read_only_state_service, latest_chain_tip, mut chain_tip_change) =

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -684,7 +684,7 @@ async fn setup(
     );
 
     // Fake syncer
-    let (sync_status, mut recent_syncs) = SyncStatus::new();
+    let (sync_status, mut recent_syncs) = SyncStatus::new(&Network::Mainnet);
 
     // Fake verifiers
     let mock_block_verifier = MockService::build().for_unit_tests();
@@ -835,7 +835,7 @@ mod submitblock_test {
 
         let _guard = tracing::subscriber::set_default(subscriber);
 
-        let (sync_status, _recent_syncs) = SyncStatus::new();
+        let (sync_status, _recent_syncs) = SyncStatus::new(&Network::Mainnet);
 
         // State
         let state_config = StateConfig::ephemeral();

--- a/zebrad/src/components/mempool/crawler.rs
+++ b/zebrad/src/components/mempool/crawler.rs
@@ -29,7 +29,7 @@
 //! #
 //! # let peer_set_service = MockService::build().for_unit_tests();
 //! # let mempool_service = MockService::build().for_unit_tests();
-//! # let (sync_status, _) = SyncStatus::new();
+//! # let (sync_status, _) = SyncStatus::new(&Network::Mainnet);
 //! # let (_, _, chain_tip_change) = ChainTipSender::new(None, &Network::Mainnet);
 //!
 //! let crawler_task = mempool::Crawler::spawn(

--- a/zebrad/src/components/mempool/crawler/tests/prop.rs
+++ b/zebrad/src/components/mempool/crawler/tests/prop.rs
@@ -263,7 +263,7 @@ fn setup_crawler() -> (
 ) {
     let peer_set = MockService::build().for_prop_tests();
     let mempool = MockService::build().for_prop_tests();
-    let (sync_status, recent_sync_lengths) = SyncStatus::new();
+    let (sync_status, recent_sync_lengths) = SyncStatus::new(&Network::Mainnet);
 
     // the network should be irrelevant here
     let (chain_tip_sender, _latest_chain_tip, chain_tip_change) =

--- a/zebrad/src/components/mempool/tests/prop.rs
+++ b/zebrad/src/components/mempool/tests/prop.rs
@@ -277,7 +277,7 @@ fn setup(
     let state_service = MockService::build().for_prop_tests();
     let tx_verifier = MockService::build().for_prop_tests();
 
-    let (sync_status, recent_syncs) = SyncStatus::new();
+    let (sync_status, recent_syncs) = SyncStatus::new(&Network::Mainnet);
     let (mut chain_tip_sender, latest_chain_tip, chain_tip_change) =
         ChainTipSender::new(None, network);
 

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -1742,7 +1742,7 @@ async fn setup_with_mempool_config(
 
     let tx_verifier = MockService::build().for_unit_tests();
 
-    let (sync_status, recent_syncs) = SyncStatus::new();
+    let (sync_status, recent_syncs) = SyncStatus::new(&Network::Mainnet);
     let (misbehavior_tx, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
     let (mempool, mempool_transaction_subscriber) = Mempool::new(
         &mempool_config,

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -487,7 +487,7 @@ where
         // We apply a timeout to the verifier to avoid hangs due to missing earlier blocks.
         let verifier = Timeout::new(verifier, BLOCK_VERIFY_TIMEOUT);
 
-        let (sync_status, recent_syncs) = SyncStatus::new();
+        let (sync_status, recent_syncs) = SyncStatus::new(&config.network.network);
 
         let (past_lookahead_limit_sender, past_lookahead_limit_receiver) = watch::channel(false);
         let past_lookahead_limit_receiver = zs::WatchReceiver::new(past_lookahead_limit_receiver);


### PR DESCRIPTION
## Summary

- Make `SyncStatus` network-aware so that `is_close_to_tip()` always returns `true` on regtest, unblocking the gossip task from advertising received blocks to peers
- Default `max_connections_per_ip` to unlimited on regtest (when not explicitly configured) so multiple localhost nodes can connect to each other
- Add 3 new tests for regtest sync status behavior including an async test for `wait_until_close_to_tip()`

Fixes #10332

## Motivation

In regtest mode, blocks received from peers were never rebroadcast beyond a single hop. The root causes (identified by @arya2):

1. The gossip task in `gossip.rs` blocks on `wait_until_close_to_tip()` before advertising blocks. On short-lived regtest chains, the sync length heuristic never considers the node "close to tip," so received blocks are never advertised.
2. `max_connections_per_ip` defaults to 1, preventing multiple nodes running on localhost from connecting.

## Approach

**`SyncStatus` (zebrad/src/components/sync/status.rs):**
- Added `is_regtest` field, set from `Network` at construction time
- `is_close_to_tip()` returns `true` immediately on regtest
- `SyncStatus::new()` now takes `&Network` instead of no args (avoids boolean blindness)

**`max_connections_per_ip` (zebra-network/src/config.rs):**
- On regtest, when user hasn't explicitly set `max_connections_per_ip`, defaults to `REGTEST_MAX_CONNS_PER_IP` (`usize::MAX`)
- Added named constant in `constants.rs` and updated doc comment on the config field

## Test plan

- [x] 3 new unit tests: `regtest_always_close_to_tip_when_empty`, `regtest_always_close_to_tip_when_syncing`, `regtest_wait_until_close_to_tip_returns_immediately`
- [x] All existing sync status tests pass (7/7)
- [x] Doc-tests pass
- [x] `cargo clippy -p zebrad -p zebra-network --all-targets -- -D warnings` clean
- [x] `cargo check --all-targets` clean
- [ ] Manual test with 3-node regtest topology (A -- B -- C): mine on A, verify C receives the block

Generated with [Claude Code](https://claude.com/claude-code)