### PR TITLE
refactor: Remove deferred_pool_balance_change from ContextuallyVerifiedBlock, SemanticallyVerifiedBlock, and CheckpointVerifiedBlock; calculate it on demand

### DIFF
--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -228,7 +228,7 @@ impl Block {
     pub fn chain_value_pool_change(
         &self,
         utxos: &HashMap<transparent::OutPoint, transparent::Utxo>,
-        deferred_pool_balance_change: Option<DeferredPoolBalanceChange>,
+        deferred_pool_balance_change: DeferredPoolBalanceChange,
     ) -> Result<ValueBalance<NegativeAllowed>, ValueBalanceError> {
         // `Result<T, E>` implements `IntoIterator`, so a `flat_map(|t| t.value_balance(utxos))`
         // would silently drop transactions whose value balance returns `Err`. Use `try_fold`
@@ -240,11 +240,9 @@ impl Block {
                 acc + tx.value_balance(utxos)?
             })?;
 
-        Ok(*tx_pool_sum.neg().set_deferred_amount(
-            deferred_pool_balance_change
-                .map(DeferredPoolBalanceChange::value)
-                .unwrap_or_default(),
-        ))
+        Ok(*tx_pool_sum
+            .neg()
+            .set_deferred_amount(deferred_pool_balance_change.value()))
     }
 
     /// Compute the root of the authorizing data Merkle tree,

--- a/zebra-chain/src/block/tests/vectors.rs
+++ b/zebra-chain/src/block/tests/vectors.rs
@@ -7,14 +7,14 @@ use std::{
 use chrono::{DateTime, Duration, LocalResult, TimeZone, Utc};
 
 use crate::{
-    amount::{Amount, NonNegative, MAX_MONEY},
+    amount::{Amount, DeferredPoolBalanceChange, MAX_MONEY, NonNegative},
     block::{
-        serialize::MAX_BLOCK_BYTES, Block, BlockTimeError, Commitment::*, Hash, Header, Height,
+        Block, BlockTimeError, Commitment::*, Hash, Header, Height, serialize::MAX_BLOCK_BYTES
     },
     parameters::{Network, NetworkUpgrade::*},
     sapling,
     serialization::{
-        sha256d, SerializationError, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize,
+        SerializationError, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize, sha256d
     },
     transaction::{LockTime, Transaction},
     transparent,
@@ -108,7 +108,7 @@ fn chain_value_pool_change_propagates_transaction_value_balance_errors() {
     };
 
     assert!(
-        block.chain_value_pool_change(&utxos, None).is_err(),
+        block.chain_value_pool_change(&utxos, DeferredPoolBalanceChange::zero()).is_err(),
         "block-level aggregation should propagate transaction value-balance errors"
     );
 }

--- a/zebra-chain/src/block/tests/vectors.rs
+++ b/zebra-chain/src/block/tests/vectors.rs
@@ -7,14 +7,14 @@ use std::{
 use chrono::{DateTime, Duration, LocalResult, TimeZone, Utc};
 
 use crate::{
-    amount::{Amount, DeferredPoolBalanceChange, MAX_MONEY, NonNegative},
+    amount::{Amount, DeferredPoolBalanceChange, NonNegative, MAX_MONEY},
     block::{
-        Block, BlockTimeError, Commitment::*, Hash, Header, Height, serialize::MAX_BLOCK_BYTES
+        serialize::MAX_BLOCK_BYTES, Block, BlockTimeError, Commitment::*, Hash, Header, Height,
     },
     parameters::{Network, NetworkUpgrade::*},
     sapling,
     serialization::{
-        SerializationError, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize, sha256d
+        sha256d, SerializationError, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize,
     },
     transaction::{LockTime, Transaction},
     transparent,
@@ -108,7 +108,9 @@ fn chain_value_pool_change_propagates_transaction_value_balance_errors() {
     };
 
     assert!(
-        block.chain_value_pool_change(&utxos, DeferredPoolBalanceChange::zero()).is_err(),
+        block
+            .chain_value_pool_change(&utxos, DeferredPoolBalanceChange::zero())
+            .is_err(),
         "block-level aggregation should propagate transaction value-balance errors"
     );
 }

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -351,7 +351,6 @@ where
                 height,
                 new_outputs,
                 transaction_hashes,
-                deferred_pool_balance_change: Some(deferred_pool_balance_change),
             };
 
             // Return early for proposal requests.

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -28,12 +28,11 @@ use tower::{Service, ServiceExt};
 use tracing::instrument;
 
 use zebra_chain::{
-    amount::{self, DeferredPoolBalanceChange},
+    amount::{self},
     block::{self, Block},
     parameters::{
-        checkpoint::list::CheckpointList,
-        subsidy::{block_subsidy, funding_stream_values, FundingStreamReceiver, SubsidyError},
-        Network, GENESIS_PREVIOUS_BLOCK_HASH,
+        checkpoint::list::CheckpointList, subsidy::SubsidyError, Network,
+        GENESIS_PREVIOUS_BLOCK_HASH,
     },
     work::equihash,
 };
@@ -610,18 +609,8 @@ where
             crate::block::check::equihash_solution_is_valid(&block.header)?;
         }
 
