### PR TITLE
feat(ci): automate checkpoint updates and end-of-support height

### DIFF
--- a/.github/scripts/validate-checkpoints.sh
+++ b/.github/scripts/validate-checkpoints.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# validate-checkpoints.sh
+#
+# Validates checkpoint file format and structure.
+# Used by the checkpoint-update workflow to verify new entries before committing.
+#
+# Usage: .github/scripts/validate-checkpoints.sh <checkpoint-file>
+#
+# Exit codes:
+#   0 — valid
+#   1 — validation error (details printed to stderr)
+
+set -euo pipefail
+
+FILE="${1:?Usage: validate-checkpoints.sh <checkpoint-file>}"
+
+if [ ! -f "$FILE" ]; then
+  echo "ERROR: File not found: $FILE" >&2
+  exit 1
+fi
+
+ERRORS=0
+
+# Check every line matches the format: HEIGHT HASH (number, space, 64 hex chars)
+BAD_FORMAT=$(grep -cvE '^[0-9]+ [0-9a-f]{64}$' "$FILE" || true)
+if [ "$BAD_FORMAT" -gt 0 ]; then
+  echo "ERROR: $BAD_FORMAT lines have invalid format (expected: HEIGHT HASH)" >&2
+  grep -nvE '^[0-9]+ [0-9a-f]{64}$' "$FILE" | head -5 >&2
+  ERRORS=$((ERRORS + BAD_FORMAT))
+fi
+
+# Check file starts at height 0
+FIRST_HEIGHT=$(head -1 "$FILE" | cut -d' ' -f1)
+if [ "$FIRST_HEIGHT" != "0" ]; then
+  echo "ERROR: File must start at height 0, found height $FIRST_HEIGHT" >&2
+  ERRORS=$((ERRORS + 1))
+fi
+
+# Check heights are monotonically increasing
+NON_MONOTONIC=$(awk '{print $1}' "$FILE" | awk 'NR>1 && $1 <= prev {print NR": "$1" <= "prev} {prev=$1}')
+if [ -n "$NON_MONOTONIC" ]; then
+  COUNT=$(echo "$NON_MONOTONIC" | wc -l)
+  echo "ERROR: $COUNT non-monotonic heights found" >&2
+  echo "$NON_MONOTONIC" | head -5 >&2
+  ERRORS=$((ERRORS + COUNT))
+fi
+
+# Check intervals (max 400 blocks between consecutive checkpoints)
+LARGE_GAPS=$(awk '{print $1}' "$FILE" | awk 'NR>1 && ($1 - prev) > 400 {print NR": gap "($1-prev)" between "prev" and "$1} {prev=$1}')
+if [ -n "$LARGE_GAPS" ]; then
+  COUNT=$(echo "$LARGE_GAPS" | wc -l)
+  echo "ERROR: $COUNT gaps exceed 400 blocks" >&2
+  echo "$LARGE_GAPS" | head -5 >&2
+  ERRORS=$((ERRORS + COUNT))
+fi
+
+# Check for duplicate heights
+DUP_HEIGHTS=$(awk '{print $1}' "$FILE" | sort | uniq -d)
+if [ -n "$DUP_HEIGHTS" ]; then
+  COUNT=$(echo "$DUP_HEIGHTS" | wc -l)
+  echo "ERROR: $COUNT duplicate heights" >&2
+  echo "$DUP_HEIGHTS" | head -5 >&2
+  ERRORS=$((ERRORS + COUNT))
+fi
+
+# Check for duplicate hashes
+DUP_HASHES=$(awk '{print $2}' "$FILE" | sort | uniq -d)
+if [ -n "$DUP_HASHES" ]; then
+  COUNT=$(echo "$DUP_HASHES" | wc -l)
+  echo "ERROR: $COUNT duplicate hashes" >&2
+  echo "$DUP_HASHES" | head -5 >&2
+  ERRORS=$((ERRORS + COUNT))
+fi
+
+TOTAL_LINES=$(wc -l < "$FILE" | tr -d ' ')
+LAST_HEIGHT=$(tail -1 "$FILE" | cut -d' ' -f1)
+echo "Validated $TOTAL_LINES entries, last height: $LAST_HEIGHT"
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo "FAILED: $ERRORS validation errors" >&2
+  exit 1
+fi
+
+echo "OK: All entries valid"

--- a/.github/scripts/validate-checkpoints.sh
+++ b/.github/scripts/validate-checkpoints.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 # validate-checkpoints.sh
 #
-# Validates checkpoint file format and structure.
-# Used by the checkpoint-update workflow to verify new entries before committing.
+# Validates checkpoint file format and structure in a single pass.
 #
 # Usage: .github/scripts/validate-checkpoints.sh <checkpoint-file>
 #
 # Exit codes:
-#   0 — valid
-#   1 — validation error (details printed to stderr)
+#   0 - valid
+#   1 - validation error (details printed to stderr)
 
 set -euo pipefail
 
@@ -19,66 +18,46 @@ if [ ! -f "$FILE" ]; then
   exit 1
 fi
 
