### PR TITLE
fix(network): Enforce 160-entry cap in `read_headers`

### DIFF
--- a/zebra-chain/src/serialization.rs
+++ b/zebra-chain/src/serialization.rs
@@ -40,5 +40,6 @@ pub use zcash_deserialize::{
 };
 pub use zcash_serialize::{
     zcash_serialize_bytes, zcash_serialize_bytes_external_count, zcash_serialize_empty_list,
-    zcash_serialize_external_count, FakeWriter, ZcashSerialize, MAX_PROTOCOL_MESSAGE_LEN,
+    zcash_serialize_external_count, FakeWriter, ZcashSerialize, MAX_HEADERS_PER_MESSAGE,
+    MAX_PROTOCOL_MESSAGE_LEN,
 };

--- a/zebra-chain/src/serialization/zcash_serialize.rs
+++ b/zebra-chain/src/serialization/zcash_serialize.rs
@@ -9,6 +9,11 @@ use super::{AtLeastOne, CompactSizeMessage};
 /// This value is used to calculate safe preallocation limits for some types
 pub const MAX_PROTOCOL_MESSAGE_LEN: usize = 2 * 1024 * 1024;
 
+/// The maximum number of block headers in a single `headers` protocol message.
+///
+/// <https://zips.z.cash/protocol/protocol.pdf#page=108>
+pub const MAX_HEADERS_PER_MESSAGE: usize = 160;
+
 /// Consensus-critical serialization for Zcash.
 ///
 /// This trait provides a generic serialization for consensus-critical

--- a/zebra-network/src/protocol/external/codec.rs
+++ b/zebra-network/src/protocol/external/codec.rs
@@ -15,9 +15,10 @@ use zebra_chain::{
     block::{self, Block},
     parameters::{Magic, Network},
     serialization::{
-        sha256d, zcash_deserialize_bytes_external_count, zcash_deserialize_string_external_count,
-        CompactSizeMessage, FakeWriter, ReadZcashExt, SerializationError as Error,
-        ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize, MAX_PROTOCOL_MESSAGE_LEN,
+        sha256d, zcash_deserialize_bytes_external_count, zcash_deserialize_external_count,
+        zcash_deserialize_string_external_count, CompactSizeMessage, FakeWriter, ReadZcashExt,
+        SerializationError as Error, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize,
+        MAX_HEADERS_PER_MESSAGE, MAX_PROTOCOL_MESSAGE_LEN,
     },
     transaction::Transaction,
 };
