### PR TITLE
fix(chain): cap upfront Vec reservation in zcash_deserialize_external_count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Security
+
+- Cap the upfront `Vec::with_capacity` reservation in
+  `zcash_deserialize_external_count` so a peer-supplied `CompactSize`
+  cannot force a large allocation before any element bytes are read. The
+  `Vec` grows naturally via `push()` as real data arrives. Complements
+  the per-type `max_allocation()` caps from PR #10494
+  ([GHSA-xr93-pcq3-pxf8](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-xr93-pcq3-pxf8)).
+  CWE-770.
+
 ### Added
 
 - Startup warning on Linux when `net.ipv4.tcp_slow_start_after_idle` is enabled (which resets TCP congestion windows between block requests and significantly reduces single-peer block-propagation throughput on long-haul links), with a "Linux TCP tuning for block propagation" troubleshooting section ([#10513](https://github.com/ZcashFoundation/zebra/pull/10513))

--- a/zebra-chain/src/serialization/zcash_deserialize.rs
+++ b/zebra-chain/src/serialization/zcash_deserialize.rs
@@ -93,7 +93,11 @@ pub fn zcash_deserialize_external_count<R: io::Read, T: ZcashDeserialize + Trust
         // for 128 bit memory spaces.)
         Err(_) => return Err(SerializationError::Parse("Vector longer than u64::MAX")),
     }
-    let mut vec = Vec::with_capacity(external_count);
+    // Cap the upfront reservation. The Vec grows via push() as elements
+    // arrive, so a peer-supplied `external_count` can't force a large
+    // allocation before any data is read. Fixes the deserializer-level
+    // case of GHSA-xr93-pcq3-pxf8.
+    let mut vec = Vec::with_capacity(external_count.min(1024));
     for _ in 0..external_count {
         vec.push(T::zcash_deserialize(&mut reader)?);
     }

--- a/zebra-chain/src/serialization/zcash_deserialize.rs
+++ b/zebra-chain/src/serialization/zcash_deserialize.rs
@@ -4,6 +4,12 @@ use std::{io, net::Ipv6Addr, sync::Arc};
 
 use super::{AtLeastOne, CompactSizeMessage, SerializationError, MAX_PROTOCOL_MESSAGE_LEN};
 
+/// Initial-allocation cap for `zcash_deserialize_external_count`.
+///
+/// 1024 is large enough that honest messages amortize their growth to a few
+/// reallocations.
+const MAX_INITIAL_ALLOCATION: usize = 1024;
+
 /// Consensus-critical deserialization for Zcash.
 ///
 /// This trait provides a generic deserialization for consensus-critical
@@ -97,7 +103,7 @@ pub fn zcash_deserialize_external_count<R: io::Read, T: ZcashDeserialize + Trust
     // arrive, so a peer-supplied `external_count` can't force a large
     // allocation before any data is read. Fixes the deserializer-level
     // case of GHSA-xr93-pcq3-pxf8.
-    let mut vec = Vec::with_capacity(external_count.min(1024));
+    let mut vec = Vec::with_capacity(external_count.min(MAX_INITIAL_ALLOCATION));
     for _ in 0..external_count {
         vec.push(T::zcash_deserialize(&mut reader)?);
     }


### PR DESCRIPTION
## Motivation

Closes #10545.
Closes #10548.

`zcash_deserialize_external_count` in `zebra-chain/src/serialization/zcash_deserialize.rs` passes the peer-supplied `CompactSize` directly to `Vec::with_capacity(external_count)`, allocating the full claimed capacity upfront before any element bytes are read.

This is the same root-cause defect class fixed for `AddrV1`/`AddrV2` in PR #10494 (GHSA-xr93-pcq3-pxf8), but the prior fixes capped each per-type `max_allocation()` rather than the shared deserializer. Capping at the deserializer level means new `TrustedPreallocate` impls can't recreate this issue if their per-type caps drift, and one change addresses both the malicious-lying-varint case (#10545) and the valid-but-large-elements case (#10548).

## Solution

```rust
let mut vec = Vec::with_capacity(external_count.min(1024));
```

The cap matches @mpguerra's exact suggestion in #10545. 1024 is amply above any realistic legitimate batch size (Bitcoin Core's `MAX_LOCATOR_SZ` = 101; AddrV2 `getaddr` response = 1000; `MAX_HEADERS_PER_MESSAGE` = 160) while keeping any pathological `CompactSize` under ~32 KiB of upfront reservation. The Vec grows naturally via `push()` as real elements arrive.

`TrustedPreallocate` and `max_allocation()` remain in place as defense-in-depth — the cap-at-deserializer rejection in `external_count > T::max_allocation()` (line 85) still fires before this code path runs.

## Test evidence

- `cargo fmt --all -- --check` ✓
- `cargo test -p zebra-chain --lib` ✓ (247 tests pass)
- `cargo clippy -p zebra-chain --all-targets -- -D warnings` ✓
- Verified locally on v4.4.1 (commit 1ec1078e).

The amortized realloc-copy cost from `push()` growth is dominated by `T::zcash_deserialize` cost on every iteration. For batches under 1024 elements, behavior is unchanged.

## Context

- Sibling fix: PR #10494 (GHSA-xr93-pcq3-pxf8) capped `AddrV1`/`AddrV2` per-type caps.
- Public root-cause issues: #10545 (lying-varint shape), #10548 (large-elements shape) — same line of code, two framings.

## AI disclosure

Patch and PR description drafted with assistance from Claude (Anthropic), following the exact one-line fix @mpguerra suggested in #10545. I reviewed each step and am the responsible author.
