### PR TITLE
release: v4.4.1, reject v5 SIGHASH_SINGLE without a corresponding output 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist.md
@@ -132,7 +132,7 @@ Check that the release will work:
 ```sh
 cargo release version --verbose --execute --allow-branch '*' -p <crate> patch # [ major | minor ]
 # zebrad only
-cargo release replace --verbose --execute --allow-branch '*' -p <crate>
+cargo release replace --verbose --execute --allow-branch '*' -p zebrad
 ```
 
 - [ ] Commit and push the above version changes to the release branch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Zebra 4.4.1](https://github.com/ZcashFoundation/zebra/releases/tag/v4.4.1) - 2026-05-04
+
+This release fixes one critical security issue. We recommend node operators update to
+4.4.1.
+
+### Security
+
+- Reject V5 transparent inputs signed with `SIGHASH_SINGLE` (or
+  `SIGHASH_SINGLE|ANYONECANPAY`) when the input has no transparent output at the
+  same index
+  ([GHSA-pvmv-cwg8-v6c8](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-pvmv-cwg8-v6c8)).
+  Follow-up to
+  [GHSA-cwfq-rfcr-8hmp](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-cwfq-rfcr-8hmp).
+
+Thanks to @sangsoo-osec, @zmanian, and @fivelittleducks for reporting the issue.
+
 ## [Zebra 4.4.0](https://github.com/ZcashFoundation/zebra/releases/tag/v4.4.0) - 2026-05-01
 
 This release includes several security and bug fixes. We recommend node

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7859,7 +7859,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-script"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "hex",
  "lazy_static",
@@ -7975,7 +7975,7 @@ dependencies = [
 
 [[package]]
 name = "zebrad"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "abscissa_core",
  "atty",

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ cargo install --locked zebrad
 Alternatively, you can install it from GitHub:
 
 ```sh
-cargo install --git https://github.com/ZcashFoundation/zebra --tag v4.4.0 zebrad
+cargo install --git https://github.com/ZcashFoundation/zebra --tag v4.4.1 zebrad
 ```
 
 You can start Zebra by running

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -2232,31 +2232,31 @@ version = "0.7.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-chain]]
-version = "6.0.2"
+version = "7.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-consensus]]
-version = "5.0.2"
+version = "6.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-network]]
-version = "5.0.1"
+version = "6.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-node-services]]
-version = "4.0.0"
+version = "5.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-rpc]]
-version = "6.0.2"
+version = "7.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-script]]
-version = "5.0.1"
+version = "6.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-state]]
-version = "5.0.0"
+version = "6.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-test]]
@@ -2264,11 +2264,11 @@ version = "3.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-utils]]
-version = "5.0.0"
+version = "6.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebrad]]
-version = "4.3.1"
+version = "4.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,6 +1,14 @@
 
 # cargo-vet imports lock
 
+[[unpublished.zebra-script]]
+version = "6.0.1"
+audited_as = "6.0.0"
+
+[[unpublished.zebrad]]
+version = "4.4.1"
+audited_as = "4.4.0"
+
 [[publisher.bumpalo]]
 version = "3.20.2"
 when = "2026-02-19"

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -66,7 +66,7 @@ zcash_proofs = { workspace = true, features = ["multicore", "bundled-prover"] }
 tower-fallback = { path = "../tower-fallback/", version = "0.2.41" }
 tower-batch-control = { path = "../tower-batch-control/", version = "1.0.1" }
 
-zebra-script = { path = "../zebra-script", version = "6.0.0" }
+zebra-script = { path = "../zebra-script", version = "6.0.1" }
 zebra-state = { path = "../zebra-state", version = "6.0.0" }
 zebra-node-services = { path = "../zebra-node-services", version = "5.0.0" }
 zebra-chain = { path = "../zebra-chain", version = "7.0.0" }

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -111,7 +111,7 @@ zebra-network = { path = "../zebra-network", version = "6.0.0" }
 zebra-node-services = { path = "../zebra-node-services", version = "5.0.0", features = [
     "rpc-client",
 ] }
-zebra-script = { path = "../zebra-script", version = "6.0.0" }
+zebra-script = { path = "../zebra-script", version = "6.0.1" }
 zebra-state = { path = "../zebra-state", version = "6.0.0" }
 
 [build-dependencies]

--- a/zebra-script/CHANGELOG.md
+++ b/zebra-script/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.1] - 2026-05-04
+
+This release fixes one security issue:
+
+- Reject V5 transparent inputs signed with `SIGHASH_SINGLE` (or
+  `SIGHASH_SINGLE|ANYONECANPAY`) when the input has no transparent output at the
+  same index
+  ([GHSA-pvmv-cwg8-v6c8](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-pvmv-cwg8-v6c8)).
+  Follow-up to
+  [GHSA-cwfq-rfcr-8hmp](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-cwfq-rfcr-8hmp).
+
+The impact of the issue for crate users will depend on the particular usage;
+if you use it as a building block for a consensus node, you should update.
+
+No public-API changes; internal-only fix.
+
 ## [6.0.0] - 2026-05-01
 
 This release fixes an important security issue:

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-script"
-version = "6.0.0"
+version = "6.0.1"
 authors.workspace = true
 description = "Zebra script verification wrapping zcashd's zcash_script library"
 license.workspace = true

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -190,6 +190,19 @@ impl CachedFfiTransaction {
                         }
                     }
 
