### PR TITLE
feat(state): add Zebra-mined block progress tracking

### DIFF
--- a/zebra-state/src/service/write.rs
+++ b/zebra-state/src/service/write.rs
@@ -1,25 +1,16 @@
 //! Writing blocks to the finalized and non-finalized states.
 
-
-
 use std::{
     collections::HashSet,
     path::{Path, PathBuf},
     sync::Arc,
 };
 
-
 use indexmap::IndexMap;
-
 use tokio::sync::{
-
     mpsc::{UnboundedReceiver, UnboundedSender},
-
     oneshot, watch,
-
 };
-
-
 
 use tracing::Span;
 use zebra_chain::{
@@ -27,145 +18,75 @@ use zebra_chain::{
     transparent::{CoinbaseData, EXTRA_ZEBRA_COINBASE_DATA},
 };
 
-
 use crate::{
-
     constants::MAX_BLOCK_REORG_HEIGHT,
-
     service::{
-
         check,
-
         finalized_state::{FinalizedState, ZebraDb},
-
         non_finalized_state::NonFinalizedState,
-
         queued_blocks::{QueuedCheckpointVerified, QueuedSemanticallyVerified},
-
         ChainTipBlock, ChainTipSender, InvalidateError, ReconsiderError,
-
     },
-
     SemanticallyVerifiedBlock, ValidateContextError,
-
 };
-
-
 
 // These types are used in doc links
-
 #[allow(unused_imports)]
-
 use crate::service::{
-
     chain_tip::{ChainTipChange, LatestChainTip},
-
     non_finalized_state::Chain,
-
 };
 
-
-
 /// The maximum size of the parent error map.
-
 ///
-
 /// We allow enough space for multiple concurrent chain forks with errors.
-
 const PARENT_ERROR_MAP_LIMIT: usize = MAX_BLOCK_REORG_HEIGHT as usize * 2;
 
-
-
 /// Run contextual validation on the prepared block and add it to the
-
 /// non-finalized state if it is contextually valid.
-
 #[tracing::instrument(
-
     level = "debug",
-
     skip(finalized_state, non_finalized_state, prepared),
-
     fields(
-
         height = ?prepared.height,
-
         hash = %prepared.hash,
-
         chains = non_finalized_state.chain_count()
-
     )
-
 )]
-
 pub(crate) fn validate_and_commit_non_finalized(
-
     finalized_state: &ZebraDb,
-
     non_finalized_state: &mut NonFinalizedState,
-
     prepared: SemanticallyVerifiedBlock,
-
 ) -> Result<(), ValidateContextError> {
-
     check::initial_contextual_validity(finalized_state, non_finalized_state, &prepared)?;
-
     let parent_hash = prepared.block.header.previous_block_hash;
 
-
-
     if finalized_state.finalized_tip_hash() == parent_hash {
-
         non_finalized_state.commit_new_chain(prepared, finalized_state)?;
-
     } else {
-
         non_finalized_state.commit_block(prepared, finalized_state)?;
-
     }
 
-
-
     Ok(())
-
 }
 
-
-
 /// Update the [`LatestChainTip`], [`ChainTipChange`], and `non_finalized_state_sender`
-
 /// channels with the latest non-finalized [`ChainTipBlock`] and
-
 /// [`Chain`].
-
 ///
-
 /// `last_zebra_mined_log_height` is used to rate-limit logging.
-
 ///
-
 /// If `backup_dir_path` is `Some`, the non-finalized state is written to the backup
-
 /// directory before updating the channels.
-
 ///
-
 /// Returns the latest non-finalized chain tip height.
-
 ///
-
 /// # Panics
-
 ///
-
 /// If the `non_finalized_state` is empty.
-
 #[instrument(
-
     level = "debug",
-
     skip(
-
         non_finalized_state,
         chain_tip_sender,
         non_finalized_state_sender,
@@ -174,13 +95,9 @@ pub(crate) fn validate_and_commit_non_finalized(
         backup_dir_path,
     ),
     fields(chains = non_finalized_state.chain_count())
-
 )]
