### PR TITLE
refactor(benches): align with prod metrics and harden CI workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,15 +11,26 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Bench list is shared by both jobs. Each entry is one `cargo ...` invocation
+# minus the leading `cargo` and the per-job flags (`--message-format=json`,
+# `--save-baseline`). Adding a bench here is the only change required.
+env:
+  BENCHES: |
+    criterion -p zebra-consensus --bench groth16
+    criterion -p zebra-consensus --bench halo2
+    criterion -p zebra-consensus --bench sapling
+    criterion -p zebra-chain --bench transaction
+    criterion -p zebra-chain --bench block --features bench
+    criterion -p zebra-chain --bench redpallas
+
 jobs:
-  # Runs all benchmarks and stores results for historical tracking.
-  # Triggered manually via workflow_dispatch.
+  # Runs all benchmarks and publishes results to gh-pages for historical
+  # tracking. Triggered manually via workflow_dispatch.
   benchmark:
     name: Run Benchmarks
     if: github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
-      deployments: write
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -30,18 +41,21 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c #v1.15.2
         with:
           toolchain: stable
+          cache-on-failure: true
 
       - name: Install cargo-criterion
-        run: cargo install cargo-criterion
+        run: cargo install cargo-criterion --locked
 
       - name: Run benchmarks
         run: |
-          cargo criterion --bench groth16 --message-format=json >> bench_output.json
-          cargo criterion --bench halo2 --message-format=json >> bench_output.json
-          cargo criterion --bench sapling --message-format=json >> bench_output.json
-          cargo criterion --bench transaction --message-format=json >> bench_output.json
-          cargo criterion -p zebra-chain --bench block --features bench --message-format=json >> bench_output.json
-          cargo criterion -p zebra-chain --bench redpallas --message-format=json >> bench_output.json
+          : > bench_output.json
+          while IFS= read -r bench; do
+            [ -z "$bench" ] && continue
+            echo "::group::cargo $bench"
+            # shellcheck disable=SC2086
+            cargo $bench --message-format=json >> bench_output.json
+            echo "::endgroup::"
+          done <<< "$BENCHES"
 
       - name: Convert criterion JSON to github-action-benchmark format
         run: |
@@ -54,15 +68,17 @@ jobs:
 
       - name: Generate summary
         run: |
-          echo "## Benchmark Results" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Benchmark | Time | ±CI |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-----------|------|-----|" >> "$GITHUB_STEP_SUMMARY"
-          jq -r 'select(.reason == "benchmark-complete") |
-            "| \(.id) | \(.typical.estimate | . / 1e3 | if . >= 1000 then "\(. / 1000 | . * 100 | round / 100) ms" elif . >= 1 then "\(. * 100 | round / 100) µs" else "\(. * 1000 | . * 100 | round / 100) ns" end) | ±\(.typical.lower_bound as $lo | .typical.upper_bound as $hi | (($hi - $lo) / 2 / .typical.estimate * 10000 | round / 100))% |"' \
-            bench_output.json >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Total benchmarks:** $(grep -c '"benchmark-complete"' bench_output.json)" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Benchmark Results"
+            echo ""
+            echo "| Benchmark | Time | ±CI |"
+            echo "|-----------|------|-----|"
+            jq -r 'select(.reason == "benchmark-complete") |
+              "| \(.id) | \(.typical.estimate | . / 1e3 | if . >= 1000 then "\(. / 1000 | . * 100 | round / 100) ms" elif . >= 1 then "\(. * 100 | round / 100) µs" else "\(. * 1000 | . * 100 | round / 100) ns" end) | ±\(.typical.lower_bound as $lo | .typical.upper_bound as $hi | (($hi - $lo) / 2 / .typical.estimate * 10000 | round / 100))% |"' \
+              bench_output.json
+            echo ""
+            echo "**Total benchmarks:** $(grep -c '"benchmark-complete"' bench_output.json)"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Store benchmark results
         uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 #v1
@@ -73,12 +89,17 @@ jobs:
           benchmark-data-dir-path: dev/bench
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
+          # 150% = a run that is 1.5x slower than the previous. Loose enough to
+          # avoid false alarms from ~10-20% runner noise, tight enough to catch
+          # meaningful regressions. Tune once a baseline history accumulates.
           alert-threshold: "150%"
           comment-on-alert: true
           fail-on-alert: false
 
-  # Compares benchmarks between PR branch and base branch.
-  # Triggered by adding the "C-benchmark" label to a PR.
+  # Compares benchmarks between the PR branch and the base branch.
+  # Triggered by maintainers adding the `C-benchmark` label to a PR.
+  # NOTE: the `C-benchmark` label must exist in the repo for this trigger to
+  # fire. Current labels: `gh api /repos/ZcashFoundation/zebra/labels`.
   compare:
     name: Compare Benchmarks
     if: github.event_name == 'pull_request' && github.event.label.name == 'C-benchmark'
@@ -96,33 +117,55 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c #v1.15.2
         with:
           toolchain: stable
+          cache-on-failure: true
 
       - name: Install critcmp
-        run: cargo install critcmp
+        run: cargo install critcmp --locked
 
       - name: Benchmark base branch
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           git checkout "$BASE_SHA"
-          cargo bench --bench groth16 -- --save-baseline base 2>/dev/null || true
-          cargo bench --bench halo2 -- --save-baseline base 2>/dev/null || true
-          cargo bench --bench sapling -- --save-baseline base 2>/dev/null || true
-          cargo bench --bench transaction -- --save-baseline base 2>/dev/null || true
-          cargo bench -p zebra-chain --bench block --features bench -- --save-baseline base 2>/dev/null || true
-          cargo bench -p zebra-chain --bench redpallas -- --save-baseline base 2>/dev/null || true
+          failures=()
+          while IFS= read -r bench; do
+            [ -z "$bench" ] && continue
+            # Strip the `criterion ` prefix so we can run via `cargo bench`.
+            cmd="${bench#criterion }"
+            echo "::group::base: cargo bench $cmd"
+            # shellcheck disable=SC2086
+            if ! cargo bench $cmd -- --save-baseline base; then
+              failures+=("$cmd")
+            fi
+            echo "::endgroup::"
+          done <<< "$BENCHES"
+          if [ "${#failures[@]}" -gt 0 ]; then
+            {
+              echo "### Base-branch benchmark failures"
+              echo ""
+              echo "The following benches failed on the base branch (likely because they are new in this PR):"
+              echo ""
+              for f in "${failures[@]}"; do
+                echo "- \`cargo bench $f\`"
+              done
+              echo ""
+              echo "critcmp will show no comparison for these."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Benchmark PR branch
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           git checkout "$HEAD_SHA"
-          cargo bench --bench groth16 -- --save-baseline pr 2>/dev/null || true
-          cargo bench --bench halo2 -- --save-baseline pr 2>/dev/null || true
-          cargo bench --bench sapling -- --save-baseline pr 2>/dev/null || true
-          cargo bench --bench transaction -- --save-baseline pr 2>/dev/null || true
-          cargo bench -p zebra-chain --bench block --features bench -- --save-baseline pr 2>/dev/null || true
-          cargo bench -p zebra-chain --bench redpallas -- --save-baseline pr 2>/dev/null || true
+          while IFS= read -r bench; do
+            [ -z "$bench" ] && continue
+            cmd="${bench#criterion }"
+            echo "::group::pr: cargo bench $cmd"
+            # shellcheck disable=SC2086
+            cargo bench $cmd -- --save-baseline pr
+            echo "::endgroup::"
+          done <<< "$BENCHES"
 
       - name: Compare results
         id: compare
@@ -130,29 +173,38 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          echo "## Benchmark Comparison: base vs PR" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
-          critcmp base pr >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          # Branch names are attacker-controlled. Strip anything that isn't a
+          # conventional ref character before rendering them inside markdown.
+          sanitize() { printf '%s' "$1" | tr -cd 'A-Za-z0-9._/-'; }
+          base_ref=$(sanitize "$BASE_REF")
+          head_ref=$(sanitize "$HEAD_REF")
 
-          # Save for PR comment
+          {
+            echo "## Benchmark Comparison: base vs PR"
+            echo ""
+            echo '```'
+            critcmp base pr
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
           {
             echo 'COMMENT<<EOF'
             echo "## Benchmark Comparison"
             echo ""
-            echo "Comparing \`${BASE_REF}\` (base) vs \`${HEAD_REF}\` (PR)"
+            echo "Comparing \`${base_ref}\` (base) vs \`${head_ref}\` (PR)"
             echo ""
             echo '```'
             critcmp base pr
             echo '```'
             echo ""
-            echo "*Benchmarks ran on CI — results may have higher variance than local runs.*"
+            echo "*Benchmarks ran on CI: results may have higher variance than local runs.*"
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
       - name: Post PR comment
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
+        env:
+          COMMENT: ${{ steps.compare.outputs.COMMENT }}
         with:
           script: |
             const body = process.env.COMMENT;
@@ -179,5 +231,3 @@ jobs:
                 body,
               });
             }
