### PR TITLE
refactor(benches): roll back non-prod-label bench renames

### DIFF
--- a/zebra-chain/benches/redpallas.rs
+++ b/zebra-chain/benches/redpallas.rs
@@ -71,45 +71,57 @@ fn bench_batch_verify(c: &mut Criterion) {
 
         let sigs = sigs_with_distinct_keys().take(n).collect::<Vec<_>>();
 
-        group.bench_with_input(BenchmarkId::new("unbatched", n), &sigs, |b, sigs| {
-            b.iter(|| {
-                for item in sigs.iter() {
-                    match item {
-                        Item::SpendAuth { vk_bytes, sig } => {
-                            assert!(VerificationKey::try_from(*vk_bytes)
-                                .and_then(|vk| vk.verify(MESSAGE_BYTES, sig))
-                                .is_ok());
-                        }
-                        Item::Binding { vk_bytes, sig } => {
-                            assert!(VerificationKey::try_from(*vk_bytes)
-                                .and_then(|vk| vk.verify(MESSAGE_BYTES, sig))
-                                .is_ok());
+        group.bench_with_input(
+            BenchmarkId::new("Unbatched verification", n),
+            &sigs,
+            |b, sigs| {
+                b.iter(|| {
+                    for item in sigs.iter() {
+                        match item {
+                            Item::SpendAuth { vk_bytes, sig } => {
+                                assert!(VerificationKey::try_from(*vk_bytes)
+                                    .and_then(|vk| vk.verify(MESSAGE_BYTES, sig))
+                                    .is_ok());
+                            }
+                            Item::Binding { vk_bytes, sig } => {
+                                assert!(VerificationKey::try_from(*vk_bytes)
+                                    .and_then(|vk| vk.verify(MESSAGE_BYTES, sig))
+                                    .is_ok());
+                            }
                         }
                     }
-                }
-            })
-        });
+                })
+            },
+        );
 
-        group.bench_with_input(BenchmarkId::new("batched", n), &sigs, |b, sigs| {
-            b.iter(|| {
-                let mut batch = batch::Verifier::new();
-                for item in sigs.iter() {
-                    match item {
-                        Item::SpendAuth { vk_bytes, sig } => {
-                            batch.queue(batch::Item::from_spendauth(
-                                *vk_bytes,
-                                *sig,
-                                MESSAGE_BYTES,
-                            ));
-                        }
-                        Item::Binding { vk_bytes, sig } => {
-                            batch.queue(batch::Item::from_binding(*vk_bytes, *sig, MESSAGE_BYTES));
+        group.bench_with_input(
+            BenchmarkId::new("Batched verification", n),
+            &sigs,
+            |b, sigs| {
+                b.iter(|| {
+                    let mut batch = batch::Verifier::new();
+                    for item in sigs.iter() {
+                        match item {
+                            Item::SpendAuth { vk_bytes, sig } => {
+                                batch.queue(batch::Item::from_spendauth(
+                                    *vk_bytes,
+                                    *sig,
+                                    MESSAGE_BYTES,
+                                ));
+                            }
+                            Item::Binding { vk_bytes, sig } => {
+                                batch.queue(batch::Item::from_binding(
+                                    *vk_bytes,
+                                    *sig,
+                                    MESSAGE_BYTES,
+                                ));
+                            }
                         }
                     }
-                }
-                assert!(batch.verify(thread_rng()).is_ok())
-            })
-        });
+                    assert!(batch.verify(thread_rng()).is_ok())
+                })
+            },
+        );
     }
     group.finish();
 }

--- a/zebra-chain/benches/transaction.rs
+++ b/zebra-chain/benches/transaction.rs
@@ -41,7 +41,7 @@ fn first_tx_of_version(block: &Block, version: u32) -> Option<Vec<u8>> {
 }
 
 fn bench_transaction_deserialize(c: &mut Criterion) {
-    let mut group = c.benchmark_group("transaction_deserialize");
+    let mut group = c.benchmark_group("Transaction Deserialization");
 
     // Collect (label, serialized_tx_bytes) pairs for each version.
     let mut tx_samples: Vec<(&str, Vec<u8>)> = Vec::new();
@@ -93,19 +93,21 @@ fn bench_transaction_deserialize(c: &mut Criterion) {
     }
 
     for (label, tx_bytes) in &tx_samples {
-        group.bench_with_input(BenchmarkId::from_parameter(*label), tx_bytes, |b, bytes| {
-            b.iter(|| Transaction::zcash_deserialize(Cursor::new(bytes)).unwrap())
-        });
+        group.bench_with_input(
+            BenchmarkId::new("deserialize", label),
+            tx_bytes,
+            |b, bytes| b.iter(|| Transaction::zcash_deserialize(Cursor::new(bytes)).unwrap()),
+        );
     }
 
     group.finish();
 
-    let mut group = c.benchmark_group("transaction_serialize");
+    let mut group = c.benchmark_group("Transaction Serialization");
 
     for (label, tx_bytes) in &tx_samples {
         let tx = Transaction::zcash_deserialize(Cursor::new(tx_bytes)).unwrap();
 
-        group.bench_with_input(BenchmarkId::from_parameter(*label), &tx, |b, tx| {
+        group.bench_with_input(BenchmarkId::new("serialize", label), &tx, |b, tx| {
             b.iter(|| tx.zcash_serialize_to_vec().unwrap())
         });
     }

--- a/zebra-consensus/benches/groth16.rs
+++ b/zebra-consensus/benches/groth16.rs
@@ -1,20 +1,9 @@
 //! Benchmarks for Groth16 proof verification (Sprout JoinSplits).
 //!
-//! Measures the cost of verifying Groth16 zero-knowledge proofs used in Sprout
-//! JoinSplit descriptions. Groth16 verification is a pairing check on BLS12-381,
-//! making it one of the most expensive per-proof operations during chain sync.
-//!
-//! # Benchmark groups
-//!
-//! - `joinsplit`: per-proof verification (mirrors `JOINSPLIT_VERIFIER`).
-//! - `joinsplit_inputs`: primary input preparation cost.
-//!
-//! # Test data limitations
-//!
-//! The hardcoded mainnet test blocks in `zebra-test` contain only a small
-//! number of Groth16 JoinSplits. Items are cycled to fill larger batches;
-//! Groth16 cost is constant per proof so this is valid for per-item
-//! throughput measurements, but cache/memory effects are not representative.
+//! Groth16 verification is a pairing check on BLS12-381. Sprout has no batch
+//! verifier in Zebra; each proof is verified individually, so the only
+//! throughput dimension is per-proof cost. Test vectors contain few
+//! JoinSplits, so items are cycled to fill larger sizes.
 
 // Disabled due to warnings in criterion macros
 #![allow(missing_docs)]
@@ -94,10 +83,10 @@ fn bench_groth16_verify(c: &mut Criterion) {
     let sources = extract_joinsplit_sources();
     let items: Vec<Item> = sources.iter().map(item_from).collect();
 
-    let mut group = c.benchmark_group("joinsplit");
+    let mut group = c.benchmark_group("Groth16 Verification");
 
     group.throughput(Throughput::Elements(1));
-    group.bench_function("single", |b| {
+    group.bench_function("single proof", |b| {
         let item = items[0].clone();
         b.iter(|| {
             item.clone().verify_single(pvk).expect("valid proof");
@@ -126,7 +115,7 @@ fn bench_groth16_inputs(c: &mut Criterion) {
     let sources = extract_joinsplit_sources();
     let source = sources.first().expect("at least one JoinSplit source");
 
-    let mut group = c.benchmark_group("joinsplit_inputs");
+    let mut group = c.benchmark_group("Groth16 Input Preparation");
 
     // Cost of computing h_sig and encoding primary inputs as BLS12-381 scalars.
     group.bench_function("primary_inputs", |b| {

--- a/zebra-consensus/benches/halo2.rs
+++ b/zebra-consensus/benches/halo2.rs
@@ -95,7 +95,7 @@ fn bench_halo2_verify(c: &mut Criterion) {
     let mut group = c.benchmark_group("halo2");
 
     group.throughput(Throughput::Elements(source_items[0].request_weight() as u64));
-    group.bench_function("single", |b| {
+    group.bench_function("single bundle", |b| {
         let item = source_items[0].clone();
         b.iter(|| {
             assert!(item.clone().verify_single(vk));

--- a/zebra-consensus/benches/sapling.rs
+++ b/zebra-consensus/benches/sapling.rs
@@ -110,7 +110,7 @@ fn bench_sapling_verify(c: &mut Criterion) {
     let mut group = c.benchmark_group("groth16_sapling");
 
     group.throughput(Throughput::Elements(1));
-    group.bench_function("single", |b| {
+    group.bench_function("single bundle", |b| {
         let item = source_items[0].clone();
         b.iter(|| {
             let mut batch = BatchValidator::default();


### PR DESCRIPTION
Follow-up to #10501. Rolls back the bench renames that had no anchor in the `zebra.consensus.batch.duration_seconds{verifier=...}` prod histogram, so `critcmp` and the gh-pages time series keep row-for-row alignment with prior baselines.

## What stays renamed

Only the three group names that match a real `verifier` label in the histogram emitted by `zebra-consensus/src/primitives/*.rs`:

- `groth16_sapling`
- `halo2`
- `redpallas`

A regression on any of those histogram series now maps to a bench file by name.

## What reverts

- `groth16.rs`: `joinsplit` / `joinsplit_inputs` → `Groth16 Verification` / `Groth16 Input Preparation`; `single` → `single proof`. Sprout has no batch verifier and no prod histogram label, so the rename had nothing to anchor against.
- `transaction.rs`: `transaction_deserialize` / `transaction_serialize` → `Transaction Deserialization` / `Transaction Serialization`. `BenchmarkId::from_parameter` reverts to `BenchmarkId::new(\"deserialize\" | \"serialize\", label)`.
- `redpallas.rs`: IDs `unbatched` / `batched` → `Unbatched verification` / `Batched verification`. Group name (`redpallas`) stays.
- `sapling.rs` / `halo2.rs`: `single` → `single bundle`. Group names (`groth16_sapling`, `halo2`) stay.

## What is preserved from #10501

- Workflow hardening in `.github/workflows/benchmarks.yml` and `.github/workflows/book.yml`.
- `zebra-consensus/benches/common.rs` shared helper.
- The `halo2` stability fix: fixed `BenchmarkId` + `Throughput::Elements` scaled by total actions. That is a correctness fix, independent of naming.

## Rationale

The first PR that renames bench groups pays a one-time cost in `critcmp` because rows match on exact `group/id` strings. Paying that cost is worth it when the new name is grounded in something load-bearing (a prod histogram label). Paying it for cosmetic consistency alone turns every future comparison into partial row coverage and breaks the gh-pages history.

## Validation

- `cargo fmt --all -- --check`
- `cargo bench --no-run -p zebra-consensus --bench {groth16,halo2,sapling}`
- `cargo bench --no-run -p zebra-chain --bench {transaction,redpallas}`
- `cargo clippy -p zebra-consensus --benches -- -D warnings`
- `cargo clippy -p zebra-chain --benches --features bench -- -D warnings`

## AI disclosure

Used Claude Code to draft the rollback and this description.