### PR TITLE
fix(docs): Typo

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1916,7 +1916,7 @@ async fn lightwalletd_test_suite() -> Result<()> {
 ///
 /// Set `FullSyncFromGenesis { allow_lightwalletd_cached_state: true }` to speed up manual full sync tests.
 ///
-/// # Relibility
+/// # Reliability
 ///
 /// The random ports in this test can cause [rare port conflicts.](#Note on port conflict)
 ///


### PR DESCRIPTION
## Motivation

Fix this typo that makes the codespell CI fails on every PR.