-        env:
-          COMMENT: ${{ steps.compare.outputs.COMMENT }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -13,7 +13,14 @@ concurrency:
 
 # Bench list is shared by both jobs. Each entry is one `cargo ...` invocation
 # minus the leading `cargo` and the per-job flags (`--message-format=json`,
-# `--save-baseline`). Adding a bench here is the only change required.
+# `--save-baseline`).
+#
+# Adding a bench requires two changes:
+# 1. Append a `criterion -p <crate> --bench <name>` line to `BENCHES` below.
+# 2. Add a matching `[[bench]]` stanza (with `harness = false`) to the
+#    crate's `Cargo.toml`. Required for every bench regardless of the
+#    crate's `autobenches` setting, because Criterion replaces the test
+#    harness.
 env:
   BENCHES: |
     criterion -p zebra-consensus --bench groth16
@@ -100,6 +107,14 @@ jobs:
   # Triggered by maintainers adding the `C-benchmark` label to a PR.
   # NOTE: the `C-benchmark` label must exist in the repo for this trigger to
   # fire. Current labels: `gh api /repos/ZcashFoundation/zebra/labels`.
+  #
+  # Baselines are ephemeral: `target/criterion/` is not cached across runs,
+  # so each job creates `base` and `pr` fresh from the two checkouts below.
+  # Renaming a bench group ID is therefore safe: it only affects comparison
+  # within the single PR that introduces the rename (critcmp shows the old
+  # and new IDs as non-overlapping benches there). If a future change adds
+  # caching for `target/`, it must exclude `target/criterion/` or bump a
+  # cache key to avoid stale baselines from previous group IDs.
   compare:
     name: Compare Benchmarks
     if: github.event_name == 'pull_request' && github.event.label.name == 'C-benchmark'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,10 +11,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-# Bench list shared by both jobs. Each entry is a `cargo ...` invocation
-# minus the leading `cargo` and per-job flags (`--message-format=json`,
-# `--save-baseline`). New benches also need a `[[bench]]` stanza with
-# `harness = false` in the crate's `Cargo.toml`.
+# Bench list shared by both jobs. New benches need a `[[bench]]` stanza
+# with `harness = false` in the crate's `Cargo.toml`.
 env:
   BENCHES: |
     criterion -p zebra-consensus --bench groth16
@@ -90,9 +88,8 @@ jobs:
           benchmark-data-dir-path: dev/bench
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
-          # 150% = a run that is 1.5x slower than the previous. Loose enough to
-          # avoid false alarms from ~10-20% runner noise, tight enough to catch
-          # meaningful regressions. Tune once a baseline history accumulates.
+          # 150% = 1.5x slower than the previous run. Stays above ~10-20%
+          # runner noise while catching real regressions.
           alert-threshold: "150%"
           comment-on-alert: true
           fail-on-alert: false

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,7 +3,7 @@ name: Benchmarks
 on:
   workflow_dispatch:
   pull_request:
-    types: [labeled]
+    types: [labeled, synchronize]
 
 permissions: {}
 
@@ -98,12 +98,13 @@ jobs:
           fail-on-alert: false
 
   # Compares benchmarks between the PR branch and the base branch.
-  # Triggered by maintainers adding the `C-benchmark` label to a PR.
-  # NOTE: the `C-benchmark` label must exist in the repo for this trigger to
-  # fire. Current labels: `gh api /repos/ZcashFoundation/zebra/labels`.
+  # Runs when the `C-benchmark` label is present: both when it is first added
+  # and on subsequent pushes to the PR.
   compare:
     name: Compare Benchmarks
-    if: github.event_name == 'pull_request' && github.event.label.name == 'C-benchmark'
+    if: >-
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.labels.*.name, 'C-benchmark')
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,16 +11,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-# Bench list is shared by both jobs. Each entry is one `cargo ...` invocation
-# minus the leading `cargo` and the per-job flags (`--message-format=json`,
-# `--save-baseline`).
-#
-# Adding a bench requires two changes:
-# 1. Append a `criterion -p <crate> --bench <name>` line to `BENCHES` below.
-# 2. Add a matching `[[bench]]` stanza (with `harness = false`) to the
-#    crate's `Cargo.toml`. Required for every bench regardless of the
-#    crate's `autobenches` setting, because Criterion replaces the test
-#    harness.
+# Bench list shared by both jobs. Each entry is a `cargo ...` invocation
+# minus the leading `cargo` and per-job flags (`--message-format=json`,
+# `--save-baseline`). New benches also need a `[[bench]]` stanza with
+# `harness = false` in the crate's `Cargo.toml`.
 env:
   BENCHES: |
     criterion -p zebra-consensus --bench groth16
@@ -107,14 +101,6 @@ jobs:
   # Triggered by maintainers adding the `C-benchmark` label to a PR.
   # NOTE: the `C-benchmark` label must exist in the repo for this trigger to
   # fire. Current labels: `gh api /repos/ZcashFoundation/zebra/labels`.
-  #
-  # Baselines are ephemeral: `target/criterion/` is not cached across runs,
-  # so each job creates `base` and `pr` fresh from the two checkouts below.
-  # Renaming a bench group ID is therefore safe: it only affects comparison
-  # within the single PR that introduces the rename (critcmp shows the old
-  # and new IDs as non-overlapping benches there). If a future change adds
-  # caching for `target/`, it must exclude `target/criterion/` or bump a
-  # cache key to avoid stale baselines from previous group IDs.
   compare:
     name: Compare Benchmarks
     if: github.event_name == 'pull_request' && github.event.label.name == 'C-benchmark'

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -71,12 +71,8 @@ jobs:
           RUSTDOCFLAGS: --html-in-header katex-header.html -D warnings -A rustdoc::private_intra_doc_links --cfg docsrs --show-type-layout --generate-link-to-definition --enable-index-page -Zunstable-options
 
       - name: Include benchmark dashboard
-        # Benchmarks are published to `gh-pages/dev/bench` by `benchmarks.yml`.
-        # This step snapshots those files into the docs artifact so they are
-        # reachable at `/dev/bench`. Known tradeoff: the dashboard lags the
-        # latest benchmark run until the book workflow runs again on `main`.
-        # When GitHub Pages is migrated off workflow-artifact deploys and onto
-        # the gh-pages branch, this step can be removed.
+        # Snapshots `gh-pages/dev/bench` (published by `benchmarks.yml`) into
+        # the docs artifact so it is reachable at `/dev/bench`.
         run: |
           if ! git fetch origin gh-pages --depth=1 2>/dev/null; then
             echo "gh-pages branch does not exist yet, skipping benchmark dashboard"
@@ -88,8 +84,8 @@ jobs:
             exit 0
           fi
 
-          # Both files are published atomically by github-action-benchmark,
-          # so a missing data.js when index.html exists is a real inconsistency.
+          # index.html and data.js are published atomically by
+          # github-action-benchmark, so data.js isn't guarded separately.
           mkdir -p target/docs/dev/bench
           git show origin/gh-pages:dev/bench/index.html > target/docs/dev/bench/index.html
           git show origin/gh-pages:dev/bench/data.js > target/docs/dev/bench/data.js

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -71,20 +71,28 @@ jobs:
           RUSTDOCFLAGS: --html-in-header katex-header.html -D warnings -A rustdoc::private_intra_doc_links --cfg docsrs --show-type-layout --generate-link-to-definition --enable-index-page -Zunstable-options
 
       - name: Include benchmark dashboard
+        # Benchmarks are published to `gh-pages/dev/bench` by `benchmarks.yml`.
+        # This step snapshots those files into the docs artifact so they are
+        # reachable at `/dev/bench`. Known tradeoff: the dashboard lags the
+        # latest benchmark run until the book workflow runs again on `main`.
+        # When GitHub Pages is migrated off workflow-artifact deploys and onto
+        # the gh-pages branch, this step can be removed.
         run: |
-          # Copy benchmark data from gh-pages branch into the docs output.
-          # This makes the benchmark dashboard available at /dev/bench/.
-          # Fails gracefully if gh-pages has no benchmark data yet.
-          git fetch origin gh-pages --depth=1 || true
-          if git rev-parse origin/gh-pages >/dev/null 2>&1; then
-            git show origin/gh-pages:dev/bench/index.html > /dev/null 2>&1 && {
-              mkdir -p target/docs/dev/bench
-              git show origin/gh-pages:dev/bench/index.html > target/docs/dev/bench/index.html
-              git show origin/gh-pages:dev/bench/data.js > target/docs/dev/bench/data.js
-            } || echo "No benchmark data on gh-pages yet, skipping"
-          else
-            echo "gh-pages branch not found, skipping benchmark dashboard"
+          if ! git fetch origin gh-pages --depth=1 2>/dev/null; then
+            echo "gh-pages branch does not exist yet, skipping benchmark dashboard"
+            exit 0
           fi
