### PR TITLE
fix(ci): remove dead `gcr-cleaner` job from GCP cleanup workflow

### DIFF
--- a/.github/workflows/zfnd-delete-gcp-resources.yml
+++ b/.github/workflows/zfnd-delete-gcp-resources.yml
@@ -4,10 +4,13 @@
 # 2. Deletes instance templates older than a set number of days.
 # 3. Deletes older disks not currently in use, with certain ones prefixed by commit hashes or "zebrad-".
 # 4. Deletes cache images from GCP, retaining a specified number of the latest images for certain types like zebrad checkpoint cache, zebrad tip cache, and lightwalletd + zebrad tip cache.
-# 5. Deletes unused artifacts from Google Artifact Registry older than a defined number of hours while retaining the latest few.
 #
-# It uses the gcloud CLI for most of its operations and also leverages specific GitHub Actions like the gcr-cleaner for deleting old images from the Google Artifact Registry.
-# The workflow is scheduled to run daily at 0700 UTC.
+# Artifact Registry image cleanup is handled server-side by a cleanup policy
+# on the zebra repository, not by this workflow. The policy is defined in the
+# cloud-foundation-fabric Terraform stage.
+#
+# It uses the gcloud CLI for its operations and is scheduled to run daily at
+# 0700 UTC.
 name: Delete GCP resources
 
 on:
@@ -27,9 +30,6 @@ env:
   # But keep the latest $KEEP_LATEST_IMAGE_COUNT images of each type.
   # We keep this small to reduce storage costs.
   KEEP_LATEST_IMAGE_COUNT: 2
-  # Delete all artifacts in registry created before $DELETE_IMAGE_HOURS hours ago.
-  # We keep this long enough for PRs that are still on the same commit can re-run with the same image.
-  DELETE_IMAGE_HOURS: 504h # 21 days
 
 permissions:
   contents: read
@@ -103,52 +103,6 @@ jobs:
         run: |
           ./.github/workflows/scripts/gcp-delete-old-cache-images.sh
 
-  # We're using a generic approach here, which allows multiple registries to be included,
-  # even those not related to GCP. Enough reason to create a separate job.
-  #
-  # The same artifacts are used for both mainnet and testnet.
-  clean-registries:
-    name: Delete unused artifacts in registry
-    if: github.repository_owner == 'ZcashFoundation'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    strategy:
-      matrix:
-        environment: [dev, prod]
-    environment: ${{ matrix.environment }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-        with:
-          persist-credentials: false
-
-      # Setup gcloud CLI
-      - name: Authenticate to Google Cloud
-        id: auth
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 #v3.0.0
-        with:
-          workload_identity_provider: '${{ vars.GCP_WIF }}'
-          service_account: '${{ vars.GCP_DEPLOYMENTS_SA }}'
-          token_format: access_token
-
-      - name: Login to Google Artifact Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 #v3.7.0
-        with:
-          registry: us-docker.pkg.dev
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
-
-      # Deletes all images older than $DELETE_IMAGE_HOURS days.
-      - uses: docker://us-docker.pkg.dev/gcr-cleaner/gcr-cleaner/gcr-cleaner-cli@sha256:333a4d0617b19a86b55f9aaae10e49294b4469590166f3b4a1c4f7bbd20eb6c2
-        # Refer to the official documentation to understand available arguments:
-        # https://github.com/GoogleCloudPlatform/gcr-cleaner
-        with:
-          args: >-
-            -repo=us-docker.pkg.dev/${{ vars.GCP_PROJECT }}/zebra/zebrad-test
-            -grace=${{ env.DELETE_IMAGE_HOURS }}
-            -keep=${{ env.KEEP_LATEST_IMAGE_COUNT }}
-
   delete-resources-success:
     name: Delete GCP resources success
     runs-on: ubuntu-latest
@@ -160,7 +114,6 @@ jobs:
       }}
     needs:
       - delete-resources
-      - clean-registries
     timeout-minutes: 1
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/zfnd-delete-gcp-resources.yml
+++ b/.github/workflows/zfnd-delete-gcp-resources.yml
@@ -5,12 +5,7 @@
 # 3. Deletes older disks not currently in use, with certain ones prefixed by commit hashes or "zebrad-".
 # 4. Deletes cache images from GCP, retaining a specified number of the latest images for certain types like zebrad checkpoint cache, zebrad tip cache, and lightwalletd + zebrad tip cache.
 #
-# Artifact Registry image cleanup is handled server-side by a cleanup policy
-# on the zebra repository, not by this workflow. The policy is defined in the
-# cloud-foundation-fabric Terraform stage.
-#
-# It uses the gcloud CLI for its operations and is scheduled to run daily at
-# 0700 UTC.
+# It uses the gcloud CLI for its operations and is scheduled to run daily at 0700 UTC.
 name: Delete GCP resources
 
 on:


### PR DESCRIPTION
## Motivation

The `clean-registries` job in `zfnd-delete-gcp-resources.yml` pinned the Docker image `us-docker.pkg.dev/gcr-cleaner/gcr-cleaner/gcr-cleaner-cli@sha256:333a4d06…`, whose hosting GCP project has been deleted. Every daily run for the last 12 days failed at the image pull with `denied: Project #78287296261 has been deleted`. Example: [run 24331381662](https://github.com/ZcashFoundation/zebra/actions/runs/24331381662).

Artifact Registry now handles this cleanup server-side. A native cleanup policy is in place on the `zebra` repository. It keeps the 2 most recent versions and deletes anything older than 504h (21 days), matching the retired gcr-cleaner args.

## Solution

Drop the `clean-registries` job, its Docker login step, the `DELETE_IMAGE_HOURS` env var it alone consumed, and its entry in `delete-resources-success.needs`. The `delete-resources` job that cleans up instances, instance templates, disks, and GCE compute cache images is unchanged; only the Artifact Registry path moves server-side.

### Tests

- `zizmor` on the edited file: no findings.
- Next scheduled run of `Delete GCP resources` executes only the `delete-resources` matrix, which has been succeeding throughout this outage.
- Artifact Registry policy is live and active; Artifact Registry runs it on its own ~daily cadence.

### AI Disclosure

- [x] AI tools were used: Claude for triaging the failure, confirming parity with the Artifact Registry cleanup policy, applying the Terraform change, and drafting the workflow cleanup.