### PR TITLE
refactor(zebra-chain): rename variables in relative_to_network for clarity

### DIFF
--- a/zebra-chain/src/work/difficulty.rs
+++ b/zebra-chain/src/work/difficulty.rs
@@ -294,25 +294,27 @@ impl CompactDifficulty {
     /// Returns a floating-point number representing a difficulty as a multiple
     /// of the minimum difficulty for the provided network.
     // Copied from <https://github.com/zcash/zcash/blob/99ad6fdc3a549ab510422820eea5e5ce9f60a5fd/src/rpc/blockchain.cpp#L34-L74>
-    // TODO: Explain here what this ported code is doing and why, request help to do so with the ECC team.
     pub fn relative_to_network(&self, network: &Network) -> f64 {
         let network_difficulty = network.target_difficulty_limit().to_compact();
 
-        let [mut n_shift, ..] = self.0.to_be_bytes();
-        let [n_shift_amount, ..] = network_difficulty.0.to_be_bytes();
-        let mut d_diff = f64::from(network_difficulty.0 << 8) / f64::from(self.0 << 8);
+        // get exponent byte from both values
+        let [mut self_exponent_byte, ..] = self.0.to_be_bytes();
+        let [network_exponent_byte, ..] = network_difficulty.0.to_be_bytes();
+        // take the ratio of network mantissa difficulty to self mantissa difficulty
+        let mut mantissa_ratio = f64::from(network_difficulty.0 << 8) / f64::from(self.0 << 8);
 
-        while n_shift < n_shift_amount {
-            d_diff *= 256.0;
-            n_shift += 1;
+        // multiply by 256 for each exponent byte difference
+        while self_exponent_byte < network_exponent_byte {
+            mantissa_ratio *= 256.0;
+            self_exponent_byte += 1;
         }
 
-        while n_shift > n_shift_amount {
-            d_diff /= 256.0;
-            n_shift -= 1;
+        while self_exponent_byte > network_exponent_byte {
+            mantissa_ratio /= 256.0;
+            self_exponent_byte -= 1;
         }
 
-        d_diff
+        mantissa_ratio
     }
 }
 

--- a/zebra-chain/src/work/difficulty.rs
+++ b/zebra-chain/src/work/difficulty.rs
@@ -291,27 +291,44 @@ impl CompactDifficulty {
         Ok(difficulty)
     }
 
-    /// Returns a floating-point number representing a difficulty as a multiple
-    /// of the minimum difficulty for the provided network.
+    /// Returns a floating-point number representing this block's difficulty
+    /// as a multiple of the minimum network difficulty.
+    ///
+    /// A result of 1.0 means the block was mined at minimum difficulty.
+    /// Values above 1.0 mean proportionally more work was done.
+    ///
+    /// # How it works
+    ///
+    /// `CompactDifficulty` encodes a target as `mantissa × 256^(exponent - 3)`.
+    /// Since difficulty is inversely proportional to the target threshold:
+    ///
+    /// ```text
+    /// result = network_min_target / self_target
+    ///        = (network_mantissa / self_mantissa) × 256^(network_exponent - self_exponent)
+    /// ```
+    ///
+    /// The mantissa ratio is computed first by stripping both exponent bytes (`<< 8`),
+    /// then the result is scaled up or down by 256 once per unit of exponent difference.
     // Copied from <https://github.com/zcash/zcash/blob/99ad6fdc3a549ab510422820eea5e5ce9f60a5fd/src/rpc/blockchain.cpp#L34-L74>
+    // Used for RPC functions only, not consensus-critical.
     pub fn relative_to_network(&self, network: &Network) -> f64 {
         let network_difficulty = network.target_difficulty_limit().to_compact();
 
         // get exponent byte from both values
-        let [mut self_exponent_byte, ..] = self.0.to_be_bytes();
+        let [mut self_exponent_cursor, ..] = self.0.to_be_bytes();
         let [network_exponent_byte, ..] = network_difficulty.0.to_be_bytes();
         // take the ratio of network mantissa difficulty to self mantissa difficulty
         let mut mantissa_ratio = f64::from(network_difficulty.0 << 8) / f64::from(self.0 << 8);
 
         // multiply by 256 for each exponent byte difference
-        while self_exponent_byte < network_exponent_byte {
+        while self_exponent_cursor < network_exponent_byte {
             mantissa_ratio *= 256.0;
-            self_exponent_byte += 1;
+            self_exponent_cursor += 1;
         }
 
-        while self_exponent_byte > network_exponent_byte {
+        while self_exponent_cursor > network_exponent_byte {
             mantissa_ratio /= 256.0;
-            self_exponent_byte -= 1;
+            self_exponent_cursor -= 1;
         }
 
         mantissa_ratio

--- a/zebra-chain/src/work/difficulty.rs
+++ b/zebra-chain/src/work/difficulty.rs
@@ -315,23 +315,25 @@ impl CompactDifficulty {
         let network_difficulty = network.target_difficulty_limit().to_compact();
 
         // get exponent byte from both values
-        let [mut self_exponent_cursor, ..] = self.0.to_be_bytes();
+        let [self_exponent_byte, ..] = self.0.to_be_bytes();
         let [network_exponent_byte, ..] = network_difficulty.0.to_be_bytes();
         // take the ratio of network mantissa difficulty to self mantissa difficulty
-        let mut mantissa_ratio = f64::from(network_difficulty.0 << 8) / f64::from(self.0 << 8);
+        let mantissa_ratio = f64::from(network_difficulty.0 << 8) / f64::from(self.0 << 8);
 
+        let mut ratio = mantissa_ratio;
+        let mut exponent_cursor = self_exponent_byte;
         // multiply by 256 for each exponent byte difference
-        while self_exponent_cursor < network_exponent_byte {
-            mantissa_ratio *= 256.0;
-            self_exponent_cursor += 1;
+        while exponent_cursor < network_exponent_byte {
+            ratio *= 256.0;
+            exponent_cursor += 1;
         }
 
-        while self_exponent_cursor > network_exponent_byte {
-            mantissa_ratio /= 256.0;
-            self_exponent_cursor -= 1;
+        while exponent_cursor > network_exponent_byte {
+            ratio /= 256.0;
+            exponent_cursor -= 1;
         }
 
-        mantissa_ratio
+        ratio
     }
 }
 


### PR DESCRIPTION
## Motivation

The relative_to_network function is overly complicated, this PR renames the variables to explain what is going on. Now its also self-readable to see whats going on, so I removed the "TODO ask ECC comment"

It makes sense when you realize were splitting out the exponent and the mantissa. We take the mantissa ratio initially, than adjust for the exponent.

### Tests

None, its just an internal variable rename

### AI Disclosure

- [x] No AI tools were used in this PR
- [ ] AI tools were used: <!-- tool name and what it was used for, e.g., "Claude for test boilerplate" -->

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