-
 fn update_latest_chain_channels(
-
     non_finalized_state: &NonFinalizedState,
-
     chain_tip_sender: &mut ChainTipSender,
     non_finalized_state_sender: &watch::Sender<NonFinalizedState>,
     last_zebra_mined_log_height: &mut Option<Height>,
@@ -189,19 +106,11 @@ fn update_latest_chain_channels(
 ) -> block::Height {
     let best_chain = non_finalized_state.best_chain().expect("unexpected empty non-finalized state: must commit at least one block before updating channels");
 
-
-
     let tip_block = best_chain
-
         .tip_block()
-
         .expect("unexpected empty chain: must commit at least one block before updating channels")
-
         .clone();
-
     let tip_block = ChainTipBlock::from(tip_block);
-
-
 
     record_zebra_mined_block(
         &tip_block,
@@ -209,405 +118,206 @@ fn update_latest_chain_channels(
         zebra_mined_block_progress,
     );
 
-
     let tip_block_height = tip_block.height;
 
-
-
     if let Some(backup_dir_path) = backup_dir_path {
-
         non_finalized_state.write_to_backup(backup_dir_path);
-
     }
 
-
-
     // If the final receiver was just dropped, ignore the error.
-
     let _ = non_finalized_state_sender.send(non_finalized_state.clone());
-
-
 
     chain_tip_sender.set_best_non_finalized_tip(tip_block);
 
-
-
     tip_block_height
-
 }
-
-
 
 /// A worker task that reads, validates, and writes blocks to the
-
 /// `finalized_state` or `non_finalized_state`.
-
 struct WriteBlockWorkerTask {
-
     finalized_block_write_receiver: UnboundedReceiver<QueuedCheckpointVerified>,
-
     non_finalized_block_write_receiver: UnboundedReceiver<NonFinalizedWriteMessage>,
-
     finalized_state: FinalizedState,
-
     non_finalized_state: NonFinalizedState,
-
     invalid_block_reset_sender: UnboundedSender<block::Hash>,
-
     chain_tip_sender: ChainTipSender,
-
     non_finalized_state_sender: watch::Sender<NonFinalizedState>,
-
     /// If `Some`, the non-finalized state is written to this backup directory
-
     /// synchronously before each channel update, instead of via the async backup task.
-
     backup_dir_path: Option<PathBuf>,
-
 }
-
-
 
 /// The message type for the non-finalized block write task channel.
-
 pub enum NonFinalizedWriteMessage {
-
     /// A newly downloaded and semantically verified block prepared for
-
     /// contextual validation and insertion into the non-finalized state.
-
     Commit(QueuedSemanticallyVerified),
-
     /// The hash of a block that should be invalidated and removed from
-
     /// the non-finalized state, if present.
-
     Invalidate {
-
         hash: block::Hash,
-
         rsp_tx: oneshot::Sender<Result<block::Hash, InvalidateError>>,
-
     },
-
     /// The hash of a block that was previously invalidated but should be
-
     /// reconsidered and reinserted into the non-finalized state.
-
     Reconsider {
-
         hash: block::Hash,
-
         rsp_tx: oneshot::Sender<Result<Vec<block::Hash>, ReconsiderError>>,
-
     },
-
 }
-
-
 
 impl From<QueuedSemanticallyVerified> for NonFinalizedWriteMessage {
-
     fn from(block: QueuedSemanticallyVerified) -> Self {
-
         NonFinalizedWriteMessage::Commit(block)
-
     }
-
 }
-
-
 
 /// A worker with a task that reads, validates, and writes blocks to the
-
 /// `finalized_state` or `non_finalized_state` and channels for sending
-
 /// it blocks.
-
 #[derive(Clone, Debug)]
-
 pub(super) struct BlockWriteSender {
-
     /// A channel to send blocks to the `block_write_task`,
-
     /// so they can be written to the [`NonFinalizedState`].
-
     pub non_finalized: Option<tokio::sync::mpsc::UnboundedSender<NonFinalizedWriteMessage>>,
 
-
-
     /// A channel to send blocks to the `block_write_task`,
-
     /// so they can be written to the [`FinalizedState`].
-
     ///
-
     /// This sender is dropped after the state has finished sending all the checkpointed blocks,
-
     /// and the lowest semantically verified block arrives.
-
     pub finalized: Option<tokio::sync::mpsc::UnboundedSender<QueuedCheckpointVerified>>,
-
 }
-
-
 
 impl BlockWriteSender {
-
     /// Creates a new [`BlockWriteSender`] with the given receivers and states.
-
     #[instrument(
-
         level = "debug",
-
         skip_all,
-
         fields(
-
             network = %non_finalized_state.network
-
         )
-
     )]
-
     pub fn spawn(
-
         finalized_state: FinalizedState,
-
         non_finalized_state: NonFinalizedState,
-
         chain_tip_sender: ChainTipSender,
-
         non_finalized_state_sender: watch::Sender<NonFinalizedState>,
-
         should_use_finalized_block_write_sender: bool,
-
         backup_dir_path: Option<PathBuf>,
-
     ) -> (
-
         Self,
-
         tokio::sync::mpsc::UnboundedReceiver<block::Hash>,
-
         Option<Arc<std::thread::JoinHandle<()>>>,
-
     ) {
-
         // Security: The number of blocks in these channels is limited by
-
         //           the syncer and inbound lookahead limits.
-
         let (non_finalized_block_write_sender, non_finalized_block_write_receiver) =
-
             tokio::sync::mpsc::unbounded_channel();
-
         let (finalized_block_write_sender, finalized_block_write_receiver) =
-
             tokio::sync::mpsc::unbounded_channel();
-
         let (invalid_block_reset_sender, invalid_block_write_reset_receiver) =
-
             tokio::sync::mpsc::unbounded_channel();
-
-
 
         let span = Span::current();
-
         let task = std::thread::spawn(move || {
-
             span.in_scope(|| {
-
                 WriteBlockWorkerTask {
-
                     finalized_block_write_receiver,
-
                     non_finalized_block_write_receiver,
-
                     finalized_state,
-
                     non_finalized_state,
-
                     invalid_block_reset_sender,
-
                     chain_tip_sender,
-
                     non_finalized_state_sender,
-
                     backup_dir_path,
-
                 }
-
                 .run()
-
             })
-
         });
 
-
-
         (
-
             Self {
-
                 non_finalized: Some(non_finalized_block_write_sender),
-
                 finalized: Some(finalized_block_write_sender)
-
                     .filter(|_| should_use_finalized_block_write_sender),
-
             },
-
             invalid_block_write_reset_receiver,
-
             Some(Arc::new(task)),
-
         )
-
     }
-
 }
 
-
-
 impl WriteBlockWorkerTask {
-
     /// Reads blocks from the channels, writes them to the `finalized_state` or `non_finalized_state`,
-
     /// sends any errors on the `invalid_block_reset_sender`, then updates the `chain_tip_sender` and
-
     /// `non_finalized_state_sender`.
-
     #[instrument(
-
         level = "debug",
-
         skip(self),
-
         fields(
-
             network = %self.non_finalized_state.network
-
         )
-
     )]
