### PR TITLE
fix(ci): harden pre-flight parse and idempotent health-check

### DIFF
--- a/.github/workflows/zfnd-deploy-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-nodes-gcp.yml
@@ -193,13 +193,9 @@ jobs:
       - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db #v3.0.1
       - run: |
           for NET in $(echo '${{ needs.set-matrix.outputs.networks }}' | jq -r '.[] | ascii_downcase'); do
-            gcloud compute health-checks create http "zebra-${NET}-health" \
+            gcloud compute health-checks describe "zebra-${NET}-health" --global &>/dev/null \
+            || gcloud compute health-checks create http "zebra-${NET}-health" \
               --port=8080 --request-path=/healthy \
-              --check-interval=60s --timeout=10s \
-              --unhealthy-threshold=3 --healthy-threshold=2 \
-              --global 2>/dev/null \
-            || gcloud compute health-checks update http "zebra-${NET}-health" \
-              --request-path=/healthy \
               --check-interval=60s --timeout=10s \
               --unhealthy-threshold=3 --healthy-threshold=2 \
               --global
@@ -363,7 +359,7 @@ jobs:
           for user in ${users}; do
             owner=$(gcloud compute instances describe "${user}" --zone="${ZONE}" \
               --format="value(metadata.items.filter(key:created-by).extract(value))" 2>/dev/null \
-              | grep -oE 'instanceGroupManagers/[^/]+' | cut -d/ -f2 || true)
+              | grep -oE 'instanceGroupManagers/[a-z0-9-]+' | cut -d/ -f2 || true)
             if [ -n "${owner}" ] && [ "${owner}" != "${MIG_NAME}" ]; then
               echo "::error::${DISK_NAME} in ${ZONE} is held by ${user} (MIG ${owner}). See gcp-deployment-operations.md."
               exit 1


### PR DESCRIPTION
## Motivation

The post-merge `main` run and four of six parallel prod dispatches failed on two races the prior workflow never exercised:

1. **Pre-flight owner parse** (`Pre-flight check for stateful disk squatter`): `grep -oE 'instanceGroupManagers/[^/]+'` accepts every non-slash character, so when gcloud renders the extracted `created-by` value with list-bracket framing, the `']` trails into the owner string. `owner != MIG_NAME` always fails when the disk is attached (every push after the first). Observed: `is held by ... (MIG zebrad-main-mainnet-c'])`.
2. **Health-check upsert race**: `create || update` on a global resource fails `update` when another run just created and the resource is still in `not ready`. Observed: `The resource ... is not ready` across four prod dispatches.

## Solution

- Tighten the pre-flight regex to `[a-z0-9-]+` (valid MIG name chars only).
- Replace the health-check create-or-update with describe-or-create: idempotent and race-free. Skips entirely when the check already exists.