### PR TITLE
ci: Add workflow to trigger Z3 integration tests

### DIFF
--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -1,0 +1,49 @@
+name: Trigger Integration Tests
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - .cargo/config.toml
+      - .github/workflows/trigger-integration-tests.yml
+
+  push:
+    branches: [main]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - .cargo/config.toml
+      - .github/workflows/trigger-integration-tests.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  trigger-integration:
+    name: Trigger integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.Z3_APP_ID }}
+          private-key: ${{ secrets.Z3_APP_PRIVATE_KEY }}
+          owner: zcash
+          repositories: integration-tests
+
+      - name: Trigger integration tests
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >
+          gh api repos/zcash/integration-tests/dispatches
+          --field event_type="zebra-interop-request"
+          --field client_payload[sha]="$SHA"


### PR DESCRIPTION
## Motivation

Enable cross-repo integration testing between Zebra and the Z3 stack. Pairs with [zcash/integration-tests#29](https://github.com/zcash/integration-tests/pull/29).

## Solution

Adds a new workflow that dispatches a `zebra-interop-request` event to `zcash/integration-tests` on Rust code changes. Uses the enterprise-owned Z3 Integration Testing GitHub App (`multi-org-z3-integration-testing`) for cross-org authentication.

The integration test results are reported back as commit statuses on the triggering SHA.

### Tests

- Secrets `Z3_APP_ID` and `Z3_APP_PRIVATE_KEY` have been configured in this repo.
- The enterprise app is installed in both `zcash` and `ZcashFoundation` orgs.
- Full validation requires merging the counterpart PR (zcash/integration-tests#29) to accept the `zebra-interop-request` dispatch type.

### Specifications & References

- [zcash/integration-tests#29](https://github.com/zcash/integration-tests/pull/29) — integration-tests side
- Enterprise app: `multi-org-z3-integration-testing` (ID: 3017274)

### Follow-up Work

- Update zcash/integration-tests#29 to use `Z3_APP_ID` / `Z3_APP_PRIVATE_KEY` secret names (replacing `ZEBRA_APP_*`)
- Optionally migrate `zcash/wallet` from the old org-owned app to the new enterprise app

### AI Disclosure

- [x] AI tools were used: Claude for workflow authoring and cross-org GitHub App research

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.