### PR TITLE
fix: Add `profiling` Cargo profile and use it in profiling docs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -91,3 +91,7 @@ rustdocflags = [
 
 [env]
 RUST_BACKTRACE="1"
+
+[profile.profiling]
+inherits = "release"
+debug = true

--- a/book/src/dev/profiling-and-benchmarking.md
+++ b/book/src/dev/profiling-and-benchmarking.md
@@ -8,13 +8,13 @@ To profile Zebra, you can use the [samply](https://github.com/mstange/samply)
 profiler. Once you have it installed, you can run:
 
 ```bash
-sudo samply record zebrad
+cargo build --profile profiling
+sudo samply record ./target/profiling/zebrad
 ```
 
-where `zebrad` is the binary you want to inspect. You can then press `Ctrl+c`,
-and the profiler will instruct you to navigate your web browser to
-<http://127.0.0.1:3000> where you can snoop around the call stack to see where
-Zebra loafs around the most.
+You can then press `Ctrl+c`, and the profiler will instruct you to navigate your
+web browser to <http://127.0.0.1:3000> where you can snoop around the call stack
+to see where Zebra loafs around the most.
 
 ## Benchmarking
 


### PR DESCRIPTION
## Motivation

- Close #10410.

## Solution

- Add `profiling` [Cargo profile](https://doc.rust-lang.org/cargo/reference/profiles.html).
- Use the profile in profiling docs.

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.