### PR TITLE
fix(ci): declare build job's dependency on set-matrix

### DIFF
--- a/.github/workflows/zfnd-deploy-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-nodes-gcp.yml
@@ -239,6 +239,7 @@ jobs:
   # The image will be commonly named `zebrad:<short-hash | github-ref | semver>`
   build:
     name: Build CD Docker
+    needs: [set-matrix]
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Motivation

The `build:` job references `needs.set-matrix.outputs.environment` (line 260) without declaring `needs: [set-matrix]`. GitHub Actions silently resolves the reference to an empty string, so the reusable build workflow receives `inputs.environment=''` and falls back to `dev`. The image is pushed to the **dev** Artifact Registry even when the deploy target is **prod**.

## Solution

Add `needs: [set-matrix]` to the build job so the `needs.set-matrix.outputs.environment` reference actually resolves.

### AI Disclosure

Claude drafted the fix and PR body.