### PR TITLE
docs: expose P2P port for inbound peer connections

### DIFF
--- a/.github/workflows/zfnd-deploy-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-nodes-gcp.yml
@@ -379,31 +379,6 @@ jobs:
             --healthy-threshold=2 \
             --global
 
-      # Ensure the VPC firewall allows inbound P2P connections to zebrad instances.
-      - name: Ensure P2P firewall rule exists
-        run: |
-          # P2P_PORT must be recomputed here because shell variables from
-          # earlier run: blocks do not persist across steps.
-          if [ "${{ matrix.network }}" = "Mainnet" ]; then
-            P2P_PORT="8233"
-          else
-            P2P_PORT="18233"
-          fi
-
-          RULE_NAME="allow-zebrad-p2p-${NETWORK}"
-          if gcloud compute firewall-rules describe "${RULE_NAME}" &>/dev/null; then
-            echo "Firewall rule ${RULE_NAME} already exists"
-          else
-            echo "Creating firewall rule ${RULE_NAME} for TCP ${P2P_PORT}"
-            gcloud compute firewall-rules create "${RULE_NAME}" \
-              --network=${{ vars.GCP_NETWORK || 'default' }} \
-              --direction=INGRESS \
-              --action=ALLOW \
-              --rules=tcp:${P2P_PORT} \
-              --source-ranges=0.0.0.0/0 \
-              --target-tags=zebrad \
-              --description="Allow inbound Zcash P2P connections to zebrad nodes (${NETWORK})"
-          fi
 
       # Check if our destination instance group exists already
       - name: Check if ${{ matrix.network }} instance group exists

--- a/.github/workflows/zfnd-deploy-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-nodes-gcp.yml
@@ -325,10 +325,12 @@ jobs:
             LOG_FILE="${{ vars.CD_LOG_FILE }}"
           fi
 
-          # Set RPC port based on network
+          # Set network-specific ports
           if [ "${{ matrix.network }}" = "Mainnet" ]; then
+            P2P_PORT="8233"
             RPC_PORT="8232"
           else
+            P2P_PORT="18233"
             RPC_PORT="18232"
           fi
 
@@ -350,7 +352,7 @@ jobs:
             --container-stdin \
             --container-tty \
             --container-image ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }} \
-            --container-env "ZEBRA_NETWORK__NETWORK=${{ matrix.network }},ZEBRA_NETWORK__LISTEN_ADDR=0.0.0.0,LOG_FILE=${LOG_FILE},SENTRY_DSN=${{ vars.SENTRY_DSN }},ZEBRA_HEALTH__LISTEN_ADDR=0.0.0.0:8080,ZEBRA_HEALTH__MIN_CONNECTED_PEERS=1,ZEBRA_RPC__LISTEN_ADDR=0.0.0.0:${RPC_PORT}" \
+            --container-env "ZEBRA_NETWORK__NETWORK=${{ matrix.network }},ZEBRA_NETWORK__LISTEN_ADDR=0.0.0.0:${P2P_PORT},LOG_FILE=${LOG_FILE},SENTRY_DSN=${{ vars.SENTRY_DSN }},ZEBRA_HEALTH__LISTEN_ADDR=0.0.0.0:8080,ZEBRA_HEALTH__MIN_CONNECTED_PEERS=1,ZEBRA_RPC__LISTEN_ADDR=0.0.0.0:${RPC_PORT}" \
             --service-account ${{ vars.GCP_DEPLOYMENTS_SA }} \
             --scopes cloud-platform \
             --metadata google-logging-enabled=true,google-logging-use-fluentbit=true,google-monitoring-enabled=true \
@@ -376,6 +378,26 @@ jobs:
             --unhealthy-threshold=3 \
             --healthy-threshold=2 \
             --global
+
+      # Ensure the VPC firewall allows inbound P2P connections to zebrad instances.
+      # Without this rule, GCP's default-deny ingress policy silently drops all
+      # peer connections, preventing the node from accepting inbound P2P traffic.
+      - name: Ensure P2P firewall rule exists
+        run: |
+          RULE_NAME="allow-zebrad-p2p-${NETWORK}"
+          if gcloud compute firewall-rules describe "${RULE_NAME}" &>/dev/null; then
+            echo "Firewall rule ${RULE_NAME} already exists"
+          else
+            echo "Creating firewall rule ${RULE_NAME} for TCP ${P2P_PORT}"
+            gcloud compute firewall-rules create "${RULE_NAME}" \
+              --network=${{ vars.GCP_NETWORK || 'default' }} \
+              --direction=INGRESS \
+              --action=ALLOW \
+              --rules=tcp:${P2P_PORT} \
+              --source-ranges=0.0.0.0/0 \
+              --target-tags=zebrad \
+              --description="Allow inbound Zcash P2P connections to zebrad nodes (${NETWORK})"
+          fi
 
       # Check if our destination instance group exists already
       - name: Check if ${{ matrix.network }} instance group exists

