### PR TITLE
feat(rpc): Extend `getpeerinfo` RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+
+### Added
+
+- Extended `getpeerinfo` RPC with `subver`, `version`, `services`, `lastrecv`, `banscore`, and `connection_state` fields
+
 ## [Zebra 5.0.0](https://github.com/ZcashFoundation/zebra/releases/tag/v5.0.0) - 2026-06-02
 
 This release activates the NU6.2 network upgrade. NU6.2 re-enables Orchard
@@ -270,6 +276,7 @@ Zebra versions are vulnerable to these issues.
   you might require additional configuration
   ([#10464](https://github.com/ZcashFoundation/zebra/pull/10464)).
 
+## [Zebra 4.3.0](https://github.com/ZcashFoundation/zebra/releases/tag/v4.3.0) - 2026-03-12
 ## [Zebra 4.3.0](https://github.com/ZcashFoundation/zebra/releases/tag/v4.3.0) - 2026-03-12
 
 This release fixes **two important security issues**:

--- a/zebra-network/CHANGELOG.md
+++ b/zebra-network/CHANGELOG.md
@@ -85,6 +85,19 @@ The impact of the issue for crate users will depend on the particular usage; if
 your application allows deserializing arbitrary `addr` and/or `addrv2` messages,
 you should update.
 
+### Breaking Changes
+
+- Removed `Copy` derive from `types::MetaAddr` (now only `Clone`) to support `String` fields
+- Changed `types::MetaAddr::new_connected()` to take additional `user_agent` and `negotiated_version` parameters
+
+### Added
+
+- Added `types::MetaAddr::user_agent()` accessor returning `Option<&str>`
+- Added `types::MetaAddr::negotiated_version()` accessor returning `Option<Version>`
+- Added `types::MetaAddr::services()` accessor returning `Option<PeerServices>`
+- Added `types::MetaAddr::last_connection_state()` accessor returning `PeerAddrState`
+- Made `types::Version` type public with `Display` impl
+
 ## [5.0.0] - 2026-03-12
 
 ### Breaking Changes

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -158,7 +158,7 @@ impl AddressBook {
         // Avoid initiating outbound handshakes when max_connections_per_ip is 1.
         let should_limit_outbound_conns_per_ip = max_connections_per_ip == 1;
         let mut new_book = AddressBook {
-            by_addr: OrderedMap::new(|meta_addr| Reverse(*meta_addr)),
+            by_addr: OrderedMap::new(|meta_addr: &MetaAddr| Reverse(meta_addr.clone())),
             local_listener: canonical_socket_addr(local_listener),
             network: network.clone(),
             addr_limit: constants::MAX_ADDRS_IN_ADDRESS_BOOK,
@@ -215,16 +215,16 @@ impl AddressBook {
             .map(|meta_addr| (meta_addr.addr, meta_addr));
 
         for (socket_addr, meta_addr) in addrs {
-            // overwrite any duplicate addresses
-            new_book.by_addr.insert(socket_addr, meta_addr);
             // Add the address to `most_recent_by_ip` if it has responded
-            if new_book.should_update_most_recent_by_ip(meta_addr) {
+            if new_book.should_update_most_recent_by_ip(&meta_addr) {
                 new_book
                     .most_recent_by_ip
                     .as_mut()
                     .expect("should be some when should_update_most_recent_by_ip is true")
-                    .insert(socket_addr.ip(), meta_addr);
+                    .insert(socket_addr.ip(), meta_addr.clone());
             }
+            // overwrite any duplicate addresses
+            new_book.by_addr.insert(socket_addr, meta_addr);
             // exit as soon as we get enough addresses
             if new_book.by_addr.len() >= addr_limit {
                 break;
@@ -347,8 +347,8 @@ impl AddressBook {
         // Unfortunately, `OrderedMap` doesn't implement `get`.
         let meta_addr = self.by_addr.remove(&addr);
 
-        if let Some(meta_addr) = meta_addr {
-            self.by_addr.insert(addr, meta_addr);
+        if let Some(ref meta_addr) = meta_addr {
+            self.by_addr.insert(addr, meta_addr.clone());
         }
 
         meta_addr
@@ -366,7 +366,7 @@ impl AddressBook {
     /// - this is the only field checked by `has_connection_recently_responded()`
     ///
     /// See [`AddressBook::is_ready_for_connection_attempt_with_ip`] for more details.
-    fn should_update_most_recent_by_ip(&self, updated: MetaAddr) -> bool {
+    fn should_update_most_recent_by_ip(&self, updated: &MetaAddr) -> bool {
         let Some(most_recent_by_ip) = self.most_recent_by_ip.as_ref() else {
             return false;
         };
@@ -429,7 +429,7 @@ impl AddressBook {
         let instant_now = Instant::now();
         let chrono_now = Utc::now();
 
-        let updated = change.apply_to_meta_addr(previous, instant_now, chrono_now);
+        let updated = change.apply_to_meta_addr(previous.clone(), instant_now, chrono_now);
 
         trace!(
             ?change,
@@ -440,7 +440,7 @@ impl AddressBook {
             "calculated updated address book entry",
         );
 
-        if let Some(updated) = updated {
+        if let Some(ref updated) = updated {
             if updated.misbehavior() >= constants::MAX_PEER_MISBEHAVIOR_SCORE {
                 // Ban and skip outbound connections with excessively misbehaving peers.
                 let banned_ip = updated.addr.ip();
@@ -499,16 +499,16 @@ impl AddressBook {
                 return None;
             }
 
-            self.by_addr.insert(updated.addr, updated);
-
             // Add the address to `most_recent_by_ip` if it sent the most recent
             // response Zebra has received from this IP.
             if self.should_update_most_recent_by_ip(updated) {
                 self.most_recent_by_ip
                     .as_mut()
                     .expect("should be some when should_update_most_recent_by_ip is true")
-                    .insert(updated.addr.ip(), updated);
+                    .insert(updated.addr.ip(), updated.clone());
             }
+
+            self.by_addr.insert(updated.addr, updated.clone());
 
             debug!(
                 ?change,

--- a/zebra-network/src/address_book/tests/prop.rs
+++ b/zebra-network/src/address_book/tests/prop.rs
@@ -119,7 +119,7 @@ proptest! {
 
         for (_addr, changes) in addr_changes_lists.iter() {
             for change in changes {
-                address_book.update(*change);
+                address_book.update(change.clone());
 
                 prop_assert!(
                     address_book.len() <= addr_limit,
@@ -143,7 +143,7 @@ proptest! {
         for index in 0..MAX_ADDR_CHANGE {
             for (_addr, changes) in addr_changes_lists.iter() {
                 if let Some(change) = changes.get(index) {
-                    address_book.update(*change);
+                    address_book.update(change.clone());
 
                     prop_assert!(
                         address_book.len() <= addr_limit,

--- a/zebra-network/src/address_book/tests/vectors.rs
+++ b/zebra-network/src/address_book/tests/vectors.rs
@@ -119,7 +119,7 @@ fn address_book_peer_order() {
     );
 
     // Regardless of the order of insertion, the most recent address should be chosen first
-    let addrs = vec![meta_addr1, meta_addr2];
+    let addrs = vec![meta_addr1.clone(), meta_addr2.clone()];
     let address_book = AddressBook::new_with_addrs(
         "0.0.0.0:0".parse().unwrap(),
         &Mainnet,
@@ -132,11 +132,11 @@ fn address_book_peer_order() {
         address_book
             .reconnection_peers(Instant::now(), Utc::now())
             .next(),
-        Some(meta_addr2),
+        Some(meta_addr2.clone()),
     );
 
     // Reverse the order, check that we get the same result
-    let addrs = vec![meta_addr2, meta_addr1];
+    let addrs = vec![meta_addr2.clone(), meta_addr1.clone()];
     let address_book = AddressBook::new_with_addrs(
         "0.0.0.0:0".parse().unwrap(),
         &Mainnet,
@@ -149,14 +149,14 @@ fn address_book_peer_order() {
         address_book
             .reconnection_peers(Instant::now(), Utc::now())
             .next(),
-        Some(meta_addr2),
+        Some(meta_addr2.clone()),
     );
 
     // Now check that the order depends on the time, not the address
     meta_addr1.addr = addr2;
     meta_addr2.addr = addr1;
 
-    let addrs = vec![meta_addr1, meta_addr2];
+    let addrs = vec![meta_addr1.clone(), meta_addr2.clone()];
     let address_book = AddressBook::new_with_addrs(
         "0.0.0.0:0".parse().unwrap(),
         &Mainnet,
@@ -169,11 +169,11 @@ fn address_book_peer_order() {
         address_book
             .reconnection_peers(Instant::now(), Utc::now())
             .next(),
-        Some(meta_addr2),
+        Some(meta_addr2.clone()),
     );
 
     // Reverse the order, check that we get the same result
-    let addrs = vec![meta_addr2, meta_addr1];
+    let addrs = vec![meta_addr2.clone(), meta_addr1];
     let address_book = AddressBook::new_with_addrs(
         "0.0.0.0:0".parse().unwrap(),
         &Mainnet,

--- a/zebra-network/src/address_book_updater.rs
+++ b/zebra-network/src/address_book_updater.rs
@@ -56,7 +56,7 @@ impl AddressBookUpdater {
     ) {
         // Create an mpsc channel for peerset address book updates,
         // based on the maximum number of inbound and outbound peers.
-        let (worker_tx, mut worker_rx) = mpsc::channel(max(
+        let (worker_tx, mut worker_rx) = mpsc::channel::<MetaAddrChange>(max(
             config.peerset_total_connection_limit(),
             MIN_CHANNEL_SIZE,
         ));
@@ -98,6 +98,7 @@ impl AddressBookUpdater {
                 //
                 // Briefly hold the address book threaded mutex, to update the
                 // state for a single address.
+                let event_ip = event.addr().ip();
                 let updated = worker_address_book
                     .lock()
                     .expect("mutex should be unpoisoned")
@@ -111,7 +112,7 @@ impl AddressBookUpdater {
                         .expect("mutex should be unpoisoned")
                         .bans();
 
-                    if bans.contains_key(&event.addr().ip()) {
+                    if bans.contains_key(&event_ip) {
                         let _ = bans_sender.send(bans);
                     }
                 }

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -200,7 +200,7 @@ pub mod types {
     pub use crate::{
         meta_addr::MetaAddr,
         protocol::{
-            external::{AddrInVersion, Nonce},
+            external::{types::Version, AddrInVersion, Nonce},
             types::PeerServices,
         },
     };

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -12,7 +12,10 @@ use zebra_chain::{parameters::Network, serialization::DateTime32};
 use crate::{
     constants,
     peer::{address_is_valid_for_outbound_connections, PeerPreference},
-    protocol::{external::canonical_peer_addr, types::PeerServices},
+    protocol::{
+        external::{canonical_peer_addr, types::Version},
+        types::PeerServices,
+    },
 };
 
 use MetaAddrChange::*;
@@ -146,7 +149,7 @@ impl PartialOrd for PeerAddrState {
 /// This struct can be created from `addr` or `addrv2` messages.
 ///
 /// [Bitcoin reference](https://en.bitcoin.it/wiki/Protocol_documentation#Network_address)
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub struct MetaAddr {
     /// The peer's canonical socket address.
@@ -223,10 +226,16 @@ pub struct MetaAddr {
     /// Whether this peer address was added to the address book
     /// when the peer made an inbound connection.
     is_inbound: bool,
+
+    /// The user agent string reported by the peer during handshake, if available.
+    user_agent: Option<String>,
+
+    /// The protocol version negotiated with the peer during handshake, if available.
+    negotiated_version: Option<Version>,
 }
 
 /// A change to an existing `MetaAddr`.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "proptest-impl"), derive(Arbitrary))]
 pub enum MetaAddrChange {
     // TODO:
@@ -280,6 +289,8 @@ pub enum MetaAddrChange {
         addr: PeerSocketAddr,
         services: PeerServices,
         is_inbound: bool,
+        user_agent: String,
+        negotiated_version: Version,
     },
 
     /// Updates an existing `MetaAddr` when we send a ping to a peer.
@@ -349,6 +360,8 @@ impl MetaAddr {
             last_connection_state: NeverAttemptedGossiped,
             misbehavior_score: 0,
             is_inbound: false,
+            user_agent: None,
+            negotiated_version: None,
         }
     }
 
@@ -385,11 +398,15 @@ impl MetaAddr {
         addr: PeerSocketAddr,
         services: &PeerServices,
         is_inbound: bool,
+        user_agent: String,
+        negotiated_version: Version,
     ) -> MetaAddrChange {
         UpdateConnected {
             addr: canonical_peer_addr(*addr),
             services: *services,
             is_inbound,
+            user_agent,
+            negotiated_version,
         }
     }
 
@@ -708,6 +725,26 @@ impl MetaAddr {
         }
     }
 
+    /// Returns the services advertised by the peer, if available.
+    pub fn services(&self) -> Option<PeerServices> {
+        self.services
+    }
+
+    /// Returns the last known connection state for this peer.
+    pub fn last_connection_state(&self) -> PeerAddrState {
+        self.last_connection_state
+    }
+
+    /// Returns the user agent string reported by this peer, if available.
+    pub fn user_agent(&self) -> Option<&str> {
+        self.user_agent.as_deref()
+    }
+
+    /// Returns the negotiated protocol version for this peer, if available.
+    pub fn negotiated_version(&self) -> Option<Version> {
+        self.negotiated_version
+    }
+
     /// Returns a score of misbehavior encountered in a peer at this address.
     pub fn misbehavior(&self) -> u32 {
         self.misbehavior_score
@@ -754,6 +791,8 @@ impl MetaAddr {
             last_connection_state: NeverAttemptedGossiped,
             misbehavior_score: 0,
             is_inbound: false,
+            user_agent: None,
+            negotiated_version: None,
         })
     }
 }
@@ -953,6 +992,8 @@ impl MetaAddrChange {
 
     /// Returns the corresponding `MetaAddr` for this change.
     pub fn into_new_meta_addr(self, instant_now: Instant, local_now: DateTime32) -> MetaAddr {
+        let user_agent = self.user_agent();
+        let negotiated_version = self.negotiated_version();
         MetaAddr {
             addr: self.addr(),
             services: self.untrusted_services(),
@@ -965,6 +1006,8 @@ impl MetaAddrChange {
             last_connection_state: self.peer_addr_state(),
             misbehavior_score: self.misbehavior_score(),
             is_inbound: self.is_inbound(),
+            user_agent,
+            negotiated_version,
         }
     }
 
@@ -984,6 +1027,27 @@ impl MetaAddrChange {
             *is_inbound
         } else {
             false
+        }
+    }
+
+    /// Returns the user agent from this change, if available.
+    pub fn user_agent(&self) -> Option<String> {
+        if let MetaAddrChange::UpdateConnected { user_agent, .. } = self {
+            Some(user_agent.clone())
+        } else {
+            None
+        }
+    }
+
+    /// Returns the negotiated protocol version from this change, if available.
+    pub fn negotiated_version(&self) -> Option<Version> {
+        if let MetaAddrChange::UpdateConnected {
+            negotiated_version, ..
+        } = self
+        {
+            Some(*negotiated_version)
+        } else {
+            None
         }
     }
 
@@ -1010,6 +1074,8 @@ impl MetaAddrChange {
             last_connection_state: self.peer_addr_state(),
             misbehavior_score: self.misbehavior_score(),
             is_inbound: self.is_inbound(),
+            user_agent: None,
+            negotiated_version: None,
         }
     }
 
@@ -1028,7 +1094,7 @@ impl MetaAddrChange {
 
         let Some(previous) = previous.into() else {
             // no previous: create a new entry
-            return Some(self.into_new_meta_addr(instant_now, local_now));
+            return Some(self.clone().into_new_meta_addr(instant_now, local_now));
         };
 
         assert_eq!(previous.addr, self.addr(), "unexpected addr mismatch");
@@ -1166,6 +1232,8 @@ impl MetaAddrChange {
                 last_connection_state: self.peer_addr_state(),
                 misbehavior_score: previous.misbehavior_score + self.misbehavior_score(),
                 is_inbound: previous.is_inbound || self.is_inbound(),
+                user_agent: None,
+                negotiated_version: None,
             })
         } else {
             // Existing entry and change are both Attempt, Responded, Failed,
@@ -1192,6 +1260,8 @@ impl MetaAddrChange {
                 last_connection_state: self.peer_addr_state(),
                 misbehavior_score: previous.misbehavior_score + self.misbehavior_score(),
                 is_inbound: previous.is_inbound || self.is_inbound(),
+                user_agent: self.user_agent().or(previous.user_agent),
+                negotiated_version: self.negotiated_version().or(previous.negotiated_version),
             })
         }
     }

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -69,6 +69,17 @@ pub enum PeerAddrState {
     AttemptPending,
 }
 
+impl std::fmt::Display for PeerAddrState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Responded => write!(f, "connected"),
+            NeverAttemptedGossiped => write!(f, "never_connected"),
+            Failed => write!(f, "failed"),
+            AttemptPending => write!(f, "connecting"),
+        }
+    }
+}
+
 impl PeerAddrState {
     /// Return true if this state is a "never attempted" state.
     pub fn is_never_attempted(&self) -> bool {

--- a/zebra-network/src/meta_addr/arbitrary.rs
+++ b/zebra-network/src/meta_addr/arbitrary.rs
@@ -69,9 +69,10 @@ impl MetaAddrChange {
     ) -> BoxedStrategy<(MetaAddr, Vec<MetaAddrChange>)> {
         any::<MetaAddr>()
             .prop_flat_map(move |addr| {
+                let peer_addr = addr.addr;
                 (
                     Just(addr),
-                    vec(MetaAddrChange::addr_strategy(addr.addr), 1..max_addr_change),
+                    vec(MetaAddrChange::addr_strategy(peer_addr), 1..max_addr_change),
                 )
             })
             .boxed()

--- a/zebra-network/src/meta_addr/tests/prop.rs
+++ b/zebra-network/src/meta_addr/tests/prop.rs
@@ -75,7 +75,7 @@ proptest! {
         let local_now: DateTime32 = chrono_now.try_into().expect("will succeed until 2038");
 
         for change in changes {
-            if let Some(changed_addr) = change.apply_to_meta_addr(addr, instant_now, chrono_now) {
+            if let Some(changed_addr) = change.apply_to_meta_addr(addr.clone(), instant_now, chrono_now) {
                 // untrusted last seen times:
                 // check that we replace None with Some, but leave Some unchanged
                 if addr.untrusted_last_seen.is_some() {
@@ -123,12 +123,12 @@ proptest! {
         for change in changes {
             while addr.is_ready_for_connection_attempt(instant_now, chrono_now, &Mainnet) {
                 // Simulate an attempt
-                addr = if let Some(addr) = MetaAddr::new_reconnect(addr.addr)
-                    .apply_to_meta_addr(addr, instant_now, chrono_now) {
+                addr = if let Some(new_addr) = MetaAddr::new_reconnect(addr.addr)
+                    .apply_to_meta_addr(addr.clone(), instant_now, chrono_now) {
                         attempt_count += 1;
                         // Assume that this test doesn't last longer than MIN_PEER_RECONNECTION_DELAY
                         prop_assert!(attempt_count <= 1);
-                        addr
+                        new_addr
                     } else {
                         // Stop updating when an attempt comes too soon after a failure.
                         // In production these are prevented by the dialer code.
@@ -137,7 +137,7 @@ proptest! {
             }
 
             // If `change` is invalid for the current MetaAddr state, skip it.
-            if let Some(changed_addr) = change.apply_to_meta_addr(addr, instant_now, chrono_now) {
+            if let Some(changed_addr) = change.apply_to_meta_addr(addr.clone(), instant_now, chrono_now) {
                 prop_assert_eq!(changed_addr.addr, addr.addr);
                 addr = changed_addr;
             }
@@ -229,7 +229,7 @@ proptest! {
             );
 
             let expected_result = new_addr;
-            let book_result = address_book.update(change);
+            let book_result = address_book.update(change.clone());
             let book_contents: Vec<MetaAddr> = address_book.peers().collect();
 
             // Ignore the same addresses that the address book ignores
@@ -255,7 +255,7 @@ proptest! {
                 expected_result,
             );
 
-            if let Some(book_result) = book_result {
+            if let Some(ref book_result) = book_result {
                 prop_assert_eq!(book_result.addr, addr.addr);
                 // TODO: pass times to MetaAddrChange::apply_to_meta_addr and AddressBook::update,
                 //       so the times are equal
@@ -328,7 +328,7 @@ proptest! {
         // Only put valid addresses in the address book.
         // This means some tests will start with an empty address book.
         let addrs = if addr.last_known_info_is_valid_for_outbound(&Mainnet) {
-            Some(addr)
+            Some(addr.clone())
         } else {
             None
         };
@@ -439,18 +439,18 @@ proptest! {
 
             for change_index in 0..MAX_ADDR_CHANGE {
                 for (addr, changes) in addr_changes_lists.iter() {
-                    let addr = addrs.entry(addr.addr).or_insert(*addr);
+                    let addr = addrs.entry(addr.addr).or_insert(addr.clone());
                     let change = changes.get(change_index);
 
                     while addr.is_ready_for_connection_attempt(instant_now, chrono_now, &Mainnet) {
                         // Simulate an attempt
-                        *addr = if let Some(addr) = MetaAddr::new_reconnect(addr.addr)
-                            .apply_to_meta_addr(*addr, instant_now, chrono_now) {
-                                *attempt_counts.entry(addr.addr).or_default() += 1;
+                        *addr = if let Some(new_addr) = MetaAddr::new_reconnect(addr.addr)
+                            .apply_to_meta_addr(addr.clone(), instant_now, chrono_now) {
+                                *attempt_counts.entry(new_addr.addr).or_default() += 1;
                                 prop_assert!(
-                                    *attempt_counts.get(&addr.addr).unwrap() <= LIVE_PEER_INTERVALS + 1
+                                    *attempt_counts.get(&new_addr.addr).unwrap() <= LIVE_PEER_INTERVALS + 1
                                 );
-                                addr
+                                new_addr
                             } else {
                                 // Stop updating when an attempt comes too soon after a failure.
                                 // In production these are prevented by the dialer code.
@@ -460,7 +460,7 @@ proptest! {
 
                     // If `change` is invalid for the current MetaAddr state, skip it.
                     // If we've run out of changes for this addr, do nothing.
-                    if let Some(changed_addr) = change.and_then(|change| change.apply_to_meta_addr(*addr, instant_now, chrono_now))
+                    if let Some(changed_addr) = change.and_then(|change| change.apply_to_meta_addr(addr.clone(), instant_now, chrono_now))
                     {
                         prop_assert_eq!(changed_addr.addr, addr.addr);
                         *addr = changed_addr;

--- a/zebra-network/src/meta_addr/tests/vectors.rs
+++ b/zebra-network/src/meta_addr/tests/vectors.rs
@@ -489,11 +489,17 @@ fn ipv4_mapped_misbehavior_panics_without_fix() {
     );
 
     // Handshake succeeds → address book stores the canonical (IPv4) address.
-    let previous = MetaAddr::new_connected(raw_addr, &PeerServices::NODE_NETWORK, true)
-        .into_new_meta_addr(
-            instant_now,
-            chrono_now.try_into().expect("will succeed until 2038"),
-        );
+    let previous = MetaAddr::new_connected(
+        raw_addr,
+        &PeerServices::NODE_NETWORK,
+        true,
+        String::new(),
+        crate::protocol::external::types::Version(170_100),
+    )
+    .into_new_meta_addr(
+        instant_now,
+        chrono_now.try_into().expect("will succeed until 2038"),
+    );
 
     assert_eq!(
         previous.addr(),
@@ -534,11 +540,17 @@ fn new_misbehavior_canonicalizes_ipv4_mapped_addr() {
     assert_ne!(raw_addr, canonical_addr);
 
     // Handshake stores canonical IPv4 address.
-    let previous = MetaAddr::new_connected(raw_addr, &PeerServices::NODE_NETWORK, true)
-        .into_new_meta_addr(
-            instant_now,
-            chrono_now.try_into().expect("will succeed until 2038"),
-        );
+    let previous = MetaAddr::new_connected(
+        raw_addr,
+        &PeerServices::NODE_NETWORK,
+        true,
+        String::new(),
+        crate::protocol::external::types::Version(170_100),
+    )
+    .into_new_meta_addr(
+        instant_now,
+        chrono_now.try_into().expect("will succeed until 2038"),
+    );
 
     assert_eq!(previous.addr(), canonical_addr);
 

--- a/zebra-network/src/meta_addr/tests/vectors.rs
+++ b/zebra-network/src/meta_addr/tests/vectors.rs
@@ -44,6 +44,8 @@ fn sanitize_extremes() {
         last_connection_state: Default::default(),
         misbehavior_score: Default::default(),
         is_inbound: false,
+        user_agent: None,
+        negotiated_version: None,
     };
 
     let max_time_entry = MetaAddr {
@@ -58,6 +60,8 @@ fn sanitize_extremes() {
         last_connection_state: Default::default(),
         misbehavior_score: Default::default(),
         is_inbound: false,
+        user_agent: None,
+        negotiated_version: None,
     };
 
     if let Some(min_sanitized) = min_time_entry.sanitize(&Mainnet) {
@@ -259,7 +263,7 @@ fn long_delayed_change_is_not_applied() {
             .expect("constant is valid");
 
     let change = MetaAddr::new_errored(address, PeerServices::NODE_NETWORK);
-    let outcome = change.apply_to_meta_addr(peer, instant_early, chrono_early);
+    let outcome = change.apply_to_meta_addr(peer.clone(), instant_early, chrono_early);
 
     assert_eq!(
         outcome, None,
@@ -302,7 +306,7 @@ fn later_revert_change_is_applied() {
             .expect("constant is valid");
 
     let change = MetaAddr::new_reconnect(address);
-    let outcome = change.apply_to_meta_addr(peer, instant_late, chrono_late);
+    let outcome = change.apply_to_meta_addr(peer.clone(), instant_late, chrono_late);
 
     assert!(
         outcome.is_some(),
@@ -343,7 +347,7 @@ fn concurrent_state_revert_change_is_not_applied() {
             .expect("constant is valid");
 
     let change = MetaAddr::new_reconnect(address);
-    let outcome = change.apply_to_meta_addr(peer, instant_early, chrono_early);
+    let outcome = change.apply_to_meta_addr(peer.clone(), instant_early, chrono_early);
 
     assert_eq!(
         outcome, None,
@@ -361,7 +365,7 @@ fn concurrent_state_revert_change_is_not_applied() {
             .expect("constant is valid");
 
     let change = MetaAddr::new_reconnect(address);
-    let outcome = change.apply_to_meta_addr(peer, instant_late, chrono_late);
+    let outcome = change.apply_to_meta_addr(peer.clone(), instant_late, chrono_late);
 
     assert_eq!(
         outcome, None,
@@ -402,7 +406,7 @@ fn concurrent_state_progress_change_is_applied() {
             .expect("constant is valid");
 
     let change = MetaAddr::new_errored(address, None);
-    let outcome = change.apply_to_meta_addr(peer, instant_early, chrono_early);
+    let outcome = change.apply_to_meta_addr(peer.clone(), instant_early, chrono_early);
 
     assert!(
         outcome.is_some(),
@@ -420,7 +424,7 @@ fn concurrent_state_progress_change_is_applied() {
             .expect("constant is valid");
 
     let change = MetaAddr::new_errored(address, None);
-    let outcome = change.apply_to_meta_addr(peer, instant_late, chrono_late);
+    let outcome = change.apply_to_meta_addr(peer.clone(), instant_late, chrono_late);
 
     assert!(
         outcome.is_some(),

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -448,7 +448,7 @@ impl Handler {
         // doesn't respond to our getaddr requests.
         //
         // Add the new addresses to the end of the cache.
-        cached_addrs.extend(new_addrs);
+        cached_addrs.extend(new_addrs.into_iter().cloned());
 
         // # Security
         //

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -984,6 +984,8 @@ where
                         book_addr,
                         &remote_services,
                         connected_addr.is_inbound(),
+                        connection_info.remote.user_agent.clone(),
+                        connection_info.negotiated_version,
                     ))
                     .await;
             }

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -1194,6 +1194,7 @@ async fn self_connections_should_fail() {
 
         let updated_addr = unlocked_address_book.update(
             real_self_listener
+                .clone()
                 .new_gossiped_change()
                 .expect("change is valid"),
         );
@@ -1204,22 +1205,20 @@ async fn self_connections_should_fail() {
     };
 
     // Make sure we modified the address book correctly
-    assert!(
-        updated_addr.is_some(),
-        "inserting our own address into the address book failed: {real_self_listener:?}"
-    );
+    let updated_addr =
+        updated_addr.expect("inserting our own address into the address book failed");
     assert_eq!(
-        updated_addr.unwrap().addr(),
+        updated_addr.addr(),
         real_self_listener.addr(),
         "wrong address inserted into address book"
     );
     assert_ne!(
-        updated_addr.unwrap().addr().ip(),
+        updated_addr.addr().ip(),
         Ipv4Addr::UNSPECIFIED,
         "invalid address inserted into address book: ip must be valid for inbound connections"
     );
     assert_ne!(
-        updated_addr.unwrap().addr().port(),
+        updated_addr.addr().port(),
         0,
         "invalid address inserted into address book: port must be valid for inbound connections"
     );
@@ -1543,7 +1542,7 @@ where
             PeerServices::NODE_NETWORK,
             DateTime32::now(),
         );
-        fake_peer = Some(addr);
+        fake_peer = Some(addr.clone());
         let addr = addr
             .new_gossiped_change()
             .expect("created MetaAddr contains enough information to represent a gossiped address");
@@ -1555,15 +1554,19 @@ where
     }
 
     // Create a fake peer set.
-    let nil_peer_set = service_fn(move |req| async move {
-        let rsp = match req {
-            // Return the correct response variant for Peers requests,
-            // reusing one of the peers we already provided.
-            Request::Peers => Response::Peers(vec![fake_peer.unwrap()]),
-            _ => unreachable!("unexpected request: {:?}", req),
-        };
+    let fake_peer = fake_peer.expect("there is at least one fake peer");
+    let nil_peer_set = service_fn(move |req| {
+        let fake_peer = fake_peer.clone();
+        async move {
+            let rsp = match req {
+                // Return the correct response variant for Peers requests,
+                // reusing one of the peers we already provided.
+                Request::Peers => Response::Peers(vec![fake_peer]),
+                _ => unreachable!("unexpected request: {:?}", req),
+            };
 
-        Ok(rsp)
+            Ok(rsp)
+        }
     });
 
     // Make the channels large enough to hold all the peers.

--- a/zebra-network/src/protocol/external/codec.rs
+++ b/zebra-network/src/protocol/external/codec.rs
@@ -293,7 +293,10 @@ impl Codec {
 
                 // Regardless of the way we received the address,
                 // Zebra always sends `addr` messages
-                let v1_addrs: Vec<AddrV1> = addrs.iter().map(|addr| AddrV1::from(*addr)).collect();
+                let v1_addrs: Vec<AddrV1> = addrs
+                    .iter()
+                    .map(|addr| AddrV1::from(addr.clone()))
+                    .collect();
                 v1_addrs.zcash_serialize(&mut writer)?
             }
             Message::GetAddr => { /* Empty payload -- no-op */ }

--- a/zebra-network/src/protocol/external/tests/prop.rs
+++ b/zebra-network/src/protocol/external/tests/prop.rs
@@ -122,7 +122,7 @@ proptest! {
         //
         // If this is a gossiped or DNS seeder address,
         // we're also checking that malicious peers can't make Zebra's serialization fail.
-        let addr_bytes = AddrV1::from(sanitized_addr).zcash_serialize_to_vec();
+        let addr_bytes = AddrV1::from(sanitized_addr.clone()).zcash_serialize_to_vec();
         prop_assert!(
             addr_bytes.is_ok(),
             "unexpected serialization error: {:?}, addr: {:?}",
@@ -144,8 +144,8 @@ proptest! {
 
         // Check that the addrs are equal
         prop_assert_eq!(
-            sanitized_addr,
-            deserialized_addr,
+            sanitized_addr.clone(),
+            deserialized_addr.clone(),
             "unexpected round-trip mismatch with bytes: {:?}",
             hex::encode(addr_bytes),
         );
@@ -155,7 +155,7 @@ proptest! {
 
         // Now check that the re-serialized bytes are equal
         // (`impl PartialEq for MetaAddr` might not match serialization equality)
-        let addr_bytes2 = AddrV1::from(deserialized_addr).zcash_serialize_to_vec();
+        let addr_bytes2 = AddrV1::from(deserialized_addr.clone()).zcash_serialize_to_vec();
         prop_assert!(
             addr_bytes2.is_ok(),
             "unexpected serialization error after round-trip: {:?}, original addr: {:?}, bytes: {:?}, deserialized addr: {:?}",
@@ -195,7 +195,7 @@ proptest! {
         //
         // If this is a gossiped or DNS seeder address,
         // we're also checking that malicious peers can't make Zebra's serialization fail.
-        let addr_bytes = AddrV2::from(sanitized_addr).zcash_serialize_to_vec();
+        let addr_bytes = AddrV2::from(sanitized_addr.clone()).zcash_serialize_to_vec();
         prop_assert!(
             addr_bytes.is_ok(),
             "unexpected serialization error: {:?}, addr: {:?}",
@@ -218,8 +218,8 @@ proptest! {
 
         // Check that the addrs are equal
         prop_assert_eq!(
-            sanitized_addr,
-            deserialized_addr,
+            sanitized_addr.clone(),
+            deserialized_addr.clone(),
             "unexpected round-trip mismatch with bytes: {:?}",
             hex::encode(addr_bytes),
         );
@@ -229,7 +229,7 @@ proptest! {
 
         // Now check that the re-serialized bytes are equal
         // (`impl PartialEq for MetaAddr` might not match serialization equality)
-        let addr_bytes2 = AddrV2::from(deserialized_addr).zcash_serialize_to_vec();
+        let addr_bytes2 = AddrV2::from(deserialized_addr.clone()).zcash_serialize_to_vec();
         prop_assert!(
             addr_bytes2.is_ok(),
             "unexpected serialization error after round-trip: {:?}, original addr: {:?}, bytes: {:?}, deserialized addr: {:?}",

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -119,6 +119,19 @@ This release fixes four RPC security issues:
   be opened publicly, but we plan to update our documentation to make this
   clear.
 
+### Breaking Changes
+
+- Changed `client::PeerInfo::new()` to take additional `services`, `lastrecv`, `banscore`, `subver`, `version`, and `connection_state` parameters
+
+### Added
+
+- Added `client::PeerInfo::services()` accessor
+- Added `client::PeerInfo::lastrecv()` accessor
+- Added `client::PeerInfo::banscore()` accessor
+- Added `client::PeerInfo::subver()` accessor
+- Added `client::PeerInfo::version()` accessor
+- Added `client::PeerInfo::connection_state()` accessor
+
 ## [6.0.1] - 2026-03-26
 
 ### Fixed

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -910,7 +910,14 @@ fn snapshot_rpc_getnetworkinfo(
 
 /// Snapshot `getpeerinfo` response, using `cargo insta` and JSON serialization.
 fn snapshot_rpc_getpeerinfo(get_peer_info: Vec<PeerInfo>, settings: &insta::Settings) {
-    settings.bind(|| insta::assert_json_snapshot!("get_peer_info", get_peer_info));
+    settings.bind(|| {
+        insta::assert_json_snapshot!("get_peer_info", get_peer_info, {
+            "[].lastrecv" => dynamic_redaction(|value, _path| {
+                assert!(value.as_u64().unwrap() > 0, "lastrecv should be non-zero");
+                "[lastrecv]"
+            })
+        })
+    });
 }
 
 /// Snapshot `getnetworksolps` response, using `cargo insta` and JSON serialization.
@@ -1047,6 +1054,8 @@ pub async fn test_mining_rpcs<State, ReadState>(
         .into(),
         &PeerServices::NODE_NETWORK,
         false,
+        "/Zebra:2.1.0/".to_string(),
+        zebra_network::constants::CURRENT_NETWORK_PROTOCOL_VERSION,
     )
     .into_new_meta_addr(Instant::now(), DateTime32::now())]);
 

--- a/zebra-rpc/src/methods/tests/snapshots/get_peer_info@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_peer_info@mainnet_10.snap
@@ -5,6 +5,12 @@ expression: get_peer_info
 [
   {
     "addr": "127.0.0.1:8233",
-    "inbound": false
+    "services": "0000000000000001",
+    "lastrecv": "[lastrecv]",
+    "inbound": false,
+    "banscore": 0,
+    "subver": "/Zebra:2.1.0/",
+    "version": 170140,
+    "connection_state": "Responded"
   }
 ]

--- a/zebra-rpc/src/methods/tests/snapshots/get_peer_info@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_peer_info@mainnet_10.snap
@@ -10,7 +10,7 @@ expression: get_peer_info
     "inbound": false,
     "banscore": 0,
     "subver": "/Zebra:2.1.0/",
-    "version": 170140,
+    "version": 170150,
     "connection_state": "connected"
   }
 ]

--- a/zebra-rpc/src/methods/tests/snapshots/get_peer_info@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_peer_info@mainnet_10.snap
@@ -11,6 +11,6 @@ expression: get_peer_info
     "banscore": 0,
     "subver": "/Zebra:2.1.0/",
     "version": 170140,
-    "connection_state": "Responded"
+    "connection_state": "connected"
   }
 ]

--- a/zebra-rpc/src/methods/tests/snapshots/get_peer_info@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_peer_info@testnet_10.snap
@@ -5,6 +5,12 @@ expression: get_peer_info
 [
   {
     "addr": "127.0.0.1:18233",
-    "inbound": false
+    "services": "0000000000000001",
+    "lastrecv": "[lastrecv]",
+    "inbound": false,
+    "banscore": 0,
+    "subver": "/Zebra:2.1.0/",
+    "version": 170140,
+    "connection_state": "Responded"
   }
 ]

--- a/zebra-rpc/src/methods/tests/snapshots/get_peer_info@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_peer_info@testnet_10.snap
@@ -10,7 +10,7 @@ expression: get_peer_info
     "inbound": false,
     "banscore": 0,
     "subver": "/Zebra:2.1.0/",
-    "version": 170140,
+    "version": 170150,
     "connection_state": "connected"
   }
 ]

--- a/zebra-rpc/src/methods/tests/snapshots/get_peer_info@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_peer_info@testnet_10.snap
@@ -11,6 +11,6 @@ expression: get_peer_info
     "banscore": 0,
     "subver": "/Zebra:2.1.0/",
     "version": 170140,
-    "connection_state": "Responded"
+    "connection_state": "connected"
   }
 ]

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -3101,7 +3101,7 @@ async fn rpc_addnode() {
     assert_eq!(peer.pingwait(), &None);
     assert_eq!(peer.services().as_str(), "0000000000000000");
     assert_eq!(peer.banscore(), 0);
-    assert_eq!(peer.connection_state().as_str(), "Responded");
+    assert_eq!(peer.connection_state().as_str(), "connected");
     assert!(peer.lastrecv() > 0);
 
     mempool.expect_no_requests().await;

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -1787,6 +1787,8 @@ async fn rpc_getpeerinfo() {
         .into(),
         &PeerServices::NODE_NETWORK,
         false,
+        "/Zebra:2.1.0/".to_string(),
+        zebra_network::constants::CURRENT_NETWORK_PROTOCOL_VERSION,
     )
     .into_new_meta_addr(
         std::time::Instant::now(),
@@ -1802,6 +1804,8 @@ async fn rpc_getpeerinfo() {
         .into(),
         &PeerServices::NODE_NETWORK,
         true,
+        "/zcashd:5.8.0/".to_string(),
+        zebra_network::constants::CURRENT_NETWORK_PROTOCOL_VERSION,
     )
     .into_new_meta_addr(
         std::time::Instant::now(),
@@ -1822,8 +1826,8 @@ async fn rpc_getpeerinfo() {
     );
 
     let mock_address_book = MockAddressBookPeers::new(vec![
-        outbound_mock_peer_address,
-        inbound_mock_peer_address,
+        outbound_mock_peer_address.clone(),
+        inbound_mock_peer_address.clone(),
         not_connected_mock_peer_adderess,
     ]);
 
@@ -3089,16 +3093,16 @@ async fn rpc_addnode() {
         .await
         .expect("We should have an array of addresses");
 
-    assert_eq!(
-        get_peer_info,
-        [PeerInfo {
-            addr,
-            inbound: false,
-            // TODO: Fix this when mock address book provides other values
-            pingtime: Some(0.1f64),
-            pingwait: None,
-        }]
-    );
+    assert_eq!(get_peer_info.len(), 1);
+    let peer = &get_peer_info[0];
+    assert_eq!(peer.addr(), addr);
+    assert!(!peer.inbound());
+    assert_eq!(peer.pingtime(), &Some(0.1f64));
+    assert_eq!(peer.pingwait(), &None);
+    assert_eq!(peer.services().as_str(), "0000000000000000");
+    assert_eq!(peer.banscore(), 0);
+    assert_eq!(peer.connection_state().as_str(), "Responded");
+    assert!(peer.lastrecv() > 0);
 
     mempool.expect_no_requests().await;
 }

--- a/zebra-rpc/src/methods/types/peer_info.rs
+++ b/zebra-rpc/src/methods/types/peer_info.rs
@@ -6,13 +6,32 @@ use zebra_network::{types::MetaAddr, PeerSocketAddr};
 
 /// Item of the `getpeerinfo` response
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, Getters, new)]
+#[allow(clippy::too_many_arguments)]
 pub struct PeerInfo {
     /// The IP address and port of the peer
     #[getter(copy)]
     pub(crate) addr: PeerSocketAddr,
 
+    /// The services offered, as a zero-padded 16-character hex string
+    pub(crate) services: String,
+
+    /// The time in seconds since epoch of the last message received from this peer
+    pub(crate) lastrecv: u32,
+
     /// Inbound (true) or Outbound (false)
     pub(crate) inbound: bool,
+
+    /// The ban score for misbehavior
+    pub(crate) banscore: u32,
+
+    /// The peer's user agent string (e.g. "/Zebra:2.1.0/" or "/MagicBean:5.8.0/")
+    pub(crate) subver: String,
+
+    /// The negotiated protocol version
+    pub(crate) version: u32,
+
+    /// The connection state (e.g. "Responded", "NeverAttemptedGossiped", "Failed", "AttemptPending")
+    pub(crate) connection_state: String,
 
     /// The round-trip ping time in seconds.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -28,9 +47,28 @@ pub type GetPeerInfoResponse = Vec<PeerInfo>;
 
 impl From<MetaAddr> for PeerInfo {
     fn from(meta_addr: MetaAddr) -> Self {
+        let services = meta_addr
+            .services()
+            .map(|s| format!("{:016x}", s.bits()))
+            .unwrap_or_else(|| "0000000000000000".to_string());
+
+        let lastrecv = meta_addr.last_seen().map(|t| t.timestamp()).unwrap_or(0);
+
+        let connection_state = format!("{:?}", meta_addr.last_connection_state());
+
+        let subver = meta_addr.user_agent().unwrap_or("").to_string();
+
+        let version = meta_addr.negotiated_version().map(|v| v.0).unwrap_or(0);
+
         Self {
             addr: meta_addr.addr(),
+            services,
+            lastrecv,
             inbound: meta_addr.is_inbound(),
+            banscore: meta_addr.misbehavior(),
+            subver,
+            version,
+            connection_state,
             pingtime: meta_addr.rtt().map(|d| d.as_secs_f64()),
             pingwait: meta_addr.ping_sent_at().map(|t| t.elapsed().as_secs_f64()),
         }
@@ -41,7 +79,13 @@ impl Default for PeerInfo {
     fn default() -> Self {
         Self {
             addr: PeerSocketAddr::unspecified(),
+            services: "0000000000000000".to_string(),
+            lastrecv: 0,
             inbound: false,
+            banscore: 0,
+            subver: String::new(),
+            version: 0,
+            connection_state: String::new(),
             pingtime: None,
             pingwait: None,
         }

--- a/zebra-rpc/src/methods/types/peer_info.rs
+++ b/zebra-rpc/src/methods/types/peer_info.rs
@@ -30,7 +30,7 @@ pub struct PeerInfo {
     /// The negotiated protocol version
     pub(crate) version: u32,
 
-    /// The connection state (e.g. "Responded", "NeverAttemptedGossiped", "Failed", "AttemptPending")
+    /// The connection state (e.g. "connected", "never_connected", "failed", "connecting")
     pub(crate) connection_state: String,
 
     /// The round-trip ping time in seconds.
@@ -54,7 +54,7 @@ impl From<MetaAddr> for PeerInfo {
 
         let lastrecv = meta_addr.last_seen().map(|t| t.timestamp()).unwrap_or(0);
 
-        let connection_state = format!("{:?}", meta_addr.last_connection_state());
+        let connection_state = meta_addr.last_connection_state().to_string();
 
         let subver = meta_addr.user_agent().unwrap_or("").to_string();
 

--- a/zebra-rpc/tests/serialization_tests.rs
+++ b/zebra-rpc/tests/serialization_tests.rs
@@ -1259,7 +1259,7 @@ fn test_get_peer_info() -> Result<(), Box<dyn std::error::Error>> {
     "banscore": 0,
     "subver": "/Zebra:2.1.0/",
     "version": 170140,
-    "connection_state": "Responded"
+    "connection_state": "connected"
   },
   {
     "addr": "[2000:2000:2000:0000::]:8233",
@@ -1269,7 +1269,7 @@ fn test_get_peer_info() -> Result<(), Box<dyn std::error::Error>> {
     "banscore": 0,
     "subver": "/zcashd:5.8.0/",
     "version": 170100,
-    "connection_state": "Responded"
+    "connection_state": "connected"
   }
 ]
 "#;
@@ -1281,7 +1281,7 @@ fn test_get_peer_info() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(obj[0].banscore(), 0);
     assert_eq!(obj[0].subver().as_str(), "/Zebra:2.1.0/");
     assert_eq!(obj[0].version(), 170140);
-    assert_eq!(obj[0].connection_state().as_str(), "Responded");
+    assert_eq!(obj[0].connection_state().as_str(), "connected");
 
     Ok(())
 }
@@ -1298,7 +1298,7 @@ fn test_get_peer_info_with_ping_values_serialization() -> Result<(), Box<dyn std
     "banscore": 0,
     "subver": "/Zebra:2.1.0/",
     "version": 170140,
-    "connection_state": "Responded",
+    "connection_state": "connected",
     "pingtime": 123,
     "pingwait": 45
   },
@@ -1310,7 +1310,7 @@ fn test_get_peer_info_with_ping_values_serialization() -> Result<(), Box<dyn std
     "banscore": 0,
     "subver": "/zcashd:5.8.0/",
     "version": 170100,
-    "connection_state": "Responded",
+    "connection_state": "connected",
     "pingtime": 67,
     "pingwait": 89
   }

--- a/zebra-rpc/tests/serialization_tests.rs
+++ b/zebra-rpc/tests/serialization_tests.rs
@@ -8,7 +8,7 @@
 
 mod vectors;
 
-use std::{io::Cursor, ops::Deref};
+use std::io::Cursor;
 
 use vectors::{
     GET_BLOCKCHAIN_INFO_RESPONSE, GET_BLOCK_RESPONSE_1, GET_BLOCK_RESPONSE_2,
@@ -32,7 +32,7 @@ use zebra_rpc::client::{
     GetBlockchainInfoResponse, GetInfoResponse, GetMiningInfoResponse, GetNetworkInfoResponse,
     GetPeerInfoResponse, GetRawMempoolResponse, GetRawTransactionResponse,
     GetSubtreesByIndexResponse, GetTreestateResponse, Hash, Input, JoinSplit, MempoolObject,
-    Orchard, OrchardAction, OrchardFlags, Output, PeerInfo, ScriptPubKey, ScriptSig,
+    Orchard, OrchardAction, OrchardFlags, Output, ScriptPubKey, ScriptSig,
     SendRawTransactionResponse, ShieldedOutput, ShieldedSpend, SubmitBlockErrorResponse,
     SubmitBlockResponse, SubtreeRpcData, TransactionObject, TransactionTemplate, Treestate, Utxo,
     ValidateAddressResponse, ZListUnifiedReceiversResponse, ZValidateAddressResponse,
@@ -1253,26 +1253,35 @@ fn test_get_peer_info() -> Result<(), Box<dyn std::error::Error>> {
 [
   {
     "addr": "192.168.0.1:8233",
-    "inbound": false
+    "services": "0000000000000001",
+    "lastrecv": 1700000000,
+    "inbound": false,
+    "banscore": 0,
+    "subver": "/Zebra:2.1.0/",
+    "version": 170140,
+    "connection_state": "Responded"
   },
   {
     "addr": "[2000:2000:2000:0000::]:8233",
-    "inbound": false
+    "services": "0000000000000001",
+    "lastrecv": 1700000000,
+    "inbound": false,
+    "banscore": 0,
+    "subver": "/zcashd:5.8.0/",
+    "version": 170100,
+    "connection_state": "Responded"
   }
 ]
 "#;
     let obj: GetPeerInfoResponse = serde_json::from_str(json)?;
 
-    let addr0 = *obj[0].addr().deref();
-    let inbound0 = obj[0].inbound();
-    let addr1 = *obj[1].addr().deref();
-    let inbound1 = obj[1].inbound();
-
-    let new_obj = vec![
-        PeerInfo::new(addr0.into(), inbound0, None, None),
-        PeerInfo::new(addr1.into(), inbound1, None, None),
-    ];
-    assert_eq!(obj, new_obj);
+    assert_eq!(obj.len(), 2);
+    assert_eq!(obj[0].services().as_str(), "0000000000000001");
+    assert_eq!(obj[0].lastrecv(), 1700000000);
+    assert_eq!(obj[0].banscore(), 0);
+    assert_eq!(obj[0].subver().as_str(), "/Zebra:2.1.0/");
+    assert_eq!(obj[0].version(), 170140);
+    assert_eq!(obj[0].connection_state().as_str(), "Responded");
 
     Ok(())
 }
@@ -1283,13 +1292,25 @@ fn test_get_peer_info_with_ping_values_serialization() -> Result<(), Box<dyn std
 [
   {
     "addr": "192.168.0.1:8233",
+    "services": "0000000000000001",
+    "lastrecv": 1700000000,
     "inbound": false,
+    "banscore": 0,
+    "subver": "/Zebra:2.1.0/",
+    "version": 170140,
+    "connection_state": "Responded",
     "pingtime": 123,
     "pingwait": 45
   },
   {
     "addr": "[2000:2000:2000:0000::]:8233",
+    "services": "0000000000000001",
+    "lastrecv": 1700000000,
     "inbound": false,
+    "banscore": 0,
+    "subver": "/zcashd:5.8.0/",
+    "version": 170100,
+    "connection_state": "Responded",
     "pingtime": 67,
     "pingwait": 89
   }
@@ -1297,21 +1318,11 @@ fn test_get_peer_info_with_ping_values_serialization() -> Result<(), Box<dyn std
 "#;
     let obj: GetPeerInfoResponse = serde_json::from_str(json)?;
 
-    let addr0 = *obj[0].addr().deref();
-    let inbound0 = obj[0].inbound();
-    let pingtime0 = obj[0].pingtime();
-    let pingwait0 = obj[0].pingwait();
-
-    let addr1 = *obj[1].addr().deref();
-    let inbound1 = obj[1].inbound();
-    let pingtime1 = obj[1].pingtime();
-    let pingwait1 = obj[1].pingwait();
-
-    let new_obj = vec![
-        PeerInfo::new(addr0.into(), inbound0, *pingtime0, *pingwait0),
-        PeerInfo::new(addr1.into(), inbound1, *pingtime1, *pingwait1),
-    ];
-    assert_eq!(obj, new_obj);
+    assert_eq!(obj.len(), 2);
+    assert_eq!(*obj[0].pingtime(), Some(123.0));
+    assert_eq!(*obj[0].pingwait(), Some(45.0));
+    assert_eq!(*obj[1].pingtime(), Some(67.0));
+    assert_eq!(*obj[1].pingwait(), Some(89.0));
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

Close #10439.

## Solution

Extend the `getpeerinfo` RPC response with:

- subver: peer's user agent string (e.g. "Zebra:4.3.0", "MagicBean:6.11.0")
- version: negotiated protocol version
- services: offered services as zero-padded hex string
- lastrecv: timestamp of last message received
- banscore: misbehavior score
- connection_state: current connection state

To plumb `user_agent` and `negotiated_version` from the handshake into the address book, `MetaAddr` and `MetaAddrChange` had `Copy` removed (`user_agent` is a `String`). All downstream code updated to use `Clone` instead.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used.

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
