### PR TITLE
fix(ci): enable workflow_dispatch deploys to prod

### DIFF
--- a/.github/workflows/zfnd-deploy-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-nodes-gcp.yml
@@ -17,17 +17,13 @@
 # release).
 name: Deploy Nodes to GCP
 
-# Ensures that only one workflow task will run at a time. Previous deployments, if
-# already in process, won't get cancelled. Instead, we let the first to complete
-# then queue the latest pending workflow, cancelling any workflows in between.
-#
-# Since the different event types each use a different Managed Instance Group or instance,
-# we can run different event types concurrently.
-#
-# For pull requests, we only run the tests from this workflow, and don't do any deployments.
-# So an in-progress pull request gets cancelled, just like other tests.
+# Concurrency is scoped per cell for workflow_dispatch: each (environment, network,
+# zone) is an independent zonal MIG, so dispatching different cells must not
+# serialize. For push/release the inputs are empty and the key collapses to one
+# group per (event, ref); the in-workflow matrix fans out the six cells inside
+# that run. Pull requests cancel in progress (only Docker tests run, no deploy).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ inputs.environment }}-${{ inputs.network }}-${{ inputs.zone }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:

--- a/.github/workflows/zfnd-deploy-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-nodes-gcp.yml
@@ -17,11 +17,15 @@
 # release).
 name: Deploy Nodes to GCP
 
-# Concurrency is scoped per cell for workflow_dispatch: each (environment, network,
-# zone) is an independent zonal MIG, so dispatching different cells must not
-# serialize. For push/release the inputs are empty and the key collapses to one
-# group per (event, ref); the in-workflow matrix fans out the six cells inside
-# that run. Pull requests cancel in progress (only Docker tests run, no deploy).
+# Ensures that only one workflow task will run at a time. Previous deployments, if
+# already in process, won't get cancelled. Instead, we let the first to complete
+# then queue the latest pending workflow, cancelling any workflows in between.
+#
+# Since the different event types each use a different Managed Instance Group or instance,
+# we can run different event types concurrently.
+#
+# For pull requests, we only run the tests from this workflow, and don't do any deployments.
+# So an in-progress pull request gets cancelled, just like other tests.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-${{ inputs.environment }}-${{ inputs.network }}-${{ inputs.zone }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -331,10 +335,6 @@ jobs:
         with:
           install_components: 'beta'
 
-      # Derive the name prefix from (environment, branch), not the event, so
-      # any path that targets prod (release or workflow_dispatch) uses the
-      # stable zonal names from ADR 0006. Dev uses a branch-derived prefix
-      # (`main-` for push to main, `${ref}-` for feature-branch dispatches).
       - name: Compute MIG and disk naming
         env:
           ENV: ${{ needs.set-matrix.outputs.environment }}
@@ -444,11 +444,11 @@ jobs:
             --stateful-disk="device-name=${DISK_NAME},auto-delete=on-permanent-instance-deletion" \
             --zone="${ZONE}"
 
-      # Assign one static IP per zone on stable deploys (prod or dev-main):
+      # Assign one static IP per zone, deterministically:
       #   zone b -> primary (`zebra-${network}`)
       #   zone c -> secondary (`zebra-${network}-secondary`)
       #   zone d -> tertiary (`zebra-${network}-tertiary`)
-      # Feature-branch dispatches to dev use ephemeral IPs (PR smoke tests).
+      # Skipped for feature-branch dispatches to dev (PR smoke tests use ephemeral IPs).
       # Empirically `instance-configs create --stateful-external-ip` accepts
       # STAGING / RUNNING-UNKNOWN instances; a short bounded poll handles the
       # async gap between MIG-create returning and list-instances reporting.

--- a/.github/workflows/zfnd-deploy-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-nodes-gcp.yml
@@ -331,18 +331,24 @@ jobs:
         with:
           install_components: 'beta'
 