-
     pub fn run(mut self) {
-
         let Self {
-
             finalized_block_write_receiver,
-
             non_finalized_block_write_receiver,
-
             finalized_state,
-
             non_finalized_state,
-
             invalid_block_reset_sender,
-
             chain_tip_sender,
-
             non_finalized_state_sender,
-
             backup_dir_path,
-
         } = &mut self;
-
-
 
         let mut last_zebra_mined_log_height = None;
         let mut zebra_mined_block_progress = ZebraMinedBlockProgress::default();
         let mut prev_finalized_note_commitment_trees = None;
 
-
         // Write all the finalized blocks sent by the state,
-
         // until the state closes the finalized block channel's sender.
-
         while let Some(ordered_block) = finalized_block_write_receiver.blocking_recv() {
-
             // TODO: split these checks into separate functions
 
-
-
             if invalid_block_reset_sender.is_closed() {
-
                 info!("StateService closed the block reset channel. Is Zebra shutting down?");
-
                 return;
-
             }
-
-
 
             // Discard any children of invalid blocks in the channel
-
             //
-
             // `commit_finalized()` requires blocks in height order.
-
             // So if there has been a block commit error,
-
             // we need to drop all the descendants of that block,
-
             // until we receive a block at the required next height.
-
             let next_valid_height = finalized_state
-
                 .db
-
                 .finalized_tip_height()
-
                 .map(|height| (height + 1).expect("committed heights are valid"))
-
                 .unwrap_or(Height(0));
 
-
-
             if ordered_block.0.height != next_valid_height {
-
                 debug!(
-
                     ?next_valid_height,
-
                     invalid_height = ?ordered_block.0.height,
-
                     invalid_hash = ?ordered_block.0.hash,
-
                     "got a block that was the wrong height. \
-
                      Assuming a parent block failed, and dropping this block",
-
                 );
 
-
-
                 // We don't want to send a reset here, because it could overwrite a valid sent hash
-
                 std::mem::drop(ordered_block);
-
                 continue;
-
             }
 
-
-
             // Try committing the block
-
             match finalized_state
-
                 .commit_finalized(ordered_block, prev_finalized_note_commitment_trees.take())
-
             {
-
                 Ok((finalized, note_commitment_trees)) => {
-
                     let tip_block = ChainTipBlock::from(finalized);
-
                     prev_finalized_note_commitment_trees = Some(note_commitment_trees);
-
-
 
                     record_zebra_mined_block(
                         &tip_block,
@@ -617,117 +327,61 @@ impl WriteBlockWorkerTask {
 
                     chain_tip_sender.set_finalized_tip(tip_block);
                 }
-
                 Err(error) => {
-
                     let finalized_tip = finalized_state.db.tip();
 
-
-
                     // The last block in the queue failed, so we can't commit the next block.
-
                     // Instead, we need to reset the state queue,
-
                     // and discard any children of the invalid block in the channel.
-
                     info!(
-
                         ?error,
-
                         last_valid_height = ?finalized_tip.map(|tip| tip.0),
-
                         last_valid_hash = ?finalized_tip.map(|tip| tip.1),
-
                         "committing a block to the finalized state failed, resetting state queue",
-
                     );
 
-
-
                     let send_result =
-
                         invalid_block_reset_sender.send(finalized_state.db.finalized_tip_hash());
 
-
-
                     if send_result.is_err() {
-
                         info!(
-
                             "StateService closed the block reset channel. Is Zebra shutting down?"
-
                         );
-
                         return;
-
                     }
-
                 }
-
             }
-
         }
-
-
 
         // Do this check even if the channel got closed before any finalized blocks were sent.
-
         // This can happen if we're past the finalized tip.
-
         if invalid_block_reset_sender.is_closed() {
-
             info!("StateService closed the block reset channel. Is Zebra shutting down?");
-
             return;
-
         }
 
-
-
         // Save any errors to propagate down to queued child blocks
-
         let mut parent_error_map: IndexMap<block::Hash, ValidateContextError> = IndexMap::new();
 
-
-
         while let Some(msg) = non_finalized_block_write_receiver.blocking_recv() {
-
             let queued_child_and_rsp_tx = match msg {
-
                 NonFinalizedWriteMessage::Commit(queued_child) => Some(queued_child),
-
                 NonFinalizedWriteMessage::Invalidate { hash, rsp_tx } => {
-
                     tracing::info!(?hash, "invalidating a block in the non-finalized state");
-
                     let _ = rsp_tx.send(non_finalized_state.invalidate_block(hash));
-
                     None
-
                 }
-
                 NonFinalizedWriteMessage::Reconsider { hash, rsp_tx } => {
-
                     tracing::info!(?hash, "reconsidering a block in the non-finalized state");
-
                     let _ = rsp_tx
-
                         .send(non_finalized_state.reconsider_block(hash, &finalized_state.db));
-
                     None
-
                 }
-
             };
 
-
-
             let Some((queued_child, rsp_tx)) = queued_child_and_rsp_tx else {
-
                 update_latest_chain_channels(
-
                     non_finalized_state,
-
                     chain_tip_sender,
                     non_finalized_state_sender,
                     &mut last_zebra_mined_log_height,
@@ -735,109 +389,57 @@ impl WriteBlockWorkerTask {
                     backup_dir_path.as_deref(),
                 );
                 continue;
-
             };
-
-
 
             let child_hash = queued_child.hash;
-
             let parent_hash = queued_child.block.header.previous_block_hash;
-
             let parent_error = parent_error_map.get(&parent_hash);
 
-
-
             // If the parent block was marked as rejected, also reject all its children.
-
             //
-
             // At this point, we know that all the block's descendants
-
             // are invalid, because we checked all the consensus rules before
-
             // committing the failing ancestor block to the non-finalized state.
-
             let result = if let Some(parent_error) = parent_error {
-
                 Err(parent_error.clone())
-
             } else {
-
                 tracing::trace!(?child_hash, "validating queued child");
-
                 validate_and_commit_non_finalized(
-
                     &finalized_state.db,
-
                     non_finalized_state,
-
                     queued_child,
-
                 )
-
             };
 
-
-
             // TODO: fix the test timing bugs that require the result to be sent
-
             //       after `update_latest_chain_channels()`,
-
             //       and send the result on rsp_tx here
 
-
-
             if let Err(ref error) = result {
-
                 // If the block is invalid, mark any descendant blocks as rejected.
-
                 parent_error_map.insert(child_hash, error.clone());
 
-
-
                 // Make sure the error map doesn't get too big.
-
                 if parent_error_map.len() > PARENT_ERROR_MAP_LIMIT {
-
                     // We only add one hash at a time, so we only need to remove one extra here.
-
                     parent_error_map.shift_remove_index(0);
-
                 }
 
-
-
                 // Update the caller with the error.
-
                 let _ = rsp_tx.send(result.map(|()| child_hash).map_err(Into::into));
 
-
-
                 // Skip the things we only need to do for successfully committed blocks
-
                 continue;
-
             }
 
-
-
             // Committing blocks to the finalized state keeps the same chain,
-
             // so we can update the chain seen by the rest of the application now.
-
             //
-
             // TODO: if this causes state request errors due to chain conflicts,
-
             //       fix the `service::read` bugs,
-
             //       or do the channel update after the finalized state commit
-
             let tip_block_height = update_latest_chain_channels(
-
                 non_finalized_state,
-
                 chain_tip_sender,
                 non_finalized_state_sender,
                 &mut last_zebra_mined_log_height,
@@ -845,88 +447,46 @@ impl WriteBlockWorkerTask {
                 backup_dir_path.as_deref(),
             );
 
-
             // Update the caller with the result.
-
             let _ = rsp_tx.send(result.map(|()| child_hash).map_err(Into::into));
 
-
-
             while non_finalized_state
-
                 .best_chain_len()
-
                 .expect("just successfully inserted a non-finalized block above")
-
                 > MAX_BLOCK_REORG_HEIGHT
-
             {
-
                 tracing::trace!("finalizing block past the reorg limit");
-
                 let contextually_verified_with_trees = non_finalized_state.finalize();
-
                 prev_finalized_note_commitment_trees = finalized_state
-
                             .commit_finalized_direct(contextually_verified_with_trees, prev_finalized_note_commitment_trees.take(), "commit contextually-verified request")
-
                             .expect(
-
                                 "unexpected finalized block commit error: note commitment and history trees were already checked by the non-finalized state",
-
                             ).1.into();
-
             }
 
-
-
             // Update the metrics if semantic and contextual validation passes
-
             //
-
             // TODO: split this out into a function?
-
             metrics::counter!("state.full_verifier.committed.block.count").increment(1);
-
             metrics::counter!("zcash.chain.verified.block.total").increment(1);
 
-
-
             metrics::gauge!("state.full_verifier.committed.block.height")
-
                 .set(tip_block_height.0 as f64);
 
-
-
             // This height gauge is updated for both fully verified and checkpoint blocks.
-
             // These updates can't conflict, because this block write task makes sure that blocks
-
             // are committed in order.
-
             metrics::gauge!("zcash.chain.verified.block.height").set(tip_block_height.0 as f64);
 
-
-
             tracing::trace!("finished processing queued block");
-
         }
 
-
-
         // We're finished receiving non-finalized blocks from the state, and
-
         // done writing to the finalized state, so we can force it to shut down.
-
         finalized_state.db.shutdown(true);
-
         std::mem::drop(self.finalized_state);
-
     }
-
 }
-
-
 
 #[derive(Default)]
 struct ZebraMinedBlockProgress {
@@ -995,21 +555,12 @@ fn log_if_mined_by_zebra(
 
     let height = tip_block.height.0;
 
-
-
     if let Some(last_height) = last_zebra_mined_log_height {
-
         if height < last_height.0 + LOG_RATE_LIMIT {
-
             // If we logged in the last 1000 blocks, don't log anything now.
-
             return;
-
         }
-
     };
-
-
 
     let text = String::from_utf8_lossy(coinbase_data.as_ref());
 

--- a/zebra-state/src/service/write.rs
+++ b/zebra-state/src/service/write.rs
@@ -1,476 +1,960 @@
 //! Writing blocks to the finalized and non-finalized states.
 
+
+
 use std::{
+    collections::HashSet,
     path::{Path, PathBuf},
     sync::Arc,
 };
 
+
 use indexmap::IndexMap;
+
 use tokio::sync::{
+
     mpsc::{UnboundedReceiver, UnboundedSender},
+
     oneshot, watch,
+
 };
+
+
 
 use tracing::Span;
 use zebra_chain::{
     block::{self, Height},
-    transparent::EXTRA_ZEBRA_COINBASE_DATA,
+    transparent::{CoinbaseData, EXTRA_ZEBRA_COINBASE_DATA},
 };
+
 
 use crate::{
+
     constants::MAX_BLOCK_REORG_HEIGHT,
+
     service::{
+
         check,
+
         finalized_state::{FinalizedState, ZebraDb},
+
         non_finalized_state::NonFinalizedState,
+
         queued_blocks::{QueuedCheckpointVerified, QueuedSemanticallyVerified},
+
         ChainTipBlock, ChainTipSender, InvalidateError, ReconsiderError,
+
     },
+
     SemanticallyVerifiedBlock, ValidateContextError,
+
 };
+
+
 
 // These types are used in doc links
+
 #[allow(unused_imports)]
+
 use crate::service::{
+
     chain_tip::{ChainTipChange, LatestChainTip},
+
     non_finalized_state::Chain,
+
 };
 
+
+
 /// The maximum size of the parent error map.
+
 ///
+
 /// We allow enough space for multiple concurrent chain forks with errors.
+
 const PARENT_ERROR_MAP_LIMIT: usize = MAX_BLOCK_REORG_HEIGHT as usize * 2;
 
+
+
 /// Run contextual validation on the prepared block and add it to the
+
 /// non-finalized state if it is contextually valid.
+
 #[tracing::instrument(
+
     level = "debug",
+
     skip(finalized_state, non_finalized_state, prepared),
+
     fields(
+
         height = ?prepared.height,
+
         hash = %prepared.hash,
+
         chains = non_finalized_state.chain_count()
+
     )
+
 )]
+
 pub(crate) fn validate_and_commit_non_finalized(
+
     finalized_state: &ZebraDb,
+
     non_finalized_state: &mut NonFinalizedState,
+
     prepared: SemanticallyVerifiedBlock,
+
 ) -> Result<(), ValidateContextError> {
+
     check::initial_contextual_validity(finalized_state, non_finalized_state, &prepared)?;
+
     let parent_hash = prepared.block.header.previous_block_hash;
 
+
+
     if finalized_state.finalized_tip_hash() == parent_hash {
+
         non_finalized_state.commit_new_chain(prepared, finalized_state)?;
+
     } else {
+
         non_finalized_state.commit_block(prepared, finalized_state)?;
+
     }
 
+
+
     Ok(())
+
 }
 
+
+
 /// Update the [`LatestChainTip`], [`ChainTipChange`], and `non_finalized_state_sender`
+
 /// channels with the latest non-finalized [`ChainTipBlock`] and
+
 /// [`Chain`].
+
 ///
+
 /// `last_zebra_mined_log_height` is used to rate-limit logging.
+
 ///
+
 /// If `backup_dir_path` is `Some`, the non-finalized state is written to the backup
+
 /// directory before updating the channels.
+
 ///
+
 /// Returns the latest non-finalized chain tip height.
+
 ///
+
 /// # Panics
+
 ///
+
 /// If the `non_finalized_state` is empty.
+
 #[instrument(
+
     level = "debug",
+
     skip(
+
         non_finalized_state,
         chain_tip_sender,
         non_finalized_state_sender,
         last_zebra_mined_log_height,
+        zebra_mined_block_progress,
         backup_dir_path,
     ),
     fields(chains = non_finalized_state.chain_count())
+
 )]
+
 fn update_latest_chain_channels(
+
     non_finalized_state: &NonFinalizedState,
+
     chain_tip_sender: &mut ChainTipSender,
     non_finalized_state_sender: &watch::Sender<NonFinalizedState>,
     last_zebra_mined_log_height: &mut Option<Height>,
+    zebra_mined_block_progress: &mut ZebraMinedBlockProgress,
     backup_dir_path: Option<&Path>,
 ) -> block::Height {
     let best_chain = non_finalized_state.best_chain().expect("unexpected empty non-finalized state: must commit at least one block before updating channels");
 
+
+
     let tip_block = best_chain
+
         .tip_block()
+
         .expect("unexpected empty chain: must commit at least one block before updating channels")
+
         .clone();
+
     let tip_block = ChainTipBlock::from(tip_block);
 
-    log_if_mined_by_zebra(&tip_block, last_zebra_mined_log_height);
+
+
+    record_zebra_mined_block(
+        &tip_block,
+        last_zebra_mined_log_height,
+        zebra_mined_block_progress,
+    );
+
 
     let tip_block_height = tip_block.height;
 
+
+
     if let Some(backup_dir_path) = backup_dir_path {
+
         non_finalized_state.write_to_backup(backup_dir_path);
+
     }
 
+
+
     // If the final receiver was just dropped, ignore the error.
+
     let _ = non_finalized_state_sender.send(non_finalized_state.clone());
+
+
 
     chain_tip_sender.set_best_non_finalized_tip(tip_block);
 
+
+
     tip_block_height
+
 }
+
+
 
 /// A worker task that reads, validates, and writes blocks to the
+
 /// `finalized_state` or `non_finalized_state`.
+
 struct WriteBlockWorkerTask {
+
     finalized_block_write_receiver: UnboundedReceiver<QueuedCheckpointVerified>,
+
     non_finalized_block_write_receiver: UnboundedReceiver<NonFinalizedWriteMessage>,
+
     finalized_state: FinalizedState,
+
     non_finalized_state: NonFinalizedState,
+
     invalid_block_reset_sender: UnboundedSender<block::Hash>,
+
     chain_tip_sender: ChainTipSender,
+
     non_finalized_state_sender: watch::Sender<NonFinalizedState>,
+
     /// If `Some`, the non-finalized state is written to this backup directory
+
     /// synchronously before each channel update, instead of via the async backup task.
+
     backup_dir_path: Option<PathBuf>,
+
 }
+
+
 
 /// The message type for the non-finalized block write task channel.
+
 pub enum NonFinalizedWriteMessage {
+
     /// A newly downloaded and semantically verified block prepared for
+
     /// contextual validation and insertion into the non-finalized state.
+
     Commit(QueuedSemanticallyVerified),
+
     /// The hash of a block that should be invalidated and removed from
+
     /// the non-finalized state, if present.
+
     Invalidate {
+
         hash: block::Hash,
+
         rsp_tx: oneshot::Sender<Result<block::Hash, InvalidateError>>,
+
     },
+
     /// The hash of a block that was previously invalidated but should be
+
     /// reconsidered and reinserted into the non-finalized state.
+
     Reconsider {
+
         hash: block::Hash,
+
         rsp_tx: oneshot::Sender<Result<Vec<block::Hash>, ReconsiderError>>,
+
     },
+
 }
+
+
 
 impl From<QueuedSemanticallyVerified> for NonFinalizedWriteMessage {
+
     fn from(block: QueuedSemanticallyVerified) -> Self {
+
         NonFinalizedWriteMessage::Commit(block)
+
     }
+
 }
+
+
 
 /// A worker with a task that reads, validates, and writes blocks to the
+
 /// `finalized_state` or `non_finalized_state` and channels for sending
+
 /// it blocks.
+
 #[derive(Clone, Debug)]
+
 pub(super) struct BlockWriteSender {
+
     /// A channel to send blocks to the `block_write_task`,
+
     /// so they can be written to the [`NonFinalizedState`].
+
     pub non_finalized: Option<tokio::sync::mpsc::UnboundedSender<NonFinalizedWriteMessage>>,
 
+
+
     /// A channel to send blocks to the `block_write_task`,
+
     /// so they can be written to the [`FinalizedState`].
+
     ///
+
     /// This sender is dropped after the state has finished sending all the checkpointed blocks,
+
     /// and the lowest semantically verified block arrives.
+
     pub finalized: Option<tokio::sync::mpsc::UnboundedSender<QueuedCheckpointVerified>>,
+
 }
+
+
 
 impl BlockWriteSender {
+
     /// Creates a new [`BlockWriteSender`] with the given receivers and states.
+
     #[instrument(
+
         level = "debug",
+
         skip_all,
+
         fields(
+
             network = %non_finalized_state.network
+
         )
+
     )]
