### PR TITLE
fix(zebrad): tolerate live-network races in acceptance tests

### DIFF
--- a/zebrad/tests/common/get_block_template_rpcs/submit_block.rs
+++ b/zebrad/tests/common/get_block_template_rpcs/submit_block.rs
@@ -74,10 +74,16 @@ pub(crate) async fn run() -> Result<()> {
         assert!(res.status().is_success());
         let res_text = res.text().await?;
 
-        // Test rpc endpoint response
+        // Accept `null` (freshly accepted) or `duplicate[-inconclusive]` (already
+        // in the chain/queue): against a live network the capture-submit window
+        // can race with finalization, and a duplicate response still proves the
+        // block was valid and the submitblock path works.
+        let accepted = res_text.contains(r#""result":null"#);
+        let duplicate = res_text.contains(r#""result":"duplicate""#)
+            || res_text.contains(r#""result":"duplicate-inconclusive""#);
         assert!(
-            res_text.contains(r#""result":null"#),
-            "unexpected response from submitblock RPC, should be null, was: {res_text}"
+            accepted || duplicate,
+            "unexpected response from submitblock RPC, should be null or duplicate, was: {res_text}"
         );
     }
 

--- a/zebrad/tests/common/lightwalletd/send_transaction_test.rs
+++ b/zebrad/tests/common/lightwalletd/send_transaction_test.rs
@@ -269,7 +269,21 @@ async fn send_transactions_from_block(
         let request = prepare_send_transaction_request(transaction.clone());
 
         match rpc_client.send_transaction(request).await {
-            Ok(response) => assert_eq!(response.into_inner(), expected_response),
+            Ok(response) => {
+                let inner = response.into_inner();
+                // Accept the success response, or the `-25 "transaction is already
+                // in state"` path: against a live network the capture-submit window
+                // can race with finalization, and "already in state" still proves
+                // the transaction was valid and reached the mempool/chain.
+                let newly_accepted = inner == expected_response;
+                let already_in_state =
+                    inner.error_code == -25 && inner.error_message.contains("already in state");
+                assert!(
+                    newly_accepted || already_in_state,
+                    "unexpected response from send-transaction gRPC: {inner:?}; \
+                     expected success or 'already in state'"
+                );
+            }
             Err(err) => {
                 tracing::warn!(?err, "failed to send transaction");
                 let send_tx_rsp = zebrad_rpc_client


### PR DESCRIPTION
## Motivation

The weekly scheduled `Integration Tests on GCP` run fails on two acceptance tests against Mainnet:

- `zebrad::acceptance::rpc_submit_block` panics with `AlreadyInChain(...)` on the block it just submitted.
- `zebrad::acceptance::lwd_rpc_send_tx` panics on `assert_eq!(response, expected_response)` when the gRPC response is `SendResponse { error_code: -25, error_message: "failed to validate tx: ..., error: transaction is already in state" }` instead of the success shape.

Both tests capture a live artifact (a block past the finalized tip, or a transaction from such a block), shut zebrad down, restart it isolated from peers, and replay the artifact through the RPC. The window between capture and replay is a race against real-network finalization. When the real network advances past the capture point, the replay is a duplicate and the RPCs honestly report so.

Example of the block panic from the scheduled run: [job 70917770622](https://github.com/ZcashFoundation/zebra/actions/runs/24286263144/job/70917770622).

## Solution

Accept both outcomes in each assertion. Both prove the same property the tests are trying to check: that the RPC accepted a valid block or transaction.

- `submitblock`: accept `null` (fresh accept) or `"duplicate"` / `"duplicate-inconclusive"` (already present in chain or queue).
- `send_transaction`: accept the original success response, or an `error_code: -25` response whose `error_message` contains `"already in state"`.

### Tests

- `cargo check -p zebrad --tests` passes.
- `cargo fmt --all -- --check` passes.
- `cargo clippy -p zebrad --tests --all-targets -- -D warnings` passes.
- Runtime verification comes from the next scheduled `Integration Tests on GCP` run, which should now pass these two tests in the common race-condition case.

### AI Disclosure

- [x] AI tools were used: Claude for triaging the panics, mapping the error codes through the mempool and RPC layers, and drafting the assertion relaxations.