+      # Derive the name prefix from (environment, branch), not the event, so
+      # any path that targets prod (release or workflow_dispatch) uses the
+      # stable zonal names from ADR 0006. Dev uses a branch-derived prefix
+      # (`main-` for push to main, `${ref}-` for feature-branch dispatches).
       - name: Compute MIG and disk naming
         env:
-          EVENT_NAME: ${{ github.event_name }}
+          ENV: ${{ needs.set-matrix.outputs.environment }}
+          REF_NAME: ${{ github.ref_name }}
           REF_SLUG: ${{ env.GITHUB_REF_SLUG_URL }}
           SHA_SHORT: ${{ env.GITHUB_SHA_SHORT }}
         run: |
-          case "${EVENT_NAME}" in
-            release)           PREFIX="" ;;
-            push)              PREFIX="main-" ;;
-            workflow_dispatch) PREFIX="${REF_SLUG}-" ;;
-            *) echo "::error::Unsupported event: ${EVENT_NAME}"; exit 1 ;;
-          esac
+          if [ "${ENV}" = "prod" ]; then
+            PREFIX=""
+          elif [ "${REF_NAME}" = "main" ]; then
+            PREFIX="main-"
+          else
+            PREFIX="${REF_SLUG}-"
+          fi
           {
             echo "MIG_NAME=zebrad-${PREFIX}${NETWORK}-${ZONE_LETTER}"
             echo "DISK_NAME=zebrad-cache-${PREFIX}${NETWORK}-${ZONE_LETTER}"
@@ -438,18 +444,16 @@ jobs:
             --stateful-disk="device-name=${DISK_NAME},auto-delete=on-permanent-instance-deletion" \
             --zone="${ZONE}"
 
-      # Assign one static IP per zone, deterministically:
+      # Assign one static IP per zone on stable deploys (prod or dev-main):
       #   zone b -> primary (`zebra-${network}`)
       #   zone c -> secondary (`zebra-${network}-secondary`)
       #   zone d -> tertiary (`zebra-${network}-tertiary`)
-      # Skipped for workflow_dispatch (PR deploys use ephemeral external IPs).
+      # Feature-branch dispatches to dev use ephemeral IPs (PR smoke tests).
       # Empirically `instance-configs create --stateful-external-ip` accepts
       # STAGING / RUNNING-UNKNOWN instances; a short bounded poll handles the
       # async gap between MIG-create returning and list-instances reporting.
-      # Zone b -> primary, c -> secondary, d -> tertiary.
-      # Skipped for workflow_dispatch (PR deploys use ephemeral IPs).
-      - name: Assign static IP (fresh MIG, non-dispatch)
-        if: ${{ steps.does-group-exist.outcome == 'failure' && github.event_name != 'workflow_dispatch' }}
+      - name: Assign static IP (fresh MIG, stable deploy)
+        if: ${{ steps.does-group-exist.outcome == 'failure' && (needs.set-matrix.outputs.environment == 'prod' || github.ref_name == 'main') }}
         run: |
           case "${ZONE_LETTER}" in
             b) SUFFIX="" ;;


### PR DESCRIPTION
## Motivation

Three bugs scoped on `github.event_name` blocked `workflow_dispatch` to prod (run 24428054473 hit `resource.sourceImage ... cannot be found` on a disk name that didn't match the prod scheme):

1. Concurrency key `workflow-event-ref` serialized independent `(env, network, zone)` cells.
2. Name prefix `${ref}-` produced `zebrad-cache-main-mainnet-b` instead of the ADR-0006 `zebrad-cache-mainnet-b`; the fallback `disks create` then reached for a dev-project cache image that prod cannot read.
3. Static IP was skipped for every dispatch, so prod dispatches got ephemeral IPs.

## Solution

Scope by `(environment, branch)`:

- Concurrency key adds `inputs.*`; push/release pass empty inputs, keeping one group per ref.
- Prefix: `prod` → empty; `dev` + `main` → `main-`; `dev` + other → `${ref}-`.
- Static IP assigned when `env=prod` or `branch=main`.

### AI Disclosure

Claude drafted the fixes and PR body.