### PR TITLE
fix(consensus): handle Elapsed timeout at AwaitUtxo call site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 - Avoid panicking in the address-book ban path when `network.max_connections_per_ip > 1`. Guard the optional `most_recent_by_ip` cache instead of unwrapping it, so a ban-threshold misbehavior update no longer crashes the address-book updater and poisons the shared mutex ([#10580](https://github.com/ZcashFoundation/zebra/issues/10580))
 - Propagate transaction-level value-balance errors from `Block::chain_value_pool_change()` instead of silently dropping them. The previous `flat_map(Result)` aggregation relied on `Result<T, E>: IntoIterator` and yielded zero items on `Err`, so a failing transaction was omitted from the block sum rather than surfacing as a `ValueBalanceError` ([#10585](https://github.com/ZcashFoundation/zebra/issues/10585))
+- Handle `Elapsed` timeout at the `AwaitUtxo` call site in the transaction verifier so it maps to `TransparentInputNotFound` instead of `InternalDowncastError`. Fixes a sync stall loop near the chain tip that surfaced after the mempool bypass removal in #10494 ([#10629](https://github.com/ZcashFoundation/zebra/issues/10629))
 
 ## [Zebra 4.4.1](https://github.com/ZcashFoundation/zebra/releases/tag/v4.4.1) - 2026-05-04
 

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -106,6 +106,12 @@ impl VerifyBlockError {
         }
     }
 
+    /// Returns `true` if this error is a transparent input timeout
+    /// (`TransparentInputNotFound` from an `AwaitUtxo` `Elapsed`).
+    pub fn is_transparent_input_not_found(&self) -> bool {
+        matches!(self, VerifyBlockError::Transaction(TransactionError::TransparentInputNotFound))
+    }
+
     /// Returns a suggested misbehaviour score increment for a certain error.
     pub fn misbehavior_score(&self) -> u32 {
         // TODO: Adjust these values based on zcashd (#9258).

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -109,7 +109,10 @@ impl VerifyBlockError {
     /// Returns `true` if this error is a transparent input timeout
     /// (`TransparentInputNotFound` from an `AwaitUtxo` `Elapsed`).
     pub fn is_transparent_input_not_found(&self) -> bool {
-        matches!(self, VerifyBlockError::Transaction(TransactionError::TransparentInputNotFound))
+        matches!(
+            self,
+            VerifyBlockError::Transaction(TransactionError::TransparentInputNotFound)
+        )
     }
 
     /// Returns a suggested misbehaviour score increment for a certain error.

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -474,8 +474,3 @@ impl BlockError {
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-}

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -474,3 +474,8 @@ impl BlockError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+}

--- a/zebra-consensus/src/router.rs
+++ b/zebra-consensus/src/router.rs
@@ -143,6 +143,14 @@ impl RouterError {
         }
     }
 
+    /// Returns `true` if this error is a transparent input timeout.
+    pub fn is_transparent_input_not_found(&self) -> bool {
+        match self {
+            RouterError::Block { source, .. } => source.is_transparent_input_not_found(),
+            RouterError::Checkpoint { .. } => false,
+        }
+    }
+
     /// Returns a suggested misbehaviour score increment for a certain error.
     pub fn misbehavior_score(&self) -> u32 {
         // TODO: Adjust these values based on zcashd (#9258).

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -719,10 +719,15 @@ where
                     let query = state
                         .clone()
                         .oneshot(zebra_state::Request::AwaitUtxo(*outpoint));
-                    if let zebra_state::Response::Utxo(utxo) = query.await? {
-                        utxo
-                    } else {
-                        unreachable!("AwaitUtxo always responds with Utxo")
+                    match query.await {
+                        Ok(zebra_state::Response::Utxo(utxo)) => utxo,
+                        Ok(_) => unreachable!("AwaitUtxo always responds with Utxo"),
+                        Err(err) => {
+                            return match err.downcast::<Elapsed>() {
+                                Ok(_) => Err(TransactionError::TransparentInputNotFound),
+                                Err(err) => Err(err.into()),
+                            };
+                        }
                     }
                 };
                 tracing::trace!(?utxo, "got UTXO");

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -3041,6 +3041,75 @@ async fn v5_consensus_branch_ids() {
 ///
 /// Note: `known_utxos` is only intended to be used for UTXOs within the same block,
 /// so future verification changes might break this mocking function.
+/// Tests that a block verification request returns `TransparentInputNotFound`
+/// when the `AwaitUtxo` state call times out (returns `Elapsed`).
+///
+/// This is the fix for #10629: before this change, `Elapsed` fell through all
+/// downcast attempts in `From<BoxError> for TransactionError` and became
+/// `InternalDowncastError`, causing a sync stall loop near the chain tip.
+#[tokio::test]
+async fn block_request_with_await_utxo_timeout_returns_transparent_input_not_found() {
+    let _init_guard = zebra_test::init();
+
+    let mut state: MockService<_, _, _, _> = MockService::build().for_prop_tests();
+    let verifier = Verifier::new_for_tests(&Network::Mainnet, state.clone());
+
+    let height = NetworkUpgrade::Canopy
+        .activation_height(&Network::Mainnet)
+        .expect("Canopy activation height is specified");
+    let fund_height = (height - 1).expect("fake source fund block height is too small");
+    let (input, output, _known_utxos) = mock_transparent_transfer(
+        fund_height,
+        true,
+        0,
+        Amount::try_from(10001).expect("invalid value"),
+    );
+
+    let tx = Transaction::V4 {
+        inputs: vec![input],
+        outputs: vec![output],
+        lock_time: LockTime::unlocked(),
+        expiry_height: height,
+        joinsplit_data: None,
+        sapling_shielded_data: None,
+    };
+
+    let input_outpoint = match tx.inputs()[0] {
+        transparent::Input::PrevOut { outpoint, .. } => outpoint,
+        transparent::Input::Coinbase { .. } => panic!("requires a non-coinbase transaction"),
+    };
+
+    tokio::spawn(async move {
+        state
+            .expect_request(zebra_state::Request::AwaitUtxo(input_outpoint))
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(Err::<zebra_state::Response, zebra_state::BoxError>(
+                tower::timeout::error::Elapsed::new().into(),
+            ));
+    });
+
+    let verifier_response = verifier
+        .oneshot(Request::Block {
+            transaction_hash: tx.hash(),
+            transaction: Arc::new(tx),
+            known_outpoint_hashes: Arc::new(HashSet::new()),
+            known_utxos: Arc::new(HashMap::new()),
+            height,
+            time: Utc::now(),
+        })
+        .await;
+
+    let err = verifier_response
+        .expect_err("expected failed verification due to AwaitUtxo timeout");
+
+    assert_eq!(
+        err,
+        TransactionError::TransparentInputNotFound,
+        "AwaitUtxo Elapsed timeout should map to TransparentInputNotFound, not InternalDowncastError"
+    );
+}
+
 fn mock_transparent_transfer(
     previous_utxo_height: block::Height,
     script_should_succeed: bool,

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -3100,8 +3100,7 @@ async fn block_request_with_await_utxo_timeout_returns_transparent_input_not_fou
         })
         .await;
 
-    let err = verifier_response
-        .expect_err("expected failed verification due to AwaitUtxo timeout");
+    let err = verifier_response.expect_err("expected failed verification due to AwaitUtxo timeout");
 
     assert_eq!(
         err,

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -1223,6 +1223,16 @@ where
                 debug!(error = ?e, "block was already verified or committed, possibly from a previous sync run, continuing");
                 false
             }
+            BlockDownloadVerifyError::Invalid { error, .. }
+                if error.is_transparent_input_not_found() =>
+            {
+                debug!(
+                    error = ?e,
+                    "transparent input UTXO lookup timed out, \
+                     will retry on next sync attempt, continuing"
+                );
+                false
+            }
 
             // Structural matches: direct
             BlockDownloadVerifyError::CancelledDuringDownload { .. }


### PR DESCRIPTION
## Summary

- Handle `Elapsed` timeout at the `AwaitUtxo` call site in the transaction verifier, mapping it to `TransparentInputNotFound` instead of falling through to `InternalDowncastError`
- Mirrors the existing `AwaitOutput` pattern at line ~746
- Add unit test proving the fix
- Add CHANGELOG entry

## Motivation

Nodes near the tip hit repeated `InternalDowncastError(... Elapsed(()))` errors, causing a sync stall loop despite having 60+ peers.

The `From<BoxError> for TransactionError` impl tries downcasting to `RedJubjub`, `ValidateContextError`, and `TransactionError`, but not `tower::timeout::error::Elapsed`. When `Timeout<State>` (AwaitUtxo, 6 min) fires, the `Elapsed` error falls through to `InternalDowncastError`, failing block verification and triggering a sync restart loop.

This was latent since #8857 (Nov 2024) but became user-visible after #10494 (Apr 2026) removed the `find_verified_unmined_tx` shortcut that previously avoided or silently swallowed these timeouts.

## Solution

Handle `Elapsed` at the specific `AwaitUtxo` call site rather than in the broad `From<BoxError>` conversion. This avoids mislabelling unrelated state timeouts (e.g. `CheckBestChainTipNullifiersAndAnchors`) as `TransparentInputNotFound`.

The two timeout handling sites now use identical patterns:

```rust
Err(err) => return match err.downcast::<Elapsed>() {
    Ok(_) => Err(TransactionError::TransparentInputNotFound),
    Err(err) => Err(err.into()),
},
```

## Test plan

- [x] New unit test `block_request_with_await_utxo_timeout_returns_transparent_input_not_found` verifies that a mock `AwaitUtxo` returning `Elapsed` produces `TransparentInputNotFound`
- [x] Existing transaction verifier tests pass

Closes #10629