+
     pub fn spawn(
+
         finalized_state: FinalizedState,
+
         non_finalized_state: NonFinalizedState,
+
         chain_tip_sender: ChainTipSender,
+
         non_finalized_state_sender: watch::Sender<NonFinalizedState>,
+
         should_use_finalized_block_write_sender: bool,
+
         backup_dir_path: Option<PathBuf>,
+
     ) -> (
+
         Self,
+
         tokio::sync::mpsc::UnboundedReceiver<block::Hash>,
+
         Option<Arc<std::thread::JoinHandle<()>>>,
+
     ) {
+
         // Security: The number of blocks in these channels is limited by
+
         //           the syncer and inbound lookahead limits.
+
         let (non_finalized_block_write_sender, non_finalized_block_write_receiver) =
+
             tokio::sync::mpsc::unbounded_channel();
+
         let (finalized_block_write_sender, finalized_block_write_receiver) =
+
             tokio::sync::mpsc::unbounded_channel();
+
         let (invalid_block_reset_sender, invalid_block_write_reset_receiver) =
+
             tokio::sync::mpsc::unbounded_channel();
+
+
 
         let span = Span::current();
+
         let task = std::thread::spawn(move || {
+
             span.in_scope(|| {
+
                 WriteBlockWorkerTask {
+
                     finalized_block_write_receiver,
+
                     non_finalized_block_write_receiver,
+
                     finalized_state,
+
                     non_finalized_state,
+
                     invalid_block_reset_sender,
+
                     chain_tip_sender,
+
                     non_finalized_state_sender,
+
                     backup_dir_path,
+
                 }
+
                 .run()
+
             })
+
         });
 
+
+
         (
+
             Self {
+
                 non_finalized: Some(non_finalized_block_write_sender),
+
                 finalized: Some(finalized_block_write_sender)
+
                     .filter(|_| should_use_finalized_block_write_sender),
+
             },
+
             invalid_block_write_reset_receiver,
+
             Some(Arc::new(task)),
+
         )
+
     }
