### PR TITLE
refactor(ci): zonal MIG per (environment, branch, network, zone)

### DIFF
--- a/.github/workflows/zfnd-deploy-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-nodes-gcp.yml
@@ -1,27 +1,15 @@
 # Deploy Zebra nodes to Google Cloud Platform.
 #
-# Two GCP environments host the deploys:
-# - `zfnd-prod-zebra` (production): receives `release` events
-# - `zfnd-dev-zebra`  (dev):        receives `push`-to-main (the staging deploy)
-#                                   and `workflow_dispatch` from any branch (PR work)
+# One zonal MIG per (environment, branch, network, zone). MIG names:
+#   - release:          zebrad-${network}-${zone-letter}
+#   - push to main:     zebrad-main-${network}-${zone-letter}
+#   - workflow_dispatch: zebrad-${branch}-${network}-${zone-letter}
 #
-# Within each environment, the MIG name encodes the source so the resource is
-# self-describing:
-# - production:   `zebrad-${network}`
-# - staging:      `zebrad-main-${network}`
-# - PR / branch:  `zebrad-${branch}-${network}`
+# Push and release fan out to 6 cells (2 networks × 3 zones);
+# workflow_dispatch deploys one cell (user picks network + zone).
 #
-# Each MIG is stable; every trigger swaps the instance template via rolling
-# action with `--max-unavailable=1`. The stateful disk policy preserves chain
-# state across the rolling restart, so cross-major-version upgrades do not
-# trigger a multi-day resync.
-#
-# Jobs:
-# - `get-disk-name`: looks up the most recent matching cache image for cold-start bootstrap
-# - `build`: builds the runtime container image and publishes to GAR
-# - `set-matrix`: chooses Mainnet, Testnet, or both based on the trigger
-# - `deploy-nodes`: creates or rolls the MIG for the matrix network
-# - `deploy-nodes-success` + `failure-issue`: success aggregation and auto-issue on failure
+# Design rationale: docs/decisions/devops/0006-gcp-deployment-naming.md
+# Operations: book/src/dev/gcp-deployment-operations.md
 #
 # See ADR docs/decisions/devops/0006-gcp-deployment-naming.md for the design
 # rationale and book/src/dev/gcp-deployment-operations.md for operational
@@ -55,6 +43,15 @@ on:
         options:
           - Mainnet
           - Testnet
+      zone:
+        description: "GCP zone for the workflow_dispatch deploy (single zone)"
+        required: true
+        type: choice
+        default: us-east1-b
+        options:
+          - us-east1-b
+          - us-east1-c
+          - us-east1-d
       environment:
         description: "Environment to deploy to"
         required: true
@@ -135,25 +132,108 @@ permissions:
   contents: read
 
 jobs:
-  # Finds a cached state disk for zebra
+  # Build the (network, zone) matrix and resolve the target environment from
+  # the trigger. Downstream jobs read `set-matrix` outputs so the event →
+  # environment mapping is computed once.
+  set-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      networks: ${{ steps.set-matrix.outputs.networks }}
+      zones: ${{ steps.set-matrix.outputs.zones }}
+      environment: ${{ steps.set-matrix.outputs.environment }}
+    steps:
+      - id: set-matrix
+        run: |
+          case "${{ github.event_name }}" in
+            release)           ENV="prod" ;;
+            workflow_dispatch) ENV="${{ inputs.environment }}" ;;
+            *)                 ENV="dev" ;;
+          esac
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            NETWORKS='["${{ inputs.network }}"]'
+            ZONES='["${{ inputs.zone }}"]'
+          else
+            NETWORKS='["Mainnet","Testnet"]'
+            ZONES='["us-east1-b","us-east1-c","us-east1-d"]'
+          fi
+
+          {
+            echo "networks=${NETWORKS}"
+            echo "zones=${ZONES}"
+            echo "environment=${ENV}"
+          } >> "$GITHUB_OUTPUT"
+
+  # Per-network cache-disk lookup. Cache images are network-specific
+  # (`zebrad-cache-…-mainnet-tip` vs `…-testnet-tip`), so the lookup must
+  # run once per network the matrix deploys to. Running a single workflow-
+  # level lookup with `inputs.network || vars.ZCASH_NETWORK` would return
+  # the wrong image for the other matrix row.
   #
-  # Passes the disk name to subsequent jobs using `cached_disk_name` output
-  #
-  # For push events, this job always runs.
-  # For workflow_dispatch events, it runs only if inputs.need_cached_disk is true.
-  # For release events, this job is skipped (releases use fixed disk names, not cached images).
-  # PRs from forked repositories are skipped.
-  get-disk-name:
-    name: Get disk name
+  # Skipped for releases (they do not use cached images) and for
+  # workflow_dispatch with `need_cached_disk=false`.
+  # One-shot upsert of the HTTP health checks used by the zonal MIGs.
+  # These are global, network-scoped resources (one per network), so running
+  # them once per push instead of once per zonal-MIG cell saves 2/3 of the
+  # upsert calls and avoids concurrent create/update races.
+  ensure-health-checks:
+    name: Ensure health checks exist
+    needs: [set-matrix]
+    runs-on: ubuntu-latest
+    environment: ${{ needs.set-matrix.outputs.environment }}
+    permissions:
+      contents: read
+      id-token: write
+    if: ${{ github.event_name != 'pull_request' }}
+    steps:
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 #v3.0.0
+        with:
+          workload_identity_provider: "${{ vars.GCP_WIF }}"
+          service_account: "${{ vars.GCP_DEPLOYMENTS_SA }}"
+      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db #v3.0.1
+      - run: |
+          for NET in $(echo '${{ needs.set-matrix.outputs.networks }}' | jq -r '.[] | ascii_downcase'); do
+            gcloud compute health-checks create http "zebra-${NET}-health" \
+              --port=8080 --request-path=/healthy \
+              --check-interval=60s --timeout=10s \
+              --unhealthy-threshold=3 --healthy-threshold=2 \
+              --global 2>/dev/null \
+            || gcloud compute health-checks update http "zebra-${NET}-health" \
+              --request-path=/healthy \
+              --check-interval=60s --timeout=10s \
+              --unhealthy-threshold=3 --healthy-threshold=2 \
+              --global
+          done
+
+  get-disk-name-mainnet:
+    name: Get Mainnet cached disk
+    needs: [set-matrix]
     permissions:
       contents: read
       id-token: write
     uses: ./.github/workflows/zfnd-find-cached-disks.yml
-    # Skip for releases (they use fixed disk names like 'zebrad-cache-mainnet-tip')
-    # For workflow_dispatch: only run if need_cached_disk is true
-    if: ${{ github.event_name != 'release' && !(github.event.pull_request.head.repo.fork) && (github.event_name != 'workflow_dispatch' || inputs.need_cached_disk) }}
+    if: ${{ github.event_name != 'release'
+      && !(github.event.pull_request.head.repo.fork)
+      && (github.event_name != 'workflow_dispatch' || inputs.need_cached_disk)
+      && contains(fromJSON(needs.set-matrix.outputs.networks), 'Mainnet') }}
     with:
-      network: ${{ inputs.network || vars.ZCASH_NETWORK }}
+      network: Mainnet
+      disk_prefix: zebrad-cache
+      disk_suffix: ${{ inputs.cached_disk_type || 'tip' }}
+
+  get-disk-name-testnet:
+    name: Get Testnet cached disk
+    needs: [set-matrix]
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/zfnd-find-cached-disks.yml
+    if: ${{ github.event_name != 'release'
+      && !(github.event.pull_request.head.repo.fork)
+      && (github.event_name != 'workflow_dispatch' || inputs.need_cached_disk)
+      && contains(fromJSON(needs.set-matrix.outputs.networks), 'Testnet') }}
+    with:
+      network: Testnet
       disk_prefix: zebrad-cache
       disk_suffix: ${{ inputs.cached_disk_type || 'tip' }}
 
@@ -181,50 +261,38 @@ jobs:
       no_cache: ${{ inputs.no_cache || false }}
       rust_log: info
       features: ${{ format('{0} {1}', vars.RUST_PROD_FEATURES, vars.RUST_TEST_FEATURES) }}
-      environment: ${{ github.event_name == 'release' && 'prod' || (github.event_name == 'workflow_dispatch' && inputs.environment) || 'dev' }}
+      environment: ${{ needs.set-matrix.outputs.environment }}
     # This step needs access to Docker Hub secrets to run successfully
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  # Choose Mainnet, Testnet, or both. Push and release fan out to both
-  # networks; workflow_dispatch deploys only the network the dispatcher chose.
-  set-matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      networks: ${{ steps.set-networks.outputs.matrix }}
-    steps:
-      - id: set-networks
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            # Manually triggered deployment: output a valid JSON array with the single chosen network.
-            echo "matrix=[\"${{ inputs.network }}\"]" >> $GITHUB_OUTPUT
-          else
-            echo 'matrix=["Mainnet","Testnet"]' >> $GITHUB_OUTPUT
-          fi
-
-  # Create or update the MIG for the matrix network. The MIG name is a
-  # deterministic function of (environment, branch), so this step swaps the
-  # instance template via rolling-action when the MIG already exists, and
-  # creates a fresh MIG bootstrapped from the cache image when it does not.
-  # Stateful disks are preserved across rolling restarts.
+  # Create or update one zonal MIG per matrix cell. Each cell is a
+  # (network, zone) tuple. MIG identity is the tuple plus environment +
+  # branch. No two MIGs ever share a disk; rolling updates are per-zone.
+  #
+  # `fail-fast: false` keeps each (network, zone) independent: one cell's
+  # failure must not cancel the five sister cells.
   deploy-nodes:
     strategy:
+      fail-fast: false
       matrix:
         network: ${{ fromJSON(needs.set-matrix.outputs.networks) }}
-    name: Deploy ${{ matrix.network }} nodes
-    needs:
-      [
-        set-matrix,
-        build,
-        get-disk-name,
-      ]
+        zone: ${{ fromJSON(needs.set-matrix.outputs.zones) }}
+    name: Deploy ${{ matrix.network }} ${{ matrix.zone }}
+    needs: [set-matrix, build, get-disk-name-mainnet, get-disk-name-testnet, ensure-health-checks]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
-      CACHED_DISK_NAME: ${{ needs.get-disk-name.outputs.cached_disk_name }}
+      # Pick the cache image for this matrix row's network. One image seeds
+      # all three zones for a given network. Released deploys skip the
+      # cache lookup entirely and get an empty value here.
+      CACHED_DISK_NAME: >-
+        ${{ matrix.network == 'Mainnet'
+            && needs.get-disk-name-mainnet.outputs.cached_disk_name
+            || needs.get-disk-name-testnet.outputs.cached_disk_name }}
     # Use prod environment for releases, allow manual selection for workflow_dispatch, default to dev for others