-ERRORS=0
-
-# Check every line matches the format: HEIGHT HASH (number, space, 64 hex chars)
-BAD_FORMAT=$(grep -cvE '^[0-9]+ [0-9a-f]{64}$' "$FILE" || true)
-if [ "$BAD_FORMAT" -gt 0 ]; then
-  echo "ERROR: $BAD_FORMAT lines have invalid format (expected: HEIGHT HASH)" >&2
-  grep -nvE '^[0-9]+ [0-9a-f]{64}$' "$FILE" | head -5 >&2
-  ERRORS=$((ERRORS + BAD_FORMAT))
-fi
-
-# Check file starts at height 0
-FIRST_HEIGHT=$(head -1 "$FILE" | cut -d' ' -f1)
-if [ "$FIRST_HEIGHT" != "0" ]; then
-  echo "ERROR: File must start at height 0, found height $FIRST_HEIGHT" >&2
-  ERRORS=$((ERRORS + 1))
-fi
-
-# Check heights are monotonically increasing
-NON_MONOTONIC=$(awk '{print $1}' "$FILE" | awk 'NR>1 && $1 <= prev {print NR": "$1" <= "prev} {prev=$1}')
-if [ -n "$NON_MONOTONIC" ]; then
-  COUNT=$(echo "$NON_MONOTONIC" | wc -l)
-  echo "ERROR: $COUNT non-monotonic heights found" >&2
-  echo "$NON_MONOTONIC" | head -5 >&2
-  ERRORS=$((ERRORS + COUNT))
-fi
-
-# Check intervals (max 400 blocks between consecutive checkpoints)
-LARGE_GAPS=$(awk '{print $1}' "$FILE" | awk 'NR>1 && ($1 - prev) > 400 {print NR": gap "($1-prev)" between "prev" and "$1} {prev=$1}')
-if [ -n "$LARGE_GAPS" ]; then
-  COUNT=$(echo "$LARGE_GAPS" | wc -l)
-  echo "ERROR: $COUNT gaps exceed 400 blocks" >&2
-  echo "$LARGE_GAPS" | head -5 >&2
-  ERRORS=$((ERRORS + COUNT))
-fi
-
-# Check for duplicate heights
-DUP_HEIGHTS=$(awk '{print $1}' "$FILE" | sort | uniq -d)
-if [ -n "$DUP_HEIGHTS" ]; then
-  COUNT=$(echo "$DUP_HEIGHTS" | wc -l)
-  echo "ERROR: $COUNT duplicate heights" >&2
-  echo "$DUP_HEIGHTS" | head -5 >&2
-  ERRORS=$((ERRORS + COUNT))
-fi
-
-# Check for duplicate hashes
-DUP_HASHES=$(awk '{print $2}' "$FILE" | sort | uniq -d)
-if [ -n "$DUP_HASHES" ]; then
-  COUNT=$(echo "$DUP_HASHES" | wc -l)
-  echo "ERROR: $COUNT duplicate hashes" >&2
-  echo "$DUP_HASHES" | head -5 >&2
-  ERRORS=$((ERRORS + COUNT))
-fi
-
-TOTAL_LINES=$(wc -l < "$FILE" | tr -d ' ')
-LAST_HEIGHT=$(tail -1 "$FILE" | cut -d' ' -f1)
-echo "Validated $TOTAL_LINES entries, last height: $LAST_HEIGHT"
-
-if [ "$ERRORS" -gt 0 ]; then
-  echo "FAILED: $ERRORS validation errors" >&2
-  exit 1
-fi
-
-echo "OK: All entries valid"
+# Single-pass validation using awk
+awk '
+  !/^[0-9]+ [0-9a-f]{64}$/ {
+    printf "ERROR: line %d: invalid format: %s\n", NR, $0 > "/dev/stderr"
+    errs++
+    next
+  }
+  NR == 1 && $1 != "0" {
+    printf "ERROR: file must start at height 0, found %s\n", $1 > "/dev/stderr"
+    errs++
+  }
+  NR > 1 && $1 <= prev_h {
+    printf "ERROR: line %d: height %d is not greater than previous %d\n", NR, $1, prev_h > "/dev/stderr"
+    errs++
+  }
+  NR > 1 && ($1 - prev_h) > 400 {
+    printf "ERROR: line %d: gap of %d blocks between %d and %d\n", NR, $1 - prev_h, prev_h, $1 > "/dev/stderr"
+    errs++
+  }
+  $1 in seen_h {
+    printf "ERROR: line %d: duplicate height %d\n", NR, $1 > "/dev/stderr"
+    errs++
+  }
+  $2 in seen_hash {
+    printf "ERROR: line %d: duplicate hash %s\n", NR, $2 > "/dev/stderr"
+    errs++
+  }
+  {
+    seen_h[$1] = 1
+    seen_hash[$2] = 1
+    prev_h = $1
+    last_h = $1
+    total++
+  }
+  END {
+    printf "Validated %d entries, last height: %d\n", total, last_h
+    if (errs > 0) {
+      printf "FAILED: %d validation errors\n", errs > "/dev/stderr"
+      exit 1
+    }
+    print "OK: All entries valid"
+  }
+' "$FILE"

--- a/.github/workflows/checkpoint-update.yml
+++ b/.github/workflows/checkpoint-update.yml
@@ -16,13 +16,18 @@ on:
     types: [completed]
     branches: [main]
 
