### PR TITLE
fix(zebra-script): fix stale sighash issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Security
 
 - Fix sigops counting ([GHSA-jv4h-j224-23cc](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-jv4h-j224-23cc)).
+- Defense-in-depth fix for a consensus-divergence follow-up to GHSA-8m29-fpq5-89jj
+  in transparent script verification. Under the prior fix, the V5 sighash
+  callback returned `None` for undefined ZIP 244 hash-type bytes, but the
+  `libzcash_script` C++ bridge did not propagate that failure to the C++
+  verifier. A crafted `OP_CHECKSIGVERIFY` + `OP_CHECKSIG` script could therefore
+  make optimized Zebra accept a spend that `zcashd` rejects. Zebra's callback
+  now substitutes a per-call CSPRNG-derived sighash when rejecting, so any
+  signature the peer shipped fails to verify and the block is rejected in
+  agreement with `zcashd`.
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7813,6 +7813,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "libzcash_script",
+ "rand 0.8.5",
  "ripemd 0.1.3",
  "secp256k1",
  "sha2 0.10.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -287,6 +287,19 @@ overflow-checks = false
 incremental = false
 codegen-units = 16
 
+# The advisory
+# https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-gq4h-3grw-2rhv
+# only reproduces reliably when the bundled libzcash_script C++ code is compiled
+# in release mode since it relies on a buffer to not be zeroed out (arrays in
+# C++ are usually zeroed out when allocated in debug mode). To reliably test
+# against that issue, and to also better simulate real-world usage of
+# libzcash_script, we enable optimizations for it in dev builds.
+[profile.dev.package.libzcash_script]
+opt-level = 3
+debug-assertions = false
+overflow-checks = false
+incremental = false
+codegen-units = 16
 
 [profile.release]
 panic = "abort"

