### PR TITLE
fix(ci): cargo-vet after release

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ on:
       - clippy.toml
       - .cargo/config.toml
       - .github/workflows/lint.yml
+      - supply-chain/**
 
   push:
     branches: [main]
@@ -20,6 +21,7 @@ on:
       - clippy.toml
       - .cargo/config.toml
       - .github/workflows/lint.yml
+      - supply-chain/**
 
 # Ensures that only one workflow task will run at a time. Previous builds, if
 # already in process, will get cancelled. Only the latest commit will be allowed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4904,9 +4904,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,7 @@ ignore = [
     "RUSTSEC-2024-0370", # proc-macro-error — transitive via abscissa_core -> structopt
     "RUSTSEC-2025-0119", # number_prefix — transitive via indicatif
     "RUSTSEC-2025-0141", # bincode — direct dependency
+    "RUSTSEC-2026-0105", # core2 — unmaintained, transitive via zcash crates, waiting on upstream corez migration
 ]
 
 # This section is considered when running `cargo deny check licenses`.

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -371,11 +371,6 @@ who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.8.4 -> 0.8.5"
 
-[[audits.rustls-webpki]]
-who = "Alfredo Garcia <alfredo@zfnd.org>"
-criteria = "safe-to-deploy"
-delta = "0.103.10 -> 0.103.12"
-
 [[audits.rlimit]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
@@ -385,6 +380,11 @@ delta = "0.10.1 -> 0.10.2"
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.38.34 -> 0.38.37"
+
+[[audits.rustls-webpki]]
+who = "Alfredo Garcia <alfredo@zfnd.org>"
+criteria = "safe-to-deploy"
+delta = "0.103.10 -> 0.103.12"
 
 [[audits.sapling-crypto]]
 who = "Alfredo Garcia <oxarbitrage@gmail.com>"
@@ -826,19 +826,19 @@ importable = false
 
 [[trusted.clap]]
 criteria = "safe-to-deploy"
-user-id = 6743 # Ed Page (epage)
+user-id = 6743
 start = "2021-12-08"
 end = "2025-07-09"
 
 [[trusted.clap_builder]]
 criteria = "safe-to-deploy"
-user-id = 6743 # Ed Page (epage)
+user-id = 6743
 start = "2023-03-28"
 end = "2025-07-09"
 
 [[trusted.clap_derive]]
 criteria = "safe-to-deploy"
-user-id = 6743 # Ed Page (epage)
+user-id = 6743
 start = "2021-12-08"
 end = "2025-07-09"
 
@@ -856,6 +856,6 @@ end = "2025-07-09"
 
 [[trusted.tokio]]
 criteria = "safe-to-deploy"
-user-id = 6741 # Alice Ryhl (Darksonn)
+user-id = 6741
 start = "2020-12-25"
 end = "2025-07-29"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -2253,7 +2253,7 @@ version = "0.7.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_script]]
-version = "0.4.2"
+version = "0.4.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_spec]]
@@ -2261,19 +2261,19 @@ version = "0.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_transparent]]
-version = "0.6.3"
+version = "0.6.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-chain]]
-version = "6.0.1"
+version = "6.0.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-consensus]]
-version = "5.0.1"
+version = "5.0.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-network]]
-version = "5.0.0"
+version = "5.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-node-services]]
@@ -2281,11 +2281,11 @@ version = "4.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-rpc]]
-version = "6.0.1"
+version = "6.0.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-script]]
-version = "5.0.0"
+version = "5.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-state]]
@@ -2301,7 +2301,7 @@ version = "5.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebrad]]
-version = "4.3.0"
+version = "4.3.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -504,12 +504,6 @@ criteria = "safe-to-deploy"
 version = "0.9.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.dunce]]
-version = "1.0.5"
-criteria = "safe-to-deploy"
-suggest = false
-notes = "Sentry 0.47 upgrade"
-
 [[exemptions.dyn-clone]]
 version = "1.0.19"
 criteria = "safe-to-deploy"
@@ -642,10 +636,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.getrandom]]
 version = "0.2.17"
-criteria = "safe-to-deploy"
-
-[[exemptions.getrandom]]
-version = "0.4.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.getset]]
@@ -835,12 +825,6 @@ criteria = "safe-to-deploy"
 [[exemptions.itoa]]
 version = "1.0.17"
 criteria = "safe-to-deploy"
-
-[[exemptions.jni]]
-version = "0.21.1"
-criteria = "safe-to-deploy"
-suggest = false
-notes = "Sentry 0.47 upgrade"
 
 [[exemptions.jni-sys]]
 version = "0.3.1"
@@ -1350,10 +1334,6 @@ criteria = "safe-to-deploy"
 version = "0.2.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.rand_xorshift]]
-version = "0.4.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.rand_xoshiro]]
 version = "0.7.0"
 criteria = "safe-to-deploy"
@@ -1482,12 +1462,6 @@ notes = "Sentry 0.47 upgrade"
 version = "0.103.10"
 criteria = "safe-to-deploy"
 
-[[exemptions.rustls-webpki]]
-version = "0.103.12"
-criteria = "safe-to-deploy"
-suggest = false
-notes = "Sentry 0.47 upgrade"
-
 [[exemptions.rusty-fork]]
 version = "0.3.1"
 criteria = "safe-to-deploy"
@@ -1553,18 +1527,10 @@ version = "1.0.27"
 criteria = "safe-to-deploy"
 
 [[exemptions.sentry]]
-version = "0.40.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.sentry]]
 version = "0.47.0"
 criteria = "safe-to-deploy"
 suggest = false
 notes = "Sentry 0.47 upgrade"
-
-[[exemptions.sentry-backtrace]]
-version = "0.40.0"
-criteria = "safe-to-deploy"
 
 [[exemptions.sentry-backtrace]]
 version = "0.47.0"
@@ -1573,18 +1539,10 @@ suggest = false
 notes = "Sentry 0.47 upgrade"
 
 [[exemptions.sentry-contexts]]
-version = "0.40.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.sentry-contexts]]
 version = "0.47.0"
 criteria = "safe-to-deploy"
 suggest = false
 notes = "Sentry 0.47 upgrade"
-
-[[exemptions.sentry-core]]
-version = "0.40.0"
-criteria = "safe-to-deploy"
 
 [[exemptions.sentry-core]]
 version = "0.47.0"
@@ -1599,18 +1557,10 @@ suggest = false
 notes = "Sentry 0.47 upgrade"
 
 [[exemptions.sentry-tracing]]
-version = "0.40.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.sentry-tracing]]
 version = "0.47.0"
 criteria = "safe-to-deploy"
 suggest = false
 notes = "Sentry 0.47 upgrade"
-
-[[exemptions.sentry-types]]
-version = "0.40.0"
-criteria = "safe-to-deploy"
 
 [[exemptions.sentry-types]]
 version = "0.47.0"
@@ -1922,10 +1872,6 @@ criteria = "safe-to-deploy"
 version = "0.9.5"
 criteria = "safe-to-deploy"
 
-[[exemptions.unarray]]
-version = "0.1.4"
-criteria = "safe-to-deploy"
-
 [[exemptions.unicase]]
 version = "2.9.0"
 criteria = "safe-to-deploy"
@@ -1971,10 +1917,6 @@ version = "2.5.0"
 criteria = "safe-to-deploy"
 suggest = false
 notes = "Sentry 0.47 upgrade"
-
-[[exemptions.walkdir]]
-version = "2.5.0"
-criteria = "safe-to-run"
 
 [[exemptions.wasi]]
 version = "0.9.0+wasi-snapshot-preview1"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1459,7 +1459,7 @@ suggest = false
 notes = "Sentry 0.47 upgrade"
 
 [[exemptions.rustls-webpki]]
-version = "0.103.10"
+version = "0.103.13"
 criteria = "safe-to-deploy"
 
 [[exemptions.rusty-fork]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -374,6 +374,12 @@ criteria = "safe-to-deploy"
 delta = "2.1.1 -> 2.3.0"
 notes = "Minor refactoring, nothing new."
 
+[[audits.bytecode-alliance.audits.getrandom]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.1 -> 0.4.2"
+notes = "Nothing awry in this update, standard updates for some platforms and other misc things."
+
 [[audits.bytecode-alliance.audits.gimli]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -614,6 +620,12 @@ who = "Chris Fallin <chris@cfallin.org>"
 criteria = "safe-to-deploy"
 version = "1.0.4"
 
+[[audits.bytecode-alliance.audits.rand_xorshift]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.0 -> 0.4.0"
+notes = "Minor updates for a new `rand` crate version, nothing awry."
+
 [[audits.bytecode-alliance.audits.sha1]]
 who = "Andrew Brown <andrew.brown@intel.com>"
 criteria = "safe-to-deploy"
@@ -685,6 +697,15 @@ who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "0.2.4"
 notes = "Implements a concurrency primitive with atomics, and is not obviously incorrect"
+
+[[audits.bytecode-alliance.audits.unarray]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.1.4"
+notes = """
+Crate is sound, albeit leaky, and not actively malicious. Probably not the best
+crate to use in practice but it's suitable for testing dependencies.
+"""
 
 [[audits.bytecode-alliance.audits.ureq-proto]]
 who = "Chris Fallin <chris@cfallin.org>"
@@ -779,6 +800,55 @@ who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
 delta = "0.3.0 -> 0.4.0"
 notes = "No unsafe usage or ambient capabilities"
+
+[[audits.embark-studios.audits.jni]]
+who = "Robert Bragg <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.21.1"
+notes = """
+Aims to provide a safe JNI (Java Native Interface) API over the
+unsafe `jni_sys` crate.
+
+This is a very general FFI abstraction for Java VMs with a lot of unsafe code
+throughout the API. There are almost certainly some edge cases with its design
+that could lead to unsound behaviour but it should still be considerably safer
+than working with JNI directly.
+
+A lot of the unsafe usage relates to quite-simple use of `from_raw` APIs to
+construct or cast wrapper types (around JNI pointers) which are fairly
+straight-forward to verify/trust in context.
+
+Some unsafe code has good `// # Safety` documentation (this has been enforced for
+newer code) but a lot of unsafe code doesn't document invariants that are
+being relied on.
+
+The design depends on non-trivial named lifetimes across many APIs to associate
+Java local references with JNI stack frames.
+
+The crate is not very actively maintained and was practically unmaintained for
+over a year before the 0.20 release.
+
+Robert Bragg who now works at Embark Studios became the maintainer of this
+crate in October 2022.
+
+In the process of working on the `jni` crate since becoming maintainer it's
+worth noting that I came across multiple APIs that I found needed to be
+re-worked to address safety issues, including ensuring that APIs that are not
+implemented safely are correctly declared as `unsafe`.
+
+There has been a focus on improving safety in the last two release.
+
+The jni crate has been used in production with the Signal messaging application
+for over two years:
+https://github.com/signalapp/libsignal/blob/main/rust/bridge/jni/Cargo.toml
+
+# Some Notable Open Issues
+- https://github.com/jni-rs/jni-rs/issues/422 - questions soundness of linking
+  multiple versions of jni crate into an application, considering the use
+  of (separately scoped) thread-local-storage to track thread attachments
+- https://github.com/jni-rs/jni-rs/issues/405 - discusses the ease with which
+  code may expose the JVM to invalid booleans with undefined behaviour
+"""
 
 [[audits.embark-studios.audits.schemars]]
 who = "Johan Andersson <opensource@embark-studios.com>"
@@ -1322,12 +1392,6 @@ delta = "1.0.19 -> 1.0.20"
 notes = "Only minor updates to documentation and the mock today used for testing."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.same-file]]
-who = "Android Legacy"
-criteria = "safe-to-run"
-version = "1.0.6"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
 [[audits.google.audits.serde]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
@@ -1852,6 +1916,16 @@ notes = "No changes to Rust code between 0.2.8 and 0.2.9"
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.3 -> 0.3.4"
+
+[[audits.isrg.audits.getrandom]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.4 -> 0.4.0"
+
+[[audits.isrg.audits.getrandom]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.4.1"
 
 [[audits.isrg.audits.once_cell]]
 who = "J.C. Jones <jc@insufficient.coffee>"
@@ -3532,6 +3606,16 @@ criteria = "safe-to-deploy"
 delta = "0.9.1 -> 0.9.2"
 aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
 
+[[audits.zcash.audits.dunce]]
+who = "Jack Grigg <jack@electriccoin.co>"
+criteria = "safe-to-deploy"
+version = "1.0.5"
+notes = """
+Does what it says on the tin. No `unsafe`, and the only IO is `std::fs::canonicalize`.
+Path and string handling looks plausibly correct.
+"""
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
 [[audits.zcash.audits.dyn-clone]]
 who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
@@ -3869,6 +3953,12 @@ who = "Jack Grigg <jack@electriccoin.co>"
 criteria = "safe-to-deploy"
 delta = "5.2.0 -> 5.3.0"
 aggregated-from = "https://raw.githubusercontent.com/zcash/wallet/main/supply-chain/audits.toml"
+
+[[audits.zcash.audits.rand_xorshift]]
+who = "Sean Bowe <ewillbefull@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.3.0"
+aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
 
 [[audits.zcash.audits.redjubjub]]
 who = "Daira Emma Hopwood <daira@jacaranda.org>"
@@ -4229,12 +4319,6 @@ who = "Kris Nuttycombe <kris@nutty.land>"
 criteria = "safe-to-deploy"
 version = "0.4.1"
 notes = "Additive-only change that exposes the ability to decrypt by pk_d and esk. No functional changes."
-aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
-
-[[audits.zcash.audits.zcash_script]]
-who = "Jack Grigg <thestr4d@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "0.4.2 -> 0.4.3"
 aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
 [[audits.zcash.audits.zerovec-derive]]


### PR DESCRIPTION
## Motivation

Cargo vet is broken after last release. We need to add exemptions for our last released crates. 

## Solution

- Update local crate exemptions. 
- Run `cargo vet prune` to clean cargo vet files.
- Add supply-chain/ to lint workflow path triggers.
- Update rustls-webpki to fix RUSTSEC-2026-0104 and ignore core2 advisory pending upstream corez migration.

### Tests

Local

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
