### PR TITLE
fix(ci): rewrite checkpoint artifact upload to scp a pre-captured file

### DIFF
--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -432,8 +432,6 @@ jobs:
 
           gcloud compute scp \
             --zone "${GCP_ZONE}" \
-            --ssh-flag="-o ServerAliveInterval=5" \
-            --ssh-flag="-o ConnectTimeout=5" \
             "${INSTANCE_NAME}:/tmp/checkpoints.txt" \
             "${OUT}"
 

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -360,9 +360,29 @@ jobs:
           fi
           "
 
-  # Upload checkpoint output as an artifact for automated checkpoint PRs.
-  # Only runs for checkpoint generation tests. Extracts "HEIGHT HASH" lines
-  # from the container logs. The checkpoint-update.yml workflow consumes these.
+      # Capture HEIGHT HASH lines from the container logs into a file on the
+      # instance so the upload-checkpoint-artifact job can retrieve them with
+      # `gcloud compute scp` instead of rediscovering the container.
+      - name: Capture checkpoints from container logs
+        if: ${{ startsWith(inputs.test_id, 'generate-checkpoints-') }}
+        env:
+          CONTAINER_ID: ${{ steps.find-container.outputs.CONTAINER_ID }}
+          INSTANCE_NAME: ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}
+          GCP_ZONE: ${{ vars.GCP_ZONE }}
+        run: |
+          gcloud compute ssh "${INSTANCE_NAME}" \
+            --zone "${GCP_ZONE}" \
+            --ssh-flag="-o ServerAliveInterval=5" \
+            --ssh-flag="-o ConnectionAttempts=20" \
+            --ssh-flag="-o ConnectTimeout=5" \
+            --command="
+            sudo docker logs ${CONTAINER_ID} 2>&1 | grep -oE '[0-9]+ [0-9a-f]{64}' > /tmp/checkpoints.txt;
+            echo \"Captured \$(wc -l < /tmp/checkpoints.txt) checkpoint lines\";
+            "
+
+  # Upload the checkpoint file captured in the test-result job as a workflow
+  # artifact for checkpoint-update.yml to consume. Only runs for checkpoint
+  # generation tests.
   upload-checkpoint-artifact:
     name: Upload ${{ inputs.test_id }} checkpoint artifact
     runs-on: ubuntu-latest
@@ -400,33 +420,28 @@ jobs:
           service_account: '${{ vars.GCP_DEPLOYMENTS_SA }}'
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db #v3.0.1
-      - name: Extract checkpoint lines from container logs
+      - name: Pull checkpoint file from instance
         run: |
           INSTANCE_NAME="${TEST_ID}-${GITHUB_REF_SLUG_URL}-${GITHUB_SHA_SHORT}"
-
-          # Single SSH session: find container and extract logs in one command
-          gcloud compute ssh "${INSTANCE_NAME}" \
-            --zone "${GCP_ZONE}" \
-            --ssh-flag="-o ServerAliveInterval=5" \
-            --ssh-flag="-o ConnectionAttempts=20" \
-            --ssh-flag="-o ConnectTimeout=5" \
-            --command="sudo docker ps -a --filter name=${TEST_ID} -q --no-trunc | head -1 | xargs -I{} sudo docker logs {} 2>/dev/null" \
-            | grep -E '^[0-9]+ [0-9a-f]{64}$' \
-            > checkpoint-output.txt || true
-
-          LINES=$(wc -l < checkpoint-output.txt)
-          echo "Extracted ${LINES} checkpoint lines"
-
-          if [ "$LINES" -eq 0 ]; then
-            echo "No checkpoint lines found in container logs"
-            exit 1
+          # Match the repo file naming used by checkpoint-update.yml.
+          if echo "${TEST_ID}" | grep -qi "testnet"; then
+            OUT="test-checkpoints.txt"
+          else
+            OUT="main-checkpoints.txt"
           fi
 
-          # Name to match the repo files: main-checkpoints.txt / test-checkpoints.txt
-          if echo "${TEST_ID}" | grep -qi "testnet"; then
-            mv checkpoint-output.txt "test-checkpoints.txt"
-          else
-            mv checkpoint-output.txt "main-checkpoints.txt"
+          gcloud compute scp \
+            --zone "${GCP_ZONE}" \
+            --ssh-flag="-o ServerAliveInterval=5" \
+            --ssh-flag="-o ConnectTimeout=5" \
+            "${INSTANCE_NAME}:/tmp/checkpoints.txt" \
+            "${OUT}"
+
+          LINES=$(wc -l < "${OUT}")
+          echo "Retrieved ${LINES} checkpoint lines into ${OUT}"
+          if [ "$LINES" -eq 0 ]; then
+            echo "ERROR: checkpoint file empty on instance"
+            exit 1
           fi
 
       - name: Upload checkpoint artifact


### PR DESCRIPTION
## Motivation

PR #10459 added an `upload-checkpoint-artifact` job that rediscovers the test container on the GCP instance and runs:

```
sudo docker ps -a --filter name=${TEST_ID} -q --no-trunc
  | head -1
  | xargs -I{} sudo docker logs {} 2>/dev/null
  | grep -E '^[0-9]+ [0-9a-f]{64}$'
```

Every run since the merge has logged `Extracted 0 checkpoint lines`. Two reasons:

1. On Container-Optimized OS, containers launched via `gcloud compute instances create-with-container` are named with a `klt-` prefix. The filter `--filter name=generate-checkpoints-mainnet` matches none of them in some Docker versions on COS. The existing `find-container` step gets this right with `CONTAINER_PREFIX="klt-${INSTANCE_NAME}"`.
2. The anchored regex `^[0-9]+ [0-9a-f]{64}$` is brittle against nextest output, which wraps child stdout with test harness formatting.

Compounding issue: all stateful integration tests were marked "skipping" during #10459's PR review, so the step was never exercised before merging.

## Solution

Capture the checkpoint lines in the `test-result` job while we still have the correct `CONTAINER_ID` from `find-container`. Save them to `/tmp/checkpoints.txt` on the instance. The upload job simply pulls that file with `gcloud compute scp`.

- Removes the broken `--filter name=` container lookup.
- Uses `grep -oE` without anchors, so nextest prefixes do not defeat the extraction.
- Instance is guaranteed alive at scp time because `delete-instance` depends on `upload-checkpoint-artifact`.

### Tests

This PR needs the `run-stateful-tests` label to trigger the integration workflow on Mainnet + Testnet checkpoint generation. Until that runs, the change is only validated by `zizmor` (no new findings).

### AI Disclosure

- [x] AI tools were used: Claude for root-cause analysis on the existing failure, architectural comparison against alternative capture strategies, and drafting this fix.