### PR TITLE
fix(rpc): return founders reward in getblocksubsidy for pre-Canopy blocks

### DIFF
--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -67,7 +67,10 @@ use zebra_chain::{
     chain_sync_status::ChainSyncStatus,
     chain_tip::{ChainTip, NetworkChainTipHeightEstimator},
     parameters::{
-        subsidy::{block_subsidy, funding_stream_values, miner_subsidy, FundingStreamReceiver},
+        subsidy::{
+            block_subsidy, founders_reward, funding_stream_values, miner_subsidy,
+            FundingStreamReceiver,
+        },
         ConsensusBranchId, Network, NetworkUpgrade, POW_AVERAGING_WINDOW,
     },
     serialization::{BytesInDisplayOrder, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize},
@@ -646,7 +649,6 @@ pub trait Rpc {
     async fn z_validate_address(&self, address: String) -> Result<ZValidateAddressResponse>;
 
     /// Returns the block subsidy reward of the block at `height`, taking into account the mining slow start.
-    /// Returns an error if `height` is less than the height of the first halving for the current network.
     ///
     /// zcashd reference: [`getblocksubsidy`](https://zcash.github.io/rpc/getblocksubsidy.html)
     /// method: post
@@ -2810,11 +2812,13 @@ where
                     .collect()
             });
 
+        let founders = founders_reward(&net, height);
+
         Ok(GetBlockSubsidyResponse {
-            miner: miner_subsidy(height, &net, subsidy)
+            miner: (miner_subsidy(height, &net, subsidy).map_misc_error()? - founders)
                 .map_misc_error()?
                 .into(),
-            founders: Amount::zero().into(),
+            founders: founders.into(),
             funding_streams,
             lockbox_streams,
             funding_streams_total: funding_streams_total?,

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -1126,6 +1126,14 @@ pub async fn test_mining_rpcs<State, ReadState>(
         .expect("We should have a success response");
     snapshot_rpc_getblocksubsidy("excessive_height", get_block_subsidy, &settings);
 
+    // Pre-Canopy height: founders' reward should be non-zero
+    let pre_canopy_height = NetworkUpgrade::Canopy.activation_height(network).unwrap().0 - 1;
+    let get_block_subsidy = rpc
+        .get_block_subsidy(Some(pre_canopy_height))
+        .await
+        .expect("We should have a success response");
+    snapshot_rpc_getblocksubsidy("pre_canopy_height", get_block_subsidy, &settings);
+
     // `getnetworkinfo`
     let get_network_info = rpc
         .get_network_info()

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_subsidy_pre_canopy_height@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_subsidy_pre_canopy_height@mainnet_10.snap
@@ -1,0 +1,11 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+expression: get_block_subsidy
+---
+{
+  "miner": 5.0,
+  "founders": 1.25,
+  "fundingstreamstotal": 0.0,
+  "lockboxtotal": 0.0,
+  "totalblocksubsidy": 6.25
+}

--- a/zebra-rpc/src/methods/tests/snapshots/get_block_subsidy_pre_canopy_height@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_block_subsidy_pre_canopy_height@testnet_10.snap
@@ -1,0 +1,11 @@
+---
+source: zebra-rpc/src/methods/tests/snapshot.rs
+expression: get_block_subsidy
+---
+{
+  "miner": 5.0,
+  "founders": 1.25,
+  "fundingstreamstotal": 0.0,
+  "lockboxtotal": 0.0,
+  "totalblocksubsidy": 6.25
+}

--- a/zebra-rpc/src/methods/types/subsidy.rs
+++ b/zebra-rpc/src/methods/types/subsidy.rs
@@ -33,8 +33,7 @@ pub struct GetBlockSubsidyResponse {
 
     /// The founders' reward amount in ZEC.
     ///
-    /// Zebra returns an error when asked for founders reward heights,
-    /// because it checkpoints those blocks instead.
+    /// This is non-zero for pre-Canopy blocks (before the first halving).
     #[getter(copy)]
     pub(crate) founders: Zec<NonNegative>,
 


### PR DESCRIPTION
## Motivation

Closes #10336

`getblocksubsidy` did not match zcashd for pre-Canopy heights (e.g. block 1,046,399 on mainnet). Zebra returned `founders: 0` and assigned the full block subsidy to `miner`, while zcashd correctly reports the 20% founders reward.

## Solution

Use the existing `founders_reward()` function from `zebra-chain` to compute the founders reward amount, subtract it from the miner subsidy, and populate the `founders` field in the RPC response.

For post-Canopy heights, `founders_reward()` returns zero, so behavior is unchanged.

### Example: block 1,046,399 (mainnet, pre-Canopy)

| Field | Before (wrong) | After (matches zcashd) |
|-------|----------------|------------------------|
| `miner` | 6.25 | 5.0 |
| `founders` | 0.0 | 1.25 |
| `totalblocksubsidy` | 6.25 | 6.25 |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p zebra-rpc --all-targets -- -D warnings`
- [x] `cargo test -p zebra-rpc` (30/30 pass)
- [x] Added snapshot test for pre-Canopy height confirming correct founders reward values

## AI Disclosure

Used Claude Code for implementation and test writing.