### PR TITLE
Align integration test trigger with zcash/integration-tests.

### DIFF
--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -39,11 +39,23 @@ jobs:
           owner: zcash
           repositories: integration-tests
 
+      - name: Get requested test branch, if any
+        if: github.event_name == 'pull_request'
+        id: test-branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          TEST_SHA=$(gh pr -R ZcashFoundation/zebra list --search "${HEAD_SHA}" --json body | jq '.[0].body' | sed '/[^ ]ZIT-Revision/!d' | sed -E 's/.*ZIT-Revision: ([^\\]*)\\.*/\1/')
+          echo "test_sha=${TEST_SHA}" >> $GITHUB_OUTPUT
+
       - name: Trigger integration tests
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          TEST_SHA: ${{ steps.test-branch.outputs.test_sha }}
         run: >
           gh api repos/zcash/integration-tests/dispatches
           --field event_type="zebra-interop-request"
-          --field client_payload[sha]="$SHA"
+          --field client_payload[sha]="${SHA}"
+          --field client_payload[test_sha]="${TEST_SHA}"


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

This change is intended to bring Zebra integration testing exactly into alignment with how `zallet` is configured, using a 2-github-app model instead of a 1-github-app model, which avoids issues with having to share github app private keys across organization boundaries.

### Specifications & References

https://zcash.github.io/integration-tests/ci/cross-repo.html#1-set-up-the-dispatch-app-requesting-org-side

### Follow-up Work

Additional github app configuration will be required, as described above.

### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [X] No AI tools were used in this PR
- [ ] AI tools were used: <!-- tool name and what it was used for, e.g., "Claude for test boilerplate" -->

### PR Checklist

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [ ] The solution is tested.
- [ ] The documentation and changelogs are up to date.
