### PR TITLE
fix(sync): Fix block propagation in regtest

### DIFF
--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -370,28 +370,29 @@ impl StartCmd {
         );
 
         info!("spawning syncer task");
-        let syncer_task_handle = if is_regtest {
-            if !syncer
+        // In regtest, commit the genesis block directly (bypassing the syncer's genesis
+        // download, which requires a connected peer). Then run the syncer normally so
+        // that multi-hop block propagation works: gossiped blocks that arrive out of
+        // order (e.g. only the latest tip hash was gossiped) will be recovered by the
+        // syncer using block locators within REGTEST_SYNC_RESTART_DELAY (2 seconds).
+        if is_regtest
+            && !syncer
                 .state_contains(config.network.network.genesis_hash())
                 .await?
-            {
-                let genesis_hash = block_verifier_router
-                    .clone()
-                    .oneshot(zebra_consensus::Request::Commit(regtest_genesis_block()))
-                    .await
-                    .expect("should validate Regtest genesis block");
+        {
+            let genesis_hash = block_verifier_router
+                .clone()
+                .oneshot(zebra_consensus::Request::Commit(regtest_genesis_block()))
+                .await
+                .expect("should validate Regtest genesis block");
 
-                assert_eq!(
-                    genesis_hash,
-                    config.network.network.genesis_hash(),
-                    "validated block hash should match network genesis hash"
-                )
-            }
-
-            tokio::spawn(std::future::pending().in_current_span())
-        } else {
-            tokio::spawn(syncer.sync().in_current_span())
-        };
+            assert_eq!(
+                genesis_hash,
+                config.network.network.genesis_hash(),
+                "validated block hash should match network genesis hash"
+            )
+        }
+        let syncer_task_handle = tokio::spawn(syncer.sync().in_current_span());
 
         // And finally, spawn the internal Zcash miner, if it is enabled.
         //

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -205,6 +205,11 @@ const FINAL_CHECKPOINT_BLOCK_VERIFY_TIMEOUT_LIMIT: HeightDiff = 100;
 /// previous sync runs.
 const SYNC_RESTART_DELAY: Duration = Duration::from_secs(67);
 
+/// In regtest, use a much shorter restart delay so that downstream nodes pick up
+/// newly-mined blocks quickly (e.g. after `generate(N)` in integration tests).
+/// The default 67-second delay exceeds the typical `sync_all` timeout of 60 seconds.
+const REGTEST_SYNC_RESTART_DELAY: Duration = Duration::from_secs(2);
+
 /// Controls how long we wait to retry a failed attempt to download
 /// and verify the genesis block.
 ///
@@ -341,6 +346,9 @@ where
 
     /// The configured full verification concurrency limit, after applying the minimum limit.
     full_verify_concurrency_limit: usize,
+
+    /// Whether the node is running on regtest. Used to apply a shorter sync restart delay.
+    is_regtest: bool,
 
     // Services
     //
@@ -487,7 +495,7 @@ where
         // We apply a timeout to the verifier to avoid hangs due to missing earlier blocks.
         let verifier = Timeout::new(verifier, BLOCK_VERIFY_TIMEOUT);
 
-        let (sync_status, recent_syncs) = SyncStatus::new();
+        let (sync_status, recent_syncs) = SyncStatus::new_for_network(&config.network.network);
 
         let (past_lookahead_limit_sender, past_lookahead_limit_receiver) = watch::channel(false);
         let past_lookahead_limit_receiver = zs::WatchReceiver::new(past_lookahead_limit_receiver);
@@ -509,6 +517,7 @@ where
             max_checkpoint_height,
             checkpoint_verify_concurrency_limit,
             full_verify_concurrency_limit,
+            is_regtest: config.network.network.is_regtest(),
             tip_network,
             downloads,
             state,
@@ -536,12 +545,17 @@ where
 
             self.update_metrics();
 
+            let restart_delay = if self.is_regtest {
+                REGTEST_SYNC_RESTART_DELAY
+            } else {
+                SYNC_RESTART_DELAY
+            };
             info!(
-                timeout = ?SYNC_RESTART_DELAY,
+                timeout = ?restart_delay,
                 state_tip = ?self.latest_chain_tip.best_tip_height(),
                 "waiting to restart sync"
             );
-            sleep(SYNC_RESTART_DELAY).await;
+            sleep(restart_delay).await;
         }
     }
 
@@ -739,13 +753,28 @@ where
                     // out-of-order first hashes.
 
                     // We use the last hash for the tip, and we want to avoid bad
