### PR TITLE
Migrate to `zcash_primitives 0.27`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,8 +1594,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4f333d4ccc9d23c06593733673026efa71a332e028b00f12cf427b9677dce9"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3104959daafcb52d78d857304309cc4295969a30#3104959daafcb52d78d857304309cc4295969a30"
 dependencies = [
  "blake2b_simd",
  "cc",
@@ -1643,8 +1642,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3104959daafcb52d78d857304309cc4295969a30#3104959daafcb52d78d857304309cc4295969a30"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1999,9 +1997,9 @@ dependencies = [
 
 [[package]]
 name = "halo2_gadgets"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73a5e510d58a07d8ed238a5a8a436fe6c2c79e1bb2611f62688bc65007b4e6e7"
+checksum = "45824ce0dd12e91ec0c68ebae2a7ed8ae19b70946624c849add59f1d1a62a143"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -3514,9 +3512,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ef66fcf99348242a20d582d7434da381a867df8dc155b3a980eca767c56137"
+checksum = "6c01cd4ea711aab5f263f2b7aa6966687a2d6c7df4f78eb1b97a66a7a4e78e3b"
 dependencies = [
  "aes",
  "bitvec",
@@ -3536,6 +3534,7 @@ dependencies = [
  "nonempty",
  "pasta_curves",
  "rand 0.8.5",
+ "rand_core 0.6.4",
  "reddsa",
  "serde",
  "sinsemilla",
@@ -4748,9 +4747,9 @@ dependencies = [
 
 [[package]]
 name = "sapling-crypto"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d3c081c83f1dc87403d9d71a06f52301c0aa9ea4c17da2a3435bbf493ffba4"
+checksum = "5433ab8c1cd52dfad3b903143e371d5bdd514ab7952f71414e6d66a5da8223cd"
 dependencies = [
  "aes",
  "bellman",
@@ -7008,9 +7007,9 @@ dependencies = [
 
 [[package]]
 name = "xdg"
-version = "2.5.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "yaml-rust2"
@@ -7049,8 +7048,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4491dddd232de02df42481757054dc19c8bc51cf709cfec58feebfef7c3c9a"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3104959daafcb52d78d857304309cc4295969a30#3104959daafcb52d78d857304309cc4295969a30"
 dependencies = [
  "bech32",
  "bs58",
@@ -7063,18 +7061,17 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca38087e6524e5f51a5b0fb3fc18f36d7b84bf67b2056f494ca0c281590953d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3104959daafcb52d78d857304309cc4295969a30#3104959daafcb52d78d857304309cc4295969a30"
 dependencies = [
  "core2",
+ "hex",
  "nonempty",
 ]
 
 [[package]]
 name = "zcash_history"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fde17bf53792f9c756b313730da14880257d7661b5bfc69d0571c3a7c11a76d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3104959daafcb52d78d857304309cc4295969a30#3104959daafcb52d78d857304309cc4295969a30"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -7084,8 +7081,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c115531caa1b7ca5ccd82dc26dbe3ba44b7542e928a3f77cd04abbe3cde4a4f2"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3104959daafcb52d78d857304309cc4295969a30#3104959daafcb52d78d857304309cc4295969a30"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -7096,7 +7092,9 @@ dependencies = [
  "group",
  "memuse",
  "nonempty",
+ "orchard",
  "rand_core 0.6.4",
+ "sapling-crypto",
  "secrecy",
  "subtle",
  "tracing",
@@ -7123,51 +7121,37 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd9ff256fb298a7e94a73c1adad6c7e0b4b194b902e777ee9f5f2e12c4c4776"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3104959daafcb52d78d857304309cc4295969a30#3104959daafcb52d78d857304309cc4295969a30"
 dependencies = [
- "bip32",
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
- "bs58",
  "core2",
  "crypto-common 0.2.0-rc.1",
  "document-features",
  "equihash",
  "ff",
- "fpe",
- "getset",
- "group",
  "hex",
  "incrementalmerkletree",
  "jubjub",
  "memuse",
  "nonempty",
  "orchard",
- "rand 0.8.5",
  "rand_core 0.6.4",
  "redjubjub",
- "ripemd 0.1.3",
  "sapling-crypto",
  "secp256k1",
  "sha2 0.10.9",
- "subtle",
- "tracing",
- "zcash_address",
  "zcash_encoding",
  "zcash_note_encryption",
  "zcash_protocol",
  "zcash_script",
- "zcash_spec",
  "zcash_transparent",
- "zip32",
 ]
 
 [[package]]
 name = "zcash_proofs"
 version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2c13bb673d542608a0e6502ac5494136e7ce4ce97e92dd239489b2523eed9"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3104959daafcb52d78d857304309cc4295969a30#3104959daafcb52d78d857304309cc4295969a30"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7177,7 +7161,6 @@ dependencies = [
  "home",
  "jubjub",
  "known-folders",
- "lazy_static",
  "rand_core 0.6.4",
  "redjubjub",
  "sapling-crypto",
@@ -7190,13 +7173,13 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b1a337bbc9a7d55ae35d31189f03507dbc7934e9a4bee5c1d5c47464860e48"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3104959daafcb52d78d857304309cc4295969a30#3104959daafcb52d78d857304309cc4295969a30"
 dependencies = [
  "core2",
  "document-features",
  "hex",
  "memuse",
+ "zcash_encoding",
 ]
 
 [[package]]
@@ -7228,11 +7211,9 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9b7b4bc11d8bb20833d1b8ab6807f4dca941b381f1129e5bbd72a84e391991"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3104959daafcb52d78d857304309cc4295969a30#3104959daafcb52d78d857304309cc4295969a30"
 dependencies = [
  "bip32",
- "blake2b_simd",
  "bs58",
  "core2",
  "document-features",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ edition = "2021"
 
 [workspace.dependencies]
 incrementalmerkletree = { version = "0.8.2", features = ["legacy-api"] }
-orchard = "0.11"
-sapling-crypto = "0.5"
+orchard = "0.12"
+sapling-crypto = "0.6"
 zcash_address = "0.10"
 zcash_encoding = "0.3"
 zcash_history = "0.4"
@@ -361,3 +361,15 @@ unwrap_in_result = "warn"
 
 # TODOs: fix this lint eventually
 result_large_err = "allow"
+
+[patch.crates-io]
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "3104959daafcb52d78d857304309cc4295969a30" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "3104959daafcb52d78d857304309cc4295969a30" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "3104959daafcb52d78d857304309cc4295969a30" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "3104959daafcb52d78d857304309cc4295969a30" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "3104959daafcb52d78d857304309cc4295969a30" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "3104959daafcb52d78d857304309cc4295969a30" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "3104959daafcb52d78d857304309cc4295969a30" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "3104959daafcb52d78d857304309cc4295969a30" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "3104959daafcb52d78d857304309cc4295969a30" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "3104959daafcb52d78d857304309cc4295969a30" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/ZcashFoundation/zebra"
 homepage = "https://zfnd.org/zebra/"
 keywords = ["zebra", "zcash"]
-rust-version = "1.85.0"
+rust-version = "1.85.1"
 edition = "2021"
 
 # `cargo release` settings

--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.0] - PLANNED
+
+### Breaking changes
+
+- Migrated to `zcash_primitives 0.27`.
+
 ## [6.0.1] - 2026-03-26
 
 This release fixes an important security issue:
@@ -21,7 +27,6 @@ update.
 ### Fixed
 
 - Fixed miner subsidy computation.
-
 
 ## [6.0.0] - 2026-03-12
 

--- a/zebra-chain/src/block/height.rs
+++ b/zebra-chain/src/block/height.rs
@@ -2,7 +2,7 @@
 
 use std::ops::{Add, Sub};
 use thiserror::Error;
-use zcash_primitives::consensus::BlockHeight;
+use zcash_protocol::consensus::BlockHeight;
 
 use crate::{serialization::SerializationError, BoxError};
 

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -66,9 +66,9 @@ impl NetworkKind {
     /// pay-to-public-key-hash payment addresses for the network.
     pub fn b58_pubkey_address_prefix(self) -> [u8; 2] {
         match self {
-            Self::Mainnet => zcash_primitives::constants::mainnet::B58_PUBKEY_ADDRESS_PREFIX,
+            Self::Mainnet => zcash_protocol::constants::mainnet::B58_PUBKEY_ADDRESS_PREFIX,
             Self::Testnet | Self::Regtest => {
-                zcash_primitives::constants::testnet::B58_PUBKEY_ADDRESS_PREFIX
+                zcash_protocol::constants::testnet::B58_PUBKEY_ADDRESS_PREFIX
             }
         }
     }
@@ -77,9 +77,9 @@ impl NetworkKind {
     /// payment addresses for the network.
     pub fn b58_script_address_prefix(self) -> [u8; 2] {
         match self {
-            Self::Mainnet => zcash_primitives::constants::mainnet::B58_SCRIPT_ADDRESS_PREFIX,
+            Self::Mainnet => zcash_protocol::constants::mainnet::B58_SCRIPT_ADDRESS_PREFIX,
             Self::Testnet | Self::Regtest => {
-                zcash_primitives::constants::testnet::B58_SCRIPT_ADDRESS_PREFIX
+                zcash_protocol::constants::testnet::B58_SCRIPT_ADDRESS_PREFIX
             }
         }
     }

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -198,11 +198,11 @@ impl fmt::Display for ConsensusBranchId {
     }
 }
 
-impl TryFrom<ConsensusBranchId> for zcash_primitives::consensus::BranchId {
+impl TryFrom<ConsensusBranchId> for zcash_protocol::consensus::BranchId {
     type Error = crate::Error;
 
     fn try_from(id: ConsensusBranchId) -> Result<Self, Self::Error> {
-        zcash_primitives::consensus::BranchId::try_from(u32::from(id))
+        zcash_protocol::consensus::BranchId::try_from(u32::from(id))
             .map_err(|_| Self::Error::InvalidConsensusBranchId)
     }
 }

--- a/zebra-chain/src/primitives/address.rs
+++ b/zebra-chain/src/primitives/address.rs
@@ -3,7 +3,7 @@
 //! Usage: <https://docs.rs/zcash_address/0.2.0/zcash_address/trait.TryFromAddress.html#examples>
 
 use zcash_address::unified::{self, Container};
-use zcash_primitives::consensus::NetworkType;
+use zcash_protocol::consensus::NetworkType;
 
 use crate::{parameters::NetworkKind, transparent, BoxError};
 

--- a/zebra-chain/src/transparent/address.rs
+++ b/zebra-chain/src/transparent/address.rs
@@ -142,12 +142,12 @@ impl std::str::FromStr for Address {
         hash_bytes.copy_from_slice(&payload);
 
         match hrp.as_str() {
-            zcash_primitives::constants::mainnet::HRP_TEX_ADDRESS => Ok(Address::Tex {
+            zcash_protocol::constants::mainnet::HRP_TEX_ADDRESS => Ok(Address::Tex {
                 network_kind: NetworkKind::Mainnet,
                 validating_key_hash: hash_bytes,
             }),
 
-            zcash_primitives::constants::testnet::HRP_TEX_ADDRESS => Ok(Address::Tex {
+            zcash_protocol::constants::testnet::HRP_TEX_ADDRESS => Ok(Address::Tex {
                 network_kind: NetworkKind::Testnet,
                 validating_key_hash: hash_bytes,
             }),
@@ -196,25 +196,25 @@ impl ZcashDeserialize for Address {
         reader.read_exact(&mut hash_bytes)?;
 
         match version_bytes {
-            zcash_primitives::constants::mainnet::B58_SCRIPT_ADDRESS_PREFIX => {
+            zcash_protocol::constants::mainnet::B58_SCRIPT_ADDRESS_PREFIX => {
                 Ok(Address::PayToScriptHash {
                     network_kind: NetworkKind::Mainnet,
                     script_hash: hash_bytes,
                 })
             }
-            zcash_primitives::constants::testnet::B58_SCRIPT_ADDRESS_PREFIX => {
+            zcash_protocol::constants::testnet::B58_SCRIPT_ADDRESS_PREFIX => {
                 Ok(Address::PayToScriptHash {
                     network_kind: NetworkKind::Testnet,
                     script_hash: hash_bytes,
                 })
             }
-            zcash_primitives::constants::mainnet::B58_PUBKEY_ADDRESS_PREFIX => {
+            zcash_protocol::constants::mainnet::B58_PUBKEY_ADDRESS_PREFIX => {
                 Ok(Address::PayToPublicKeyHash {
                     network_kind: NetworkKind::Mainnet,
                     pub_key_hash: hash_bytes,
                 })
             }
-            zcash_primitives::constants::testnet::B58_PUBKEY_ADDRESS_PREFIX => {
+            zcash_protocol::constants::testnet::B58_PUBKEY_ADDRESS_PREFIX => {
                 Ok(Address::PayToPublicKeyHash {
                     network_kind: NetworkKind::Testnet,
                     pub_key_hash: hash_bytes,

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.0] - PLANNED
+
+### Breaking changes
+
+- Migrated to `zcash_primitives 0.27`.
+
 ## [6.0.1] - 2026-03-26
 
 ### Fixed

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -59,7 +59,7 @@ use tower::ServiceExt;
 use tracing::Instrument;
 
 use zcash_address::{unified::Encoding, TryFromAddress};
-use zcash_primitives::consensus::Parameters;
+use zcash_protocol::consensus::Parameters;
 
 use zebra_chain::{
     amount::{Amount, NegativeAllowed},
@@ -1882,7 +1882,7 @@ where
         let time = u32::try_from(block.header.time.timestamp())
             .expect("Timestamps of valid blocks always fit into u32.");
 
-        let sapling_nu = zcash_primitives::consensus::NetworkUpgrade::Sapling;
+        let sapling_nu = zcash_protocol::consensus::NetworkUpgrade::Sapling;
         let sapling = if network.is_nu_active(sapling_nu, height.into()) {
             match read_state
                 .ready()
@@ -1903,7 +1903,7 @@ where
         let (sapling_tree, sapling_root) =
             sapling.map_or((None, None), |(tree, root)| (Some(tree), Some(root)));
 
-        let orchard_nu = zcash_primitives::consensus::NetworkUpgrade::Nu5;
+        let orchard_nu = zcash_protocol::consensus::NetworkUpgrade::Nu5;
         let orchard = if network.is_nu_active(orchard_nu, height.into()) {
             match read_state
                 .ready()

--- a/zebra-script/CHANGELOG.md
+++ b/zebra-script/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0] - PLANNED
+
+### Breaking changes
+
+- Migrated to `zcash_primitives 0.27`.
+
 ## [5.0.0] - 2026-03-12
 
 - `zebra-chain` was bumped to `6.0.0`


### PR DESCRIPTION
## Motivation

Prepare for the next `zcash_primitives` etc. stack release.

## Solution

Update to the current state of the librustzcash repo for testing purposes, then migrate to the final published crates before merging the PR.

### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [x] No AI tools were used in this PR
- [ ] AI tools were used: <!-- tool name and what it was used for, e.g., "Claude for test boilerplate" -->

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
