### PR TITLE
fix(ci): re-run stateful tests on push while label is present

### DIFF
--- a/.github/workflows/zfnd-ci-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-ci-integration-tests-gcp.yml
@@ -53,7 +53,7 @@ on:
 
   pull_request:
     branches: [main]
-    types: [labeled]
+    types: [labeled, synchronize, reopened]
 
   push:
     # Run only on main branch updates that modify Rust code or dependencies.
@@ -126,7 +126,7 @@ jobs:
   build:
     name: Build CI Docker
     # Skip PRs from external repositories, let them pass, and then GitHub's Merge Queue will check them
-    if: ${{ (!startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork) && (github.event_name != 'pull_request' || github.event.label.name == 'run-stateful-tests') }}
+    if: ${{ (!startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork) && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-stateful-tests')) }}
     permissions:
       contents: read
       id-token: write
@@ -155,7 +155,7 @@ jobs:
   get-available-disks:
     name: Check if cached state disks exist for ${{ inputs.network || vars.ZCASH_NETWORK }}
     # Skip PRs from external repositories, let them pass, and then GitHub's Merge Queue will check them
-    if: ${{ (!startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork) && (github.event_name != 'pull_request' || github.event.label.name == 'run-stateful-tests') }}
+    if: ${{ (!startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork) && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-stateful-tests')) }}
     permissions:
       contents: read
       id-token: write
@@ -169,7 +169,7 @@ jobs:
   # Some outputs are ignored, because we don't run those jobs on testnet.
   get-available-disks-testnet:
     name: Check if cached state disks exist for testnet
-    if: ${{ (!startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork) && (github.event_name != 'pull_request' || github.event.label.name == 'run-stateful-tests') }}
+    if: ${{ (!startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork) && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-stateful-tests')) }}
     permissions:
       contents: read
       id-token: write
@@ -666,7 +666,7 @@ jobs:
       ${{
         always() &&
         (!startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork) &&
-        (github.event_name != 'pull_request' || github.event.label.name == 'run-stateful-tests')
+        (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-stateful-tests'))
       }}
     needs:
       - build


### PR DESCRIPTION
## Motivation

The `run-stateful-tests` label has to be removed and re-added after every push to re-trigger the integration tests. Once applied, the label should keep gating the suite across every PR synchronize.

## Solution

Two coordinated fixes to `zfnd-ci-integration-tests-gcp.yml`:

1. Expand the `pull_request` trigger from `types: [labeled]` to `types: [labeled, synchronize, reopened]` so the workflow fires when new commits land on a labelled PR.
2. Replace `github.event.label.name == 'run-stateful-tests'` with `contains(github.event.pull_request.labels.*.name, 'run-stateful-tests')` at all four gate sites. The old expression is null outside `labeled`/`unlabeled` events; the new expression reads the PR's current label set on any `pull_request` activity. This matches the pattern already used for the `A-release` label in `tests-unit.yml`.

`concurrency.cancel-in-progress` is already true for `pull_request`, so re-firing on every push cancels the previous run rather than piling up.

### Tests

CI on this PR exercises the new path: applying `run-stateful-tests` and then pushing commits should re-run the suite without re-toggling the label.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude for root-cause diagnosis and drafting the fix

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.