### PR TITLE
chore: Release Zebra v4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [Zebra 4.3](https://github.com/ZcashFoundation/zebra/releases/tag/v4.3) - 2026-03-12
+
+This release adds support for [ZIP-235](https://zips.z.cash/zip-0235) and
+extends the documentation on performance profiling. It also fixes issues with
+block propagation on Regtest, the computation of miner rewards for pre-Canopy
+blocks in the `getblocksubsidy` RPC, and a performance regression on Testnet
+where Zebra would hog a single CPU thread.
+
+### Added
+
+- Network Sustainability Mechanism: ZIP-235 ([#10357](https://github.com/ZcashFoundation/zebra/pull/10357))
+- Add `profiling` Cargo profile and use it in profiling docs ([#10411](https://github.com/ZcashFoundation/zebra/pull/10411))
+
+### Fixed
+
+- Fix block propagation on Regtest ([#10403](https://github.com/ZcashFoundation/zebra/pull/10403))
+- Subtract Founders' Reward from block subsidy ([#10338](https://github.com/ZcashFoundation/zebra/pull/10338))
+- Cache parsed checkpoints ([#10409](https://github.com/ZcashFoundation/zebra/pull/10409))
+
+### Contributors
+
+Thank you to everyone who contributed to this release, we couldn't make Zebra without you:
+@gustavovalverde, @judah-caruso, @nuttycom, @oxarbitrage and @upbqdn.
+
 ## [Zebra 4.2.0](https://github.com/ZcashFoundation/zebra/releases/tag/v4.2.0) - 2026-03-12
 
 This release expands Zebra’s RPC functionality, improves mempool policy,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7253,7 +7253,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "bech32",
  "bitflags 2.11.0",
@@ -7323,7 +7323,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-consensus"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7426,7 +7426,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/book/src/dev/ecc-updates.md
+++ b/book/src/dev/ecc-updates.md
@@ -1,6 +1,6 @@
 # Updating the ECC dependencies
 
-Zebra relies on numerous Electric Coin Company ([ECC](https://electriccoin.co/)) dependencies, and updating them can be a complex task. This guide will help you navigate the process.
+Zebra relies on numerous dependencies maintained by ZODL, and updating them can be a complex task. This guide will help you navigate the process.
 
 The main dependency that influences that is [zcash](https://github.com/zcash/zcash) itself. This is because [zebra_script](https://github.com/ZcashFoundation/zcash_script) links to specific files from it (zcash_script.cpp and all on which it depends). Due to the architecture of zcash, this requires linking to a lot of seemingly unrelated dependencies like orchard, halo2, etc (which are all Rust crates).
 

--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.1] - 2026-03-26
+
+### Fixed
+
+- Fixed miner subsidy computation.
+
+
 ## [6.0.0] - 2026-03-12
 
 ### Breaking Changes

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-chain"
-version = "6.0.0"
+version = "6.0.1"
 authors.workspace = true
 description = "Core Zcash data structures"
 license.workspace = true

--- a/zebra-chain/src/parameters/network/subsidy.rs
+++ b/zebra-chain/src/parameters/network/subsidy.rs
@@ -397,6 +397,7 @@ pub enum SubsidyError {
     #[error("invalid amount")]
     InvalidAmount(#[from] amount::Error),
 
+    #[cfg(zcash_unstable = "zip235")]
     #[error("invalid zip233 amount")]
     InvalidZip233Amount,
 }

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.1] - 2026-03-25
+
+### Added
+
+- ZIP-235 support under the `zcash_unstable = "zip235"` flag
+
 ## [5.0.0] - 2026-03-12
 
 ### Added

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-consensus"
-version = "5.0.0"
+version = "5.0.1"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks"
 license.workspace = true
@@ -65,7 +65,7 @@ tower-batch-control = { path = "../tower-batch-control/", version = "1.0.1" }
 zebra-script = { path = "../zebra-script", version = "5.0.0" }
 zebra-state = { path = "../zebra-state", version = "5.0.0" }
 zebra-node-services = { path = "../zebra-node-services", version = "4.0.0" }
-zebra-chain = { path = "../zebra-chain", version = "6.0.0" }
+zebra-chain = { path = "../zebra-chain", version = "6.0.1" }
 
 zcash_protocol.workspace = true
 
@@ -90,7 +90,7 @@ tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 zebra-state = { path = "../zebra-state", version = "5.0.0", features = ["proptest-impl"] }
-zebra-chain = { path = "../zebra-chain", version = "6.0.0", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "6.0.1", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/", version = "3.0.0" }
 
 [lints]

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -325,10 +325,14 @@ pub fn miner_fees_are_valid(
     let orchard_value_balance = coinbase_tx.orchard_value_balance().orchard_amount();
 
     // Coinbase transaction can still have a NSM deposit
+    #[cfg(zcash_unstable = "zip235")]
     let zip233_amount: Amount<NegativeAllowed> = coinbase_tx
         .zip233_amount()
         .constrain()
         .map_err(|_| SubsidyError::InvalidZip233Amount)?;
+
+    #[cfg(not(zcash_unstable = "zip235"))]
+    let zip233_amount = Amount::zero();
 
     #[cfg(zcash_unstable = "zip235")]
     if let Some(nsm_activation_height) = NetworkUpgrade::Nu7.activation_height(network) {

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -85,7 +85,7 @@ howudoin = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "6.0.0", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "6.0.1", features = ["async-error"] }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -31,7 +31,7 @@ rpc-client = [
 ]
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain" , version = "6.0.0" }
+zebra-chain = { path = "../zebra-chain" , version = "6.0.1" }
 tower = { workspace = true }
 
 # Optional dependencies

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.1] - 2026-03-26
+
+### Fixed
+
+- Fixed the computation of miner rewards in `getblocksubsidy` RPC
+
 ## [6.0.0] - 2026-03-12
 
 ### Breaking Changes

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-rpc"
-version = "6.0.0"
+version = "6.0.1"
 authors.workspace = true
 description = "A Zebra JSON Remote Procedure Call (JSON-RPC) interface"
 license.workspace = true
@@ -103,10 +103,10 @@ sapling-crypto = { workspace = true }
 # Test-only feature proptest-impl
 proptest = { workspace = true, optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "6.0.0", features = [
+zebra-chain = { path = "../zebra-chain", version = "6.0.1", features = [
     "json-conversion",
 ] }
-zebra-consensus = { path = "../zebra-consensus", version = "5.0.0" }
+zebra-consensus = { path = "../zebra-consensus", version = "5.0.1" }
 zebra-network = { path = "../zebra-network", version = "5.0.0" }
 zebra-node-services = { path = "../zebra-node-services", version = "4.0.0", features = [
     "rpc-client",
@@ -127,10 +127,10 @@ proptest = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zebra-chain = { path = "../zebra-chain", version = "6.0.0", features = [
+zebra-chain = { path = "../zebra-chain", version = "6.0.1", features = [
     "proptest-impl",
 ] }
-zebra-consensus = { path = "../zebra-consensus", version = "5.0.0", features = [
+zebra-consensus = { path = "../zebra-consensus", version = "5.0.1", features = [
     "proptest-impl",
 ] }
 zebra-network = { path = "../zebra-network", version = "5.0.0", features = [

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -26,7 +26,7 @@ comparison-interpreter = []
 libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
-zebra-chain = { path = "../zebra-chain", version = "6.0.0" }
+zebra-chain = { path = "../zebra-chain", version = "6.0.1" }
 
 thiserror = { workspace = true }
 

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -79,7 +79,7 @@ elasticsearch = { workspace = true, features = ["rustls-tls"], optional = true }
 serde_json = { workspace = true, optional = true }
 
 zebra-node-services = { path = "../zebra-node-services", version = "4.0.0" }
-zebra-chain = { path = "../zebra-chain", version = "6.0.0", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "6.0.1", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { workspace = true, optional = true }
@@ -109,7 +109,7 @@ jubjub = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zebra-chain = { path = "../zebra-chain", version = "6.0.0", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "6.0.1", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/", version = "3.0.0" }
 
 [lints]

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -61,10 +61,10 @@ tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 
 zebra-node-services = { path = "../zebra-node-services", version = "4.0.0" }
-zebra-chain = { path = "../zebra-chain", version = "6.0.0" }
+zebra-chain = { path = "../zebra-chain", version = "6.0.1" }
 
 # These crates are needed for the block-template-to-proposal binary
-zebra-rpc = { path = "../zebra-rpc", version = "6.0.0" }
+zebra-rpc = { path = "../zebra-rpc", version = "6.0.1" }
 
 # These crates are needed for the zebra-checkpoints binary
 itertools = { workspace = true, optional = true }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -150,11 +150,11 @@ tx_v6 = ["zebra-chain/tx_v6", "zebra-state/tx_v6", "zebra-consensus/tx_v6", "zeb
 comparison-interpreter = ["zebra-script/comparison-interpreter"]
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain", version = "6.0.0" }
-zebra-consensus = { path = "../zebra-consensus", version = "5.0.0" }
+zebra-chain = { path = "../zebra-chain", version = "6.0.1" }
+zebra-consensus = { path = "../zebra-consensus", version = "5.0.1" }
 zebra-network = { path = "../zebra-network", version = "5.0.0" }
 zebra-node-services = { path = "../zebra-node-services", version = "4.0.0", features = ["rpc-client"] }
-zebra-rpc = { path = "../zebra-rpc", version = "6.0.0" }
+zebra-rpc = { path = "../zebra-rpc", version = "6.0.1" }
 zebra-state = { path = "../zebra-state", version = "5.0.0" }
 # zebra-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
@@ -293,8 +293,8 @@ proptest-derive = { workspace = true }
 # enable span traces and track caller in tests
 color-eyre = { workspace = true }
 
-zebra-chain = { path = "../zebra-chain", version = "6.0.0", features = ["proptest-impl"] }
-zebra-consensus = { path = "../zebra-consensus", version = "5.0.0", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "6.0.1", features = ["proptest-impl"] }
+zebra-consensus = { path = "../zebra-consensus", version = "5.0.1", features = ["proptest-impl"] }
 zebra-network = { path = "../zebra-network", version = "5.0.0", features = ["proptest-impl"] }
 zebra-state = { path = "../zebra-state", version = "5.0.0", features = ["proptest-impl"] }
 

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_271_000;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_286_000;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.


### PR DESCRIPTION
---
name: "Release Checklist Template"
about: "Checklist to create and publish a Zebra release"
title: "Release Zebra (version)"
labels: "A-release, C-exclude-from-changelog, P-Critical :ambulance:"
assignees: ""
---

# Prepare for the Release

- [x] Make sure there has been [at least one successful full sync test in the main branch](https://github.com/ZcashFoundation/zebra/actions/workflows/zfnd-ci-integration-tests-gcp.yml?query=branch%3Amain) since the last state change, or start a manual full sync.

# Checkpoints

For performance and security, we want to update the Zebra checkpoints in every release.

- [x] You can copy the latest checkpoints from CI by following [the zebra-checkpoints README](https://github.com/ZcashFoundation/zebra/blob/main/zebra-utils/README.md#zebra-checkpoints).

# Missed Dependency Updates

Sometimes `dependabot` misses some dependency updates, or we accidentally turned them off.

This step can be skipped if there is a large pending dependency upgrade. (For example, shared ECC crates.)

Here's how we make sure we got everything:

- [x] Run `cargo update` on the latest `main` branch, and keep the output
- [x] Until we bump the MSRV to 1.88 or higher, `home` must be downgraded manually: `cargo update home@0.5.12 --precise 0.5.11`
- [x] If needed, [add duplicate dependency exceptions to deny.toml](https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/continuous-integration.md#fixing-duplicate-dependencies-in-check-denytoml-bans)
- [x] If needed, remove resolved duplicate dependencies from `deny.toml`
- [x] Open a separate PR with the changes
- [x] Add the output of `cargo update` to that PR as a comment

# Summarise Release Changes

These steps can be done a few days before the release, in the same PR:

## Change Log

**Important**: Any merge into `main` deletes any edits to the draft changelog.
Once you are ready to tag a release, copy the draft changelog into `CHANGELOG.md`.

We use [the Release Drafter workflow](https://github.com/marketplace/actions/release-drafter) to automatically create a [draft changelog](https://github.com/ZcashFoundation/zebra/releases). We follow the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.

To create the final change log:

- [x] Copy the [**latest** draft
      changelog](https://github.com/ZcashFoundation/zebra/releases) into
      `CHANGELOG.md` (there can be multiple draft releases)
- [x] Delete any trivial changes
  - [x] Put the list of deleted changelog entries in a PR comment to make reviewing easier
- [x] Combine duplicate changes
- [x] Edit change descriptions so they will make sense to Zebra users
- [x] Check the category for each change
  - Prefer the "Fix" category if you're not sure

## README

README updates can be skipped for urgent releases.

Update the README to:

- [x] Remove any "Known Issues" that have been fixed since the last release.
- [x] Update the "Build and Run Instructions" with any new dependencies.
      Check for changes in the `Dockerfile` since the last tag: `git diff <previous-release-tag> docker/Dockerfile`.
- [x] If Zebra has started using newer Rust language features or standard library APIs, update the known working Rust version in the README, book, and `Cargo.toml`s

You can use a command like:

```sh
fastmod --fixed-strings '1.58' '1.65'
```

## Create the Release PR

- [x] Push the updated changelog and README into a new branch
      for example: `bump-v1.0.0` - this needs to be different to the tag name
- [x] Create a release PR by adding `&template=release-checklist.md` to the comparing url ([Example](https://github.com/ZcashFoundation/zebra/compare/bump-v1.0.0?expand=1&template=release-checklist.md)).
- [x] Freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [x] Mark all the release PRs as `Critical` priority, so they go in the `urgent` Mergify queue.
- [x] Mark all non-release PRs with `do-not-merge`, because Mergify checks approved PRs against every commit, even when a queue is frozen.
- [x] Add the `A-release` tag to the release pull request in order for the `check-no-git-dependencies` to run.

## Zebra git sources dependencies

- [ ] Ensure the `check-no-git-dependencies` check passes.

This check runs automatically on pull requests with the `A-release` label. It must pass for crates to be published to crates.io. If the check fails, you should either halt the release process or proceed with the understanding that the crates will not be published on crates.io.

# Update Versions and End of Support

## Update Zebra Version

Zebra follows [semantic versioning](https://semver.org). Semantic versions look like: MAJOR.MINOR.PATCH[-TAG.PRE-RELEASE]

Choose a release level for `zebrad`. Release levels are based on user-visible changes from the changelog:

- Mainnet Network Upgrades are `major` releases
- significant new features or behaviour changes; changes to RPCs, command-line, or configs; and deprecations or removals are `minor` releases
- otherwise, it is a `patch` release

## Update Crate Versions and Crate Change Logs

If you're publishing crates for the first time, [log in to crates.io](https://zebra.zfnd.org/dev/crate-owners.html#logging-in-to-cratesio),
and make sure you're a member of owners group.

Check that the release will work:

- [x] Determine which crates require release. Run `git diff --stat <previous_tag>`
      and enumerate the crates that had changes.
- [x] Update (or install) `semver-checks`: `cargo +stable install cargo-semver-checks --locked`
- [x] Update (or install) `public-api`: `cargo +stable install cargo-public-api --locked`
- [x] For each crate that requires a release:
  - [x] Determine which type of release to make. Run `semver-checks` to list API
        changes: `cargo semver-checks -p <crate> --default-features`. If there are
        breaking API changes, do a major release, or try to revert the API change
        if it was accidental. Otherwise do a minor or patch release depending on
        whether a new API was added. Note that `semver-checks` won't work
        if the previous realase was yanked; you will have to determine the
        type of release manually.
  - [x] Update the crate `CHANGELOG.md` listing the API changes or other
        relevant information for a crate consumer. Use `public-api` to list all
        API changes: `cargo public-api diff latest -p <crate> -sss`. You can use
        e.g. copilot to turn it into a human-readable list, e.g. (write the output
        to `api.txt` beforehand):
        ```
        copilot -p "Transform @api.txt which is a API diff into a human-readable description of the API changes. Be terse. Write output api-readable.txt. Use backtick quotes for identifiers. Use '### Breaking Changes' header for changes and removals, and '### Added' for additions. Make each item start with a verb e.g, Added, Changed" --allow-tool write
        ```
        It might also make sense to copy entries from the `zebrad` changelog.
  - [x] Update crate versions:

```sh
cargo release version --verbose --execute --allow-branch '*' -p <crate> patch # [ major | minor ]
cargo release replace --verbose --execute --allow-branch '*' -p <crate>
```

- [x] Commit and push the above version changes to the release branch.

## Update End of Support

The end of support height is calculated from the current blockchain height:

- [x] Find where the Zcash blockchain tip is now by using a [Zcash Block Explorer](https://mainnet.zcashexplorer.app/) or other tool.
- [x] Replace `ESTIMATED_RELEASE_HEIGHT` in [`end_of_support.rs`](https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/sync/end_of_support.rs) with the height you estimate the release will be tagged.

<details>

<summary>Optional: calculate the release tagging height</summary>

- Find where the Zcash blockchain tip is now by using a [Zcash Block Explorer](https://mainnet.zcashexplorer.app/) or other tool.
- Add `1152` blocks for each day until the release
- For example, if the release is in 3 days, add `1152 * 3` to the current Mainnet block height

</details>

## Update the Release PR

- [x] Push the version increments and the release constants to the release branch.

# Publish the Zebra Release

## Create the GitHub Pre-Release

- [x] Wait for all the release PRs to be merged
- [x] Create a new release using the draft release as a base, by clicking the Edit icon in the [draft release](https://github.com/ZcashFoundation/zebra/releases)
- [x] Set the tag name to the version tag,
      for example: `v1.0.0`
- [x] Set the release to target the `main` branch
- [x] Set the release title to `Zebra ` followed by the version tag,
      for example: `Zebra 1.0.0`
- [x] Replace the prepopulated draft changelog in the release description with the final changelog you created;
      starting just _after_ the title `## [Zebra ...` of the current version being released,
      and ending just _before_ the title of the previous release.
- [x] Mark the release as 'pre-release', until it has been built and tested
- [x] Publish the pre-release to GitHub using "Publish Release"
- [x] Delete all the [draft releases from the list of releases](https://github.com/ZcashFoundation/zebra/releases)

## Test the Pre-Release

- [ ] Wait until the Docker binaries have been built on `main`, and the quick tests have passed:
  - [ ] [zfnd-ci-integration-tests-gcp.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/zfnd-ci-integration-tests-gcp.yml?query=branch%3Amain)
- [ ] Wait until the [pre-release deployment machines have successfully launched](https://github.com/ZcashFoundation/zebra/actions/workflows/zfnd-deploy-nodes-gcp.yml?query=event%3Arelease)

## Publish Release

- [x] [Publish the release to GitHub](https://github.com/ZcashFoundation/zebra/releases) by disabling 'pre-release', then clicking "Set as the latest release"

## Publish Crates

- [x] [Run `cargo login`](https://zebra.zfnd.org/dev/crate-owners.html#logging-in-to-cratesio)
- [ ] It is recommended that the following step be run from a fresh checkout of
      the repo, to avoid accidentally publishing files like e.g. logs that might
      be lingering around
- [ ] Publish the crates to crates.io; edit the list to only include the crates that
      have been changed, but keep their overall order:

```
for c in zebra-test tower-fallback zebra-chain tower-batch-control zebra-node-services zebra-script zebra-state zebra-consensus zebra-network zebra-rpc zebra-utils zebrad; do cargo release publish --verbose --execute -p $c; done
```

- [ ] Check that Zebra can be installed from `crates.io`:
      `cargo install --locked --force --version <version> zebrad && ~/.cargo/bin/zebrad`
      and put the output in a comment on the PR.

## Publish Docker Images

- [ ] Wait for the [the Docker images to be published successfully](https://github.com/ZcashFoundation/zebra/actions/workflows/release-binaries.yml?query=event%3Arelease).
- [ ] Wait for the new tag in the [dockerhub zebra space](https://hub.docker.com/r/zfnd/zebra/tags)
- [ ] Un-freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [ ] Remove `do-not-merge` from the PRs you added it to

## Release Failures

If building or running fails after tagging:

<details>

<summary>Tag a new release, following these instructions...</summary>

1. Fix the bug that caused the failure
2. Start a new `patch` release
3. Skip the **Release Preparation**, and start at the **Release Changes** step
4. Update `CHANGELOG.md` with details about the fix
5. Follow the release checklist for the new Zebra version

</details>
