### PR TITLE
fix(ci): Make `lychee` accept GitHub's rate limits

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -72,6 +72,3 @@ include_mail = false
 max_retries = 3
 retry_wait_time = 2
 
-# GitHub token environment variable (for higher rate limits)
-# Set GITHUB_TOKEN in your environment or CI
-github_token = ""

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -44,7 +44,7 @@ exclude_path = [
 ]
 
 # Accept these HTTP status codes as valid
-accept = ["200", "204", "206", "301", "302", "307", "308"]
+accept = ["200", "204", "206", "301", "302", "307", "308", "429"]
 
 # Timeout for requests (seconds)
 timeout = 30
@@ -57,10 +57,10 @@ exclude_loopback = true
 cache = true
 
 # Maximum age of cached results
-max_cache_age = "1d"
+max_cache_age = "7d"
 
 # Maximum concurrent requests
-max_concurrency = 16
+max_concurrency = 8
 
 # User agent string
 user_agent = "lychee/0.14 (Zebra link checker; https://github.com/ZcashFoundation/zebra)"
@@ -70,5 +70,4 @@ include_mail = false
 
 # Retry configuration
 max_retries = 3
-retry_wait_time = 2
-
+retry_wait_time = 10


### PR DESCRIPTION
## Motivation

The CI link checker (lychee) is failing due to GitHub rate limits.

Closes #10386

## Solution

- Remove the empty `github_token` config that was overriding the environment variable
- Reduce max concurrency from 16 to 8
- Accept HTTP 429 (Too Many Requests) so transient rate limits don't fail the check
- Increase `max_cache_age` from 1 day to 7 days to reduce repeated requests
- Increase `retry_wait_time` from 2 to 10 seconds