-        // See [ZIP-1015](https://zips.z.cash/zip-1015).
-        let expected_deferred_amount =
-            funding_stream_values(height, &self.network, block_subsidy(height, &self.network)?)?
-                .remove(&FundingStreamReceiver::Deferred);
-
-        let deferred_pool_balance_change = expected_deferred_amount
-            .unwrap_or_default()
-            .checked_sub(self.network.lockbox_disbursement_total_amount(height))
-            .map(DeferredPoolBalanceChange::new);
-
         // don't do precalculation until the block passes basic difficulty checks
-        let block = CheckpointVerifiedBlock::new(block, Some(hash), deferred_pool_balance_change);
+        let block = CheckpointVerifiedBlock::new(block, Some(hash));
 
         crate::block::check::merkle_root_validity(
             &self.network,

--- a/zebra-state/src/arbitrary.rs
+++ b/zebra-state/src/arbitrary.rs
@@ -97,7 +97,6 @@ impl ContextuallyVerifiedBlock {
             height,
             new_outputs,
             transaction_hashes,
-            deferred_pool_balance_change: _,
         } = block.into();
 
         Self {

--- a/zebra-state/src/arbitrary.rs
+++ b/zebra-state/src/arbitrary.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use zebra_chain::{
-    amount::Amount,
+    amount::{Amount, DeferredPoolBalanceChange},
     block::{self, Block},
     transaction::Transaction,
     transparent,
@@ -82,8 +82,12 @@ impl ContextuallyVerifiedBlock {
             .map(|outpoint| (outpoint, zero_utxo.clone()))
             .collect();
 
-        ContextuallyVerifiedBlock::with_block_and_spent_utxos(block, zero_spent_utxos)
-            .expect("all UTXOs are provided with zero values")
+        ContextuallyVerifiedBlock::with_block_and_spent_utxos(
+            block,
+            zero_spent_utxos,
+            DeferredPoolBalanceChange::zero(),
+        )
+        .expect("all UTXOs are provided with zero values")
     }
 
     /// Create a [`ContextuallyVerifiedBlock`] from a [`Block`] or [`SemanticallyVerifiedBlock`],

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -258,8 +258,6 @@ pub struct SemanticallyVerifiedBlock {
     /// A precomputed list of the hashes of the transactions in this block,
     /// in the same order as `block.transactions`.
     pub transaction_hashes: Arc<[transaction::Hash]>,
-    /// This block's deferred pool value balance change.
-    pub deferred_pool_balance_change: Option<DeferredPoolBalanceChange>,
 }
 
 /// A block ready to be committed directly to the finalized state with
@@ -391,25 +389,42 @@ pub struct FinalizedBlock {
     /// The tresstate associated with the block.
     pub(super) treestate: Treestate,
     /// This block's deferred pool value balance change.
-    pub(super) deferred_pool_balance_change: Option<DeferredPoolBalanceChange>,
+    pub(super) deferred_pool_balance_change: DeferredPoolBalanceChange,
 }
 
 impl FinalizedBlock {
     /// Constructs [`FinalizedBlock`] from [`CheckpointVerifiedBlock`] and its [`Treestate`].
-    pub fn from_checkpoint_verified(block: CheckpointVerifiedBlock, treestate: Treestate) -> Self {
-        Self::from_semantically_verified(SemanticallyVerifiedBlock::from(block), treestate)
+    pub fn from_checkpoint_verified(
+        block: CheckpointVerifiedBlock,
+        treestate: Treestate,
+        deferred_pool_balance_change: DeferredPoolBalanceChange,
+    ) -> Self {
+        Self::from_semantically_verified(
+            SemanticallyVerifiedBlock::from(block),
+            treestate,
+            deferred_pool_balance_change,
+        )
     }
 
     /// Constructs [`FinalizedBlock`] from [`ContextuallyVerifiedBlock`] and its [`Treestate`].
     pub fn from_contextually_verified(
         block: ContextuallyVerifiedBlock,
         treestate: Treestate,
+        deferred_pool_balance_change: DeferredPoolBalanceChange,
     ) -> Self {
-        Self::from_semantically_verified(SemanticallyVerifiedBlock::from(block), treestate)
+        Self::from_semantically_verified(
+            SemanticallyVerifiedBlock::from(block),
+            treestate,
+            deferred_pool_balance_change,
+        )
     }
 
     /// Constructs [`FinalizedBlock`] from [`SemanticallyVerifiedBlock`] and its [`Treestate`].
-    fn from_semantically_verified(block: SemanticallyVerifiedBlock, treestate: Treestate) -> Self {
+    fn from_semantically_verified(
+        block: SemanticallyVerifiedBlock,
+        treestate: Treestate,
+        deferred_pool_balance_change: DeferredPoolBalanceChange,
+    ) -> Self {
         Self {
             block: block.block,
             hash: block.hash,
@@ -417,7 +432,7 @@ impl FinalizedBlock {
             new_outputs: block.new_outputs,
             transaction_hashes: block.transaction_hashes,
             treestate,
-            deferred_pool_balance_change: block.deferred_pool_balance_change,
+            deferred_pool_balance_change,
         }
     }
 }
@@ -490,7 +505,6 @@ impl ContextuallyVerifiedBlock {
             height,
             new_outputs,
             transaction_hashes,
-            deferred_pool_balance_change,
         } = semantically_verified;
 
         // This is redundant for the non-finalized state,
@@ -508,7 +522,7 @@ impl ContextuallyVerifiedBlock {
             transaction_hashes,
             chain_value_pool_change: block.chain_value_pool_change(
                 &utxos_from_ordered_utxos(spent_outputs),
-                deferred_pool_balance_change,
+                DeferredPoolBalanceChange::zero(),
             )?,
         })
     }
@@ -517,14 +531,8 @@ impl ContextuallyVerifiedBlock {
 impl CheckpointVerifiedBlock {
     /// Creates a [`CheckpointVerifiedBlock`] from [`Block`] with optional deferred balance and
     /// optional pre-computed hash.
-    pub fn new(
-        block: Arc<Block>,
-        hash: Option<block::Hash>,
-        deferred_pool_balance_change: Option<DeferredPoolBalanceChange>,
-    ) -> Self {
-        let mut block = Self::with_hash(block.clone(), hash.unwrap_or(block.hash()));
-        block.deferred_pool_balance_change = deferred_pool_balance_change;
-        block
+    pub fn new(block: Arc<Block>, hash: Option<block::Hash>) -> Self {
+        Self::with_hash(block.clone(), hash.unwrap_or(block.hash()))
     }
     /// Creates a block that's ready to be committed to the finalized state,
     /// using a precalculated [`block::Hash`].
@@ -551,17 +559,7 @@ impl SemanticallyVerifiedBlock {
             height,
             new_outputs,
             transaction_hashes,
-            deferred_pool_balance_change: None,
         }
-    }
-
-    /// Sets the deferred balance in the block.
-    pub fn with_deferred_pool_balance_change(
-        mut self,
-        deferred_pool_balance_change: Option<DeferredPoolBalanceChange>,
-    ) -> Self {
-        self.deferred_pool_balance_change = deferred_pool_balance_change;
-        self
     }
 }
 
@@ -586,7 +584,6 @@ impl From<Arc<Block>> for SemanticallyVerifiedBlock {
             height,
             new_outputs,
             transaction_hashes,
-            deferred_pool_balance_change: None,
         }
     }
 }
@@ -599,9 +596,6 @@ impl From<ContextuallyVerifiedBlock> for SemanticallyVerifiedBlock {
             height: valid.height,
             new_outputs: valid.new_outputs,
             transaction_hashes: valid.transaction_hashes,
-            deferred_pool_balance_change: Some(DeferredPoolBalanceChange::new(
-                valid.chain_value_pool_change.deferred_amount(),
-            )),
         }
     }
 }
@@ -614,7 +608,6 @@ impl From<FinalizedBlock> for SemanticallyVerifiedBlock {
             height: finalized.height,
             new_outputs: finalized.new_outputs,
             transaction_hashes: finalized.transaction_hashes,
-            deferred_pool_balance_change: finalized.deferred_pool_balance_change,
         }
     }
 }

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -358,7 +358,7 @@ impl Treestate {
 ///
 /// Zebra's state service passes this `enum` over to the finalized state
 /// when committing a block.
-#[allow(missing_docs)]
+#[allow(missing_docs, clippy::large_enum_variant)]
 pub enum FinalizableBlock {
     Checkpoint {
         checkpoint_verified: CheckpointVerifiedBlock,

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -498,6 +498,7 @@ impl ContextuallyVerifiedBlock {
     pub fn with_block_and_spent_utxos(
         semantically_verified: SemanticallyVerifiedBlock,
         mut spent_outputs: HashMap<transparent::OutPoint, transparent::OrderedUtxo>,
+        deferred_pool_balance_change: DeferredPoolBalanceChange,
     ) -> Result<Self, ValueBalanceError> {
         let SemanticallyVerifiedBlock {
             block,
@@ -522,7 +523,7 @@ impl ContextuallyVerifiedBlock {
             transaction_hashes,
             chain_value_pool_change: block.chain_value_pool_change(
                 &utxos_from_ordered_utxos(spent_outputs),
-                DeferredPoolBalanceChange::zero(),
+                deferred_pool_balance_change,
             )?,
         })
     }

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -115,7 +115,6 @@ impl From<SemanticallyVerifiedBlock> for ChainTipBlock {
             height,
             new_outputs: _,
             transaction_hashes,
-            deferred_pool_balance_change: _,
         } = prepared;
 
         Self {

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -19,7 +19,12 @@ use std::{
     sync::Arc,
 };
 
-use zebra_chain::{block, parallel::tree::NoteCommitmentTrees, parameters::Network};
+use zebra_chain::{
+    amount::DeferredPoolBalanceChange,
+    block,
+    parallel::tree::NoteCommitmentTrees,
+    parameters::{subsidy::block_subsidy, Network},
+};
 use zebra_db::{
     chain::BLOCK_INFO,
     transparent::{BALANCE_BY_TRANSPARENT_ADDR, TX_LOC_BY_SPENT_OUT_LOC},
@@ -386,22 +391,35 @@ impl FinalizedState {
                     history_tree,
                 };
 
+                let height = checkpoint_verified.height;
+
                 (
-                    checkpoint_verified.height,
+                    height,
                     checkpoint_verified.hash,
-                    FinalizedBlock::from_checkpoint_verified(checkpoint_verified, treestate),
+                    FinalizedBlock::from_checkpoint_verified(
+                        checkpoint_verified,
+                        treestate,
+                        calculate_deferred_pool_balance_change(height, &self.network()),
+                    ),
                     Some(prev_note_commitment_trees),
                 )
             }
             FinalizableBlock::Contextual {
                 contextually_verified,
                 treestate,
-            } => (
-                contextually_verified.height,
-                contextually_verified.hash,
-                FinalizedBlock::from_contextually_verified(contextually_verified, treestate),
-                prev_note_commitment_trees,
-            ),
+            } => {
+                let height = contextually_verified.height;
+                (
+                    height,
+                    contextually_verified.hash,
+                    FinalizedBlock::from_contextually_verified(
+                        contextually_verified,
+                        treestate,
+                        calculate_deferred_pool_balance_change(height, &self.network()),
+                    ),
+                    prev_note_commitment_trees,
+                )
+            }
         };
 
         let committed_tip_hash = self.db.finalized_tip_hash();
@@ -594,5 +612,29 @@ impl FinalizedState {
         // dropping any lines that haven't already been written to stdout.
         // This is okay for now because this is test-only code
         std::process::exit(0);
+    }
+}
+
+/// Calculates the deferred pool balance change for a given height and network.
+///
+/// Returns a deferred pool balance change of zero if it cannot be calculated.
+pub(crate) fn calculate_deferred_pool_balance_change(
+    height: block::Height,
+    network: &Network,
+) -> DeferredPoolBalanceChange {
+    if height > network.slow_start_interval() {
+        zebra_chain::parameters::subsidy::funding_stream_values(
+            height,
+            network,
+            block_subsidy(height, network).unwrap_or_default(),
+        )
+        .unwrap_or_default()
+        .remove(&zebra_chain::parameters::subsidy::FundingStreamReceiver::Deferred)
+        .unwrap_or_default()
+        .checked_sub(network.lockbox_disbursement_total_amount(height))
+        .map(DeferredPoolBalanceChange::new)
+        .unwrap_or_default()
+    } else {
+        DeferredPoolBalanceChange::zero()
     }
 }

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/block_info_and_address_received.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/block_info_and_address_received.rs
@@ -7,16 +7,16 @@ use crossbeam_channel::TryRecvError;
 use itertools::Itertools;
 use rayon::iter::{IntoParallelIterator, ParallelIterator as _};
 use zebra_chain::{
-    amount::{DeferredPoolBalanceChange, NonNegative},
+    amount::NonNegative,
     block::{Block, Height},
     block_info::BlockInfo,
-    parameters::subsidy::{block_subsidy, funding_stream_values, FundingStreamReceiver},
     transparent::{self, OutPoint, Utxo},
     value_balance::ValueBalance,
 };
 
 use crate::{
     service::finalized_state::{
+        calculate_deferred_pool_balance_change,
         disk_format::transparent::{AddressBalanceLocationChange, AddressLocation},
         MAX_ON_DISK_HEIGHT,
     },
@@ -176,34 +176,13 @@ impl DiskFormatUpgrade for Upgrade {
                 } => (block, size, utxos, address_balance_changes),
             };
 
-            // Get the deferred amount which is required to update the value pool.
-            let deferred_pool_balance_change = if height > network.slow_start_interval() {
-                // See [ZIP-1015](https://zips.z.cash/zip-1015).
-                let deferred_pool_balance_change = funding_stream_values(
-                    height,
-                    &network,
-                    block_subsidy(height, &network).unwrap_or_default(),
-                )
-                .expect("should have valid funding stream values")
-                .remove(&FundingStreamReceiver::Deferred)
-                .unwrap_or_default()
-                .checked_sub(network.lockbox_disbursement_total_amount(height));
-
-                Some(
-                    deferred_pool_balance_change
-                        .expect("deferred pool balance change should be valid Amount"),
-                )
-            } else {
-                None
-            };
-
             // Add this block's value pool changes to the total value pool.
             value_pool = value_pool
                 .add_chain_value_pool_change(
                     block
                         .chain_value_pool_change(
                             &utxos,
-                            deferred_pool_balance_change.map(DeferredPoolBalanceChange::new),
+                            calculate_deferred_pool_balance_change(height, &network),
                         )
                         .unwrap_or_default(),
                 )

--- a/zebra-state/src/service/finalized_state/tests/transparent.rs
+++ b/zebra-state/src/service/finalized_state/tests/transparent.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 use zebra_chain::{
-    amount::{Amount, NonNegative, MAX_MONEY},
+    amount::{Amount, DeferredPoolBalanceChange, NonNegative, MAX_MONEY},
     block::{self, Block, Height},
     parameters::{Network, NetworkKind},
     serialization::ZcashDeserializeInto,
@@ -127,11 +127,11 @@ fn intra_block_self_spend_chain_in_finalized_state() {
         height,
         new_outputs,
         transaction_hashes,
-        deferred_pool_balance_change: None,
     };
     let finalized = FinalizedBlock::from_checkpoint_verified(
         CheckpointVerifiedBlock(semantically_verified),
         Treestate::default(),
+        DeferredPoolBalanceChange::zero(),
     );
 
     // Inputs to `prepare_transparent_transaction_batch`, prepared the way `write_block` does.

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
@@ -13,6 +13,7 @@
 use std::{iter, sync::Arc};
 
 use zebra_chain::{
+    amount::DeferredPoolBalanceChange,
     block::{
         tests::generate::{
             large_multi_transaction_block, large_single_transaction_block_many_inputs,
@@ -136,13 +137,15 @@ fn test_block_db_round_trip_with(
                 height: Height(0),
                 new_outputs,
                 transaction_hashes,
-                deferred_pool_balance_change: None,
             })
         };
 
         let dummy_treestate = Treestate::default();
-        let finalized =
-            FinalizedBlock::from_checkpoint_verified(checkpoint_verified, dummy_treestate);
+        let finalized = FinalizedBlock::from_checkpoint_verified(
+            checkpoint_verified,
+            dummy_treestate,
+            DeferredPoolBalanceChange::zero(),
+        );
 
         // Skip validation by writing the block directly to the database
         let mut batch = DiskWriteBatch::new();

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -22,7 +22,11 @@ use crate::{
     constants::{MAX_INVALIDATED_BLOCKS, MAX_NON_FINALIZED_CHAIN_FORKS},
     error::ReconsiderError,
     request::{ContextuallyVerifiedBlock, FinalizableBlock},
-    service::{check, finalized_state::ZebraDb, InvalidateError},
+    service::{
+        check,
+        finalized_state::{calculate_deferred_pool_balance_change, ZebraDb},
+        InvalidateError,
+    },
     SemanticallyVerifiedBlock, ValidateContextError, WatchReceiver,
 };
 
@@ -592,6 +596,7 @@ impl NonFinalizedState {
         let contextual = ContextuallyVerifiedBlock::with_block_and_spent_utxos(
             prepared.clone(),
             spent_utxos.clone(),
+            calculate_deferred_pool_balance_change(prepared.height, &self.network),
         )
         .map_err(|value_balance_error| {
             ValidateContextError::CalculateBlockChainValueChange {

--- a/zebra-state/src/service/non_finalized_state/backup.rs
+++ b/zebra-state/src/service/non_finalized_state/backup.rs
@@ -9,7 +9,7 @@ use std::{
 
 use hex::ToHex;
 use zebra_chain::{
-    amount::{Amount, DeferredPoolBalanceChange},
+    amount::Amount,
     block::{self, Block, Height},
     serialization::{ZcashDeserializeInto, ZcashSerialize},
 };
@@ -238,10 +238,7 @@ fn read_non_finalized_blocks_from_backup<'a>(
                     block,
                     deferred_pool_balance_change,
                 }) if block.coinbase_height().is_some() => {
-                    let block = SemanticallyVerifiedBlock::from(block)
-                        .with_deferred_pool_balance_change(Some(DeferredPoolBalanceChange::new(
-                            deferred_pool_balance_change,
-                        )));
+                    let block = SemanticallyVerifiedBlock::from(block);
                     if block.hash != expected_block_hash {
                         tracing::warn!(
                             block_hash = ?block.hash,

--- a/zebra-state/src/service/non_finalized_state/backup.rs
+++ b/zebra-state/src/service/non_finalized_state/backup.rs
@@ -236,7 +236,7 @@ fn read_non_finalized_blocks_from_backup<'a>(
             match NonFinalizedBlockBackup::from_bytes(backup_block_file_contents) {
                 Ok(NonFinalizedBlockBackup {
                     block,
-                    deferred_pool_balance_change,
+                    deferred_pool_balance_change: _,
                 }) if block.coinbase_height().is_some() => {
                     let block = SemanticallyVerifiedBlock::from(block);
                     if block.hash != expected_block_hash {

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -5,7 +5,7 @@ use std::{collections::BTreeMap, env, sync::Arc};
 use zebra_test::prelude::*;
 
 use zebra_chain::{
-    amount::NonNegative,
+    amount::{DeferredPoolBalanceChange, NonNegative},
     block::{self, arbitrary::allow_all_transparent_coinbase_spends, Block, Height},
     history_tree::{HistoryTree, NonEmptyHistoryTree},
     parameters::NetworkUpgrade::*,
@@ -52,6 +52,7 @@ fn push_genesis_chain() -> Result<()> {
             ContextuallyVerifiedBlock::with_block_and_spent_utxos(
                     block,
                     only_chain.unspent_utxos(),
+                    DeferredPoolBalanceChange::zero(),
                 )
                 .map_err(|e| (e, chain_values.clone()))
                 .expect("invalid block value pool change");
@@ -148,6 +149,7 @@ fn forked_equals_pushed_genesis() -> Result<()> {
             let block = ContextuallyVerifiedBlock::with_block_and_spent_utxos(
                 block,
                 partial_chain.unspent_utxos(),
+                DeferredPoolBalanceChange::zero(),
             )?;
             partial_chain = partial_chain
                 .push(block)
@@ -167,7 +169,7 @@ fn forked_equals_pushed_genesis() -> Result<()> {
 
         for block in chain.iter().cloned() {
             let block =
-            ContextuallyVerifiedBlock::with_block_and_spent_utxos(block, full_chain.unspent_utxos())?;
+            ContextuallyVerifiedBlock::with_block_and_spent_utxos(block, full_chain.unspent_utxos(), DeferredPoolBalanceChange::zero())?;
 
             // Check some properties of the genesis block and don't push it to the chain.
             if block.height == block::Height(0) {
@@ -210,7 +212,7 @@ fn forked_equals_pushed_genesis() -> Result<()> {
         // same original full chain.
         for block in chain.iter().skip(fork_at_count).cloned() {
             let block =
-            ContextuallyVerifiedBlock::with_block_and_spent_utxos(block, forked.unspent_utxos())?;
+            ContextuallyVerifiedBlock::with_block_and_spent_utxos(block, forked.unspent_utxos(), DeferredPoolBalanceChange::zero())?;
             forked = forked.push(block).expect("forked chain push is valid");
         }
 

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -3,25 +3,28 @@
 use std::{sync::Arc, time::Duration};
 
 use zebra_chain::{
-    amount::NonNegative,
+    amount::{Amount, DeferredPoolBalanceChange, NonNegative},
     block::{self, Block, Height},
     history_tree::NonEmptyHistoryTree,
     orchard,
     parameters::{Network, NetworkUpgrade},
     serialization::ZcashDeserializeInto,
     subtree::NoteCommitmentSubtree,
+    transaction::Transaction,
+    transparent,
     value_balance::ValueBalance,
 };
 use zebra_test::prelude::*;
 
 use crate::{
     arbitrary::Prepare,
+    request::ContextuallyVerifiedBlock,
     service::{
-        finalized_state::FinalizedState,
+        finalized_state::{calculate_deferred_pool_balance_change, FinalizedState},
         non_finalized_state::{Chain, NonFinalizedState, MIN_DURATION_BETWEEN_BACKUP_UPDATES},
     },
     tests::FakeChainHelper,
-    Config,
+    Config, SemanticallyVerifiedBlock,
 };
 
 #[test]
@@ -883,6 +886,82 @@ fn fork_drops_subtrees_above_fork_point() -> Result<()> {
         forked.orchard_subtrees.is_empty(),
         "fork should have dropped the Orchard subtree completed above the fork point"
     );
+
+    Ok(())
+}
+
+/// Check that the `deferred_pool_balance_change` passed to `with_block_and_spent_utxos`
+/// flows through to the resulting block's `chain_value_pool_change`.
+#[test]
+fn with_block_and_spent_utxos_preserves_deferred_pool_balance_change() -> Result<()> {
+    let _init_guard = zebra_test::init();
+    let block: Arc<Block> =
+        zebra_test::vectors::BLOCK_MAINNET_434873_BYTES.zcash_deserialize_into()?;
+    let prepared = SemanticallyVerifiedBlock::from(block);
+
+    let zero_output = transparent::Output {
+        value: Amount::zero(),
+        lock_script: transparent::Script::new(&[]),
+    };
+    let zero_utxo = transparent::OrderedUtxo::new(zero_output, Height(1), 1);
+    let spent_utxos = prepared
+        .block
+        .transactions
+        .iter()
+        .map(AsRef::as_ref)
+        .flat_map(Transaction::inputs)
+        .flat_map(transparent::Input::outpoint)
+        .map(|outpoint| (outpoint, zero_utxo.clone()))
+        .collect();
+
+    let expected_deferred = Amount::try_from(123_456_789)?;
+    let contextual = ContextuallyVerifiedBlock::with_block_and_spent_utxos(
+        prepared,
+        spent_utxos,
+        DeferredPoolBalanceChange::new(expected_deferred),
+    )?;
+
+    assert_eq!(
+        contextual.chain_value_pool_change.deferred_amount(),
+        expected_deferred,
+    );
+
+    Ok(())
+}
+
+/// Check that after committing a block via `commit_new_chain`, the non-finalized chain's
+/// deferred pool amount matches what `calculate_deferred_pool_balance_change` returns for
+/// the block's height and network.
+#[test]
+fn commit_new_chain_sets_chain_value_pools_deferred_amount() -> Result<()> {
+    let _init_guard = zebra_test::init();
+    let network = Network::Mainnet;
+
+    let block: Arc<Block> = Arc::new(network.test_block(653_599, 583_999).unwrap());
+    let height = block.coinbase_height().expect("coinbase height");
+    assert!(
+        height > network.slow_start_interval(),
+        "test block must be past slow_start_interval to exercise the non-trivial branch \
+         of calculate_deferred_pool_balance_change",
+    );
+
+    let mut state = NonFinalizedState::new(&network);
+    let finalized_state = FinalizedState::new(
+        &Config::ephemeral(),
+        &network,
+        #[cfg(feature = "elasticsearch")]
+        false,
+    );
+    finalized_state.set_finalized_value_pool(ValueBalance::<NonNegative>::fake_populated_pool());
+
+    state.commit_new_chain(block.prepare(), &finalized_state.db)?;
+
+    let chain = state.best_chain().expect("chain was just committed");
+    let expected = calculate_deferred_pool_balance_change(height, &network)
+        .value()
+        .constrain::<NonNegative>()?;
+
+    assert_eq!(chain.chain_value_pools.deferred_amount(), expected);
 
     Ok(())
 }

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -10,6 +10,7 @@ use tokio::runtime::Runtime;
 use tower::{buffer::Buffer, util::BoxService};
 
 use zebra_chain::{
+    amount::DeferredPoolBalanceChange,
     block::{self, Block, CountedHeader, Height},
     chain_tip::ChainTip,
     fmt::SummaryDebug,
@@ -424,7 +425,7 @@ proptest! {
             // which is not included in the UTXO set
             if block.height > block::Height(0) {
                 let utxos = &block.new_outputs.iter().map(|(k, ordered_utxo)| (*k, ordered_utxo.utxo.clone())).collect();
-                let block_value_pool = &block.block.chain_value_pool_change(utxos, None)?;
+                let block_value_pool = &block.block.chain_value_pool_change(utxos, DeferredPoolBalanceChange::zero())?;
                 expected_finalized_value_pool += *block_value_pool;
             }
 
@@ -451,7 +452,7 @@ proptest! {
         let mut expected_non_finalized_value_pool = Ok(expected_finalized_value_pool?);
         for block in non_finalized_blocks {
             let utxos = block.new_outputs.clone();
-            let block_value_pool = &block.block.chain_value_pool_change(&transparent::utxos_from_ordered_utxos(utxos), None)?;
+            let block_value_pool = &block.block.chain_value_pool_change(&transparent::utxos_from_ordered_utxos(utxos), DeferredPoolBalanceChange::zero())?;
             expected_non_finalized_value_pool += *block_value_pool;
 
             let result_receiver = state_service.queue_and_commit_to_non_finalized_state(block.clone());


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

This refactor came up during a conversation around ZIP-234's implementation and how it could be simplified.

It was agreed that removing the `deferred_pool_balance_change` field from `ContextuallyVerifiedBlock`, `SemanticallyVerifiedBlock`, and `CheckpointVerifiedBlock` simplifies codepaths, as it should only be calculated when all of the required information is available, and isn't required before that point.

## Solution

- `deferred_pool_balance_change` is now calculated when committing a block to finalized state.

### Tests

Current test suite passes. 

Regression tests should ensure this is working as expected.

### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [x] No AI tools were used in this PR
- [ ] AI tools were used: <!-- tool name and what it was used for, e.g., "Claude for test boilerplate" -->

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
