### PR TITLE
docs: add pre-Canopy consensus check audit

### DIFF
--- a/pre-canopy-check-audit.md
+++ b/pre-canopy-check-audit.md
@@ -1,0 +1,180 @@
+# Pre-Canopy Consensus Check Audit
+
+**Issue**: [#10184](https://github.com/ZcashFoundation/zebra/issues/10184)
+**Date**: 2026-03-30
+**Scope**: Consensus checks in `zebra-consensus`, `zebra-state`, and `zebra-chain` that are NOT enforced for pre-Canopy blocks
+
+## Background
+
+Zebra uses a mandatory checkpoint at the block just before Canopy activation (`zebra-chain/src/parameters/network.rs:256-263`). All blocks at or below this height are verified by the `CheckpointVerifier`, which validates (`zebra-consensus/src/checkpoint.rs:579-633`):
+
+- Block hash matches a hardcoded checkpoint (if a checkpoint exists at that height)
+- Block height is sequential (coinbase height extraction)
+- Proof of work: difficulty threshold and equihash solution (`checkpoint.rs:601-611`)
+- Merkle root validity and duplicate transaction detection (`checkpoint.rs:626-630`)
+- Subsidy-related deferred pool balance changes (`checkpoint.rs:614-621`)
+
+The `CheckpointVerifier` **skips contextual and most semantic verification checks** (`zebra-consensus/src/checkpoint.rs:1-15`). This means checks in the `SemanticBlockVerifier` path — such as proof verification, script verification, and most upgrade-gated rules — are not enforced for pre-Canopy blocks.
+
+Even with `checkpoint_sync = false`, the mandatory checkpoint height (just before Canopy) is always used as the minimum checkpoint height (`zebra-consensus/src/router.rs:401-406`).
+
+## Findings
+
+### 1. Coinbase Output Descriptions (Pre-Heartwood)
+
+| | |
+|---|---|
+| **File** | `zebra-consensus/src/transaction/check.rs:156-189` |
+| **Rule** | Pre-Heartwood: coinbase transactions MUST NOT have any Output descriptions |
+| **Gate** | Heartwood activation (explicitly documented as NOT VALIDATED) |
+| **Risk** | **Documented gap** — Zebra explicitly notes at line 168-170: "Zebra does not validate this last rule explicitly because we checkpoint until Canopy activation." |
+
+### 2. Shielded Coinbase Output Decryption
+
+| | |
+|---|---|
+| **File** | `zebra-consensus/src/transaction/check.rs:307-366` |
+| **Rule** | Heartwood+: Sapling and Orchard coinbase outputs MUST decrypt with the all-zeros outgoing viewing key (ZIP-212) |
+| **Gate** | Heartwood activation (line 348-354: returns `Ok(())` for pre-Heartwood) |
+| **Risk** | Low — pre-Heartwood coinbase transactions should not have shielded outputs (see #1), so this check is moot for pre-Heartwood. For Heartwood-to-Canopy blocks, this is skipped by checkpoint. |
+
+### 3. Sprout Pool Closure
+
+| | |
+|---|---|
+| **File** | `zebra-consensus/src/transaction/check.rs:215-246` |
+| **Rule** | Canopy+: `vpub_old` MUST be zero (no new value entering Sprout pool) |
+| **Gate** | Canopy activation (line 234) |
+| **Risk** | None for pre-Canopy — the Sprout pool was open pre-Canopy by design. |
+
+### 4. Subsidy Validation: Founders Reward vs Funding Streams
+
+| | |
+|---|---|
+| **File** | `zebra-consensus/src/block/check.rs:156-303` |
+| **Rule** | Pre-Canopy and pre-first-halving: validate Founders Reward outputs. Canopy+: validate Funding Streams (ZIP-1014). |
+| **Gate** | Canopy activation (line 190) and first halving height (line 204) |
+| **Risk** | Low — the Founders Reward check only applies for heights before the first halving (`height < net.height_for_first_halving()`). On Testnet, there is a pre-Canopy range after the first halving where neither the Founders Reward nor Funding Stream checks apply. This validation is skipped entirely for checkpoint-verified blocks. |
+
+### 5. Coinbase Expiry Height (NU5)
+
+| | |
+|---|---|
+| **File** | `zebra-consensus/src/transaction/check.rs:368-407` |
+| **Rule** | NU5+: coinbase `nExpiryHeight` MUST equal block height. Pre-NU5: only validates expiry_height <= 499999999. |
+| **Gate** | NU5 activation (lines 380-387) |
+| **Risk** | None for pre-Canopy — this is a post-NU5 rule. |
+
+### 6. Consensus Branch ID for V5 Transactions
+
+| | |
+|---|---|
+| **File** | `zebra-consensus/src/transaction/check.rs:519-558` |
+| **Rule** | NU5+: V5 transactions must have correct `nConsensusBranchId` |
+| **Gate** | NU5 activation (line 545: returns `Ok(())` for pre-NU5) |
+| **Risk** | None for pre-Canopy — V5 transactions don't exist pre-NU5. |
+
+### 7. V4 Transaction Network Upgrade Support
+
+| | |
+|---|---|
+| **File** | `zebra-consensus/src/transaction.rs:920-961` |
+| **Rule** | V4 transactions supported from Sapling through NU6.1 |
+| **Gate** | Sapling activation |
+| **Risk** | None for pre-Canopy — V4 transactions existing pre-Sapling would be caught by other validation, and are checkpointed. |
+
+### 8. V5 Transaction Network Upgrade Support
+
+| | |
+|---|---|
+| **File** | `zebra-consensus/src/transaction.rs:1010-1048` |
+| **Rule** | V5 transactions only supported from NU5 onward |
+| **Gate** | NU5 activation (line 1028-1031) |
+| **Risk** | None for pre-Canopy — V5 transactions don't exist pre-NU5. |
+
+### 9. Miner Fee Exactness (NU6)
+
+| | |
+|---|---|
+| **File** | `zebra-consensus/src/block/check.rs:305-361` |
+| **Rule** | NU6+: coinbase total_output_value MUST equal total_input_value (exact). Pre-NU6: total_output_value must not exceed total_input_value. |
+| **Gate** | NU6 activation (line 352) |
+| **Risk** | None for pre-Canopy — this is a post-NU6 rule. |
+
+### 10. NU6.1 Lockbox Disbursements
+
+| | |
+|---|---|
+| **File** | `zebra-consensus/src/block/check.rs:261-282` |
+| **Rule** | At NU6.1 activation height: validate one-time lockbox disbursement outputs (ZIP-271, ZIP-1016) |
+| **Gate** | NU6.1 activation height (line 261) |
+| **Risk** | None for pre-Canopy — this is a post-NU6.1 rule. |
+
+### 11. Block Header Commitment Validation (Sapling Root, Chain History Root)
+
+| | |
+|---|---|
+| **File** | `zebra-state/src/service/check.rs:137-222` and `zebra-chain/src/block/commitment.rs:108-151` |
+| **Rule** | Sapling/Blossom: `hashLightClientRoot` MUST equal the Sapling note commitment tree root. Heartwood/Canopy: `hashLightClientRoot` MUST equal the chain history root (ZIP-221). NU5+: `hashBlockCommitments` MUST match (ZIP-244). |
+| **Gate** | Upgrade-dependent interpretation of the block header commitment field |
+| **Risk** | **Documented gap** — The contextual equality check in `service/check.rs:155` explicitly states: "We don't need to validate this rule since we checkpoint on Canopy." The pre-Sapling, Sapling/Blossom, and Heartwood activation reserved cases all return `Ok(())` without contextual validation. Note: structural parsing of the commitment bytes IS performed at the `zebra-chain` level (`block/commitment.rs:116-151`) — Sapling/Blossom bytes must parse as a valid Sapling root, and Heartwood activation bytes must be all-zeros. This structural validation happens during deserialization regardless of the verification path. The gap is specifically in the contextual check that the parsed value matches the expected tree root. |
+
+### 12. Non-Coinbase Expiry Height Validation
+
+| | |
+|---|---|
+| **File** | `zebra-consensus/src/transaction/check.rs:414-439` |
+| **Rule** | Overwinter+: non-coinbase transactions must have `nExpiryHeight` <= 499999999, and MUST NOT be mined at a block height greater than their `nExpiryHeight` (ZIP-203) |
+| **Gate** | Not upgrade-gated (applies to all Overwinter+ transactions), but only enforced during semantic verification |
+| **Risk** | Low — this is a semantic-only check skipped for checkpoint-verified blocks. The correct expiry heights are implicitly guaranteed by checkpoint hash verification. |
+
+### Note: Transaction Network Upgrade Consistency
+
+The `check_transaction_network_upgrade_consistency` check at `zebra-consensus/src/block/check.rs:411` (called via `merkle_root_validity()`) validates that all transactions with a `nConsensusBranchId` field match the expected network upgrade for the block height. This check is called in **both** the semantic block verifier and the checkpoint verifier (`zebra-consensus/src/checkpoint.rs:626`), so it IS enforced for pre-Canopy blocks.
+
+## Checks NOT Gated (Always Enforced When Semantic Verification Runs)
+
+These checks apply to all blocks but are still **skipped by checkpoint verification**:
+
+| Check | Location |
+|-------|----------|
+| Sprout JoinSplit proofs (Groth16) | `zebra-consensus/src/transaction.rs:1095-1159` |
+| Sapling bundle proofs | `zebra-consensus/src/transaction.rs:1161-1224` |
+| Orchard bundle proofs (Halo2) | `zebra-consensus/src/transaction.rs:1226-1253` |
+| Transparent script verification | `zebra-consensus/src/transaction.rs:1065-1093` |
+| Block sigops limit (MAX_BLOCK_SIGOPS = 20,000) | `zebra-consensus/src/block.rs:128` (enforced at `block.rs:307`) |
+| Non-coinbase expiry height (Finding #12) | `zebra-consensus/src/transaction/check.rs:414-439` |
+
+These are always enforced for blocks that go through semantic verification (post-checkpoint), but are **not** enforced for checkpoint-verified blocks.
+
+## Summary
+
+### Risk Assessment
+
+**Two explicitly documented validation gaps exist**:
+- **Finding #1**: Pre-Heartwood coinbase transactions with Sapling/Orchard Output descriptions are not rejected. The code explicitly notes this is intentional because these blocks are always checkpointed.
+- **Finding #11**: Sapling note commitment tree root contextual equality validation (Sapling/Blossom) and chain history root validation (Heartwood/Canopy) are skipped with an explicit code comment acknowledging the checkpoint dependency. Structural parsing of the commitment bytes is still performed at the chain type level.
+
+**All other upgrade-gated checks** fall into two categories:
+1. **Rules that don't apply pre-Canopy** (#3, #5, #6, #7, #8, #9, #10) — these are correctly gated because the rules themselves were introduced at later network upgrades.
+2. **Rules that apply between their activation and Canopy** (#2, #4, #11, #12) — these are covered by the mandatory checkpoint range and the correct chain is guaranteed by checkpoint hash verification.
+
+### Key Concern for Future Changes
+
+If the mandatory checkpoint height is ever lowered below Canopy activation, or if Zebra needs to validate historical blocks without checkpoints (e.g., for a new testnet or custom network), the following checks would need to be added or verified:
+
+1. Pre-Heartwood coinbase Output description prohibition (Finding #1 — currently explicitly skipped)
+2. Heartwood-to-Canopy coinbase output decryption (Finding #2)
+3. Pre-first-halving Founders Reward validation (Finding #4 — the code exists but is not exercised during checkpoint sync; note this only applies before the first halving height, not all pre-Canopy blocks)
+4. Sapling note commitment tree root contextual equality validation for Sapling/Blossom blocks (Finding #11 — structural parsing exists but contextual equality check is explicitly skipped)
+5. Chain history root (ZIP-221) contextual equality validation for Heartwood-to-Canopy blocks (Finding #11)
+6. History tree construction for Heartwood+ blocks
+7. Non-coinbase expiry height enforcement (Finding #12 — semantic-only, not enforced during checkpoint sync)
+8. Pre-Sapling transaction version handling — semantic verification rejects V1/V2/V3 at `zebra-consensus/src/transaction.rs:497`, and `zebra-chain/src/transaction.rs:72` does not validate pre-Sapling types. If historical blocks go through semantic verification, these version checks would need review.
+9. All "always enforced" semantic checks (proofs, scripts, sigops) would need to work correctly for older transaction formats
+
+### Recommendation
+
+The current approach is sound for Mainnet and standard Testnet, where the mandatory checkpoint height is just before Canopy. The reliance on checkpoint verification for pre-Canopy blocks is well-understood and explicitly documented.
+
+For custom testnets or any scenario where the checkpoint list may not cover pre-Canopy heights, consider adding the pre-Heartwood coinbase Output description check (Finding #1) as a defensive measure, since it's the only known gap that isn't covered by an upgrade gate.

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -130,7 +130,7 @@ pub enum RejectionError {
 }
 
 /// Non-standard transaction error.
-#[derive(Error, Clone, Debug, PartialEq, Eq)]
+#[derive(Error, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub enum NonStandardTransactionError {
     #[error("transaction is dust")]
@@ -305,8 +305,9 @@ impl Storage {
             // Rule: per-transaction sigops (legacy + P2SH) must not exceed the limit.
             // zcashd sums GetLegacySigOpCount + GetP2SHSigOpCount for AcceptToMemoryPool:
             // https://github.com/zcash/zcash/blob/v6.11.0/src/main.cpp#L1819
-            let total_sigops =
-                tx.legacy_sigop_count + policy::p2sh_sigop_count(transaction, spent_outputs);
+            let total_sigops = tx
+                .legacy_sigop_count
+                .saturating_add(policy::p2sh_sigop_count(transaction, spent_outputs));
             if total_sigops > policy::MAX_STANDARD_TX_SIGOPS {
                 return self.reject_non_standard(tx, NonStandardTransactionError::TooManySigops);
             }
@@ -336,6 +337,7 @@ impl Storage {
                 }
                 Some(solver::ScriptKind::NullData { .. }) => {
                     // Rule: OP_RETURN script size is limited.
+                    // Cast is safe: u32 always fits in usize on 32-bit and 64-bit platforms.
                     if script_len > self.max_datacarrier_bytes as usize {
                         return self.reject_non_standard(
                             tx,
@@ -347,13 +349,16 @@ impl Storage {
                 }
                 Some(solver::ScriptKind::MultiSig { pubkeys, .. }) => {
                     // Rule: multisig must be at most 3-of-3 for standardness.
+                    // Note: This check is technically subsumed by the unconditional BareMultiSig
+                    // rejection below, but we keep it to distinguish the two error reasons
+                    // (ScriptPubKeyNonStandard for >3 keys vs BareMultiSig for valid multisig).
                     if pubkeys.len() > policy::MAX_STANDARD_MULTISIG_PUBKEYS {
                         return self.reject_non_standard(
                             tx,
                             NonStandardTransactionError::ScriptPubKeyNonStandard,
                         );
                     }
-                    // Rule: bare multisig outputs are non-standard.
+                    // Rule: bare multisig outputs are non-standard (fIsBareMultisigStd = false).
                     return self.reject_non_standard(tx, NonStandardTransactionError::BareMultiSig);
                 }
                 Some(_) => {
@@ -374,6 +379,11 @@ impl Storage {
     }
 
     /// Rejects a transaction as non-standard, caches the rejection, and returns the mempool error.
+    ///
+    /// Note: The returned error is `MempoolError::NonStandardTransaction`, while the cached
+    /// rejection (via `reject()`) is stored as
+    /// `ExactTipRejectionError::FailedStandard`. Callers that later check
+    /// `rejection_error()` will get `MempoolError::StorageExactTip(FailedStandard(...))`.
     fn reject_non_standard(
         &mut self,
         tx: &VerifiedUnminedTx,

--- a/zebrad/src/components/mempool/storage.rs
+++ b/zebrad/src/components/mempool/storage.rs
@@ -130,7 +130,7 @@ pub enum RejectionError {
 }
 
 /// Non-standard transaction error.
-#[derive(Error, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Error, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub enum NonStandardTransactionError {
     #[error("transaction is dust")]

--- a/zebrad/src/components/mempool/storage/policy.rs
+++ b/zebrad/src/components/mempool/storage/policy.rs
@@ -226,6 +226,37 @@ pub(super) fn are_inputs_standard(tx: &Transaction, spent_outputs: &[transparent
     true
 }
 
+// -- Test helper functions shared across test modules --
+
+/// Build a P2PKH lock script: OP_DUP OP_HASH160 <20-byte hash> OP_EQUALVERIFY OP_CHECKSIG
+#[cfg(test)]
+pub(super) fn p2pkh_lock_script(hash: &[u8; 20]) -> transparent::Script {
+    let mut s = vec![0x76, 0xa9, 0x14];
+    s.extend_from_slice(hash);
+    s.push(0x88);
+    s.push(0xac);
+    transparent::Script::new(&s)
+}
+
+/// Build a P2SH lock script: OP_HASH160 <20-byte hash> OP_EQUAL
+#[cfg(test)]
+pub(super) fn p2sh_lock_script(hash: &[u8; 20]) -> transparent::Script {
+    let mut s = vec![0xa9, 0x14];
+    s.extend_from_slice(hash);
+    s.push(0x87);
+    transparent::Script::new(&s)
+}
+
+/// Build a P2PK lock script: <compressed_pubkey> OP_CHECKSIG
+#[cfg(test)]
+pub(super) fn p2pk_lock_script(pubkey: &[u8; 33]) -> transparent::Script {
+    let mut s = Vec::with_capacity(1 + 33 + 1);
+    s.push(0x21); // OP_PUSHBYTES_33
+    s.extend_from_slice(pubkey);
+    s.push(0xac); // OP_CHECKSIG
+    transparent::Script::new(&s)
+}
+
 #[cfg(test)]
 mod tests {
     use zebra_chain::{
@@ -236,34 +267,6 @@ mod tests {
     use super::*;
 
     // -- Helper functions --
-
-    /// Build a P2PKH lock script: OP_DUP OP_HASH160 <20-byte hash> OP_EQUALVERIFY OP_CHECKSIG
-    fn p2pkh_lock_script(hash: &[u8; 20]) -> transparent::Script {
-        let mut s = vec![0x76, 0xa9, 0x14];
-        s.extend_from_slice(hash);
-        s.push(0x88);
-        s.push(0xac);
-        transparent::Script::new(&s)
-    }
-
-    /// Build a P2SH lock script: OP_HASH160 <20-byte hash> OP_EQUAL
-    fn p2sh_lock_script(hash: &[u8; 20]) -> transparent::Script {
-        let mut s = vec![0xa9, 0x14];
-        s.extend_from_slice(hash);
-        s.push(0x87);
-        transparent::Script::new(&s)
-    }
-
-    /// Build a P2PK lock script: <compressed_pubkey> OP_CHECKSIG
-    fn p2pk_lock_script(pubkey: &[u8; 33]) -> transparent::Script {
-        let mut s = Vec::with_capacity(1 + 33 + 1);
-        // OP_PUSHBYTES_33
-        s.push(0x21);
-        s.extend_from_slice(pubkey);
-        // OP_CHECKSIG
-        s.push(0xac);
-        transparent::Script::new(&s)
-    }
 
     /// Build a bare multisig lock script: OP_<required> <pubkeys...> OP_<total> OP_CHECKMULTISIG
     fn multisig_lock_script(required: u8, pubkeys: &[&[u8; 33]]) -> transparent::Script {

--- a/zebrad/src/components/mempool/storage/policy.rs
+++ b/zebrad/src/components/mempool/storage/policy.rs
@@ -40,6 +40,11 @@ pub(super) fn standard_script_kind(
 ///
 /// The redeemed script is the last data push in the scriptSig.
 /// Returns `None` if the scriptSig has no push operations.
+///
+/// # Precondition
+///
+/// The scriptSig should be push-only (enforced by `reject_if_non_standard_tx`
+/// before this function is called). Non-push opcodes are silently ignored.
 fn extract_p2sh_redeemed_script(unlock_script: &transparent::Script) -> Option<Vec<u8>> {
     let code = script::Code(unlock_script.as_raw_bytes().to_vec());
     let mut last_push_data: Option<Vec<u8>> = None;
@@ -108,10 +113,17 @@ fn p2sh_redeemed_script_sigop_count(
 /// Mirrors zcashd's `GetP2SHSigOpCount()`:
 /// <https://github.com/zcash/zcash/blob/v6.11.0/src/main.cpp#L1191>
 ///
-/// # Panics
+/// # Correctness
 ///
 /// Callers must ensure `spent_outputs.len()` matches the number of transparent inputs.
+/// If the lengths differ, `zip()` silently truncates the longer iterator, which may
+/// cause incorrect sigop counts.
 pub(super) fn p2sh_sigop_count(tx: &Transaction, spent_outputs: &[transparent::Output]) -> u32 {
+    debug_assert_eq!(
+        tx.inputs().len(),
+        spent_outputs.len(),
+        "spent_outputs must align with transaction inputs"
+    );
     tx.inputs()
         .iter()
         .zip(spent_outputs.iter())
@@ -132,10 +144,17 @@ pub(super) fn p2sh_sigop_count(tx: &Transaction, spent_outputs: &[transparent::O
 ///    - If the redeemed script is standard, its expected args are added to the total.
 ///    - If the redeemed script is non-standard, it must have <= [`MAX_P2SH_SIGOPS`] sigops.
 ///
-/// # Panics
+/// # Correctness
 ///
 /// Callers must ensure `spent_outputs.len()` matches the number of transparent inputs.
+/// If the lengths differ, `zip()` silently truncates the longer iterator, which may
+/// cause incorrect standardness decisions.
 pub(super) fn are_inputs_standard(tx: &Transaction, spent_outputs: &[transparent::Output]) -> bool {
+    debug_assert_eq!(
+        tx.inputs().len(),
+        spent_outputs.len(),
+        "spent_outputs must align with transaction inputs"
+    );
     for (input, spent_output) in tx.inputs().iter().zip(spent_outputs.iter()) {
         let unlock_script = match input {
             transparent::Input::PrevOut { unlock_script, .. } => unlock_script,
@@ -209,7 +228,126 @@ pub(super) fn are_inputs_standard(tx: &Transaction, spent_outputs: &[transparent
 
 #[cfg(test)]
 mod tests {
+    use zebra_chain::{
+        block::Height,
+        transaction::{self, LockTime, Transaction},
+    };
+
     use super::*;
+
+    // -- Helper functions --
+
+    /// Build a P2PKH lock script: OP_DUP OP_HASH160 <20-byte hash> OP_EQUALVERIFY OP_CHECKSIG
+    fn p2pkh_lock_script(hash: &[u8; 20]) -> transparent::Script {
+        let mut s = vec![0x76, 0xa9, 0x14];
+        s.extend_from_slice(hash);
+        s.push(0x88);
+        s.push(0xac);
+        transparent::Script::new(&s)
+    }
+
+    /// Build a P2SH lock script: OP_HASH160 <20-byte hash> OP_EQUAL
+    fn p2sh_lock_script(hash: &[u8; 20]) -> transparent::Script {
+        let mut s = vec![0xa9, 0x14];
+        s.extend_from_slice(hash);
+        s.push(0x87);
+        transparent::Script::new(&s)
+    }
+
+    /// Build a P2PK lock script: <compressed_pubkey> OP_CHECKSIG
+    fn p2pk_lock_script(pubkey: &[u8; 33]) -> transparent::Script {
+        let mut s = Vec::with_capacity(1 + 33 + 1);
+        // OP_PUSHBYTES_33
+        s.push(0x21);
+        s.extend_from_slice(pubkey);
+        // OP_CHECKSIG
+        s.push(0xac);
+        transparent::Script::new(&s)
+    }
+
+    /// Build a bare multisig lock script: OP_<required> <pubkeys...> OP_<total> OP_CHECKMULTISIG
+    fn multisig_lock_script(required: u8, pubkeys: &[&[u8; 33]]) -> transparent::Script {
+        let mut s = Vec::new();
+        // OP_1 through OP_16 are 0x51 through 0x60
+        s.push(0x50 + required);
+        for pk in pubkeys {
+            s.push(0x21); // OP_PUSHBYTES_33
+            s.extend_from_slice(*pk);
+        }
+        // OP_N for total pubkeys, safe because pubkeys.len() <= 3 for standard
+        s.push(0x50 + pubkeys.len() as u8);
+        // OP_CHECKMULTISIG
+        s.push(0xae);
+        transparent::Script::new(&s)
+    }
+
+    /// Build a scriptSig with the specified number of push operations.
+    /// Each push is a 1-byte constant value.
+    fn push_only_script_sig(n_pushes: usize) -> transparent::Script {
+        let mut bytes = Vec::with_capacity(n_pushes * 2);
+        for _ in 0..n_pushes {
+            // OP_PUSHBYTES_1 <byte>
+            bytes.push(0x01);
+            bytes.push(0x42);
+        }
+        transparent::Script::new(&bytes)
+    }
+
+    /// Build a P2SH scriptSig from a list of push data items.
+    /// Each item is pushed as a single OP_PUSHBYTES data push (max 75 bytes).
+    /// The last item should be the redeemed script.
+    fn p2sh_script_sig(push_items: &[&[u8]]) -> transparent::Script {
+        let mut bytes = Vec::new();
+        for item in push_items {
+            assert!(
+                item.len() <= 75,
+                "p2sh_script_sig only supports OP_PUSHBYTES (max 75 bytes), got {}",
+                item.len()
+            );
+            // OP_PUSHBYTES_N where N = item.len(), safe because len <= 75 < 256
+            bytes.push(item.len() as u8);
+            bytes.extend_from_slice(item);
+        }
+        transparent::Script::new(&bytes)
+    }
+
+    /// Build a simple V4 transaction with the given transparent inputs and outputs.
+    fn make_v4_tx(
+        inputs: Vec<transparent::Input>,
+        outputs: Vec<transparent::Output>,
+    ) -> Transaction {
+        Transaction::V4 {
+            inputs,
+            outputs,
+            lock_time: LockTime::min_lock_time_timestamp(),
+            expiry_height: Height(0),
+            joinsplit_data: None,
+            sapling_shielded_data: None,
+        }
+    }
+
+    /// Build a PrevOut input with the given unlock script.
+    fn prevout_input(unlock_script: transparent::Script) -> transparent::Input {
+        transparent::Input::PrevOut {
+            outpoint: transparent::OutPoint {
+                hash: transaction::Hash([0xaa; 32]),
+                index: 0,
+            },
+            unlock_script,
+            sequence: 0xffffffff,
+        }
+    }
+
+    /// Build a transparent output with the given lock script.
+    /// Uses a non-dust value to avoid false positives in standardness checks.
+    fn output_with_script(lock_script: transparent::Script) -> transparent::Output {
+        transparent::Output {
+            value: 100_000u64.try_into().unwrap(),
+            lock_script,
+        }
+    }
+
+    // -- count_script_push_ops tests --
 
     #[test]
     fn count_script_push_ops_counts_pushes() {
@@ -226,6 +364,60 @@ mod tests {
         let count = count_script_push_ops(&[]);
         assert_eq!(count, 0, "empty script should have 0 push ops");
     }
+
+    #[test]
+    fn count_script_push_ops_pushdata1() {
+        let _init_guard = zebra_test::init();
+        // OP_PUSHDATA1 <length=3> <3 bytes of data>
+        let script_bytes = vec![0x4c, 0x03, 0xaa, 0xbb, 0xcc];
+        let count = count_script_push_ops(&script_bytes);
+        assert_eq!(count, 1, "OP_PUSHDATA1 should count as 1 push operation");
+    }
+
+    #[test]
+    fn count_script_push_ops_pushdata2() {
+        let _init_guard = zebra_test::init();
+        // OP_PUSHDATA2 <length=3 as 2 little-endian bytes> <3 bytes of data>
+        let script_bytes = vec![0x4d, 0x03, 0x00, 0xaa, 0xbb, 0xcc];
+        let count = count_script_push_ops(&script_bytes);
+        assert_eq!(count, 1, "OP_PUSHDATA2 should count as 1 push operation");
+    }
+
+    #[test]
+    fn count_script_push_ops_pushdata4() {
+        let _init_guard = zebra_test::init();
+        // OP_PUSHDATA4 <length=2 as 4 little-endian bytes> <2 bytes of data>
+        let script_bytes = vec![0x4e, 0x02, 0x00, 0x00, 0x00, 0xaa, 0xbb];
+        let count = count_script_push_ops(&script_bytes);
+        assert_eq!(count, 1, "OP_PUSHDATA4 should count as 1 push operation");
+    }
+
+    #[test]
+    fn count_script_push_ops_mixed_push_types() {
+        let _init_guard = zebra_test::init();
+        // OP_0, then OP_PUSHBYTES_1 <byte>, then OP_PUSHDATA1 <len=1> <byte>
+        let script_bytes = vec![0x00, 0x01, 0xaa, 0x4c, 0x01, 0xbb];
+        let count = count_script_push_ops(&script_bytes);
+        assert_eq!(
+            count, 3,
+            "mixed push types should each count as 1 push operation"
+        );
+    }
+
+    #[test]
+    fn count_script_push_ops_truncated_script() {
+        let _init_guard = zebra_test::init();
+        // OP_PUSHBYTES_10 followed by only 3 bytes (truncated) -- parser should
+        // produce an error for the incomplete push, which is filtered out.
+        let script_bytes = vec![0x0a, 0xaa, 0xbb, 0xcc];
+        let count = count_script_push_ops(&script_bytes);
+        assert_eq!(
+            count, 0,
+            "truncated script should count 0 successful push operations"
+        );
+    }
+
+    // -- extract_p2sh_redeemed_script tests --
 
     #[test]
     fn extract_p2sh_redeemed_script_extracts_last_push() {
@@ -249,6 +441,8 @@ mod tests {
         assert!(redeemed.is_none(), "empty scriptSig should return None");
     }
 
+    // -- script_sig_args_expected tests --
+
     #[test]
     fn script_sig_args_expected_values() {
         let _init_guard = zebra_test::init();
@@ -264,5 +458,260 @@ mod tests {
         // NullData expects None (non-standard to spend)
         let nd_kind = solver::ScriptKind::NullData { data: vec![] };
         assert_eq!(script_sig_args_expected(&nd_kind), None);
+
+        // P2PK expects 1 arg (sig only) -- test via script classification
+        let p2pk_script = p2pk_lock_script(&[0x02; 33]);
+        let p2pk_kind =
+            standard_script_kind(&p2pk_script).expect("P2PK should be a standard script kind");
+        assert_eq!(script_sig_args_expected(&p2pk_kind), Some(1));
+
+        // MultiSig 1-of-1 expects 2 args (OP_0 + 1 sig) -- test via script classification
+        let ms_script = multisig_lock_script(1, &[&[0x02; 33]]);
+        let ms_kind = standard_script_kind(&ms_script)
+            .expect("1-of-1 multisig should be a standard script kind");
+        assert_eq!(script_sig_args_expected(&ms_kind), Some(2));
+    }
+
+    // -- are_inputs_standard tests --
+
+    #[test]
+    fn are_inputs_standard_accepts_valid_p2pkh() {
+        let _init_guard = zebra_test::init();
+
+        // P2PKH expects 2 scriptSig pushes: <sig> <pubkey>
+        let script_sig = push_only_script_sig(2);
+        let tx = make_v4_tx(vec![prevout_input(script_sig)], vec![]);
+        let spent_outputs = vec![output_with_script(p2pkh_lock_script(&[0xaa; 20]))];
+
+        assert!(
+            are_inputs_standard(&tx, &spent_outputs),
+            "valid P2PKH input with correct stack depth should be standard"
+        );
+    }
+
+    #[test]
+    fn are_inputs_standard_rejects_wrong_stack_depth() {
+        let _init_guard = zebra_test::init();
+
+        // P2PKH expects 2 pushes, but we provide 3
+        let script_sig = push_only_script_sig(3);
+        let tx = make_v4_tx(vec![prevout_input(script_sig)], vec![]);
+        let spent_outputs = vec![output_with_script(p2pkh_lock_script(&[0xaa; 20]))];
+
+        assert!(
+            !are_inputs_standard(&tx, &spent_outputs),
+            "P2PKH input with 3 pushes instead of 2 should be non-standard"
+        );
+    }
+
+    #[test]
+    fn are_inputs_standard_rejects_too_few_pushes() {
+        let _init_guard = zebra_test::init();
+
+        // P2PKH expects 2 pushes, but we provide 1
+        let script_sig = push_only_script_sig(1);
+        let tx = make_v4_tx(vec![prevout_input(script_sig)], vec![]);
+        let spent_outputs = vec![output_with_script(p2pkh_lock_script(&[0xaa; 20]))];
+
+        assert!(
+            !are_inputs_standard(&tx, &spent_outputs),
+            "P2PKH input with 1 push instead of 2 should be non-standard"
+        );
+    }
+
+    #[test]
+    fn are_inputs_standard_rejects_non_standard_spent_output() {
+        let _init_guard = zebra_test::init();
+
+        // OP_1 OP_2 OP_ADD -- not a recognized standard script type
+        let non_standard_lock = transparent::Script::new(&[0x51, 0x52, 0x93]);
+        let script_sig = push_only_script_sig(1);
+        let tx = make_v4_tx(vec![prevout_input(script_sig)], vec![]);
+        let spent_outputs = vec![output_with_script(non_standard_lock)];
+
+        assert!(
+            !are_inputs_standard(&tx, &spent_outputs),
+            "input spending a non-standard script should be non-standard"
+        );
+    }
+
+    #[test]
+    fn are_inputs_standard_accepts_p2sh_with_standard_redeemed_script() {
+        let _init_guard = zebra_test::init();
+
+        // Build a P2SH input where the redeemed script is a P2PKH script.
+        // The redeemed script itself is the serialized P2PKH:
+        //   OP_DUP OP_HASH160 <20 bytes> OP_EQUALVERIFY OP_CHECKSIG
+        let redeemed_script_bytes = {
+            let mut s = vec![0x76, 0xa9, 0x14];
+            s.extend_from_slice(&[0xcc; 20]);
+            s.push(0x88);
+            s.push(0xac);
+            s
+        };
+
+        // For P2SH with a P2PKH redeemed script:
+        //   script_sig_args_expected(ScriptHash) = 1  (the redeemed script push)
+        //   script_sig_args_expected(PubKeyHash) = 2  (sig + pubkey inside redeemed)
+        //   total expected = 1 + 2 = 3
+        //
+        // scriptSig: <sig_placeholder> <pubkey_placeholder> <redeemed_script>
+        let script_sig = p2sh_script_sig(&[&[0xaa], &[0xbb], &redeemed_script_bytes]);
+
+        // The policy check uses is_pay_to_script_hash() which only checks the
+        // script pattern (OP_HASH160 <20 bytes> OP_EQUAL), not the hash value.
+        // Any 20-byte hash works for testing the policy logic.
+        let lock_script = p2sh_lock_script(&[0xdd; 20]);
+        let tx = make_v4_tx(vec![prevout_input(script_sig)], vec![]);
+        let spent_outputs = vec![output_with_script(lock_script)];
+
+        assert!(
+            are_inputs_standard(&tx, &spent_outputs),
+            "P2SH input with standard P2PKH redeemed script and correct stack depth should be standard"
+        );
+    }
+
+    #[test]
+    fn are_inputs_standard_rejects_p2sh_with_too_many_sigops() {
+        let _init_guard = zebra_test::init();
+
+        // Build a redeemed script that has more than MAX_P2SH_SIGOPS (15) sigops.
+        // Use 16 consecutive OP_CHECKSIG (0xac) opcodes.
+        let redeemed_script_bytes: Vec<u8> = vec![0xac; 16];
+
+        // scriptSig: just push the redeemed script (1 push)
+        // Since the redeemed script is non-standard, are_inputs_standard
+        // checks sigops. With 16 > MAX_P2SH_SIGOPS (15), it should reject.
+        let script_sig = p2sh_script_sig(&[&redeemed_script_bytes]);
+
+        let lock_script = p2sh_lock_script(&[0xdd; 20]);
+        let tx = make_v4_tx(vec![prevout_input(script_sig)], vec![]);
+        let spent_outputs = vec![output_with_script(lock_script)];
+
+        assert!(
+            !are_inputs_standard(&tx, &spent_outputs),
+            "P2SH input with redeemed script exceeding MAX_P2SH_SIGOPS should be non-standard"
+        );
+    }
+
+    #[test]
+    fn are_inputs_standard_accepts_p2sh_with_non_standard_low_sigops() {
+        let _init_guard = zebra_test::init();
+
+        // Build a redeemed script that is non-standard but has <= MAX_P2SH_SIGOPS (15).
+        // Use exactly 15 OP_CHECKSIG (0xac) opcodes -- should be accepted.
+        let redeemed_script_bytes: Vec<u8> = vec![0xac; 15];
+
+        let script_sig = p2sh_script_sig(&[&redeemed_script_bytes]);
+
+        let lock_script = p2sh_lock_script(&[0xdd; 20]);
+        let tx = make_v4_tx(vec![prevout_input(script_sig)], vec![]);
+        let spent_outputs = vec![output_with_script(lock_script)];
+
+        assert!(
+            are_inputs_standard(&tx, &spent_outputs),
+            "P2SH input with non-standard redeemed script at exactly MAX_P2SH_SIGOPS should be accepted"
+        );
+    }
+
+    // -- p2sh_sigop_count tests --
+
+    #[test]
+    fn p2sh_sigop_count_returns_sigops_for_p2sh_input() {
+        let _init_guard = zebra_test::init();
+
+        // Build a P2SH input whose redeemed script has 5 OP_CHECKSIG opcodes.
+        let redeemed_script_bytes: Vec<u8> = vec![0xac; 5];
+
+        let script_sig = p2sh_script_sig(&[&redeemed_script_bytes]);
+
+        let lock_script = p2sh_lock_script(&[0xdd; 20]);
+        let tx = make_v4_tx(vec![prevout_input(script_sig)], vec![]);
+        let spent_outputs = vec![output_with_script(lock_script)];
+
+        let count = p2sh_sigop_count(&tx, &spent_outputs);
+        assert_eq!(
+            count, 5,
+            "p2sh_sigop_count should return 5 for a redeemed script with 5 OP_CHECKSIG"
+        );
+    }
+
+    #[test]
+    fn p2sh_sigop_count_returns_zero_for_non_p2sh() {
+        let _init_guard = zebra_test::init();
+
+        // P2PKH spent output -- not P2SH, so p2sh_sigop_count should return 0.
+        let script_sig = push_only_script_sig(2);
+        let tx = make_v4_tx(vec![prevout_input(script_sig)], vec![]);
+        let spent_outputs = vec![output_with_script(p2pkh_lock_script(&[0xaa; 20]))];
+
+        let count = p2sh_sigop_count(&tx, &spent_outputs);
+        assert_eq!(
+            count, 0,
+            "p2sh_sigop_count should return 0 for non-P2SH inputs"
+        );
+    }
+
+    #[test]
+    fn p2sh_sigop_count_sums_across_multiple_inputs() {
+        let _init_guard = zebra_test::init();
+
+        // Input 0: P2SH with redeemed script having 3 OP_CHECKSIG
+        let redeemed_1: Vec<u8> = vec![0xac; 3];
+        let script_sig_1 = p2sh_script_sig(&[&redeemed_1]);
+        let lock_1 = p2sh_lock_script(&[0xdd; 20]);
+
+        // Input 1: P2PKH (non-P2SH, contributes 0)
+        let script_sig_2 = push_only_script_sig(2);
+        let lock_2 = p2pkh_lock_script(&[0xaa; 20]);
+
+        // Input 2: P2SH with redeemed script having 7 OP_CHECKSIG
+        let redeemed_3: Vec<u8> = vec![0xac; 7];
+        let script_sig_3 = p2sh_script_sig(&[&redeemed_3]);
+        let lock_3 = p2sh_lock_script(&[0xee; 20]);
+
+        let tx = make_v4_tx(
+            vec![
+                prevout_input(script_sig_1),
+                prevout_input(script_sig_2),
+                prevout_input(script_sig_3),
+            ],
+            vec![],
+        );
+        let spent_outputs = vec![
+            output_with_script(lock_1),
+            output_with_script(lock_2),
+            output_with_script(lock_3),
+        ];
+
+        let count = p2sh_sigop_count(&tx, &spent_outputs);
+        assert_eq!(
+            count, 10,
+            "p2sh_sigop_count should sum sigops across all P2SH inputs (3 + 0 + 7)"
+        );
+    }
+
+    #[test]
+    fn are_inputs_standard_rejects_second_non_standard_input() {
+        let _init_guard = zebra_test::init();
+
+        // Input 0: valid P2PKH (2 pushes)
+        let script_sig_ok = push_only_script_sig(2);
+        let lock_ok = p2pkh_lock_script(&[0xaa; 20]);
+
+        // Input 1: P2PKH with wrong stack depth (3 pushes instead of 2)
+        let script_sig_bad = push_only_script_sig(3);
+        let lock_bad = p2pkh_lock_script(&[0xbb; 20]);
+
+        let tx = make_v4_tx(
+            vec![prevout_input(script_sig_ok), prevout_input(script_sig_bad)],
+            vec![],
+        );
+        let spent_outputs = vec![output_with_script(lock_ok), output_with_script(lock_bad)];
+
+        assert!(
+            !are_inputs_standard(&tx, &spent_outputs),
+            "should reject when second input is non-standard even if first is valid"
+        );
     }
 }

--- a/zebrad/src/components/mempool/storage/tests/vectors.rs
+++ b/zebrad/src/components/mempool/storage/tests/vectors.rs
@@ -407,7 +407,7 @@ fn mempool_removes_dependent_transactions() -> Result<()> {
 
 // ---- Policy function unit tests ----
 
-use super::super::policy::{p2pkh_lock_script, p2pk_lock_script, p2sh_lock_script};
+use super::super::policy::{p2pk_lock_script, p2pkh_lock_script, p2sh_lock_script};
 
 #[test]
 fn standard_script_kind_classifies_p2pkh() {

--- a/zebrad/src/components/mempool/storage/tests/vectors.rs
+++ b/zebrad/src/components/mempool/storage/tests/vectors.rs
@@ -407,25 +407,7 @@ fn mempool_removes_dependent_transactions() -> Result<()> {
 
 // ---- Policy function unit tests ----
 
-// Note: p2pkh_lock_script and p2sh_lock_script are intentionally duplicated from
-// policy::tests because Rust's #[cfg(test)] module boundaries prevent sharing.
-
-/// Build a P2PKH lock script: OP_DUP OP_HASH160 <20-byte hash> OP_EQUALVERIFY OP_CHECKSIG
-fn p2pkh_lock_script(hash: &[u8; 20]) -> transparent::Script {
-    let mut s = vec![0x76, 0xa9, 0x14];
-    s.extend_from_slice(hash);
-    s.push(0x88);
-    s.push(0xac);
-    transparent::Script::new(&s)
-}
-
-/// Build a P2SH lock script: OP_HASH160 <20-byte hash> OP_EQUAL
-fn p2sh_lock_script(hash: &[u8; 20]) -> transparent::Script {
-    let mut s = vec![0xa9, 0x14];
-    s.extend_from_slice(hash);
-    s.push(0x87);
-    transparent::Script::new(&s)
-}
+use super::super::policy::{p2pkh_lock_script, p2pk_lock_script, p2sh_lock_script};
 
 #[test]
 fn standard_script_kind_classifies_p2pkh() {
@@ -468,15 +450,6 @@ fn standard_script_kind_classifies_op_return() {
         ),
         "OP_RETURN script should be classified as NullData"
     );
-}
-
-/// Build a P2PK lock script: <33-byte compressed pubkey> OP_CHECKSIG
-fn p2pk_lock_script(pubkey: &[u8; 33]) -> transparent::Script {
-    let mut s = Vec::with_capacity(1 + 33 + 1);
-    s.push(0x21); // OP_PUSHBYTES_33
-    s.extend_from_slice(pubkey);
-    s.push(0xac); // OP_CHECKSIG
-    transparent::Script::new(&s)
 }
 
 #[test]

--- a/zebrad/src/components/mempool/storage/tests/vectors.rs
+++ b/zebrad/src/components/mempool/storage/tests/vectors.rs
@@ -407,8 +407,11 @@ fn mempool_removes_dependent_transactions() -> Result<()> {
 
 // ---- Policy function unit tests ----
 
+// Note: p2pkh_lock_script and p2sh_lock_script are intentionally duplicated from
+// policy::tests because Rust's #[cfg(test)] module boundaries prevent sharing.
+
 /// Build a P2PKH lock script: OP_DUP OP_HASH160 <20-byte hash> OP_EQUALVERIFY OP_CHECKSIG
-fn p2pkh_script(hash: &[u8; 20]) -> transparent::Script {
+fn p2pkh_lock_script(hash: &[u8; 20]) -> transparent::Script {
     let mut s = vec![0x76, 0xa9, 0x14];
     s.extend_from_slice(hash);
     s.push(0x88);
@@ -427,7 +430,7 @@ fn p2sh_lock_script(hash: &[u8; 20]) -> transparent::Script {
 #[test]
 fn standard_script_kind_classifies_p2pkh() {
     let _init_guard = zebra_test::init();
-    let script = p2pkh_script(&[0xaa; 20]);
+    let script = p2pkh_lock_script(&[0xaa; 20]);
     let kind = super::super::policy::standard_script_kind(&script);
     assert!(
         matches!(
@@ -464,6 +467,29 @@ fn standard_script_kind_classifies_op_return() {
             Some(zcash_script::solver::ScriptKind::NullData { .. })
         ),
         "OP_RETURN script should be classified as NullData"
+    );
+}
+
+/// Build a P2PK lock script: <33-byte compressed pubkey> OP_CHECKSIG
+fn p2pk_lock_script(pubkey: &[u8; 33]) -> transparent::Script {
+    let mut s = Vec::with_capacity(1 + 33 + 1);
+    s.push(0x21); // OP_PUSHBYTES_33
+    s.extend_from_slice(pubkey);
+    s.push(0xac); // OP_CHECKSIG
+    transparent::Script::new(&s)
+}
+
+#[test]
+fn standard_script_kind_classifies_p2pk() {
+    let _init_guard = zebra_test::init();
+    // Compressed pubkey starts with 0x02 or 0x03
+    let mut pubkey = [0x02; 33];
+    pubkey[1..].fill(0xaa);
+    let script = p2pk_lock_script(&pubkey);
+    let kind = super::super::policy::standard_script_kind(&script);
+    assert!(
+        matches!(kind, Some(zcash_script::solver::ScriptKind::PubKey { .. })),
+        "P2PK script should be classified as PubKey"
     );
 }
 


### PR DESCRIPTION
## Motivation

Closes #10184

As Zebra becomes the single Zcash node implementation, it is important to explicitly document which consensus rules are not enforced for pre-Canopy blocks (which rely on mandatory checkpoint verification).

## Solution

Added `pre-canopy-check-audit.md` with a systematic audit of all upgrade-gated and semantic-only consensus checks across `zebra-consensus`, `zebra-state`, and `zebra-chain`.

### Key Findings

- **12 checks documented**: upgrade-gated rules, semantic-only checks, and their risk assessments
- **2 explicitly documented validation gaps**:
  1. Pre-Heartwood coinbase Output description prohibition (code comment acknowledges this)
  2. Block header commitment contextual equality validation (Sapling root, chain history root)
- **Checkpoint verifier coverage**: PoW, equihash, difficulty, Merkle root, duplicate tx detection, and transaction network upgrade consistency are all enforced even for checkpointed blocks
- **Future concerns**: detailed list of checks that would need attention if mandatory checkpoint height is ever lowered or custom testnets skip pre-Canopy checkpoints

### Methodology

- Systematically searched `zebra-consensus/src/` and `zebra-state/src/service/check.rs` for `NetworkUpgrade` comparisons, height-gated logic, and checkpoint vs semantic verification paths
- Cross-referenced checkpoint verifier (`checkpoint.rs:579-633`) to distinguish checks that ARE enforced from those that are not
- Verified all line numbers and code references against source

## AI Disclosure

Used Claude Code for codebase search and initial finding enumeration. All findings were cross-referenced against source code and reviewed with multiple rounds of code review (both automated and manual).