-    environment: ${{ github.event_name == 'release' && 'prod' || (github.event_name == 'workflow_dispatch' && inputs.environment) || 'dev' }}
+    environment: ${{ needs.set-matrix.outputs.environment }}
     permissions:
       contents: read
       id-token: write
@@ -245,11 +313,15 @@ jobs:
         with:
           short-length: 7
 
-      # GCP labels must be lowercase; matrix.network is sentence-case.
-      - name: Downcase network name
+      - name: Extract matrix values
         run: |
-          NETWORK_CAPS="${{ matrix.network }}"
-          echo "NETWORK=${NETWORK_CAPS,,}" >> "$GITHUB_ENV"
+          ZONE="${{ matrix.zone }}"
+          NET_CAPS="${{ matrix.network }}"
+          {
+            echo "NETWORK=${NET_CAPS,,}"
+            echo "ZONE=${ZONE}"
+            echo "ZONE_LETTER=${ZONE##*-}"
+          } >> "$GITHUB_ENV"
 
       - name: Authenticate to Google Cloud
         id: auth
@@ -263,272 +335,207 @@ jobs:
         with:
           install_components: 'beta'
 
-      # Derive MIG, disk, and template names from the trigger. The release event
-      # produces unprefixed names (the production deploy in zfnd-prod-zebra);
-      # `push` to main produces `main-` prefixed names (the staging deploy in
-      # zfnd-dev-zebra); `workflow_dispatch` produces branch-prefixed names (PR
-      # work in zfnd-dev-zebra). See ADR 0006.
-      - name: Compute MIG and disk naming for ${{ matrix.network }}
+      - name: Compute MIG and disk naming
         env:
           EVENT_NAME: ${{ github.event_name }}
           REF_SLUG: ${{ env.GITHUB_REF_SLUG_URL }}
           SHA_SHORT: ${{ env.GITHUB_SHA_SHORT }}
         run: |
           case "${EVENT_NAME}" in
-            release)           MIG_PREFIX="" ;;
-            push)              MIG_PREFIX="main-" ;;
-            workflow_dispatch) MIG_PREFIX="${REF_SLUG}-" ;;
-            *)
-              echo "::error::Unsupported event for deploy: ${EVENT_NAME}"
-              exit 1
-              ;;
+            release)           PREFIX="" ;;
+            push)              PREFIX="main-" ;;
+            workflow_dispatch) PREFIX="${REF_SLUG}-" ;;
+            *) echo "::error::Unsupported event: ${EVENT_NAME}"; exit 1 ;;
           esac
-
-          MIG_NAME="zebrad-${MIG_PREFIX}${NETWORK}"
-          DISK_NAME="zebrad-cache-${MIG_PREFIX}${NETWORK}"
-          TEMPLATE_NAME="zebrad-${MIG_PREFIX}${SHA_SHORT}-${NETWORK}"
-
           {
-            echo "MIG_NAME=${MIG_NAME}"
-            echo "DISK_NAME=${DISK_NAME}"
-            echo "TEMPLATE_NAME=${TEMPLATE_NAME}"
+            echo "MIG_NAME=zebrad-${PREFIX}${NETWORK}-${ZONE_LETTER}"
+            echo "DISK_NAME=zebrad-cache-${PREFIX}${NETWORK}-${ZONE_LETTER}"
+            echo "TEMPLATE_NAME=zebrad-${PREFIX}${SHA_SHORT}-${NETWORK}-${ZONE_LETTER}"
           } >> "$GITHUB_ENV"
 
-          echo "Computed: mig=${MIG_NAME} disk=${DISK_NAME} template=${TEMPLATE_NAME}"
-
-      # Reject early when the target disk is held by an instance from a
-      # different MIG. Without this check, the symptom is a 20-minute
-      # `wait-until --stable` timeout with no actionable error.
-      - name: Pre-flight check for stateful disk squatters
-        env:
-          GCP_REGION: ${{ vars.GCP_REGION }}
+      # Reject early if the zonal disk is held by an instance from another MIG.
+      - name: Pre-flight check for stateful disk squatter
         run: |
-          SQUATTERS=""
-          for zone in $(gcloud compute zones list \
-              --filter="region:${GCP_REGION}" \
-              --format="value(name)" --limit=3); do
-            users=$(gcloud compute disks describe "${DISK_NAME}" --zone="${zone}" \
-              --format="value(users.basename())" 2>/dev/null || true)
-            for user in ${users}; do
-              owner=$(gcloud compute instances describe "${user}" --zone="${zone}" \
-                --format="value(metadata.items.filter(key:created-by).extract(value))" 2>/dev/null \
-                | grep -oE 'instanceGroupManagers/[^/]+' | cut -d/ -f2 || true)
-              if [ -n "${owner}" ] && [ "${owner}" != "${MIG_NAME}" ]; then
-                SQUATTERS="${SQUATTERS}\n  - ${zone}: held by instance ${user} (MIG: ${owner})"
-              fi
-            done
+          users=$(gcloud compute disks describe "${DISK_NAME}" --zone="${ZONE}" \
+            --format="value(users.basename())" 2>/dev/null || true)
+          for user in ${users}; do
+            owner=$(gcloud compute instances describe "${user}" --zone="${ZONE}" \
+              --format="value(metadata.items.filter(key:created-by).extract(value))" 2>/dev/null \
+              | grep -oE 'instanceGroupManagers/[^/]+' | cut -d/ -f2 || true)
+            if [ -n "${owner}" ] && [ "${owner}" != "${MIG_NAME}" ]; then
+              echo "::error::${DISK_NAME} in ${ZONE} is held by ${user} (MIG ${owner}). See gcp-deployment-operations.md."
+              exit 1
+            fi
           done
-          if [ -n "${SQUATTERS}" ]; then
-            printf '::error::Stateful disk %s is held by a different MIG; cannot create or update %s.\nSquatters:%b\n' \
-              "${DISK_NAME}" "${MIG_NAME}" "${SQUATTERS}"
-            printf '\nSee book/src/dev/gcp-deployment-operations.md for cleanup steps.\n'
+
+      # Create zonal disk from cache image on first deploy; attach existing on
+      # subsequent deploys or after a manual bootstrap.
+      - name: Ensure zonal disk exists
+        env:
+          ENV: ${{ needs.set-matrix.outputs.environment }}
+        run: |
+          if gcloud compute disks describe "${DISK_NAME}" --zone="${ZONE}" &>/dev/null; then
+            exit 0
+          fi
+          if [ -z "${CACHED_DISK_NAME}" ]; then
+            echo "::error::No ${DISK_NAME} and no cache image. Seed via integration-tests or manual snapshot."
             exit 1
           fi
+          gcloud compute disks create "${DISK_NAME}" --zone="${ZONE}" \
+            --image="${CACHED_DISK_NAME}" \
+            --size=400 --type=pd-balanced \
+            --labels="app=zebrad,environment=${ENV},network=${NETWORK},zone=${ZONE_LETTER},created_by=${{ github.event_name }},github_ref=${{ env.GITHUB_REF_SLUG_URL }},github_sha=${{ env.GITHUB_SHA_SHORT }}"
 
-      - name: Create instance template for ${{ matrix.network }}
+      - name: Create instance template
         run: |
-          # Stateful cache disk: created on first deploy from the cache image,
-          # then preserved by the MIG's stateful policy on every rolling update.
-          DISK_PARAMS="name=${DISK_NAME},device-name=${DISK_NAME},size=400GB,type=pd-balanced"
-          if [ -n "${{ env.CACHED_DISK_NAME }}" ]; then
-            DISK_PARAMS+=",image=${{ env.CACHED_DISK_NAME }}"
-          fi
-
-          # Log file: workflow_dispatch can override, otherwise repo variable.
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.log_file }}" ]; then
             LOG_FILE="${{ inputs.log_file }}"
           else
             LOG_FILE="${{ vars.CD_LOG_FILE }}"
           fi
-
-          # Network-specific ports
           if [ "${{ matrix.network }}" = "Mainnet" ]; then
-            P2P_PORT="8233"
-            RPC_PORT="8232"
+            P2P=8233; RPC=8232
           else
-            P2P_PORT="18233"
-            RPC_PORT="18232"
+            P2P=18233; RPC=18232
           fi
-
-          # Templates are immutable; reuse if a template for this commit+network already exists
           if gcloud compute instance-templates describe "${TEMPLATE_NAME}" &>/dev/null; then
-            echo "Template ${TEMPLATE_NAME} already exists, reusing existing template"
-          else
-            gcloud compute instance-templates create-with-container "${TEMPLATE_NAME}" \
-            --machine-type ${{ vars.GCP_SMALL_MACHINE }} \
-            --provisioning-model=SPOT \
-            --boot-disk-size=10GB \
-            --boot-disk-type=pd-standard \
-            --image-project=cos-cloud \
-            --image-family=cos-stable \
-            --subnet=${{ vars.GCP_SUBNETWORK }} \
-            --no-address \
-            --create-disk="${DISK_PARAMS}" \
-            --container-mount-disk=mount-path='/home/zebra/.cache/zebra',name=${DISK_NAME},mode=rw \
-            --container-stdin \
-            --container-tty \
-            --container-image ${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }} \
-            --container-env "ZEBRA_NETWORK__NETWORK=${{ matrix.network }},ZEBRA_NETWORK__LISTEN_ADDR=0.0.0.0:${P2P_PORT},LOG_FILE=${LOG_FILE},SENTRY_DSN=${{ vars.SENTRY_DSN }},ZEBRA_HEALTH__LISTEN_ADDR=0.0.0.0:8080,ZEBRA_HEALTH__MIN_CONNECTED_PEERS=1,ZEBRA_RPC__LISTEN_ADDR=0.0.0.0:${RPC_PORT}" \
-            --service-account ${{ vars.GCP_DEPLOYMENTS_SA }} \
-            --scopes cloud-platform \
-            --metadata google-logging-enabled=true,google-logging-use-fluentbit=true,google-monitoring-enabled=true \
-            --labels=app=zebrad,environment=${{ github.event_name == 'release' && 'prod' || (github.event_name == 'workflow_dispatch' && inputs.environment) || 'dev' }},network=${NETWORK},created_by=${{ github.event_name }},github_ref=${{ env.GITHUB_REF_SLUG_URL }},github_sha=${{ env.GITHUB_SHA_SHORT }} \
-            --tags zebrad
+            exit 0
           fi