--- a/.github/workflows/zfnd-deploy-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-nodes-gcp.yml
@@ -380,10 +380,16 @@ jobs:
             --global
 
       # Ensure the VPC firewall allows inbound P2P connections to zebrad instances.
-      # Without this rule, GCP's default-deny ingress policy silently drops all
-      # peer connections, preventing the node from accepting inbound P2P traffic.
       - name: Ensure P2P firewall rule exists
         run: |
+          # P2P_PORT must be recomputed here because shell variables from
+          # earlier run: blocks do not persist across steps.
+          if [ "${{ matrix.network }}" = "Mainnet" ]; then
+            P2P_PORT="8233"
+          else
+            P2P_PORT="18233"
+          fi
+
           RULE_NAME="allow-zebrad-p2p-${NETWORK}"
           if gcloud compute firewall-rules describe "${RULE_NAME}" &>/dev/null; then
             echo "Firewall rule ${RULE_NAME} already exists"

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -25,6 +25,8 @@ exclude = [
     "^https://github.com/.*/pull/0000",
     # Mergify dashboard (requires auth)
     "^https://dashboard.mergify.com/",
+    # IACR eprint server returns 403 to automated link checkers
+    "^https://eprint\\.iacr\\.org/",
 
     # Dead upstream links in historical audit document (zebra-dependencies-for-audit.md)
     "^https://github.com/iqlusioninc/abscissa/tree/develop",

--- a/README.md
+++ b/README.md
@@ -31,10 +31,17 @@ image](https://hub.docker.com/r/zfnd/zebra/tags) or you can install it manually.
 This command will run our latest release, and sync it to the tip:
 
 ```sh
-docker run zfnd/zebra:latest
+docker run -d \
+  --name zebra \
+  -p 8233:8233 \
+  -v zebrad-cache:/home/zebra/.cache/zebra \
+  zfnd/zebra:latest
 ```
 
-For more information, read our [Docker documentation](https://zebra.zfnd.org/user/docker.html).
+The `-p 8233:8233` flag exposes the P2P port so other Zcash nodes can connect to
+yours, and `-v` persists the chain state across restarts (use port `18233` for
+Testnet). For more information, read our [Docker
+documentation](https://zebra.zfnd.org/user/docker.html).
 
 ### Manual Install
 

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -18,8 +18,7 @@ docker run -d \
 This command:
 
 - **`-p 8233:8233`**: Exposes the P2P port so other Zcash nodes can connect to
-  yours. Without this, the node can only make outbound connections and does not
-  contribute to network health. Use `-p 18233:18233` for Testnet.
+  yours. Use `-p 18233:18233` for Testnet.
 - **`-v zebrad-cache:...`**: Persists the chain state across container restarts,
   avoiding re-syncing ~300 GB of blockchain data.
 
@@ -157,18 +156,16 @@ For Kubernetes, configure liveness and readiness probes against `/healthy` and `
 Zebra uses TCP port **8233** (Mainnet) or **18233** (Testnet) for peer-to-peer
 connections. This is the port that other Zcash nodes use to connect to yours.
 
-When running in Docker, you **must** publish this port for your node to accept
-inbound connections:
+When running in Docker, publish this port for your node to accept inbound
+connections:
 
 ```shell
 docker run -p 8233:8233 zfnd/zebra    # Mainnet
 docker run -p 18233:18233 zfnd/zebra  # Testnet
 ```
 
-Without the `-p` flag, your node can still sync (via outbound connections) but
-will not be reachable by other peers. This reduces the overall health of the
-Zcash network, and prevents the node from being used as a network shield for
-zcashd.
+Without the `-p` flag, your node can still sync via outbound connections but
+will not accept inbound connections from other peers.
 
 **Behind a NAT or load balancer:** If your node is behind a NAT, firewall, or
 load balancer, set `external_addr` so Zebra advertises your public IP to peers:
@@ -184,9 +181,9 @@ Or via environment variable:
 -e ZEBRA_NETWORK__EXTERNAL_ADDR=203.0.113.42:8233
 ```
 
-Without `external_addr`, Zebra advertises its bind address (`[::]:8233`), which
-other nodes cannot use to dial back. They may still discover your node through
-observed connection IPs, but setting `external_addr` makes discovery reliable.
+Without `external_addr`, Zebra advertises its bind address (`[::]:8233`).
+Setting `external_addr` to your public IP ensures peers can reliably connect
+to your node.
 
 **Port summary:**
 

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -8,23 +8,20 @@ To get Zebra quickly up and running, you can use an off-the-rack image from
 [Docker Hub](https://hub.docker.com/r/zfnd/zebra/tags):
 
 ```shell
-docker run --name zebra zfnd/zebra
-```
-
-If you want to preserve Zebra's state, you can create a Docker volume:
-
-```shell
-docker volume create zebrad-cache
-```
-
-And mount it before you start the container:
-
-```shell
-docker run \
-  --mount source=zebrad-cache,target=/home/zebra/.cache/zebra \
+docker run -d \
   --name zebra \
+  -p 8233:8233 \
+  -v zebrad-cache:/home/zebra/.cache/zebra \
   zfnd/zebra
 ```
+
+This command:
+
+- **`-p 8233:8233`**: Exposes the P2P port so other Zcash nodes can connect to
+  yours. Without this, the node can only make outbound connections and does not
+  contribute to network health. Use `-p 18233:18233` for Testnet.
+- **`-v zebrad-cache:...`**: Persists the chain state across container restarts,
+  avoiding re-syncing ~300 GB of blockchain data.
 
 You can also use `docker compose`, which we recommend. First get the repo:
 
@@ -38,6 +35,8 @@ Then run:
 ```shell
 docker compose -f docker/docker-compose.yml up
 ```
+
+The default compose file already exposes the Mainnet P2P port.
 
 ## Custom Images
 
@@ -153,6 +152,53 @@ ports:
 
 For Kubernetes, configure liveness and readiness probes against `/healthy` and `/ready` respectively. See the [Health Endpoints](./health.md) page for details.
 
+### P2P Networking
+
+Zebra uses TCP port **8233** (Mainnet) or **18233** (Testnet) for peer-to-peer
+connections. This is the port that other Zcash nodes use to connect to yours.
+
+When running in Docker, you **must** publish this port for your node to accept
+inbound connections:
+
+```shell
+docker run -p 8233:8233 zfnd/zebra    # Mainnet
+docker run -p 18233:18233 zfnd/zebra  # Testnet
+```
+
+Without the `-p` flag, your node can still sync (via outbound connections) but
+will not be reachable by other peers. This reduces the overall health of the
+Zcash network, and prevents the node from being used as a network shield for
+zcashd.
+
+**Behind a NAT or load balancer:** If your node is behind a NAT, firewall, or
+load balancer, set `external_addr` so Zebra advertises your public IP to peers:
+
+```toml
+[network]
+external_addr = "203.0.113.42:8233"
+```
+
+Or via environment variable:
+
+```shell
+-e ZEBRA_NETWORK__EXTERNAL_ADDR=203.0.113.42:8233
+```
+
+Without `external_addr`, Zebra advertises its bind address (`[::]:8233`), which
+other nodes cannot use to dial back. They may still discover your node through
+observed connection IPs, but setting `external_addr` makes discovery reliable.
+
+**Port summary:**
+
+| Port | Protocol | Purpose | Default State |
+|------|----------|---------|---------------|
+| 8233 | TCP | P2P (Mainnet) | Listening |
+| 18233 | TCP | P2P (Testnet) | Listening |
+| 8232 | TCP | RPC (Mainnet) | Disabled |
+| 18232 | TCP | RPC (Testnet) | Disabled |
+| 9999 | TCP | Prometheus metrics | Disabled |
+| 8080 | TCP | Health endpoints | Disabled |
+
 ## Examples
 
 To make the initial setup of Zebra with other services easier, we provide some
@@ -174,28 +220,23 @@ directly in `docker/docker-compose.lwd.yml` (or an accompanying `.env` file).
 
 ### Running Zebra with Prometheus and Grafana
 
-The following commands will run Zebra with Prometheus and Grafana:
+The following commands will run Zebra with the observability stack (Prometheus,
+Grafana, Jaeger, and AlertManager):
 
 ```shell
-docker compose -f docker/docker-compose.grafana.yml build --no-cache
-docker compose -f docker/docker-compose.grafana.yml up
+docker compose -f docker/docker-compose.observability.yml build --no-cache
+docker compose -f docker/docker-compose.observability.yml up
 ```
 
-In this example, we build a local Zebra image with the `prometheus` Cargo
-compilation feature. Note that we enable this feature by specifying its name in
-the build arguments. Having this Cargo feature specified at build time makes
-`cargo` compile Zebra with the metrics support for Prometheus enabled. Note that
-we also specify this feature as an environment variable at run time. Having this
-feature specified at run time makes Docker's entrypoint script configure Zebra
-to open a scraping endpoint on `localhost:9999` for Prometheus.
+This builds a local Zebra image with the `opentelemetry` Cargo feature and
+starts all observability services. Once running:
 
-Once all services are up, the Grafana web UI should be available at
-`localhost:3000`, the Prometheus web UI should be at `localhost:9090`, and
-Zebra's scraping page should be at `localhost:9999`. The default login and
-password for Grafana are both `admin`. To make Grafana use Prometheus, you need
-to add Prometheus as a data source with the URL `http://localhost:9090` in
-Grafana's UI. You can then import various Grafana dashboards from the `grafana`
-directory in the Zebra repo.
+- Grafana: `http://localhost:3000` (default login: admin/admin)
+- Prometheus: `http://localhost:9094`
+- Jaeger: `http://localhost:16686`
+- Zebra metrics: `http://localhost:9999`
+
+See `docker/observability/README.md` for dashboard setup and configuration.
 
 ### Running CI Tests Locally
 

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -156,16 +156,10 @@ For Kubernetes, configure liveness and readiness probes against `/healthy` and `
 Zebra uses TCP port **8233** (Mainnet) or **18233** (Testnet) for peer-to-peer
 connections. This is the port that other Zcash nodes use to connect to yours.
 
-When running in Docker, publish this port for your node to accept inbound
-connections:
-
-```shell
-docker run -p 8233:8233 zfnd/zebra    # Mainnet
-docker run -p 18233:18233 zfnd/zebra  # Testnet
-```
-
-Without the `-p` flag, your node can still sync via outbound connections but
-will not accept inbound connections from other peers.
+When running in Docker, publish this port with `-p` (as shown in the
+[Quick Start](#quick-start)) for your node to accept inbound connections.
+Without it, the node can still sync via outbound connections but will not
+accept inbound connections from other peers.
 
 **Behind a NAT or load balancer:** If your node is behind a NAT, firewall, or
 load balancer, set `external_addr` so Zebra advertises your public IP to peers:

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -15,12 +15,9 @@ docker run -d \
   zfnd/zebra
 ```
 
-This command:
-
-- **`-p 8233:8233`**: Exposes the P2P port so other Zcash nodes can connect to
-  yours. Use `-p 18233:18233` for Testnet.
-- **`-v zebrad-cache:...`**: Persists the chain state across container restarts,
-  avoiding re-syncing ~300 GB of blockchain data.
+The `-p 8233:8233` flag publishes Zebra's P2P port so other Zcash nodes can
+connect to yours (use `-p 18233:18233` for Testnet), and `-v` mounts a named
+volume so the chain state survives container restarts.
 
 You can also use `docker compose`, which we recommend. First get the repo:
 
@@ -153,16 +150,9 @@ For Kubernetes, configure liveness and readiness probes against `/healthy` and `
 
 ### P2P Networking
 
-Zebra uses TCP port **8233** (Mainnet) or **18233** (Testnet) for peer-to-peer
-connections. This is the port that other Zcash nodes use to connect to yours.
+Zebra uses TCP port 8233 on Mainnet and 18233 on Testnet for peer-to-peer connections. When running in Docker, publish this port with `-p` (as shown in the [Quick Start](#quick-start)) so other nodes can connect to yours. Without it, Zebra still syncs via outbound connections but does not accept inbound peers.
 
-When running in Docker, publish this port with `-p` (as shown in the
-[Quick Start](#quick-start)) for your node to accept inbound connections.
-Without it, the node can still sync via outbound connections but will not
-accept inbound connections from other peers.
-
-**Behind a NAT or load balancer:** If your node is behind a NAT, firewall, or
-load balancer, set `external_addr` so Zebra advertises your public IP to peers:
+If Zebra is behind a NAT, firewall, or load balancer, set `external_addr` so it advertises your public address to peers instead of the internal bind address:
 
 ```toml
 [network]
@@ -175,20 +165,16 @@ Or via environment variable:
 -e ZEBRA_NETWORK__EXTERNAL_ADDR=203.0.113.42:8233
 ```
 
-Without `external_addr`, Zebra advertises its bind address (`[::]:8233`).
-Setting `external_addr` to your public IP ensures peers can reliably connect
-to your node.
+For reference, the ports Zebra can use are:
 
-**Port summary:**
-
-| Port | Protocol | Purpose | Default State |
-|------|----------|---------|---------------|
-| 8233 | TCP | P2P (Mainnet) | Listening |
-| 18233 | TCP | P2P (Testnet) | Listening |
-| 8232 | TCP | RPC (Mainnet) | Disabled |
-| 18232 | TCP | RPC (Testnet) | Disabled |
-| 9999 | TCP | Prometheus metrics | Disabled |
-| 8080 | TCP | Health endpoints | Disabled |
+| Port  | Protocol | Purpose            | Default  |
+|-------|----------|--------------------|----------|
+| 8233  | TCP      | P2P (Mainnet)      | Enabled  |
+| 18233 | TCP      | P2P (Testnet)      | Enabled  |
+| 8232  | TCP      | RPC (Mainnet)      | Disabled |
+| 18232 | TCP      | RPC (Testnet)      | Disabled |
+| 9999  | TCP      | Prometheus metrics | Disabled |
+| 8080  | TCP      | Health endpoints   | Disabled |
 
 ## Examples
 

--- a/book/src/user/mining-docker.md
+++ b/book/src/user/mining-docker.md
@@ -7,20 +7,25 @@ configuration instructions](https://zebra.zfnd.org/user/mining.html).
 Using docker, you can start mining by running:
 
 ```bash
-docker run --name -zebra_local -e MINER_ADDRESS="t3dvVE3SQEi7kqNzwrfNePxZ1d4hUyztBA1" -e ZEBRA_RPC_PORT=8232 -p 8232:8232 zfnd/zebra:latest
+docker run -d --name zebra_local \
+  -e MINER_ADDRESS="t3dvVE3SQEi7kqNzwrfNePxZ1d4hUyztBA1" \
+  -e ZEBRA_RPC__LISTEN_ADDR=0.0.0.0:8232 \
+  -p 8233:8233 \
+  -p 8232:8232 \
+  -v zebrad-cache:/home/zebra/.cache/zebra \
+  zfnd/zebra:latest
 ```
 
-This command starts a container on Mainnet and binds port 8232 on your Docker
-host. If you want to start generating blocks, you need to let Zebra sync first.
+This command starts a container on Mainnet and binds both the P2P port (8233)
+and the RPC port (8232). The P2P port is needed so peers can connect to your
+node and receive newly mined blocks. If you want to start generating blocks, you
+need to let Zebra sync first.
 
 Note that you must pass the address for your mining rewards via the
 `MINER_ADDRESS` environment variable when you are starting the container, as we
 did with the ZF funding stream address above. The address we used starts with
 the prefix `t1`, meaning it is a Mainnet P2PKH address. Please remember to set
 your own address for the rewards.
-
-The port we mapped between the container and the host with the `-p` flag in the
-example above is Zebra's default Mainnet RPC port.
 
 Instead of listing the environment variables on the command line, you can use
 Docker's `--env-file` flag to specify a file containing the variables. You can
@@ -37,11 +42,18 @@ variable to `Testnet` and use a Testnet address for the rewards. For example,
 running
 
 ```bash
-docker run --name zebra_local -e ZEBRA_NETWORK__NETWORK="Testnet" -e MINER_ADDRESS="t27eWDgjFYJGVXmzrXeVjnb5J3uXDM9xH9v" -e ZEBRA_RPC_PORT=18232 -p 18232:18232 zfnd/zebra:latest
+docker run -d --name zebra_local \
+  -e ZEBRA_NETWORK__NETWORK="Testnet" \
+  -e MINER_ADDRESS="t27eWDgjFYJGVXmzrXeVjnb5J3uXDM9xH9v" \
+  -e ZEBRA_RPC__LISTEN_ADDR=0.0.0.0:18232 \
+  -p 18233:18233 \
+  -p 18232:18232 \
+  -v zebrad-cache:/home/zebra/.cache/zebra \
+  zfnd/zebra:latest
 ```
 
-will start a container on Testnet and bind port 18232 on your Docker host, which
-is the standard Testnet RPC port. Notice that we also used a different rewards
+will start a container on Testnet and bind the P2P port (18233) and the RPC port
+(18232) on your Docker host. Notice that we also used a different rewards
 address. It starts with the prefix `t2`, indicating that it is a Testnet
 address. A Mainnet address would prevent Zebra from starting on Testnet, and
 conversely, a Testnet address would prevent Zebra from starting on Mainnet.

--- a/book/src/user/mining-docker.md
+++ b/book/src/user/mining-docker.md
@@ -17,9 +17,8 @@ docker run -d --name zebra_local \
 ```
 
 This command starts a container on Mainnet and binds both the P2P port (8233)
-and the RPC port (8232). The P2P port is needed so peers can connect to your
-node and receive newly mined blocks. If you want to start generating blocks, you
-need to let Zebra sync first.
+and the RPC port (8232). Publishing the P2P port allows inbound peer connections.
+If you want to start generating blocks, you need to let Zebra sync first.
 
 Note that you must pass the address for your mining rewards via the
 `MINER_ADDRESS` environment variable when you are starting the container, as we

--- a/book/src/user/mining-docker.md
+++ b/book/src/user/mining-docker.md
@@ -16,9 +16,10 @@ docker run -d --name zebra_local \
   zfnd/zebra:latest
 ```
 
-This command starts a container on Mainnet and binds both the P2P port (8233)
-and the RPC port (8232). Publishing the P2P port allows inbound peer connections.
-If you want to start generating blocks, you need to let Zebra sync first.
+This command starts a container on Mainnet and binds the P2P port (8233) and
+the RPC port (8232) on your Docker host. The P2P port lets other Zcash nodes
+connect to your node. If you want to start generating blocks, you need to let
+Zebra sync first.
 
 Note that you must pass the address for your mining rewards via the
 `MINER_ADDRESS` environment variable when you are starting the container, as we

--- a/book/src/user/requirements.md
+++ b/book/src/user/requirements.md
@@ -43,14 +43,12 @@ connections are required to sync, inbound connections are optional but
 recommended. Zebra also needs access to the Zcash DNS seeders, via the OS DNS
 resolver (usually port 53).
 
-**Docker users:** You must publish the P2P port with `-p 8233:8233` (Mainnet) or
-`-p 18233:18233` (Testnet) for inbound connections. See
-[Docker](./docker.md#p2p-networking) for details.
-
-**Firewall/NAT:** If your node is behind a firewall or NAT, open the P2P port
-and consider setting
+If Zebra runs in Docker, publish the P2P port with `-p 8233:8233` (Mainnet) or
+`-p 18233:18233` (Testnet) so other peers can connect to it. See the
+[P2P section of the Docker guide](./docker.md#p2p-networking) for details. If
+the node sits behind a firewall or NAT, open the P2P port and consider setting
 [`external_addr`](https://docs.rs/zebra-network/latest/zebra_network/config/struct.Config.html#structfield.external_addr)
-to your public IP so peers can discover your node.
+to your public IP so peers can discover it.
 
 Zebra makes outbound connections to peers on any port. But `zcashd` prefers
 peers on the default ports, so that it can't be used for DDoS attacks on other

--- a/book/src/user/requirements.md
+++ b/book/src/user/requirements.md
@@ -39,9 +39,9 @@ Zebra uses the following inbound and outbound TCP ports:
 If you configure Zebra with a specific
 [`listen_addr`](https://docs.rs/zebra-network/latest/zebra_network/config/struct.Config.html#structfield.listen_addr),
 it will advertise this address to other nodes for inbound connections. Outbound
-connections are required to sync, inbound connections are optional but strongly
-recommended for network health. Zebra also needs access to the Zcash DNS
-seeders, via the OS DNS resolver (usually port 53).
+connections are required to sync, inbound connections are optional but
+recommended. Zebra also needs access to the Zcash DNS seeders, via the OS DNS
+resolver (usually port 53).
 
 **Docker users:** You must publish the P2P port with `-p 8233:8233` (Mainnet) or
 `-p 18233:18233` (Testnet) for inbound connections. See

--- a/book/src/user/requirements.md
+++ b/book/src/user/requirements.md
@@ -39,9 +39,18 @@ Zebra uses the following inbound and outbound TCP ports:
 If you configure Zebra with a specific
 [`listen_addr`](https://docs.rs/zebra-network/latest/zebra_network/config/struct.Config.html#structfield.listen_addr),
 it will advertise this address to other nodes for inbound connections. Outbound
-connections are required to sync, inbound connections are optional. Zebra also
-needs access to the Zcash DNS seeders, via the OS DNS resolver (usually port
-53).
+connections are required to sync, inbound connections are optional but strongly
+recommended for network health. Zebra also needs access to the Zcash DNS
+seeders, via the OS DNS resolver (usually port 53).
+
+**Docker users:** You must publish the P2P port with `-p 8233:8233` (Mainnet) or
+`-p 18233:18233` (Testnet) for inbound connections. See
+[Docker](./docker.md#p2p-networking) for details.
+
+**Firewall/NAT:** If your node is behind a firewall or NAT, open the P2P port
+and consider setting
+[`external_addr`](https://docs.rs/zebra-network/latest/zebra_network/config/struct.Config.html#structfield.external_addr)
+to your public IP so peers can discover your node.
 
 Zebra makes outbound connections to peers on any port. But `zcashd` prefers
 peers on the default ports, so that it can't be used for DDoS attacks on other

--- a/docker/.env
+++ b/docker/.env
@@ -16,18 +16,18 @@
 #
 # ZEBRA_NETWORK__EXTERNAL_ADDR=203.0.113.42:8233
 
-# Zebra's RPC server is disabled by default. To enable it, set its port number.
+# Zebra's RPC server is disabled by default. To enable it, set the listen address.
 #
-# ZEBRA_RPC_PORT=8232   # Default RPC port number on Mainnet.
-# ZEBRA_RPC_PORT=18232  # Default RPC port number on Testnet.
+# ZEBRA_RPC__LISTEN_ADDR=0.0.0.0:8232   # Mainnet
+# ZEBRA_RPC__LISTEN_ADDR=0.0.0.0:18232  # Testnet
 
 # To disable cookie authentication, set the value below to false.
 #
-# ENABLE_COOKIE_AUTH=true
+# ZEBRA_RPC__ENABLE_COOKIE_AUTH=true
 
 # Sets a custom directory for the cookie authentication file.
 #
-# ZEBRA_COOKIE_DIR="/home/zebra/.config/cookie"
+# ZEBRA_RPC__COOKIE_DIR="/home/zebra/.config/cookie"
 
 # Sets a custom directory for the state and network caches.
 #

--- a/docker/.env
+++ b/docker/.env
@@ -6,9 +6,15 @@
 #
 # ZEBRA_CONF_PATH="/path/to/your/custom/zebrad.toml"
 
-# Sets the network Zebra runs will run on.
+# Sets the network Zebra will run on.
 #
-# NETWORK=Mainnet
+# ZEBRA_NETWORK__NETWORK=Mainnet
+
+# If behind a NAT, firewall, or load balancer, set this to your public IP:port
+# so other Zcash nodes can connect to yours. Port 8233 for Mainnet, 18233 for
+# Testnet.
+#
+# ZEBRA_NETWORK__EXTERNAL_ADDR=203.0.113.42:8233
 
 # Zebra's RPC server is disabled by default. To enable it, set its port number.
 #

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -212,10 +212,6 @@ RUN chown -R ${UID}:${GID} ${HOME}
 COPY --link --from=release /usr/local/bin/zebrad /usr/local/bin/
 COPY --link --chown=${UID}:${GID} ./docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 
-# P2P ports: 8233 (Mainnet), 18233 (Testnet)
-# Publish at runtime with -p 8233:8233 for inbound peer connections.
-EXPOSE 8233 18233
-
 ENTRYPOINT [ "entrypoint.sh" ]
 CMD ["zebrad"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -212,6 +212,12 @@ RUN chown -R ${UID}:${GID} ${HOME}
 COPY --link --from=release /usr/local/bin/zebrad /usr/local/bin/
 COPY --link --chown=${UID}:${GID} ./docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 
+# P2P ports: 8233 (Mainnet), 18233 (Testnet)
+# These must be published at runtime (-p 8233:8233) for inbound peer connections.
+# Without inbound P2P, the node can only make outbound connections and does not
+# contribute to network health.
+EXPOSE 8233 18233
+
 ENTRYPOINT [ "entrypoint.sh" ]
 CMD ["zebrad"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -213,9 +213,7 @@ COPY --link --from=release /usr/local/bin/zebrad /usr/local/bin/
 COPY --link --chown=${UID}:${GID} ./docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 # P2P ports: 8233 (Mainnet), 18233 (Testnet)
-# These must be published at runtime (-p 8233:8233) for inbound peer connections.
-# Without inbound P2P, the node can only make outbound connections and does not
-# contribute to network health.
+# Publish at runtime with -p 8233:8233 for inbound peer connections.
 EXPOSE 8233 18233
 
 ENTRYPOINT [ "entrypoint.sh" ]

--- a/docker/default-zebra-config.toml
+++ b/docker/default-zebra-config.toml
@@ -15,9 +15,7 @@
 network = "Mainnet"
 listen_addr = "[::]:8233"
 
-# If behind a NAT or load balancer, set external_addr to your public IP so peers
-# can connect to your node. Without this, Zebra advertises its bind address
-# ([::]:8233) which other nodes cannot dial.
+# Set to your public IP:port if behind a NAT or load balancer.
 
 # external_addr = "203.0.113.42:8233"
 

--- a/docker/default-zebra-config.toml
+++ b/docker/default-zebra-config.toml
@@ -14,6 +14,13 @@
 [network]
 network = "Mainnet"
 listen_addr = "[::]:8233"
+
+# If behind a NAT or load balancer, set external_addr to your public IP so peers
+# can connect to your node. Without this, Zebra advertises its bind address
+# ([::]:8233) which other nodes cannot dial.
+
+# external_addr = "203.0.113.42:8233"
+
 cache_dir = "/home/zebra/.cache/zebra"
 
 [rpc]

--- a/docker/docker-compose.lwd.yml
+++ b/docker/docker-compose.lwd.yml
@@ -16,7 +16,8 @@ services:
       - ZEBRA_RPC__LISTEN_ADDR=0.0.0.0:8232
       - ZEBRA_RPC__ENABLE_COOKIE_AUTH=false
     ports:
-      - "8232:8232"
+      - "8233:8233"   # P2P (inbound peer connections)
+      - "8232:8232"   # RPC (used by lightwalletd)
 
   lightwalletd:
     image: electriccoinco/lightwalletd

--- a/docker/docker-compose.observability.yml
+++ b/docker/docker-compose.observability.yml
@@ -32,8 +32,9 @@ services:
       - ZEBRA_TRACING__OPENTELEMETRY_SERVICE_NAME=zebra
       - ZEBRA_TRACING__OPENTELEMETRY_SAMPLE_PERCENT=100
     ports:
-      - "9999:9999"
-      - "8232:8232"
+      - "8233:8233"   # P2P (inbound peer connections)
+      - "9999:9999"   # Prometheus metrics
+      - "8232:8232"   # RPC
     networks:
       - observability
     depends_on:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,14 +21,15 @@ services:
       - source: zebra-config
         target: /home/zebra/.config/zebrad.toml
 
-    # Uncomment the `ports` mapping below to map ports between the container and
-    # host.
-    #
-    # ports:
+    # P2P port for inbound peer connections (required for full network
+    # participation). Without this, the node can only make outbound connections.
+    ports:
+      - "8233:8233"   # P2P on Mainnet (use 18233:18233 for Testnet)
+
+    # Uncomment any of these to expose additional services:
+    #   - "18233:18233" # P2P on Testnet
     #   - "8232:8232"   # RPC endpoint on Mainnet
     #   - "18232:18232" # RPC endpoint on Testnet
-    #   - "8233:8233"   # peer connections on Mainnet
-    #   - "18233:18233" # peer connections on Testnet
     #   - "9999:9999"   # Metrics
     #   - "3000:3000"   # Tracing
     #   - "8080:8080"   # Health endpoints (/healthy, /ready)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,8 +21,7 @@ services:
       - source: zebra-config
         target: /home/zebra/.config/zebrad.toml
 
-    # P2P port for inbound peer connections (required for full network
-    # participation). Without this, the node can only make outbound connections.
+    # P2P port for inbound peer connections (recommended).
     ports:
       - "8233:8233"   # P2P on Mainnet (use 18233:18233 for Testnet)
 


### PR DESCRIPTION
## Motivation

Zebra's Docker image and compose files didn't publish the P2P port (8233 Mainnet, 18233 Testnet). Containerized nodes synced fine but couldn't accept inbound peers, so they contributed no upstream capacity and DNS seeders couldn't list them as reachable. The GCP deploy also bound Zebra to `0.0.0.0` with no explicit port.

## Solution

**Docker image and compose.** The Dockerfile declares `EXPOSE 8233 18233` and `docker-compose.yml` enables the `8233:8233` mapping by default. The `lwd` and `observability` compose files also publish the P2P port. `default-zebra-config.toml` documents `external_addr` for NAT and load-balancer deployments, and the `.env` template adds `ZEBRA_NETWORK__EXTERNAL_ADDR` while migrating the deprecated `ZEBRA_RPC_PORT` and `ENABLE_COOKIE_AUTH` entries to the current `ZEBRA_*__*` config-rs form.

**Documentation.** A new P2P Networking section in `docker.md` covers port requirements, NAT guidance, `external_addr`, and a port reference table. `requirements.md` gains Docker and firewall/NAT notes. `mining-docker.md` switches to `ZEBRA_RPC__LISTEN_ADDR` and publishes the P2P port. A stale reference to `docker-compose.grafana.yml` is updated to `docker-compose.observability.yml`.

**GCP deployment.** `ZEBRA_NETWORK__LISTEN_ADDR` now carries an explicit, network-specific port (`0.0.0.0:${P2P_PORT}`, 8233 or 18233) instead of the bare `0.0.0.0`.

### Not addressed in this PR

- **VPC firewall rule.** An earlier commit added an inline `gcloud firewall-rules create` step; it was removed to keep firewall management out of the deploy workflow. This should be provisioned via the GCP IaC instead.
- **Per-instance `ZEBRA_NETWORK__EXTERNAL_ADDR` on GCP.** Instance templates are immutable and shared across MIG members, so each instance can't advertise its own static IP without either `gcloud compute instances update-container` per instance, or metadata-server lookup in the entrypoint. Zebra's existing compensation (peers record observed source IPs) keeps these nodes reachable without it.

### References

- Zcash protocol: nodes advertise their address in the `Version` message's `address_from` field.
- `zebra-network/src/config.rs`: "other Zebra instances compensate for unspecified or incorrect listener addresses by adding the external IP addresses of peers to their address books."
- Related issues: #1890 (advertise external IP), #1893 (auto-discover external IP).

### Follow-up Work

- Provision the VPC firewall rule for P2P ingress via IaC.
- Set `ZEBRA_NETWORK__EXTERNAL_ADDR` per GCP instance after static-IP assignment.
- Auto-detect the external IP via the GCP metadata server in the Docker entrypoint.

### AI Disclosure

- [x] AI tools were used: Claude for analysis, implementation, and text review.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
