### PR TITLE
fix(ci): enforce conventional commit format on PR titles

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,7 +42,7 @@
 
 ### PR Checklist
 
-- [ ] The PR name is suitable for the release notes.
+- [ ] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
 - [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
 - [ ] This change was discussed in an issue or with the team beforehand.
 - [ ] The solution is tested.

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -3,21 +3,28 @@
 #
 # Since PRs are squash-merged, the PR title becomes the commit message on main.
 # This is the foundation for automated changelog generation and version bumping.
+#
+# Uses pull_request_target to post sticky comments on invalid titles (requires
+# pull-requests: write). No code checkout or secret access — only reads the
+# PR title via the API and posts/deletes a comment.
 name: PR Title Check
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
-  check:
+  validate:
     name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 #v6.1.1
+      - name: Check PR title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 #v6.1.1
+        id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -71,3 +78,24 @@ jobs:
 
             See: https://www.conventionalcommits.org/
             Docs: https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md#pull-requests
+
+      - name: Comment on invalid PR title
+        uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 #v3
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/) format. Your title needs a small adjustment.
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+            See the [contribution guide](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md#pull-requests) for details.
+
+      - name: Remove comment on valid PR title
+        uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 #v3
+        if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        with:
+          header: pr-title-lint-error
+          delete: true

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,74 @@
+# Validates that PR titles follow the conventional commits specification.
+# https://www.conventionalcommits.org/en/v1.0.0/
+#
+# Since PRs are squash-merged, the PR title becomes the commit message on main.
+# This is the foundation for automated changelog generation and version bumping.
+name: PR Title Check
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  statuses: write
+  pull-requests: read
+
+jobs:
+  check:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 #v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            build
+            chore
+            docs
+            test
+            ci
+            style
+            revert
+            release
+          scopes: |
+            zebra-chain
+            zebra-consensus
+            zebra-network
+            zebra-state
+            zebra-rpc
+            zebra-script
+            zebra-node-services
+            zebra-test
+            zebra-utils
+            zebrad
+            tower-batch-control
+            tower-fallback
+            chain
+            consensus
+            network
+            state
+            rpc
+            script
+            deps
+            ci
+            release
+          requireScope: false
+          subjectPattern: ^.+$
+          subjectPatternError: |
+            PR title must follow conventional commits:
+
+              <type>(<optional scope>): <description>
+
+            Examples:
+              fix(zebra-rpc): correct connection timeout
+              feat(zebra-chain): add signature verification
+              docs: update installation guide
+              build(deps): bump serde to 1.0.220
+
+            See: https://www.conventionalcommits.org/
+            Docs: https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md#pull-requests

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -10,6 +10,7 @@
 name: PR Title Check
 
 on:
+  # zizmor: ignore[dangerous-triggers] -- no checkout, no secrets, only API reads + PR comment write
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
@@ -80,7 +81,7 @@ jobs:
             Docs: https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md#pull-requests
 
       - name: Comment on invalid PR title
-        uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 #v3
+        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff #v3.0.3
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
         with:
           header: pr-title-lint-error
@@ -94,7 +95,7 @@ jobs:
             See the [contribution guide](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md#pull-requests) for details.
 
       - name: Remove comment on valid PR title
-        uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 #v3
+        uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff #v3.0.3
         if: ${{ steps.lint_pr_title.outputs.error_message == null }}
         with:
           header: pr-title-lint-error

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -6,12 +6,11 @@
 name: PR Title Check
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize, reopened]
 
 permissions:
-  statuses: write
-  pull-requests: read
+  contents: read
 
 jobs:
   check:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -82,6 +82,9 @@ jobs:
 
       - name: Comment on invalid PR title
         uses: marocchino/sticky-pull-request-comment@d4d6b0936434b21bc8345ad45a440c5f7d2c40ff #v3.0.3
+        # null comparison is intentional: the action only sets error_message on failure.
+        # When validation passes the output key is absent (null), not empty string.
+        # See: https://github.com/amannn/action-semantic-pull-request#outputs
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
         with:
           header: pr-title-lint-error


### PR DESCRIPTION
## Motivation

Zebra squash-merges PRs, so the PR title becomes the commit message on main. `CONTRIBUTING.md` already requires conventional commits, but there is no CI enforcement.

## Solution

Enforce the conventional commit format on PR titles via CI. Scopes are optional and match crate names. Invalid titles get an actionable error with examples and a link to the contribution guide.

Also adds a format reminder to the PR template checklist.

### Tests

This PR itself validates the check on open.

### AI Disclosure

- [x] AI tools were used: Claude for researching the action and drafting the scope list.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed with the team beforehand.
- [x] The solution is tested.
- [ ] The documentation and changelogs are up to date.