### PR TITLE
test(rpc): reduce GBT snapshot mock timeout flake

### DIFF
--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -9,7 +9,7 @@ use std::{
     collections::BTreeMap,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::Arc,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use futures::FutureExt;
@@ -215,8 +215,11 @@ async fn test_rpc_response_data_for_network(network: &Network) {
         .map(|block_bytes| block_bytes.zcash_deserialize_into().unwrap())
         .collect();
 
-    let mut mempool: MockService<_, _, _, zebra_node_services::BoxError> =
-        MockService::build().for_unit_tests();
+    let mut mempool: MockService<_, _, _, zebra_node_services::BoxError> = MockService::build()
+        // This test runs multiple network snapshots concurrently; on busy CI runners the default
+        // mock request timeout can elapse before the GBT long-poll request is observed.
+        .with_max_request_delay(Duration::from_secs(2))
+        .for_unit_tests();
 
     // Create a populated state service
     let (state, read_state, tip, _) = zebra_state::populated_state(blocks.clone(), network).await;


### PR DESCRIPTION
## Summary

Stabilize test_rpc_response_data by increasing the mock mempool request timeout used in snapshot RPC tests.

This addresses intermittent failures where the test panics with:

timeout while waiting for a request
from zebra-test/src/mock_service.rs.

## Root cause

The snapshot test runs multiple network cases concurrently, and under CI load the default mock request timeout can expire before the getblocktemplate long-poll mempool request is observed.

## Changes

- zebra-rpc/src/methods/tests/snapshot.rs
  - import Duration
  - configure the mempool mock with with_max_request_delay(Duration::from_secs(2))

## Why this is safe

This is test-only behavior. No production RPC logic is changed.

## Verification

- Re-ran:
  - cargo test -p zebra-rpc methods::tests::snapshot::test_rpc_response_data -- --exact --test-threads=1
- Repeated targeted run multiple times to validate stability.
