### PR TITLE
fix(state): correct dequeue_children by_height index handling

### DIFF
--- a/zebra-state/src/service/queued_blocks.rs
+++ b/zebra-state/src/service/queued_blocks.rs
@@ -107,7 +107,14 @@ impl QueuedBlocks {
             .collect::<Vec<_>>();
 
         for queued in &queued_children {
-            self.by_height.remove(&queued.0.height);
+            if let Some(hashes) = self.by_height.get_mut(&queued.0.height) {
+                hashes.remove(&queued.0.hash);
+
+                if hashes.is_empty() {
+                    self.by_height.remove(&queued.0.height);
+                }
+            }
+
             // TODO: only remove UTXOs if there are no queued blocks with that UTXO
             //       (known_utxos is best-effort, so this is ok for now)
             for outpoint in queued.0.new_outputs.keys() {

--- a/zebra-state/src/service/queued_blocks/tests/vectors.rs
+++ b/zebra-state/src/service/queued_blocks/tests/vectors.rs
@@ -197,3 +197,51 @@ fn sent_hashes_remove_drops_rejected_hash_and_utxos() -> Result<()> {
 
     Ok(())
 }
+
+// Ensures `dequeue_children` does not remove same-height sibling blocks from other forks.
+#[test]
+fn dequeue_children_preserves_same_height_siblings() -> Result<()> {
+    let _init_guard = zebra_test::init();
+
+    let root_block: Arc<Block> =
+        zebra_test::vectors::BLOCK_MAINNET_419200_BYTES.zcash_deserialize_into()?;
+
+    let left_child: Arc<Block> =
+        zebra_test::vectors::BLOCK_MAINNET_419201_BYTES.zcash_deserialize_into()?;
+    let left_grandchild = left_child.make_fake_child();
+
+    let right_child = root_block.make_fake_child();
+    let right_grandchild = right_child.make_fake_child();
+
+    let mut queue = QueuedBlocks::default();
+    queue.queue(left_grandchild.clone().into_queued());
+    queue.queue(right_grandchild.clone().into_queued());
+
+    let height = left_grandchild.coinbase_height().unwrap();
+
+    // Sanity check: both entries are indexed under the same height bucket
+    assert_eq!(
+        queue.by_height.get(&height).unwrap().len(),
+        2,
+        "expected both fork grandchildren to be in the same height bucket"
+    );
+
+    // Dequeue only one branch
+    queue.dequeue_children(left_child.hash());
+
+    assert!(
+        queue.blocks.contains_key(&right_grandchild.hash()),
+        "sibling block must remain in queue after unrelated dequeue"
+    );
+
+    assert!(
+        queue
+            .by_height
+            .get(&height)
+            .unwrap()
+            .contains(&right_grandchild.hash()),
+        "sibling must remain indexed by height after unrelated dequeue"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

<!--
- Describe the goals of the PR.
- If it closes any issues, enumerate them here.
-->

Fixes incorrect behavior in `QueuedBlocks::dequeue_children` where removing queued children incorrectly removed entire `by_height` buckets instead of only the matching block hash.

Closes #10597

## Solution

<!-- Describe the changes in the PR. -->

Update `dequeue_children` to remove only the specific block hash from the `by_height` index, and only remove the height entry when no hashes remain.

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

Added a regression test that constructs a forked chain scenario where two queued blocks exist at the same height but belong to different parents. The test fails on the previous implementation and passes after the fix.

### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [ ] No AI tools were used in this PR
- [x] AI tools were used: assisted in drafting the test and initial fix structure

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
