### PR TITLE
 refactor(zebra-consensus): remove remaining groth16 abstractions after Sapling migration

### DIFF
--- a/zebra-consensus/benches/groth16.rs
+++ b/zebra-consensus/benches/groth16.rs
@@ -22,7 +22,7 @@ use zebra_chain::{
     sprout::JoinSplit,
 };
 
-use zebra_consensus::groth16::{Description, DescriptionWrapper, Item, SPROUT};
+use zebra_consensus::groth16::{Item, SPROUT};
 
 /// A Sprout JoinSplit paired with its transaction's JoinSplit public key,
 /// ready to be converted into a Groth16 verification [`Item`].
@@ -73,9 +73,7 @@ fn extract_joinsplit_sources() -> Vec<JoinSplitSource> {
 
 /// Converts a [`JoinSplitSource`] into a verification [`Item`].
 fn item_from(source: &JoinSplitSource) -> Item {
-    DescriptionWrapper(&(&source.joinsplit, &source.pub_key))
-        .try_into()
-        .expect("valid groth16 item")
+    Item::from_joinsplit(&source.joinsplit, &source.pub_key).expect("valid groth16 item")
 }
 
 fn bench_groth16_verify(c: &mut Criterion) {
@@ -114,14 +112,6 @@ fn bench_groth16_inputs(c: &mut Criterion) {
     let source = sources.first().expect("at least one JoinSplit source");
 
     let mut group = c.benchmark_group("Groth16 Input Preparation");
-
-    // Cost of computing h_sig and encoding primary inputs as BLS12-381 scalars.
-    group.bench_function("primary_inputs", |b| {
-        b.iter(|| {
-            let description: (&JoinSplit<Groth16Proof>, &_) = (&source.joinsplit, &source.pub_key);
-            description.primary_inputs()
-        })
-    });
 
     // Cost of Proof::read (192 bytes) + primary input computation, i.e. the
     // full Item construction that runs before verification.

--- a/zebra-consensus/benches/sapling.rs
+++ b/zebra-consensus/benches/sapling.rs
@@ -37,8 +37,8 @@ use zebra_chain::{
 };
 
 use sapling_crypto::{bundle::Authorized, BatchValidator, Bundle};
+use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::value::ZatBalance;
-use zebra_consensus::groth16::SAPLING;
 
 /// A Sapling bundle paired with its transaction sighash, ready for verification.
 #[derive(Clone)]
@@ -98,7 +98,8 @@ fn extract_sapling_items_from_blocks() -> Vec<SaplingItem> {
 }
 
 fn bench_sapling_verify(c: &mut Criterion) {
-    let (spend_vk, output_vk) = SAPLING.verifying_keys();
+    let sapling = LocalTxProver::bundled();
+    let (spend_vk, output_vk) = sapling.verifying_keys();
     let source_items = extract_sapling_items_from_blocks();
 
     let mut group = c.benchmark_group("groth16_sapling");

--- a/zebra-consensus/src/primitives/groth16.rs
+++ b/zebra-consensus/src/primitives/groth16.rs
@@ -1,4 +1,4 @@
-//! Async Groth16 batch verifier service
+//! Async Groth16 verifier service for Sprout JoinSplit proofs
 
 use std::fmt;
 
@@ -35,7 +35,7 @@ mod tests;
 #[cfg(test)]
 mod vectors;
 
-pub use params::{SAPLING, SPROUT};
+pub use params::SPROUT;
 
 use crate::error::TransactionError;
 
@@ -101,15 +101,6 @@ pub static JOINSPLIT_VERIFIER: Lazy<
     )
 });
 
-/// A Groth16 Description (JoinSplit, Spend, or Output) with a Groth16 proof
-/// and its inputs encoded as scalars.
-pub trait Description {
-    /// The Groth16 proof of this description.
-    fn proof(&self) -> &Groth16Proof;
-    /// The primary inputs for this proof, encoded as [`jubjub::Fq`] scalars.
-    fn primary_inputs(&self) -> Vec<jubjub::Fq>;
-}
-
 /// Compute the [h_{Sig} hash function][1] which is used in JoinSplit descriptions.
 ///
 /// `random_seed`: the random seed from the JoinSplit description.
@@ -139,7 +130,10 @@ pub(super) fn h_sig(
     h_sig
 }
 
-impl Description for (&JoinSplit<Groth16Proof>, &ed25519::VerificationKeyBytes) {
+impl Item {
+    /// Converts a Sprout JoinSplit description and its associated public key into a
+    /// Groth16 verification [`Item`].
+    ///
     /// Encodes the primary input for the JoinSplit proof statement as Bls12_381 base
     /// field elements, to match [`bellman::groth16::verify_proof()`].
     ///
@@ -151,12 +145,12 @@ impl Description for (&JoinSplit<Groth16Proof>, &ed25519::VerificationKeyBytes) 
     /// This is not yet officially documented; see the reference implementation:
     /// <https://github.com/zcash/librustzcash/blob/0ec7f97c976d55e1a194a37b27f247e8887fca1d/zcash_proofs/src/sprout.rs#L152-L166>
     /// <https://zips.z.cash/protocol/protocol.pdf#joinsplitdesc>
-    //
     // The borrows are actually needed to avoid taking ownership
     #[allow(clippy::needless_borrow)]
-    fn primary_inputs(&self) -> Vec<jubjub::Fq> {
-        let (joinsplit, joinsplit_pub_key) = self;
-
+    pub fn from_joinsplit(
+        joinsplit: &JoinSplit<Groth16Proof>,
+        joinsplit_pub_key: &ed25519::VerificationKeyBytes,
+    ) -> Result<Self, TransactionError> {
         let rt: [u8; 32] = joinsplit.anchor.into();
         let mac1: [u8; 32] = (&joinsplit.vmacs[0]).into();
         let mac2: [u8; 32] = (&joinsplit.vmacs[1]).into();
@@ -188,27 +182,8 @@ impl Description for (&JoinSplit<Groth16Proof>, &ed25519::VerificationKeyBytes) 
         public_input.extend(vpub_new);
 
         let public_input = multipack::bytes_to_bits(&public_input);
+        let primary_inputs = multipack::compute_multipacking(&public_input);
 
-        multipack::compute_multipacking(&public_input)
-    }
-
-    fn proof(&self) -> &Groth16Proof {
-        &self.0.zkproof
-    }
-}
-
-/// A wrapper to allow a TryFrom blanket implementation of the [`Description`]
-/// trait for the [`Item`] struct.
-/// See <https://github.com/rust-lang/rust/issues/50133> for more details.
-pub struct DescriptionWrapper<T>(pub T);
-
-impl<T> TryFrom<DescriptionWrapper<&T>> for Item
-where
-    T: Description,
-{
-    type Error = TransactionError;
-
-    fn try_from(input: DescriptionWrapper<&T>) -> Result<Self, Self::Error> {
         // # Consensus
         //
         // > Elements of a JoinSplit description MUST have the types given above
@@ -217,11 +192,10 @@ where
         //
         // This validates the 𝜋_{ZKJoinSplit} element. In #3179 we plan to validate
         // during deserialization, see [`JoinSplit::zcash_deserialize`].
-        Ok(Item::from((
-            bellman::groth16::Proof::read(&input.0.proof().0[..])
-                .map_err(|e| TransactionError::MalformedGroth16(e.to_string()))?,
-            input.0.primary_inputs(),
-        )))
+        let proof = bellman::groth16::Proof::read(&joinsplit.zkproof.0[..])
+            .map_err(|e| TransactionError::MalformedGroth16(e.to_string()))?;
+
+        Ok(Item::from((proof, primary_inputs)))
     }
 }
 

--- a/zebra-consensus/src/primitives/groth16/params.rs
+++ b/zebra-consensus/src/primitives/groth16/params.rs
@@ -1,19 +1,10 @@
-//! Loading and checking correctness of Groth16 Sapling and Sprout parameters.
+//! Loading and checking correctness of Groth16 Sprout parameters.
 
 use bellman::groth16::{prepare_verifying_key, PreparedVerifyingKey, VerifyingKey};
 use bls12_381::Bls12;
 use derive_getters::Getters;
-use zcash_proofs::prover::LocalTxProver;
 
 lazy_static::lazy_static! {
-    /// Sapling prover containing spend and output params for the Sapling circuit.
-    ///
-    /// Used to:
-    ///
-    /// - construct Sapling outputs in coinbase txs, and
-    /// - verify Sapling shielded data in the tx verifier.
-    pub static ref SAPLING: LocalTxProver = LocalTxProver::bundled();
-
     /// Spend parameters for the Sprout circuit.
     ///
     /// Used to verify Sprout shielded data in transactions.

--- a/zebra-consensus/src/primitives/groth16/tests.rs
+++ b/zebra-consensus/src/primitives/groth16/tests.rs
@@ -41,8 +41,7 @@ where
                 .sprout_joinsplit_pub_key()
                 .expect("pub key must exist since there are joinsplits");
             let joinsplit_rsp = verifier.ready().await?.call(
-                DescriptionWrapper(&(joinsplit, &pub_key))
-                    .try_into()
+                Item::from_joinsplit(joinsplit, &pub_key)
                     .map_err(tower_fallback::BoxedError::from)?,
             );
 
@@ -104,11 +103,10 @@ where
 
     tracing::trace!(?joinsplit);
 
-    let joinsplit_rsp = verifier.ready().await?.call(
-        DescriptionWrapper(&(joinsplit, pub_key))
-            .try_into()
-            .map_err(tower_fallback::BoxedError::from)?,
-    );
+    let joinsplit_rsp = verifier
+        .ready()
+        .await?
+        .call(Item::from_joinsplit(joinsplit, pub_key).map_err(tower_fallback::BoxedError::from)?);
 
     async_checks.push(joinsplit_rsp);
 
@@ -225,8 +223,7 @@ where
             // which will make the verification fail.
             let modified_pub_key = [0x42; 32].into();
             let joinsplit_rsp = verifier.ready().await?.call(
-                DescriptionWrapper(&(joinsplit, &modified_pub_key))
-                    .try_into()
+                Item::from_joinsplit(joinsplit, &modified_pub_key)
                     .map_err(tower_fallback::BoxedError::from)?,
             );
 

--- a/zebra-consensus/src/primitives/sapling.rs
+++ b/zebra-consensus/src/primitives/sapling.rs
@@ -17,10 +17,17 @@ use tower_batch_control::{Batch, BatchControl, RequestWeight};
 use tower_fallback::Fallback;
 
 use sapling_crypto::{bundle::Authorized, BatchValidator, Bundle};
+use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::value::ZatBalance;
 use zebra_chain::transaction::SigHash;
 
-use crate::groth16::SAPLING;
+/// Sapling prover containing spend and output params for the Sapling circuit.
+///
+/// Used to:
+///
+/// - construct Sapling outputs in coinbase txs, and
+/// - verify Sapling shielded data in the tx verifier.
+static SAPLING: Lazy<LocalTxProver> = Lazy::new(LocalTxProver::bundled);
 
 #[derive(Clone)]
 pub struct Item {
@@ -115,10 +122,10 @@ impl Service<BatchControl<Item>> for Verifier {
                             rx.borrow()
                                 .ok_or("threadpool unexpectedly dropped channel sender")?
                                 .then(|| {
-                                    metrics::counter!("proofs.groth16.verified").increment(1);
+                                    metrics::counter!("proofs.sapling.verified").increment(1);
                                 })
                                 .ok_or_else(|| {
-                                    metrics::counter!("proofs.groth16.invalid").increment(1);
+                                    metrics::counter!("proofs.sapling.invalid").increment(1);
                                     "batch verification of Sapling shielded data failed"
                                 })
                         })

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -41,7 +41,7 @@ use zebra_node_services::mempool;
 use zebra_script::{CachedFfiTransaction, Sigops};
 use zebra_state as zs;
 
-use crate::{error::TransactionError, groth16::DescriptionWrapper, primitives, script, BoxError};
+use crate::{error::TransactionError, primitives, script, BoxError};
 
 pub mod check;
 #[cfg(test)]
@@ -1036,7 +1036,7 @@ where
                 // checks that (at a minimum) must pass for the
                 // transaction to verify.
                 checks.push(primitives::groth16::JOINSPLIT_VERIFIER.oneshot(
-                    DescriptionWrapper(&(joinsplit, &joinsplit_data.pub_key)).try_into()?,
+                    primitives::groth16::Item::from_joinsplit(joinsplit, &joinsplit_data.pub_key)?,
                 ));
             }
 


### PR DESCRIPTION
## Motivation                                                                                                                                              
                                                                                                                                                             
Completes the cleanup started in #10052. After switching Sapling verification to `sapling_crypto::BatchValidator` (#9737, #9828), the `Description` trait  and `DescriptionWrapper` only served the Sprout JoinSplit case. This removes the over-general abstraction layer.

Closes #9891

## Solution

- Remove the `Description` trait and `DescriptionWrapper<T>` struct
- Replace with a direct `Item::from_joinsplit()` constructor that inlines proof parsing and primary input encoding
- Relocate `SAPLING` (`LocalTxProver`) static from `groth16/params.rs` to `sapling.rs` where it is actually used                                    
- Rename `proofs.groth16.verified/invalid` metrics to `proofs.sapling.verified/invalid` in the Sapling verifier

### Tests                                                                                    
  
- All existing groth16 tests pass (`verify_sprout_groth16`, `verify_sprout_groth16_vector`, `correctly_err_on_invalid_joinsplit_proof`, `h_sig_works`)
- `cargo clippy` and `cargo fmt` clean
- Full workspace builds without warnings   

### AI Disclosure

- [x] AI tools were used: Claude for research, implementation, and testing

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [ ] The documentation and changelogs are up to date.
