### PR TITLE
fix(chain): propagate transaction value-balance errors in chain_value_pool_change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Fixed
 
 - Avoid panicking in the address-book ban path when `network.max_connections_per_ip > 1`. Guard the optional `most_recent_by_ip` cache instead of unwrapping it, so a ban-threshold misbehavior update no longer crashes the address-book updater and poisons the shared mutex ([#10580](https://github.com/ZcashFoundation/zebra/issues/10580))
+- Propagate transaction-level value-balance errors from `Block::chain_value_pool_change()` instead of silently dropping them. The previous `flat_map(Result)` aggregation relied on `Result<T, E>: IntoIterator` and yielded zero items on `Err`, so a failing transaction was omitted from the block sum rather than surfacing as a `ValueBalanceError` ([#10585](https://github.com/ZcashFoundation/zebra/issues/10585))
 
 ## [Zebra 4.4.1](https://github.com/ZcashFoundation/zebra/releases/tag/v4.4.1) - 2026-05-04
 

--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -230,17 +230,21 @@ impl Block {
         utxos: &HashMap<transparent::OutPoint, transparent::Utxo>,
         deferred_pool_balance_change: Option<DeferredPoolBalanceChange>,
     ) -> Result<ValueBalance<NegativeAllowed>, ValueBalanceError> {
-        Ok(*self
+        // `Result<T, E>` implements `IntoIterator`, so a `flat_map(|t| t.value_balance(utxos))`
+        // would silently drop transactions whose value balance returns `Err`. Use `try_fold`
+        // to propagate the first error instead.
+        let tx_pool_sum = self
             .transactions
             .iter()
-            .flat_map(|t| t.value_balance(utxos))
-            .sum::<Result<ValueBalance<NegativeAllowed>, _>>()?
-            .neg()
-            .set_deferred_amount(
-                deferred_pool_balance_change
-                    .map(DeferredPoolBalanceChange::value)
-                    .unwrap_or_default(),
-            ))
+            .try_fold(ValueBalance::<NegativeAllowed>::zero(), |acc, tx| {
+                acc + tx.value_balance(utxos)?
+            })?;
+
+        Ok(*tx_pool_sum.neg().set_deferred_amount(
+            deferred_pool_balance_change
+                .map(DeferredPoolBalanceChange::value)
+                .unwrap_or_default(),
+        ))
     }
 
     /// Compute the root of the authorizing data Merkle tree,

--- a/zebra-chain/src/block/tests/vectors.rs
+++ b/zebra-chain/src/block/tests/vectors.rs
@@ -1,11 +1,13 @@
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     io::{Cursor, Write},
+    sync::Arc,
 };
 
 use chrono::{DateTime, Duration, LocalResult, TimeZone, Utc};
 
 use crate::{
+    amount::{Amount, NonNegative, MAX_MONEY},
     block::{
         serialize::MAX_BLOCK_BYTES, Block, BlockTimeError, Commitment::*, Hash, Header, Height,
     },
@@ -14,7 +16,8 @@ use crate::{
     serialization::{
         sha256d, SerializationError, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize,
     },
-    transaction::LockTime,
+    transaction::{LockTime, Transaction},
+    transparent,
 };
 
 use super::generate; // TODO: this should be rewritten as strategies
@@ -60,6 +63,50 @@ fn blockheaderhash_from_blockheader() {
         .expect("these bytes to deserialize into a blockheader without issue");
 
     assert_eq!(blockheader, other_header);
+}
+
+/// Regression test for https://github.com/ZcashFoundation/zebra/issues/10585.
+///
+/// `Block::chain_value_pool_change()` previously aggregated transaction value
+/// balances with `flat_map(|tx| tx.value_balance(utxos))`. Because
+/// `Result<T, E>` implements `IntoIterator`, `Err(_)` yielded zero items and
+/// silently dropped the failing transaction from the block sum. The block
+/// helper now uses `try_fold` so transaction-level value-balance errors
+/// propagate.
+#[test]
+fn chain_value_pool_change_propagates_transaction_value_balance_errors() {
+    let _init_guard = zebra_test::init();
+
+    let max_money: Amount<NonNegative> = MAX_MONEY.try_into().expect("MAX_MONEY is a valid amount");
+    // Two `MAX_MONEY` transparent outputs make the transaction-level output
+    // sum exceed `MAX_MONEY`, so `value_balance` returns `Err`.
+    let coinbase = Transaction::V1 {
+        inputs: vec![transparent::Input::new_coinbase(Height(1), vec![], None)],
+        outputs: vec![
+            transparent::Output::new(max_money, transparent::Script::new(&[])),
+            transparent::Output::new(max_money, transparent::Script::new(&[])),
+        ],
+        lock_time: LockTime::unlocked(),
+    };
+    let utxos = HashMap::new();
+
+    assert!(
+        coinbase.value_balance(&utxos).is_err(),
+        "transaction-level value balance should reject an output sum above MAX_MONEY"
+    );
+
+    let header: Header = zebra_test::vectors::DUMMY_HEADER
+        .zcash_deserialize_into()
+        .expect("dummy header should deserialize");
+    let block = Block {
+        header: Arc::new(header),
+        transactions: vec![Arc::new(coinbase)],
+    };
+
+    assert!(
+        block.chain_value_pool_change(&utxos, None).is_err(),
+        "block-level aggregation should propagate transaction value-balance errors"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

Closes #10585.

`Block::chain_value_pool_change()` in `zebra-chain/src/block.rs` computes the block's chain value-pool delta with:

```rust
self.transactions
    .iter()
    .flat_map(|t| t.value_balance(utxos))
    .sum::<Result<ValueBalance<NegativeAllowed>, _>>()?
```

Because `Result<T, E>` implements `IntoIterator` (yielding zero items on `Err`), a transaction whose `value_balance()` returns `Err` is silently dropped from the block sum rather than causing `chain_value_pool_change()` to return that error. The function's signature is `Result<ValueBalance<NegativeAllowed>, ValueBalanceError>` and state callers (`zebra-state/src/service/finalized_state/zebra_db/chain.rs`, `zebra-state/src/service/non_finalized_state.rs`) map that error into `CalculateBlockChainValueChange` / `AddValuePool` contextual validation failures — so the silent drop violates the documented contract.

Normal semantic verification catches transaction-level value-balance failures earlier through `miner_fees_are_valid()` and `remaining_transaction_value()`, so this is a consensus-adjacent correctness fix, not an obvious remote-acceptance bypass.

## Solution

Replace the `flat_map(Result)` aggregation with `try_fold`, which propagates the first error:

```rust
let tx_pool_sum = self
    .transactions
    .iter()
    .try_fold(ValueBalance::<NegativeAllowed>::zero(), |acc, tx| {
        acc + tx.value_balance(utxos)?
    })?;
```

`ValueBalance + ValueBalance -> Result<ValueBalance, ValueBalanceError>` is already defined, so the closure body composes naturally.

## Test evidence

Added `chain_value_pool_change_propagates_transaction_value_balance_errors` in `zebra-chain/src/block/tests/vectors.rs`. The test builds a V1 coinbase with two `MAX_MONEY` transparent outputs (each individually valid as `Amount<NonNegative>`, sum above `MAX_MONEY`), asserts the transaction's `value_balance()` returns `Err`, and now asserts that `Block::chain_value_pool_change()` also returns `Err`. The test fails on `main` (block-level helper returns `Ok` with a zero delta) and passes with this change.

```
cargo test -p zebra-chain --lib
# test result: ok. 248 passed; 0 failed
cargo clippy -p zebra-chain --all-targets -- -D warnings   # clean
cargo fmt --all -- --check                                 # clean
```

## AI disclosure

Used Claude Code (Opus 4.7) for the patch, regression test, and PR description, working from a pre-existing private investigation note that identified the silent-drop bug, the contractual mismatch, and the suggested `try_fold` shape.