### PR TITLE
feat(network): add mainnet stall observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Added
 
 - Startup warning on Linux when `net.ipv4.tcp_slow_start_after_idle` is enabled (which resets TCP congestion windows between block requests and significantly reduces single-peer block-propagation throughput on long-haul links), with a "Linux TCP tuning for block propagation" troubleshooting section ([#10513](https://github.com/ZcashFoundation/zebra/pull/10513))
+- Sync-stall observability for node operators: restart-cause counters, typed
+  block download/verify error counters, missing-inventory retry counters,
+  pending-hash and download-slot gauges, checkpoint range timing, state request
+  timeout counters, peer discovery/handshake/source metrics, peer request
+  duration/error/timeout metrics, and redacted tracing spans for sync, peer
+  routing, block downloads, and `AwaitUtxo` requests.
 - Support ZIP-213
 
 ### Fixed

--- a/book/src/user/metrics.md
+++ b/book/src/user/metrics.md
@@ -60,4 +60,36 @@ front end that you can visualize:
 
 ![image info](grafana.png)
 
+## Sync Stall Metrics
+
+Zebra exposes low-cardinality metrics for diagnosing stalled or slow syncs:
+
+- `sync.restart.count{reason,made_progress,sync_failed}`
+- `sync.block_download.error.count{kind}`
+- `sync.block_verify.error.count{kind}`
+- `sync.validation_request.elapsed.count`
+- `sync.state_request.timeout.count{request}`
+- `sync.missing_inventory.retry.count`
+- `sync.missing_inventory.retry.exhausted.count`
+- `sync.download.slot.age.seconds`
+- `sync.download.slots{state}`
+- `sync.pending_hashes.count{source}`
+- `sync.checkpoint.range.duration.seconds{result}`
+- `sync.exhausted_prospective_tips.count`
+- `peer.request.error.count{command,error_kind,user_agent_family}`
+- `peer.request.duration.seconds{command,outcome}`
+- `peer.request.timeout.count{command,source,user_agent_family}`
+- `peer.connection.churn.count{reason,user_agent_family}`
+- `peer.discovery.resolved.count{source}`
+- `peer.discovery.candidate.count{source}`
+- `peer.handshake.count{source,outcome,error_kind}`
+- `peer.ready.count{source,user_agent_family}`
+
+Peer `source` labels are bounded values such as `dnsseed_str4d`,
+`dnsseed_zcash`, `dnsseed_shieldedinfra`, `dnsseed_zfnd`, `peer_cache`,
+`gossip`, and `configured`.
+
+High-cardinality details such as block hashes, outpoints, and redacted peer
+addresses are recorded on tracing spans instead of Prometheus labels.
+
 [metrics_section]: https://docs.rs/zebrad/latest/zebrad/components/metrics/struct.Config.html

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -19,6 +19,7 @@ use std::{
     pin::Pin,
     sync::{mpsc, Arc},
     task::{Context, Poll},
+    time::Instant,
 };
 
 use futures::{Future, FutureExt, TryFutureExt};
@@ -815,6 +816,7 @@ where
                 .expect("earlier code checks if verification has finished"),
             Included(target_checkpoint_height),
         );
+        let range_start = Instant::now();
         let range_heights: Vec<block::Height> = self
             .queued
             .range_mut(current_range)
@@ -871,6 +873,9 @@ where
                     "we must decrease or eliminate our target on failure"
                 );
 
+                metrics::histogram!("sync.checkpoint.range.duration.seconds", "result" => "failure")
+                    .record(range_start.elapsed().as_secs_f64());
+
                 // Stop verifying, and wait for the next valid block
                 return;
             }
@@ -886,6 +891,8 @@ where
         let block_count = rev_valid_blocks.len();
         tracing::info!(?block_count, ?current_range, "verified checkpoint range");
         metrics::counter!("checkpoint.verified.block.count").increment(block_count as u64);
+        metrics::histogram!("sync.checkpoint.range.duration.seconds", "result" => "success")
+            .record(range_start.elapsed().as_secs_f64());
 
         // All the blocks we've kept are valid, so let's verify them
         // in height order.

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -78,6 +78,10 @@ const MEMPOOL_OUTPUT_LOOKUP_TIMEOUT: std::time::Duration = std::time::Duration::
 /// response from the transaction verifier.
 const POLL_MEMPOOL_DELAY: std::time::Duration = Duration::from_millis(50);
 
+fn count_state_request_timeout(request: &'static str) {
+    metrics::counter!("sync.state_request.timeout.count", "request" => request).increment(1);
+}
+
 /// Asynchronous transaction verification.
 ///
 /// # Correctness
@@ -702,10 +706,19 @@ where
                         .clone()
                         .oneshot(zs::Request::UnspentBestChainUtxo(*outpoint));
 
-                    let zebra_state::Response::UnspentBestChainUtxo(utxo) = query
-                        .await
-                        .map_err(|_| TransactionError::TransparentInputNotFound)?
-                    else {
+                    let state_response = query.await.map_err(|error| {
+                        if error.is::<Elapsed>() {
+                            count_state_request_timeout("unspent_best_chain_utxo");
+                            tracing::warn!(
+                                ?outpoint,
+                                "timed out waiting for UnspentBestChainUtxo state request"
+                            );
+                        }
+
+                        TransactionError::TransparentInputNotFound
+                    })?;
+
+                    let zebra_state::Response::UnspentBestChainUtxo(utxo) = state_response else {
                         unreachable!("UnspentBestChainUtxo always responds with Option<Utxo>")
                     };
 
@@ -719,10 +732,21 @@ where
                     let query = state
                         .clone()
                         .oneshot(zebra_state::Request::AwaitUtxo(*outpoint));
-                    if let zebra_state::Response::Utxo(utxo) = query.await? {
-                        utxo
-                    } else {
-                        unreachable!("AwaitUtxo always responds with Utxo")
+
+                    match query.await {
+                        Ok(zebra_state::Response::Utxo(utxo)) => utxo,
+                        Ok(_) => unreachable!("AwaitUtxo always responds with Utxo"),
+                        Err(error) => {
+                            if error.is::<Elapsed>() {
+                                count_state_request_timeout("await_utxo");
+                                tracing::warn!(
+                                    ?outpoint,
+                                    "timed out waiting for AwaitUtxo state request"
+                                );
+                            }
+
+                            return Err(error.into());
+                        }
                     }
                 };
                 tracing::trace!(?utxo, "got UTXO");

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -1,7 +1,7 @@
 //! Configuration for Zebra's network communication.
 
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     io::{self, ErrorKind},
     net::{IpAddr, SocketAddr},
     sync::Arc,
@@ -31,6 +31,7 @@ use crate::{
         DEFAULT_PEERSET_INITIAL_TARGET_SIZE, DNS_LOOKUP_TIMEOUT, INBOUND_PEER_LIMIT_MULTIPLIER,
         MAX_PEER_DISK_CACHE_SIZE, OUTBOUND_PEER_LIMIT_MULTIPLIER,
     },
+    peer::PeerSource,
     protocol::external::{canonical_peer_addr, canonical_socket_addr},
     BoxError, PeerSocketAddr,
 };
