### PR TITLE
fix(ci): solve Rust 1.97 beta clippy lints

### DIFF
--- a/zebra-chain/src/work/difficulty/tests/vectors.rs
+++ b/zebra-chain/src/work/difficulty/tests/vectors.rs
@@ -403,7 +403,7 @@ fn testnet_minimum_difficulty() -> Result<(), Report> {
         block::Height(1_028_500),
     ];
 
-    for (&height, _block) in zebra_test::vectors::TESTNET_BLOCKS.iter() {
+    for &height in zebra_test::vectors::TESTNET_BLOCKS.keys() {
         let height = block::Height(height);
 
         /// SPANDOC: Do minimum difficulty checks for testnet block {?height}

--- a/zebra-consensus/benches/groth16.rs
+++ b/zebra-consensus/benches/groth16.rs
@@ -40,7 +40,7 @@ struct JoinSplitSource {
 fn extract_joinsplit_sources() -> Vec<JoinSplitSource> {
     let mut sources = Vec::new();
 
-    for (_height, bytes) in zebra_test::vectors::MAINNET_BLOCKS.iter() {
+    for bytes in zebra_test::vectors::MAINNET_BLOCKS.values() {
         let block: Block = bytes.zcash_deserialize_into().expect("valid block");
 
         for tx in &block.transactions {

--- a/zebra-consensus/benches/halo2.rs
+++ b/zebra-consensus/benches/halo2.rs
@@ -50,7 +50,7 @@ use zebra_consensus::halo2::{Item, VERIFYING_KEY};
 fn extract_halo2_items_from_blocks() -> Vec<Item> {
     let mut items = Vec::new();
 
-    for (_height, bytes) in zebra_test::vectors::MAINNET_BLOCKS.iter() {
+    for bytes in zebra_test::vectors::MAINNET_BLOCKS.values() {
         let block: Block = bytes.zcash_deserialize_into().expect("valid block");
 
         for tx in &block.transactions {

--- a/zebra-node-services/src/rpc_client.rs
+++ b/zebra-node-services/src/rpc_client.rs
@@ -34,7 +34,7 @@ impl RpcRequestClient {
         let params = params.as_ref();
 
         self.client
-            .post(format!("http://{}", &self.rpc_address))
+            .post(format!("http://{}", self.rpc_address))
             .body(format!(
                 r#"{{"jsonrpc": "2.0", "method": "{method}", "params": {params}, "id":123 }}"#
             ))
@@ -54,7 +54,7 @@ impl RpcRequestClient {
         let params = params.as_ref();
 
         self.client
-            .post(format!("http://{}", &self.rpc_address))
+            .post(format!("http://{}", self.rpc_address))
             .body(format!(
                 r#"{{"jsonrpc": "2.0", "method": "{method}", "params": {params}, "id":123 }}"#
             ))
@@ -73,7 +73,7 @@ impl RpcRequestClient {
         let params = params.as_ref();
 
         self.client
-            .post(format!("http://{}", &self.rpc_address))
+            .post(format!("http://{}", self.rpc_address))
             .body(format!(
                 r#"{{"jsonrpc": "2.0", "method": "{method}", "params": {params}, "id":123 }}"#
             ))

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -2405,7 +2405,7 @@ async fn rpc_submitblock_errors() {
     );
 
     // Try to submit pre-populated blocks and assert that it responds with duplicate.
-    for (_height, &block_bytes) in zebra_test::vectors::CONTINUOUS_MAINNET_BLOCKS.iter() {
+    for &block_bytes in zebra_test::vectors::CONTINUOUS_MAINNET_BLOCKS.values() {
         let submit_block_response = rpc.submit_block(HexData(block_bytes.into()), None).await;
 
         assert_eq!(

--- a/zebra-state/src/service/write.rs
+++ b/zebra-state/src/service/write.rs
@@ -225,8 +225,8 @@ impl BlockWriteSender {
         (
             Self {
                 non_finalized: Some(non_finalized_block_write_sender),
-                finalized: Some(finalized_block_write_sender)
-                    .filter(|_| should_use_finalized_block_write_sender),
+                finalized: should_use_finalized_block_write_sender
+                    .then_some(finalized_block_write_sender),
             },
             invalid_block_write_reset_receiver,
             Some(Arc::new(task)),

--- a/zebrad/src/application.rs
+++ b/zebrad/src/application.rs
@@ -342,7 +342,7 @@ impl Application for ZebradApp {
         let mut metadata_section = "Diagnostic metadata:".to_string();
         for (k, v) in panic_metadata {
             builder = builder.add_issue_metadata(k, v.clone());
-            write!(&mut metadata_section, "\n{k}: {}", &v)
+            write!(&mut metadata_section, "\n{k}: {v}")
                 .expect("unexpected failure writing to string");
         }
 


### PR DESCRIPTION
## Motivation

Three lints promoted in the Rust 1.97 beta toolchain fail every PR's `clippy beta` job under `-D warnings`, stalling the merge queue regardless of PR content. The failures surface across `zebra-node-services`, `zebra-chain`, `zebra-consensus`, `zebra-rpc`, `zebra-state`, and `zebrad`.

## Solution

Each edit is the lint's own suggested rewrite, semantics-preserving:

- `useless_borrows_in_formatting`: drop the redundant `&` on `Copy + Display` arguments inside `format!`/`write!`.
- `for_kv_map`: iterate via `.keys()` or `.values()` when the loop body ignores the other half of the pair.
- `some_filter`: replace `Some(x).filter(|_| cond)` with `cond.then_some(x)`.

### Tests

- `cargo +beta clippy --workspace --all-targets -- -D warnings` (clean)
- `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- `cargo fmt --all -- --check` (clean)
- `cargo test -p zebra-node-services` and `cargo test -p zebra-chain -- work::difficulty` (pass)
- `cargo build -p zebra-consensus --benches` (compiles)

### AI Disclosure

- [x] AI tools were used: Claude Code identified the lints from the failing CI log, ran beta clippy locally to enumerate the full set, and drafted the edits and PR body.