+  # Manual trigger for testing; resolves the latest successful integration test run automatically
+  workflow_dispatch:
+
 permissions: {}
 
 jobs:
   update-checkpoints:
     name: Update checkpoint files
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     permissions:
       actions: read
       contents: write
@@ -31,13 +36,42 @@ jobs:
       MAINNET_CHECKPOINTS: zebra-chain/src/parameters/checkpoint/main-checkpoints.txt
       TESTNET_CHECKPOINTS: zebra-chain/src/parameters/checkpoint/test-checkpoints.txt
       EOS_FILE: zebrad/src/components/sync/end_of_support.rs
-      WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
-      WORKFLOW_RUN_URL: ${{ github.event.workflow_run.html_url }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: true
           ref: main
+
+      # Resolve the integration test run ID.
+      # For workflow_run: use the triggering run directly.
+      # For workflow_dispatch: find the latest successful run via the API.
+      - name: Resolve integration test run ID
+        id: resolve-run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            RUN_ID="${{ github.event.workflow_run.id }}"
+            RUN_URL="${{ github.event.workflow_run.html_url }}"
+          else
+            RUN_ID=$(gh run list \
+              --workflow "Integration Tests on GCP" \
+              --branch main \
+              --status success \
+              --limit 1 \
+              --json databaseId \
+              --jq '.[0].databaseId')
+            RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}"
+          fi
+
+          if [ -z "$RUN_ID" ]; then
+            echo "No successful integration test run found"
+            exit 1
+          fi
+
+          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+          echo "run_url=${RUN_URL}" >> "$GITHUB_OUTPUT"
+          echo "Using integration test run: ${RUN_URL}"
 
       # Download checkpoint artifacts from the integration test run.
       - name: Download mainnet checkpoint artifact
@@ -45,7 +79,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
         with:
           name: generate-checkpoints-mainnet-checkpoints
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ steps.resolve-run.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
@@ -54,7 +88,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
         with:
           name: generate-checkpoints-testnet-checkpoints
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ steps.resolve-run.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
@@ -171,7 +205,7 @@ jobs:
           body: |
             Automated checkpoint update from the weekly integration test run.
 