+
+          if ! git show origin/gh-pages:dev/bench/index.html >/dev/null 2>&1; then
+            echo "gh-pages has no benchmark data yet, skipping benchmark dashboard"
+            exit 0
+          fi
+
+          # Both files are published atomically by github-action-benchmark,
+          # so a missing data.js when index.html exists is a real inconsistency.
+          mkdir -p target/docs/dev/bench
+          git show origin/gh-pages:dev/bench/index.html > target/docs/dev/bench/index.html
+          git show origin/gh-pages:dev/bench/data.js > target/docs/dev/bench/data.js
 
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b #v5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- Public benchmark dashboard at [zebra.zfnd.org/dev/bench](https://zebra.zfnd.org/dev/bench) covering Groth16, Halo2, Sapling, RedPallas, block, and transaction benchmarks ([#10444](https://github.com/ZcashFoundation/zebra/pull/10444))
+
 ## [Zebra 4.3](https://github.com/ZcashFoundation/zebra/releases/tag/v4.3) - 2026-03-12
 
 This release adds support for [ZIP-235](https://zips.z.cash/zip-0235) and

--- a/zebra-chain/benches/redpallas.rs
+++ b/zebra-chain/benches/redpallas.rs
@@ -71,45 +71,57 @@ fn bench_batch_verify(c: &mut Criterion) {
 
         let sigs = sigs_with_distinct_keys().take(n).collect::<Vec<_>>();
 
-        group.bench_with_input(BenchmarkId::new("unbatched", n), &sigs, |b, sigs| {
-            b.iter(|| {
-                for item in sigs.iter() {
-                    match item {
-                        Item::SpendAuth { vk_bytes, sig } => {
-                            assert!(VerificationKey::try_from(*vk_bytes)
-                                .and_then(|vk| vk.verify(MESSAGE_BYTES, sig))
-                                .is_ok());
-                        }
-                        Item::Binding { vk_bytes, sig } => {
-                            assert!(VerificationKey::try_from(*vk_bytes)
-                                .and_then(|vk| vk.verify(MESSAGE_BYTES, sig))
-                                .is_ok());
+        group.bench_with_input(
+            BenchmarkId::new("Unbatched verification", n),
+            &sigs,
+            |b, sigs| {
+                b.iter(|| {
+                    for item in sigs.iter() {
+                        match item {
+                            Item::SpendAuth { vk_bytes, sig } => {
+                                assert!(VerificationKey::try_from(*vk_bytes)
+                                    .and_then(|vk| vk.verify(MESSAGE_BYTES, sig))
+                                    .is_ok());
+                            }
+                            Item::Binding { vk_bytes, sig } => {
+                                assert!(VerificationKey::try_from(*vk_bytes)
+                                    .and_then(|vk| vk.verify(MESSAGE_BYTES, sig))
+                                    .is_ok());
+                            }
                         }
                     }
-                }
-            })
-        });
+                })
+            },
+        );
 
-        group.bench_with_input(BenchmarkId::new("batched", n), &sigs, |b, sigs| {
-            b.iter(|| {
-                let mut batch = batch::Verifier::new();
-                for item in sigs.iter() {
-                    match item {
-                        Item::SpendAuth { vk_bytes, sig } => {
-                            batch.queue(batch::Item::from_spendauth(
-                                *vk_bytes,
-                                *sig,
-                                MESSAGE_BYTES,
-                            ));
-                        }
-                        Item::Binding { vk_bytes, sig } => {
-                            batch.queue(batch::Item::from_binding(*vk_bytes, *sig, MESSAGE_BYTES));
+        group.bench_with_input(
+            BenchmarkId::new("Batched verification", n),
+            &sigs,
+            |b, sigs| {
+                b.iter(|| {
+                    let mut batch = batch::Verifier::new();
+                    for item in sigs.iter() {
+                        match item {
+                            Item::SpendAuth { vk_bytes, sig } => {
+                                batch.queue(batch::Item::from_spendauth(
+                                    *vk_bytes,
+                                    *sig,
+                                    MESSAGE_BYTES,
+                                ));
+                            }
+                            Item::Binding { vk_bytes, sig } => {
+                                batch.queue(batch::Item::from_binding(
+                                    *vk_bytes,
+                                    *sig,
+                                    MESSAGE_BYTES,
+                                ));
+                            }
                         }
                     }
-                }
-                assert!(batch.verify(thread_rng()).is_ok())
-            })
-        });
+                    assert!(batch.verify(thread_rng()).is_ok())
+                })
+            },
+        );
     }
     group.finish();
 }

--- a/zebra-chain/benches/redpallas.rs
+++ b/zebra-chain/benches/redpallas.rs
@@ -42,7 +42,6 @@ enum Item {
 fn sigs_with_distinct_keys() -> impl Iterator<Item = Item> {
     std::iter::repeat_with(|| {
         let mut rng = thread_rng();
-        // let msg = b"";
         match rng.gen::<u8>() % 2 {
             0 => {
                 let sk = SigningKey::<SpendAuth>::new(thread_rng());

--- a/zebra-chain/benches/redpallas.rs
+++ b/zebra-chain/benches/redpallas.rs
@@ -1,4 +1,9 @@
-//! Benchmarks for batch verifiication of RedPallas signatures.
+//! Benchmarks for batch verification of RedPallas signatures.
+//!
+//! Group name `redpallas` matches the `verifier` label in
+//! `zebra.consensus.batch.duration_seconds` emitted from
+//! `zebra-consensus/src/primitives/redpallas.rs`, so a prod regression on
+//! that histogram maps to this file by name.
 
 // Disabled due to warnings in criterion macros
 #![allow(missing_docs)]
@@ -60,66 +65,58 @@ fn sigs_with_distinct_keys() -> impl Iterator<Item = Item> {
 ///
 /// Includes heterogeneous groups across [SigType], [SigningKey]s, and messages.
 fn bench_batch_verify(c: &mut Criterion) {
-    let mut group = c.benchmark_group("Batch Verification");
+    let mut group = c.benchmark_group("redpallas");
     for &n in [8usize, 16, 24, 32, 40, 48, 56, 64].iter() {
         group.throughput(Throughput::Elements(n as u64));
 
         let sigs = sigs_with_distinct_keys().take(n).collect::<Vec<_>>();
 
-        group.bench_with_input(
-            BenchmarkId::new("Unbatched verification", n),
-            &sigs,
-            |b, sigs| {
-                b.iter(|| {
-                    for item in sigs.iter() {
-                        match item {
-                            Item::SpendAuth { vk_bytes, sig } => {
-                                assert!(VerificationKey::try_from(*vk_bytes)
-                                    .and_then(|vk| vk.verify(MESSAGE_BYTES, sig))
-                                    .is_ok());
-                            }
-                            Item::Binding { vk_bytes, sig } => {
-                                assert!(VerificationKey::try_from(*vk_bytes)
-                                    .and_then(|vk| vk.verify(MESSAGE_BYTES, sig))
-                                    .is_ok());
-                            }
+        group.bench_with_input(BenchmarkId::new("unbatched", n), &sigs, |b, sigs| {
+            b.iter(|| {
+                for item in sigs.iter() {
+                    match item {
+                        Item::SpendAuth { vk_bytes, sig } => {
+                            assert!(VerificationKey::try_from(*vk_bytes)
+                                .and_then(|vk| vk.verify(MESSAGE_BYTES, sig))
+                                .is_ok());
+                        }
+                        Item::Binding { vk_bytes, sig } => {
+                            assert!(VerificationKey::try_from(*vk_bytes)
+                                .and_then(|vk| vk.verify(MESSAGE_BYTES, sig))
+                                .is_ok());
                         }
                     }
-                })
-            },
-        );
+                }
+            })
+        });
 
-        group.bench_with_input(
-            BenchmarkId::new("Batched verification", n),
-            &sigs,
-            |b, sigs| {
-                b.iter(|| {
-                    let mut batch = batch::Verifier::new();
-                    for item in sigs.iter() {
-                        match item {
-                            Item::SpendAuth { vk_bytes, sig } => {
-                                batch.queue(batch::Item::from_spendauth(
-                                    *vk_bytes,
-                                    *sig,
-                                    MESSAGE_BYTES,
-                                ));
-                            }
-                            Item::Binding { vk_bytes, sig } => {
-                                batch.queue(batch::Item::from_binding(
-                                    *vk_bytes,
-                                    *sig,
-                                    MESSAGE_BYTES,
-                                ));
-                            }
+        group.bench_with_input(BenchmarkId::new("batched", n), &sigs, |b, sigs| {
+            b.iter(|| {
+                let mut batch = batch::Verifier::new();
+                for item in sigs.iter() {
+                    match item {
+                        Item::SpendAuth { vk_bytes, sig } => {
+                            batch.queue(batch::Item::from_spendauth(
+                                *vk_bytes,
+                                *sig,
+                                MESSAGE_BYTES,
+                            ));
+                        }
+                        Item::Binding { vk_bytes, sig } => {
+                            batch.queue(batch::Item::from_binding(*vk_bytes, *sig, MESSAGE_BYTES));
                         }
                     }
-                    assert!(batch.verify(thread_rng()).is_ok())
-                })
-            },
-        );
+                }
+                assert!(batch.verify(thread_rng()).is_ok())
+            })
+        });
     }
     group.finish();
 }
 
-criterion_group!(benches, bench_batch_verify);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().noise_threshold(0.1).sample_size(50);
+    targets = bench_batch_verify
+}
 criterion_main!(benches);

--- a/zebra-chain/benches/transaction.rs
+++ b/zebra-chain/benches/transaction.rs
@@ -41,8 +41,7 @@ fn first_tx_of_version(block: &Block, version: u32) -> Option<Vec<u8>> {
 }
 
 fn bench_transaction_deserialize(c: &mut Criterion) {
-    let mut group = c.benchmark_group("Transaction Deserialization");
-    group.noise_threshold(0.05).sample_size(50);
+    let mut group = c.benchmark_group("transaction_deserialize");
 
     // Collect (label, serialized_tx_bytes) pairs for each version.
     let mut tx_samples: Vec<(&str, Vec<u8>)> = Vec::new();
@@ -94,23 +93,19 @@ fn bench_transaction_deserialize(c: &mut Criterion) {
     }
 
     for (label, tx_bytes) in &tx_samples {
-        group.bench_with_input(
-            BenchmarkId::new("deserialize", *label),
-            tx_bytes,
-            |b, bytes| b.iter(|| Transaction::zcash_deserialize(Cursor::new(bytes)).unwrap()),
-        );
+        group.bench_with_input(BenchmarkId::from_parameter(*label), tx_bytes, |b, bytes| {
+            b.iter(|| Transaction::zcash_deserialize(Cursor::new(bytes)).unwrap())
+        });
     }
 
     group.finish();
 
-    // Serialization benchmarks: measure the reverse direction.
-    let mut group = c.benchmark_group("Transaction Serialization");
-    group.noise_threshold(0.05).sample_size(50);
+    let mut group = c.benchmark_group("transaction_serialize");
 
     for (label, tx_bytes) in &tx_samples {
         let tx = Transaction::zcash_deserialize(Cursor::new(tx_bytes)).unwrap();
 
-        group.bench_with_input(BenchmarkId::new("serialize", *label), &tx, |b, tx| {
+        group.bench_with_input(BenchmarkId::from_parameter(*label), &tx, |b, tx| {
             b.iter(|| tx.zcash_serialize_to_vec().unwrap())
         });
     }
@@ -118,5 +113,9 @@ fn bench_transaction_deserialize(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_transaction_deserialize);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().noise_threshold(0.1).sample_size(50);
+    targets = bench_transaction_deserialize
+}
 criterion_main!(benches);

--- a/zebra-chain/benches/transaction.rs
+++ b/zebra-chain/benches/transaction.rs
@@ -74,7 +74,6 @@ fn bench_transaction_deserialize(c: &mut Criterion) {
     }
 
     // V4 — Sapling block with shielded data.
-    // Try 419201 first (has Sapling transactions), fall back to 419200.
     let block = Block::zcash_deserialize(Cursor::new(
         zebra_test::vectors::BLOCK_MAINNET_419201_BYTES.as_slice(),
     ))

--- a/zebra-chain/benches/transaction.rs
+++ b/zebra-chain/benches/transaction.rs
@@ -41,7 +41,7 @@ fn first_tx_of_version(block: &Block, version: u32) -> Option<Vec<u8>> {
 }
 
 fn bench_transaction_deserialize(c: &mut Criterion) {
-    let mut group = c.benchmark_group("transaction_deserialize");
+    let mut group = c.benchmark_group("Transaction Deserialization");
 
     // Collect (label, serialized_tx_bytes) pairs for each version.
     let mut tx_samples: Vec<(&str, Vec<u8>)> = Vec::new();
@@ -93,19 +93,21 @@ fn bench_transaction_deserialize(c: &mut Criterion) {
     }
 
     for (label, tx_bytes) in &tx_samples {
-        group.bench_with_input(BenchmarkId::from_parameter(*label), tx_bytes, |b, bytes| {
-            b.iter(|| Transaction::zcash_deserialize(Cursor::new(bytes)).unwrap())
-        });
+        group.bench_with_input(
+            BenchmarkId::new("deserialize", label),
+            tx_bytes,
+            |b, bytes| b.iter(|| Transaction::zcash_deserialize(Cursor::new(bytes)).unwrap()),
+        );
     }
 
     group.finish();
 
-    let mut group = c.benchmark_group("transaction_serialize");
+    let mut group = c.benchmark_group("Transaction Serialization");
 
     for (label, tx_bytes) in &tx_samples {
         let tx = Transaction::zcash_deserialize(Cursor::new(tx_bytes)).unwrap();
 
-        group.bench_with_input(BenchmarkId::from_parameter(*label), &tx, |b, tx| {
+        group.bench_with_input(BenchmarkId::new("serialize", label), &tx, |b, tx| {
             b.iter(|| tx.zcash_serialize_to_vec().unwrap())
         });
     }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -8,6 +8,10 @@ repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
+# Disable bench auto-discovery so `benches/common.rs` is only compiled when
+# explicitly imported via `mod common;` from a bench.
+autobenches = false
+
 readme = "../README.md"
 homepage.workspace = true
 # crates.io is limited to 5 keywords and categories
@@ -92,7 +96,6 @@ tracing-subscriber = { workspace = true }
 zebra-state = { path = "../zebra-state", version = "5.0.0", features = ["proptest-impl"] }
 zebra-chain = { path = "../zebra-chain", version = "6.0.1", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/", version = "3.0.0" }
-tower-batch-control = { path = "../tower-batch-control/", version = "1.0.1" }
 
 criterion = { workspace = true, features = ["html_reports"] }
 

--- a/zebra-consensus/benches/common.rs
+++ b/zebra-consensus/benches/common.rs
@@ -1,0 +1,17 @@
+//! Shared helpers for zebra-consensus benchmarks.
+//!
+//! Each bench file under `benches/` is its own crate, so helpers shared across
+//! them live here and are wired in via `mod common;` at the top of each bench.
+
+#![allow(dead_code)]
+
+/// Creates a batch of `n` items by cycling through `source`.
+///
+/// The source test vectors in `zebra-test` contain only a handful of real
+/// proofs/bundles. To benchmark realistic batch sizes, items are repeated.
+/// This is valid for cost-per-proof measurements because proof verification
+/// runs the same curve operations regardless of proof content, but it does
+/// not capture the memory/cache patterns of fully unique inputs.
+pub fn cycled<T: Clone>(source: &[T], n: usize) -> Vec<T> {
+    source.iter().cycle().take(n).cloned().collect()
+}

--- a/zebra-consensus/benches/groth16.rs
+++ b/zebra-consensus/benches/groth16.rs
@@ -6,14 +6,17 @@
 //!
 //! # Benchmark groups
 //!
-//! - `groth16_sprout`: matches the hypothetical `verifier` label if Sprout
-//!   gets its own batch verifier (none exists today; see the production path
-//!   in `zebra-consensus/src/primitives/groth16.rs`).
-//! - `groth16_sprout_inputs`: primary input preparation cost.
-//!
-//! Group names intentionally mirror the `verifier` label values emitted from
-//! `zebra-consensus/src/primitives/*.rs` (e.g. `groth16_sapling`, `halo2`,
-//! `redpallas`) so prod regressions can be traced to benchmarks by label.
+//! - `joinsplit`: Groth16 verification for Sprout JoinSplit descriptions.
+//!   Named after `JOINSPLIT_VERIFIER`, the authoritative verifier service
+//!   in `zebra-consensus/src/primitives/groth16.rs`. Unlike the `halo2`,
+//!   `groth16_sapling`, and `redpallas` benches, there is no matching
+//!   `verifier` label on the `zebra.consensus.batch.duration_seconds`
+//!   histogram because Sprout has no batch verifier today: each JoinSplit
+//!   is verified individually via a `service_fn` (see the comment on
+//!   `JOINSPLIT_VERIFIER`). Tracked in the Zebra performance issue
+//!   (closed #3127, now rolled into #3153).
+//! - `joinsplit_inputs`: primary input preparation cost, isolated from
+//!   pairing verification so the two can be measured separately.
 //!
 //! # Test data limitations
 //!
@@ -100,7 +103,7 @@ fn bench_groth16_verify(c: &mut Criterion) {
     let sources = extract_joinsplit_sources();
     let items: Vec<Item> = sources.iter().map(item_from).collect();
 
-    let mut group = c.benchmark_group("groth16_sprout");
+    let mut group = c.benchmark_group("joinsplit");
 
     group.throughput(Throughput::Elements(1));
     group.bench_function("single", |b| {
@@ -132,7 +135,7 @@ fn bench_groth16_inputs(c: &mut Criterion) {
     let sources = extract_joinsplit_sources();
     let source = sources.first().expect("at least one JoinSplit source");
 
-    let mut group = c.benchmark_group("groth16_sprout_inputs");
+    let mut group = c.benchmark_group("joinsplit_inputs");
 
     // Cost of computing h_sig and encoding primary inputs as BLS12-381 scalars.
     group.bench_function("primary_inputs", |b| {

--- a/zebra-consensus/benches/groth16.rs
+++ b/zebra-consensus/benches/groth16.rs
@@ -6,17 +6,8 @@
 //!
 //! # Benchmark groups
 //!
-//! - `joinsplit`: Groth16 verification for Sprout JoinSplit descriptions.
-//!   Named after `JOINSPLIT_VERIFIER`, the authoritative verifier service
-//!   in `zebra-consensus/src/primitives/groth16.rs`. Unlike the `halo2`,
-//!   `groth16_sapling`, and `redpallas` benches, there is no matching
-//!   `verifier` label on the `zebra.consensus.batch.duration_seconds`
-//!   histogram because Sprout has no batch verifier today: each JoinSplit
-//!   is verified individually via a `service_fn` (see the comment on
-//!   `JOINSPLIT_VERIFIER`). Tracked in the Zebra performance issue
-//!   (closed #3127, now rolled into #3153).
-//! - `joinsplit_inputs`: primary input preparation cost, isolated from
-//!   pairing verification so the two can be measured separately.
+//! - `joinsplit`: per-proof verification (mirrors `JOINSPLIT_VERIFIER`).
+//! - `joinsplit_inputs`: primary input preparation cost.
 //!
 //! # Test data limitations
 //!

--- a/zebra-consensus/benches/groth16.rs
+++ b/zebra-consensus/benches/groth16.rs
@@ -1,20 +1,9 @@
 //! Benchmarks for Groth16 proof verification (Sprout JoinSplits).
 //!
-//! Measures the cost of verifying Groth16 zero-knowledge proofs used in Sprout
-//! JoinSplit descriptions. Groth16 verification is a pairing check on BLS12-381,
-//! making it one of the most expensive per-proof operations during chain sync.
-//!
-//! # Benchmark groups
-//!
-//! - `joinsplit`: per-proof verification (mirrors `JOINSPLIT_VERIFIER`).
-//! - `joinsplit_inputs`: primary input preparation cost.
-//!
-//! # Test data limitations
-//!
-//! The hardcoded mainnet test blocks in `zebra-test` contain only a small
-//! number of Groth16 JoinSplits. Items are cycled to fill larger batches;
-//! Groth16 cost is constant per proof so this is valid for per-item
-//! throughput measurements, but cache/memory effects are not representative.
+//! Groth16 verification is a pairing check on BLS12-381. Sprout has no batch
+//! verifier in Zebra; each proof is verified individually, so the only
+//! throughput dimension is per-proof cost. Test vectors contain few
+//! JoinSplits, so items are cycled to fill larger sizes.
 
 // Disabled due to warnings in criterion macros
 #![allow(missing_docs)]
@@ -94,10 +83,10 @@ fn bench_groth16_verify(c: &mut Criterion) {
     let sources = extract_joinsplit_sources();
     let items: Vec<Item> = sources.iter().map(item_from).collect();
 
-    let mut group = c.benchmark_group("joinsplit");
+    let mut group = c.benchmark_group("Groth16 Verification");
 
     group.throughput(Throughput::Elements(1));
-    group.bench_function("single", |b| {
+    group.bench_function("single proof", |b| {
         let item = items[0].clone();
         b.iter(|| {
             item.clone().verify_single(pvk).expect("valid proof");
@@ -126,7 +115,7 @@ fn bench_groth16_inputs(c: &mut Criterion) {
     let sources = extract_joinsplit_sources();
     let source = sources.first().expect("at least one JoinSplit source");
 
-    let mut group = c.benchmark_group("joinsplit_inputs");
+    let mut group = c.benchmark_group("Groth16 Input Preparation");
 
     // Cost of computing h_sig and encoding primary inputs as BLS12-381 scalars.
     group.bench_function("primary_inputs", |b| {

--- a/zebra-consensus/benches/groth16.rs
+++ b/zebra-consensus/benches/groth16.rs
@@ -93,8 +93,6 @@ fn bench_groth16_verify(c: &mut Criterion) {
         })
     });
 
-    // Sprout has no batch verifier in Zebra today: every proof is verified
-    // individually in the production path, so this is the cost profile.
     for n in [2, 4, 8, 16, 32, 64] {
         let batch = common::cycled(&items, n);
 

--- a/zebra-consensus/benches/groth16.rs
+++ b/zebra-consensus/benches/groth16.rs
@@ -1,27 +1,31 @@
 //! Benchmarks for Groth16 proof verification (Sprout JoinSplits).
 //!
-//! These benchmarks measure the cost of verifying Groth16 zero-knowledge proofs
-//! used in Sprout JoinSplit descriptions. Groth16 verification involves a pairing
-//! check on BLS12-381, making it one of the most expensive per-proof operations
-//! during chain sync.
+//! Measures the cost of verifying Groth16 zero-knowledge proofs used in Sprout
+//! JoinSplit descriptions. Groth16 verification is a pairing check on BLS12-381,
+//! making it one of the most expensive per-proof operations during chain sync.
+//!
+//! # Benchmark groups
+//!
+//! - `groth16_sprout`: matches the hypothetical `verifier` label if Sprout
+//!   gets its own batch verifier (none exists today; see the production path
+//!   in `zebra-consensus/src/primitives/groth16.rs`).
+//! - `groth16_sprout_inputs`: primary input preparation cost.
+//!
+//! Group names intentionally mirror the `verifier` label values emitted from
+//! `zebra-consensus/src/primitives/*.rs` (e.g. `groth16_sapling`, `halo2`,
+//! `redpallas`) so prod regressions can be traced to benchmarks by label.
 //!
 //! # Test data limitations
 //!
-//! The hardcoded mainnet test blocks in `zebra-test` contain only a small number
-//! of Groth16 JoinSplits (~5 items). To benchmark realistic batch sizes, items
-//! are cycled (repeated) to fill larger batches.
-//!
-//! This is valid for measuring verification throughput because:
-//! - Groth16 pairing checks perform the same curve operations regardless of the
-//!   specific proof bytes — the cost is constant per proof.
-//! - Primary input preparation (blake2b hashing + field element packing) is also
-//!   constant-cost regardless of input values.
-//!
-//! However, this means the benchmarks do **not** capture any cache effects or
-//! memory access patterns that might differ with truly unique proofs at scale.
+//! The hardcoded mainnet test blocks in `zebra-test` contain only a small
+//! number of Groth16 JoinSplits. Items are cycled to fill larger batches;
+//! Groth16 cost is constant per proof so this is valid for per-item
+//! throughput measurements, but cache/memory effects are not representative.
 
 // Disabled due to warnings in criterion macros
 #![allow(missing_docs)]
+
+mod common;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 
@@ -29,21 +33,29 @@ use bellman::groth16::PreparedVerifyingKey;
 use bls12_381::Bls12;
 
 use zebra_chain::{
-    block::Block, primitives::Groth16Proof, serialization::ZcashDeserializeInto, sprout::JoinSplit,
+    block::Block,
+    primitives::{ed25519, Groth16Proof},
+    serialization::ZcashDeserializeInto,
+    sprout::JoinSplit,
 };
 
 use zebra_consensus::groth16::{Description, DescriptionWrapper, Item, SPROUT};
 
-/// Extracts valid Groth16 items from the hardcoded mainnet test blocks.
+/// A Sprout JoinSplit paired with its transaction's JoinSplit public key,
+/// ready to be converted into a Groth16 verification [`Item`].
+#[derive(Clone)]
+struct JoinSplitSource {
+    joinsplit: JoinSplit<Groth16Proof>,
+    pub_key: ed25519::VerificationKeyBytes,
+}
+
+/// Extracts JoinSplit/pub-key pairs from the mainnet test blocks.
 ///
-/// Iterates over `MAINNET_BLOCKS`, deserializes each block, and collects all
-/// Groth16 JoinSplit proofs along with their primary inputs. Only V4 transactions
-/// contain Groth16 JoinSplits (earlier versions use BCTV14 proofs, V5+ dropped
-/// Sprout support).
-///
-/// Returns a small set of real, valid proof items (~5 from current test vectors).
-fn extract_groth16_items_from_blocks() -> Vec<Item> {
-    let mut items = Vec::new();
+/// Only V4 transactions contain Groth16 JoinSplits (V2/V3 use BCTV14 proofs,
+/// V5+ dropped Sprout support). The returned pairs are the raw inputs to
+/// [`Item`] construction and to `primary_inputs()`.
+fn extract_joinsplit_sources() -> Vec<JoinSplitSource> {
+    let mut sources = Vec::new();
 
     for (_height, bytes) in zebra_test::vectors::MAINNET_BLOCKS.iter() {
         let block: Block = bytes.zcash_deserialize_into().expect("valid block");
@@ -61,115 +73,85 @@ fn extract_groth16_items_from_blocks() -> Vec<Item> {
                 .expect("pub key must exist since there are joinsplits");
 
             for joinsplit in joinsplits {
-                let item: Item = DescriptionWrapper(&(joinsplit, &pub_key))
-                    .try_into()
-                    .expect("valid groth16 item");
-                items.push(item);
+                sources.push(JoinSplitSource {
+                    joinsplit: joinsplit.clone(),
+                    pub_key,
+                });
             }
         }
     }
 
     assert!(
-        !items.is_empty(),
+        !sources.is_empty(),
         "test blocks must contain Groth16 JoinSplits"
     );
-    items
+    sources
 }
 
-/// Creates a batch of `n` items by cycling through the source items.
-///
-/// Since Groth16 verification cost is constant per proof (the same pairing
-/// operations run regardless of proof content), repeating proofs produces
-/// benchmarks with the same per-item cost as unique proofs would.
-fn cycled_items(source: &[Item], n: usize) -> Vec<Item> {
-    source.iter().cycle().take(n).cloned().collect()
+/// Converts a [`JoinSplitSource`] into a verification [`Item`].
+fn item_from(source: &JoinSplitSource) -> Item {
+    DescriptionWrapper(&(&source.joinsplit, &source.pub_key))
+        .try_into()
+        .expect("valid groth16 item")
 }
 
-/// Benchmarks Groth16 proof verification at various batch sizes, and the cost
-/// of preparing primary inputs from JoinSplit descriptions.
 fn bench_groth16_verify(c: &mut Criterion) {
     let pvk: &'static PreparedVerifyingKey<Bls12> = SPROUT.prepared_verifying_key();
-    let source_items = extract_groth16_items_from_blocks();
+    let sources = extract_joinsplit_sources();
+    let items: Vec<Item> = sources.iter().map(item_from).collect();
 
-    // -- Verification benchmarks --
+    let mut group = c.benchmark_group("groth16_sprout");
 
-    let mut group = c.benchmark_group("Groth16 Verification");
-
-    // Single proof verification: baseline cost of one pairing check.
     group.throughput(Throughput::Elements(1));
-    group.bench_function("single proof", |b| {
-        let item = source_items[0].clone();
+    group.bench_function("single", |b| {
+        let item = items[0].clone();
         b.iter(|| {
             item.clone().verify_single(pvk).expect("valid proof");
         })
     });
 
-    // Multiple proofs verified individually (no batching).
-    // Items are cycled to reach batch sizes larger than the source set.
-    // This measures linear scaling since Zebra does not yet batch Groth16
-    // (see https://github.com/ZcashFoundation/zebra/issues/3127).
+    // Sprout has no batch verifier in Zebra today: every proof is verified
+    // individually in the production path, so this is the cost profile.
     for n in [2, 4, 8, 16, 32, 64] {
-        let items = cycled_items(&source_items, n);
+        let batch = common::cycled(&items, n);
 
         group.throughput(Throughput::Elements(n as u64));
-        group.bench_with_input(
-            BenchmarkId::new("unbatched", n),
-            &items,
-            |b, items: &Vec<Item>| {
-                b.iter(|| {
-                    for item in items.iter() {
-                        item.clone().verify_single(pvk).expect("valid proof");
-                    }
-                })
-            },
-        );
+        group.bench_with_input(BenchmarkId::new("unbatched", n), &batch, |b, batch| {
+            b.iter(|| {
+                for item in batch {
+                    item.clone().verify_single(pvk).expect("valid proof");
+                }
+            })
+        });
     }
 
     group.finish();
-
-    // -- Input preparation benchmarks --
-
-    let mut group = c.benchmark_group("Groth16 Input Preparation");
-
-    for (_height, bytes) in zebra_test::vectors::MAINNET_BLOCKS.iter() {
-        let block: Block = bytes.zcash_deserialize_into().expect("valid block");
-
-        for tx in &block.transactions {
-            let joinsplits: Vec<&JoinSplit<Groth16Proof>> =
-                tx.sprout_groth16_joinsplits().collect();
-
-            if joinsplits.is_empty() {
-                continue;
-            }
-
-            let pub_key = tx
-                .sprout_joinsplit_pub_key()
-                .expect("pub key must exist since there are joinsplits");
-
-            let joinsplit = joinsplits[0];
-
-            // Cost of computing h_sig + encoding primary inputs as BLS12-381 scalars.
-            group.bench_function("primary_inputs", |b| {
-                b.iter(|| {
-                    let description: (&JoinSplit<Groth16Proof>, &_) = (joinsplit, &pub_key);
-                    description.primary_inputs()
-                })
-            });
-
-            // Cost of proof deserialization (Proof::read on 192 bytes) + input computation.
-            group.bench_function("item_creation", |b| {
-                b.iter(|| {
-                    let _item: Item = DescriptionWrapper(&(joinsplit, &pub_key))
-                        .try_into()
-                        .expect("valid groth16 item");
-                })
-            });
-
-            group.finish();
-            return;
-        }
-    }
 }
 
-criterion_group!(benches, bench_groth16_verify);
+fn bench_groth16_inputs(c: &mut Criterion) {
+    let sources = extract_joinsplit_sources();
+    let source = sources.first().expect("at least one JoinSplit source");
+
+    let mut group = c.benchmark_group("groth16_sprout_inputs");
+
+    // Cost of computing h_sig and encoding primary inputs as BLS12-381 scalars.
+    group.bench_function("primary_inputs", |b| {
+        b.iter(|| {
+            let description: (&JoinSplit<Groth16Proof>, &_) = (&source.joinsplit, &source.pub_key);
+            description.primary_inputs()
+        })
+    });
+
+    // Cost of Proof::read (192 bytes) + primary input computation, i.e. the
+    // full Item construction that runs before verification.
+    group.bench_function("item_creation", |b| b.iter(|| item_from(source)));
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().noise_threshold(0.1).sample_size(50);
+    targets = bench_groth16_verify, bench_groth16_inputs
+}
 criterion_main!(benches);

--- a/zebra-consensus/benches/halo2.rs
+++ b/zebra-consensus/benches/halo2.rs
@@ -1,34 +1,35 @@
 //! Benchmarks for Halo2 proof verification (Orchard Actions).
 //!
-//! These benchmarks measure the cost of verifying Halo2 zero-knowledge proofs
-//! used in Orchard Action descriptions. Unlike Groth16 (which uses a pairing
-//! check), Halo2 uses an inner product argument on the Pallas curve. Each
-//! Orchard bundle contains an aggregate proof covering all its actions.
+//! Measures the cost of verifying Halo2 zero-knowledge proofs used in Orchard
+//! Action descriptions. Halo2 uses an inner product argument on the Pallas
+//! curve; each bundle contains an aggregate proof covering all its actions.
 //!
-//! # Test data limitations
+//! # Benchmark group
 //!
-//! The hardcoded NU5 mainnet test blocks contain only a small number of Orchard
-//! transactions. Items are cycled (repeated) to fill larger batch sizes when
-//! needed.
+//! `halo2`: matches the `verifier` label in
+//! `zebra.consensus.batch.duration_seconds` emitted from
+//! `zebra-consensus/src/primitives/halo2.rs`, so a prod regression on the
+//! Halo2 histogram maps to this file by name.
+//!
+//! # Throughput dimension
 //!
 //! Halo2 verification cost scales with the number of actions in the aggregate
-//! proof, not just the number of bundles. The benchmarks report both bundle
-//! count and total action count for context.
+//! proof, not the number of bundles. The benchmark reports throughput in
+//! actions (via [`Throughput::Elements`]) so the dashboard shows
+//! time-per-action — the unit that actually matters for capacity planning.
 //!
-//! Since we reuse the same bundles, cache effects and memory access patterns
-//! may differ from a real workload with unique proofs.
+//! # Batching
 //!
-//! # Batched vs unbatched
-//!
-//! The `orchard::bundle::BatchValidator` supports true batch verification, but
-//! `Item`'s internal fields are private, so the benchmark can only exercise
-//! `verify_single()` (which creates a one-item batch internally). This still
-//! measures the dominant cost — the Halo2 proof verification itself — and
-//! provides a useful baseline. To benchmark cross-bundle batching, a public
-//! batch API would need to be exposed on `Item`.
+//! `orchard::bundle::BatchValidator` supports cross-bundle batching, but
+//! [`Item`]'s internal fields are private, so this benchmark can only
+//! exercise `verify_single()` (a one-item batch). That still captures the
+//! dominant cost; exposing a public batch API on `Item` would unlock a
+//! cross-bundle variant analogous to the Sapling bench.
 
 // Disabled due to warnings in criterion macros
 #![allow(missing_docs)]
+
+mod common;
 
 use std::sync::Arc;
 
@@ -44,17 +45,10 @@ use zebra_consensus::halo2::{Item, VERIFYING_KEY};
 /// Extracts valid Halo2 items (Orchard bundles + sighashes) from NU5+ mainnet
 /// test blocks.
 ///
-/// Iterates over `MAINNET_BLOCKS`, deserializes each block, and for each V5
-/// transaction with Orchard shielded data, converts it to a librustzcash
-/// representation to extract the `orchard::bundle::Bundle` and compute the
-/// transaction sighash.
-///
 /// Transactions with transparent inputs are skipped because computing their
 /// sighash requires the previous outputs they spend, which are not available
 /// in the test vectors. Orchard-only and Sapling-to-Orchard transactions
 /// work with an empty previous outputs set.
-///
-/// Returns a small set of real, valid Halo2 items from current test vectors.
 fn extract_halo2_items_from_blocks() -> Vec<Item> {
     let mut items = Vec::new();
 
@@ -66,23 +60,18 @@ fn extract_halo2_items_from_blocks() -> Vec<Item> {
                 continue;
             }
 
-            // Skip transactions with transparent inputs: we don't have their
-            // previous outputs in the test vectors, so we can't compute the
-            // sighash correctly.
             if !tx.inputs().is_empty() {
                 continue;
             }
 
             let all_previous_outputs: Arc<Vec<transparent::Output>> = Arc::new(Vec::new());
 
-            let sighasher = match tx.sighasher(NetworkUpgrade::Nu5, all_previous_outputs) {
-                Ok(s) => s,
-                Err(_) => continue,
+            let Ok(sighasher) = tx.sighasher(NetworkUpgrade::Nu5, all_previous_outputs) else {
+                continue;
             };
 
-            let bundle = match sighasher.orchard_bundle() {
-                Some(b) => b,
-                None => continue,
+            let Some(bundle) = sighasher.orchard_bundle() else {
+                continue;
             };
 
             let sighash = sighasher.sighash(zebra_chain::transaction::HashType::ALL, None);
@@ -99,48 +88,34 @@ fn extract_halo2_items_from_blocks() -> Vec<Item> {
     items
 }
 
-/// Creates a batch of `n` items by cycling through the source items.
-///
-/// Halo2 verification cost depends on the number of actions in each bundle's
-/// aggregate proof. Cycling reuses the same proof structures, so the per-action
-/// cost is representative but cache effects are not.
-fn cycled_items(source: &[Item], n: usize) -> Vec<Item> {
-    source.iter().cycle().take(n).cloned().collect()
-}
-
-/// Benchmarks Halo2 proof verification at various batch sizes.
-///
-/// Each call to `verify_single` internally creates a `BatchValidator` with one
-/// item and runs the full verification circuit. This is the per-bundle cost and
-/// matches the fallback path used when batch verification fails in production.
 fn bench_halo2_verify(c: &mut Criterion) {
     let vk = &*VERIFYING_KEY;
     let source_items = extract_halo2_items_from_blocks();
 
-    let mut group = c.benchmark_group("Halo2 Verification");
+    let mut group = c.benchmark_group("halo2");
 
-    // Single bundle verification.
-    group.throughput(Throughput::Elements(1));
-    group.bench_function("single bundle", |b| {
+    group.throughput(Throughput::Elements(source_items[0].request_weight() as u64));
+    group.bench_function("single", |b| {
         let item = source_items[0].clone();
         b.iter(|| {
             assert!(item.clone().verify_single(vk));
         })
     });
 
-    // Multiple bundles verified individually (no cross-bundle batching).
-    // Each call to verify_single creates its own BatchValidator.
+    // Unbatched verification across N bundles: each call creates its own
+    // one-item BatchValidator. Reports throughput in total actions so the
+    // dashboard series is stable across test-vector changes.
     for n in [2, 4, 8, 16, 32] {
-        let items = cycled_items(&source_items, n);
-        let total_actions: usize = items.iter().map(|i| i.request_weight()).sum();
+        let items = common::cycled(&source_items, n);
+        let total_actions: u64 = items.iter().map(|i| i.request_weight() as u64).sum();
 
-        group.throughput(Throughput::Elements(n as u64));
+        group.throughput(Throughput::Elements(total_actions));
         group.bench_with_input(
-            BenchmarkId::new(format!("unbatched ({total_actions} actions)"), n),
+            BenchmarkId::new("unbatched", n),
             &items,
             |b, items: &Vec<Item>| {
                 b.iter(|| {
-                    for item in items.iter() {
+                    for item in items {
                         assert!(item.clone().verify_single(vk));
                     }
                 })
@@ -151,5 +126,9 @@ fn bench_halo2_verify(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_halo2_verify);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().noise_threshold(0.1).sample_size(50);
+    targets = bench_halo2_verify
+}
 criterion_main!(benches);

--- a/zebra-consensus/benches/halo2.rs
+++ b/zebra-consensus/benches/halo2.rs
@@ -22,9 +22,7 @@
 //!
 //! `orchard::bundle::BatchValidator` supports cross-bundle batching, but
 //! [`Item`]'s internal fields are private, so this benchmark can only
-//! exercise `verify_single()` (a one-item batch). That still captures the
-//! dominant cost; exposing a public batch API on `Item` would unlock a
-//! cross-bundle variant analogous to the Sapling bench.
+//! exercise `verify_single()` (a one-item batch).
 
 // Disabled due to warnings in criterion macros
 #![allow(missing_docs)]
@@ -102,11 +100,10 @@ fn bench_halo2_verify(c: &mut Criterion) {
         })
     });
 
-    // Unbatched verification across N bundles: each call creates its own
-    // one-item BatchValidator. Reports throughput in total actions so the
-    // dashboard series is stable across test-vector changes.
     for n in [2, 4, 8, 16, 32] {
         let items = common::cycled(&source_items, n);
+        // Scale throughput by total actions, not bundles, so the dashboard
+        // series stays stable across test-vector changes.
         let total_actions: u64 = items.iter().map(|i| i.request_weight() as u64).sum();
 
         group.throughput(Throughput::Elements(total_actions));

--- a/zebra-consensus/benches/halo2.rs
+++ b/zebra-consensus/benches/halo2.rs
@@ -95,7 +95,7 @@ fn bench_halo2_verify(c: &mut Criterion) {
     let mut group = c.benchmark_group("halo2");
 
     group.throughput(Throughput::Elements(source_items[0].request_weight() as u64));
-    group.bench_function("single", |b| {
+    group.bench_function("single bundle", |b| {
         let item = source_items[0].clone();
         b.iter(|| {
             assert!(item.clone().verify_single(vk));

--- a/zebra-consensus/benches/sapling.rs
+++ b/zebra-consensus/benches/sapling.rs
@@ -1,28 +1,33 @@
 //! Benchmarks for Sapling proof and signature verification.
 //!
-//! These benchmarks measure the cost of verifying Sapling shielded transaction
-//! data, which includes Groth16 spend/output proofs and binding/spend-auth
-//! signatures. Sapling verification uses `sapling_crypto::BatchValidator`, which
-//! supports true batch verification across multiple bundles.
+//! Measures the cost of verifying Sapling shielded transaction data: Groth16
+//! spend/output proofs plus binding/spend-auth signatures. Uses
+//! `sapling_crypto::BatchValidator` directly, which supports true batch
+//! verification across bundles.
 //!
-//! # Test data limitations
+//! # Benchmark group
 //!
-//! The hardcoded mainnet test blocks contain only a small number of Sapling
-//! transactions. Items are cycled (repeated) to fill larger batch sizes.
-//!
-//! Sapling verification cost depends on the number of spends and outputs in each
-//! bundle. Cycling reuses the same bundles, so per-bundle cost is representative
-//! but cache effects may differ from a real workload with unique proofs.
+//! `groth16_sapling`: matches the `verifier` label in
+//! `zebra.consensus.batch.duration_seconds` emitted from
+//! `zebra-consensus/src/primitives/sapling.rs`, so a prod regression on the
+//! Sapling histogram maps to this file by name.
 //!
 //! # Batched vs unbatched
 //!
-//! Unlike the Halo2 benchmark, this benchmark can exercise true batch
-//! verification because we call `sapling_crypto::BatchValidator` directly with
-//! the public verifying keys. This measures the actual production verification
-//! path, including the speedup from batching multiple bundles together.
+//! Unlike the Halo2 bench, this file can exercise true batch verification
+//! because `sapling_crypto::BatchValidator` is public. The `batched` series
+//! is the production path; the `unbatched` series is the fallback taken when
+//! a batch fails verification and items are re-verified individually.
+//!
+//! # Test data limitations
+//!
+//! Bundles are cycled from the small set in `zebra-test`, so cache effects
+//! are not representative of a real workload with unique inputs.
 
 // Disabled due to warnings in criterion macros
 #![allow(missing_docs)]
+
+mod common;
 
 use std::sync::Arc;
 
@@ -50,15 +55,8 @@ struct SaplingItem {
 
 /// Extracts valid Sapling bundles and sighashes from mainnet test blocks.
 ///
-/// Iterates over `MAINNET_BLOCKS`, deserializes each block, and for each
-/// transaction with Sapling shielded data, converts it to a librustzcash
-/// representation to extract the `sapling_crypto::Bundle` and compute the
-/// sighash.
-///
 /// Transactions with transparent inputs are skipped because their sighash
 /// computation requires previous outputs not available in the test vectors.
-///
-/// Returns a small set of real, valid Sapling items from current test vectors.
 fn extract_sapling_items_from_blocks() -> Vec<SaplingItem> {
     let mut items = Vec::new();
 
@@ -73,8 +71,6 @@ fn extract_sapling_items_from_blocks() -> Vec<SaplingItem> {
                 continue;
             }
 
-            // Skip transactions with transparent inputs: we don't have their
-            // previous outputs in the test vectors.
             if !tx.inputs().is_empty() {
                 continue;
             }
@@ -85,14 +81,12 @@ fn extract_sapling_items_from_blocks() -> Vec<SaplingItem> {
 
             let all_previous_outputs: Arc<Vec<transparent::Output>> = Arc::new(Vec::new());
 
-            let sighasher = match tx.sighasher(nu, all_previous_outputs) {
-                Ok(s) => s,
-                Err(_) => continue,
+            let Ok(sighasher) = tx.sighasher(nu, all_previous_outputs) else {
+                continue;
             };
 
-            let bundle = match sighasher.sapling_bundle() {
-                Some(b) => b,
-                None => continue,
+            let Some(bundle) = sighasher.sapling_bundle() else {
+                continue;
             };
 
             let sighash = sighasher.sighash(HashType::ALL, None);
@@ -109,27 +103,14 @@ fn extract_sapling_items_from_blocks() -> Vec<SaplingItem> {
     items
 }
 
-/// Creates a batch of `n` items by cycling through the source items.
-///
-/// Sapling verification cost depends on the number of spends and outputs in
-/// each bundle. Cycling reuses the same proof structures, so per-bundle cost
-/// is representative but cache effects are not.
-fn cycled_items(source: &[SaplingItem], n: usize) -> Vec<SaplingItem> {
-    source.iter().cycle().take(n).cloned().collect()
-}
-
-/// Benchmarks Sapling proof verification at various batch sizes, comparing
-/// single verification (one-item batches) against true batch verification
-/// (multiple bundles validated together).
 fn bench_sapling_verify(c: &mut Criterion) {
     let (spend_vk, output_vk) = SAPLING.verifying_keys();
     let source_items = extract_sapling_items_from_blocks();
 
-    let mut group = c.benchmark_group("Sapling Verification");
+    let mut group = c.benchmark_group("groth16_sapling");
 
-    // Single bundle verification: creates a BatchValidator with one item.
     group.throughput(Throughput::Elements(1));
-    group.bench_function("single bundle", |b| {
+    group.bench_function("single", |b| {
         let item = source_items[0].clone();
         b.iter(|| {
             let mut batch = BatchValidator::default();
@@ -138,9 +119,10 @@ fn bench_sapling_verify(c: &mut Criterion) {
         })
     });
 
-    // Multiple bundles verified individually (one-item batch per bundle).
+    // Unbatched: one BatchValidator per bundle. This is the fallback path
+    // used when a batch fails and items are re-verified individually.
     for n in [2, 4, 8, 16, 32, 64] {
-        let items = cycled_items(&source_items, n);
+        let items = common::cycled(&source_items, n);
 
         group.throughput(Throughput::Elements(n as u64));
         group.bench_with_input(
@@ -148,7 +130,7 @@ fn bench_sapling_verify(c: &mut Criterion) {
             &items,
             |b, items: &Vec<SaplingItem>| {
                 b.iter(|| {
-                    for item in items.iter() {
+                    for item in items {
                         let mut batch = BatchValidator::default();
                         assert!(batch.check_bundle(item.bundle.clone(), item.sighash.into()));
                         assert!(batch.validate(&spend_vk, &output_vk, thread_rng()));
@@ -158,11 +140,10 @@ fn bench_sapling_verify(c: &mut Criterion) {
         );
     }
 
-    // True batch verification: all bundles in a single BatchValidator.
-    // This is the production path — bundles are accumulated and validated
-    // together, amortizing the cost of the final multi-scalar multiplication.
+    // Batched: all bundles in one BatchValidator, amortizing the final
+    // multi-scalar multiplication. This is the production path.
     for n in [2, 4, 8, 16, 32, 64] {
-        let items = cycled_items(&source_items, n);
+        let items = common::cycled(&source_items, n);
 
         group.throughput(Throughput::Elements(n as u64));
         group.bench_with_input(
@@ -171,7 +152,7 @@ fn bench_sapling_verify(c: &mut Criterion) {
             |b, items: &Vec<SaplingItem>| {
                 b.iter(|| {
                     let mut batch = BatchValidator::default();
-                    for item in items.iter() {
+                    for item in items {
                         assert!(batch.check_bundle(item.bundle.clone(), item.sighash.into()));
                     }
                     assert!(batch.validate(&spend_vk, &output_vk, thread_rng()));
@@ -183,5 +164,9 @@ fn bench_sapling_verify(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_sapling_verify);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().noise_threshold(0.1).sample_size(50);
+    targets = bench_sapling_verify
+}
 criterion_main!(benches);

--- a/zebra-consensus/benches/sapling.rs
+++ b/zebra-consensus/benches/sapling.rs
@@ -14,15 +14,9 @@
 //!
 //! # Batched vs unbatched
 //!
-//! Unlike the Halo2 bench, this file can exercise true batch verification
-//! because `sapling_crypto::BatchValidator` is public. The `batched` series
-//! is the production path; the `unbatched` series is the fallback taken when
-//! a batch fails verification and items are re-verified individually.
-//!
-//! # Test data limitations
-//!
-//! Bundles are cycled from the small set in `zebra-test`, so cache effects
-//! are not representative of a real workload with unique inputs.
+//! The `batched` series is the production path; the `unbatched` series is
+//! the fallback taken when a batch fails verification and items are
+//! re-verified individually.
 
 // Disabled due to warnings in criterion macros
 #![allow(missing_docs)]
@@ -119,8 +113,6 @@ fn bench_sapling_verify(c: &mut Criterion) {
         })
     });
 
-    // Unbatched: one BatchValidator per bundle. This is the fallback path
-    // used when a batch fails and items are re-verified individually.
     for n in [2, 4, 8, 16, 32, 64] {
         let items = common::cycled(&source_items, n);
 
@@ -140,8 +132,8 @@ fn bench_sapling_verify(c: &mut Criterion) {
         );
     }
 
-    // Batched: all bundles in one BatchValidator, amortizing the final
-    // multi-scalar multiplication. This is the production path.
+    // All bundles share one BatchValidator, amortizing the final
+    // multi-scalar multiplication.
     for n in [2, 4, 8, 16, 32, 64] {
         let items = common::cycled(&source_items, n);
 

--- a/zebra-consensus/benches/sapling.rs
+++ b/zebra-consensus/benches/sapling.rs
@@ -110,7 +110,7 @@ fn bench_sapling_verify(c: &mut Criterion) {
     let mut group = c.benchmark_group("groth16_sapling");
 
     group.throughput(Throughput::Elements(1));
-    group.bench_function("single", |b| {
+    group.bench_function("single bundle", |b| {
         let item = source_items[0].clone();
         b.iter(|| {
             let mut batch = BatchValidator::default();


### PR DESCRIPTION
Follow-up to #10444.

## Changes

**Benches**
- Group names match the `verifier` histogram labels on `zebra.consensus.batch.duration_seconds` where one exists: `groth16_sapling`, `halo2`, `redpallas`. Sprout has no batch verifier and no prod label, so its groups (`Groth16 Verification`, `Groth16 Input Preparation`) keep their original names.
- `halo2.rs` uses a fixed `BenchmarkId` and scales `Throughput::Elements` by total actions, so gh-pages series and `critcmp` survive test-vector changes.
- Shared `cycled` helper in `benches/common.rs` replaces three local copies; `autobenches = false` in `zebra-consensus` gates the helper file.
- `groth16.rs` split into verify and input-prep benches.
- Criterion noise threshold raised to 10% to match Ubuntu CI variance.

**Workflows**
- Shared `BENCHES` list across both jobs in `benchmarks.yml`.
- `book.yml` dashboard include: explicit "not ready yet" vs atomicity-violation paths instead of a silent-failure chain.
- CodeQL findings: dropped `deployments: write`, sanitized branch refs before markdown rendering.

## Verification

`cargo fmt`, `cargo clippy --benches -D warnings`, `cargo bench --no-run` on all six benches.

### AI Disclosure

- [x] Claude drafted the patch and PR body; I reviewed and ran verification.

### PR Checklist

- [x] PR name suitable for release notes
- [x] Follows contribution guidelines
- [x] Discussed with team (follow-up to #10444)
- [x] Solution is tested
- [x] Docs and changelogs up to date