-                    // tips. So we discard the last hash. (We don't need to worry
-                    // about missed downloads, because we will pick them up again
-                    // in ExtendTips.)
-                    let hashes = match hashes.as_slice() {
-                        [] => continue,
-                        [rest @ .., _last] => rest,
+                    // tips from zcashd's quirk of appending an unrelated hash.
+                    // So we discard the last hash on mainnet/testnet.
+                    // (We don't need to worry about missed downloads, because we
+                    // will pick them up again in ExtendTips.)
+                    //
+                    // In regtest we only connect to Zebra nodes, not zcashd,
+                    // so we trust all hashes in the response and keep them all.
+                    // This is necessary when there are only a small number of
+                    // blocks to sync (e.g. 2 new blocks), where stripping the
+                    // last hash leaves only 1 unknown hash and rchunks_exact(2)
+                    // would discard the entire response.
+                    let hashes = if self.is_regtest {
+                        hashes.as_slice()
+                    } else {
+                        match hashes.as_slice() {
+                            [] => continue,
+                            [rest @ .., _last] => rest,
+                        }
                     };
+                    if hashes.is_empty() {
+                        continue;
+                    }
 
                     let mut first_unknown = None;
                     for (i, &hash) in hashes.iter().enumerate() {

--- a/zebrad/src/components/sync/status.rs
+++ b/zebrad/src/components/sync/status.rs
@@ -16,6 +16,7 @@ mod tests;
 #[derive(Clone, Debug)]
 pub struct SyncStatus {
     latest_sync_length: watch::Receiver<Vec<usize>>,
+    is_regtest: bool,
 }
 
 impl SyncStatus {
@@ -26,13 +27,32 @@ impl SyncStatus {
     /// once Zebra reaches the tip.
     const MIN_DIST_FROM_TIP: usize = 20;
 
+    /// Create an instance of [`SyncStatus`] for a specific network.
+    ///
+    /// The status is determined based on the latest counts of synchronized blocks, observed
+    /// through `latest_sync_length`. In regtest, [`ChainSyncStatus::is_close_to_tip`] always returns `true`.
+    pub fn new_for_network(
+        network: &zebra_chain::parameters::Network,
+    ) -> (Self, RecentSyncLengths) {
+        let (recent_sync_lengths, latest_sync_length) = RecentSyncLengths::new();
+        let status = SyncStatus {
+            latest_sync_length,
+            is_regtest: network.is_regtest(),
+        };
+
+        (status, recent_sync_lengths)
+    }
+
     /// Create an instance of [`SyncStatus`].
     ///
     /// The status is determined based on the latest counts of synchronized blocks, observed
     /// through `latest_sync_length`.
     pub fn new() -> (Self, RecentSyncLengths) {
         let (recent_sync_lengths, latest_sync_length) = RecentSyncLengths::new();
-        let status = SyncStatus { latest_sync_length };
+        let status = SyncStatus {
+            latest_sync_length,
+            is_regtest: false,
+        };
 
         (status, recent_sync_lengths)
     }
@@ -52,6 +72,10 @@ impl SyncStatus {
 impl ChainSyncStatus for SyncStatus {
     /// Check if the synchronization is likely close to the chain tip.
     fn is_close_to_tip(&self) -> bool {
+        if self.is_regtest {
+            return true;
+        }
+
         let sync_lengths = self.latest_sync_length.borrow();
 
         // Return early if sync_lengths is empty.


### PR DESCRIPTION
## Motivation

In regtest, blocks mined on one node failed to propagate across multi-hop topologies (`A → B → C`). Node B would receive a block from A but not relay it to C, causing integration tests using `generate(N)` with N > 1 to time out during `sync_all()`.

This was caused by three issues:

- Syncer disabled in regtest (`start.rs`): The syncer task was replaced with `std::future::pending()`, leaving only gossip for propagation. Gossip only advertises the latest tip hash, so rapidly mined blocks caused intermediate blocks to be missed with no recovery path.
- `obtain_tips()` discarding small responses (`sync.rs`): A workaround for a zcashd quirk strips the last hash from `FindBlocks` responses. For short chains this left too few hashes, causing the response to be discarded and preventing recovery of the final block.
- SyncStatus::is_close_to_tip() always false (`sync/status.rs`): Gossip waits for `wait_until_close_to_tip()` before relaying blocks. On fresh regtest nodes this condition never became true, effectively blocking relay.

## Solution

- `start.rs`: Re-enable the syncer in regtest (genesis still committed locally).
- `sync.rs`:
  - Reduced delay in regtest with `REGTEST_SYNC_RESTART_DELAY` to 2s
  - Skip the zcashd last-hash stripping in regtest.
- `sync/status.rs`: Add `SyncStatus::new_for_network()`. In regtest, `is_close_to_tip()` returns true immediately so gossip can relay blocks.

### Tests

Added `regtest_block_relay.py` to the integration tests, reproducing the scenario from #10332: three nodes in a linear `A -- B -- C` topology, mining on A and verifying propagation to C.

Closes #10332.

### Follow-up Work


### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude for text and some code

### PR Checklist

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [ ] The solution is tested.
- [ ] The documentation and changelogs are up to date.