+                    // For v5+ transactions: reject SIGHASH_SINGLE when there is
+                    // no corresponding output (an output at the same index as
+                    // the input being verified). ZIP-244 §S.2a marks this as a
+                    // consensus failure; zcashd throws in `SignatureHash` and
+                    // `CheckSig` catches the exception to fail the script.
+                    if self.transaction.version() >= 5
+                        && hash_type.signed_outputs()
+                            == zcash_script::signature::SignedOutputs::Single
+                        && input_index >= self.transaction.outputs().len()
+                    {
+                        return None;
+                    }
+
                     let script_code_vec = script_code.0.clone();
 
                     // For pre-v5 (v4) transactions: zcashd serializes the raw

--- a/zebra-script/src/tests.rs
+++ b/zebra-script/src/tests.rs
@@ -434,6 +434,171 @@ fn sighash_divergence_v5_p2pkh_malformed_0x84_wrong_canonical_type_rejected() {
     );
 }
 
+/// Build a V5 transaction with two transparent inputs and one transparent output,
+/// sign the input at `signed_input_index` with SIGHASH_SINGLE (or
+/// SIGHASH_SINGLE|ANYONECANPAY when `anyone_can_pay` is set) using whatever
+/// digest Zebra computes for that input, and run that input through the script
+/// verifier.
+///
+/// This reproduces the ZIP-244 §S.2a "no corresponding output" scenario from
+/// GHSA-cwfq-rfcr-8hmp: the transaction has fewer transparent outputs than
+/// inputs, so for `signed_input_index >= 1` there is no `vout[k]` for the input
+/// being signed. `zcashd` rejects this at script verification; before the fix,
+/// Zebra accepted it because librustzcash returned a digest computed from an
+/// empty output list instead of failing.
+fn build_and_verify_v5_p2pkh_single_with_missing_output(
+    signed_input_index: usize,
+    anyone_can_pay: bool,
+) -> std::result::Result<(), crate::Error> {
+    use ripemd::{Digest as _, Ripemd160};
+    use secp256k1::{Message, Secp256k1, SecretKey};
+    use sha2::Sha256;
+
+    assert!(signed_input_index < 2, "test fixture only has two inputs");
+
+    let secp = Secp256k1::new();
+    let secret_key = SecretKey::from_slice(&[0xcd; 32]).expect("valid secret key");
+    let public_key = secp256k1::PublicKey::from_secret_key(&secp, &secret_key);
+    let pubkey_bytes = public_key.serialize();
+
+    // Standard P2PKH lock script reused for every prevout.
+    let sha_hash = Sha256::digest(pubkey_bytes);
+    let pub_key_hash: [u8; 20] = Ripemd160::digest(sha_hash).into();
+    let mut lock_script_bytes = vec![0x76, 0xa9, 0x14];
+    lock_script_bytes.extend_from_slice(&pub_key_hash);
+    lock_script_bytes.push(0x88);
+    lock_script_bytes.push(0xac);
+    let lock_script = transparent::Script::new(&lock_script_bytes);
+
+    let prevout = || transparent::Output {
+        value: 1_0000_0000u64.try_into().expect("valid amount"),
+        lock_script: lock_script.clone(),
+    };
+    let all_previous_outputs = Arc::new(vec![prevout(), prevout()]);
+
+    // Two inputs, one output: any input at index >= 1 has no corresponding
+    // output for SIGHASH_SINGLE.
+    let make_tx = |unlock_scripts: [Vec<u8>; 2]| Transaction::V5 {
+        network_upgrade: NetworkUpgrade::Nu5,
+        lock_time: LockTime::unlocked(),
+        expiry_height: block::Height(0),
+        inputs: vec![
+            transparent::Input::PrevOut {
+                outpoint: transparent::OutPoint {
+                    hash: transaction::Hash([0u8; 32]),
+                    index: 0,
+                },
+                unlock_script: transparent::Script::new(&unlock_scripts[0]),
+                sequence: u32::MAX,
+            },
+            transparent::Input::PrevOut {
+                outpoint: transparent::OutPoint {
+                    hash: transaction::Hash([1u8; 32]),
+                    index: 0,
+                },
+                unlock_script: transparent::Script::new(&unlock_scripts[1]),
+                sequence: u32::MAX,
+            },
+        ],
+        outputs: vec![transparent::Output {
+            value: 1_5000_0000u64.try_into().expect("valid amount"),
+            lock_script: transparent::Script::new(&[0x00]),
+        }],
+        sapling_shielded_data: None,
+        orchard_shielded_data: None,
+    };
+
+    let placeholder_tx = make_tx([Vec::new(), Vec::new()]);
+
+    let canonical_hash_type = if anyone_can_pay {
+        HashType::SINGLE | HashType::ANYONECANPAY
+    } else {
+        HashType::SINGLE
+    };
+    let raw_hash_type_byte = if anyone_can_pay { 0x83u8 } else { 0x03u8 };
+
+    let sighasher = SigHasher::new(
+        &placeholder_tx,
+        NetworkUpgrade::Nu5,
+        all_previous_outputs.clone(),
+    )
+    .expect("sighasher creation should succeed");
+    let sighash = sighasher.sighash(
+        canonical_hash_type,
+        Some((signed_input_index, lock_script_bytes.clone())),
+    );
+
+    let msg = Message::from_digest(*sighash.as_ref());
+    let signature = secp.sign_ecdsa(&msg, &secret_key);
+    let der_sig = signature.serialize_der();
+
+    let mut signed_unlock = Vec::new();
+    signed_unlock.push((der_sig.len() + 1) as u8);
+    signed_unlock.extend_from_slice(&der_sig);
+    signed_unlock.push(raw_hash_type_byte);
+    signed_unlock.push(pubkey_bytes.len() as u8);
+    signed_unlock.extend_from_slice(&pubkey_bytes);
+
+    // Other input is left empty; it isn't being verified by this call.
+    let mut unlock_scripts: [Vec<u8>; 2] = [Vec::new(), Vec::new()];
+    unlock_scripts[signed_input_index] = signed_unlock;
+
+    let final_tx = make_tx(unlock_scripts);
+
+    let verifier = super::CachedFfiTransaction::new(
+        Arc::new(final_tx),
+        all_previous_outputs,
+        NetworkUpgrade::Nu5,
+    )
+    .expect("network upgrade should be valid for v5 tx");
+    verifier.is_valid(signed_input_index)
+}
+
+/// V5 SIGHASH_SINGLE on input 1 of a 2-in/1-out transaction must be rejected:
+/// there is no `vout[1]` to commit to.
+///
+/// Before the fix, Zebra accepted this because librustzcash returns a digest
+/// computed from an empty output list when the input index is past the output
+/// vector. ZIP-244 §S.2a requires consensus-level rejection; zcashd enforces it.
+#[test]
+fn sighash_divergence_v5_sighash_single_no_corresponding_output_rejected() {
+    let _init_guard = zebra_test::init();
+
+    let result = build_and_verify_v5_p2pkh_single_with_missing_output(1, false);
+
+    assert!(
+        result.is_err(),
+        "V5 SIGHASH_SINGLE with no corresponding output must fail script verification, \
+         matching zcashd (ZIP-244 §S.2a)"
+    );
+}
+
+/// Same as above with SIGHASH_SINGLE|ANYONECANPAY (0x83). The
+/// corresponding-output rule applies regardless of the ANYONECANPAY flag.
+#[test]
+fn sighash_divergence_v5_sighash_single_anyonecanpay_no_corresponding_output_rejected() {
+    let _init_guard = zebra_test::init();
+
+    let result = build_and_verify_v5_p2pkh_single_with_missing_output(1, true);
+
+    assert!(
+        result.is_err(),
+        "V5 SIGHASH_SINGLE|ANYONECANPAY with no corresponding output must fail script \
+         verification, matching zcashd (ZIP-244 §S.2a)"
+    );
+}
+
+/// Positive control: SIGHASH_SINGLE on input 0 of a 2-in/1-out transaction is
+/// valid because `vout[0]` exists. This guards against the new check rejecting
+/// legitimate SIGHASH_SINGLE spends.
+#[test]
+fn sighash_divergence_v5_sighash_single_with_corresponding_output_accepted() {
+    let _init_guard = zebra_test::init();
+
+    build_and_verify_v5_p2pkh_single_with_missing_output(0, false)
+        .expect("V5 SIGHASH_SINGLE on an input with a corresponding output should be accepted");
+}
+
 /// Build a V4 P2PKH transparent spend, sign it under the supplied raw `hash_type`
 /// byte using the V4 raw-byte sighash semantics, and run it through the script
 /// verifier.

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate metadata
 name = "zebrad"
