### PR TITLE
fix(zebra-rpc): fix 4 RPC security advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7780,6 +7780,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -123,6 +123,7 @@ which = { workspace = true }
 bytes = { workspace = true }
 http-body = { workspace = true }
 insta = { workspace = true, features = ["redactions", "json", "ron"] }
+tempfile = { workspace = true }
 
 proptest = { workspace = true }
 

--- a/zebra-rpc/src/indexer/methods.rs
+++ b/zebra-rpc/src/indexer/methods.rs
@@ -17,8 +17,8 @@ use super::{
     MempoolChangeMessage,
 };
 
-/// The maximum number of messages that can be queued to be streamed to a client
-const RESPONSE_BUFFER_SIZE: usize = 4_000;
+/// The maximum number of messages that can be queued to be streamed to a client.
+const RESPONSE_BUFFER_SIZE: usize = 64;
 
 #[tonic::async_trait]
 impl<ReadStateService, Tip> Indexer for IndexerRPC<ReadStateService, Tip>
@@ -50,14 +50,20 @@ where
                     continue;
                 };
 
-                if let Err(error) = response_sender
-                    .send(Ok(BlockHashAndHeight::new(tip_hash, tip_height)))
-                    .await
-                {
-                    span.in_scope(|| {
-                        tracing::info!(?error, "failed to send chain tip change, dropping task");
-                    });
-                    return;
+                match response_sender.try_send(Ok(BlockHashAndHeight::new(tip_hash, tip_height))) {
+                    Ok(()) => {}
+                    Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                        span.in_scope(|| {
+                            tracing::info!("client disconnected, dropping chain_tip_change task");
+                        });
+                        return;
+                    }
+                    Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                        span.in_scope(|| {
+                            tracing::warn!("slow consumer, dropping chain_tip_change stream");
+                        });
+                        return;
+                    }
                 }
             }
 
@@ -110,17 +116,24 @@ where
 
             // Notify the client of chain tip changes until the channel is closed
             while let Some((hash, block)) = non_finalized_state_change.recv().await {
-                if let Err(error) = response_sender
-                    .send(Ok(BlockAndHash::new(hash, block)))
-                    .await
-                {
-                    span.in_scope(|| {
-                        tracing::info!(
-                            ?error,
-                            "failed to send non-finalized state change, dropping task"
-                        );
-                    });
-                    return;
+                match response_sender.try_send(Ok(BlockAndHash::new(hash, block))) {
+                    Ok(()) => {}
+                    Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                        span.in_scope(|| {
+                            tracing::info!(
+                                "client disconnected, dropping non_finalized_state_change task"
+                            );
+                        });
+                        return;
+                    }
+                    Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                        span.in_scope(|| {
+                            tracing::warn!(
+                                "slow consumer, dropping non_finalized_state_change stream"
+                            );
+                        });
+                        return;
+                    }
                 }
             }
 
@@ -155,25 +168,33 @@ where
                         tracing::debug!("mempool change: {:?}", change);
                     });
 
-                    if let Err(error) = response_sender
-                        .send(Ok(MempoolChangeMessage {
-                            change_type: match change.kind() {
-                                MempoolChangeKind::Added => 0,
-                                MempoolChangeKind::Invalidated => 1,
-                                MempoolChangeKind::Mined => 2,
-                            },
-                            tx_hash: tx_id.mined_id().bytes_in_display_order().to_vec(),
-                            auth_digest: tx_id
-                                .auth_digest()
-                                .map(|d| d.bytes_in_display_order().to_vec())
-                                .unwrap_or_default(),
-                        }))
-                        .await
-                    {
-                        span.in_scope(|| {
-                            tracing::info!(?error, "failed to send mempool change, dropping task");
-                        });
-                        return;
+                    let msg = Ok(MempoolChangeMessage {
+                        change_type: match change.kind() {
+                            MempoolChangeKind::Added => 0,
+                            MempoolChangeKind::Invalidated => 1,
+                            MempoolChangeKind::Mined => 2,
+                        },
+                        tx_hash: tx_id.mined_id().bytes_in_display_order().to_vec(),
+                        auth_digest: tx_id
+                            .auth_digest()
+                            .map(|d| d.bytes_in_display_order().to_vec())
+                            .unwrap_or_default(),
+                    });
+
+                    match response_sender.try_send(msg) {
+                        Ok(()) => {}
+                        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                            span.in_scope(|| {
+                                tracing::info!("client disconnected, dropping mempool_change task");
+                            });
+                            return;
+                        }
+                        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                            span.in_scope(|| {
+                                tracing::warn!("slow consumer, dropping mempool_change stream");
+                            });
+                            return;
+                        }
                     }
                 }
             }

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1739,7 +1739,7 @@ where
             };
         }
 