@@ -255,30 +256,45 @@ impl Config {
     ///
     /// If a configured address is an invalid [`SocketAddr`] or DNS name.
     pub async fn initial_peers(&self) -> HashSet<PeerSocketAddr> {
+        self.initial_peers_with_sources()
+            .await
+            .into_keys()
+            .collect()
+    }
+
+    /// Resolve initial seed peer IP addresses with bounded source labels, and
+    /// load cached peers from disk if available.
+    pub(crate) async fn initial_peers_with_sources(&self) -> HashMap<PeerSocketAddr, PeerSource> {
         // TODO: do DNS and disk in parallel if startup speed becomes important
-        let dns_peers =
-            Config::resolve_peers(&self.initial_peer_hostnames().iter().cloned().collect()).await;
+        let dns_peers = Config::resolve_peers_with_sources(
+            &self.initial_peer_hostnames().iter().cloned().collect(),
+        )
+        .await;
 
         if self.network.is_regtest() {
             // Only return local peer addresses and skip loading the peer cache on Regtest.
             dns_peers
                 .into_iter()
-                .filter(PeerSocketAddr::is_localhost)
+                .filter(|(addr, _source)| addr.is_localhost())
                 .collect()
         } else {
             // Ignore disk errors because the cache is optional and the method already logs them.
             let disk_peers = self.load_peer_cache().await.unwrap_or_default();
+            let mut peers = dns_peers;
 
-            dns_peers.into_iter().chain(disk_peers).collect()
+            for peer in disk_peers {
+                peers.entry(peer).or_insert(PeerSource::PeerCache);
+            }
+
+            peers
         }
     }
 
-    /// Concurrently resolves `peers` into zero or more IP addresses, with a
-    /// timeout of a few seconds on each DNS request.
-    ///
-    /// If DNS resolution fails or times out for all peers, continues retrying
-    /// until at least one peer is found.
-    async fn resolve_peers(peers: &HashSet<String>) -> HashSet<PeerSocketAddr> {
+    /// Concurrently resolves `peers` into zero or more IP addresses with
+    /// bounded source labels, with a timeout of a few seconds on each DNS request.
+    async fn resolve_peers_with_sources(
+        peers: &HashSet<String>,
+    ) -> HashMap<PeerSocketAddr, PeerSource> {
         use futures::stream::StreamExt;
 
         if peers.is_empty() {
@@ -288,7 +304,7 @@ impl Config {
                  give it some previously cached peer IP addresses on disk, \
                  or make sure Zebra's listener port gets inbound connections."
             );
-            return HashSet::new();
+            return HashMap::new();
         }
 
         loop {
@@ -298,9 +314,18 @@ impl Config {
             // address peers. Individual retries avoid this issue.
             let peer_addresses = peers
                 .iter()
-                .map(|s| Config::resolve_host(s, MAX_SINGLE_SEED_PEER_DNS_RETRIES))
+                .map(|s| Config::resolve_host_with_source(s, MAX_SINGLE_SEED_PEER_DNS_RETRIES))
                 .collect::<futures::stream::FuturesUnordered<_>>()
-                .concat()
+                .fold(
+                    HashMap::new(),
+                    |mut peers_by_addr, host_addresses| async move {
+                        for (addr, source) in host_addresses {
+                            peers_by_addr.entry(addr).or_insert(source);
+                        }
+
+                        peers_by_addr
+                    },
+                )
                 .await;
 
             if peer_addresses.is_empty() {
@@ -317,18 +342,17 @@ impl Config {
         }
     }
 
-    /// Resolves `host` into zero or more IP addresses, retrying up to
-    /// `max_retries` times.
-    ///
-    /// If DNS continues to fail, returns an empty list of addresses.
-    ///
-    /// # Panics
-    ///
-    /// If a configured address is an invalid [`SocketAddr`] or DNS name.
-    async fn resolve_host(host: &str, max_retries: usize) -> HashSet<PeerSocketAddr> {
+    /// Resolves `host` into zero or more IP addresses and bounded source labels,
+    /// retrying up to `max_retries` times.
+    async fn resolve_host_with_source(
+        host: &str,
+        max_retries: usize,
+    ) -> HashMap<PeerSocketAddr, PeerSource> {
         for retries in 0..=max_retries {
             if let Ok(addresses) = Config::resolve_host_once(host).await {
-                return addresses;
+                let source = PeerSource::from_initial_peer_host(host);
+
+                return addresses.into_iter().map(|addr| (addr, source)).collect();
             }
 
             if retries < max_retries {
@@ -347,7 +371,7 @@ impl Config {
             }
         }
 
-        HashSet::new()
+        HashMap::new()
     }
 
     /// Resolves `host` into zero or more IP addresses.
@@ -385,6 +409,11 @@ impl Config {
                     )
                     .increment(1);
                 }
+                metrics::counter!(
+                    "peer.discovery.resolved.count",
+                    "source" => PeerSource::from_initial_peer_host(host).label(),
+                )
+                .increment(ip_addrs.len() as u64);
 
                 Ok(ip_addrs.into_iter().collect())
             }
@@ -472,6 +501,11 @@ impl Config {
             )
             .increment(1);
         }
+        metrics::counter!(
+            "peer.discovery.resolved.count",
+            "source" => PeerSource::PeerCache.label(),
+        )
+        .increment(peer_list.len() as u64);
 
         Ok(peer_list)
     }

--- a/zebra-network/src/isolated.rs
+++ b/zebra-network/src/isolated.rs
@@ -107,6 +107,7 @@ where
             data_stream,
             connected_addr,
             connection_tracker,
+            source: peer::PeerSource::Isolated,
         },
     )
 }

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -186,7 +186,10 @@ pub use crate::{
     config::{CacheDir, Config},
     isolated::{connect_isolated, connect_isolated_tcp_direct},
     meta_addr::{PeerAddrState, PeerSocketAddr},
-    peer::{Client, ConnectedAddr, ConnectionInfo, HandshakeError, PeerError, SharedPeerError},
+    peer::{
+        Client, ConnectedAddr, ConnectionInfo, HandshakeError, PeerError, PeerSource,
+        SharedPeerError,
+    },
     peer_set::init,
     policies::RetryLimit,
     protocol::{

--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -34,3 +34,71 @@ pub use priority::{
     address_is_valid_for_inbound_listeners, address_is_valid_for_outbound_connections,
     AttributePreference, PeerPreference,
 };
+
+/// Low-cardinality source of a peer address for metrics labels.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum PeerSource {
+    /// Peers resolved from `dnsseed.str4d.xyz`.
+    DnsSeedStr4d,
+    /// Peers resolved from `dnsseed.z.cash` or testnet `z.cash` seeders.
+    DnsSeedZcash,
+    /// Peers resolved from Shielded Infrastructure seeders.
+    DnsSeedShieldedInfra,
+    /// Peers resolved from Zcash Foundation seeders.
+    DnsSeedZfnd,
+    /// Peers loaded from Zebra's disk peer cache.
+    PeerCache,
+    /// Peers learned from peer gossip or address responses.
+    Gossip,
+    /// Peers configured explicitly by the node operator.
+    Configured,
+    /// Peers accepted through Zebra's inbound listener.
+    Inbound,
+    /// Isolated peers created without address-book metadata.
+    Isolated,
+}
+
+impl PeerSource {
+    /// Returns the bounded label used in Prometheus metrics.
+    pub fn label(self) -> &'static str {
+        match self {
+            PeerSource::DnsSeedStr4d => "dnsseed_str4d",
+            PeerSource::DnsSeedZcash => "dnsseed_zcash",
+            PeerSource::DnsSeedShieldedInfra => "dnsseed_shieldedinfra",
+            PeerSource::DnsSeedZfnd => "dnsseed_zfnd",
+            PeerSource::PeerCache => "peer_cache",
+            PeerSource::Gossip => "gossip",
+            PeerSource::Configured => "configured",
+            PeerSource::Inbound => "inbound",
+            PeerSource::Isolated => "isolated",
+        }
+    }
+
+    /// Returns the source label for a configured initial peer entry.
+    pub fn from_initial_peer_host(host: &str) -> Self {
+        if host.contains("str4d") {
+            PeerSource::DnsSeedStr4d
+        } else if host.contains("z.cash") {
+            PeerSource::DnsSeedZcash
+        } else if host.contains("shieldedinfra") {
+            PeerSource::DnsSeedShieldedInfra
+        } else if host.contains("zfnd") {
+            PeerSource::DnsSeedZfnd
+        } else {
+            PeerSource::Configured
+        }
+    }
+}
+
+/// Returns a low-cardinality user-agent family for metrics labels.
+pub fn user_agent_family(user_agent: &str) -> &'static str {
+    if user_agent.contains("Zebra") {
+        "zebra"
+    } else if user_agent.contains("MagicBean") || user_agent.contains("zcashd") {
+        "zcashd"
+    } else if user_agent.is_empty() {
+        "unknown"
+    } else {
+        "other"
+    }
+}

--- a/zebra-network/src/peer/client/tests.rs
+++ b/zebra-network/src/peer/client/tests.rs
@@ -327,6 +327,7 @@ where
             connected_addr: crate::peer::ConnectedAddr::Isolated,
             remote,
             negotiated_version,
+            source: crate::peer::PeerSource::Isolated,
         });
 
         let client = Client {

--- a/zebra-network/src/peer/connection/tests.rs
+++ b/zebra-network/src/peer/connection/tests.rs
@@ -76,6 +76,7 @@ fn new_test_connection<A>() -> (
         connected_addr: ConnectedAddr::Isolated,
         remote,
         negotiated_version: fake_version,
+        source: crate::peer::PeerSource::Isolated,
     };
 
     let connection = Connection::new(

--- a/zebra-network/src/peer/connector.rs
+++ b/zebra-network/src/peer/connector.rs
@@ -13,10 +13,35 @@ use tracing_futures::Instrument;
 use zebra_chain::chain_tip::{ChainTip, NoChainTip};
 
 use crate::{
-    peer::{Client, ConnectedAddr, Handshake, HandshakeRequest},
+    peer::{Client, ConnectedAddr, Handshake, HandshakeRequest, PeerSource},
     peer_set::ConnectionTracker,
     BoxError, PeerSocketAddr, Request, Response,
 };
+
+fn io_error_kind(error: &std::io::Error) -> &'static str {
+    use std::io::ErrorKind::*;
+
+    match error.kind() {
+        TimedOut => "timeout",
+        ConnectionRefused => "connection_refused",
+        ConnectionReset => "connection_reset",
+        ConnectionAborted => "connection_aborted",
+        NotConnected => "not_connected",
+        AddrNotAvailable => "addr_not_available",
+        AddrInUse => "addr_in_use",
+        _ => "io_error",
+    }
+}
+
+fn count_peer_handshake(source: PeerSource, outcome: &'static str, error_kind: &'static str) {
+    metrics::counter!(
+        "peer.handshake.count",
+        "source" => source.label(),
+        "outcome" => outcome,
+        "error_kind" => error_kind,
+    )
+    .increment(1);
+}
 
 /// A wrapper around [`Handshake`] that opens a TCP connection before
 /// forwarding to the inner handshake service. Writing this as its own
@@ -64,6 +89,9 @@ pub struct OutboundConnectorRequest {
     ///
     /// Used to limit the number of open connections in Zebra.
     pub connection_tracker: ConnectionTracker,
+
+    /// The low-cardinality source of this peer address.
+    pub source: PeerSource,
 }
 
 impl<S, C> Service<OutboundConnectorRequest> for Connector<S, C>
@@ -85,6 +113,7 @@ where
         let OutboundConnectorRequest {
             addr,
             connection_tracker,
+            source,
         }: OutboundConnectorRequest = req;
 
         let hs = self.handshaker.clone();
@@ -96,12 +125,19 @@ where
         // `zebra_network::init()` implements a connection timeout on this future.
         // Any code outside this future does not have a timeout.
         async move {
-            let tcp_stream = TcpStream::connect(*addr).await?;
+            let tcp_stream = match TcpStream::connect(*addr).await {
+                Ok(tcp_stream) => tcp_stream,
+                Err(error) => {
+                    count_peer_handshake(source, "failure", io_error_kind(&error));
+                    return Err(error.into());
+                }
+            };
             let client = hs
                 .oneshot(HandshakeRequest::<TcpStream> {
                     data_stream: tcp_stream,
                     connected_addr,
                     connection_tracker,
+                    source,
                 })
                 .await?;
             Ok((addr, client))

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -38,7 +38,7 @@ use crate::{
     meta_addr::MetaAddrChange,
     peer::{
         CancelHeartbeatTask, Client, ClientRequest, Connection, ErrorSlot, HandshakeError,
-        MinimumPeerVersion, PeerError,
+        MinimumPeerVersion, PeerError, PeerSource,
     },
     peer_set::{ConnectionTracker, InventoryChange},
     protocol::{
@@ -139,6 +139,9 @@ pub struct ConnectionInfo {
     /// Derived from `remote.version` and the
     /// [current `zebra_network` protocol version](constants::CURRENT_NETWORK_PROTOCOL_VERSION).
     pub negotiated_version: Version,
+
+    /// The low-cardinality source of this peer address.
+    pub source: PeerSource,
 }
 
 /// The peer address that we are handshaking with.
@@ -204,6 +207,29 @@ pub fn get_unspecified_ipv4_addr(network: Network) -> SocketAddr {
 }
 
 use ConnectedAddr::*;
+
+fn handshake_error_kind(error: &HandshakeError) -> &'static str {
+    match error {
+        HandshakeError::UnexpectedMessage(_) => "unexpected_message",
+        HandshakeError::RemoteNonceReuse => "nonce_reuse",
+        HandshakeError::LocalDuplicateNonce => "duplicate_nonce",
+        HandshakeError::ConnectionClosed => "connection_closed",
+        HandshakeError::Io(_) => "io_error",
+        HandshakeError::Serialization(_) => "serialization",
+        HandshakeError::ObsoleteVersion(_) => "obsolete_version",
+        HandshakeError::Timeout => "timeout",
+    }
+}
+
+fn count_peer_handshake(source: PeerSource, outcome: &'static str, error_kind: &'static str) {
+    metrics::counter!(
+        "peer.handshake.count",
+        "source" => source.label(),
+        "outcome" => outcome,
+        "error_kind" => error_kind,
+    )
+    .increment(1);
+}
 
 impl ConnectedAddr {
     /// Returns a new outbound directly connected addr.
@@ -574,6 +600,7 @@ where
 pub async fn negotiate_version<PeerTransport>(
     peer_conn: &mut Framed<PeerTransport, Codec>,
     connected_addr: &ConnectedAddr,
+    source: PeerSource,
     config: Config,
     nonces: Arc<futures::lock::Mutex<IndexSet<Nonce>>>,
     user_agent: String,
@@ -784,6 +811,7 @@ where
         connected_addr: *connected_addr,
         remote,
         negotiated_version,
+        source,
     });
 
     debug!(
@@ -858,6 +886,9 @@ where
     ///
     /// Used to limit the number of open connections in Zebra.
     pub connection_tracker: ConnectionTracker,
+
+    /// The low-cardinality source of this peer address.
+    pub source: PeerSource,
 }
 
 impl<S, PeerTransport, C> Service<HandshakeRequest<PeerTransport>> for Handshake<S, C>
@@ -881,6 +912,7 @@ where
             data_stream,
             connected_addr,
             mut connection_tracker,
+            source,
         } = req;
 
         let negotiator_span = debug_span!("negotiator", peer = ?connected_addr);
@@ -925,6 +957,7 @@ where
             let connection_info = match negotiate_version(
                 &mut peer_conn,
                 &connected_addr,
+                source,
                 config,
                 nonces,
                 user_agent,
@@ -942,21 +975,13 @@ where
                         "result" => "success"
                     )
                     .record(duration);
+                    count_peer_handshake(source, "success", "none");
                     info
                 }
                 Err(err) => {
                     // Record failed handshake duration and failure reason
                     let duration = handshake_start.elapsed().as_secs_f64();
-                    let reason = match &err {
-                        HandshakeError::UnexpectedMessage(_) => "unexpected_message",
-                        HandshakeError::RemoteNonceReuse => "nonce_reuse",
-                        HandshakeError::LocalDuplicateNonce => "duplicate_nonce",
-                        HandshakeError::ConnectionClosed => "connection_closed",
-                        HandshakeError::Io(_) => "io_error",
-                        HandshakeError::Serialization(_) => "serialization",
-                        HandshakeError::ObsoleteVersion(_) => "obsolete_version",
-                        HandshakeError::Timeout => "timeout",
-                    };
+                    let reason = handshake_error_kind(&err);
                     metrics::histogram!(
                         "zcash.net.peer.handshake.duration_seconds",
                         "result" => "failure"
@@ -967,6 +992,7 @@ where
                         "reason" => reason
                     )
                     .increment(1);
+                    count_peer_handshake(source, "failure", reason);
                     return Err(err);
                 }
             };
