### PR TITLE
fix(rpc): avoid rebuilding mempool index per transaction in getrawmempool

### DIFF
--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1634,6 +1634,10 @@ where
                 last_seen_tip_hash: _,
             } => {
                 if verbose {
+                    let transactions_by_id = transactions
+                        .iter()
+                        .map(|unmined_tx| (unmined_tx.transaction.id.mined_id(), unmined_tx))
+                        .collect::<HashMap<_, _>>();
                     let map = transactions
                         .iter()
                         .map(|unmined_tx| {
@@ -1641,7 +1645,7 @@ where
                                 unmined_tx.transaction.id.mined_id().encode_hex(),
                                 get_raw_mempool::MempoolObject::from_verified_unmined_tx(
                                     unmined_tx,
-                                    &transactions,
+                                    &transactions_by_id,
                                     &transaction_dependencies,
                                 ),
                             )

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -257,6 +257,10 @@ proptest! {
         runtime.block_on(async move {
             if verbose.unwrap_or(false) {
                 let (expected_response, mempool_query) = {
+                    let transactions_by_id = transactions
+                        .iter()
+                        .map(|unmined_tx| {(unmined_tx.transaction.id.mined_id(), unmined_tx)})
+                        .collect::<HashMap<_, _>>();
                     let transaction_dependencies = Default::default();
                     let txs = transactions
                         .iter()
@@ -265,7 +269,7 @@ proptest! {
                                 unmined_tx.transaction.id.mined_id().encode_hex(),
                                 MempoolObject::from_verified_unmined_tx(
                                     unmined_tx,
-                                    &transactions,
+                                    &transactions_by_id,
                                     &transaction_dependencies,
                                 ),
                             )

--- a/zebra-rpc/src/methods/types/get_raw_mempool.rs
+++ b/zebra-rpc/src/methods/types/get_raw_mempool.rs
@@ -6,7 +6,11 @@ use derive_getters::Getters;
 use derive_new::new;
 use hex::ToHex as _;
 
-use zebra_chain::{amount::NonNegative, block::Height, transaction::VerifiedUnminedTx};
+use zebra_chain::{
+    amount::NonNegative,
+    block::Height,
+    transaction::{Hash, VerifiedUnminedTx},
+};
 use zebra_node_services::mempool::TransactionDependencies;
 
 use super::zec::Zec;
@@ -58,15 +62,9 @@ pub struct MempoolObject {
 impl MempoolObject {
     pub(crate) fn from_verified_unmined_tx(
         unmined_tx: &VerifiedUnminedTx,
-        transactions: &[VerifiedUnminedTx],
+        transactions_by_id: &HashMap<Hash, &VerifiedUnminedTx>,
         transaction_dependencies: &TransactionDependencies,
     ) -> Self {
-        // Map transactions by their txids to make lookups easier
-        let transactions_by_id = transactions
-            .iter()
-            .map(|unmined_tx| (unmined_tx.transaction.id.mined_id(), unmined_tx))
-            .collect::<HashMap<_, _>>();
-
         // Get txids of this transaction's descendants (dependents)
         let empty_set = HashSet::new();
         let deps = transaction_dependencies


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

<!--
- Describe the goals of the PR.
- If it closes any issues, enumerate them here.
-->

Closes #10587

Fix performance issue in `getrawmempool` by avoiding repeated reconstruction of the mempool index for each transaction.

Implements the optimization suggested in the issue.

## Solution

<!-- Describe the changes in the PR. -->

Move construction of `transactions_by_id` to the RPC caller and pass it into `from_verified_unmined_tx`, as outlined in the issue. 

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

Existing property tests were updated to reflect the changed function signature. All tests pass locally.

### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [ ] No AI tools were used in this PR
- [x] AI tools were used: ChatGPT was used to draft the PR description and polish text.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [ ] The documentation and changelogs are up to date.
