### PR TITLE
test(state, rpc): handle coinbase Sapling spends in proptests broken by #10527

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7864,7 +7864,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "libzcash_script",
- "rand 0.8.5",
+ "rand 0.8.6",
  "ripemd 0.1.3",
  "secp256k1",
  "sha2 0.10.9",

--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -582,6 +582,31 @@ where
         + Copy
         + 'static,
 {
+    // Coinbase transactions must not contain Sapling spends (GHSA-rgwx-8r98-p34c).
+    // The arbitrary `Transaction` strategy generates these independently, so clear
+    // any generated Sapling shielded data on coinbase transactions before the chain
+    // builder commits them. The deserialization rejection path is still exercised
+    // by the `transaction_roundtrip` proptest and the GHSA-rgwx-8r98-p34c reproduction
+    // vector in `zebra-chain`.
+    if transaction.is_coinbase() {
+        match &mut transaction {
+            Transaction::V4 {
+                sapling_shielded_data,
+                ..
+            } => *sapling_shielded_data = None,
+            Transaction::V5 {
+                sapling_shielded_data,
+                ..
+            } => *sapling_shielded_data = None,
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+            Transaction::V6 {
+                sapling_shielded_data,
+                ..
+            } => *sapling_shielded_data = None,
+            Transaction::V1 { .. } | Transaction::V2 { .. } | Transaction::V3 { .. } => {}
+        }
+    }
+
     let mut spend_restriction = transaction.coinbase_spend_restriction(&Network::Mainnet, height);
     let mut new_inputs = Vec::new();
     let mut spent_outputs = HashMap::new();

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -48,6 +48,8 @@ proptest! {
     /// Test that when sending a raw transaction, it is received by the mempool service.
     #[test]
     fn mempool_receives_raw_tx(transaction in any::<Transaction>(), network in any::<Network>()) {
+        prop_assume!(!(transaction.is_coinbase() && transaction.sapling_spends_per_anchor().count() > 0));
+
         let (runtime, _init_guard) = zebra_test::init_async();
         let _guard = runtime.enter();
         let (mut mempool, mut state, rpc, mempool_tx_queue) = mock_services(network, NoChainTip);
@@ -93,6 +95,8 @@ proptest! {
     /// Mempool service errors should become server errors.
     #[test]
     fn mempool_errors_are_forwarded(transaction in any::<Transaction>(), network in any::<Network>()) {
+        prop_assume!(!(transaction.is_coinbase() && transaction.sapling_spends_per_anchor().count() > 0));
+
         let (runtime, _init_guard) = zebra_test::init_async();
         let _guard = runtime.enter();
         let (mut mempool, mut state, rpc, mempool_tx_queue) = mock_services(network, NoChainTip);
@@ -147,6 +151,8 @@ proptest! {
     /// Test that when the mempool rejects a transaction the caller receives an error.
     #[test]
     fn rejected_txs_are_reported(transaction in any::<Transaction>(), network in any::<Network>()) {
+        prop_assume!(!(transaction.is_coinbase() && transaction.sapling_spends_per_anchor().count() > 0));
+
         let (runtime, _init_guard) = zebra_test::init_async();
         let _guard = runtime.enter();
         let (mut mempool, mut state, rpc, mempool_tx_queue) = mock_services(network, NoChainTip);
@@ -714,6 +720,8 @@ proptest! {
     /// Test the queue functionality using `send_raw_transaction`
     #[test]
     fn rpc_queue_main_loop(tx in any::<Transaction>(), network in any::<Network>()) {
+        prop_assume!(!(tx.is_coinbase() && tx.sapling_spends_per_anchor().count() > 0));
+
         let (runtime, _init_guard) = zebra_test::init_async();
         let _guard = runtime.enter();
         let (mut mempool, mut state, rpc, mempool_tx_queue) = mock_services(network, NoChainTip);
@@ -792,6 +800,7 @@ proptest! {
     #[test]
     fn rpc_queue_receives_all_txs_from_channel(txs in any::<[Transaction; 2]>(),
                                                network in any::<Network>()) {
+        prop_assume!(txs.iter().all(|tx| !(tx.is_coinbase() && tx.sapling_spends_per_anchor().count() > 0)));
         let (runtime, _init_guard) = zebra_test::init_async();
         let _guard = runtime.enter();
         let (mut mempool, mut state, rpc, mempool_tx_queue) = mock_services(network, NoChainTip);

--- a/zebra-state/src/service/finalized_state/disk_format/tests/prop.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/prop.rs
@@ -94,7 +94,14 @@ fn roundtrip_transaction_hash() {
 fn roundtrip_transaction() {
     let _init_guard = zebra_test::init();
 
-    proptest!(|(val in any::<Transaction>())| assert_value_properties(val));
+    proptest!(|(val in any::<Transaction>())| {
+        // Coinbase transactions with Sapling spends are rejected during deserialization
+        // (GHSA-rgwx-8r98-p34c), so they cannot round-trip through `IntoDisk`/`FromDisk`.
+        // The arbitrary `Transaction` strategy still produces them so the
+        // `transaction_roundtrip` proptest in `zebra-chain` can exercise the rejection path.
+        prop_assume!(!(val.is_coinbase() && val.sapling_spends_per_anchor().count() > 0));
+        assert_value_properties(val)
+    });
 }
 
 // Transparent

--- a/zebrad/src/components/inbound/downloads.rs
+++ b/zebrad/src/components/inbound/downloads.rs
@@ -157,12 +157,11 @@ where
         //
         // TODO: this would be cleaner with poll_map (#2693)
         if let Some(join_result) = ready!(this.pending.poll_next(cx)) {
-            let (result, hash) = match join_result
-                .expect("block download and verify tasks must not panic")
-            {
-                Ok(hash) => (Ok(hash), hash),
-                Err((e, hash, advertiser_addr)) => (Err((e, advertiser_addr)), hash),
-            };
+            let (result, hash) =
+                match join_result.expect("block download and verify tasks must not panic") {
+                    Ok(hash) => (Ok(hash), hash),
+                    Err((e, hash, advertiser_addr)) => (Err((e, advertiser_addr)), hash),
+                };
             if let Some((_, Some(ip))) = this.cancel_handles.remove(&hash) {
                 assert!(
                     this.in_flight_ips.remove(&ip),


### PR DESCRIPTION
## Motivation

Several CI jobs are red on `main`:

1. Five proptests in `zebra-rpc::methods::tests::prop` fail after #10527. The `any::<Transaction>()` (and `any::<[Transaction; 2]>()`) arbitrary strategies can produce coinbase transactions containing Sapling spends. After #10527 those are rejected during deserialization, so `send_raw_transaction` returns a deserialization error before reaching the mempool, and each affected test waits indefinitely for a mempool request that never arrives.
2. Three proptests in `zebra-state::service::finalized_state` panic for the same reason: chains generated by `PreparedChain` contain coinbase transactions with Sapling shielded data that fail to round-trip through `IntoDisk`/`FromDisk`. `roundtrip_transaction` hits the same panic via `any::<Transaction>()`.
3. `Cargo.lock` is out of date (missing the `rand 0.8.5` → `rand 0.8.6` bump for `zebra-script`).
4. `cargo fmt --check` fails.

#10527 updated the `transaction_roundtrip` proptest in `zebra-chain` for the same case but missed the downstream proptests that consume the same arbitrary strategy.

## Solution

- Skip the invalid coinbase-with-Sapling-spends combination with
  `prop_assume!` in the five affected RPC proptests:
  - `mempool_receives_raw_tx`
  - `mempool_errors_are_forwarded`
  - `rejected_txs_are_reported`
  - `rpc_queue_main_loop`
  - `rpc_queue_receives_all_txs_from_channel`
- For `zebra-state`, fix the chain-builder fixup layer: clear
  `sapling_shielded_data` on coinbase transactions in
  `fix_generated_transaction`. This covers `blocks_with_v5_transactions`
  and `all_upgrades_and_wrong_commitments_with_fake_activation_heights`,
  which both build chains via `PreparedChain`.
- Add a `prop_assume!` to `roundtrip_transaction` since it bypasses the
  chain builder and uses `any::<Transaction>()` directly.
- The `Transaction::Arbitrary` strategy is intentionally left unchanged
  so the rejection path is still exercised by `transaction_roundtrip`
  and the GHSA-rgwx-8r98-p34c reproduction vector in `zebra-chain` (per
  the design choice in #10527).
- Refresh `Cargo.lock`.
- Apply `cargo fmt --all`.

### AI Disclosure

- [x] AI tools were used: Claude (Opus 4) for investigation and patch drafting.

### PR Checklist

- [x] The PR title follows conventional commits format.
- [x] The PR follows the contribution guidelines.
- [x] This change was discussed in an issue or with the team beforehand. *(Maintainer-driven: fixes CI breakage on `main`.)*
- [x] The solution is tested.
- [ ] The documentation and changelogs are up to date. *(No changelog entry — test-only / build-only changes.)*