@@ -1169,14 +1195,17 @@ where
         // Spawn a new task to drive this handshake, forwarding panics to the calling task.
         tokio::spawn(fut.instrument(negotiator_span))
             .map(
-                |join_result: Result<
+                move |join_result: Result<
                     Result<Result<Client, HandshakeError>, error::Elapsed>,
                     JoinError,
                 >| {
                     match join_result {
                         Ok(Ok(Ok(connection_client))) => Ok(connection_client),
                         Ok(Ok(Err(handshake_error))) => Err(handshake_error.into()),
-                        Ok(Err(timeout_error)) => Err(timeout_error.into()),
+                        Ok(Err(timeout_error)) => {
+                            count_peer_handshake(source, "failure", "timeout");
+                            Err(timeout_error.into())
+                        }
                         Err(join_error) => match join_error.try_into_panic() {
                             // Forward panics to the calling task
                             Ok(panic_reason) => panic::resume_unwind(panic_reason),

--- a/zebra-network/src/peer/load_tracked_client.rs
+++ b/zebra-network/src/peer/load_tracked_client.rs
@@ -13,7 +13,7 @@ use tower::{
 
 use crate::{
     constants::{EWMA_DECAY_TIME_NANOS, EWMA_DEFAULT_RTT},
-    peer::{Client, ConnectionInfo},
+    peer::{user_agent_family, Client, ConnectionInfo},
     protocol::external::types::Version,
 };
 
@@ -52,6 +52,16 @@ impl LoadTrackedClient {
     /// Retrieve the peer's reported protocol version.
     pub fn remote_version(&self) -> Version {
         self.connection_info.remote.version
+    }
+
+    /// Returns a low-cardinality user-agent family for metrics labels.
+    pub fn user_agent_family(&self) -> &'static str {
+        user_agent_family(self.connection_info.remote.user_agent.as_str())
+    }
+
+    /// Returns the low-cardinality peer source label for metrics.
+    pub fn source_label(&self) -> &'static str {
+        self.connection_info.source.label()
     }
 }
 

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -352,6 +352,11 @@ where
             .collect();
 
         debug!(count = ?addrs.len(), "sending gossiped addresses to the address book");
+        metrics::counter!(
+            "peer.discovery.candidate.count",
+            "source" => "gossip",
+        )
+        .increment(addrs.len() as u64);
 
         // Don't bother spawning a task if there are no addresses left.
         if addrs.is_empty() {

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -5,7 +5,7 @@
 //! [tower-balance]: https://github.com/tower-rs/tower/tree/master/tower/src/balance
 
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap},
     convert::Infallible,
     net::{IpAddr, SocketAddr},
     pin::Pin,
@@ -40,7 +40,7 @@ use crate::{
     meta_addr::{MetaAddr, MetaAddrChange},
     peer::{
         self, address_is_valid_for_inbound_listeners, HandshakeRequest, MinimumPeerVersion,
-        OutboundConnectorRequest, PeerPreference,
+        OutboundConnectorRequest, PeerPreference, PeerSource,
     },
     peer_cache_updater::peer_cache_updater,
     peer_set::{set::MorePeers, ActiveConnectionCounter, CandidateSet, ConnectionTracker, PeerSet},
@@ -347,8 +347,14 @@ where
     );
 
     // TODO: update when we add Tor peers or other kinds of addresses.
-    let ipv4_peer_count = initial_peers.iter().filter(|ip| ip.is_ipv4()).count();
-    let ipv6_peer_count = initial_peers.iter().filter(|ip| ip.is_ipv6()).count();
+    let ipv4_peer_count = initial_peers
+        .keys()
+        .filter(|peer_addr| peer_addr.is_ipv4())
+        .count();
+    let ipv6_peer_count = initial_peers
+        .keys()
+        .filter(|peer_addr| peer_addr.is_ipv6())
+        .count();
     info!(
         ?ipv4_peer_count,
         ?ipv6_peer_count,
@@ -369,11 +375,12 @@ where
     let mut handshakes: FuturesUnordered<_> = initial_peers
         .into_iter()
         .enumerate()
-        .map(|(i, addr)| {
+        .map(|(i, (addr, source))| {
             let connection_tracker = active_outbound_connections.track_connection();
             let req = OutboundConnectorRequest {
                 addr,
                 connection_tracker,
+                source,
             };
             let outbound_connector = outbound_connector.clone();
 
@@ -475,9 +482,10 @@ where
 async fn limit_initial_peers(
     config: &Config,
     address_book_updater: tokio::sync::mpsc::Sender<MetaAddrChange>,
-) -> HashSet<PeerSocketAddr> {
-    let all_peers: HashSet<PeerSocketAddr> = config.initial_peers().await;
+) -> HashMap<PeerSocketAddr, PeerSource> {
+    let all_peers = config.initial_peers_with_sources().await;
     let mut preferred_peers: BTreeMap<PeerPreference, Vec<PeerSocketAddr>> = BTreeMap::new();
+    let mut source_by_addr: HashMap<PeerSocketAddr, PeerSource> = HashMap::new();
 
     let all_peers_count = all_peers.len();
     if all_peers_count > config.peerset_initial_target_size {
@@ -489,14 +497,17 @@ async fn limit_initial_peers(
 
     // Filter out invalid initial peers, and prioritise valid peers for initial connections.
     // (This treats initial peers the same way we treat gossiped peers.)
-    for peer_addr in all_peers {
+    for (peer_addr, source) in all_peers {
         let preference = PeerPreference::new(peer_addr, config.network.clone());
 
         match preference {
-            Ok(preference) => preferred_peers
-                .entry(preference)
-                .or_default()
-                .push(peer_addr),
+            Ok(preference) => {
+                source_by_addr.insert(peer_addr, source);
+                preferred_peers
+                    .entry(preference)
+                    .or_default()
+                    .push(peer_addr);
+            }
             Err(error) => info!(
                 ?peer_addr,
                 ?error,
@@ -522,7 +533,7 @@ async fn limit_initial_peers(
 
     // Split out the `initial_peers` that will be shuffled and returned,
     // choosing preferred peers first.
-    let mut initial_peers: HashSet<PeerSocketAddr> = HashSet::new();
+    let mut initial_peers: HashMap<PeerSocketAddr, PeerSource> = HashMap::new();
     for better_peers in preferred_peers.values() {
         let mut better_peers = better_peers.clone();
         let (chosen_peers, _unused_peers) = better_peers.partial_shuffle(
@@ -530,7 +541,18 @@ async fn limit_initial_peers(
             config.peerset_initial_target_size - initial_peers.len(),
         );
 
-        initial_peers.extend(chosen_peers.iter());
+        for peer in chosen_peers {
+            let source = source_by_addr
+                .get(&*peer)
+                .copied()
+                .expect("preferred peers have source labels");
+            metrics::counter!(
+                "peer.discovery.candidate.count",
+                "source" => source.label(),
+            )
+            .increment(1);
+            initial_peers.insert(*peer, source);
+        }
 
         if initial_peers.len() >= config.peerset_initial_target_size {
             break;
@@ -745,6 +767,7 @@ where
         data_stream: tcp_stream,
         connected_addr,
         connection_tracker,
+        source: PeerSource::Inbound,
     });
     // ... instead, spawn a new task to handle this connection
     let mut peerset_tx = peerset_tx.clone();
@@ -1127,6 +1150,7 @@ where
     let req = OutboundConnectorRequest {
         addr: candidate.addr,
         connection_tracker: outbound_connection_tracker,
+        source: PeerSource::Gossip,
     };
 
     // the handshake has timeouts, so it shouldn't hang

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -35,7 +35,7 @@ use crate::{
     config::CacheDir,
     constants, init,
     meta_addr::{MetaAddr, PeerAddrState},
-    peer::{self, ClientTestHarness, HandshakeRequest, OutboundConnectorRequest},
+    peer::{self, ClientTestHarness, HandshakeRequest, OutboundConnectorRequest, PeerSource},
     peer_set::{
         initialize::{
             accept_inbound_connections, add_initial_peers, crawl_and_dial, open_listener,
@@ -468,6 +468,7 @@ async fn crawler_peer_limit_one_connect_ok_then_drop() {
             let OutboundConnectorRequest {
                 addr,
                 connection_tracker,
+                source: _,
             } = req;
 
             let (fake_client, _harness) = ClientTestHarness::build().finish();
@@ -520,6 +521,7 @@ async fn crawler_peer_limit_one_connect_ok_stay_open() {
             let OutboundConnectorRequest {
                 addr,
                 connection_tracker,
+                source: _,
             } = req;
 
             let (fake_client, _harness) = ClientTestHarness::build().finish();
@@ -616,6 +618,7 @@ async fn crawler_peer_limit_default_connect_ok_then_drop() {
             let OutboundConnectorRequest {
                 addr,
                 connection_tracker,
+                source: _,
             } = req;
 
             let (fake_client, _harness) = ClientTestHarness::build().finish();
@@ -670,6 +673,7 @@ async fn crawler_peer_limit_default_connect_ok_stay_open() {
             let OutboundConnectorRequest {
                 addr,
                 connection_tracker,
+                source: _,
             } = req;
 
             let (fake_client, _harness) = ClientTestHarness::build().finish();
@@ -798,6 +802,7 @@ async fn listener_peer_limit_one_handshake_ok_then_drop() {
                 data_stream: tcp_stream,
                 connected_addr: _,
                 connection_tracker,
+                source: _,
             } = req;
 
             let (fake_client, _harness) = ClientTestHarness::build().finish();
@@ -859,6 +864,7 @@ async fn listener_peer_limit_one_handshake_ok_stay_open() {
                     data_stream: tcp_stream,
                     connected_addr: _,
                     connection_tracker,
+                    source: _,
                 } = req;
 
                 let (fake_client, _harness) = ClientTestHarness::build().finish();
@@ -965,6 +971,7 @@ async fn listener_peer_limit_default_handshake_ok_then_drop() {
                 data_stream: tcp_stream,
                 connected_addr: _,
                 connection_tracker,
+                source: _,
             } = req;
 
             let (fake_client, _harness) = ClientTestHarness::build().finish();
@@ -1026,6 +1033,7 @@ async fn listener_peer_limit_default_handshake_ok_stay_open() {
                     data_stream: tcp_stream,
                     connected_addr: _,
                     connection_tracker,
+                    source: _,
                 } = req;
 
                 let (fake_client, _harness) = ClientTestHarness::build().finish();
@@ -1327,6 +1335,7 @@ async fn remnant_nonces_from_outbound_connections_are_limited() {
         let req = OutboundConnectorRequest {
             addr: addr.into(),
             connection_tracker,
+            source: PeerSource::Configured,
         };
 
         outbound_connector

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -196,6 +196,7 @@ where
     let request_start = Instant::now();
     let result = fut.await;
     let outcome = if result.is_ok() { "success" } else { "error" };
+    tracing::Span::current().record("outcome", outcome);
 
     metrics::histogram!(
         "peer.request.duration.seconds",
@@ -206,6 +207,7 @@ where
 
     if let Err(error) = &result {
         let error_kind = peer_error_kind(error);
+        tracing::Span::current().record("error_kind", error_kind);
         metrics::counter!(
             "peer.request.error.count",
             "command" => command,
@@ -223,6 +225,8 @@ where
             )
             .increment(1);
         }
+    } else {
+        tracing::Span::current().record("error_kind", "none");
     }
 
     result
@@ -1067,8 +1071,15 @@ where
             let fut = svc.call(req);
             self.push_unready(p2c_key, svc);
             let fut = observe_peer_request(command, source, user_agent_family, fut);
-            let span =
-                tracing::debug_span!("peer.route_p2c", ?p2c_key, command, user_agent_family,);
+            let span = tracing::debug_span!(
+                "peer.route_p2c",
+                ?p2c_key,
+                command,
+                source,
+                user_agent_family,
+                outcome = tracing::field::Empty,
+                error_kind = tracing::field::Empty,
+            );
 
             if track_stalls {
                 let stall_tx = self.stall_event_tx.clone();
@@ -1155,6 +1166,9 @@ where
                 source,
                 user_agent_family,
                 advertising_peers = advertising_peer_list.len(),
+                missing_peers = 0,
+                outcome = tracing::field::Empty,
+                error_kind = tracing::field::Empty,
             );
             metrics::counter!(
                 "peer.route_inv.count",
@@ -1200,6 +1214,8 @@ where
                 user_agent_family,
                 advertising_peers = advertising_peer_list.len(),
                 missing_peers = missing_peer_list.len(),
+                outcome = tracing::field::Empty,
+                error_kind = tracing::field::Empty,
             );
             metrics::counter!(
                 "peer.route_inv.count",
@@ -1235,6 +1251,19 @@ where
         )
         .increment(1);
 
+        let span = tracing::debug_span!(
+            "peer.route_inv",
+            route = "missing_inventory_exhausted",
+            ?hash,
+            command,
+            source = "none",
+            user_agent_family = "unknown",
+            advertising_peers = advertising_peer_list.len(),
+            missing_peers = missing_peer_list.len(),
+            outcome = "error",
+            error_kind = "not_found_registry",
+        );
+
         async move {
             // Let other tasks run, so a retry request might get different ready peers.
             tokio::task::yield_now().await;
@@ -1248,6 +1277,7 @@ where
                 hash,
             ])))
         }
+        .instrument(span)
         .map_err(Into::into)
         .boxed()
     }

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -124,6 +124,7 @@ use tower::{
     load::Load,
     Service,
 };
+use tracing_futures::Instrument;
 
 use zebra_chain::{chain_tip::ChainTip, parameters::Network};
 
@@ -181,6 +182,94 @@ fn classify_find_response<E>(result: &Result<Response, E>) -> Option<StallOutcom
         Ok(_) => None,
         Err(_) => Some(StallOutcome::Stall),
     }
+}
+
+async fn observe_peer_request<F>(
+    command: &'static str,
+    source: &'static str,
+    user_agent_family: &'static str,
+    fut: F,
+) -> Result<Response, SharedPeerError>
+where
+    F: std::future::Future<Output = Result<Response, SharedPeerError>> + Send,
+{
+    let request_start = Instant::now();
+    let result = fut.await;
+    let outcome = if result.is_ok() { "success" } else { "error" };
+
+    metrics::histogram!(
+        "peer.request.duration.seconds",
+        "command" => command,
+        "outcome" => outcome,
+    )
+    .record(request_start.elapsed().as_secs_f64());
+
+    if let Err(error) = &result {
+        let error_kind = peer_error_kind(error);
+        metrics::counter!(
+            "peer.request.error.count",
+            "command" => command,
+            "error_kind" => error_kind,
+            "user_agent_family" => user_agent_family,
+        )
+        .increment(1);
+
+        if is_request_timeout(error_kind) {
+            metrics::counter!(
+                "peer.request.timeout.count",
+                "command" => command,
+                "source" => source,
+                "user_agent_family" => user_agent_family,
+            )
+            .increment(1);
+        }
+    }
+
+    result
+}
+
+fn peer_error_kind(error: &SharedPeerError) -> &'static str {
+    let error = error.inner_debug();
+
+    if error.contains("NotFoundRegistry") {
+        "not_found_registry"
+    } else if error.contains("NotFoundResponse") {
+        "not_found_response"
+    } else if error.contains("NoReadyPeers") {
+        "no_ready_peers"
+    } else if error.contains("ConnectionClosed") {
+        "connection_closed"
+    } else if error.contains("ConnectionDropped") {
+        "connection_dropped"
+    } else if error.contains("ConnectionSendTimeout") {
+        "connection_send_timeout"
+    } else if error.contains("ConnectionReceiveTimeout") {
+        "connection_receive_timeout"
+    } else if error.contains("InboundTimeout") {
+        "inbound_timeout"
+    } else if error.contains("Overloaded") {
+        "overloaded"
+    } else if error.contains("ServiceShutdown") {
+        "service_shutdown"
+    } else {
+        "other"
+    }
+}
+
+fn is_request_timeout(error_kind: &'static str) -> bool {
+    matches!(
+        error_kind,
+        "connection_send_timeout" | "connection_receive_timeout" | "inbound_timeout" | "timeout"
+    )
+}
+
+fn count_peer_connection_churn(reason: &'static str, user_agent_family: &'static str) {
+    metrics::counter!(
+        "peer.connection.churn.count",
+        "reason" => reason,
+        "user_agent_family" => user_agent_family,
+    )
+    .increment(1);
 }
 
 /// A [`tower::Service`] that abstractly represents "the rest of the network".
@@ -563,6 +652,7 @@ where
 
                     if self.bans_receiver.borrow().contains_key(&key.ip()) {
                         warn!(?key, "service is banned, dropping service");
+                        count_peer_connection_churn("banned", svc.user_agent_family());
                         std::mem::drop(svc);
                         let cancel = self.cancel_handles.remove(&key);
                         debug_assert!(
@@ -583,6 +673,7 @@ where
                     // A service be canceled because we've connected to the same service twice.
                     // In that case, there is a cancel handle for the peer address,
                     // but it belongs to the service for the newer connection.
+                    count_peer_connection_churn("canceled", "unknown");
                     trace!(
                         ?key,
                         duplicate_connection = self.cancel_handles.contains_key(&key),
@@ -591,6 +682,7 @@ where
                 }
                 Some(Err((key, UnreadyError::CancelHandleDropped(_)))) => {
                     // Similarly, services with dropped cancel handes can have duplicates.
+                    count_peer_connection_churn("cancel_handle_dropped", "unknown");
                     trace!(
                         ?key,
                         duplicate_connection = self.cancel_handles.contains_key(&key),
@@ -601,6 +693,7 @@ where
                 // Unready -> Errored
                 Some(Err((key, UnreadyError::Inner(error)))) => {
                     debug!(%error, "service failed while unready, dropping service");
+                    count_peer_connection_churn("unready_error", "unknown");
 
                     let cancel = self.cancel_handles.remove(&key);
                     assert!(cancel.is_some(), "missing cancel handle");
@@ -644,6 +737,7 @@ where
                 Ok(()) => {
                     if self.bans_receiver.borrow().contains_key(&key.ip()) {
                         debug!(?key, "service ip is banned, dropping service");
+                        count_peer_connection_churn("banned", svc.user_agent_family());
                         std::mem::drop(svc);
                         continue;
                     }
@@ -654,6 +748,7 @@ where
                 // Ready -> Errored
                 Err(error) => {
                     debug!(%error, "service failed while ready, dropping service");
+                    count_peer_connection_churn("ready_error", svc.user_agent_family());
 
                     // Ready services can just be dropped, they don't need any cleanup.
                     std::mem::drop(svc);
@@ -732,6 +827,7 @@ where
                     // Drop the new peer if we are already connected to it.
                     // Preferring old connections avoids connection thrashing.
                     if self.has_peer_with_addr(key) {
+                        count_peer_connection_churn("duplicate", svc.user_agent_family());
                         std::mem::drop(svc);
                         continue;
                     }
@@ -741,10 +837,21 @@ where
                     // drop the new peer if there are already `max_conns_per_ip` peers with
                     // the same IP address in the peer set.
                     if self.num_peers_with_ip(key.ip()) >= self.max_conns_per_ip {
+                        count_peer_connection_churn(
+                            "max_connections_per_ip",
+                            svc.user_agent_family(),
+                        );
                         std::mem::drop(svc);
                         continue;
                     }
 
+                    metrics::counter!(
+                        "peer.ready.count",
+                        "source" => svc.source_label(),
+                        "user_agent_family" => svc.user_agent_family(),
+                    )
+                    .increment(1);
+                    count_peer_connection_churn("inserted", svc.user_agent_family());
                     self.push_unready(key, svc);
                 }
             }
@@ -806,11 +913,13 @@ where
 
         if let Some(ready_service) = self.take_ready_service(key) {
             // A ready service has no work to cancel, so just drop it.
+            count_peer_connection_churn("removed", ready_service.user_agent_family());
             std::mem::drop(ready_service);
         } else if let Some(handle) = self.cancel_handles.remove(key) {
             // Cancel the work, implicitly dropping the cancel handle.
             // The service future returns a `Canceled` error,
             // making `poll_unready` drop the service.
+            count_peer_connection_churn("removed", "unknown");
             let _ = handle.send(CancelClientWork);
         }
     }
@@ -830,6 +939,7 @@ where
         if svc.remote_version() >= self.minimum_peer_version.current() {
             self.ready_services.insert(key, svc);
         } else {
+            count_peer_connection_churn("outdated", svc.user_agent_family());
             std::mem::drop(svc);
         }
     }
@@ -841,6 +951,7 @@ where
     /// service is dropped.
     fn push_unready(&mut self, key: D::Key, svc: D::Service) {
         let peer_version = svc.remote_version();
+        let user_agent_family = svc.user_agent_family();
         let (tx, rx) = oneshot::channel();
 
         self.unready_services.push(UnreadyService {
@@ -855,6 +966,7 @@ where
         } else {
             // Cancel any request made to the service because it is using an outdated protocol
             // version.
+            count_peer_connection_churn("outdated", user_agent_family);
             let _ = tx.send(CancelClientWork);
         }
     }
@@ -936,6 +1048,8 @@ where
 
     /// Routes a request using P2C load-balancing.
     fn route_p2c(&mut self, req: Request) -> <Self as tower::Service<Request>>::Future {
+        let command = req.command();
+
         if let Some(p2c_key) = self.select_ready_p2c_peer() {
             tracing::trace!(?p2c_key, "routing based on p2c");
 
@@ -943,6 +1057,8 @@ where
                 .take_ready_service(&p2c_key)
                 .expect("selected peer must be ready");
 
+            let user_agent_family = svc.user_agent_family();
+            let source = svc.source_label();
             let track_stalls = matches!(
                 &req,
                 Request::FindBlocks { .. } | Request::FindHeaders { .. }
@@ -950,6 +1066,9 @@ where
 
             let fut = svc.call(req);
             self.push_unready(p2c_key, svc);
+            let fut = observe_peer_request(command, source, user_agent_family, fut);
+            let span =
+                tracing::debug_span!("peer.route_p2c", ?p2c_key, command, user_agent_family,);
 
             if track_stalls {
                 let stall_tx = self.stall_event_tx.clone();
@@ -960,11 +1079,20 @@ where
                     }
                     result.map_err(Into::into)
                 }
+                .instrument(span)
                 .boxed();
             }
 
-            return fut.map_err(Into::into).boxed();
+            return fut.instrument(span).map_err(Into::into).boxed();
         }
+
+        metrics::counter!(
+            "peer.request.error.count",
+            "command" => command,
+            "error_kind" => "no_ready_peers",
+            "user_agent_family" => "unknown",
+        )
+        .increment(1);
 
         async move {
             // Let other tasks run, so a retry request might get different ready peers.
@@ -993,6 +1121,7 @@ where
         req: Request,
         hash: InventoryHash,
     ) -> <Self as tower::Service<Request>>::Future {
+        let command = req.command();
         let advertising_peer_list = self
             .inventory_registry
             .advertising_peers(hash)
@@ -1012,10 +1141,31 @@ where
 
         if let Some(mut svc) = peer.and_then(|key| self.take_ready_service(&key)) {
             let peer = peer.expect("just checked peer is Some");
+            let user_agent_family = svc.user_agent_family();
+            let source = svc.source_label();
             tracing::trace!(?hash, ?peer, "routing to a peer which advertised inventory");
             let fut = svc.call(req);
             self.push_unready(peer, svc);
-            return fut.map_err(Into::into).boxed();
+            let span = tracing::debug_span!(
+                "peer.route_inv",
+                route = "advertised",
+                ?hash,
+                ?peer,
+                command,
+                source,
+                user_agent_family,
+                advertising_peers = advertising_peer_list.len(),
+            );
+            metrics::counter!(
+                "peer.route_inv.count",
+                "route" => "advertised",
+                "command" => command,
+            )
+            .increment(1);
+            return observe_peer_request(command, source, user_agent_family, fut)
+                .instrument(span)
+                .map_err(Into::into)
+                .boxed();
         }
 
         let missing_peer_list: HashSet<PeerSocketAddr> = self
@@ -1035,16 +1185,55 @@ where
 
         if let Some(mut svc) = peer.and_then(|key| self.take_ready_service(&key)) {
             let peer = peer.expect("just checked peer is Some");
+            let user_agent_family = svc.user_agent_family();
+            let source = svc.source_label();
             tracing::trace!(?hash, ?peer, "routing to a peer that might have inventory");
             let fut = svc.call(req);
             self.push_unready(peer, svc);
-            return fut.map_err(Into::into).boxed();
+            let span = tracing::debug_span!(
+                "peer.route_inv",
+                route = "fallback",
+                ?hash,
+                ?peer,
+                command,
+                source,
+                user_agent_family,
+                advertising_peers = advertising_peer_list.len(),
+                missing_peers = missing_peer_list.len(),
+            );
+            metrics::counter!(
+                "peer.route_inv.count",
+                "route" => "fallback",
+                "command" => command,
+            )
+            .increment(1);
+            if !missing_peer_list.is_empty() {
+                metrics::counter!("sync.missing_inventory.retry.count").increment(1);
+            }
+            return observe_peer_request(command, source, user_agent_family, fut)
+                .instrument(span)
+                .map_err(Into::into)
+                .boxed();
         }
 
         tracing::debug!(
             ?hash,
             "all ready peers are missing inventory, failing request"
         );
+        metrics::counter!(
+            "peer.route_inv.count",
+            "route" => "missing_inventory_exhausted",
+            "command" => command,
+        )
+        .increment(1);
+        metrics::counter!("sync.missing_inventory.retry.exhausted.count").increment(1);
+        metrics::counter!(
+            "peer.request.error.count",
+            "command" => command,
+            "error_kind" => "not_found_registry",
+            "user_agent_family" => "unknown",
+        )
+        .increment(1);
 
         async move {
             // Let other tasks run, so a retry request might get different ready peers.
@@ -1099,11 +1288,17 @@ where
         peers: Vec<D::Key>,
     ) -> <Self as tower::Service<Request>>::Future {
         let futs = FuturesUnordered::new();
+        let command = req.command();
         for key in peers {
             let mut svc = self
                 .take_ready_service(&key)
                 .expect("selected peers are ready");
-            futs.push(svc.call(req.clone()).map_err(|_| ()));
+            let user_agent_family = svc.user_agent_family();
+            let source = svc.source_label();
+            futs.push(
+                observe_peer_request(command, source, user_agent_family, svc.call(req.clone()))
+                    .map_err(|_| ()),
+            );
             self.push_unready(key, svc);
         }
 

--- a/zebra-network/tests/acceptance.rs
+++ b/zebra-network/tests/acceptance.rs
@@ -10,7 +10,7 @@ use chrono::Utc;
 use zebra_chain::block::Height;
 use zebra_network::{
     types::{AddrInVersion, Nonce, PeerServices},
-    ConnectedAddr, ConnectionInfo, PeerSocketAddr, Version, VersionMessage,
+    ConnectedAddr, ConnectionInfo, PeerSocketAddr, PeerSource, Version, VersionMessage,
 };
 
 /// Test that the types used in [`ConnectionInfo`] are public,
@@ -41,5 +41,6 @@ fn connection_info_types_are_public() {
         connected_addr,
         remote,
         negotiated_version,
+        source: PeerSource::Configured,
     });
 }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1028,14 +1028,22 @@ impl Service<Request> for StateService {
                 // Await the channel response, flatten the result, map receive errors to
                 // `CommitSemanticallyVerifiedError::WriteTaskExited`.
                 // Then flatten the nested Result and convert any errors to a BoxError.
-                let span = Span::current();
+                let span = tracing::debug_span!(
+                    "sync.commit_block",
+                    kind = "semantic",
+                    result = tracing::field::Empty,
+                );
                 async move {
-                    rsp_rx
+                    let result = rsp_rx
                         .await
                         .map_err(|_recv_error| CommitBlockError::WriteTaskExited.into())
                         .and_then(|result| result)
-                        .map_err(BoxError::from)
-                        .map(Response::Committed)
+                        .map_err(BoxError::from);
+
+                    Span::current()
+                        .record("result", if result.is_ok() { "success" } else { "failure" });
+
+                    result.map(Response::Committed)
                 }
                 .instrument(span)
                 .boxed()
@@ -1079,13 +1087,22 @@ impl Service<Request> for StateService {
                 // Await the channel response, flatten the result, map receive errors to
                 // `CommitCheckpointVerifiedError::WriteTaskExited`.
                 // Then flatten the nested Result and convert any errors to a BoxError.
+                let span = tracing::debug_span!(
+                    "sync.commit_block",
+                    kind = "checkpoint",
+                    result = tracing::field::Empty,
+                );
                 async move {
-                    rsp_rx
+                    let result = rsp_rx
                         .await
                         .map_err(|_recv_error| CommitBlockError::WriteTaskExited.into())
                         .and_then(|result| result)
-                        .map_err(BoxError::from)
-                        .map(Response::Committed)
+                        .map_err(BoxError::from);
+
+                    Span::current()
+                        .record("result", if result.is_ok() { "success" } else { "failure" });
+
+                    result.map(Response::Committed)
                 }
                 .instrument(span)
                 .boxed()
@@ -1095,12 +1112,18 @@ impl Service<Request> for StateService {
             // If the UTXO isn't in the queued blocks, runs concurrently using the ReadStateService.
             Request::AwaitUtxo(outpoint) => {
                 let timer = CodeTimer::start();
+                let await_utxo_span = tracing::info_span!(
+                    parent: &span,
+                    "state.await_utxo",
+                    ?outpoint,
+                    result = tracing::field::Empty,
+                );
                 // Prepare the AwaitUtxo future from PendingUxtos.
                 let response_fut = self.pending_utxos.queue(outpoint);
                 // Only instrument `response_fut`, the ReadStateService already
                 // instruments its requests with the same span.
 
-                let response_fut = response_fut.instrument(span).boxed();
+                let response_fut = response_fut.instrument(await_utxo_span.clone()).boxed();
 
                 // Check the non-finalized block queue outside the returned future,
                 // so we can access mutable state fields.
@@ -1109,6 +1132,7 @@ impl Service<Request> for StateService {
 
                     // We're finished, the returned future gets the UTXO from the respond() channel.
                     timer.finish_desc("AwaitUtxo/queued-non-finalized");
+                    await_utxo_span.record("result", "queued_non_finalized");
 
                     return response_fut;
                 }
@@ -1119,6 +1143,7 @@ impl Service<Request> for StateService {
 
                     // We're finished, the returned future gets the UTXO from the respond() channel.
                     timer.finish_desc("AwaitUtxo/sent-non-finalized");
+                    await_utxo_span.record("result", "sent_non_finalized");
 
                     return response_fut;
                 }
@@ -1132,6 +1157,7 @@ impl Service<Request> for StateService {
                 // Manually send a request to the ReadStateService,
                 // to get UTXOs from any non-finalized chain or the finalized chain.
                 let read_service = self.read_service.clone();
+                let await_utxo_result_span = await_utxo_span.clone();
 
                 // Run the request in an async block, so we can await the response.
                 async move {
@@ -1154,15 +1180,18 @@ impl Service<Request> for StateService {
                     if let ReadResponse::AnyChainUtxo(Some(utxo)) = rsp {
                         // We got a UTXO, so we replace the response future with the result own.
                         timer.finish_desc("AwaitUtxo/any-chain");
+                        await_utxo_result_span.record("result", "any_chain");
 
                         return Ok(Response::Utxo(utxo));
                     }
 
                     // We're finished, but the returned future is waiting on the respond() channel.
                     timer.finish_desc("AwaitUtxo/waiting");
+                    await_utxo_result_span.record("result", "waiting");
 
                     response_fut.await
                 }
+                .instrument(await_utxo_span)
                 .boxed()
             }
 

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -311,6 +311,39 @@ struct CheckedTip {
     expected_next: block::Hash,
 }
 
+fn bool_label(value: bool) -> &'static str {
+    if value {
+        "true"
+    } else {
+        "false"
+    }
+}
+
+fn sync_made_progress(starting_tip: Option<Height>, ending_tip: Option<Height>) -> bool {
+    match (starting_tip, ending_tip) {
+        (Some(starting_tip), Some(ending_tip)) => ending_tip > starting_tip,
+        (None, Some(_)) => true,
+        _ => false,
+    }
+}
+
+fn sync_restart_reason(result: &Result<(), Report>) -> &'static str {
+    let Err(error) = result else {
+        return "exhausted_prospective_tips";
+    };
+
+    let error = format!("{error:?}");
+    if error.contains("Elapsed") || error.contains("deadline has elapsed") {
+        "timeout"
+    } else if error.contains("NotFoundRegistry") {
+        "not_found_registry"
+    } else if error.contains("NotFoundResponse") {
+        "not_found_response"
+    } else {
+        "error"
+    }
+}
+
 pub struct ChainSync<ZN, ZS, ZV, ZSTip>
 where
     ZN: Service<zn::Request, Response = zn::Response, Error = BoxError>
@@ -539,7 +572,22 @@ where
         self.request_genesis().await?;
 
         loop {
-            if self.try_to_sync().await.is_err() {
+            let starting_tip = self.latest_chain_tip.best_tip_height();
+            let sync_result = self.try_to_sync().await;
+            let ending_tip = self.latest_chain_tip.best_tip_height();
+            let made_progress = sync_made_progress(starting_tip, ending_tip);
+            let sync_failed = sync_result.is_err();
+            let restart_reason = sync_restart_reason(&sync_result);
+
+            metrics::counter!(
+                "sync.restart.count",
+                "reason" => restart_reason,
+                "made_progress" => bool_label(made_progress),
+                "sync_failed" => bool_label(sync_failed),
+            )
+            .increment(1);
+
+            if sync_failed {
                 self.downloads.cancel_all();
             }
 
@@ -571,7 +619,7 @@ where
     /// Returns `Err` if there was an unrecoverable error and restarting the synchronization is
     /// necessary. This includes outer timeouts, where an entire syncing step takes an extremely
     /// long time. (These usually indicate hangs.)
-    #[instrument(skip(self))]
+    #[instrument(name = "sync.try", skip(self))]
     async fn try_to_sync(&mut self) -> Result<(), Report> {
         self.prospective_tips = HashSet::new();
 
@@ -600,6 +648,7 @@ where
         }
 
         info!("exhausted prospective tip set");
+        metrics::counter!("sync.exhausted_prospective_tips.count").increment(1);
 
         Ok(())
     }
@@ -611,11 +660,36 @@ where
     /// Returns `Ok(extra_hashes)` if it was able to extend once and synchronize sone of the chain.
     /// Returns `Err` if there was an unrecoverable error and restarting the synchronization is
     /// necessary.
-    #[instrument(skip(self, extra_hashes))]
+    #[instrument(
+        name = "sync.try_once",
+        skip(self, extra_hashes),
+        fields(
+            extra_hashes = extra_hashes.len(),
+            tips = self.prospective_tips.len(),
+            in_flight = tracing::field::Empty,
+            lookahead_limit = tracing::field::Empty,
+            state_tip = tracing::field::Empty,
+        )
+    )]
     async fn try_to_sync_once(
         &mut self,
         mut extra_hashes: IndexSet<block::Hash>,
     ) -> Result<IndexSet<block::Hash>, Report> {
+        metrics::gauge!("sync.pending_hashes.count", "source" => "extra_hashes")
+            .set(extra_hashes.len() as f64);
+        tracing::Span::current().record(
+            "in_flight",
+            tracing::field::debug(self.downloads.in_flight()),
+        );
+        tracing::Span::current().record(
+            "lookahead_limit",
+            tracing::field::debug(self.lookahead_limit(extra_hashes.len())),
+        );
+        tracing::Span::current().record(
+            "state_tip",
+            tracing::field::debug(self.latest_chain_tip.best_tip_height()),
+        );
+
         // Check whether any block tasks are currently ready.
         while let Poll::Ready(Some(rsp)) = futures::poll!(self.downloads.next()) {
             // Some temporary errors are ignored, and syncing continues with other blocks.
@@ -683,7 +757,7 @@ where
 
     /// Given a block_locator list fan out request for subsequent hashes to
     /// multiple peers
-    #[instrument(skip(self))]
+    #[instrument(name = "sync.obtain_tips", skip(self))]
     async fn obtain_tips(&mut self) -> Result<IndexSet<block::Hash>, Report> {
         let stage_start = std::time::Instant::now();
 
@@ -849,6 +923,8 @@ where
         let new_downloads = download_set.len();
         debug!(new_downloads, "queueing new downloads");
         metrics::gauge!("sync.obtain.queued.hash.count").set(new_downloads as f64);
+        metrics::gauge!("sync.pending_hashes.count", "source" => "obtain_tips")
+            .set(new_downloads as f64);
 
         // security: use the actual number of new downloads from all peers,
         // so the last peer to respond can't toggle our mempool
@@ -862,7 +938,7 @@ where
         Self::handle_hash_response(response).map_err(Into::into)
     }
 
-    #[instrument(skip(self))]
+    #[instrument(name = "sync.extend_tips", skip(self))]
     async fn extend_tips(&mut self) -> Result<IndexSet<block::Hash>, Report> {
         let stage_start = std::time::Instant::now();
 
@@ -992,6 +1068,8 @@ where
         let new_downloads = download_set.len();
         debug!(new_downloads, "queueing new downloads");
         metrics::gauge!("sync.extend.queued.hash.count").set(new_downloads as f64);
+        metrics::gauge!("sync.pending_hashes.count", "source" => "extend_tips")
+            .set(new_downloads as f64);
 
         // security: use the actual number of new downloads from all peers,
         // so the last peer to respond can't toggle our mempool
@@ -1069,11 +1147,24 @@ where
     /// Queue download and verify tasks for each block that isn't currently known to our node.
     ///
     /// TODO: turn obtain and extend tips into a separate task, which sends hashes via a channel?
+    #[instrument(
+        name = "sync.request_blocks",
+        level = "debug",
+        skip(self, hashes),
+        fields(
+            hash_count = hashes.len(),
+            lookahead_limit = tracing::field::Empty,
+            queued_hashes = tracing::field::Empty,
+            deferred_hashes = tracing::field::Empty,
+            result = tracing::field::Empty,
+        )
+    )]
     async fn request_blocks(
         &mut self,
         mut hashes: IndexSet<block::Hash>,
     ) -> Result<IndexSet<block::Hash>, BlockDownloadVerifyError> {
         let lookahead_limit = self.lookahead_limit(hashes.len());
+        tracing::Span::current().record("lookahead_limit", tracing::field::debug(lookahead_limit));
 
         debug!(
             hashes.len = hashes.len(),
@@ -1087,9 +1178,19 @@ where
             IndexSet::new()
         };
 
+        tracing::Span::current().record("queued_hashes", hashes.len());
+        tracing::Span::current().record("deferred_hashes", extra_hashes.len());
+
+        metrics::gauge!("sync.pending_hashes.count", "source" => "queued_for_download")
+            .set(hashes.len() as f64);
+        metrics::gauge!("sync.pending_hashes.count", "source" => "deferred_by_lookahead")
+            .set(extra_hashes.len() as f64);
+
         for hash in hashes.into_iter() {
             self.downloads.download_and_verify(hash).await?;
         }
+
+        tracing::Span::current().record("result", "success");
 
         Ok(extra_hashes)
     }
@@ -1182,6 +1283,8 @@ where
         match response {
             Ok(_t) => Ok(()),
             Err(error) => {
+                error.count_metrics();
+
                 // TODO: exit syncer on permanent service errors (NetworkError, VerifierError)
                 if Self::should_restart_sync(&error) {
                     Err(error)
@@ -1211,7 +1314,12 @@ where
 
     fn update_metrics(&mut self) {
         metrics::gauge!("sync.prospective_tips.len",).set(self.prospective_tips.len() as f64);
-        metrics::gauge!("sync.downloads.in_flight",).set(self.downloads.in_flight() as f64);
+        let in_flight = self.downloads.in_flight();
+        let lookahead_limit = self.lookahead_limit(0);
+        metrics::gauge!("sync.downloads.in_flight",).set(in_flight as f64);
+        metrics::gauge!("sync.download.slots", "state" => "in_flight").set(in_flight as f64);
+        metrics::gauge!("sync.download.slots", "state" => "available")
+            .set(lookahead_limit.saturating_sub(in_flight) as f64);
     }
 
     /// Return if the sync should be restarted based on the given error

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -168,6 +168,89 @@ impl From<tokio::time::error::Elapsed> for BlockDownloadVerifyError {
     }
 }
 
+impl BlockDownloadVerifyError {
+    /// Returns the low-cardinality error kind used by sync metrics.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            BlockDownloadVerifyError::NetworkServiceError { .. } => "network_service",
+            BlockDownloadVerifyError::VerifierServiceError { .. } => "verifier_service",
+            BlockDownloadVerifyError::DuplicateBlockQueuedForDownload { .. } => "duplicate_block",
+            BlockDownloadVerifyError::DownloadFailed { error, .. } => {
+                classified_error_kind(error.as_ref())
+            }
+            BlockDownloadVerifyError::AboveLookaheadHeightLimit { .. } => {
+                "above_lookahead_height_limit"
+            }
+            BlockDownloadVerifyError::BehindTipHeightLimit { .. } => "behind_tip_height_limit",
+            BlockDownloadVerifyError::InvalidHeight { .. } => "invalid_height",
+            BlockDownloadVerifyError::Invalid { error, .. } if error.is_duplicate_request() => {
+                "duplicate_request"
+            }
+            BlockDownloadVerifyError::Invalid { .. } => "invalid",
+            BlockDownloadVerifyError::ValidationRequestError { error, .. } => {
+                classified_error_kind(error.as_ref())
+            }
+            BlockDownloadVerifyError::CancelledDuringDownload { .. } => "cancelled_download",
+            BlockDownloadVerifyError::CancelledAwaitingVerifierReadiness { .. } => {
+                "cancelled_verify_ready"
+            }
+            BlockDownloadVerifyError::CancelledDuringVerification { .. } => "cancelled_verify",
+            BlockDownloadVerifyError::Timeout => "timeout",
+        }
+    }
+
+    /// Count sync error metrics for this failure at the boundary where the
+    /// download slot finishes.
+    pub(super) fn count_metrics(&self) {
+        match self {
+            BlockDownloadVerifyError::NetworkServiceError { .. }
+            | BlockDownloadVerifyError::DuplicateBlockQueuedForDownload { .. }
+            | BlockDownloadVerifyError::DownloadFailed { .. }
+            | BlockDownloadVerifyError::AboveLookaheadHeightLimit { .. }
+            | BlockDownloadVerifyError::BehindTipHeightLimit { .. }
+            | BlockDownloadVerifyError::InvalidHeight { .. }
+            | BlockDownloadVerifyError::CancelledDuringDownload { .. }
+            | BlockDownloadVerifyError::Timeout => {
+                metrics::counter!("sync.block_download.error.count", "kind" => self.kind())
+                    .increment(1);
+            }
+
+            BlockDownloadVerifyError::VerifierServiceError { .. }
+            | BlockDownloadVerifyError::Invalid { .. }
+            | BlockDownloadVerifyError::ValidationRequestError { .. }
+            | BlockDownloadVerifyError::CancelledAwaitingVerifierReadiness { .. }
+            | BlockDownloadVerifyError::CancelledDuringVerification { .. } => {
+                metrics::counter!("sync.block_verify.error.count", "kind" => self.kind())
+                    .increment(1);
+            }
+        }
+
+        if let BlockDownloadVerifyError::ValidationRequestError { error, .. } = self {
+            if classified_error_kind(error.as_ref()) == "timeout" {
+                metrics::counter!("sync.validation_request.elapsed.count").increment(1);
+            }
+        }
+    }
+}
+
+fn classified_error_kind(error: &(dyn std::error::Error + Send + Sync + 'static)) -> &'static str {
+    let error = format!("{error:?}");
+
+    if error.contains("NotFoundRegistry") {
+        "not_found_registry"
+    } else if error.contains("NotFoundResponse") {
+        "not_found_response"
+    } else if error.contains("Elapsed") || error.contains("timed out") {
+        "timeout"
+    } else if error.contains("ConnectionClosed") {
+        "connection_closed"
+    } else if error.contains("ConnectionDropped") {
+        "connection_dropped"
+    } else {
+        "other"
+    }
+}
+
 /// Represents a [`Stream`] of download and verification tasks during chain sync.
 #[pin_project]
 #[derive(Debug)]
@@ -325,7 +408,18 @@ where
     /// This method waits for the network to become ready, and returns an error
     /// only if the network service fails. It returns immediately after queuing
     /// the request.
-    #[instrument(level = "debug", skip(self), fields(%hash))]
+    #[instrument(
+        name = "sync.download_block",
+        level = "debug",
+        skip(self),
+        fields(
+            %hash,
+            height = tracing::field::Empty,
+            peer = tracing::field::Empty,
+            request_command = "BlocksByHash",
+            result = tracing::field::Empty,
+        )
+    )]
     pub async fn download_and_verify(
         &mut self,
         hash: block::Hash,
@@ -363,6 +457,8 @@ where
 
         let task = tokio::spawn(
             async move {
+                let slot_start = std::time::Instant::now();
+
                 // Download the block.
                 // Prefer the cancel handle if both are ready.
                 let download_start = std::time::Instant::now();
@@ -373,9 +469,20 @@ where
                         metrics::counter!("sync.cancelled.download.count").increment(1);
                         metrics::histogram!("sync.block.download.duration_seconds", "result" => "cancelled")
                             .record(download_start.elapsed().as_secs_f64());
+                        metrics::histogram!("sync.download.slot.age.seconds")
+                            .record(slot_start.elapsed().as_secs_f64());
+                        tracing::Span::current().record("result", "cancelled_download");
                         return Err(BlockDownloadVerifyError::CancelledDuringDownload { hash })
                     }
-                    rsp = block_req => rsp.map_err(|error| BlockDownloadVerifyError::DownloadFailed { error, hash})?,
+                    rsp = block_req => match rsp {
+                        Ok(rsp) => rsp,
+                        Err(error) => {
+                            metrics::histogram!("sync.download.slot.age.seconds")
+                                .record(slot_start.elapsed().as_secs_f64());
+                            tracing::Span::current().record("result", "download_failed");
+                            return Err(BlockDownloadVerifyError::DownloadFailed { error, hash });
+                        }
+                    },
                 };
 
                 let (block, advertiser_addr) = if let zn::Response::Blocks(blocks) = rsp {
@@ -396,6 +503,10 @@ where
                 metrics::counter!("sync.downloaded.block.count").increment(1);
                 metrics::histogram!("sync.block.download.duration_seconds", "result" => "success")
                     .record(download_start.elapsed().as_secs_f64());
+                tracing::Span::current().record(
+                    "peer",
+                    tracing::field::display(advertiser_addr.unwrap_or_else(PeerSocketAddr::unspecified)),
+                );
 
                 // Security & Performance: reject blocks that are too far ahead of our tip.
                 // Avoids denial of service attacks, and reduces wasted work on high blocks
@@ -447,11 +558,18 @@ where
                         "synced block with no height: dropped downloaded block"
                     );
                     metrics::counter!("sync.no.height.dropped.block.count").increment(1);
+                    metrics::histogram!("sync.download.slot.age.seconds")
+                        .record(slot_start.elapsed().as_secs_f64());
+                    tracing::Span::current().record("result", "invalid_height");
 
                     return Err(BlockDownloadVerifyError::InvalidHeight { hash });
                 };
+                tracing::Span::current().record("height", tracing::field::debug(block_height));
 
                 if block_height > lookahead_drop_height {
+                    metrics::histogram!("sync.download.slot.age.seconds")
+                        .record(slot_start.elapsed().as_secs_f64());
+                    tracing::Span::current().record("result", "above_lookahead_height_limit");
                     Err(BlockDownloadVerifyError::AboveLookaheadHeightLimit { height: block_height, hash })?;
                 } else if block_height > lookahead_pause_height {
                     // This log can be very verbose, usually hundreds of blocks are dropped.
@@ -508,9 +626,19 @@ where
                         "synced block height behind the finalized tip: dropped downloaded block"
                     );
                     metrics::counter!("gossip.min.height.limit.dropped.block.count").increment(1);
+                    metrics::histogram!("sync.download.slot.age.seconds")
+                        .record(slot_start.elapsed().as_secs_f64());
+                    tracing::Span::current().record("result", "behind_tip_height_limit");
 
                     Err(BlockDownloadVerifyError::BehindTipHeightLimit { height: block_height, hash })?;
                 }
+
+                let verify_span = tracing::debug_span!(
+                    "sync.verify_block",
+                    %hash,
+                    ?block_height,
+                    result = tracing::field::Empty,
+                );
 
                 // Wait for the verifier service to be ready.
                 let readiness = verifier.ready();
@@ -520,9 +648,13 @@ where
                     _ = &mut cancel_rx => {
                         trace!("task cancelled waiting for verifier service readiness");
                         metrics::counter!("sync.cancelled.verify.ready.count").increment(1);
+                        metrics::histogram!("sync.download.slot.age.seconds")
+                            .record(slot_start.elapsed().as_secs_f64());
+                        tracing::Span::current().record("result", "cancelled_verify_ready");
+                        verify_span.record("result", "cancelled_ready");
                         return Err(BlockDownloadVerifyError::CancelledAwaitingVerifierReadiness { height: block_height, hash })
                     }
-                    verifier = readiness => verifier,
+                    verifier = readiness.instrument(verify_span.clone()) => verifier,
                 };
 
                 // Verify the block.
@@ -546,14 +678,22 @@ where
                         metrics::counter!("sync.cancelled.verify.count").increment(1);
                         metrics::histogram!("sync.block.verify.duration_seconds", "result" => "cancelled")
                             .record(verify_start.elapsed().as_secs_f64());
+                        metrics::histogram!("sync.download.slot.age.seconds")
+                            .record(slot_start.elapsed().as_secs_f64());
+                        tracing::Span::current().record("result", "cancelled_verify");
+                        verify_span.record("result", "cancelled");
                         return Err(BlockDownloadVerifyError::CancelledDuringVerification { height: block_height, hash })
                     }
-                    verification = rsp => verification,
+                    verification = rsp.instrument(verify_span.clone()) => verification,
                 };
 
                 let verify_result = if verification.is_ok() { "success" } else { "failure" };
                 metrics::histogram!("sync.block.verify.duration_seconds", "result" => verify_result)
                     .record(verify_start.elapsed().as_secs_f64());
+                metrics::histogram!("sync.download.slot.age.seconds")
+                    .record(slot_start.elapsed().as_secs_f64());
+                tracing::Span::current().record("result", verify_result);
+                verify_span.record("result", verify_result);
 
                 if verification.is_ok() {
                     metrics::counter!("sync.verified.block.count").increment(1);

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -418,6 +418,7 @@ where
             peer = tracing::field::Empty,
             request_command = "BlocksByHash",
             result = tracing::field::Empty,
+            error_kind = tracing::field::Empty,
         )
     )]
     pub async fn download_and_verify(
@@ -426,6 +427,8 @@ where
     ) -> Result<(), BlockDownloadVerifyError> {
         if self.cancel_handles.contains_key(&hash) {
             metrics::counter!("sync.already.queued.dropped.block.hash.count").increment(1);
+            tracing::Span::current().record("result", "duplicate_block");
+            tracing::Span::current().record("error_kind", "duplicate_block");
             return Err(BlockDownloadVerifyError::DuplicateBlockQueuedForDownload { hash });
         }
 
@@ -436,12 +439,14 @@ where
         // if we waited for readiness and did the service call in the spawned
         // tasks, all of the spawned tasks would race each other waiting for the
         // network to become ready.
-        let block_req = self
-            .network
-            .ready()
-            .await
-            .map_err(|error| BlockDownloadVerifyError::NetworkServiceError { error })?
-            .call(zn::Request::BlocksByHash(std::iter::once(hash).collect()));
+        let block_req = self.network.ready().await.map_err(|error| {
+            tracing::Span::current().record("result", "network_service_error");
+            tracing::Span::current().record("error_kind", "network_service");
+
+            BlockDownloadVerifyError::NetworkServiceError { error }
+        })?;
+
+        let block_req = block_req.call(zn::Request::BlocksByHash(std::iter::once(hash).collect()));
 
         // This oneshot is used to signal cancellation to the download task.
         let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
@@ -472,14 +477,17 @@ where
                         metrics::histogram!("sync.download.slot.age.seconds")
                             .record(slot_start.elapsed().as_secs_f64());
                         tracing::Span::current().record("result", "cancelled_download");
+                        tracing::Span::current().record("error_kind", "cancelled_download");
                         return Err(BlockDownloadVerifyError::CancelledDuringDownload { hash })
                     }
                     rsp = block_req => match rsp {
                         Ok(rsp) => rsp,
                         Err(error) => {
+                            let error_kind = classified_error_kind(error.as_ref());
                             metrics::histogram!("sync.download.slot.age.seconds")
                                 .record(slot_start.elapsed().as_secs_f64());
                             tracing::Span::current().record("result", "download_failed");
+                            tracing::Span::current().record("error_kind", error_kind);
                             return Err(BlockDownloadVerifyError::DownloadFailed { error, hash });
                         }
                     },
@@ -561,6 +569,7 @@ where
                     metrics::histogram!("sync.download.slot.age.seconds")
                         .record(slot_start.elapsed().as_secs_f64());
                     tracing::Span::current().record("result", "invalid_height");
+                    tracing::Span::current().record("error_kind", "invalid_height");
 
                     return Err(BlockDownloadVerifyError::InvalidHeight { hash });
                 };
@@ -570,6 +579,7 @@ where
                     metrics::histogram!("sync.download.slot.age.seconds")
                         .record(slot_start.elapsed().as_secs_f64());
                     tracing::Span::current().record("result", "above_lookahead_height_limit");
+                    tracing::Span::current().record("error_kind", "above_lookahead_height_limit");
                     Err(BlockDownloadVerifyError::AboveLookaheadHeightLimit { height: block_height, hash })?;
                 } else if block_height > lookahead_pause_height {
                     // This log can be very verbose, usually hundreds of blocks are dropped.
@@ -629,6 +639,7 @@ where
                     metrics::histogram!("sync.download.slot.age.seconds")
                         .record(slot_start.elapsed().as_secs_f64());
                     tracing::Span::current().record("result", "behind_tip_height_limit");
+                    tracing::Span::current().record("error_kind", "behind_tip_height_limit");
 
                     Err(BlockDownloadVerifyError::BehindTipHeightLimit { height: block_height, hash })?;
                 }
@@ -638,6 +649,7 @@ where
                     %hash,
                     ?block_height,
                     result = tracing::field::Empty,
+                    error_kind = tracing::field::Empty,
                 );
 
                 // Wait for the verifier service to be ready.
@@ -651,16 +663,26 @@ where
                         metrics::histogram!("sync.download.slot.age.seconds")
                             .record(slot_start.elapsed().as_secs_f64());
                         tracing::Span::current().record("result", "cancelled_verify_ready");
+                        tracing::Span::current().record("error_kind", "cancelled_verify_ready");
                         verify_span.record("result", "cancelled_ready");
+                        verify_span.record("error_kind", "cancelled_verify_ready");
                         return Err(BlockDownloadVerifyError::CancelledAwaitingVerifierReadiness { height: block_height, hash })
                     }
                     verifier = readiness.instrument(verify_span.clone()) => verifier,
                 };
 
+                let verifier = verifier.map_err(|error| {
+                    tracing::Span::current().record("result", "verifier_service_error");
+                    tracing::Span::current().record("error_kind", "verifier_service");
+                    verify_span.record("result", "verifier_service_error");
+                    verify_span.record("error_kind", "verifier_service");
+
+                    BlockDownloadVerifyError::VerifierServiceError { error }
+                })?;
+
                 // Verify the block.
                 let verify_start = std::time::Instant::now();
                 let mut rsp = verifier
-                    .map_err(|error| BlockDownloadVerifyError::VerifierServiceError { error })?
                     .call(zebra_consensus::Request::Commit(block)).boxed();
 
                 // Add a shorter timeout to workaround a known bug (#5125)
@@ -681,19 +703,28 @@ where
                         metrics::histogram!("sync.download.slot.age.seconds")
                             .record(slot_start.elapsed().as_secs_f64());
                         tracing::Span::current().record("result", "cancelled_verify");
+                        tracing::Span::current().record("error_kind", "cancelled_verify");
                         verify_span.record("result", "cancelled");
+                        verify_span.record("error_kind", "cancelled_verify");
                         return Err(BlockDownloadVerifyError::CancelledDuringVerification { height: block_height, hash })
                     }
                     verification = rsp.instrument(verify_span.clone()) => verification,
                 };
 
                 let verify_result = if verification.is_ok() { "success" } else { "failure" };
+                let verify_error_kind = verification
+                    .as_ref()
+                    .err()
+                    .map(|error| classified_error_kind(error.as_ref()))
+                    .unwrap_or("none");
                 metrics::histogram!("sync.block.verify.duration_seconds", "result" => verify_result)
                     .record(verify_start.elapsed().as_secs_f64());
                 metrics::histogram!("sync.download.slot.age.seconds")
                     .record(slot_start.elapsed().as_secs_f64());
                 tracing::Span::current().record("result", verify_result);
+                tracing::Span::current().record("error_kind", verify_error_kind);
                 verify_span.record("result", verify_result);
+                verify_span.record("error_kind", verify_error_kind);
 
                 if verification.is_ok() {
                     metrics::counter!("sync.verified.block.count").increment(1);


### PR DESCRIPTION
## Motivation

Add low-cardinality observability for mainnet sync stalls and peer-source behavior, so operators can distinguish peer discovery, handshake, routing, block download, verification, state wait, and sync restart failure modes without using high-cardinality Prometheus labels.

## Solution

- Add sync-stall metrics for restart reasons, pending hashes, download slots, download-slot age, validation elapsed errors, state request timeouts, missing-inventory retries, and checkpoint range timing.
- Add peer-source metrics for DNS seed/cache/gossip/configured discovery, handshake outcomes, ready peers, and peer request timeouts.
- Thread bounded peer source labels through initial peer resolution, outbound connector requests, handshakes, and tracked peer services.
- Add redacted tracing spans around sync attempts, peer routing, block downloads, block verification, state commits, and `AwaitUtxo` waits.
- Document the new metrics and update the changelog.

### Tests

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p zebra-network --all-targets`
- `cargo clippy -p zebrad --all-targets -- -D warnings`
- Built local Docker image: `z3-zebra-local:mainnet-stall-telemetry-f25cb9f26b07`
- Deployed the image into the local z3 mainnet stack.
- Verified `/healthy` and `/ready` both returned `200 OK`.
- Verified mainnet RPC `getblockchaininfo` succeeded at height `3357011`.
- Verified Prometheus was scraping `zebra:9999` with no error.
- Verified live Prometheus/Zebra metrics for `peer_discovery_resolved_count`, `peer_discovery_candidate_count`, `peer_handshake_count`, `peer_ready_count`, and sync-stall counters.

### Specifications & References

- New peer `source` labels are bounded values such as `dnsseed_str4d`, `dnsseed_zcash`, `dnsseed_shieldedinfra`, `dnsseed_zfnd`, `peer_cache`, `gossip`, and `configured`.
- High-cardinality details such as block hashes, outpoints, and redacted peer addresses are recorded on tracing spans instead of Prometheus labels.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Codex was used for implementation, local validation commands, and PR description preparation.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.