+          gcloud compute instance-templates create-with-container "${TEMPLATE_NAME}" \
+            --machine-type=${{ vars.GCP_SMALL_MACHINE }} \
+            --provisioning-model=SPOT \
+            --boot-disk-size=10GB --boot-disk-type=pd-standard \
+            --image-project=cos-cloud --image-family=cos-stable \
+            --subnet=${{ vars.GCP_SUBNETWORK }} --no-address \
+            --disk="name=${DISK_NAME},device-name=${DISK_NAME},mode=rw,auto-delete=no,boot=no" \
+            --container-mount-disk="mount-path=/home/zebra/.cache/zebra,name=${DISK_NAME},mode=rw" \
+            --container-stdin --container-tty \
+            --container-image="${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}" \
+            --container-env="ZEBRA_NETWORK__NETWORK=${{ matrix.network }},ZEBRA_NETWORK__LISTEN_ADDR=0.0.0.0:${P2P},LOG_FILE=${LOG_FILE},SENTRY_DSN=${{ vars.SENTRY_DSN }},ZEBRA_HEALTH__LISTEN_ADDR=0.0.0.0:8080,ZEBRA_HEALTH__MIN_CONNECTED_PEERS=1,ZEBRA_RPC__LISTEN_ADDR=0.0.0.0:${RPC}" \
+            --service-account=${{ vars.GCP_DEPLOYMENTS_SA }} --scopes=cloud-platform \
+            --metadata=google-logging-enabled=true,google-logging-use-fluentbit=true,google-monitoring-enabled=true \
+            --labels="app=zebrad,environment=${{ needs.set-matrix.outputs.environment }},network=${NETWORK},zone=${ZONE_LETTER},created_by=${{ github.event_name }},github_ref=${{ env.GITHUB_REF_SLUG_URL }},github_sha=${{ env.GITHUB_SHA_SHORT }}" \
+            --tags=zebrad
 
-      # HTTP health check on /healthy endpoint (sync-aware: 200 during sync, 503 on failure)
-      - name: Create or update health check
-        run: |
-          gcloud compute health-checks create http zebra-${NETWORK}-health \
-            --port=8080 \
-            --request-path=/healthy \
-            --check-interval=60s \
-            --timeout=10s \
-            --unhealthy-threshold=3 \
-            --healthy-threshold=2 \
-            --global 2>/dev/null || \
-          gcloud compute health-checks update http zebra-${NETWORK}-health \
-            --request-path=/healthy \
-            --check-interval=60s \
-            --timeout=10s \
-            --unhealthy-threshold=3 \
-            --healthy-threshold=2 \
-            --global
-
-
-      # Check if our destination instance group exists already
-      - name: Check if ${{ matrix.network }} instance group exists
+      - name: Check if zonal MIG exists
         id: does-group-exist
         continue-on-error: true
         run: |
-          gcloud compute instance-groups list | grep "${MIG_NAME}" | grep "${{ vars.GCP_REGION }}"
+          gcloud compute instance-groups managed describe "${MIG_NAME}" --zone="${ZONE}" >/dev/null 2>&1
 
-      # Deploy new managed instance group with 1 instance per zone (2-3 total)
-      - name: Create managed instance group for ${{ matrix.network }}
+      # Fresh MIG: size=1 (one instance per zonal MIG). The template's
+      # `--disk=name=…` attaches the pre-created zonal disk.
+      - name: Create zonal MIG
         if: steps.does-group-exist.outcome == 'failure'
         run: |
-          # Query available zones (up to 3) and set instance count to match
-          ZONES=$(gcloud compute zones list \
-            --filter="region:${{ vars.GCP_REGION }}" \
-            --format="value(name)" \
-            --limit=3 | paste -sd,)
+          gcloud compute instance-groups managed create "${MIG_NAME}" \
+            --template="${TEMPLATE_NAME}" \
+            --zone="${ZONE}" \
+            --size=1 \
+            --health-check="zebra-${NETWORK}-health" \
+            --initial-delay=3600
 
-          ZONE_COUNT=$(echo "${ZONES}" | tr ',' '\n' | wc -l)
-
-          echo "Using ${ZONE_COUNT} zones: ${ZONES}"
-
-          gcloud compute instance-groups managed create \
-          "${MIG_NAME}" \
-          --template "${TEMPLATE_NAME}" \
-          --region "${{ vars.GCP_REGION }}" \
-          --size "${ZONE_COUNT}" \
-          --health-check="zebra-${NETWORK}-health" \
-          --initial-delay=3600 \
-          --instance-redistribution-type=NONE \
-          --target-distribution-shape=EVEN \
-          --zones="${ZONES}"
-
-      # Stateful policy preserves disks across updates (auto-delete on MIG deletion)
-      - name: Configure stateful disk policy
+      - name: Apply stateful disk policy (fresh MIG)
         if: steps.does-group-exist.outcome == 'failure'
         run: |
           gcloud compute instance-groups managed update "${MIG_NAME}" \
-            --stateful-disk "device-name=${DISK_NAME},auto-delete=on-permanent-instance-deletion" \
-            --region "${{ vars.GCP_REGION }}"
+            --stateful-disk="device-name=${DISK_NAME},auto-delete=on-permanent-instance-deletion" \
+            --zone="${ZONE}"
 
-      # Assign static IPs to instances (only for main branch and releases, not manual deployments)
-      - name: Assign static IPs to instances
+      # Assign one static IP per zone, deterministically:
+      #   zone b -> primary (`zebra-${network}`)
+      #   zone c -> secondary (`zebra-${network}-secondary`)
+      #   zone d -> tertiary (`zebra-${network}-tertiary`)
+      # Skipped for workflow_dispatch (PR deploys use ephemeral external IPs).
+      # Empirically `instance-configs create --stateful-external-ip` accepts
+      # STAGING / RUNNING-UNKNOWN instances; a short bounded poll handles the
+      # async gap between MIG-create returning and list-instances reporting.
+      # Zone b -> primary, c -> secondary, d -> tertiary.
+      # Skipped for workflow_dispatch (PR deploys use ephemeral IPs).
+      - name: Assign static IP (fresh MIG, non-dispatch)
         if: ${{ steps.does-group-exist.outcome == 'failure' && github.event_name != 'workflow_dispatch' }}
         run: |
-          # Wait for MIG to be stable (all instances created)
-          gcloud compute instance-groups managed wait-until "${MIG_NAME}" \
-            --stable \
-            --region "${{ vars.GCP_REGION }}" \
-            --timeout=1200
-
-          # Get static IPs and instances
-          IP_NAMES=("zebra-${NETWORK}" "zebra-${NETWORK}-secondary" "zebra-${NETWORK}-tertiary")
-          mapfile -t IP_ADDRESSES < <(
-            for ip_name in "${IP_NAMES[@]}"; do
-              gcloud compute addresses describe "$ip_name" \
-                --region ${{ vars.GCP_REGION }} \
-                --format='value(address)' 2>/dev/null || echo ""
-            done
-          )
-
-          mapfile -t INSTANCES < <(
-            gcloud compute instance-groups managed list-instances "${MIG_NAME}" \
-              --region "${{ vars.GCP_REGION }}" \
-              --format="value(instance.basename())" | sort
-          )
-
-          # Assign IPs via stateful instance config (creates config + assigns IP in one command)
-          for i in "${!INSTANCES[@]}"; do
-            [ -z "${IP_ADDRESSES[$i]}" ] && continue
-
-            echo "Assigning ${IP_ADDRESSES[$i]} to ${INSTANCES[$i]}"
-            gcloud compute instance-groups managed instance-configs create "${MIG_NAME}" \
-              --instance="${INSTANCES[$i]}" \
-              --stateful-external-ip="address=${IP_ADDRESSES[$i]},interface-name=nic0,auto-delete=never" \
-              --region "${{ vars.GCP_REGION }}"
+          case "${ZONE_LETTER}" in
+            b) SUFFIX="" ;;
+            c) SUFFIX="-secondary" ;;
+            d) SUFFIX="-tertiary" ;;
+          esac
+          IP_NAME="zebra-${NETWORK}${SUFFIX}"
+          IP_ADDRESS=$(gcloud compute addresses describe "${IP_NAME}" \
+            --region="${{ vars.GCP_REGION }}" --format='value(address)' 2>/dev/null || true)
+          if [ -z "${IP_ADDRESS}" ]; then
+            echo "::warning::${IP_NAME} not reserved; skipping"
+            exit 0
+          fi
+          for _ in $(seq 1 30); do
+            INSTANCE=$(gcloud compute instance-groups managed list-instances "${MIG_NAME}" \
+              --zone="${ZONE}" --format='value(instance.basename())' | head -1)
+            [ -n "${INSTANCE}" ] && break
+            sleep 2
           done
+          [ -z "${INSTANCE}" ] && { echo "::error::instance did not appear within 60s"; exit 1; }
+          gcloud compute instance-groups managed instance-configs create "${MIG_NAME}" \
+            --instance="${INSTANCE}" --zone="${ZONE}" \
+            --stateful-external-ip="address=${IP_ADDRESS},interface-name=nic0,auto-delete=never"
 
-      # Rolling template swap, one zone at a time. Stateful disks are preserved
-      # across the recreation; the other zones keep serving while one is replaced.
-      # `--max-surge=0` is required for stateful MIGs (no extra capacity allowed);
-      # `--max-unavailable=1` gives us the safest rolling behavior (one zone down).
-      - name: Update managed instance group for ${{ matrix.network }}
+      # Rolling update waits only for the new template to start rolling out;
+      # full health convergence is the verify-nodes job's concern.
+      - name: Rolling update on existing MIG
         if: steps.does-group-exist.outcome == 'success'
         run: |
-          gcloud compute instance-groups managed rolling-action start-update \
-          "${MIG_NAME}" \
-          --version template="${TEMPLATE_NAME}" \
-          --replacement-method=recreate \
-          --max-surge=0 \
-          --max-unavailable=1 \
-          --region "${{ vars.GCP_REGION }}"
+          gcloud compute instance-groups managed rolling-action start-update "${MIG_NAME}" \
+            --version=template="${TEMPLATE_NAME}" \
+            --replacement-method=recreate \
+            --max-surge=0 --max-unavailable=1 \
+            --zone="${ZONE}"
 
-      # Re-assign static IPs after rolling update (instances are recreated without external IPs)
-      - name: Re-assign static IPs after rolling update
-        if: ${{ steps.does-group-exist.outcome == 'success' && github.event_name != 'workflow_dispatch' }}
+  # Waits for each zonal MIG to reach HEALTHY (app-level: peer mesh + chain
+  # tip). Runs async from deploy-nodes. Skipped for workflow_dispatch.
+  verify-nodes:
+    name: Verify ${{ matrix.network }} ${{ matrix.zone }}
+    strategy:
+      fail-fast: false
+      matrix:
+        network: ${{ fromJSON(needs.set-matrix.outputs.networks) }}
+        zone: ${{ fromJSON(needs.set-matrix.outputs.zones) }}
+    needs: [set-matrix, deploy-nodes]
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    environment: ${{ needs.set-matrix.outputs.environment }}
+    permissions:
+      contents: read
+      id-token: write
+    if: >-
+      ${{
+        !cancelled() && !failure() &&
+        needs.deploy-nodes.result == 'success' &&
+        github.event_name != 'workflow_dispatch' &&
+        github.repository_owner == 'ZcashFoundation'
+      }}
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 #v3.0.0
+        with:
+          workload_identity_provider: "${{ vars.GCP_WIF }}"
+          service_account: "${{ vars.GCP_DEPLOYMENTS_SA }}"
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db #v3.0.1
+
+      - name: Wait for MIG stable
         run: |
