### PR TITLE
test(zebrad): reduce sync_large_checkpoints_mempool_mainnet timeout flakes

### DIFF
--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -203,10 +203,10 @@ use common::{
     },
     lightwalletd::{can_spawn_lightwalletd_for_rpc, spawn_lightwalletd_for_rpc},
     sync::{
-        create_cached_database_height, sync_until, MempoolBehavior, LARGE_CHECKPOINT_TEST_HEIGHT,
-        LARGE_CHECKPOINT_TIMEOUT, MEDIUM_CHECKPOINT_TEST_HEIGHT, STOP_AT_HEIGHT_REGEX,
-        STOP_ON_LOAD_TIMEOUT, SYNC_FINISHED_REGEX, TINY_CHECKPOINT_TEST_HEIGHT,
-        TINY_CHECKPOINT_TIMEOUT,
+        create_cached_database_height, sync_until, MempoolBehavior,
+        LARGE_CHECKPOINT_MEMPOOL_TIMEOUT, LARGE_CHECKPOINT_TEST_HEIGHT, LARGE_CHECKPOINT_TIMEOUT,
+        MEDIUM_CHECKPOINT_TEST_HEIGHT, STOP_AT_HEIGHT_REGEX, STOP_ON_LOAD_TIMEOUT,
+        SYNC_FINISHED_REGEX, TINY_CHECKPOINT_TEST_HEIGHT, TINY_CHECKPOINT_TIMEOUT,
     },
     test_type::TestType::{self, *},
 };
@@ -1214,7 +1214,7 @@ fn sync_large_checkpoints_mempool_mainnet() -> Result<()> {
         MEDIUM_CHECKPOINT_TEST_HEIGHT,
         &Mainnet,
         STOP_AT_HEIGHT_REGEX,
-        LARGE_CHECKPOINT_TIMEOUT,
+        LARGE_CHECKPOINT_MEMPOOL_TIMEOUT,
         None,
         MempoolBehavior::ForceActivationAt(TINY_CHECKPOINT_TEST_HEIGHT),
         // checkpoint sync is irrelevant here - all tested checkpoints are mandatory

--- a/zebrad/tests/common/sync.rs
+++ b/zebrad/tests/common/sync.rs
@@ -68,6 +68,11 @@ pub const TINY_CHECKPOINT_TIMEOUT: Duration = Duration::from_secs(240);
 // TODO: reduce to 180 when #6506 is fixed
 pub const LARGE_CHECKPOINT_TIMEOUT: Duration = Duration::from_secs(240);
 
+/// The maximum amount of time Zebra should take to sync medium checkpoints with mempool enabled.
+///
+/// This path depends on external network peers and can be slower than empty-checkpoint sync in CI.
+pub const LARGE_CHECKPOINT_MEMPOOL_TIMEOUT: Duration = Duration::from_secs(360);
+
 /// The maximum time to wait for Zebrad to synchronize up to the chain tip starting from a
 /// partially synchronized state.
 ///


### PR DESCRIPTION
## Summary

Increase timeout for the network-dependent `sync_large_checkpoints_mempool_mainnet` acceptance test to reduce CI flakiness/timeouts.

## Root cause evidence

- Recent CI failures were timing out at ~240s in `sync_large_checkpoints_mempool_mainnet`.
- Logs show repeated external peer connection/download timeouts while this test runs (`initial sync is waiting to download the genesis block`, `error downloading and verifying block e=Timeout`).
- `disconnects_from_misbehaving_peers` was slow but passing in those same runs.

## Changes

- Add `LARGE_CHECKPOINT_MEMPOOL_TIMEOUT = 360s` in `zebrad/tests/common/sync.rs`.
- Use the new timeout only in `sync_large_checkpoints_mempool_mainnet` in `zebrad/tests/acceptance.rs`.

## Scope

- Test-only change; no production runtime code modified.
- Keeps existing 240s timeout for other large-checkpoint tests.