+
 }
 
+
+
 impl WriteBlockWorkerTask {
+
     /// Reads blocks from the channels, writes them to the `finalized_state` or `non_finalized_state`,
+
     /// sends any errors on the `invalid_block_reset_sender`, then updates the `chain_tip_sender` and
+
     /// `non_finalized_state_sender`.
+
     #[instrument(
+
         level = "debug",
+
         skip(self),
+
         fields(
+
             network = %self.non_finalized_state.network
+
         )
+
     )]
+
     pub fn run(mut self) {
+
         let Self {
+
             finalized_block_write_receiver,
+
             non_finalized_block_write_receiver,
+
             finalized_state,
+
             non_finalized_state,
+
             invalid_block_reset_sender,
+
             chain_tip_sender,
+
             non_finalized_state_sender,
+
             backup_dir_path,
+
         } = &mut self;
 
+
+
         let mut last_zebra_mined_log_height = None;
+        let mut zebra_mined_block_progress = ZebraMinedBlockProgress::default();
         let mut prev_finalized_note_commitment_trees = None;
 
+
         // Write all the finalized blocks sent by the state,
+
         // until the state closes the finalized block channel's sender.
+
         while let Some(ordered_block) = finalized_block_write_receiver.blocking_recv() {
+
             // TODO: split these checks into separate functions
 
+
+
             if invalid_block_reset_sender.is_closed() {
+
                 info!("StateService closed the block reset channel. Is Zebra shutting down?");
+
                 return;
+
             }
+
+
 
             // Discard any children of invalid blocks in the channel
+
             //
+
             // `commit_finalized()` requires blocks in height order.
+
             // So if there has been a block commit error,
+
             // we need to drop all the descendants of that block,
+
             // until we receive a block at the required next height.
+
             let next_valid_height = finalized_state
+
                 .db
+
                 .finalized_tip_height()
+
                 .map(|height| (height + 1).expect("committed heights are valid"))
+
                 .unwrap_or(Height(0));
 
+
+
             if ordered_block.0.height != next_valid_height {
+
                 debug!(
+
                     ?next_valid_height,
+
                     invalid_height = ?ordered_block.0.height,
+
                     invalid_hash = ?ordered_block.0.hash,
+
                     "got a block that was the wrong height. \
+
                      Assuming a parent block failed, and dropping this block",
+
                 );
 
+
+
                 // We don't want to send a reset here, because it could overwrite a valid sent hash
+
                 std::mem::drop(ordered_block);
+
                 continue;
+
             }
 
+
+
             // Try committing the block
+
             match finalized_state
+
                 .commit_finalized(ordered_block, prev_finalized_note_commitment_trees.take())
+
             {
+
                 Ok((finalized, note_commitment_trees)) => {
+
                     let tip_block = ChainTipBlock::from(finalized);
+
                     prev_finalized_note_commitment_trees = Some(note_commitment_trees);
 
-                    log_if_mined_by_zebra(&tip_block, &mut last_zebra_mined_log_height);
+
+
+                    record_zebra_mined_block(
+                        &tip_block,
+                        &mut last_zebra_mined_log_height,
+                        &mut zebra_mined_block_progress,
+                    );
 
                     chain_tip_sender.set_finalized_tip(tip_block);
                 }
+
                 Err(error) => {
+
                     let finalized_tip = finalized_state.db.tip();
 
+
+
                     // The last block in the queue failed, so we can't commit the next block.
+
                     // Instead, we need to reset the state queue,
+
                     // and discard any children of the invalid block in the channel.
+
                     info!(
+
                         ?error,
+
                         last_valid_height = ?finalized_tip.map(|tip| tip.0),
+
                         last_valid_hash = ?finalized_tip.map(|tip| tip.1),
+
                         "committing a block to the finalized state failed, resetting state queue",
+
                     );
 
+
+
                     let send_result =
+
                         invalid_block_reset_sender.send(finalized_state.db.finalized_tip_hash());
 
+
+
                     if send_result.is_err() {
+
                         info!(
+
                             "StateService closed the block reset channel. Is Zebra shutting down?"
+
                         );
+
                         return;
+
                     }
+
                 }
+
             }
+
         }
+
+
 
         // Do this check even if the channel got closed before any finalized blocks were sent.
+
         // This can happen if we're past the finalized tip.
+
         if invalid_block_reset_sender.is_closed() {
+
             info!("StateService closed the block reset channel. Is Zebra shutting down?");
+
             return;
+
         }
 
+
+
         // Save any errors to propagate down to queued child blocks
+
         let mut parent_error_map: IndexMap<block::Hash, ValidateContextError> = IndexMap::new();
 
+
+
         while let Some(msg) = non_finalized_block_write_receiver.blocking_recv() {
+
             let queued_child_and_rsp_tx = match msg {
+
                 NonFinalizedWriteMessage::Commit(queued_child) => Some(queued_child),
+
                 NonFinalizedWriteMessage::Invalidate { hash, rsp_tx } => {
+
                     tracing::info!(?hash, "invalidating a block in the non-finalized state");
+
                     let _ = rsp_tx.send(non_finalized_state.invalidate_block(hash));
+
                     None
+
                 }
+
                 NonFinalizedWriteMessage::Reconsider { hash, rsp_tx } => {
+
                     tracing::info!(?hash, "reconsidering a block in the non-finalized state");
+
                     let _ = rsp_tx
+
                         .send(non_finalized_state.reconsider_block(hash, &finalized_state.db));
+
                     None
+
                 }
+
             };
 
+
+
             let Some((queued_child, rsp_tx)) = queued_child_and_rsp_tx else {
+
                 update_latest_chain_channels(
+
                     non_finalized_state,
+
                     chain_tip_sender,
                     non_finalized_state_sender,
                     &mut last_zebra_mined_log_height,
+                    &mut zebra_mined_block_progress,
                     backup_dir_path.as_deref(),
                 );
                 continue;
+
             };
+
+
 
             let child_hash = queued_child.hash;
+
             let parent_hash = queued_child.block.header.previous_block_hash;
+
             let parent_error = parent_error_map.get(&parent_hash);
 
+
+
             // If the parent block was marked as rejected, also reject all its children.
+
             //
+
             // At this point, we know that all the block's descendants
+
             // are invalid, because we checked all the consensus rules before
+
             // committing the failing ancestor block to the non-finalized state.
+
             let result = if let Some(parent_error) = parent_error {
+
                 Err(parent_error.clone())
+
             } else {
+
                 tracing::trace!(?child_hash, "validating queued child");
+
                 validate_and_commit_non_finalized(
+
                     &finalized_state.db,
+
                     non_finalized_state,
+
                     queued_child,
+
                 )
+
             };
 
+
+
             // TODO: fix the test timing bugs that require the result to be sent
+
             //       after `update_latest_chain_channels()`,
+
             //       and send the result on rsp_tx here
 
+
+
             if let Err(ref error) = result {
+
                 // If the block is invalid, mark any descendant blocks as rejected.
+
                 parent_error_map.insert(child_hash, error.clone());
 
+
+
                 // Make sure the error map doesn't get too big.
+
                 if parent_error_map.len() > PARENT_ERROR_MAP_LIMIT {
+
                     // We only add one hash at a time, so we only need to remove one extra here.
+
                     parent_error_map.shift_remove_index(0);
+
                 }
 
+
+
                 // Update the caller with the error.
+
                 let _ = rsp_tx.send(result.map(|()| child_hash).map_err(Into::into));
 
+
+
                 // Skip the things we only need to do for successfully committed blocks
+
                 continue;
+
             }
 
+
+
             // Committing blocks to the finalized state keeps the same chain,
+
             // so we can update the chain seen by the rest of the application now.
+
             //
+
             // TODO: if this causes state request errors due to chain conflicts,
+
             //       fix the `service::read` bugs,
+
             //       or do the channel update after the finalized state commit
+
             let tip_block_height = update_latest_chain_channels(
+
                 non_finalized_state,
+
                 chain_tip_sender,
                 non_finalized_state_sender,
                 &mut last_zebra_mined_log_height,
+                &mut zebra_mined_block_progress,
                 backup_dir_path.as_deref(),
             );
 
+
             // Update the caller with the result.
+
             let _ = rsp_tx.send(result.map(|()| child_hash).map_err(Into::into));
 
+
+
             while non_finalized_state
+
                 .best_chain_len()
+
                 .expect("just successfully inserted a non-finalized block above")
+
                 > MAX_BLOCK_REORG_HEIGHT
+
             {
+
                 tracing::trace!("finalizing block past the reorg limit");
+
                 let contextually_verified_with_trees = non_finalized_state.finalize();
+
                 prev_finalized_note_commitment_trees = finalized_state
+
                             .commit_finalized_direct(contextually_verified_with_trees, prev_finalized_note_commitment_trees.take(), "commit contextually-verified request")
+
                             .expect(
+
                                 "unexpected finalized block commit error: note commitment and history trees were already checked by the non-finalized state",
+
                             ).1.into();
+
             }
 
+
+
             // Update the metrics if semantic and contextual validation passes
+
             //
+
             // TODO: split this out into a function?
+
             metrics::counter!("state.full_verifier.committed.block.count").increment(1);
+
             metrics::counter!("zcash.chain.verified.block.total").increment(1);
 
+
+
             metrics::gauge!("state.full_verifier.committed.block.height")
+
                 .set(tip_block_height.0 as f64);
 
+
+
             // This height gauge is updated for both fully verified and checkpoint blocks.
+
             // These updates can't conflict, because this block write task makes sure that blocks
+
             // are committed in order.
+
             metrics::gauge!("zcash.chain.verified.block.height").set(tip_block_height.0 as f64);
 
+
+
             tracing::trace!("finished processing queued block");
+
         }
 
+
+
         // We're finished receiving non-finalized blocks from the state, and
+
         // done writing to the finalized state, so we can force it to shut down.
+
         finalized_state.db.shutdown(true);
+
         std::mem::drop(self.finalized_state);
+
+    }
+
+}
+
+
+
+#[derive(Default)]
+struct ZebraMinedBlockProgress {
+    count: u64,
+    seen_hashes: HashSet<block::Hash>,
+    #[cfg(feature = "progress-bar")]
+    bar: Option<howudoin::Tx>,
+}
+
+impl ZebraMinedBlockProgress {
+    fn record(&mut self, tip_block: &ChainTipBlock) {
+        if !self.seen_hashes.insert(tip_block.hash) {
+            return;
+        }
+
+        self.count += 1;
+
+        metrics::counter!("state.zebra_mined.block.count").increment(1);
+
+        #[cfg(feature = "progress-bar")]
+        if !matches!(howudoin::cancelled(), Some(true)) {
+            let bar = self
+                .bar
+                .get_or_insert_with(|| howudoin::new_root().label("Zebra-Mined Blocks"));
+
+            bar.set_pos(self.count)
+                .desc(format!("Latest height {}", tip_block.height.0));
+        }
     }
 }
 