-            **Source:** [Integration test run #${{ env.WORKFLOW_RUN_ID }}](${{ env.WORKFLOW_RUN_URL }})
+            **Source:** [Integration test run #${{ steps.resolve-run.outputs.run_id }}](${{ steps.resolve-run.outputs.run_url }})
 
             ### Changes
 

--- a/.github/workflows/checkpoint-update.yml
+++ b/.github/workflows/checkpoint-update.yml
@@ -60,12 +60,18 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true
 
+      # The generate-checkpoints-* jobs are skipped when no tip disk exists
+      # (e.g., full sync still in progress) or when the workflow runs in
+      # regenerate/sync-only mode. When skipped, no artifact is produced.
       - name: Check if any artifacts were downloaded
         id: check-artifacts
         run: |
           HAS_MAINNET="false"
           HAS_TESTNET="false"
 
+          # These are the CI-generated checkpoint files (new entries only),
+          # not the full repo checkpoint files. Named by the upload step in
+          # zfnd-deploy-integration-tests-gcp.yml.
           if [ -f "checkpoints-mainnet.txt" ]; then
             LINES=$(wc -l < checkpoints-mainnet.txt | tr -d ' ')
             echo "Mainnet artifact: ${LINES} checkpoint lines"

--- a/.github/workflows/checkpoint-update.yml
+++ b/.github/workflows/checkpoint-update.yml
@@ -40,8 +40,6 @@ jobs:
           ref: main
 
       # Download checkpoint artifacts from the integration test run.
-      # The artifact names are: generate-checkpoints-mainnet-checkpoints
-      # and generate-checkpoints-testnet-checkpoints.
       - name: Download mainnet checkpoint artifact
         id: mainnet-artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
@@ -69,17 +67,16 @@ jobs:
           HAS_MAINNET="false"
           HAS_TESTNET="false"
 
-          # These are the CI-generated checkpoint files (new entries only),
-          # not the full repo checkpoint files. Named by the upload step in
-          # zfnd-deploy-integration-tests-gcp.yml.
-          if [ -f "checkpoints-mainnet.txt" ]; then
-            LINES=$(wc -l < checkpoints-mainnet.txt | tr -d ' ')
+              # Artifact files mirror the repo naming: main-checkpoints.txt / test-checkpoints.txt
+          # These contain only the new entries from the CI run, not the full file.
+          if [ -f "main-checkpoints.txt" ]; then
+            LINES=$(wc -l < main-checkpoints.txt | tr -d ' ')
             echo "Mainnet artifact: ${LINES} checkpoint lines"
             HAS_MAINNET="true"
           fi
 
-          if [ -f "checkpoints-testnet.txt" ]; then
-            LINES=$(wc -l < checkpoints-testnet.txt | tr -d ' ')
+          if [ -f "test-checkpoints.txt" ]; then
+            LINES=$(wc -l < test-checkpoints.txt | tr -d ' ')
             echo "Testnet artifact: ${LINES} checkpoint lines"
             HAS_TESTNET="true"
           fi
@@ -102,11 +99,11 @@ jobs:
           echo "Current last mainnet checkpoint: ${CURRENT_LAST}"
 
           # Extract only new entries (height > current last)
-          NEW_COUNT=$(awk -v last="$CURRENT_LAST" '$1 > last' checkpoints-mainnet.txt | wc -l | tr -d ' ')
+          NEW_COUNT=$(awk -v last="$CURRENT_LAST" '$1 > last' main-checkpoints.txt | wc -l | tr -d ' ')
           echo "New mainnet checkpoints to append: ${NEW_COUNT}"
 
           if [ "$NEW_COUNT" -gt 0 ]; then
-            awk -v last="$CURRENT_LAST" '$1 > last' checkpoints-mainnet.txt >> "${MAINNET_CHECKPOINTS}"
+            awk -v last="$CURRENT_LAST" '$1 > last' main-checkpoints.txt >> "${MAINNET_CHECKPOINTS}"
             NEW_LAST=$(tail -1 "${MAINNET_CHECKPOINTS}" | awk '{print $1}')
             echo "Updated last mainnet checkpoint: ${NEW_LAST}"
           fi
@@ -118,11 +115,11 @@ jobs:
           CURRENT_LAST=$(tail -1 "${TESTNET_CHECKPOINTS}" | awk '{print $1}')
           echo "Current last testnet checkpoint: ${CURRENT_LAST}"
 
-          NEW_COUNT=$(awk -v last="$CURRENT_LAST" '$1 > last' checkpoints-testnet.txt | wc -l | tr -d ' ')
+          NEW_COUNT=$(awk -v last="$CURRENT_LAST" '$1 > last' test-checkpoints.txt | wc -l | tr -d ' ')
           echo "New testnet checkpoints to append: ${NEW_COUNT}"
 
           if [ "$NEW_COUNT" -gt 0 ]; then
-            awk -v last="$CURRENT_LAST" '$1 > last' checkpoints-testnet.txt >> "${TESTNET_CHECKPOINTS}"
+            awk -v last="$CURRENT_LAST" '$1 > last' test-checkpoints.txt >> "${TESTNET_CHECKPOINTS}"
             NEW_LAST=$(tail -1 "${TESTNET_CHECKPOINTS}" | awk '{print $1}')
             echo "Updated last testnet checkpoint: ${NEW_LAST}"
           fi

--- a/.github/workflows/checkpoint-update.yml
+++ b/.github/workflows/checkpoint-update.yml
@@ -5,7 +5,7 @@
 # appends new entries to the checkpoint files, updates the end-of-support
 # height, validates everything, and opens a PR.
 #
-# The PR requires human review before merge — checkpoints are consensus-critical.
+# The PR requires human review before merge; checkpoints are consensus-critical.
 name: Checkpoint Update
 
 on:
@@ -82,7 +82,7 @@ jobs:
           fi
 
           if [ "$HAS_MAINNET" = "false" ] && [ "$HAS_TESTNET" = "false" ]; then
-            echo "No checkpoint artifacts found — skipping update"
+            echo "No checkpoint artifacts found, skipping update"
             echo "has_updates=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -189,7 +189,7 @@ jobs:
 
             ### Review
 
-            Checkpoints are consensus-critical — incorrect hashes could cause nodes
+            Checkpoints are consensus-critical; incorrect hashes could cause nodes
             to follow a wrong fork. Verify the source integration test run linked
             above completed successfully against the real Zcash network.
           labels: A-release,C-enhancement

--- a/.github/workflows/checkpoint-update.yml
+++ b/.github/workflows/checkpoint-update.yml
@@ -49,10 +49,14 @@ jobs:
         id: resolve-run
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          WF_RUN_ID: ${{ github.event.workflow_run.id }}
+          WF_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          REPO: ${{ github.repository }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            RUN_ID="${{ github.event.workflow_run.id }}"
-            RUN_URL="${{ github.event.workflow_run.html_url }}"
+          if [ "$EVENT_NAME" = "workflow_run" ]; then
+            RUN_ID="$WF_RUN_ID"
+            RUN_URL="$WF_RUN_URL"
           else
             RUN_ID=$(gh run list \
               --workflow "Integration Tests on GCP" \
@@ -61,7 +65,7 @@ jobs:
               --limit 1 \
               --json databaseId \
               --jq '.[0].databaseId')
-            RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}"
+            RUN_URL="https://github.com/${REPO}/actions/runs/${RUN_ID}"
           fi
 
           if [ -z "$RUN_ID" ]; then

--- a/.github/workflows/checkpoint-update.yml
+++ b/.github/workflows/checkpoint-update.yml
@@ -67,8 +67,7 @@ jobs:
           HAS_MAINNET="false"
           HAS_TESTNET="false"
 
-              # Artifact files mirror the repo naming: main-checkpoints.txt / test-checkpoints.txt
-          # These contain only the new entries from the CI run, not the full file.
+          # Artifact files use the same names as the repo files (new entries only)
           if [ -f "main-checkpoints.txt" ]; then
             LINES=$(wc -l < main-checkpoints.txt | tr -d ' ')
             echo "Mainnet artifact: ${LINES} checkpoint lines"
@@ -131,8 +130,8 @@ jobs:
         if: steps.check-artifacts.outputs.has_mainnet == 'true'
         run: |
           LAST_HEIGHT=$(tail -1 "${MAINNET_CHECKPOINTS}" | awk '{print $1}')
-          # Format with underscores for readability (e.g., 3_282_406)
-          FORMATTED=$(echo "$LAST_HEIGHT" | sed ':a;s/\B[0-9]\{3\}\>/_&/;ta')
+          # Format with underscores for Rust readability (e.g., 3_282_406)
+          FORMATTED=$(echo "$LAST_HEIGHT" | awk '{n=$0; r=""; for(i=length(n);i>0;i--) { r=substr(n,i,1) r; if((length(n)-i)%3==2 && i>1) r="_" r }; print r}')
           echo "Setting ESTIMATED_RELEASE_HEIGHT to ${FORMATTED} (height ${LAST_HEIGHT})"
 
           sed -i "s/ESTIMATED_RELEASE_HEIGHT: u32 = [0-9_]*/ESTIMATED_RELEASE_HEIGHT: u32 = ${FORMATTED}/" \

--- a/.github/workflows/checkpoint-update.yml
+++ b/.github/workflows/checkpoint-update.yml
@@ -12,8 +12,9 @@ on:
   # zizmor: ignore[dangerous-triggers] -- triggers only on internal CI workflow completion,
   # processes deterministic checkpoint data from artifacts, no untrusted user input
   workflow_run:
-    workflows: ["CI integration tests on GCP"]
+    workflows: ["Integration Tests on GCP"]
     types: [completed]
+    branches: [main]
 
 permissions: {}
 
@@ -23,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
     permissions:
+      actions: read
       contents: write
       pull-requests: write
     env:

--- a/.github/workflows/checkpoint-update.yml
+++ b/.github/workflows/checkpoint-update.yml
@@ -1,0 +1,190 @@
+# Automated checkpoint and end-of-support height updates.
+#
+# Triggered when the weekly integration tests complete successfully.
+# Downloads checkpoint artifacts produced by generate-checkpoints-* jobs,
+# appends new entries to the checkpoint files, updates the end-of-support
+# height, validates everything, and opens a PR.
+#
+# The PR requires human review before merge — checkpoints are consensus-critical.
+name: Checkpoint Update
+
+on:
+  workflow_run:
+    workflows: ["CI integration tests on GCP"]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  update-checkpoints:
+    name: Update checkpoint files
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      MAINNET_CHECKPOINTS: zebra-chain/src/parameters/checkpoint/main-checkpoints.txt
+      TESTNET_CHECKPOINTS: zebra-chain/src/parameters/checkpoint/test-checkpoints.txt
+      EOS_FILE: zebrad/src/components/sync/end_of_support.rs
+      WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+      WORKFLOW_RUN_URL: ${{ github.event.workflow_run.html_url }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: true
+          ref: main
+
+      # Download checkpoint artifacts from the integration test run.
+      # The artifact names are: generate-checkpoints-mainnet-checkpoints
+      # and generate-checkpoints-testnet-checkpoints.
+      - name: Download mainnet checkpoint artifact
+        id: mainnet-artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
+        with:
+          name: generate-checkpoints-mainnet-checkpoints
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Download testnet checkpoint artifact
+        id: testnet-artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
+        with:
+          name: generate-checkpoints-testnet-checkpoints
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Check if any artifacts were downloaded
+        id: check-artifacts
+        run: |
+          HAS_MAINNET="false"
+          HAS_TESTNET="false"
+
+          if [ -f "checkpoints-mainnet.txt" ]; then
+            LINES=$(wc -l < checkpoints-mainnet.txt | tr -d ' ')
+            echo "Mainnet artifact: ${LINES} checkpoint lines"
+            HAS_MAINNET="true"
+          fi
+
+          if [ -f "checkpoints-testnet.txt" ]; then
+            LINES=$(wc -l < checkpoints-testnet.txt | tr -d ' ')
+            echo "Testnet artifact: ${LINES} checkpoint lines"
+            HAS_TESTNET="true"
+          fi
+
+          if [ "$HAS_MAINNET" = "false" ] && [ "$HAS_TESTNET" = "false" ]; then
+            echo "No checkpoint artifacts found — skipping update"
+            echo "has_updates=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "has_mainnet=${HAS_MAINNET}" >> "$GITHUB_OUTPUT"
+          echo "has_testnet=${HAS_TESTNET}" >> "$GITHUB_OUTPUT"
+          echo "has_updates=true" >> "$GITHUB_OUTPUT"
+
+      # Append new mainnet checkpoints (entries with heights higher than current last)
+      - name: Append new mainnet checkpoints
+        if: steps.check-artifacts.outputs.has_mainnet == 'true'
+        run: |
+          CURRENT_LAST=$(tail -1 "${MAINNET_CHECKPOINTS}" | awk '{print $1}')
+          echo "Current last mainnet checkpoint: ${CURRENT_LAST}"
+
+          # Extract only new entries (height > current last)
+          NEW_COUNT=$(awk -v last="$CURRENT_LAST" '$1 > last' checkpoints-mainnet.txt | wc -l | tr -d ' ')
+          echo "New mainnet checkpoints to append: ${NEW_COUNT}"
+
+          if [ "$NEW_COUNT" -gt 0 ]; then
+            awk -v last="$CURRENT_LAST" '$1 > last' checkpoints-mainnet.txt >> "${MAINNET_CHECKPOINTS}"
+            NEW_LAST=$(tail -1 "${MAINNET_CHECKPOINTS}" | awk '{print $1}')
+            echo "Updated last mainnet checkpoint: ${NEW_LAST}"
+          fi
+
+      # Append new testnet checkpoints
+      - name: Append new testnet checkpoints
+        if: steps.check-artifacts.outputs.has_testnet == 'true'
+        run: |
+          CURRENT_LAST=$(tail -1 "${TESTNET_CHECKPOINTS}" | awk '{print $1}')
+          echo "Current last testnet checkpoint: ${CURRENT_LAST}"
+
+          NEW_COUNT=$(awk -v last="$CURRENT_LAST" '$1 > last' checkpoints-testnet.txt | wc -l | tr -d ' ')
+          echo "New testnet checkpoints to append: ${NEW_COUNT}"
+
+          if [ "$NEW_COUNT" -gt 0 ]; then
+            awk -v last="$CURRENT_LAST" '$1 > last' checkpoints-testnet.txt >> "${TESTNET_CHECKPOINTS}"
+            NEW_LAST=$(tail -1 "${TESTNET_CHECKPOINTS}" | awk '{print $1}')
+            echo "Updated last testnet checkpoint: ${NEW_LAST}"
+          fi
+
+      # Update the end-of-support estimated release height using the latest
+      # mainnet checkpoint height. This is a lower bound (~3-7 days behind
+      # the real tip), but the EOS window is 105 days, making it negligible.
+      - name: Update end-of-support height
+        if: steps.check-artifacts.outputs.has_mainnet == 'true'
+        run: |
+          LAST_HEIGHT=$(tail -1 "${MAINNET_CHECKPOINTS}" | awk '{print $1}')
+          # Format with underscores for readability (e.g., 3_282_406)
+          FORMATTED=$(echo "$LAST_HEIGHT" | sed ':a;s/\B[0-9]\{3\}\>/_&/;ta')
+          echo "Setting ESTIMATED_RELEASE_HEIGHT to ${FORMATTED} (height ${LAST_HEIGHT})"
+
+          sed -i "s/ESTIMATED_RELEASE_HEIGHT: u32 = [0-9_]*/ESTIMATED_RELEASE_HEIGHT: u32 = ${FORMATTED}/" \
+            "${EOS_FILE}"
+
+          grep "ESTIMATED_RELEASE_HEIGHT" "${EOS_FILE}" | head -1
+
+      # Validate the updated checkpoint files
+      - name: Validate checkpoint files
+        if: steps.check-artifacts.outputs.has_updates == 'true'
+        run: |
+          .github/scripts/validate-checkpoints.sh "${MAINNET_CHECKPOINTS}"
+          .github/scripts/validate-checkpoints.sh "${TESTNET_CHECKPOINTS}"
+
+      # Check if there are actual changes to commit
+      - name: Check for changes
+        id: changes
+        if: steps.check-artifacts.outputs.has_updates == 'true'
+        run: |
+          if git diff --quiet; then
+            echo "No changes to commit"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Changes detected:"
+            git diff --stat
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Open or update a PR with the checkpoint changes
+      - name: Create checkpoint update PR
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 #v8.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/update-checkpoints
+          title: "chore(chain): update checkpoints and end-of-support height"
+          body: |
+            Automated checkpoint update from the weekly integration test run.
+
+            **Source:** [Integration test run #${{ env.WORKFLOW_RUN_ID }}](${{ env.WORKFLOW_RUN_URL }})
+
+            ### Changes
+
+            - Updated mainnet and/or testnet checkpoint files with new entries
+            - Updated `ESTIMATED_RELEASE_HEIGHT` in `end_of_support.rs` to match the latest mainnet checkpoint
+
+            ### Validation
+
+            The checkpoint validation script verified:
+            - All entries match `HEIGHT HASH` format
+            - Heights are monotonically increasing
+            - No gaps exceed 400 blocks
+            - No duplicate heights or hashes
+
+            ### Review
+
+            Checkpoints are consensus-critical — incorrect hashes could cause nodes
+            to follow a wrong fork. Verify the source integration test run linked
+            above completed successfully against the real Zcash network.
+          labels: A-release,C-enhancement
+          commit-message: "chore(chain): update checkpoints and end-of-support height"
+          delete-branch: true

--- a/.github/workflows/checkpoint-update.yml
+++ b/.github/workflows/checkpoint-update.yml
@@ -9,6 +9,8 @@
 name: Checkpoint Update
 
 on:
+  # zizmor: ignore[dangerous-triggers] -- triggers only on internal CI workflow completion,
+  # processes deterministic checkpoint data from artifacts, no untrusted user input
   workflow_run:
     workflows: ["CI integration tests on GCP"]
     types: [completed]

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -426,12 +426,12 @@ jobs:
             exit 1
           fi
 
-          # Determine the network from the test_id
-          NETWORK="mainnet"
+          # Name to match the repo files: main-checkpoints.txt / test-checkpoints.txt
           if echo "${TEST_ID}" | grep -qi "testnet"; then
-            NETWORK="testnet"
+            mv checkpoint-output.txt "test-checkpoints.txt"
+          else
+            mv checkpoint-output.txt "main-checkpoints.txt"
           fi
-          mv checkpoint-output.txt "checkpoints-${NETWORK}.txt"
 
       - name: Upload checkpoint artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -360,6 +360,86 @@ jobs:
           fi
           "
 
+  # Upload checkpoint output as an artifact for automated checkpoint PRs.
+  # Only runs for checkpoint generation tests — extracts "HEIGHT HASH" lines
+  # from the container logs. The checkpoint-update.yml workflow consumes these.
+  upload-checkpoint-artifact:
+    name: Upload ${{ inputs.test_id }} checkpoint artifact
+    runs-on: ubuntu-latest
+    needs: [ test-result ]
+    if: ${{ needs.test-result.result == 'success' && startsWith(inputs.test_id, 'generate-checkpoints-') }}
+    env:
+      TEST_ID: ${{ inputs.test_id }}
+      GCP_ZONE: ${{ vars.GCP_ZONE }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@9e7def61550737ba68c62d34a32dd31792e3f429 #v5.5.0
+        with:
+          short-length: 7
+          slug-maxlength: 23
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 #v2.1.10
+        with:
+          workload_identity_provider: '${{ vars.GCP_WIF }}'
+          service_account: '${{ vars.GCP_DEPLOYMENTS_SA }}'
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a #v2.1.4
+      - name: Extract checkpoint lines from container logs
+        run: |
+          INSTANCE_NAME="${TEST_ID}-${GITHUB_REF_SLUG_URL}-${GITHUB_SHA_SHORT}"
+          CONTAINER_PREFIX="${TEST_ID}"
+
+          CONTAINER_ID=$(gcloud compute ssh "${INSTANCE_NAME}" \
+            --zone "${GCP_ZONE}" \
+            --ssh-flag="-o ServerAliveInterval=5" \
+            --ssh-flag="-o ConnectionAttempts=20" \
+            --ssh-flag="-o ConnectTimeout=5" \
+            --command="sudo docker ps -a --filter name=${CONTAINER_PREFIX} -q --no-trunc" 2>/dev/null | head -1)
+
+          if [ -z "$CONTAINER_ID" ]; then
+            echo "No container found for ${CONTAINER_PREFIX}"
+            exit 1
+          fi
+
+          echo "Extracting checkpoint lines from container ${CONTAINER_ID}..."
+          gcloud compute ssh "${INSTANCE_NAME}" \
+            --zone "${GCP_ZONE}" \
+            --ssh-flag="-o ServerAliveInterval=5" \
+            --ssh-flag="-o ConnectionAttempts=20" \
+            --ssh-flag="-o ConnectTimeout=5" \
+            --command="sudo docker logs ${CONTAINER_ID} 2>/dev/null" \
+            | grep -E '^[0-9]+ [0-9a-f]{64}$' \
+            > checkpoint-output.txt || true
+
+          LINES=$(wc -l < checkpoint-output.txt)
+          echo "Extracted ${LINES} checkpoint lines"
+
+          if [ "$LINES" -eq 0 ]; then
+            echo "WARNING: No checkpoint lines found in container logs"
+            exit 1
+          fi
+
+          # Determine the network from the test_id
+          NETWORK="mainnet"
+          if echo "${TEST_ID}" | grep -qi "testnet"; then
+            NETWORK="testnet"
+          fi
+          mv checkpoint-output.txt "checkpoints-${NETWORK}.txt"
+
+      - name: Upload checkpoint artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
+        with:
+          name: ${{ inputs.test_id }}-checkpoints
+          path: checkpoints-*.txt
+          retention-days: 30
+
   # create a state image from the instance's state disk, if requested by the caller
   create-state-image:
     name: Create ${{ inputs.test_id }} cached state image

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -779,9 +779,11 @@ jobs:
   delete-instance:
     name: Delete ${{ inputs.test_id }} instance
     runs-on: ubuntu-latest
-    needs: [ create-state-image ]
+    needs: [ create-state-image, upload-checkpoint-artifact ]
     # If a disk generation step timeouts (+6 hours) the previous job (creating the image) will be skipped.
     # Even if the instance continues running, no image will be created, so it's better to delete it.
+    # upload-checkpoint-artifact is included to prevent the instance from being deleted
+    # before checkpoint data is extracted from the container logs.
     if: always()
     continue-on-error: true
     permissions:

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -383,14 +383,23 @@ jobs:
         with:
           short-length: 7
           slug-maxlength: 23
+      - uses: shimataro/ssh-key-action@6b84f2e793b32fa0b03a379cadadec75cc539391 #v2.8.0
+        with:
+          key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
+          name: google_compute_engine
+          known_hosts: unnecessary
+      - name: Generate public SSH key
+        run: |
+          sudo apt-get update && sudo apt-get -qq install -y --no-install-recommends openssh-client
+          ssh-keygen -y -f ~/.ssh/google_compute_engine > ~/.ssh/google_compute_engine.pub
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 #v2.1.10
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 #v3.0.0
         with:
           workload_identity_provider: '${{ vars.GCP_WIF }}'
           service_account: '${{ vars.GCP_DEPLOYMENTS_SA }}'
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a #v2.1.4
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db #v3.0.1
       - name: Extract checkpoint lines from container logs
         run: |
           INSTANCE_NAME="${TEST_ID}-${GITHUB_REF_SLUG_URL}-${GITHUB_SHA_SHORT}"
@@ -820,6 +829,7 @@ jobs:
       - get-disk-name
       - test-result
       - create-state-image
+      - upload-checkpoint-artifact
       - delete-instance
     timeout-minutes: 1
     steps:
@@ -827,4 +837,6 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe #v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: ${{ (inputs.saves_to_disk || inputs.force_save_to_disk) && '' || 'create-state-image' }}
+          allowed-skips: >-
+            ${{ (inputs.saves_to_disk || inputs.force_save_to_disk) && '' || 'create-state-image' }},
+            ${{ startsWith(inputs.test_id, 'generate-checkpoints-') && '' || 'upload-checkpoint-artifact' }}

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -361,7 +361,7 @@ jobs:
           "
 
   # Upload checkpoint output as an artifact for automated checkpoint PRs.
-  # Only runs for checkpoint generation tests — extracts "HEIGHT HASH" lines
+  # Only runs for checkpoint generation tests. Extracts "HEIGHT HASH" lines
   # from the container logs. The checkpoint-update.yml workflow consumes these.
   upload-checkpoint-artifact:
     name: Upload ${{ inputs.test_id }} checkpoint artifact
@@ -394,27 +394,14 @@ jobs:
       - name: Extract checkpoint lines from container logs
         run: |
           INSTANCE_NAME="${TEST_ID}-${GITHUB_REF_SLUG_URL}-${GITHUB_SHA_SHORT}"
-          CONTAINER_PREFIX="${TEST_ID}"
 
-          CONTAINER_ID=$(gcloud compute ssh "${INSTANCE_NAME}" \
-            --zone "${GCP_ZONE}" \
-            --ssh-flag="-o ServerAliveInterval=5" \
-            --ssh-flag="-o ConnectionAttempts=20" \
-            --ssh-flag="-o ConnectTimeout=5" \
-            --command="sudo docker ps -a --filter name=${CONTAINER_PREFIX} -q --no-trunc" 2>/dev/null | head -1)
-
-          if [ -z "$CONTAINER_ID" ]; then
-            echo "No container found for ${CONTAINER_PREFIX}"
-            exit 1
-          fi
-
-          echo "Extracting checkpoint lines from container ${CONTAINER_ID}..."
+          # Single SSH session: find container and extract logs in one command
           gcloud compute ssh "${INSTANCE_NAME}" \
             --zone "${GCP_ZONE}" \
             --ssh-flag="-o ServerAliveInterval=5" \
             --ssh-flag="-o ConnectionAttempts=20" \
             --ssh-flag="-o ConnectTimeout=5" \
-            --command="sudo docker logs ${CONTAINER_ID} 2>/dev/null" \
+            --command="sudo docker ps -a --filter name=${TEST_ID} -q --no-trunc | head -1 | xargs -I{} sudo docker logs {} 2>/dev/null" \
             | grep -E '^[0-9]+ [0-9a-f]{64}$' \
             > checkpoint-output.txt || true
 
@@ -422,7 +409,7 @@ jobs:
           echo "Extracted ${LINES} checkpoint lines"
 
           if [ "$LINES" -eq 0 ]; then
-            echo "WARNING: No checkpoint lines found in container logs"
+            echo "No checkpoint lines found in container logs"
             exit 1
           fi
 
@@ -437,7 +424,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: ${{ inputs.test_id }}-checkpoints
-          path: checkpoints-*.txt
+          path: "*-checkpoints.txt"
           retention-days: 30
 
   # create a state image from the instance's state disk, if requested by the caller


### PR DESCRIPTION
## Motivation

Checkpoint updates require manually navigating CI logs, copying lines, and pasting into checkpoint files. The end-of-support height requires looking up the blockchain tip on a block explorer. Both are error-prone during releases.

## Solution

Automate both by capturing checkpoint CI output as artifacts and processing them in a downstream workflow.

The integration test already generates checkpoints weekly; this PR adds artifact upload so the output is machine-readable, then a `checkpoint-update.yml` workflow appends new entries, updates `ESTIMATED_RELEASE_HEIGHT`, validates the files, and opens a PR.

The EOS height uses the latest checkpoint height (a lower bound, ~3-7 days behind the tip). The 105-day EOS window makes this negligible. This avoids external dependencies and GCP credentials.

The automated PR still requires human review because checkpoints are consensus-critical.

### Tests

Validation script tested against both current checkpoint files (13,822 mainnet + 9,793 testnet entries, all passing).

### AI Disclosure

- [x] AI tools were used: Claude for checkpoint system analysis and workflow design.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed with the team beforehand.
- [x] The solution is tested.
- [ ] The documentation and changelogs are up to date.