--- a/zebra-script/CHANGELOG.md
+++ b/zebra-script/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+This release fixes an important security issue:
+
+- [CVE-2026-XXXXX: Consensus Divergence in Transparent Sighash Hash-Type
+  Handling due to Stale
+  Buffer](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-gq4h-3grw-2rhv)
+
+The impact of the issue for crate users will depend on the particular usage;
+if you use it as a building block for a consensus node, you should update.
+
 ### Breaking Changes
 
 - `Sigops::scripts` now returns `impl Iterator<Item = Vec<u8>>` instead of `impl

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -28,6 +28,7 @@ zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
 zebra-chain = { path = "../zebra-chain", version = "6.0.2" }
 
+rand = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -177,43 +177,67 @@ impl CachedFfiTransaction {
 
         let calculate_sighash =
             |script_code: &script::Code, hash_type: &zcash_script::signature::HashType| {
-                // For v5+ transactions: reject undefined hash_type values,
-                // matching zcashd's SighashType::parse behavior.
-                // Valid values: {0x01, 0x02, 0x03, 0x81, 0x82, 0x83}.
-                if self.transaction.version() >= 5 {
-                    let valid_v5_types: &[i32] = &[0x01, 0x02, 0x03, 0x81, 0x82, 0x83];
-                    if !valid_v5_types.contains(&hash_type.raw_bits()) {
-                        return None;
+                // Inner helper: returns None when the hash type is invalid
+                // and the callback should signal failure.
+                let computed: Option<[u8; 32]> = (|| {
+                    // For v5+ transactions: reject undefined hash_type values,
+                    // matching zcashd's SighashType::parse behavior.
+                    // Valid values: {0x01, 0x02, 0x03, 0x81, 0x82, 0x83}.
+                    if self.transaction.version() >= 5 {
+                        let valid_v5_types: &[i32] = &[0x01, 0x02, 0x03, 0x81, 0x82, 0x83];
+                        if !valid_v5_types.contains(&hash_type.raw_bits()) {
+                            return None;
+                        }
                     }
-                }
 
-                let script_code_vec = script_code.0.clone();
+                    let script_code_vec = script_code.0.clone();
 
-                // For pre-v5 (v4) transactions: zcashd serializes the raw
-                // hash_type byte into the sighash preimage (only masking with
-                // 0x1f for selection logic). Use the raw byte to match.
-                if self.transaction.version() < 5 {
-                    let raw_byte = hash_type.raw_bits() as u8;
-                    return Some(
+                    // For pre-v5 (v4) transactions: zcashd serializes the raw
+                    // hash_type byte into the sighash preimage (only masking with
+                    // 0x1f for selection logic). Use the raw byte to match.
+                    if self.transaction.version() < 5 {
+                        let raw_byte = hash_type.raw_bits() as u8;
+                        return Some(
+                            self.sighasher()
+                                .sighash_v4_raw(raw_byte, Some((input_index, script_code_vec)))
+                                .0,
+                        );
+                    }
+
+                    let mut our_hash_type = match hash_type.signed_outputs() {
+                        zcash_script::signature::SignedOutputs::All => HashType::ALL,
+                        zcash_script::signature::SignedOutputs::Single => HashType::SINGLE,
+                        zcash_script::signature::SignedOutputs::None => HashType::NONE,
+                    };
+                    if hash_type.anyone_can_pay() {
+                        our_hash_type |= HashType::ANYONECANPAY;
+                    }
+                    Some(
                         self.sighasher()
-                            .sighash_v4_raw(raw_byte, Some((input_index, script_code_vec)))
+                            .sighash(our_hash_type, Some((input_index, script_code_vec)))
                             .0,
-                    );
-                }
+                    )
+                })();
 
-                let mut our_hash_type = match hash_type.signed_outputs() {
-                    zcash_script::signature::SignedOutputs::All => HashType::ALL,
-                    zcash_script::signature::SignedOutputs::Single => HashType::SINGLE,
-                    zcash_script::signature::SignedOutputs::None => HashType::NONE,
-                };
-                if hash_type.anyone_can_pay() {
-                    our_hash_type |= HashType::ANYONECANPAY;
-                }
-                Some(
-                    self.sighasher()
-                        .sighash(our_hash_type, Some((input_index, script_code_vec)))
-                        .0,
-                )
+                // Workaround for the libzcash_script callback API: returning
+                // `None` from this callback does not propagate failure to the
+                // C++ verifier.
+                //
+                // Instead of returning `None` to indicate an error, we return a
+                // per-call randomly-generated dummy sighash so any signature
+                // fails to verify with overwhelming probability. Note that a
+                // fixed sentinel value would be unsafe: an attacker who knows
+                // it can construct an ECDSA signature that verifies against any
+                // 32-byte value under a chosen pubkey.
+                //
+                // This shim can be removed once libzcash_script propagates
+                // callback failure to the C++ verifier.
+                Some(computed.unwrap_or_else(|| {
+                    use rand::RngCore;
+                    let mut bytes = [0u8; 32];
+                    rand::rngs::OsRng.fill_bytes(&mut bytes);
+                    bytes
+                }))
             };
         let interpreter = get_interpreter(&calculate_sighash, lock_time, is_final);
         interpreter

--- a/zebra-script/src/tests.rs
+++ b/zebra-script/src/tests.rs
@@ -1053,3 +1053,155 @@ fn is_valid_rejects_out_of_range_input_index() {
         .expect_err("out-of-range input_index must error, not panic");
     assert_eq!(err, super::Error::TxIndex);
 }
+
+/// Regression test for the libzcash_script stale-sighash-buffer bypass.
+///
+/// Construct a V5 transaction whose scriptPubKey is:
+///
+/// ```text
+/// <pubkey> OP_CHECKSIGVERIFY <pubkey> OP_CHECKSIG
+/// ```
+///
+/// and whose scriptSig pushes two signatures over the same canonical
+/// `SIGHASH_ALL` (0x01) digest, the first tagged with an *invalid* V5
+/// hash-type byte (0x50) and the second tagged with the canonical 0x01:
+///
+/// ```text
+/// <der_sig || 0x50>   (pushed first → bottom of stack)
+/// <der_sig || 0x01>   (pushed second → top of stack)
+/// ```
+///
+/// Script evaluation then:
+///
+/// 1. Consumes `<der_sig || 0x01>` via `OP_CHECKSIGVERIFY`. Zebra's callback
+///    returns the canonical SIGHASH_ALL digest, the C++ verifier fills its
+///    stack-local `sighashArray` with that digest, and the signature passes.
+/// 2. Consumes `<der_sig || 0x50>` via `OP_CHECKSIG`. Zebra's callback sees
+///    an invalid V5 hash-type byte. Prior to this fix the callback returned
+///    `None`, libzcash_script silently wrote nothing to the C++ buffer, and
+///    the C++ `CheckSig` verified the signature against the stale
+///    SIGHASH_ALL digest from step 1 — accepting a spend that `zcashd`
+///    rejects and splitting Zebra nodes from `zcashd` nodes.
+///
+/// With the defense-in-depth fix in `zebra-script::calculate_sighash`, the
+/// callback now returns a per-call CSPRNG-derived sighash when the hash
+/// type would have been rejected, so the second signature fails to verify
+/// and `is_valid` returns an error — matching `zcashd`.
+///
+/// The bypass requires release-grade C++ optimizations in `libzcash_script`
+/// (so the stack buffer is not zero-initialized and the prior digest
+/// lingers between callbacks). The workspace `Cargo.toml` forces
+/// `[profile.dev.package.libzcash_script]` to `opt-level = 3` in all
+/// profiles so that `cargo test` exercises the vulnerable code path and
+/// this regression test catches any re-introduction of the bug in both
+/// dev and release builds.
+#[test]
+fn stale_sighash_buffer_v5_two_checksig_rejected() {
+    use secp256k1::{Message, Secp256k1, SecretKey};
+
+    let _init_guard = zebra_test::init();
+
+    let secp = Secp256k1::new();
+    let secret_key = SecretKey::from_slice(&[0xcd; 32]).expect("valid secret key");
+    let public_key = secp256k1::PublicKey::from_secret_key(&secp, &secret_key);
+    let pubkey_bytes = public_key.serialize();
+
+    // scriptPubKey: <0x21> <pubkey 33 bytes> OP_CHECKSIGVERIFY
+    //               <0x21> <pubkey 33 bytes> OP_CHECKSIG
+    // OP_CHECKSIGVERIFY = 0xad, OP_CHECKSIG = 0xac
+    let mut lock_script_bytes = Vec::with_capacity(1 + 33 + 1 + 1 + 33 + 1);
+    lock_script_bytes.push(0x21);
+    lock_script_bytes.extend_from_slice(&pubkey_bytes);
+    lock_script_bytes.push(0xad);
+    lock_script_bytes.push(0x21);
+    lock_script_bytes.extend_from_slice(&pubkey_bytes);
+    lock_script_bytes.push(0xac);
+    let lock_script = transparent::Script::new(&lock_script_bytes);
+
+    let previous_output = transparent::Output {
+        value: 1_0000_0000u64.try_into().expect("valid amount"),
+        lock_script: lock_script.clone(),
+    };
+
+    // Placeholder V5 tx used to compute the sighash; the V5 (ZIP 244) sighash
+    // does not depend on the unlock script contents, so we can sign, then
+    // rebuild the transaction with the real unlock script.
+    let placeholder_tx = Transaction::V5 {
+        network_upgrade: NetworkUpgrade::Nu5,
+        lock_time: LockTime::unlocked(),
+        expiry_height: block::Height(0),
+        inputs: vec![transparent::Input::PrevOut {
+            outpoint: transparent::OutPoint {
+                hash: transaction::Hash([0u8; 32]),
+                index: 0,
+            },
+            unlock_script: transparent::Script::new(&[]),
+            sequence: u32::MAX,
+        }],
+        outputs: vec![transparent::Output {
+            value: 9000_0000u64.try_into().expect("valid amount"),
+            lock_script: transparent::Script::new(&[0x00]),
+        }],
+        sapling_shielded_data: None,
+        orchard_shielded_data: None,
+    };
+
+    let all_previous_outputs = Arc::new(vec![previous_output.clone()]);
+    let sighasher = SigHasher::new(&placeholder_tx, NetworkUpgrade::Nu5, all_previous_outputs)
+        .expect("sighasher creation should succeed");
+
+    // Canonical SIGHASH_ALL digest — this is the digest the attacker needs
+    // the stale C++ buffer to still hold when the second CHECKSIG runs.
+    let sighash = sighasher.sighash(HashType::ALL, Some((0, lock_script_bytes.clone())));
+    let msg = Message::from_digest(*sighash.as_ref());
+    let signature = secp.sign_ecdsa(&msg, &secret_key);
+    let der_sig = signature.serialize_der();
+
+    // scriptSig pushes:
+    //   1. <der_sig || 0x50>  (bottom)
+    //   2. <der_sig || 0x01>  (top, consumed by OP_CHECKSIGVERIFY first)
+    let mut unlock_script_bytes = Vec::new();
+    let sig_with_hashtype_len = (der_sig.len() + 1) as u8;
+
+    unlock_script_bytes.push(sig_with_hashtype_len);
+    unlock_script_bytes.extend_from_slice(&der_sig);
+    unlock_script_bytes.push(0x50);
+
+    unlock_script_bytes.push(sig_with_hashtype_len);
+    unlock_script_bytes.extend_from_slice(&der_sig);
+    unlock_script_bytes.push(0x01);
+
+    let final_tx = Transaction::V5 {
+        network_upgrade: NetworkUpgrade::Nu5,
+        lock_time: LockTime::unlocked(),
+        expiry_height: block::Height(0),
+        inputs: vec![transparent::Input::PrevOut {
+            outpoint: transparent::OutPoint {
+                hash: transaction::Hash([0u8; 32]),
+                index: 0,
+            },
+            unlock_script: transparent::Script::new(&unlock_script_bytes),
+            sequence: u32::MAX,
+        }],
+        outputs: vec![transparent::Output {
+            value: 9000_0000u64.try_into().expect("valid amount"),
+            lock_script: transparent::Script::new(&[0x00]),
+        }],
+        sapling_shielded_data: None,
+        orchard_shielded_data: None,
+    };
+
+    let verifier = super::CachedFfiTransaction::new(
+        Arc::new(final_tx),
+        Arc::new(vec![previous_output]),
+        NetworkUpgrade::Nu5,
+    )
+    .expect("network upgrade should be valid for v5 tx");
+
+    assert!(
+        verifier.is_valid(0).is_err(),
+        "V5 tx exploiting the stale libzcash_script sighash buffer via \
+         OP_CHECKSIGVERIFY + OP_CHECKSIG with an invalid second hash-type \
+         byte (0x50) must be rejected, matching zcashd"
+    );
+}


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

Fixes https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-gq4h-3grw-2rhv

## Solution

This is a bit of a ugly solution, but effective. Properly fixing it would require a breaking API change in zcash_script. The workaround consists of filling the sighash output buffer with random bytes instead of returning None. This makes the signature verification fail as expected (the odds of the buffer being correct is neglibly small). We can remove the workaround after whe do a proper fix in zcash_script.

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
-->

### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude for the fix and the test. Reviewed and cleaned up manually.

### PR Checklist

- [ ] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [ ] The solution is tested.
- [ ] The documentation and changelogs are up to date.