@@ -678,7 +679,19 @@ impl Codec {
     ///
     /// [Zcash block header](https://zips.z.cash/protocol/protocol.pdf#page=84)
     fn read_headers<R: Read>(&self, mut reader: R) -> Result<Message, Error> {
-        Ok(Message::Headers(Vec::zcash_deserialize(&mut reader)?))
+        // CompactSizeMessage is bounded to MAX_PROTOCOL_MESSAGE_LEN on deserialization.
+        let count: CompactSizeMessage = (&mut reader).zcash_deserialize_into()?;
+        // Infallible: CompactSizeMessage wraps u32, which always fits in usize.
+        let count: usize = count.into();
+        if count > MAX_HEADERS_PER_MESSAGE {
+            return Err(Error::Parse(
+                "headers message exceeds the protocol limit of 160 entries",
+            ));
+        }
+        Ok(Message::Headers(zcash_deserialize_external_count(
+            count,
+            &mut reader,
+        )?))
     }
 
     fn read_getheaders<R: Read>(&self, mut reader: R) -> Result<Message, Error> {

--- a/zebra-network/src/protocol/external/codec/tests/vectors.rs
+++ b/zebra-network/src/protocol/external/codec/tests/vectors.rs
@@ -588,16 +588,14 @@ fn reject_command_and_reason_size_limits() {
     }
 }
 
-/// Reproduce GHSA-438q-jx8f-cccv: read_headers() accepts more than the
-/// protocol-maximum 160 headers because the receive path relies on
-/// TrustedPreallocate (ceiling ≈ 1 409) instead of MAX_FIND_BLOCK_HEADERS_RESULTS.
+/// Regression test for GHSA-438q-jx8f-cccv: read_headers() must reject
+/// inbound `headers` messages with more than 160 entries.
 #[test]
-fn headers_message_exceeding_protocol_cap_is_accepted() {
+fn headers_message_exceeding_protocol_cap_is_rejected() {
     use zebra_chain::serialization::ZcashDeserializeInto;
 
     let _init_guard = zebra_test::init();
 
-    // Parse the dummy header from test vectors.
     let header: block::Header = zebra_test::vectors::DUMMY_HEADER
         .zcash_deserialize_into()
         .expect("dummy header should deserialize");
@@ -605,38 +603,51 @@ fn headers_message_exceeding_protocol_cap_is_accepted() {
         header: header.into(),
     };
 
-    // 161 headers — one more than the Zcash protocol limit of 160.
-    let count = 161;
-    let msg = Message::Headers(vec![counted; count]);
+    // 161 headers — one more than the protocol limit of 160.
+    let msg = Message::Headers(vec![counted.clone(); 161]);
 
-    // Encode via the codec (no cap on the send side either).
     let mut codec = Codec::builder().finish();
     let mut bytes = BytesMut::new();
     codec
         .encode(msg, &mut bytes)
-        .expect("encoding 161 headers should succeed");
+        .expect("encoding should succeed");
 
-    // Decode — this succeeds because read_headers() has no 160-entry cap.
+    codec
+        .decode(&mut bytes)
+        .expect_err("decoding 161 headers should be rejected");
+}
+
+/// Verify that a headers message at exactly the protocol cap (160) is accepted.
+#[test]
+fn headers_message_at_protocol_cap_is_accepted() {
+    use zebra_chain::serialization::ZcashDeserializeInto;
+
+    let _init_guard = zebra_test::init();
+
+    let header: block::Header = zebra_test::vectors::DUMMY_HEADER
+        .zcash_deserialize_into()
+        .expect("dummy header should deserialize");
+    let counted = block::CountedHeader {
+        header: header.into(),
+    };
+
+    let msg = Message::Headers(vec![counted; 160]);
+
+    let mut codec = Codec::builder().finish();
+    let mut bytes = BytesMut::new();
+    codec
+        .encode(msg, &mut bytes)
+        .expect("encoding should succeed");
+
     let decoded = codec
         .decode(&mut bytes)
         .expect("decoding should not error")
         .expect("a message should be present");
 
     match decoded {
-        Message::Headers(headers) => {
-            assert_eq!(
-                headers.len(),
-                count,
-                "codec accepted {count} headers; protocol cap is 160"
-            );
-        }
+        Message::Headers(headers) => assert_eq!(headers.len(), 160),
         other => panic!("expected Headers, got {other:?}"),
     }
-
-    // Show the TrustedPreallocate ceiling that enables the amplification.
-    use zebra_chain::serialization::TrustedPreallocate;
-    let max = block::CountedHeader::max_allocation();
-    assert_eq!(max, 1409, "preallocation ceiling should be ~8.8x the protocol cap of 160");
 }
 
 /// Check that the version test vector deserialization fails when there's a network magic mismatch.

--- a/zebra-network/src/protocol/external/codec/tests/vectors.rs
+++ b/zebra-network/src/protocol/external/codec/tests/vectors.rs
@@ -588,6 +588,57 @@ fn reject_command_and_reason_size_limits() {
     }
 }
 
+/// Reproduce GHSA-438q-jx8f-cccv: read_headers() accepts more than the
+/// protocol-maximum 160 headers because the receive path relies on
+/// TrustedPreallocate (ceiling ≈ 1 409) instead of MAX_FIND_BLOCK_HEADERS_RESULTS.
+#[test]
+fn headers_message_exceeding_protocol_cap_is_accepted() {
+    use zebra_chain::serialization::ZcashDeserializeInto;
+
+    let _init_guard = zebra_test::init();
+
+    // Parse the dummy header from test vectors.
+    let header: block::Header = zebra_test::vectors::DUMMY_HEADER
+        .zcash_deserialize_into()
+        .expect("dummy header should deserialize");
+    let counted = block::CountedHeader {
+        header: header.into(),
+    };
+
+    // 161 headers — one more than the Zcash protocol limit of 160.
+    let count = 161;
+    let msg = Message::Headers(vec![counted; count]);
+
+    // Encode via the codec (no cap on the send side either).
+    let mut codec = Codec::builder().finish();
+    let mut bytes = BytesMut::new();
+    codec
+        .encode(msg, &mut bytes)
+        .expect("encoding 161 headers should succeed");
+
+    // Decode — this succeeds because read_headers() has no 160-entry cap.
+    let decoded = codec
+        .decode(&mut bytes)
+        .expect("decoding should not error")
+        .expect("a message should be present");
+
+    match decoded {
+        Message::Headers(headers) => {
+            assert_eq!(
+                headers.len(),
+                count,
+                "codec accepted {count} headers; protocol cap is 160"
+            );
+        }
+        other => panic!("expected Headers, got {other:?}"),
+    }
+
+    // Show the TrustedPreallocate ceiling that enables the amplification.
+    use zebra_chain::serialization::TrustedPreallocate;
+    let max = block::CountedHeader::max_allocation();
+    assert_eq!(max, 1409, "preallocation ceiling should be ~8.8x the protocol cap of 160");
+}
+
 /// Check that the version test vector deserialization fails when there's a network magic mismatch.
 #[test]
 fn message_with_wrong_network_magic_returns_error() {


### PR DESCRIPTION
Reproduce and propose fix.