### PR TITLE
fix(ci): correct job-level permissions across workflows

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -28,6 +28,7 @@ jobs:
   build:
     name: Build Docs
     permissions:
+      contents: read
       id-token: write
       statuses: write
     runs-on: ubuntu-latest

--- a/.github/workflows/zfnd-ci-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-ci-integration-tests-gcp.yml
@@ -649,6 +649,9 @@ jobs:
     # (PR statuses are already reported in the PR jobs list, and checked by GitHub's Merge Queue.)
     if: (failure() && github.event.pull_request == null) || (cancelled() && github.event.pull_request == null)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: jayqi/failed-build-issue-action@1a893bbf43ef1c2a8705e2b115cd4f0fe3c5649b #v1.2.0
         with:

--- a/.github/workflows/zfnd-deploy-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-nodes-gcp.yml
@@ -551,6 +551,9 @@ jobs:
     # (PR statuses are already reported in the PR jobs list, and checked by GitHub's Merge Queue.)
     if: (failure() && github.event.pull_request == null) || (cancelled() && github.event.pull_request == null)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: jayqi/failed-build-issue-action@1a893bbf43ef1c2a8705e2b115cd4f0fe3c5649b #v1.2.0
         with:


### PR DESCRIPTION
## Motivation

Job-level `permissions:` blocks in GitHub Actions **replace** the workflow-level block entirely; permissions not re-declared fall to `none`. Two workflows had the same class of bug:

- The `failure-issue` jobs in `zfnd-ci-integration-tests-gcp.yml` and `zfnd-deploy-nodes-gcp.yml` did not declare a job-level block, so they inherited only `contents: read` from the workflow scope. `jayqi/failed-build-issue-action` needs `issues: write`, so every real failure produced `Resource not accessible by integration` instead of opening or updating the tracking issue. Example: [run 24286263144 / Open or update issues for main branch failures](https://github.com/ZcashFoundation/zebra/actions/runs/24286263144/job/70919040088) could not comment on issue #9524.
- The `build` job in `book.yml` declared `id-token: write, statuses: write`, which silently dropped `contents: read`. `actions/checkout` happens to work because the repo is public (anonymous HTTPS clone), but the job should declare the token access it needs.

## Solution

- Add a job-scoped `permissions:` block (`contents: read`, `issues: write`) to both `failure-issue` jobs.
- Restore `contents: read` on the `book.yml` `build` job alongside its existing `id-token: write` and `statuses: write`.

Scoping stays job-local so the elevated tokens do not bleed into the rest of the workflow; `zizmor` stays clean.

### Tests

- `zizmor` on all three files: no new findings introduced.
- Runtime verification: the next real failure on `main` should open or update its tracking issue instead of erroring.

### AI Disclosure

- [x] AI tools were used: Claude for triaging recent CI failures, the permissions audit across all workflows, and drafting the fixes.