@@ -478,8 +962,32 @@ impl WriteBlockWorkerTask {
 ///
 /// Does not detect early Zebra blocks, and blocks with custom coinbase transactions.
 /// Rate-limited to every 1000 blocks using `last_zebra_mined_log_height`.
+fn record_zebra_mined_block(
+    tip_block: &ChainTipBlock,
+    last_zebra_mined_log_height: &mut Option<Height>,
+    zebra_mined_block_progress: &mut ZebraMinedBlockProgress,
+) {
+    let Some(coinbase_data) = zebra_mined_coinbase_data(tip_block) else {
+        return;
+    };
+
+    zebra_mined_block_progress.record(tip_block);
+
+    log_if_mined_by_zebra(tip_block, coinbase_data, last_zebra_mined_log_height);
+}
+
+fn zebra_mined_coinbase_data(tip_block: &ChainTipBlock) -> Option<&CoinbaseData> {
+    let coinbase_data = tip_block.transactions[0].inputs()[0].extra_coinbase_data()?;
+
+    coinbase_data
+        .as_ref()
+        .starts_with(EXTRA_ZEBRA_COINBASE_DATA.as_bytes())
+        .then_some(coinbase_data)
+}
+
 fn log_if_mined_by_zebra(
     tip_block: &ChainTipBlock,
+    coinbase_data: &CoinbaseData,
     last_zebra_mined_log_height: &mut Option<Height>,
 ) {
     // This logs at most every 2-3 checkpoints, which seems fine.
@@ -487,58 +995,56 @@ fn log_if_mined_by_zebra(
 
     let height = tip_block.height.0;
 
+
+
     if let Some(last_height) = last_zebra_mined_log_height {
+
         if height < last_height.0 + LOG_RATE_LIMIT {
+
             // If we logged in the last 1000 blocks, don't log anything now.
+
             return;
+
         }
+
     };
 
-    // This code is rate-limited, so we can do expensive transformations here.
-    let coinbase_data = tip_block.transactions[0].inputs()[0]
-        .extra_coinbase_data()
-        .expect("valid blocks must start with a coinbase input")
-        .clone();
 
-    if coinbase_data
-        .as_ref()
-        .starts_with(EXTRA_ZEBRA_COINBASE_DATA.as_bytes())
-    {
-        let text = String::from_utf8_lossy(coinbase_data.as_ref());
 
-        *last_zebra_mined_log_height = Some(Height(height));
+    let text = String::from_utf8_lossy(coinbase_data.as_ref());
 
-        // No need for hex-encoded data if it's exactly what we expected.
-        if coinbase_data.as_ref() == EXTRA_ZEBRA_COINBASE_DATA.as_bytes() {
-            info!(
-                %text,
-                %height,
-                hash = %tip_block.hash,
-                "looks like this block was mined by Zebra!"
-            );
-        } else {
-            // # Security
-            //
-            // Use the extra data as an allow-list, replacing unknown characters.
-            // This makes sure control characters and harmful messages don't get logged
-            // to the terminal.
-            let text = text.replace(
-                |c: char| {
-                    !EXTRA_ZEBRA_COINBASE_DATA
-                        .to_ascii_lowercase()
-                        .contains(c.to_ascii_lowercase())
-                },
-                "?",
-            );
-            let data = hex::encode(coinbase_data.as_ref());
+    *last_zebra_mined_log_height = Some(Height(height));
 
-            info!(
-                %text,
-                %data,
-                %height,
-                hash = %tip_block.hash,
-                "looks like this block was mined by Zebra!"
-            );
-        }
+    // No need for hex-encoded data if it's exactly what we expected.
+    if coinbase_data.as_ref() == EXTRA_ZEBRA_COINBASE_DATA.as_bytes() {
+        info!(
+            %text,
+            %height,
+            hash = %tip_block.hash,
+            "looks like this block was mined by Zebra!"
+        );
+    } else {
+        // # Security
+        //
+        // Use the extra data as an allow-list, replacing unknown characters.
+        // This makes sure control characters and harmful messages don't get logged
+        // to the terminal.
+        let text = text.replace(
+            |c: char| {
+                !EXTRA_ZEBRA_COINBASE_DATA
+                    .to_ascii_lowercase()
+                    .contains(c.to_ascii_lowercase())
+            },
+            "?",
+        );
+        let data = hex::encode(coinbase_data.as_ref());
+
+        info!(
+            %text,
+            %data,
+            %height,
+            hash = %tip_block.hash,
+            "looks like this block was mined by Zebra!"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Detect Zebra-mined blocks using the existing coinbase extra data marker.
- Track unique Zebra-mined blocks with a dedicated `Zebra-Mined Blocks` progress bar when `progress-bar` is enabled.
- Add the `state.zebra_mined.block.count` metric while keeping the existing rate-limited log behavior.

## Motivation
Resolves #10190.

## Testing
- `cargo fmt --check`
- `git diff --check`
- `cargo check -p zebra-state --features progress-bar`