### PR TITLE
fix(docs): Markdown lint in state changelog

### DIFF
--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -26,8 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CommitBlockError` enum with `Duplicate`, `ValidateContextError`, `WriteTaskExited` variants.
 - `KnownBlock::Finalized` and `KnownBlock::WriteChannel` variants.
 - `impl From<ValidateContextError> for CommitSemanticallyVerifiedError`.
-- Added the concrete error type `CommitCheckpointVerifiedError` for handling failed state requests during checkpoint verification ([#9979](https://github.com/ZcashFoundation/zebra/pull/9979)) *(documented after release)*
-- Added `MappedRequest` for `CommitCheckpointVerifiedBlockRequest` ([#9979](https://github.com/ZcashFoundation/zebra/pull/9979)) *(documented after release)*
+- Added the concrete error type `CommitCheckpointVerifiedError` for handling failed state requests during checkpoint verification ([#9979](https://github.com/ZcashFoundation/zebra/pull/9979)) _(documented after release)_
+- Added `MappedRequest` for `CommitCheckpointVerifiedBlockRequest` ([#9979](https://github.com/ZcashFoundation/zebra/pull/9979)) _(documented after release)_
 
 ## [3.1.2] - 2026-01-21 - Yanked
 


### PR DESCRIPTION
## Motivation

After https://github.com/ZcashFoundation/zebra/pull/10204, we merged additional changes to the state changelog that results in a markdown lint: https://github.com/ZcashFoundation/zebra/actions/runs/22690554059/job/65784697202?pr=10363

## Solution

Fix the lint.

### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [x] No AI tools were used in this PR
- [ ] AI tools were used: <!-- tool name and what it was used for, e.g., "Claude for test boilerplate" -->
