### PR TITLE
docs: fix broken NetworkConstants link in custom-testnets

### DIFF
--- a/book/src/user/custom-testnets.md
+++ b/book/src/user/custom-testnets.md
@@ -140,8 +140,8 @@ Aside from the configurable parameters, custom Testnets in Zebra validate the sa
 
 Zebra's Testnet validates almost all of the same consensus rules as Mainnet, the differences are:
 
-- Constants defined in the `zcash_primitives::consensus::Parameters` trait, which includes but may not be limited to:
-  - Zcash address prefixes (see [`NetworkConstants`](https://docs.rs/zcash_primitives/latest/zcash_primitives/consensus/trait.NetworkConstants.html)), and coin type, which is `133` on `Mainnet` or `1` elsewhere.
+- Constants defined in the `zcash_protocol::consensus::Parameters` trait, which includes but may not be limited to:
+  - Zcash address prefixes (see [`NetworkConstants`](https://docs.rs/zcash_protocol/latest/zcash_protocol/consensus/trait.NetworkConstants.html)), and coin type, which is `133` on `Mainnet` or `1` elsewhere.
   - Network upgrade activation heights.
 - Constants defined in Zebra:
   - `PoWLimit` defined in the Zcash protocol specification, or target difficulty limit, which is `2^243 - 1` on Mainnet and `2^251 - 1` on the default Testnet.


### PR DESCRIPTION
## Motivation

The `Docs Check` / `link-check` job started failing on `main` (and on every PR
that touches markdown — e.g. #10513's [failing run](https://github.com/ZcashFoundation/zebra/actions/runs/25064581382/job/73800407454)):

```
[404] https://docs.rs/zcash_primitives/latest/zcash_primitives/consensus/trait.NetworkConstants.html
```

The 404 was introduced by zcash/librustzcash#2313 (released `zcash_primitives` 0.27.0,
merged 2026-04-24). `docs.rs/zcash_primitives/latest` now resolves to 0.27.0,
where the trait page returns a hard 404. At 0.26.0 the same path returned a
302 redirect that lychee silently accepted (`.lychee.toml` accepts 301/302/307/308),
so the link looked valid even though `NetworkConstants`'s canonical home had
already moved to `zcash_protocol::consensus`.

| `zcash_primitives` version | `consensus/trait.NetworkConstants.html` |
|---|---|
| 0.27.0 (released by librustzcash#2313) | **404** |
| 0.26.0 | 302 → `/crate/zcash_primitives/0.26.0` (lychee tolerated) |
| 0.20.0 – 0.25.0 | 200 |

## Solution

Repoint the prose reference and hyperlink in `book/src/user/custom-testnets.md`
from `zcash_primitives::consensus` to `zcash_protocol::consensus`, which is
where Zebra's own code already imports the trait from
(`zebra-chain/src/parameters/network/tests/vectors.rs:3`).

Verified both replacement URLs return 200:
- https://docs.rs/zcash_protocol/latest/zcash_protocol/consensus/trait.NetworkConstants.html
- https://docs.rs/zcash_protocol/latest/zcash_protocol/consensus/trait.Parameters.html

### Tests

CI's `link-check` job is the test — it should turn green on this PR.

### Specifications & References

- Root cause: zcash/librustzcash#2313 (zcash_primitives 0.27.0 release)
- Failing run that surfaced this: https://github.com/ZcashFoundation/zebra/actions/runs/25064581382/job/73800407454

### Follow-up Work

None. Doc-only fix; no `CHANGELOG.md` entry needed (not user-visible).

### AI Disclosure

- [x] AI tools were used: Claude Code for tracing the broken link to the upstream release and drafting the patch. Author reviewed the change and the upstream cause analysis.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand. (maintainer-driven CI fix; same pattern as recent `fix(ci): ...` PRs)
- [x] The solution is tested. (CI link-check job)
- [x] The documentation and changelogs are up to date.