### PR TITLE
docs(zebra-consensus): ZCG reporting boundary + mempool spent_outputs alignment

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,6 +50,24 @@ AQC1Wmyb9ul/2QNi//8sKNDfaYbn3h6OU45BTAWggp+ACQ==
 -----END PGP PUBLIC KEY BLOCK-----
 ```
 
+### Important Reporting Boundary
+
+Zcash Community Grants (ZCG) funds vulnerability payouts, but it is not a vulnerability disclosure intake or triage channel.
+
+- Do not send vulnerability details, PoCs, or exploit artifacts to ZCG.
+- Do not attempt to register with ZCG for bounty eligibility.
+- Submit Zebra and `zebrad` vulnerability reports through this policy (`security@zfnd.org`).
+
+### Recommended Report Contents
+
+To reduce triage delays, please include:
+
+- impacted component(s) and version(s),
+- a clear impact statement,
+- reproducible steps,
+- environment/configuration details,
+- and logs or PoC evidence where possible.
+
 ## Sending Disclosures
 
 In the case where we become aware of security issues affecting other projects that has never affected Zebra or Zcash, our intention is to inform those projects of security issues on a best effort basis.

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -376,6 +376,8 @@ pub struct VerifiedUnminedTx {
 
     /// The spent outputs for this transaction's transparent inputs.
     ///
+    /// One entry per transparent input, in the same order as the transparent inputs on the
+    /// wrapped transaction.
     /// Used by mempool policy checks (`AreInputsStandard`, `GetP2SHSigOpCount`).
     /// Empty for transactions with no transparent inputs or in test contexts.
     pub spent_outputs: Arc<Vec<transparent::Output>>,

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -586,11 +586,10 @@ where
                     sigops,
                 },
                 Request::Mempool { transaction: tx, .. } => {
-                    // TODO: `spent_outputs` may not align with `tx.inputs()` when a transaction
-                    // spends both chain and mempool UTXOs (mempool outputs are appended last by
-                    // `spent_utxos()`), causing policy checks to pair the wrong input with
-                    // the wrong spent output.
-                    // https://github.com/ZcashFoundation/zebra/issues/10346
+                    // `spent_utxos()` fills `spent_outputs` by **transparent input index** (see
+                    // `spent_outputs[input_idx]`), so pairing matches `tx.inputs()` order even when
+                    // some UTXOs come from the mempool. Mempool insertion rejects a length mismatch
+                    // with `tx.inputs()` before policy zips inputs with `spent_outputs`.
                     let spent_outputs = cached_ffi_transaction.all_previous_outputs().clone();
                     let transaction = VerifiedUnminedTx::new(
                         tx,

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -728,6 +728,152 @@ async fn mempool_request_with_unmined_output_spends_is_accepted() {
     );
 }
 
+/// When a mempool transaction spends a mempool-only UTXO at input index 0 and a chain UTXO at
+/// index 1, `spent_outputs` must stay aligned with input order (regression guard for #10356).
+#[tokio::test]
+async fn mempool_spent_outputs_order_matches_inputs_for_mempool_then_chain_utxos() {
+    let _init_guard = zebra_test::init();
+
+    let mut state: MockService<_, _, _, _> = MockService::build().for_prop_tests();
+    let mempool: MockService<_, _, _, _> = MockService::build().for_prop_tests();
+    let (mempool_setup_tx, mempool_setup_rx) = tokio::sync::oneshot::channel();
+    let verifier = Verifier::new(&Network::Mainnet, state.clone(), mempool_setup_rx);
+    mempool_setup_tx
+        .send(mempool.clone())
+        .ok()
+        .expect("send should succeed");
+
+    let height = NetworkUpgrade::Canopy
+        .activation_height(&Network::Mainnet)
+        .expect("Canopy activation height is specified");
+    let fund_height = (height - 1).expect("fake source fund block height is too small");
+
+    let (input_mempool_first, output_mempool, mut merged_utxos) = mock_transparent_transfer(
+        fund_height,
+        true,
+        0,
+        Amount::try_from(10001).expect("invalid value"),
+    );
+    let (input_chain_second, output_chain, map_chain) = mock_transparent_transfer(
+        fund_height,
+        true,
+        1,
+        Amount::try_from(10001).expect("invalid value"),
+    );
+    merged_utxos.extend(map_chain);
+
+    let out_mempool = match &input_mempool_first {
+        transparent::Input::PrevOut { outpoint, .. } => *outpoint,
+        transparent::Input::Coinbase { .. } => panic!("expected prevout"),
+    };
+    let out_chain = match &input_chain_second {
+        transparent::Input::PrevOut { outpoint, .. } => *outpoint,
+        transparent::Input::Coinbase { .. } => panic!("expected prevout"),
+    };
+
+    let utxo_chain = merged_utxos
+        .get(&out_chain)
+        .expect("chain outpoint in merged map")
+        .utxo
+        .clone();
+    let utxo_mempool = merged_utxos
+        .get(&out_mempool)
+        .expect("mempool outpoint in merged map")
+        .utxo
+        .clone();
+    let expected_chain_output = utxo_chain.output.clone();
+    let expected_mempool_output = utxo_mempool.output.clone();
+
+    let tx = Transaction::V4 {
+        inputs: vec![input_mempool_first, input_chain_second],
+        outputs: vec![output_mempool, output_chain],
+        lock_time: LockTime::min_lock_time_timestamp(),
+        expiry_height: height,
+        joinsplit_data: None,
+        sapling_shielded_data: None,
+    };
+
+    tokio::spawn(async move {
+        state
+            .expect_request(zebra_state::Request::BestChainNextMedianTimePast)
+            .await
+            .expect("verifier asks median time past")
+            .respond(zebra_state::Response::BestChainNextMedianTimePast(
+                DateTime32::MAX,
+            ));
+
+        state
+            .expect_request(zebra_state::Request::UnspentBestChainUtxo(out_mempool))
+            .await
+            .expect("first outpoint: not in best chain UTXO set")
+            .respond(zebra_state::Response::UnspentBestChainUtxo(None));
+
+        state
+            .expect_request(zebra_state::Request::UnspentBestChainUtxo(out_chain))
+            .await
+            .expect("second outpoint: in best chain UTXO set")
+            .respond(zebra_state::Response::UnspentBestChainUtxo(Some(
+                utxo_chain.clone(),
+            )));
+
+        state
+            .expect_request_that(|req| {
+                matches!(
+                    req,
+                    zebra_state::Request::CheckBestChainTipNullifiersAndAnchors(_)
+                )
+            })
+            .await
+            .expect("nullifiers check")
+            .respond(zebra_state::Response::ValidBestChainTipNullifiersAndAnchors);
+    });
+
+    let mempool_output = expected_mempool_output.clone();
+    let mut mempool_clone = mempool.clone();
+    tokio::spawn(async move {
+        mempool_clone
+            .expect_request(mempool::Request::AwaitOutput(out_mempool))
+            .await
+            .expect("await mempool-created output")
+            .respond(mempool::Response::UnspentOutput(mempool_output));
+    });
+
+    let verifier_response = verifier
+        .oneshot(Request::Mempool {
+            transaction: tx.into(),
+            height,
+        })
+        .await;
+
+    assert!(
+        verifier_response.is_ok(),
+        "expected successful verification, got: {verifier_response:?}"
+    );
+
+    let crate::transaction::Response::Mempool { transaction, .. } =
+        verifier_response.expect("already checked that response is ok")
+    else {
+        panic!("expected Mempool response from transaction verifier");
+    };
+
+    let spent = transaction.spent_outputs.as_ref();
+    assert_eq!(
+        spent.len(),
+        2,
+        "spent_outputs must include one entry per transparent input"
+    );
+    assert_eq!(
+        &spent[0],
+        &expected_mempool_output,
+        "input 0 (mempool-funded) must pair with the mempool previous output"
+    );
+    assert_eq!(
+        &spent[1],
+        &expected_chain_output,
+        "input 1 (chain-funded) must pair with the chain previous output"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn skips_verification_of_block_transactions_in_mempool() {
     let mut state: MockService<_, _, _, _> = MockService::build().for_prop_tests();


### PR DESCRIPTION
## Summary

- Clarifies in `SECURITY.md` that vulnerability reports must go to the Zcash Foundation security contact (`security@zfnd.org`) and must **not** be sent to ZCG (funding/administration only).
- Documents that `VerifiedUnminedTx::spent_outputs` is ordered parallel to transparent inputs.
- Replaces a stale `spent_outputs` / mempool TODO in the transaction verifier with an accurate explanation.
- Adds a regression test that spends a mempool-only UTXO at input index 0 and a chain UTXO at index 1, asserting `spent_outputs` stays aligned with input order.

## Motivation

The ZCG security payout initiative increases the risk of researchers misrouting disclosures to ZCG. Explicit `SECURITY.md` guidance reduces accidental broad exposure and duplicate handling.

Separately, mempool standardness checks zip transparent inputs with `spent_outputs`; documenting and testing input-index alignment prevents future regressions around mixed chain/mempool UTXO sources.

## Testing

- `cargo test -p zebra-consensus mempool_spent_outputs_order_matches_inputs_for_mempool_then_chain_utxos`