### PR TITLE
fix(script): Validate transparent input/output alignment before script verification

### DIFF
--- a/zebra-consensus/src/script.rs
+++ b/zebra-consensus/src/script.rs
@@ -58,7 +58,9 @@ impl tower::Service<Request> for Verifier {
             let input = &cached_ffi_transaction
                 .inputs()
                 .get(input_index)
-                .ok_or_else(|| "cached_ffi_transaction missing input at input_index")?;
+                .ok_or_else(|| {
+                    format!("cached_ffi_transaction missing input at index {input_index}")
+                })?;
 
             match input {
                 transparent::Input::PrevOut { outpoint, .. } => {

--- a/zebra-consensus/src/script.rs
+++ b/zebra-consensus/src/script.rs
@@ -52,26 +52,28 @@ impl tower::Service<Request> for Verifier {
             cached_ffi_transaction,
             input_index,
         } = req;
-        let input = &cached_ffi_transaction.inputs()[input_index];
-        match input {
-            transparent::Input::PrevOut { outpoint, .. } => {
-                let outpoint = *outpoint;
 
-                // Avoid calling the state service if the utxo is already known
-                let span = tracing::trace_span!("script", ?outpoint);
+        let span = tracing::trace_span!("script");
+        async move {
+            let input = &cached_ffi_transaction
+                .inputs()
+                .get(input_index)
+                .ok_or_else(|| "cached_ffi_transaction missing input at input_index")?;
 
-                async move {
+            match input {
+                transparent::Input::PrevOut { outpoint, .. } => {
+                    let outpoint = *outpoint;
+
+                    // Avoid calling the state service if the utxo is already known
                     cached_ffi_transaction.is_valid(input_index)?;
-                    tracing::trace!("script verification succeeded");
+                    tracing::trace!(?outpoint, "script verification succeeded");
 
                     Ok(())
                 }
-                .instrument(span)
-                .boxed()
-            }
-            transparent::Input::Coinbase { .. } => {
-                async { Err("unexpected coinbase input".into()) }.boxed()
+                transparent::Input::Coinbase { .. } => Err("unexpected coinbase input".into()),
             }
         }
+        .instrument(span)
+        .boxed()
     }
 }

--- a/zebra-consensus/src/script.rs
+++ b/zebra-consensus/src/script.rs
@@ -7,6 +7,9 @@ use zebra_script::CachedFfiTransaction;
 
 use crate::BoxError;
 
+#[cfg(test)]
+mod tests;
+
 /// Asynchronous script verification.
 ///
 /// The verifier asynchronously requests the UTXO a transaction attempts

--- a/zebra-consensus/src/script/tests.rs
+++ b/zebra-consensus/src/script/tests.rs
@@ -1,0 +1,66 @@
+//! Tests for the script verifier service.
+
+use std::sync::Arc;
+
+use tower::ServiceExt;
+use zebra_chain::{
+    block::Block, parameters::NetworkUpgrade, serialization::ZcashDeserialize, transparent,
+};
+use zebra_script::CachedFfiTransaction;
+
+use super::{Request, Verifier};
+
+/// Calling the script `Verifier` with an `input_index` past the end of the transaction's
+/// inputs must return an error instead of panicking.
+#[tokio::test]
+async fn verifier_returns_error_for_out_of_range_input_index() {
+    let _init_guard = zebra_test::init();
+
+    // Use a v4 mainnet block whose second transaction has at least one transparent input.
+    let block = Block::zcash_deserialize(&zebra_test::vectors::BLOCK_MAINNET_419199_BYTES[..])
+        .expect("test vector is a valid block");
+    let tx = block
+        .transactions
+        .iter()
+        .find(|tx| {
+            tx.inputs()
+                .iter()
+                .any(|i| matches!(i, transparent::Input::PrevOut { .. }))
+        })
+        .expect("block has a non-coinbase tx")
+        .clone();
+
+    // Build matching previous outputs (one per input). Their content does not matter
+    // because the verifier should error on the out-of-range index before touching them.
+    let previous_outputs: Vec<transparent::Output> = tx
+        .inputs()
+        .iter()
+        .map(|_| transparent::Output {
+            value: 0.try_into().expect("zero is a valid amount"),
+            lock_script: transparent::Script::new(&[]),
+        })
+        .collect();
+
+    let cached = Arc::new(
+        CachedFfiTransaction::new(
+            tx.clone(),
+            Arc::new(previous_outputs),
+            NetworkUpgrade::Sapling,
+        )
+        .expect("constructor accepts the test fixture"),
+    );
+
+    let out_of_range = tx.inputs().len();
+    let result = Verifier
+        .oneshot(Request {
+            cached_ffi_transaction: cached,
+            input_index: out_of_range,
+        })
+        .await;
+
+    let err = result.expect_err("out-of-range input_index must error, not panic");
+    assert!(
+        err.to_string().contains("missing input"),
+        "unexpected error message: {err}",
+    );
+}

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -148,8 +148,10 @@ impl CachedFfiTransaction {
         let previous_output = self
             .all_previous_outputs
             .get(input_index)
+            .filter(|_| self.all_previous_outputs.len() == self.transaction.inputs().len())
             .ok_or(Error::TxIndex)?
             .clone();
+
         let transparent::Output {
             value: _,
             lock_script,

--- a/zebra-script/src/tests.rs
+++ b/zebra-script/src/tests.rs
@@ -997,3 +997,59 @@ fn block_sigop_total_includes_coinbase_and_p2sh() -> Result<()> {
 
     Ok(())
 }
+
+/// Calling `is_valid` when `all_previous_outputs.len()` differs from `transaction.inputs().len()`
+/// must return `Error::TxIndex`, even when the requested `input_index` is in range for
+/// `all_previous_outputs`. This guards against verifying a script against a misaligned
+/// previous output.
+#[test]
+fn is_valid_rejects_mismatched_previous_outputs_length() {
+    let _init_guard = zebra_test::init();
+
+    let transaction = SCRIPT_TX
+        .zcash_deserialize_into::<Arc<zebra_chain::transaction::Transaction>>()
+        .expect("test fixture deserializes");
+
+    // SCRIPT_TX has exactly one input. Pass two previous outputs so `.get(0)` succeeds
+    // but the lengths disagree.
+    let output = Output {
+        value: (212 * u64::pow(10, 8)).try_into().expect("valid amount"),
+        lock_script: transparent::Script::new(&SCRIPT_PUBKEY),
+    };
+    let mismatched_outputs = Arc::new(vec![output.clone(), output]);
+
+    let verifier =
+        super::CachedFfiTransaction::new(transaction, mismatched_outputs, NetworkUpgrade::Blossom)
+            .expect("constructor accepts mismatched-length outputs");
+
+    let err = verifier
+        .is_valid(0)
+        .expect_err("mismatched length must be rejected by is_valid");
+    assert_eq!(err, super::Error::TxIndex);
+}
+
+/// Calling `is_valid` with an `input_index` past the end of `all_previous_outputs` must
+/// return `Error::TxIndex` instead of panicking.
+#[test]
+fn is_valid_rejects_out_of_range_input_index() {
+    let _init_guard = zebra_test::init();
+
+    let transaction = SCRIPT_TX
+        .zcash_deserialize_into::<Arc<zebra_chain::transaction::Transaction>>()
+        .expect("test fixture deserializes");
+    let output = Output {
+        value: (212 * u64::pow(10, 8)).try_into().expect("valid amount"),
+        lock_script: transparent::Script::new(&SCRIPT_PUBKEY),
+    };
+    let previous_outputs = Arc::new(vec![output]);
+
+    let verifier =
+        super::CachedFfiTransaction::new(transaction, previous_outputs, NetworkUpgrade::Blossom)
+            .expect("matched-length construction succeeds");
+
+    // SCRIPT_TX has one input at index 0; index 1 is out of range.
+    let err = verifier
+        .is_valid(1)
+        .expect_err("out-of-range input_index must error, not panic");
+    assert_eq!(err, super::Error::TxIndex);
+}


### PR DESCRIPTION
## Motivation

The transparent script verifier in `zebra-script` previously indexed into `inputs()` and `all_previous_outputs` without validating the caller-provided request. If a caller passed an out-of-range `input_index`, or an `all_previous_outputs` vec whose length did not match `transaction.inputs().len()`, the verifier could either panic on the `inputs()[input_index]` index or silently verify against a misaligned previous output.

## Solution

- `zebra-consensus/src/script.rs`: switch from `inputs()[input_index]` to `inputs().get(input_index).ok_or(...)` so a missing input returns an error instead of panicking. Restructured the async block so the `get` lives inside it and the span is attached once at the outer level.
- `zebra-script/src/lib.rs`: in `CachedFfiTransaction::is_valid`, reject the request with `Error::TxIndex` unless `all_previous_outputs.len() == transaction.inputs().len()`, so we never verify a script against a mismatched/misaligned previous output.

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test -p zebra-script`
- [ ] `cargo test -p zebra-consensus`

## AI disclosure

Used Claude Code to draft the `is_valid` length check and this PR description.