### PR TITLE
feat: introduce deterministic builds using stagex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@ zebra-rpc/qa/cache/
 # Lychee link checker cache
 .lycheecache
 /.agent-shell/
+
+# Build artifacts from deterministic build
+build/

--- a/docker/Dockerfile.deterministic
+++ b/docker/Dockerfile.deterministic
@@ -1,0 +1,264 @@
+# syntax=docker/dockerfile:1
+# check=skip=UndefinedVar,UserExist # We use setpriv in the entrypoint instead of USER directive
+
+# If you want to include a file in the Docker image, add it to .dockerignore.
+#
+# We use 4 (TODO: 5) stages:
+# - deps: installs build dependencies and sets default values
+# - tests: prepares a test image
+# - release: builds release binaries
+# - runtime: prepares the release image
+# - TODO: Add a `monitoring` stage
+#
+# We first set default values for build arguments used across the stages.
+# Each stage must define the build arguments (ARGs) it uses.
+
+# Note: In the deterministic build, the actual Rust version comes from the pallet-rust image below.
+ARG RUST_VERSION=1.94.0
+
+ARG FEATURES="default-release-binaries"
+
+ARG UID=10001
+ARG GID=${UID}
+ARG USER="zebra"
+ARG HOME="/home/${USER}"
+ARG CARGO_HOME="${HOME}/.cargo"
+ARG CARGO_TARGET_DIR="${HOME}/target"
+ARG TARGET_ARCH="x86_64-unknown-linux-musl"
+
+# StageX base images: fully source-bootstrapped and bit-for-bit reproducible.
+# Pinned by SHA-256 digest to prevent tag-reassignment attacks.
+FROM stagex/core-busybox:1.37.0@sha256:d608daa946e4799cf28b105aba461db00187657bd55ea7c2935ff11dac237e27 AS busybox
+FROM stagex/pallet-rust:1.94.0@sha256:2fbe7b164dd92edb9c1096152f6d27592d8a69b1b8eb2fc907b5fadea7d11668 AS pallet-rust
+FROM stagex/pallet-clang@sha256:07c01477a41eba3ec57a0e84c73659dec17662247a8f92b8b902f0aa02b58ca3 AS pallet-clang
+FROM stagex/user-protobuf:26.1@sha256:a135aaf060990b6ef8a7c715c16f175811d3a1f5383970f5771adef05a0bc56a AS protobuf
+FROM stagex/user-abseil-cpp:20240116.2@sha256:20a241145158a0aa7cb83ed5dc4f9ad6360dc975352787f4e6b00e8a39943f62 AS abseil-cpp
+FROM stagex/core-gmp:6.3.0@sha256:35f1f6f285efd438e7d985dc0538b7a5ca1a228e69f50d39de2bcafe830b4beb AS gmp
+FROM stagex/core-mpfr:4.1.0@sha256:b390b6023fce662a834d207e683864d4c37001b0af9e56a62aab6b7ee9fda097 AS mpfr
+FROM stagex/core-mpc:1.2.1@sha256:5385d8ddf991a1911da0d2ee69b0eaeb95baa111101ebf50933559956ac5ca71 AS mpc
+FROM stagex/core-isl:0.24@sha256:6c78dd13483288b4ddd967866cf4ccf5cc20f9130368c0d10e3e498ddb6d3573 AS isl
+
+# This stage prepares Zebra's build deps and captures build args as env vars.
+FROM pallet-rust AS deps
+SHELL ["/bin/sh", "-xo", "pipefail", "-c"]
+
+# Install zebra build deps
+COPY --from=pallet-clang . /
+COPY --from=protobuf . /
+COPY --from=abseil-cpp . /
+# GCC runtime dependencies needed for C++ compilation
+COPY --from=gmp . /
+COPY --from=mpfr . /
+COPY --from=mpc . /
+COPY --from=isl . /
+
+# Crate build scripts (librocksdb-sys, libzcash-script) emit -lstdc++, but
+# pallet-clang provides libc++ (LLVM) instead. Create a linker script so lld
+# resolves -lstdc++ to libc++ + libc++abi.
+RUN printf 'INPUT(-lc++ -lc++abi)\n' > /usr/lib/libstdc++.a
+
+# Build arguments and variables
+ARG CARGO_INCREMENTAL
+ENV CARGO_INCREMENTAL=${CARGO_INCREMENTAL:-0}
+
+ARG CARGO_HOME
+ENV CARGO_HOME=${CARGO_HOME}
+
+ARG CARGO_TARGET_DIR
+ENV CARGO_TARGET_DIR=${CARGO_TARGET_DIR}
+
+# This stage builds tests without running them.
+#
+# We also download needed dependencies for tests to work, from other images.
+# An entrypoint.sh is only available in this step for easier test handling with variables.
+FROM deps AS tests
+
+ARG SHORT_SHA
+ARG FEATURES
+ENV FEATURES=${FEATURES}
+
+# Skip IPv6 tests by default, as some CI environment don't have IPv6 available
+ARG SKIP_IPV6_TESTS
+ENV SKIP_IPV6_TESTS=${SKIP_IPV6_TESTS:-1}
+
+# This environment setup is almost identical to the `runtime` target so that the
+# `tests` target differs minimally. In fact, a subset of this setup is used for
+# the `runtime` target.
+ARG UID
+ENV UID=${UID}
+ARG GID
+ENV GID=${GID}
+ARG USER
+ENV USER=${USER}
+ARG HOME
+ENV HOME=${HOME}
+
+# StageX images use static passwd/group files instead of adduser/addgroup
+COPY --chmod=644 <<-EOF /etc/passwd
+	root:x:0:0:root:/root:/bin/sh
+	user:x:${UID}:${GID}::${HOME}:/bin/sh
+EOF
+COPY --chmod=644 <<-EOF /etc/group
+	root:x:0:
+	user:x:${GID}:
+EOF
+
+USER ${UID}:${GID}
+
+# Set the working directory for the build.
+WORKDIR ${HOME}
+
+ARG CARGO_HOME
+ARG CARGO_TARGET_DIR
+
+# Build Zebra test binaries, but don't run them.
+#
+# Leverage a cache mount to /usr/local/cargo/registry/
+# for downloaded dependencies, a cache mount to /usr/local/cargo/git/db
+# for git repository dependencies, and a cache mount to ${HOME}/target/ for
+# compiled dependencies which will speed up subsequent builds.
+# Leverage a bind mount to each crate directory to avoid having to copy the
+# source code into the container. Once built, copy the executable to an
+# output directory before the cache mounted ${HOME}/target/ is unmounted.
+RUN --mount=type=bind,source=zebrad,target=zebrad \
+    --mount=type=bind,source=zebra-chain,target=zebra-chain \
+    --mount=type=bind,source=zebra-network,target=zebra-network \
+    --mount=type=bind,source=zebra-state,target=zebra-state \
+    --mount=type=bind,source=zebra-script,target=zebra-script \
+    --mount=type=bind,source=zebra-consensus,target=zebra-consensus \
+    --mount=type=bind,source=zebra-rpc,target=zebra-rpc \
+    --mount=type=bind,source=zebra-node-services,target=zebra-node-services \
+    --mount=type=bind,source=zebra-test,target=zebra-test \
+    --mount=type=bind,source=zebra-utils,target=zebra-utils \
+    --mount=type=bind,source=tower-batch-control,target=tower-batch-control \
+    --mount=type=bind,source=tower-fallback,target=tower-fallback \
+    --mount=type=bind,source=Cargo.toml,target=Cargo.toml \
+    --mount=type=bind,source=Cargo.lock,target=Cargo.lock \
+    --mount=type=cache,target=${HOME}/target/ \
+    cargo test --locked --release --workspace --no-run \
+    --features "${FEATURES} zebra-checkpoints" && \
+    cp ${HOME}/target/release/zebrad /usr/local/bin && \
+    cp ${HOME}/target/release/zebra-checkpoints /usr/local/bin
+
+# Copy the lightwalletd binary and source files to be able to run tests
+COPY --link --from=electriccoinco/lightwalletd:v0.4.17 /usr/local/bin/lightwalletd /usr/local/bin/
+
+COPY --link --chown=${UID}:${GID} ./ ${HOME}
+COPY --link --chown=${UID}:${GID} ./docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT [ "entrypoint.sh", "test" ]
+CMD [ "cargo", "test" ]
+
+# This stage builds the zebrad release binary.
+#
+# It also adds `cache mounts` as this stage is completely independent from the
+# `test` stage. The resulting zebrad binary is used in the `runtime` stage.
+FROM deps AS release
+
+ARG SHORT_SHA
+ARG FEATURES
+ENV FEATURES=${FEATURES}
+
+# Set the working directory for the build.
+ARG HOME
+WORKDIR ${HOME}
+
+ARG CARGO_HOME
+ARG CARGO_TARGET_DIR
+ARG TARGET_ARCH
+
+# Deterministic build flags
+ENV RUST_BACKTRACE=1
+ENV RUSTFLAGS="-C codegen-units=1"
+# Statically link musl libc
+ENV RUSTFLAGS="${RUSTFLAGS} -C target-feature=+crt-static"
+# Use Clang as the linker driver with lld as the backend
+ENV RUSTFLAGS="${RUSTFLAGS} -C linker=clang"
+ENV RUSTFLAGS="${RUSTFLAGS} -C link-arg=-fuse-ld=lld"
+# pallet-clang provides libc++ (LLVM), not libstdc++ (GCC). Crate build scripts
+# for librocksdb-sys and libzcash-script emit -lstdc++, which is satisfied by
+# the /usr/lib/libstdc++.a linker script created in the deps stage. Force-include
+# libc++, libc++abi, and RocksDB's runtime deps (zstd, zlib) as whole archives
+# so all symbols are available. --allow-multiple-definition handles any overlap.
+ENV RUSTFLAGS="${RUSTFLAGS} -C link-arg=-Wl,--allow-multiple-definition"
+ENV RUSTFLAGS="${RUSTFLAGS} -C link-arg=-Wl,--whole-archive"
+ENV RUSTFLAGS="${RUSTFLAGS} -C link-arg=/usr/lib/libc++.a"
+ENV RUSTFLAGS="${RUSTFLAGS} -C link-arg=/usr/lib/libc++abi.a"
+ENV RUSTFLAGS="${RUSTFLAGS} -C link-arg=/usr/lib/libzstd.a"
+ENV RUSTFLAGS="${RUSTFLAGS} -C link-arg=/usr/lib/libz.a"
+ENV RUSTFLAGS="${RUSTFLAGS} -C link-arg=-Wl,--no-whole-archive"
+ENV RUSTFLAGS="${RUSTFLAGS} -C link-arg=-ldl"
+ENV RUSTFLAGS="${RUSTFLAGS} -C link-arg=-lm"
+# Omit build-id for bit-for-bit reproducibility
+ENV RUSTFLAGS="${RUSTFLAGS} -C link-arg=-Wl,--build-id=none"
+ENV SOURCE_DATE_EPOCH=1
+ENV CXXFLAGS="-stdlib=libc++ -include cstdint"
+ENV ROCKSDB_USE_PKG_CONFIG=0
+
+# Copy only the workspace manifests and crates needed to build zebrad
+COPY Cargo.toml Cargo.lock ./
+COPY tower-batch-control ./tower-batch-control
+COPY tower-fallback ./tower-fallback
+COPY zebra-chain ./zebra-chain
+COPY zebra-consensus ./zebra-consensus
+COPY zebra-network ./zebra-network
+COPY zebra-node-services ./zebra-node-services
+COPY zebra-rpc ./zebra-rpc
+COPY zebra-script ./zebra-script
+COPY zebra-state ./zebra-state
+COPY zebra-test ./zebra-test
+COPY zebra-utils ./zebra-utils
+COPY zebrad ./zebrad
+
+RUN cargo fetch --locked --target ${TARGET_ARCH} && \
+    cargo metadata --locked --format-version=1 > /dev/null 2>&1
+
+RUN --network=none \
+    cargo build --frozen --release \
+    --features "${FEATURES}" \
+    --target ${TARGET_ARCH} \
+    --package zebrad --bin zebrad && \
+    install -D -m 0755 ${HOME}/target/${TARGET_ARCH}/release/zebrad /usr/local/bin/zebrad
+
+# This stage is used for exporting the binary
+FROM scratch AS export
+COPY --from=release /usr/local/bin/zebrad /zebrad
+
+# This stage starts from scratch using StageX and copies the built zebrad binary
+# from the `release` stage along with other binaries and files.
+FROM scratch AS runtime
+
+# Minimal userspace
+COPY --from=deps /usr/bin/busybox . /
+RUN ["busybox", "--install", "-s", "usr/bin"]
+
+ARG FEATURES="default-release-binaries"
+ENV FEATURES=${FEATURES}
+
+# Safe deterministic runtime identity
+ENV UID=10001
+ENV GID=10001
+ENV USER=zebra
+ENV HOME=/home/zebra
+
+# Static passwd/group files for scratch-style image
+COPY --chmod=0644 <<-'EOF' /etc/passwd
+root:x:0:0:root:/root:/bin/sh
+zebra:x:10001:10001::/home/zebra:/bin/sh
+EOF
+
+COPY --chmod=0644 <<-'EOF' /etc/group
+root:x:0:
+zebra:x:10001:
+EOF
+
+WORKDIR /home/zebra
+
+# Copy runtime artifacts with fixed permissions, no chown needed
+COPY --from=release /usr/local/bin/zebrad /usr/local/bin/zebrad
+COPY --chmod=0755 docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+USER 10001:10001
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["/usr/local/bin/zebrad"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,99 @@
+# Zebra Docker Builds
+
+This directory contains two Dockerfiles that produce Zebra container images using
+different build strategies.
+
+## Standard Build (`Dockerfile`)
+
+The standard build uses the official Rust Docker image (`rust:<version>-trixie`)
+and Debian (`debian:trixie-slim`) as its base layers. It installs build
+dependencies from the Debian package archive via `apt-get` and produces a
+container image suitable for general development and testing.
+
+## Deterministic and Full-source Bootstrapped Build (`Dockerfile.deterministic`)
+
+While the convential approach remains standard, deterministic and bootstrapped builds
+address several topics of concern for mission critical applications.
+
+A conventional Docker build pulls opaque binary blobs from upstream registries, and
+a user must trust that the images were built honestly. However, there is no practical
+way to verify that the binaries inside them correspond to the published source code.
+For example, an attacker who compromises an upstream image, a mirror, or the build
+infrastructure could inject malicious code that is invisible to anyone who does not
+reproduce the build from scratch. For operationally essential deployments, higher
+levels of confidence in the integrity of the entire build may be desirable.
+
+The deterministic and bootstrapped build replaces build dependencies with
+packages from [StageX](https://stagex.tools), a collection of OCI images that
+are **full-source bootstrapped** and **bit-for-bit reproducible**, which makes
+them more suitable for use-cases where system integrity is non-negotiable.
+
+StageX confronts risks that exist in standard builds via several strategies:
+
+1. **Full-source bootstrap.** Every package in the StageX dependency tree is
+   compiled from source, starting from a minimal, auditable seed binary. There
+   are no opaque binary blobs in the chain. This closes the
+   [trusting trust](https://www.cs.cmu.edu/~rdriley/487/papers/Thompson_1984_RessureflectionsonTrustingTrust.pdf)
+   gap for the entire toolchain: compiler, linker, C library, and all dependencies.
+
+2. **Bit-for-bit reproducibility.** Given the same inputs, the build produces
+   the same outputs bit-for-bit. This means anyone can independently rebuild
+   the image and verify that the result matches a published hash, without trusting
+   the original builder.
+
+3. **Release artifact signing.** Before publication, every release artifact must be
+   independently reproduced by at least two maintainers on diverse hardware (at minimum
+   Intel and AMD chipsets) and co-signed with their PGP keys.
+
+4. **Source tree signing.** Every change to the StageX source tree must be reviewed
+   and cryptographically signed by at least two maintainers before it can be merged.
+   A single compromised or malicious maintainer cannot unilaterally modify the distribution.
+
+5. **Minimalism.** The runtime image is built `FROM scratch` with only BusyBox and the
+   `zebrad` binary. StageX uses musl libc instead of glibc and LLVM/Clang instead of
+   GCC, reducing the trusted computing base and attack surface compared to conventional
+   distributions.
+
+Additionally, StageX signing keys for both release and source tree signing follow strict
+key management requirements: private key material must never be exposed to an
+internet-connected environment; keys must be stored on a hardware security device (e.g.
+YubiKey 5 series, NitroKey 3, or a Split GPG Qubes setup); PIN protection with a non-default
+PIN must be enabled; and physical touch must be required for every signing operation.
+
+To learn more, refer to the [StageX](https://codeberg.org/stagex/stagex/src/branch/main)
+repository and [paper](https://codeberg.org/stagex/whitepapers/).
+
+### Build
+
+Use the included `build.sh` script, which handles OCI output and binary
+extraction:
+
+```sh
+./docker/build.sh
+```
+
+Or build directly:
+
+```sh
+docker build -f docker/Dockerfile.deterministic . \
+  --target runtime \
+  --output type=oci,rewrite-timestamp=true,force-compression=true,dest=build/oci/zebra.tar,name=zebra
+```
+
+### Verifying a build
+
+Because the build is reproducible, if maintainer-signed hashes are published, anyone
+can verify a published image.
+
+```sh
+# Rebuild from source
+./docker/build.sh
+
+# Look for the "manifest" hash value Docker outputs
+
+# You may also hash the binary
+sha256sum build/oci/zebra.tar
+```
+
+If the hashes match, you have cryptographic assurance that the image contains
+exactly the code in the source repository.

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -e
+
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PLATFORM="linux/amd64"
+OCI_OUTPUT="$REPO_ROOT/build/oci"
+DOCKERFILE="$REPO_ROOT/docker/Dockerfile.deterministic"
+NAME=zebra
+
+export DOCKER_BUILDKIT=1
+export SOURCE_DATE_EPOCH=1
+
+echo $DOCKERFILE
+mkdir -p $OCI_OUTPUT
+
+# Build runtime image for docker run
+echo "Building runtime image..."
+docker build -f "$DOCKERFILE" "$REPO_ROOT" \
+	--platform "$PLATFORM" \
+	--target runtime \
+	--output type=oci,rewrite-timestamp=true,force-compression=true,dest=$OCI_OUTPUT/zebra.tar,name=zebra \
+	"$@"
+
+# Extract binary locally from export stage
+echo "Extracting binary..."
+docker build -f "$DOCKERFILE" "$REPO_ROOT" --quiet \
+	--platform "$PLATFORM" \
+	--target export \
+	--output type=local,dest="$REPO_ROOT/build" \
+	"$@"
+


### PR DESCRIPTION
## Motivation

Supply chain security for cryptocurrency node software is critical. This PR follows up on #10068, which attempted to bring Zebra's build security in line with Bitcoin Core's approach ([bitcoin/bitcoin#15277](https://github.com/bitcoin/bitcoin/pull/15277)), adopted by them in 2018.

[StageX](https://codeberg.org/stagex/whitepapers) is a bootstrapped, fully deterministic build distribution that goes further than Guix in supply chain security while adopting modern tooling. LLVM as the primary compiler, mold as the linker, and mimalloc as the allocator, for improved performance.

This PR is related to the grant: https://forum.zcashcommunity.com/t/bootstrapped-and-deterministic-builds-a-la-stagex/53040

## Solution

This PR introduces a `Dockerfile.deterministic` alongside the existing `Dockerfile`, so maintainers can evaluate and test the deterministic build path without disrupting the current setup.

Since #10068, StageX has matured to support LLVM as the default compiler, mimalloc as the default memory allocator, and mold as the primary linker, for dramatic speed improvements and cross-compiling support across the board, without compromising on determinism

## Follow-up Work

- Determine target architectures to support and add cross-compilation stages
- CI integration for verifying build reproducibility

## References

- Previous PR: #10068
- Bitcoin Core precedent: [bitcoin/bitcoin#15277](https://github.com/bitcoin/bitcoin/pull/15277)
- StageX whitepaper draft: https://codeberg.org/stagex/whitepapers

## PR Checklist

- [ ] The PR name is suitable for the release notes.
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] The library crate changelogs are up to date.
- [ ] The solution is tested.
- [ ] The documentation is up to date.