-        let txid = if let Some(block_hash) = block_hash {
+        let caller_block_context = if let Some(block_hash) = block_hash {
             let block_hash = block::Hash::from_hex(block_hash)
                 .map_error(server::error::LegacyCode::InvalidAddressOrKey)?;
             match self
@@ -1751,24 +1751,25 @@ where
                 .await
                 .map_misc_error()?
             {
-                zebra_state::ReadResponse::AnyChainTransactionIdsForBlock(tx_ids) => *tx_ids
-                    .ok_or_error(
+                zebra_state::ReadResponse::AnyChainTransactionIdsForBlock(tx_ids) => {
+                    let (ids, in_best_chain) = tx_ids.ok_or_error(
                         server::error::LegacyCode::InvalidAddressOrKey,
                         "block not found",
-                    )?
-                    .0
-                    .iter()
-                    .find(|id| **id == txid)
-                    .ok_or_error(
+                    )?;
+
+                    ids.iter().find(|id| **id == txid).ok_or_error(
                         server::error::LegacyCode::InvalidAddressOrKey,
                         "txid not found",
-                    )?,
+                    )?;
+
+                    Some((block_hash, in_best_chain))
+                }
                 _ => {
                     unreachable!("unmatched response to a `AnyChainTransactionIdsForBlock` request")
                 }
             }
         } else {
-            txid
+            None
         };
 
         // If the tx wasn't in the mempool, check the state.
@@ -1780,48 +1781,80 @@ where
             .map_misc_error()?
         {
             zebra_state::ReadResponse::AnyChainTransaction(Some(tx)) => Ok(if verbose {
-                match tx {
-                    AnyTx::Mined(tx) => {
-                        let block_hash = match self
-                            .read_state
-                            .clone()
-                            .oneshot(zebra_state::ReadRequest::BestChainBlockHash(tx.height))
-                            .await
-                            .map_misc_error()?
-                        {
-                            zebra_state::ReadResponse::BlockHash(block_hash) => block_hash,
-                            _ => {
-                                unreachable!("unmatched response to a `BestChainBlockHash` request")
-                            }
-                        };
+                if let Some((caller_block_hash, in_best_chain)) = caller_block_context {
+                    // Use the caller-provided block context to avoid TOCTOU races
+                    // between the validation query and the transaction fetch.
+                    let (raw_tx, height, confirmations, block_time) = match &tx {
+                        AnyTx::Mined(mined) if in_best_chain => (
+                            mined.tx.clone(),
+                            Some(mined.height),
+                            Some(mined.confirmations),
+                            Some(mined.block_time),
+                        ),
+                        _ => {
+                            let raw_tx: Arc<Transaction> = tx.into();
+                            (raw_tx, None, None, None)
+                        }
+                    };
 
-                        GetRawTransactionResponse::Object(Box::new(
-                            TransactionObject::from_transaction(
-                                tx.tx.clone(),
-                                Some(tx.height),
-                                Some(tx.confirmations),
-                                &self.network,
-                                // TODO: Performance gain:
-                                // https://github.com/ZcashFoundation/zebra/pull/9458#discussion_r2059352752
-                                Some(tx.block_time),
-                                block_hash,
-                                Some(true),
-                                txid,
-                            ),
-                        ))
-                    }
-                    AnyTx::Side((tx, block_hash)) => GetRawTransactionResponse::Object(Box::new(
+                    GetRawTransactionResponse::Object(Box::new(
                         TransactionObject::from_transaction(
-                            tx.clone(),
-                            None,
-                            None,
+                            raw_tx,
+                            height,
+                            confirmations,
                             &self.network,
-                            None,
-                            Some(block_hash),
-                            Some(false),
+                            block_time,
+                            Some(caller_block_hash),
+                            Some(in_best_chain),
                             txid,
                         ),
-                    )),
+                    ))
+                } else {
+                    match tx {
+                        AnyTx::Mined(tx) => {
+                            let block_hash = match self
+                                .read_state
+                                .clone()
+                                .oneshot(zebra_state::ReadRequest::BestChainBlockHash(tx.height))
+                                .await
+                                .map_misc_error()?
+                            {
+                                zebra_state::ReadResponse::BlockHash(block_hash) => block_hash,
+                                _ => {
+                                    unreachable!(
+                                        "unmatched response to a `BestChainBlockHash` request"
+                                    )
+                                }
+                            };
+
+                            GetRawTransactionResponse::Object(Box::new(
+                                TransactionObject::from_transaction(
+                                    tx.tx.clone(),
+                                    Some(tx.height),
+                                    Some(tx.confirmations),
+                                    &self.network,
+                                    // TODO: Performance gain:
+                                    // https://github.com/ZcashFoundation/zebra/pull/9458#discussion_r2059352752
+                                    Some(tx.block_time),
+                                    block_hash,
+                                    Some(true),
+                                    txid,
+                                ),
+                            ))
+                        }
+                        AnyTx::Side((tx, block_hash)) => GetRawTransactionResponse::Object(
+                            Box::new(TransactionObject::from_transaction(
+                                tx.clone(),
+                                None,
+                                None,
+                                &self.network,
+                                None,
+                                Some(block_hash),
+                                Some(false),
+                                txid,
+                            )),
+                        ),
+                    }
                 }
             } else {
                 let tx: Arc<Transaction> = tx.into();

--- a/zebra-rpc/src/server.rs
+++ b/zebra-rpc/src/server.rs
@@ -14,7 +14,10 @@ use jsonrpsee::server::{middleware::rpc::RpcServiceBuilder, Server, ServerHandle
 use tokio::task::JoinHandle;
 use tracing::*;
 
-use zebra_chain::{chain_sync_status::ChainSyncStatus, chain_tip::ChainTip, parameters::Network};
+use zebra_chain::{
+    block::MAX_BLOCK_BYTES, chain_sync_status::ChainSyncStatus, chain_tip::ChainTip,
+    parameters::Network,
+};
 use zebra_consensus::router::service_trait::BlockVerifierService;
 use zebra_network::AddressBookPeers;
 use zebra_node_services::mempool::MempoolService;
@@ -117,13 +120,17 @@ impl RpcServer {
             .listen_addr
             .expect("caller should make sure listen_addr is set");
 
+        // The largest RPC request is submitblock, which sends a full block
+        // as a hex string (2x MAX_BLOCK_BYTES) plus a small JSON-RPC wrapper.
+        let max_request_body_size = (MAX_BLOCK_BYTES as usize) * 2 + 1024;
+
         let http_middleware_layer = if conf.enable_cookie_auth {
             let cookie = Cookie::default();
             cookie::write_to_disk(&cookie, &conf.cookie_dir)
                 .expect("Zebra must be able to write the auth cookie to the disk");
-            HttpRequestMiddlewareLayer::new(Some(cookie))
+            HttpRequestMiddlewareLayer::new(Some(cookie), max_request_body_size)
         } else {
-            HttpRequestMiddlewareLayer::new(None)
+            HttpRequestMiddlewareLayer::new(None, max_request_body_size)
         };
 
         let http_middleware = tower::ServiceBuilder::new().layer(http_middleware_layer);

--- a/zebra-rpc/src/server/cookie.rs
+++ b/zebra-rpc/src/server/cookie.rs
@@ -10,6 +10,9 @@ use std::{
     path::Path,
 };
 
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+
 /// The name of the cookie file on the disk
 const FILE: &str = ".cookie";
 
@@ -34,14 +37,45 @@ impl Default for Cookie {
 }
 
 /// Writes the given cookie to the given dir.
+///
+/// Uses restrictive file permissions (0600 on Unix) to prevent other
+/// local users from reading the cookie secret.
 pub fn write_to_disk(cookie: &Cookie, dir: &Path) -> Result<()> {
-    // Create the directory if needed.
     std::fs::create_dir_all(dir)?;
-    File::create(dir.join(FILE))?.write_all(format!("__cookie__:{}", cookie.0).as_bytes())?;
+
+    let cookie_path = dir.join(FILE);
+
+    if cookie_path
+        .symlink_metadata()
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
+    {
+        return Err(color_eyre::eyre::eyre!(
+            "cookie path {cookie_path:?} is a symlink, refusing to write"
+        ));
+    }
+
+    let mut file = create_owner_only_file(&cookie_path)?;
+    file.write_all(format!("__cookie__:{}", cookie.0).as_bytes())?;
 
     tracing::info!("RPC auth cookie written to disk");
 
     Ok(())
+}
+
+/// Creates a file readable and writable only by the owner.
+///
+/// On Unix, this sets mode 0600 regardless of umask.
+/// On Windows, default ACLs already restrict access to the creating user,
+/// so no explicit hardening is needed.
+fn create_owner_only_file(path: &Path) -> Result<File> {
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create(true).truncate(true);
+
+    #[cfg(unix)]
+    opts.mode(0o600);
+
+    Ok(opts.open(path)?)
 }
 
 /// Removes a cookie from the given dir.

--- a/zebra-rpc/src/server/http_request_compatibility.rs
+++ b/zebra-rpc/src/server/http_request_compatibility.rs
@@ -7,7 +7,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 use futures::{future, FutureExt};
-use http_body_util::BodyExt;
+use http_body_util::{BodyExt, Limited};
 use hyper::header;
 use jsonrpsee::{
     core::BoxError,
@@ -56,12 +56,17 @@ use base64::{engine::general_purpose::STANDARD, Engine as _};
 pub struct HttpRequestMiddleware<S> {
     service: S,
     cookie: Option<Cookie>,
+    max_request_body_size: usize,
 }
 
 impl<S> HttpRequestMiddleware<S> {
-    /// Create a new `HttpRequestMiddleware` with the given service and cookie.
-    pub fn new(service: S, cookie: Option<Cookie>) -> Self {
-        Self { service, cookie }
+    /// Create a new `HttpRequestMiddleware` with the given service, cookie, and request body size limit.
+    pub fn new(service: S, cookie: Option<Cookie>, max_request_body_size: usize) -> Self {
+        Self {
+            service,
+            cookie,
+            max_request_body_size,
+        }
     }
 
     /// Check if the request is authenticated.
@@ -122,9 +127,13 @@ impl<S> HttpRequestMiddleware<S> {
     /// Maps whatever JSON-RPC version the client is using to JSON-RPC 2.0.
     async fn request_to_json_rpc_2(
         request: HttpRequest<HttpBody>,
+        max_request_body_size: usize,
     ) -> Result<(JsonRpcVersion, HttpRequest<HttpBody>), BoxError> {
         let (parts, body) = request.into_parts();
-        let bytes = body.collect().await?.to_bytes();
+        let bytes = Limited::new(body, max_request_body_size)
+            .collect()
+            .await?
+            .to_bytes();
         let (version, bytes) =
             if let Ok(request) = serde_json::from_slice::<'_, JsonRpcRequest>(bytes.as_ref()) {
                 let version = request.version();
@@ -170,12 +179,16 @@ impl<S> HttpRequestMiddleware<S> {
 #[derive(Clone)]
 pub struct HttpRequestMiddlewareLayer {
     cookie: Option<Cookie>,
+    max_request_body_size: usize,
 }
 
 impl HttpRequestMiddlewareLayer {
-    /// Create a new `HttpRequestMiddlewareLayer` with the given cookie.
-    pub fn new(cookie: Option<Cookie>) -> Self {
-        Self { cookie }
+    /// Create a new `HttpRequestMiddlewareLayer` with the given cookie and request body size limit.
+    pub fn new(cookie: Option<Cookie>, max_request_body_size: usize) -> Self {
+        Self {
+            cookie,
+            max_request_body_size,
+        }
     }
 }
 
@@ -183,7 +196,7 @@ impl<S> tower::Layer<S> for HttpRequestMiddlewareLayer {
     type Service = HttpRequestMiddleware<S>;
 
     fn layer(&self, service: S) -> Self::Service {
-        HttpRequestMiddleware::new(service, self.cookie.clone())
+        HttpRequestMiddleware::new(service, self.cookie.clone(), self.max_request_body_size)
     }
 }
 
@@ -230,9 +243,11 @@ where
         Self::insert_or_replace_content_type_header(request.headers_mut());
 
         let mut service = self.service.clone();
+        let max_request_body_size = self.max_request_body_size;
 
         async move {
-            let (version, request) = Self::request_to_json_rpc_2(request).await?;
+            let (version, request) =
+                Self::request_to_json_rpc_2(request, max_request_body_size).await?;
             let response = service.call(request).await.map_err(Into::into)?;
             Self::response_from_json_rpc_2(version, response).await
         }

--- a/zebra-rpc/src/server/tests.rs
+++ b/zebra-rpc/src/server/tests.rs
@@ -2,5 +2,6 @@
 
 #![allow(clippy::unwrap_in_result)]
 
+mod cookie;
 mod http_request_compatibility;
 mod vectors;

--- a/zebra-rpc/src/server/tests/cookie.rs
+++ b/zebra-rpc/src/server/tests/cookie.rs
@@ -1,0 +1,47 @@
+//! Tests for cookie file creation security.
+
+use std::fs;
+
+use super::super::cookie;
+use crate::server::cookie::Cookie;
+
+#[test]
+fn cookie_file_has_restrictive_permissions() {
+    let _init_guard = zebra_test::init();
+
+    let dir = tempfile::tempdir().unwrap();
+    let cookie = Cookie::default();
+
+    cookie::write_to_disk(&cookie, dir.path()).unwrap();
+
+    let cookie_path = dir.path().join(".cookie");
+    let metadata = fs::metadata(&cookie_path).unwrap();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = metadata.permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "cookie file should have mode 0600, got {mode:o}"
+        );
+    }
+
+    assert!(metadata.len() > 0, "cookie file should not be empty");
+}
+
+#[cfg(unix)]
+#[test]
+fn cookie_write_rejects_symlink() {
+    let _init_guard = zebra_test::init();
+
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("decoy");
+    fs::write(&target, b"").unwrap();
+
+    std::os::unix::fs::symlink(&target, dir.path().join(".cookie")).unwrap();
+
+    let cookie = Cookie::default();
+    let result = cookie::write_to_disk(&cookie, dir.path());
+    assert!(result.is_err(), "should reject symlink at cookie path");
+}

--- a/zebra-rpc/src/server/tests/http_request_compatibility.rs
+++ b/zebra-rpc/src/server/tests/http_request_compatibility.rs
@@ -64,11 +64,29 @@ async fn request_body_error_returns_err_instead_of_panic() {
         .body(error_body)
         .expect("valid request");
 
-    let mut middleware = HttpRequestMiddleware::new(MockRpcService, None);
+    let mut middleware = HttpRequestMiddleware::new(MockRpcService, None, 2_097_152);
     let result = middleware.call(request).await;
 
     assert!(
         result.is_err(),
         "body collection error should return Err, not panic"
     );
+}
+
+/// Verifies that a request body exceeding `max_request_body_size` is rejected.
+#[tokio::test]
+async fn oversized_request_body_is_rejected() {
+    let limit = 64;
+    let oversized = vec![b'x'; limit + 1];
+    let body = HttpBody::from(oversized);
+    let request = HttpRequest::builder()
+        .method("POST")
+        .header("content-type", "application/json")
+        .body(body)
+        .expect("valid request");
+
+    let mut middleware = HttpRequestMiddleware::new(MockRpcService, None, limit);
+    let result = middleware.call(request).await;
+
+    assert!(result.is_err(), "oversized request body should be rejected");
 }


### PR DESCRIPTION
## Summary

Fixes 4 RPC security advisories.

| Commit | Advisory | Fix |
|--------|----------|-----|
| [26c419a9](https://github.com/ZcashFoundation/zebra-private/commit/26c419a9) | [GHSA-jg86-rwhm-fhg4](https://github.com/ZcashFoundation/zebra-private/security/advisories/GHSA-jg86-rwhm-fhg4) | Cookie file now written with explicit 0600 permissions on Unix; symlinks at the cookie path are rejected |
| [06b55908](https://github.com/ZcashFoundation/zebra-private/commit/06b55908) | [GHSA-8r29-5wjm-jgvx](https://github.com/ZcashFoundation/zebra-private/security/advisories/GHSA-8r29-5wjm-jgvx) | HTTP request body bounded via `http_body_util::Limited` before allocation, limit derived from `MAX_BLOCK_BYTES` to accommodate `submitblock` |
| [3918c509](https://github.com/ZcashFoundation/zebra-private/commit/3918c509) | [GHSA-826r-gfq8-x79q](https://github.com/ZcashFoundation/zebra-private/security/advisories/GHSA-826r-gfq8-x79q) | gRPC indexer streams use `try_send` to drop slow consumers instead of backpressuring the server, buffer reduced from 4000 to 64 |
| [cba4cecd](https://github.com/ZcashFoundation/zebra-private/commit/cba4cecd) | [GHSA-w23c-6rpp-ff87](https://github.com/ZcashFoundation/zebra-private/security/advisories/GHSA-w23c-6rpp-ff87) | `getrawtransaction` reuses the caller-provided blockhash and its best-chain flag from the initial query, avoiding a TOCTOU race with a third state lookup |

## Breaking changes

- gRPC subscribers that fall behind are now dropped instead of backpressuring the server. Well-behaved clients are unaffected.