-version = "4.4.0"
+version = "4.4.1"
 authors.workspace = true
 description = "The Zcash Foundation's independent, consensus-compatible implementation of a Zcash node"
 license.workspace = true
@@ -157,7 +157,7 @@ zebra-state = { path = "../zebra-state", version = "6.0.0" }
 # zebra-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
 # enabling it in the other imports of zcash-script.)
-zebra-script = { path = "../zebra-script", version = "6.0.0" }
+zebra-script = { path = "../zebra-script", version = "6.0.1" }
 zcash_script = { workspace = true }
 
 # Required for crates.io publishing, but it's only used in tests

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_330_000;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_331_000;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.


### PR DESCRIPTION
---
name: "Release Checklist Template"
about: "Checklist to create and publish a Zebra release"
title: "Release Zebra (version)"
labels: "A-release, C-exclude-from-changelog, P-Critical :ambulance:"
assignees: ""
---

# Prepare for the Release

- [x] Make sure there has been [at least one successful full sync test in the main branch](https://github.com/ZcashFoundation/zebra/actions/workflows/zfnd-ci-integration-tests-gcp.yml?query=branch%3Amain) since the last state change, or start a manual full sync.

# Checkpoints

For performance and security, we want to update the Zebra checkpoints in every release.

- [ ] You can copy the latest checkpoints from CI by following [the zebra-checkpoints README](https://github.com/ZcashFoundation/zebra/blob/main/zebra-utils/README.md#zebra-checkpoints).

# Missed Dependency Updates

Sometimes `dependabot` misses some dependency updates, or we accidentally turned them off.

This step can be skipped if there is a large pending dependency upgrade. (For example, shared ECC crates.)

Here's how we make sure we got everything:

- [ ] Run `cargo update` on the latest `main` branch, and keep the output
- [ ] Until we bump the workspace MSRV to 1.88 or higher, `home` must be downgraded manually: `cargo update home@0.5.12 --precise 0.5.11`
- [ ] If needed, [add duplicate dependency exceptions to deny.toml](https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/continuous-integration.md#fixing-duplicate-dependencies-in-check-denytoml-bans)
- [ ] If needed, remove resolved duplicate dependencies from `deny.toml`
- [ ] Open a separate PR with the changes
- [ ] Add the output of `cargo update` to that PR as a comment

# Summarise Release Changes

These steps can be done a few days before the release, in the same PR:

## Change Log

**Important**: Any merge into `main` deletes any edits to the draft changelog.
Once you are ready to tag a release, copy the draft changelog into `CHANGELOG.md`.

We use [the Release Drafter workflow](https://github.com/marketplace/actions/release-drafter) to automatically create a [draft changelog](https://github.com/ZcashFoundation/zebra/releases). We follow the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.

To create the final change log:

- [ ] Copy the [**latest** draft
      changelog](https://github.com/ZcashFoundation/zebra/releases) into
      `CHANGELOG.md` (there can be multiple draft releases)
- [ ] Delete any trivial changes
  - [ ] Put the list of deleted changelog entries in a PR comment to make reviewing easier
- [ ] Combine duplicate changes
- [ ] Edit change descriptions so they will make sense to Zebra users
- [ ] Check the category for each change
  - Prefer the "Fix" category if you're not sure

## README

README updates can be skipped for urgent releases.

Update the README to:

- [ ] Remove any "Known Issues" that have been fixed since the last release.
- [ ] Update the "Build and Run Instructions" with any new dependencies.
      Check for changes in the `Dockerfile` since the last tag: `git diff <previous-release-tag> docker/Dockerfile`.
- [ ] If Zebra has started using newer Rust language features or standard library APIs, update the known working Rust version in the README, book, and `Cargo.toml`s

You can use a command like:

```sh
fastmod --fixed-strings '1.58' '1.65'
```

## Create the Release PR

- [x] Push the updated changelog and README into a new branch
      for example: `bump-v1.0.0` - this needs to be different to the tag name
- [x] Create a release PR by adding `&template=release-checklist.md` to the comparing url ([Example](https://github.com/ZcashFoundation/zebra/compare/bump-v1.0.0?expand=1&template=release-checklist.md)).
- [ ] Freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [ ] Mark all the release PRs as `Critical` priority, so they go in the `urgent` Mergify queue.
- [ ] Mark all non-release PRs with `do-not-merge`, because Mergify checks approved PRs against every commit, even when a queue is frozen.
- [x] Add the `A-release` tag to the release pull request in order for the `check-no-git-dependencies` to run.

## Zebra git sources dependencies

- [x] Ensure the `check-no-git-dependencies` check passes.

This check runs automatically on pull requests with the `A-release` label. It must pass for crates to be published to crates.io. If the check fails, you should either halt the release process or proceed with the understanding that the crates will not be published on crates.io.

# Update Versions and End of Support

## Update Zebra Version

Zebra follows [semantic versioning](https://semver.org). Semantic versions look like: MAJOR.MINOR.PATCH[-TAG.PRE-RELEASE]

Choose a release level for `zebrad`. Release levels are based on user-visible changes from the changelog:

- Mainnet Network Upgrades are `major` releases
- significant new features or behaviour changes; changes to RPCs, command-line, or configs; and deprecations or removals are `minor` releases
- otherwise, it is a `patch` release

## Update Crate Versions and Crate Change Logs

If you're publishing crates for the first time, [log in to crates.io](https://zebra.zfnd.org/dev/crate-owners.html#logging-in-to-cratesio),
and make sure you're a member of owners group.

Check that the release will work:

- [x] Determine which crates require release. Run `git diff --stat <previous_tag>`
      and enumerate the crates that had changes.
- [x] Update (or install) `semver-checks`: `cargo +stable install cargo-semver-checks --locked`
- [x] Update (or install) `public-api`: `cargo +stable install cargo-public-api --locked`
- [x] For each crate that requires a release:
  - [x] Determine which type of release to make. Run `semver-checks` to list API
        changes: `cargo semver-checks -p <crate> --default-features`. If there are
        breaking API changes, do a major release, or try to revert the API change
        if it was accidental. Otherwise do a minor or patch release depending on
        whether a new API was added. Note that `semver-checks` won't work
        if the previous realase was yanked; you will have to determine the
        type of release manually.
  - [x] Update the crate `CHANGELOG.md` listing the API changes or other
        relevant information for a crate consumer. Use `public-api` to list all
        API changes: `cargo public-api diff latest -p <crate> -sss`. You can use
        e.g. copilot to turn it into a human-readable list, e.g. (write the output
        to `api.txt` beforehand):
        ```
        copilot -p "Transform @api.txt which is a API diff into a human-readable description of the API changes. Be terse. Write output api-readable.txt. Use backtick quotes for identifiers. Use '### Breaking Changes' header for changes and removals, and '### Added' for additions. Make each item start with a verb e.g, Added, Changed" --allow-tool write
        ```
        It might also make sense to copy entries from the `zebrad` changelog.
  - [x] Update crate versions:

```sh
cargo release version --verbose --execute --allow-branch '*' -p <crate> patch # [ major | minor ]
# zebrad only
cargo release replace --verbose --execute --allow-branch '*' -p <crate>
```

- [x] Commit and push the above version changes to the release branch.

## Update End of Support

The end of support height is calculated from the current blockchain height:

- [x] Find where the Zcash blockchain tip is now by using a [Zcash Block Explorer](https://mainnet.zcashexplorer.app/) or other tool.
- [x] Replace `ESTIMATED_RELEASE_HEIGHT` in [`end_of_support.rs`](https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/sync/end_of_support.rs) with the height you estimate the release will be tagged.

<details>

<summary>Optional: calculate the release tagging height</summary>

- Find where the Zcash blockchain tip is now by using a [Zcash Block Explorer](https://mainnet.zcashexplorer.app/) or other tool.
- Add `1152` blocks for each day until the release
- For example, if the release is in 3 days, add `1152 * 3` to the current Mainnet block height

</details>

## Update the Release PR

- [x] Push the version increments and the release constants to the release branch.

# Publish the Zebra Release

## Create the GitHub Pre-Release

- [x] Wait for all the release PRs to be merged
- [x] Create a new release using the draft release as a base, by clicking the Edit icon in the [draft release](https://github.com/ZcashFoundation/zebra/releases)
- [x] Set the tag name to the version tag,
      for example: `v1.0.0`
- [x] Set the release to target the `main` branch
- [x] Set the release title to `Zebra ` followed by the version tag,
      for example: `Zebra 1.0.0`
- [x] Replace the prepopulated draft changelog in the release description with the final changelog you created;
      starting just _after_ the title `## [Zebra ...` of the current version being released,
      and ending just _before_ the title of the previous release.
- [x] Mark the release as 'pre-release', until it has been built and tested
- [x] Publish the pre-release to GitHub using "Publish Release"
- [x] Delete all the [draft releases from the list of releases](https://github.com/ZcashFoundation/zebra/releases)

## Test the Pre-Release

- [x] Wait until the Docker binaries have been built on `main`, and the quick tests have passed:
  - [x] [zfnd-ci-integration-tests-gcp.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/zfnd-ci-integration-tests-gcp.yml?query=branch%3Amain)
- [x] Wait until the [pre-release deployment machines have successfully launched](https://github.com/ZcashFoundation/zebra/actions/workflows/zfnd-deploy-nodes-gcp.yml?query=event%3Arelease)

## Publish Release

- [x] [Publish the release to GitHub](https://github.com/ZcashFoundation/zebra/releases) by disabling 'pre-release', then clicking "Set as the latest release"

## Publish Crates

- [x] [Run `cargo login`](https://zebra.zfnd.org/dev/crate-owners.html#logging-in-to-cratesio)
- [x] It is recommended that the following step be run from a fresh checkout of
      the repo, to avoid accidentally publishing files like e.g. logs that might
      be lingering around
- [x] Publish the crates to crates.io; edit the list to only include the crates that
      have been changed, but keep their overall order:

```
for c in zebra-test tower-fallback zebra-chain tower-batch-control zebra-node-services zebra-script zebra-state zebra-consensus zebra-network zebra-rpc zebra-utils zebrad; do cargo release publish --verbose --execute -p $c; done
```

- [x] Check that Zebra can be installed from `crates.io`:
      `cargo install --locked --force --version <version> zebrad && ~/.cargo/bin/zebrad`
      and put the output in a comment on the PR.

## Publish Docker Images

- [ ] Wait for the [the Docker images to be published successfully](https://github.com/ZcashFoundation/zebra/actions/workflows/release-binaries.yml?query=event%3Arelease).
- [x] Wait for the new tag in the [dockerhub zebra space](https://hub.docker.com/r/zfnd/zebra/tags)
- [x] Un-freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [x] Remove `do-not-merge` from the PRs you added it to

## Release Failures

If building or running fails after tagging:

<details>

<summary>Tag a new release, following these instructions...</summary>

1. Fix the bug that caused the failure
2. Start a new `patch` release
3. Skip the **Release Preparation**, and start at the **Release Changes** step
4. Update `CHANGELOG.md` with details about the fix
5. Follow the release checklist for the new Zebra version

</details>