-          # Wait for rolling update to complete
+          ZONE="${{ matrix.zone }}"
+          NET_CAPS="${{ matrix.network }}"
+          NETWORK="${NET_CAPS,,}"
+          ZONE_LETTER="${ZONE##*-}"
+          case "${{ github.event_name }}" in
+            release) PREFIX="" ;;
+            push)    PREFIX="main-" ;;
+            *) echo "::error::unsupported event"; exit 1 ;;
+          esac
+          MIG_NAME="zebrad-${PREFIX}${NETWORK}-${ZONE_LETTER}"
           gcloud compute instance-groups managed wait-until "${MIG_NAME}" \
-            --stable \
-            --region "${{ vars.GCP_REGION }}" \
-            --timeout=1200
-
-          # Get static IPs and instances
-          IP_NAMES=("zebra-${NETWORK}" "zebra-${NETWORK}-secondary" "zebra-${NETWORK}-tertiary")
-          mapfile -t IP_ADDRESSES < <(
-            for ip_name in "${IP_NAMES[@]}"; do
-              gcloud compute addresses describe "$ip_name" \
-                --region ${{ vars.GCP_REGION }} \
-                --format='value(address)' 2>/dev/null || echo ""
-            done
-          )
-
-          mapfile -t INSTANCES < <(
-            gcloud compute instance-groups managed list-instances "${MIG_NAME}" \
-              --region "${{ vars.GCP_REGION }}" \
-              --format="value(instance.basename())" | sort
-          )
-
-          # Assign IPs via stateful instance config (creates config + assigns IP in one command)
-          for i in "${!INSTANCES[@]}"; do
-            [ -z "${IP_ADDRESSES[$i]}" ] && continue
-
-            echo "Assigning ${IP_ADDRESSES[$i]} to ${INSTANCES[$i]}"
-            gcloud compute instance-groups managed instance-configs create "${MIG_NAME}" \
-              --instance="${INSTANCES[$i]}" \
-              --stateful-external-ip="address=${IP_ADDRESSES[$i]},interface-name=nic0,auto-delete=never" \
-              --region "${{ vars.GCP_REGION }}" \
-              --update-instance 2>/dev/null || \
-            gcloud compute instance-groups managed instance-configs update "${MIG_NAME}" \
-              --instance="${INSTANCES[$i]}" \
-              --stateful-external-ip="address=${IP_ADDRESSES[$i]},interface-name=nic0,auto-delete=never" \
-              --region "${{ vars.GCP_REGION }}"
-          done
+            --stable --zone="${ZONE}" --timeout=5400
 
   deploy-nodes-success:
     name: Deploy nodes success
@@ -539,21 +546,16 @@ jobs:
         always() &&
         needs.deploy-nodes.result != 'skipped'
       }}
-    needs:
-      - get-disk-name
-      - build
-      - set-matrix
-      - deploy-nodes
+    needs: [set-matrix, get-disk-name-mainnet, get-disk-name-testnet, ensure-health-checks, build, deploy-nodes]
     timeout-minutes: 1
     steps:
-      - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe #v1.2.2
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe #v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: get-disk-name, build
+          allowed-skips: get-disk-name-mainnet, get-disk-name-testnet, build
 
   failure-issue:
-    name: Open or update issues for release failures
+    name: Open or update issues for deploy failures
     # When a new job is added to this workflow, add it to this list.
     needs: [build, deploy-nodes]
 
@@ -571,5 +573,25 @@ jobs:
           # New failures open an issue with this label.
           label-name: S-ci-fail-release-auto-issue
           # If there is already an open issue with this label, any failures become comments on that issue.
+          always-create-new-issue: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  verify-failure-issue:
+    name: Open or update issues for verify failures
+    needs: [verify-nodes]
+    # Deploy succeeded but the node did not reach HEALTHY within the verify
+    # window. Separate from `failure-issue` so on-call can distinguish an
+    # infrastructure problem (deploy-nodes) from a node-level warmup/sync
+    # problem (verify-nodes).
+    if: (failure() && github.event.pull_request == null) || (cancelled() && github.event.pull_request == null)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: jayqi/failed-build-issue-action@1a893bbf43ef1c2a8705e2b115cd4f0fe3c5649b #v1.2.0
+        with:
+          title-template: "{{refname}} verify failed: {{eventName}} in {{workflow}}"
+          label-name: S-ci-fail-verify-auto-issue
           always-create-new-issue: false
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/book/src/dev/continuous-delivery.md
+++ b/book/src/dev/continuous-delivery.md
@@ -1,43 +1,40 @@
 # Zebra Continuous Delivery
 
-The continuous-delivery pipeline deploys every commit merged to `main` to a staging environment, and every published release to production, on Google Cloud Platform.
+The continuous-delivery pipeline deploys every commit merged to `main` to a staging environment and every published release to production, on Google Cloud Platform.
 
-## Two GCP environments, three deploy kinds
+## Topology: one zonal MIG per (environment, branch, network, zone)
 
-The pipeline targets two GCP environments. Within the dev environment, the source branch determines whether the deploy is the persistent staging node or an ephemeral PR deploy. ADR [0006](../../../docs/decisions/devops/0006-gcp-deployment-naming.md) records the rationale; the [operations runbook](gcp-deployment-operations.md) covers day-to-day procedures.
+The pipeline targets two GCP environments. Each network in each environment deploys to three zonal Managed Instance Groups (MIGs) in `us-east1` zones `b`, `c`, and `d`. Each zonal MIG holds one Zebra instance with one stateful cache disk and one static IP.
 
-| Trigger              | GCP environment    | Branch / tag | MIG                            | Stateful disk                       | Lifetime                                                   |
-| -------------------- | ------------------ | ------------ | ------------------------------ | ----------------------------------- | ---------------------------------------------------------- |
-| `release`            | `zfnd-prod-zebra`  | `${tag}`     | `zebrad-${network}`            | `zebrad-cache-${network}`           | Permanent. Rolling template swap on every release.         |
-| `push` to `main`     | `zfnd-dev-zebra`   | `main`       | `zebrad-main-${network}`       | `zebrad-cache-main-${network}`      | Permanent. Rolling template swap on every commit.          |
-| `workflow_dispatch`  | `zfnd-dev-zebra`   | `${branch}`  | `zebrad-${branch}-${network}`  | `zebrad-cache-${branch}-${network}` | Per-branch. Manually reaped via labels (see runbook).      |
+| Trigger              | Environment          | MIGs per network | MIG name                                      | Stateful disk                                 |
+| -------------------- | -------------------- | ---------------- | --------------------------------------------- | --------------------------------------------- |
+| `release`            | `zfnd-prod-zebra`    | 3 (one per zone) | `zebrad-${network}-${zone-letter}`            | `zebrad-cache-${network}-${zone-letter}`      |
+| `push` to `main`     | `zfnd-dev-zebra`     | 3 (one per zone) | `zebrad-main-${network}-${zone-letter}`       | `zebrad-cache-main-${network}-${zone-letter}` |
+| `workflow_dispatch`  | `zfnd-dev-zebra`     | 1 (user-chosen zone) | `zebrad-${branch}-${network}-${zone-letter}` | `zebrad-cache-${branch}-${network}-${zone-letter}` |
 
-For each network (`mainnet`, `testnet`), the MIG runs one Spot instance per zone in the configured region, typically three zones in `us-east1`. The stateful disk persists the chain across template swaps, so a release upgrade does not trigger a multi-day resync.
-
-The MIG name encodes the source so the resource is self-describing: a reader sees `zebrad-feat-foo-mainnet` and knows the deploy came from branch `feat-foo` on Mainnet in the dev environment.
+ADR [0006](../../../docs/decisions/devops/0006-gcp-deployment-naming.md) records the rationale; the [runbook](gcp-deployment-operations.md) covers day-to-day procedures.
 
 ## Update mechanics
 
-Every trigger runs the same flow:
+Each push and each release fans out to six `deploy-nodes` jobs (2 networks × 3 zones). A workflow_dispatch is a single job (user picks the zone). Every job runs the same flow for its zonal MIG:
 
-1. Build a new instance template containing the commit's container image.
-2. If the MIG already exists, run a rolling template swap with `--max-unavailable=1`. The other zones keep serving while one instance is replaced.
-3. If the MIG does not exist, create it. The stateful disk bootstraps from the latest matching cache image found by `find-cached-disks`, so the new MIG does not start from genesis.
-4. Apply per-instance configurations to assign static IPs.
+1. Build a new instance template with the commit's container image.
+2. Ensure the zonal stateful disk exists. On first deploy, create it from the latest matching cache image. On subsequent deploys, attach the existing disk.
+3. If the zonal MIG exists, run `rolling-action start-update --max-unavailable=1`. True per-zone rolling: this zone's MIG replaces its instance while the other two zones keep serving. The stateful disk persists across the replace.
+4. If the zonal MIG does not exist, create it with `--size=1` and apply the stateful policy.
+5. Assign the static IP (push and release only; workflow_dispatch uses ephemeral). Zone-to-IP mapping is deterministic: zone `b` → primary, zone `c` → secondary, zone `d` → tertiary.
 
-Integration tests produce cache images in `zfnd-ci-integration-tests-gcp.yml`'s `create-state-image` job. The image name encodes the branch, commit, state-DB version, network, and timestamp. The lookup falls back from the current branch to `main` to any branch.
+Cache images come from `zfnd-ci-integration-tests-gcp.yml`'s `create-state-image` job. Image names encode branch, commit, state-DB version, network, and timestamp. One image per network seeds all three zones. Lookup priority in `gcp-get-cached-disks.sh`: current branch, then `main`, then any branch; most recent first.
 
-## Failure handling
-
-The deploy workflow opens an issue (label `S-ci-fail-release-auto-issue`) when a deploy fails on `main` or a release. The same issue collects subsequent failures and must be closed manually after recovery. The runbook covers common failure modes (`RESOURCE_IN_USE_BY_ANOTHER_RESOURCE`, `wait-until --stable` timeouts, disk corruption).
+Deploy success has two channels: `deploy-nodes` reports infrastructure, `verify-nodes` reports application health. See the [runbook](gcp-deployment-operations.md#deploy-success-has-two-channels) for details.
 
 ## Triggers
 
 The workflow runs on:
 
-- a `push` to `main` that touches Rust code, dependencies, Docker files, or the workflow itself,
-- a published `release`, or
-- a `workflow_dispatch` from any branch. The dispatcher chooses the environment (`dev` by default, `prod` if selected explicitly).
+- a `push` to `main` that touches Rust code, dependencies, Docker files, or the workflow itself
+- a published `release`
+- a `workflow_dispatch` from any branch (dispatcher picks `network`, `zone`, and `environment`)
 
 Pull requests run only the Docker-configuration tests; they do not deploy.
 

--- a/book/src/dev/gcp-deployment-operations.md
+++ b/book/src/dev/gcp-deployment-operations.md
@@ -2,36 +2,50 @@
 
 Operational procedures for the GCP Continuous Delivery pipeline. Architectural rationale: [ADR 0006](../../../docs/decisions/devops/0006-gcp-deployment-naming.md). High-level model: [Continuous Delivery](continuous-delivery.md).
 
-Two GCP projects (`zfnd-prod-zebra`, `zfnd-dev-zebra`) in `us-east1`, zones `b`, `c`, `d`. Every MIG, instance, and disk carries `environment`, `created_by`, `github_ref`, and `github_sha` labels. Use `created_by` as the kind discriminator: `release` (production), `push` (staging), `workflow_dispatch` (PR deploy).
+Two GCP projects (`zfnd-prod-zebra`, `zfnd-dev-zebra`) in `us-east1`, zones `b`, `c`, `d`. Every MIG, instance, and disk carries `environment`, `network`, `zone`, `created_by`, `github_ref`, and `github_sha` labels. Use `created_by` as the kind discriminator: `release` (production), `push` (staging), `workflow_dispatch` (PR deploy).
 
 The recipes below assume `gh` and `gcloud` are authenticated, and use these shell defaults when scoped to dev:
 
 ```bash
-P=zfnd-dev-zebra; R=us-east1
+P=zfnd-dev-zebra
 ```
 
 For production, set `P=zfnd-prod-zebra` instead.
 
+Zonal MIGs use `--zone` (not `--region`). One MIG per zone per network. MIG names end with the zone letter (`-b`, `-c`, `-d`).
+
+## Deploy success has two channels
+
+The workflow reports two independent signals:
+
+- `deploy-nodes` (and `failure-issue` with label `S-ci-fail-release-auto-issue`) reports **infrastructure**: template, zonal MIG, stateful disk, and static IP landed. Usually green within 3-5 minutes per matrix cell; a failure means the deploy itself broke.
+- `verify-nodes` (and `verify-failure-issue` with label `S-ci-fail-verify-auto-issue`) reports **application**: the zonal MIG reached HEALTHY. Up to 90 minutes; a failure means the node took longer than that to establish peers and catch up to chain tip. The MIG itself is fine; on-call action is usually "wait, or investigate why sync is slow".
+
 ## Quick reference
 
-| Goal                                                | Section                                                       |
-| --------------------------------------------------- | ------------------------------------------------------------- |
-| Smoke-test a PR branch / find / label / reap        | [PR deploys](#pr-deploys)                                     |
-| Diagnose a deploy that does not converge            | [Diagnose a stuck MIG](#diagnose-a-stuck-mig)                 |
-| Recover from a corrupted cache disk                 | [Recover a corrupted cache disk](#recover-a-corrupted-cache-disk) |
+| Goal                                                 | Section                                                       |
+| ---------------------------------------------------- | ------------------------------------------------------------- |
+| Smoke-test a PR branch / find / label / reap         | [PR deploys](#pr-deploys)                                     |
+| Diagnose a deploy that does not converge             | [Diagnose a stuck MIG](#diagnose-a-stuck-mig)                 |
+| Recover from a corrupted cache disk                  | [Recover a corrupted cache disk](#recover-a-corrupted-cache-disk) |
 | Cut a release with a backwards-incompatible DB format | [DB-format-version-break release](#db-format-version-break-release) |
-| Look up cache images, static IPs, daily cleanup     | [Reference](#reference)                                       |
+| Migrate a regional MIG to zonal                      | [Regional-to-zonal migration](#regional-to-zonal-migration)   |
+| Look up cache images, static IPs, daily cleanup      | [Reference](#reference)                                       |
 
 ## PR deploys
 
-A PR deploy creates `zebrad-${branch}-${network}` in `zfnd-dev-zebra`, bootstrapped from the latest matching cache image (preferring images from the same branch, falling back to `main`, then any branch). It lives until you reap it.
+A PR deploy creates one zonal MIG `zebrad-${branch}-${network}-${zone-letter}` in `zfnd-dev-zebra`, bootstrapped from the latest matching cache image (preferring images from the same branch, falling back to `main`, then any branch). Lives until you reap it.
 
 ### Run one
 
 ```bash
 gh workflow run zfnd-deploy-nodes-gcp.yml -R ZcashFoundation/zebra \
-  --ref my-branch -f network=Mainnet -f environment=dev \
-  -f need_cached_disk=true -f cached_disk_type=tip
+  --ref my-branch \
+  -f network=Mainnet \
+  -f zone=us-east1-b \
+  -f environment=dev \
+  -f need_cached_disk=true \
+  -f cached_disk_type=tip
 ```
 
 ### Find yours
@@ -48,37 +62,40 @@ Apply one of two labels:
 - `keep_until=YYYY-MM-DD` — self-expiring; eligible for reaping after the date passes.
 - `delete_protection=true` — indefinite; requires manual removal before reaping.
 
-Apply to instances and disks now if you need protection immediately (otherwise the labels arrive on the next template swap):
+Apply to the instance and disk now if you need protection immediately (labels propagate to new instances on the next template swap):
 
 ```bash
-MIG=zebrad-my-branch-mainnet
-for inst in $(gcloud compute instance-groups managed list-instances "$MIG" \
-  --region $R --project $P --format='value(name)'); do
-  zone=$(gcloud compute instances describe "$inst" --project $P \
-    --format='value(zone.basename())')
-  gcloud compute instances add-labels "$inst" --zone "$zone" --project $P \
-    --labels="keep_until=2026-05-01"
-done
+MIG=zebrad-my-branch-mainnet-b
+ZONE=us-east1-b
+INSTANCE=$(gcloud compute instance-groups managed list-instances "$MIG" \
+  --zone "$ZONE" --project $P --format='value(instance.basename())' | head -1)
+gcloud compute instances add-labels "$INSTANCE" --zone "$ZONE" --project $P \
+  --labels="keep_until=2026-05-01"
+gcloud compute disks add-labels "zebrad-cache-my-branch-mainnet-b" \
+  --zone "$ZONE" --project $P \
+  --labels="keep_until=2026-05-01"
 ```
 
 ### Reap one
 
-The stateful policy `auto-delete=on-permanent-instance-deletion` deletes the disks with the MIG.
+The stateful policy `auto-delete=on-permanent-instance-deletion` removes the disk with the MIG.
 
 ```bash
-gcloud compute instance-groups managed delete "$MIG" --region $R --project $P --quiet
+gcloud compute instance-groups managed delete "$MIG" --zone "$ZONE" --project $P --quiet
 ```
 
 ### Sweep expired
 
 ```bash
 TODAY=$(date +%Y-%m-%d)
-for mig in $(gcloud compute instance-groups managed list --project $P \
+for line in $(gcloud compute instance-groups managed list --project $P \
     --filter="labels.created_by=workflow_dispatch" \
-    --format='value(name,labels.keep_until,labels.delete_protection)' \
-    | awk -v today="$TODAY" '$3 == "true" || $2 == "" { next } $2 < today { print $1 }'); do
-  echo "Reaping $mig"
-  gcloud compute instance-groups managed delete "$mig" --region $R --project $P --quiet
+    --format='csv[no-heading](name,zone.basename(),labels.keep_until,labels.delete_protection)' \
+    | awk -F, -v today="$TODAY" '$4 == "true" || $3 == "" { next } $3 < today { print $1 "|" $2 }'); do
+  MIG="${line%|*}"
+  ZONE="${line#*|}"
+  echo "Reaping $MIG in $ZONE"
+  gcloud compute instance-groups managed delete "$MIG" --zone "$ZONE" --project $P --quiet
 done
 ```
 
@@ -87,90 +104,147 @@ Review the candidate list before piping into delete.
 ## Diagnose a stuck MIG
 
 ```bash
-MIG=zebrad-main-mainnet   # or the MIG you are debugging
-gcloud compute instance-groups managed describe "$MIG" --region $R --project $P \
-  --format="value(currentActions,status.isStable)"
-gcloud compute instance-groups managed list-instances "$MIG" --region $R --project $P \
-  --format="table(NAME,ZONE.basename(),STATUS,HEALTH_STATE,LAST_ERROR)"
-gcloud compute instance-groups managed list-errors "$MIG" --region $R --project $P --limit=10
+MIG=zebrad-main-mainnet-b
+ZONE=us-east1-b
+
+gcloud compute instance-groups managed describe "$MIG" --zone "$ZONE" --project $P \
+  --format="value(currentActions,status.isStable,status.versionTarget.isReached)"
+gcloud compute instance-groups managed list-instances "$MIG" --zone "$ZONE" --project $P \
+  --format="table(NAME,STATUS,HEALTH_STATE,LAST_ERROR)"
+gcloud compute instance-groups managed list-errors "$MIG" --zone "$ZONE" --project $P --limit=10
 ```
 
 When `list-errors` reports `RESOURCE_IN_USE_BY_ANOTHER_RESOURCE` on a stateful disk, find the squatter:
 
 ```bash
-DISK=zebrad-cache-main-mainnet
-for z in b c d; do
-  echo "us-east1-$z:"
-  gcloud compute disks describe "$DISK" --zone "us-east1-$z" --project $P \
-    --format="value(users.basename())" 2>/dev/null
-done
+DISK=zebrad-cache-main-mainnet-b
+gcloud compute disks describe "$DISK" --zone "$ZONE" --project $P \
+  --format="value(users.basename())"
 ```
 
-The squatter is some other MIG's instance. Reap that MIG using the PR-deploy recipe above.
+The squatter is another MIG's instance. Reap that MIG (recipe above).
 
 ## Recover a corrupted cache disk
 
-When Zebra crash-loops on a stateful disk (bad RocksDB write, hardware fault), recover from the last good cache image. Three steps: drain, snapshot-and-delete, redeploy.
+When Zebra crash-loops on a zonal disk, recover that one zone from the last good cache image. Sister zones keep serving.
 
 ```bash
-NET=mainnet
-MIG=zebrad-main-${NET}; DISK=zebrad-cache-main-${NET}; TS=$(date +%Y%m%d-%H%M)
+NET=mainnet; ZONE=us-east1-b; ZONE_LETTER=b
+MIG=zebrad-main-${NET}-${ZONE_LETTER}
+DISK=zebrad-cache-main-${NET}-${ZONE_LETTER}
+TS=$(date +%Y%m%d-%H%M)
 
-# 1. Drain: preserve disks via auto-delete=never, then scale to 0
-for inst in $(gcloud compute instance-groups managed list-instances "$MIG" \
-  --region $R --project $P --format='value(name)'); do
-  gcloud compute instance-groups managed instance-configs update "$MIG" \
-    --region $R --project $P --instance "$inst" \
-    --stateful-disk "device-name=${DISK},auto-delete=never"
-done
-gcloud compute instance-groups managed resize "$MIG" --size 0 --region $R --project $P
+# 1. Drain: preserve the disk via auto-delete=never, then scale to 0
+INSTANCE=$(gcloud compute instance-groups managed list-instances "$MIG" \
+  --zone "$ZONE" --project $P --format='value(name)' | head -1)
+gcloud compute instance-groups managed instance-configs update "$MIG" \
+  --zone "$ZONE" --project $P --instance "$INSTANCE" \
+  --stateful-disk "device-name=${DISK},auto-delete=never"
+gcloud compute instance-groups managed resize "$MIG" --size 0 --zone "$ZONE" --project $P
 
-# 2. Snapshot the corrupted disks for forensics, then delete them
-for z in b c d; do
-  gcloud compute snapshots create "${DISK}-${z}-corrupted-${TS}" \
-    --source-disk "$DISK" --source-disk-zone "us-east1-${z}" --project $P
-  gcloud compute disks delete "$DISK" --zone "us-east1-${z}" --project $P --quiet
-done
+# 2. Snapshot the corrupted disk for forensics, then delete it
+gcloud compute snapshots create "${DISK}-corrupted-${TS}" \
+  --source-disk "$DISK" --source-disk-zone "$ZONE" --project $P
+gcloud compute disks delete "$DISK" --zone "$ZONE" --project $P --quiet
 
-# 3. Redeploy; the workflow recreates disks from the latest cache image
+# 3. Redeploy via workflow_dispatch for this single zone
 gh workflow run zfnd-deploy-nodes-gcp.yml -R ZcashFoundation/zebra \
-  -f network=Mainnet -f environment=dev -f need_cached_disk=true -f cached_disk_type=tip
+  -f network=Mainnet -f zone="$ZONE" -f environment=dev \
+  -f need_cached_disk=true -f cached_disk_type=tip
 ```
 
-For production: set `P=zfnd-prod-zebra`, `MIG=zebrad-${NET}`, `DISK=zebrad-cache-${NET}`. Production has no automatic cache image; restore from a recent operator-taken snapshot instead.
+For production: set `P=zfnd-prod-zebra`, `MIG=zebrad-${NET}-${ZONE_LETTER}`, `DISK=zebrad-cache-${NET}-${ZONE_LETTER}`. Production has no automatic cache image; restore from a recent operator-taken snapshot.
 
 ## DB-format-version-break release
 
-When `zebra-state/src/constants.rs::DATABASE_FORMAT_VERSION` changes in a backwards-incompatible way, the in-place rolling swap fails: the new Zebra cannot read the old RocksDB. Use snapshot-based handoff.
+When `zebra-state/src/constants.rs::DATABASE_FORMAT_VERSION` changes in a backwards-incompatible way, the in-place rolling swap fails because the new Zebra can't read the old RocksDB. Do it one zone at a time with snapshot-based handoff:
 
 ```bash
-P=zfnd-prod-zebra; NET=mainnet
-MIG=zebrad-${NET}; DISK=zebrad-cache-${NET}; TS=$(date +%Y%m%d-%H%M)
+P=zfnd-prod-zebra; NET=mainnet; TS=$(date +%Y%m%d-%H%M)
 
-# 1. Snapshot every zonal disk
-for z in b c d; do
-  gcloud compute snapshots create "${DISK}-${z}-pre-major-${TS}" \
-    --source-disk "$DISK" --source-disk-zone "us-east1-${z}" --project $P
+for Z in b c d; do
+  MIG=zebrad-${NET}-${Z}; DISK=zebrad-cache-${NET}-${Z}; ZONE=us-east1-${Z}
+
+  # Snapshot before touching
+  gcloud compute snapshots create "${DISK}-pre-major-${TS}" \
+    --source-disk "$DISK" --source-disk-zone "$ZONE" --project $P
+
+  # Drain, preserving disk
+  INSTANCE=$(gcloud compute instance-groups managed list-instances "$MIG" \
+    --zone "$ZONE" --project $P --format='value(name)' | head -1)
+  gcloud compute instance-groups managed instance-configs update "$MIG" \
+    --zone "$ZONE" --project $P --instance "$INSTANCE" \
+    --stateful-disk "device-name=${DISK},auto-delete=never"
+  gcloud compute instance-groups managed resize "$MIG" --size 0 --zone "$ZONE" --project $P
 done
 
-# 2. Drain the MIG, preserving disks (same drain block as the recovery recipe above)
+# Publish the release; the workflow's release path recreates each zonal MIG
+# with the new template, which attaches the preserved disks.
 
-# 3. Publish the release. The deploy workflow's release path creates a new MIG
-#    that attaches the preserved disks. Watch for crash loops on the old DB.
-
-# 4. Rollback (only if step 3 fails): restore disks from snapshots, deploy the previous tag
-for z in b c d; do
-  gcloud compute disks delete "$DISK" --zone "us-east1-${z}" --project $P --quiet
-  gcloud compute disks create "$DISK" --zone "us-east1-${z}" --project $P \
-    --source-snapshot "${DISK}-${z}-pre-major-${TS}"
+# Rollback (only if the release fails): restore disks from snapshots, deploy previous tag
+for Z in b c d; do
+  DISK=zebrad-cache-${NET}-${Z}; ZONE=us-east1-${Z}
+  gcloud compute disks delete "$DISK" --zone "$ZONE" --project $P --quiet
+  gcloud compute disks create "$DISK" --zone "$ZONE" --project $P \
+    --source-snapshot "${DISK}-pre-major-${TS}"
 done
 ```
 
+## Regional-to-zonal migration
+
+One-shot procedure to convert an environment from the old regional architecture (one regional MIG per network holding three instances) to zonal (three zonal MIGs per network, one instance each). Run once per environment.
+
+```bash
+P=zfnd-prod-zebra   # or zfnd-dev-zebra
+NET=mainnet
+OLD_MIG=zebrad-${NET}    # for prod; use zebrad-main-${NET} for dev
+OLD_DISK=zebrad-cache-${NET}    # for prod; use zebrad-cache-main-${NET} for dev
+TS=$(date +%Y%m%d-%H%M)
+
+# 1. Snapshot each zonal disk (three per network)
+for Z in b c d; do
+  gcloud compute snapshots create "${OLD_DISK}-${Z}-pre-zonal-${TS}" \
+    --source-disk "$OLD_DISK" --source-disk-zone "us-east1-${Z}" --project $P
+done
+
+# 2. Delete the old regional MIG (disks auto-deleted; we have snapshots)
+gcloud compute instance-groups managed delete "$OLD_MIG" \
+  --region us-east1 --project $P --quiet
+
+# 3. Create zonal disks from the snapshots with the new name scheme
+#    Prod:    zebrad-cache-${NET}-${Z}
+#    Staging: zebrad-cache-main-${NET}-${Z}
+for Z in b c d; do
+  NEW_DISK=zebrad-cache-${NET}-${Z}    # or zebrad-cache-main-${NET}-${Z}
+  gcloud compute disks create "$NEW_DISK" \
+    --zone "us-east1-${Z}" --project $P \
+    --source-snapshot "${OLD_DISK}-${Z}-pre-zonal-${TS}" \
+    --size 400 --type pd-balanced
+done
+
+# 4. Trigger workflow_dispatch for each (network, zone). The workflow sees
+#    the zonal disks exist and attaches them; no fresh bootstrap from cache.
+for Z in b c d; do
+  gh workflow run zfnd-deploy-nodes-gcp.yml -R ZcashFoundation/zebra \
+    -f network=Mainnet -f zone="us-east1-${Z}" \
+    -f environment=$([ "$P" = "zfnd-prod-zebra" ] && echo prod || echo dev) \
+    -f need_cached_disk=false
+done
+```
+
+Repeat for Testnet. After all six (2 networks × 3 zones) zonal MIGs are HEALTHY, the migration for this environment is complete; retire the pre-zonal snapshots after a hold period.
+
 ## Reference
 
-**Static IPs** are externally provisioned, named `zebra-${network}`, `zebra-${network}-secondary`, and `zebra-${network}-tertiary`. The workflow assigns them via per-instance configs; it does not create them. Reserve new ones manually with `gcloud compute addresses create` before adding capacity in a new region.
+**Static IPs** are externally provisioned and map deterministically to zones:
 
-**Cache images** are produced by `zfnd-ci-integration-tests-gcp.yml`'s `create-state-image` job. Naming pattern: `{prefix}-{branch}-{sha}-v{state-version}-{network}-{tip|checkpoint}[-u]-{HHMMSS}`. Lookup priority in `gcp-get-cached-disks.sh`: current branch, then `main`, then any branch; most recent first. List recent:
+- `us-east1-b` → `zebra-${network}` (primary)
+- `us-east1-c` → `zebra-${network}-secondary`
+- `us-east1-d` → `zebra-${network}-tertiary`
+
+The workflow assigns them via per-instance configs for push and release deploys; workflow_dispatch deploys use ephemeral IPs. Reserve new ones manually with `gcloud compute addresses create` before adding capacity.
+
+**Cache images** are produced by `zfnd-ci-integration-tests-gcp.yml`'s `create-state-image` job. Naming pattern: `{prefix}-{branch}-{sha}-v{state-version}-{network}-{tip|checkpoint}[-u]-{HHMMSS}`. One image per network seeds all three zones. Lookup priority: current branch, then `main`, then any branch; most recent first. List recent:
 
 ```bash
 gcloud compute images list --project zfnd-dev-zebra \
@@ -178,4 +252,4 @@ gcloud compute images list --project zfnd-dev-zebra \
   --sort-by=~creationTimestamp --limit=5
 ```
 
-**Daily cleanup** (`zfnd-delete-gcp-resources.yml`) sweeps old instances, templates, disks, and cache images by age and name. It does not honor `keep_until` or `delete_protection` labels; use the [PR-deploy sweep](#sweep-expired) for label-aware control. The four stable cache disks (`zebrad-cache-{mainnet,testnet}` in production, `zebrad-cache-main-{mainnet,testnet}` in staging) are never eligible because GCP refuses to delete attached disks; if a stable disk ever shows up unattached, that is itself an incident.
+**Daily cleanup** (`zfnd-delete-gcp-resources.yml`) sweeps old instances, templates, disks, and cache images by age and name. It does not honor `keep_until` or `delete_protection` labels on PR deploys; use the [sweep recipe](#sweep-expired) for label-aware control. The twelve stable cache disks (`zebrad-cache-{mainnet,testnet}-{b,c,d}` in production, `zebrad-cache-main-{mainnet,testnet}-{b,c,d}` in staging) are never eligible because GCP refuses to delete attached disks; if any stable disk ever shows up unattached, that is itself an incident.

--- a/docs/decisions/devops/0006-gcp-deployment-naming.md
+++ b/docs/decisions/devops/0006-gcp-deployment-naming.md
@@ -111,4 +111,4 @@ Every MIG, instance, and disk carries `app`, `environment`, `network`, `zone`, `
 
 - [GCP Deployment Operations runbook](../../../book/src/dev/gcp-deployment-operations.md): PR-deploy cleanup, disk-corruption recovery, DB-format-version-break release procedure, regional-to-zonal migration procedure.
 - [Continuous Delivery overview](../../../book/src/dev/continuous-delivery.md): the high-level model.
-- GCP documentation on [zonal MIGs](https://cloud.google.com/compute/docs/instance-groups/zonal-migs), [stateful MIGs](https://cloud.google.com/compute/docs/instance-groups/stateful-migs), and [persistent disk attachment limits](https://cloud.google.com/compute/docs/disks#pd_modes).
+- GCP documentation on [instance groups](https://cloud.google.com/compute/docs/instance-groups), [stateful MIGs](https://cloud.google.com/compute/docs/instance-groups/stateful-migs), and [persistent disk attachment limits](https://cloud.google.com/compute/docs/disks#pd_modes).

--- a/docs/decisions/devops/0006-gcp-deployment-naming.md
+++ b/docs/decisions/devops/0006-gcp-deployment-naming.md
@@ -2,108 +2,113 @@
 status: accepted
 date: 2026-04-14
 builds-on: [Continuous Delivery](../../../book/src/dev/continuous-delivery.md)
-story: Stateful disk collisions during release rollouts and silent main-branch CD failures on Google Cloud Platform.
+story: Stateful disk collisions during release rollouts, silent main-branch CD failures, and the regional-stateful-MIG quirks that made rolling updates impossible on Google Cloud Platform.
 ---
 
-# GCP Deployment Naming: stable MIG per environment with branch-derived sub-naming
+# GCP Deployment Topology: zonal MIG per (environment, branch, network, zone)
 
 ## Context and Problem Statement
 
 Zebra runs as a stateful node: chain state on disk represents many hours or days of synchronization. The continuous-delivery pipeline must update the running container without re-syncing from genesis on every release. On Google Cloud Platform, this constraint is satisfied by attaching a persistent disk (PD) to a Managed Instance Group (MIG) under a stateful policy, so the disk survives instance recreation during rolling updates.
 
-A read-write PD can attach to only one instance at a time. Any deployment design that places two MIGs in front of the same disk creates a single-writer race that the platform cannot resolve. The previous design encoded the major version in the MIG name (`zebrad-v${MAJOR}-${network}`) while keeping a stable disk name (`zebrad-cache-${network}`); each major release created a new MIG that competed with its predecessor for the existing disk. The same workflow used a shell conditional to pick the disk name per trigger, which silently fell through and routed every event to the same disk.
+A read-write PD can attach to only one instance at a time. The first design used a single **regional** MIG per `(environment, network)` holding three instances, one per zone, each attached to a same-named zonal disk. Two architectural problems arose from that shape:
 
-The prior model coupled three independent concerns (MIG identity, container image version, disk identity) and relied on shell-conditional fragility to keep them separate. The combination produced predictable collisions on every major release and indistinct failure modes on routine pushes.
+1. **Two MIGs cannot share a disk.** Encoding the major Zebra version in the MIG name (`zebrad-v${MAJOR}-${network}`) meant each major release spun up a competing MIG. The platform cannot atomically transfer the stable disk from one MIG to another; the new MIG retried instance creation until one of the two won a zone.
+2. **Regional stateful MIGs cannot do per-zone rolling.** GCP requires `--max-surge=0` (no extra capacity with a single-writer disk) and `--max-unavailable` to be either 0 or at least the zone count. A three-zone regional MIG can only update all-at-once or not at all. Empirically, the workflow's `--max-unavailable=1` was silently invalid.
+
+Operating a multi-instance regional MIG also coupled deploy-landed to node-healthy (a single `wait-until --stable` covered both, so testnet's slow peer warmup timed out deploys that had actually landed), conflated network failures under matrix fail-fast, and leaked mainnet cache images into the testnet deploy path because the cache lookup ran once at the workflow level.
 
 ## Priorities & Constraints
 
 - Chain state must persist across releases, including major-version upgrades. A multi-day resync is unacceptable.
-- A failed deploy must surface a clear error within minutes, not after a 20-minute `wait-until --stable` timeout.
-- A developer must be able to deploy a PR branch to the dev environment without colliding with the staging deploy or with another developer's PR deploy.
-- Cleanup must be auditable and reversible: developers must be able to mark a PR deploy "do not delete" with an explicit expiry, and the standard cleanup must never destroy a production stateful disk.
-- Cache images produced by integration tests must remain the cold-start mechanism for fresh deploys.
-- The architecture must compose with the existing `release:published` trigger contract (downstream automation depends on it).
-- The naming model must reuse existing label vocabulary. Adding a parallel discriminator label is a cost on every reader.
+- A failed deploy must surface a clear, per-zone, per-network error within minutes.
+- A developer must be able to deploy a PR branch to a single zone in dev without colliding with other deploys.
+- Updates must be true rolling: one zone at a time, others keep serving.
+- Cleanup must be auditable and reversible: label-based protection, manual reap commands, no accidental destruction of live stateful disks.
+- Cache images produced by integration tests must remain the cold-start mechanism for fresh deploys; cache images are network-scoped (same image seeds all zones).
+- The architecture must compose with the existing `release:published` trigger contract.
+- The naming model must reuse existing label vocabulary.
 
 ## Considered Options
 
-- **Option 1: Versioned MIG names per major version (status quo).** Each major release creates a new MIG that fights its predecessor for the stable disk. Cross-major migration requires manual choreography.
-- **Option 2: Stable MIG per environment with branch-derived naming.** The MIG identity is a deterministic function of (environment, branch). The major version is metadata in the template, not in the MIG name. Cross-version transitions become `set-instance-template` plus `rolling-action` on the existing MIG.
-- **Option 3: Blue-green with snapshot-based handoff.** Snapshot the live disks, create the new MIG with new disks from snapshot, switch traffic, delete the old MIG.
+- **Option 1: Regional MIG per `(environment, network)`, versioned MIG names** (original). Each major release spawns a new MIG; disks shared across versions; rolling updates are all-at-once.
+- **Option 2: Regional MIG per `(environment, network)`, stable MIG name, branch-derived disk** (first refactor, PR #10482). Fixes the versioned-MIG collision but keeps regional-stateful constraints (all-at-once updates, no per-zone rolling, `wait-until --stable` covering both deploy and health).
+- **Option 3: Zonal MIG per `(environment, branch, network, zone)`, each MIG holds 1 instance with 1 stateful disk.** Three zonal MIGs per network per environment for push/release; one zonal MIG for workflow_dispatch. Rolling updates are per-zone with `--max-unavailable=1`. Deploy-landed and node-healthy are separate signals.
 
 ### Pros and Cons of the Options
 
-#### Option 1: Versioned MIG names
+#### Option 1: Regional versioned MIG (status quo, replaced by #10482)
 
-- Bad, because every major release recreates a single-writer disk collision the platform cannot resolve.
-- Bad, because no automatic mechanism retires the previous major-version MIG, so old MIGs accumulate indefinitely.
-- Bad, because a fall-through in trigger-to-disk routing also routed staging and PR deploys into the prod-disk path, multiplying the collision surface.
-- Good, because each major version had clearly separable infrastructure for audit purposes.
+- Bad, because every major release recreates a single-writer disk collision.
+- Bad, because no automatic mechanism retires the previous major-version MIG.
+- Bad, because a fall-through in trigger-to-disk routing leaked staging and PR deploys into the prod-disk path.
+- Good, because each major version had clearly separable infrastructure.
 
-#### Option 2: Stable MIG per environment, branch-derived naming
+#### Option 2: Regional stable MIG, branch-derived disk
 
-- Good, because the MIG name is a function of inputs that cannot collide: each (environment, branch) tuple has exactly one MIG. Two MIGs never share a disk.
-- Good, because rolling updates with `--max-unavailable=1` keep the other zones serving while one zone is replaced. Per-zone downtime is bounded by Zebra start plus RocksDB replay (minutes).
-- Good, because no new label vocabulary is needed: existing labels (`environment`, `created_by`, `github_ref`) already encode the kind of deploy, so cleanup and inspection use one-predicate filters.
-- Good, because failure modes simplify: a stuck rolling update blocks one MIG instead of creating a parallel MIG.
-- Bad, because a backwards-incompatible RocksDB format change cannot be done in place; that case requires the snapshot-based handoff (Option 3) as a one-shot operator procedure.
-- Neutral, because the MIG name no longer carries the major version (cosmetic only).
+- Good, because the MIG is stable per network, so cross-major-version upgrades are `set-instance-template` plus `rolling-action`.
+- Bad, because regional stateful MIGs cannot do per-zone rolling (all-at-once updates, significant downtime window).
+- Bad, because `--max-unavailable=1` is platform-rejected; only `0` or `zone_count` are valid. Either no update or all zones down.
+- Bad, because `wait-until --stable` couples deploy success to instance health, and testnet peer warmup regularly exceeds any reasonable timeout.
+- Bad, because matrix fail-fast default cancels one network when the other fails.
+- Good, because this was a large improvement over Option 1 for the versioning problem.
 
-#### Option 3: Blue-green with snapshot-based handoff
+#### Option 3: Zonal MIG per (environment, branch, network, zone)
 
-- Good, because a crash-loop on the new version is recoverable by switching back to the previous MIG.
-- Good, because it remains the right answer for the rare case of a backwards-incompatible RocksDB format change.
-- Bad, because storage cost doubles during cutover and snapshots are only crash-consistent.
-- Bad, because every release requires manual choreography, which makes the developer experience poor for the common case.
+- Good, because the MIG is the instance: 1:1:1:1 between MIG, instance, stateful disk, static IP. No "regional disks with the same name across zones" ambiguity.
+- Good, because `--max-unavailable=1` is natively valid (single-instance MIG). Updates are true per-zone rolling: one zonal MIG replaces its instance while the sister zonal MIGs keep serving.
+- Good, because per-zone failures are isolated: one zone's warmup slowness doesn't block the others, and the matrix's `fail-fast: false` gives six independent (network, zone) status cells on the GitHub UI.
+- Good, because deploy-landed (`--version-target-reached`) and node-healthy (`--stable` in a separate `verify-nodes` job) are already distinct signals with distinct failure labels.
+- Good, because `find-cached-disks` runs per-network (one lookup per network, image seeds all three zones).
+- Neutral, because the resource count grows from 2 MIGs to 6 per environment. Fewer resources per MIG (1 instance, 1 disk, 1 IP each) keeps each MIG's blast radius tiny.
+- Bad, because migrating from regional-stateful to zonal is a one-shot operator-driven migration per environment.
 
 ## Decision Outcome
 
-Chosen option: **Option 2 (stable MIG per environment with branch-derived naming)** as the default for every trigger. **Option 3 stays as a documented runbook procedure** for the rare DB-format-version break.
+Chosen option: **Option 3 (zonal MIG per `(environment, branch, network, zone)`)**. The migration from the previous regional-stateful architecture is documented as a one-shot procedure in the runbook.
 
-The naming derives from two existing concepts: the GCP environment (the project the deploy lands in) and the source branch or release tag.
+### Naming
 
-| Trigger              | Environment          | Branch / tag    | MIG                            | Disk                                |
-| -------------------- | -------------------- | --------------- | ------------------------------ | ----------------------------------- |
-| `release`            | `zfnd-prod-zebra`    | `${tag}`        | `zebrad-${network}`            | `zebrad-cache-${network}`           |
-| `push` to `main`     | `zfnd-dev-zebra`     | `main`          | `zebrad-main-${network}`       | `zebrad-cache-main-${network}`      |
-| `workflow_dispatch`  | `zfnd-dev-zebra`     | `${branch}`     | `zebrad-${branch}-${network}`  | `zebrad-cache-${branch}-${network}` |
+One MIG per matrix cell. Names encode every identity axis:
 
-Two GCP environments host the deploys (`dev` and `prod`). Within `dev`, the `main` branch holds the persistent staging deploy; every other branch produces an ephemeral PR deploy with branch-prefixed naming. The MIG name reads as a self-describing identity: a reader sees `zebrad-feat-foo-mainnet` and knows the deploy came from branch `feat-foo` on Mainnet, in the dev environment.
+| Trigger              | Environment          | MIG                                      | Disk                                          |
+| -------------------- | -------------------- | ---------------------------------------- | --------------------------------------------- |
+| `release`            | `zfnd-prod-zebra`    | `zebrad-${network}-${zone-letter}`       | `zebrad-cache-${network}-${zone-letter}`      |
+| `push` to `main`     | `zfnd-dev-zebra`     | `zebrad-main-${network}-${zone-letter}`  | `zebrad-cache-main-${network}-${zone-letter}` |
+| `workflow_dispatch`  | `zfnd-dev-zebra`     | `zebrad-${branch}-${network}-${zone-letter}` | `zebrad-cache-${branch}-${network}-${zone-letter}` |
 
-The stateful policy keeps `auto-delete=on-permanent-instance-deletion`. The trigger-to-naming mapping is computed by a `case` on `github.event_name`, removing the prior shell-conditional fall-through risk. The rolling action uses `--max-unavailable=1`.
+`zone-letter` is `b`, `c`, or `d` (the last segment of `us-east1-b`, etc.). Push and release fan out to six zonal MIGs (2 networks × 3 zones). A `workflow_dispatch` deploys a single zonal MIG with user-selected network and zone (default `us-east1-b`).
 
-A pre-flight squatter check runs before every MIG create or update. The check queries whether the target stateful disk is held by an instance from a different MIG and fails fast with the holding instance's name, replacing the prior 20-minute `wait-until --stable` timeout for this failure class.
+### Update mechanics
 
-Every deploy stamps four labels on its instance template, which propagate to instances and disks: `environment` (`dev` or `prod`), `created_by` (`release`, `push`, or `workflow_dispatch`), `github_ref` (branch or tag), and `github_sha`. These cover both the GCP environment and the kind of deploy without introducing a new vocabulary. Filtering examples:
+- Every trigger runs per-cell: `rolling-action start-update` on an existing zonal MIG with `--max-unavailable=1 --max-surge=0 --replacement-method=recreate`. True per-zone rolling.
+- Fresh MIG creation pre-creates the zonal disk from the network-scoped cache image, then the template attaches it via `--disk=name=…` (not `--create-disk`). This decouples "disk populated from image" from "MIG attaches disk" and handles both fresh deploys and manual pre-seeding identically.
+- The MIG's health check (`/healthy`, `--initial-delay=3600`) governs autohealing tolerance.
+- Deploy-landed waits `--version-target-reached --timeout=600` (template rollout done). Verify-nodes waits `--stable --timeout=5400` (peer mesh + warmup complete). Distinct failure labels: `S-ci-fail-release-auto-issue` for infrastructure, `S-ci-fail-verify-auto-issue` for slow warmup.
 
-- All production resources: `--filter="labels.created_by=release"`
-- All staging resources: `--filter="labels.created_by=push"`
-- All PR deploys (cleanup candidates): `--filter="labels.created_by=workflow_dispatch"`
+### Static IPs
 
-PR-deploy cleanup is **manual**. Operators apply labels to override the default (delete after some retention):
+Deterministic zone-to-IP mapping for push and release:
 
-- `keep_until=YYYY-MM-DD` to mark a PR deploy as "do not delete before this date".
-- `delete_protection=true` for indefinite preservation, requiring manual reset.
+- `us-east1-b` → `zebra-${network}` (primary)
+- `us-east1-c` → `zebra-${network}-secondary`
+- `us-east1-d` → `zebra-${network}-tertiary`
 
-The runbook documents the `gcloud` filters that respect these labels. The policy is ritualized rather than mechanical, in line with existing team practice.
+Workflow_dispatch deploys use ephemeral IPs (PR smoke tests don't need stable external addresses).
 
-### Expected Consequences
+### Labels
 
-Positive:
+Every MIG, instance, and disk carries `app`, `environment`, `network`, `zone`, `created_by`, `github_ref`, `github_sha`. The `created_by` label (`release`, `push`, or `workflow_dispatch`) discriminates the three deploy kinds for cleanup and inspection. PR-deploy cleanup uses `keep_until=YYYY-MM-DD` and `delete_protection=true` opt-out labels.
 
-- Cross-major-version upgrades become a non-event: `set-instance-template` plus `rolling-action` on the existing MIG. Two MIGs never exist for the same network in the same environment.
-- The class of silent fall-through failures disappears: trigger-to-naming routing is explicit in the workflow, and the pre-flight check fails fast with actionable text.
-- The developer experience improves: a `workflow_dispatch` from a PR branch creates `zebrad-${branch}-${network}` without colliding with `main` or with another developer's branch. Filters such as `--filter="labels.created_by=workflow_dispatch AND labels.github_ref=my-branch"` make resources discoverable and reapable.
-- No new label vocabulary is added; the existing `environment` and `created_by` labels carry the discriminator without requiring a new word in the team's working memory.
+### Accepted trade-offs
 
-Accepted trade-offs:
-
-- Breaking change for existing infrastructure: prior versioned MIGs (`zebrad-v${MAJOR}-${network}`) are removed. A one-shot operator-driven migration handles the transition with snapshot-based recovery.
-- Backwards-incompatible RocksDB format changes still require manual snapshot-based handoff. The runbook covers the procedure.
-- The `cos-stable` plus `gce-container-declaration` deploy pattern that Zebra uses is deprecated by Google. A future ADR will plan the migration to a non-deprecated container-on-VM pattern; this ADR does not address it.
+- Breaking migration from regional to zonal: snapshot-based one-shot procedure in the runbook.
+- More MIGs per environment (6 vs 2), each simpler.
+- Backwards-incompatible RocksDB format changes still need a snapshot-based handoff at release time; runbook covers it.
+- The `cos-stable` + `gce-container-declaration` deploy pattern is deprecated by Google; a future ADR will address it.
 
 ## More Information
 
-- [GCP Deployment Operations runbook](../../../book/src/dev/gcp-deployment-operations.md): PR-deploy cleanup, disk-corruption recovery, DB-format-version-break release procedure.
+- [GCP Deployment Operations runbook](../../../book/src/dev/gcp-deployment-operations.md): PR-deploy cleanup, disk-corruption recovery, DB-format-version-break release procedure, regional-to-zonal migration procedure.
 - [Continuous Delivery overview](../../../book/src/dev/continuous-delivery.md): the high-level model.
-- GCP documentation on [stateful MIGs](https://cloud.google.com/compute/docs/instance-groups/stateful-migs) and [persistent disk attachment limits](https://cloud.google.com/compute/docs/disks#pd_modes).
+- GCP documentation on [zonal MIGs](https://cloud.google.com/compute/docs/instance-groups/zonal-migs), [stateful MIGs](https://cloud.google.com/compute/docs/instance-groups/stateful-migs), and [persistent disk attachment limits](https://cloud.google.com/compute/docs/disks#pd_modes).


### PR DESCRIPTION
## Motivation

The prior regional stateful MIG (one MIG per network, three instances across three zones) hits a GCP constraint: regional stateful MIGs require `max-surge=0` and `max-unavailable >= zone_count`, so rolling updates are all-at-once. The workflow's earlier `--max-unavailable=1` would have been rejected by GCP on the first rolling update. Deploy-vs-health signalling, matrix failure isolation, and per-network cache-image lookup all hang off the same topology mismatch.

## Solution

One zonal MIG per `(environment, branch, network, zone)`. Each MIG holds 1 instance, 1 stateful disk, 1 static IP.

- Push and release: matrix fans out to 6 cells (2 networks × 3 zones). Each cell deploys independently with `fail-fast: false`.
- `workflow_dispatch`: single zonal MIG (user picks network and zone) for cheap PR smoke-tests.
- `--max-unavailable=1` is natively valid on a single-instance MIG, so updates are true per-zone rolling: the zone being replaced goes down briefly while the other two keep serving.
- `deploy-nodes` reports infrastructure landed (template, MIG, IP); `verify-nodes` reports application healthy (peer mesh, chain tip) async with a 90-minute timeout. Distinct failure labels (`S-ci-fail-release-auto-issue` and `S-ci-fail-verify-auto-issue`).
- `get-disk-name` split per-network, fixing the cross-network cache-image leak.
- `ensure-health-checks` is a one-shot job (runs once per push, not once per matrix cell).
- Template uses `--disk=name=X` (attach existing). An explicit "Ensure zonal disk exists" step creates from the cache image when missing; otherwise attaches pre-seeded disks (for migrations and manual seeds).

Full rationale: [ADR 0006](docs/decisions/devops/0006-gcp-deployment-naming.md). Operations (PR-deploy cleanup, disk recovery, DB-format-version-break release, regional-to-zonal migration): [runbook](book/src/dev/gcp-deployment-operations.md).

### Tests

Empirical validation against live GCP, all reproducible:

- Primitive timing on a rolling-replace: `wait-until --version-target-reached` returned in 57s, `--stable` in 265s. Confirms deploy-landed and node-healthy separate cleanly.
- `instance-configs create --stateful-external-ip` accepts STAGING and RUNNING-UNKNOWN instances, so the prior 20-min wait before IP assignment was unnecessary.
- `--max-unavailable=1` rejected by GCP for regional stateful MIGs; accepted natively for zonal.
- Workflow_dispatch from this branch (run #24423871755) succeeded end-to-end on a dev cell, producing the expected zonal MIG, disk attachment, and labels.

Manual regional-to-zonal migration is complete: 12 zonal disks seeded from snapshots, 4 regional MIGs removed, workflow disabled during the cutover and re-enabled for the validation dispatch.

### AI Disclosure

Claude drafted the workflow refactor, ADR, runbook, and continuous-delivery updates.