### PR TITLE
feat: Network Sustainability Mechanism - ZIP-234 implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -328,7 +328,7 @@ debug = false
 # The linter should ignore these expected config flags/values
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(tokio_unstable)', # Used by tokio-console
-    'cfg(zcash_unstable, values("zfuture", "nu6.1", "nu7", "zip234", "zip235"))' # Used in Zebra and librustzcash
+    'cfg(zcash_unstable, values("zfuture", "nu6.1", "nu7", "zip234", "zip234alt", "zip235"))' # Used in Zebra and librustzcash
 ] }
 
 # High-risk code

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -328,7 +328,7 @@ debug = false
 # The linter should ignore these expected config flags/values
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(tokio_unstable)', # Used by tokio-console
-    'cfg(zcash_unstable, values("zfuture", "nu6.1", "nu7", "zip235"))' # Used in Zebra and librustzcash
+    'cfg(zcash_unstable, values("zfuture", "nu6.1", "nu7", "zip234", "zip235"))' # Used in Zebra and librustzcash
 ] }
 
 # High-risk code

--- a/zebra-chain/src/parameters/network/subsidy.rs
+++ b/zebra-chain/src/parameters/network/subsidy.rs
@@ -445,10 +445,55 @@ pub fn halving(height: Height, network: &Network) -> u32 {
         .expect("already checked for negatives")
 }
 
+/// Returns the height at which ZIP-234 applies (lowest height after the second halving following NU7).
+///
+/// Returns `None` when NU7 isn't configured.
+#[cfg(zcash_unstable = "zip234")]
+pub fn zip234_start_height(net: &Network) -> Option<Height> {
+    let nu7 = NetworkUpgrade::Nu7.activation_height(net)?;
+    let target_halving = halving(nu7, net).checked_add(2)?;
+    height_for_halving(target_halving, net)
+}
+
 /// `BlockSubsidy(height)` as described in [protocol specification §7.8][7.8]
+/// and [ZIP-234] for post-activation smoothed issuance.
 ///
 /// [7.8]: https://zips.z.cash/protocol/protocol.pdf#subsidies
-pub fn block_subsidy(height: Height, net: &Network) -> Result<Amount<NonNegative>, SubsidyError> {
+/// [ZIP-234]: https://zips.z.cash/zip-0234
+pub fn block_subsidy(
+    height: Height,
+    net: &Network,
+    money_reserve: Option<Amount<NonNegative>>,
+) -> Result<Amount<NonNegative>, SubsidyError> {
+    #[cfg(zcash_unstable = "zip234")]
+    if let Some(start) = zip234_start_height(net) {
+        if height >= start {
+            // ZIP-234 `BLOCK_SUBSIDY_FRACTION`, calibrated so
+            // `(1 − 4126/10¹⁰)^POST_BLOSSOM_HALVING_INTERVAL ≈ 0.5` within ±0.002%.
+            const NUMERATOR: u128 = 4_126;
+            const DENOMINATOR: u128 = 10_000_000_000;
+
+            let money_reserve = money_reserve
+                .expect("money_reserve is required at post-activation heights");
+            let reserve = u128::from(
+                u64::try_from(i64::from(money_reserve))
+                    .expect("money_reserve is Amount<NonNegative> so its i64 is >= 0"),
+            );
+            let subsidy_u128 = reserve
+                .checked_mul(NUMERATOR)
+                .expect("reserve <= MAX_MONEY ~ 2.1e15, * 4126 ~ 8.7e18 fits in u128")
+                .div_ceil(DENOMINATOR);
+
+            let subsidy = i64::try_from(subsidy_u128)
+                .expect("subsidy <= MAX_MONEY * 4126 / 10^10 ~ 8.66e8 zat, fits in i64");
+            return Ok(subsidy
+                .try_into()
+                .expect("subsidy is non-negative and <= MAX_MONEY"));
+        }
+    }
+
+    // Pre ZIP-234 subsidy calculation.
+    //
     let Some(halving_div) = halving_divisor(height, net) else {
         return Ok(Amount::zero());
     };
@@ -543,7 +588,7 @@ pub fn founders_reward(net: &Network, height: Height) -> Amount<NonNegative> {
     // inconsistency in the definition of the founders reward, which should occur only before
     // Canopy, so we check if Canopy is active as well.
     if halving(height, net) < 1 && NetworkUpgrade::current(net, height) < NetworkUpgrade::Canopy {
-        block_subsidy(height, net)
+        block_subsidy(height, net, None)
             .map(|subsidy| subsidy.div_exact(5))
             .expect("block subsidy must be valid for founders rewards")
     } else {

--- a/zebra-chain/src/parameters/network/subsidy.rs
+++ b/zebra-chain/src/parameters/network/subsidy.rs
@@ -23,6 +23,9 @@ use crate::{
     transparent,
 };
 
+#[cfg(zcash_unstable = "zip234alt")]
+use crate::amount::MAX_MONEY;
+
 use constants::{
     regtest, testnet, BLOSSOM_POW_TARGET_SPACING_RATIO, FUNDING_STREAM_RECEIVER_DENOMINATOR,
     FUNDING_STREAM_SPECIFICATION, LOCKBOX_SPECIFICATION, MAX_BLOCK_SUBSIDY,
@@ -445,14 +448,120 @@ pub fn halving(height: Height, network: &Network) -> u32 {
         .expect("already checked for negatives")
 }
 
+#[cfg(all(zcash_unstable = "zip234", zcash_unstable = "zip234alt"))]
+compile_error!("`zip234` and `zip234alt` are mutually exclusive");
+
 /// Returns the height at which ZIP-234 applies (lowest height after the second halving following NU7).
 ///
 /// Returns `None` when NU7 isn't configured.
-#[cfg(zcash_unstable = "zip234")]
+#[cfg(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt"))]
 pub fn zip234_start_height(net: &Network) -> Option<Height> {
     let nu7 = NetworkUpgrade::Nu7.activation_height(net)?;
     let target_halving = halving(nu7, net).checked_add(2)?;
     height_for_halving(target_halving, net)
+}
+
+/// The halving-based block subsidy at `height` (i.e. ZIP-234 smoothing branches not applied).
+#[cfg(zcash_unstable = "zip234alt")]
+pub(crate) fn halving_subsidy_at(height: Height, net: &Network) -> Amount<NonNegative> {
+    let Some(halving_div) = halving_divisor(height, net) else {
+        return Amount::zero();
+    };
+    let slow_start_interval = net.slow_start_interval();
+    let amount = if height < slow_start_interval {
+        let slow_start_rate = MAX_BLOCK_SUBSIDY / u64::from(slow_start_interval);
+        if height < net.slow_start_shift() {
+            slow_start_rate * u64::from(height)
+        } else {
+            slow_start_rate * (u64::from(height) + 1)
+        }
+    } else {
+        let base = if NetworkUpgrade::current(net, height) < NetworkUpgrade::Blossom {
+            MAX_BLOCK_SUBSIDY
+        } else {
+            MAX_BLOCK_SUBSIDY / u64::from(BLOSSOM_POW_TARGET_SPACING_RATIO)
+        };
+        base / halving_div
+    };
+    Amount::try_from(amount).expect("halving subsidy is non-negative and bounded by MAX_BLOCK_SUBSIDY")
+}
+
+/// Cumulative halving-only block subsidies issued for blocks 1..=`height`.
+/// Used by `zip234alt` to compute the burned-and-unrecycled deficit as `expected_supply − actual_supply`.
+#[cfg(zcash_unstable = "zip234alt")]
+pub fn cumulative_halving_subsidies(net: &Network, height: Height) -> Amount<NonNegative> {
+    let h = u64::from(height.0);
+    let ss_shift = u64::from(net.slow_start_shift().0);
+    let ss_interval = u64::from(net.slow_start_interval().0);
+    let blossom = u64::from(
+        NetworkUpgrade::Blossom
+            .activation_height(net)
+            .expect("blossom activation height should be available")
+            .0,
+    );
+    let ss_rate = MAX_BLOCK_SUBSIDY / ss_interval;
+
+    let mut total: u128 = 0;
+
+    // Slow-start phase 1
+    let s1_end = h.min(ss_shift);
+    if s1_end >= 2 {
+        let n = s1_end - 1;
+        total += u128::from(n) * u128::from(n + 1) / 2 * u128::from(ss_rate);
+    }
+
+    // Slow-start phase 2
+    if h > ss_shift {
+        let e = h.min(ss_interval);
+        let sum_to_e = u128::from(e) * u128::from(e + 1) / 2;
+        let sum_below = u128::from(ss_shift) * u128::from(ss_shift + 1) / 2;
+        total += (sum_to_e - sum_below) * u128::from(ss_rate);
+    }
+
+    // Halving eras
+    if h > ss_interval {
+        let mut era: u32 = 0;
+        loop {
+            let era_start = u64::from(height_for_halving(era, net).expect("era start").0);
+            if era_start >= h {
+                break;
+            }
+            let next_era_start =
+                u64::from(height_for_halving(era + 1, net).unwrap_or(Height::MAX).0);
+            let era_end = next_era_start.min(h);
+            let clipped_start = era_start.max(ss_interval);
+            if clipped_start >= era_end {
+                era += 1;
+                continue;
+            }
+
+            // pre-blossom slice
+            if clipped_start < blossom {
+                let pre_end = era_end.min(blossom);
+                let blocks = u128::from(pre_end - clipped_start);
+                let subsidy = MAX_BLOCK_SUBSIDY >> era;
+                total += blocks * u128::from(subsidy);
+            }
+
+            // post-blossom slice
+            if era_end > blossom {
+                let post_start = clipped_start.max(blossom);
+                let blocks = u128::from(era_end - post_start);
+                let subsidy = (MAX_BLOCK_SUBSIDY / 2) >> era;
+                if subsidy == 0 {
+                    break;
+                }
+                total += blocks * u128::from(subsidy);
+            }
+
+            era += 1;
+        }
+    }
+
+    let total_i64 = i64::try_from(total).expect("cumulative subsidies fit in i64");
+    total_i64
+        .try_into()
+        .expect("cumulative subsidies are ≤ MAX_MONEY")
 }
 
 /// `BlockSubsidy(height)` as described in [protocol specification §7.8][7.8]
@@ -466,10 +575,10 @@ pub fn block_subsidy(
     money_reserve: Option<Amount<NonNegative>>,
 ) -> Result<Amount<NonNegative>, SubsidyError> {
     #[cfg(zcash_unstable = "zip234")]
+    // ZIP-234 smoothed subsidy
+    //
     if let Some(start) = zip234_start_height(net) {
         if height >= start {
-            // ZIP-234 `BLOCK_SUBSIDY_FRACTION`, calibrated so
-            // `(1 − 4126/10¹⁰)^POST_BLOSSOM_HALVING_INTERVAL ≈ 0.5` within ±0.002%.
             const NUMERATOR: u128 = 4_126;
             const DENOMINATOR: u128 = 10_000_000_000;
 
@@ -492,7 +601,43 @@ pub fn block_subsidy(
         }
     }
 
-    // Pre ZIP-234 subsidy calculation.
+    // ZIP-234 (alt) halving-based subsidy
+    //
+    #[cfg(zcash_unstable = "zip234alt")]
+    if let Some(start) = zip234_start_height(net) {
+        if height >= start {
+            const NUMERATOR: u128 = 4_126;
+            const DENOMINATOR: u128 = 10_000_000_000;
+
+            let money_reserve = money_reserve
+                .expect("money_reserve is required at post-activation heights");
+
+            // Halving subsidy at this height (the base).
+            let halving = halving_subsidy_at(height, net);
+
+            // deficit = expected_supply(parent) − actual_supply(parent)
+            //         = cumulative_halvings(h-1) − (MAX_MONEY − money_reserve)
+            let parent = height.previous().unwrap_or(Height(0));
+            let expected_supply: i64 =
+                cumulative_halving_subsidies(net, parent).into();
+            let actual_supply: i64 =
+                (MAX_MONEY as i64) - i64::from(money_reserve);
+            let deficit = expected_supply.saturating_sub(actual_supply).max(0);
+
+            let bonus_u128 = u128::from(u64::try_from(deficit).expect("deficit non-negative"))
+                .checked_mul(NUMERATOR)
+                .expect("deficit ≤ MAX_MONEY, * 4126 fits in u128")
+                .div_ceil(DENOMINATOR);
+            let bonus = i64::try_from(bonus_u128).expect("bonus fits in i64");
+            let bonus: Amount<NonNegative> = bonus
+                .try_into()
+                .expect("bonus is non-negative and bounded by deficit");
+
+            return Ok((halving + bonus)?);
+        }
+    }
+
+    // Pre ZIP-234 subsidy calculation
     //
     let Some(halving_div) = halving_divisor(height, net) else {
         return Ok(Amount::zero());

--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -1219,4 +1219,5 @@ impl Network {
             Network::Testnet(_) => &testnet::FOUNDER_ADDRESS_LIST,
         }
     }
+
 }

--- a/zebra-chain/src/parameters/network/tests.rs
+++ b/zebra-chain/src/parameters/network/tests.rs
@@ -163,25 +163,25 @@ fn block_subsidy_for_network(network: &Network) -> Result<(), Report> {
     // https://z.cash/support/faq/#what-is-slow-start-mining
     assert_eq!(
         Amount::<NonNegative>::try_from(1_250_000_000)?,
-        block_subsidy((network.slow_start_interval() + 1).unwrap(), network)?
+        block_subsidy((network.slow_start_interval() + 1).unwrap(), network, None)?
     );
     assert_eq!(
         Amount::<NonNegative>::try_from(1_250_000_000)?,
-        block_subsidy((blossom_height - 1).unwrap(), network)?
+        block_subsidy((blossom_height - 1).unwrap(), network, None)?
     );
 
     // After Blossom the block subsidy is reduced to 6.25 ZEC without halving
     // https://z.cash/upgrade/blossom/
     assert_eq!(
         Amount::<NonNegative>::try_from(625_000_000)?,
-        block_subsidy(blossom_height, network)?
+        block_subsidy(blossom_height, network, None)?
     );
 
     // After the 1st halving, the block subsidy is reduced to 3.125 ZEC
     // https://z.cash/upgrade/canopy/
     assert_eq!(
         Amount::<NonNegative>::try_from(312_500_000)?,
-        block_subsidy(first_halving_height, network)?
+        block_subsidy(first_halving_height, network, None)?
     );
 
     // After the 2nd halving, the block subsidy is reduced to 1.5625 ZEC
@@ -190,7 +190,8 @@ fn block_subsidy_for_network(network: &Network) -> Result<(), Report> {
         Amount::<NonNegative>::try_from(156_250_000)?,
         block_subsidy(
             (first_halving_height + POST_BLOSSOM_HALVING_INTERVAL).unwrap(),
-            network
+            network,
+            None,
         )?
     );
 
@@ -200,7 +201,8 @@ fn block_subsidy_for_network(network: &Network) -> Result<(), Report> {
         Amount::<NonNegative>::try_from(4_882_812)?,
         block_subsidy(
             (first_halving_height + (POST_BLOSSOM_HALVING_INTERVAL * 6)).unwrap(),
-            network
+            network,
+            None,
         )?
     );
 
@@ -210,7 +212,8 @@ fn block_subsidy_for_network(network: &Network) -> Result<(), Report> {
         Amount::<NonNegative>::try_from(1)?,
         block_subsidy(
             (first_halving_height + (POST_BLOSSOM_HALVING_INTERVAL * 28)).unwrap(),
-            network
+            network,
+            None,
         )?
     );
 
@@ -220,7 +223,8 @@ fn block_subsidy_for_network(network: &Network) -> Result<(), Report> {
         Amount::<NonNegative>::try_from(0)?,
         block_subsidy(
             (first_halving_height + (POST_BLOSSOM_HALVING_INTERVAL * 29)).unwrap(),
-            network
+            network,
+            None,
         )?
     );
 
@@ -228,7 +232,8 @@ fn block_subsidy_for_network(network: &Network) -> Result<(), Report> {
         Amount::<NonNegative>::try_from(0)?,
         block_subsidy(
             (first_halving_height + (POST_BLOSSOM_HALVING_INTERVAL * 39)).unwrap(),
-            network
+            network,
+            None,
         )?
     );
 
@@ -236,7 +241,8 @@ fn block_subsidy_for_network(network: &Network) -> Result<(), Report> {
         Amount::<NonNegative>::try_from(0)?,
         block_subsidy(
             (first_halving_height + (POST_BLOSSOM_HALVING_INTERVAL * 49)).unwrap(),
-            network
+            network,
+            None,
         )?
     );
 
@@ -244,7 +250,8 @@ fn block_subsidy_for_network(network: &Network) -> Result<(), Report> {
         Amount::<NonNegative>::try_from(0)?,
         block_subsidy(
             (first_halving_height + (POST_BLOSSOM_HALVING_INTERVAL * 59)).unwrap(),
-            network
+            network,
+            None,
         )?
     );
 
@@ -253,7 +260,8 @@ fn block_subsidy_for_network(network: &Network) -> Result<(), Report> {
         Amount::<NonNegative>::try_from(0)?,
         block_subsidy(
             (first_halving_height + (POST_BLOSSOM_HALVING_INTERVAL * 62)).unwrap(),
-            network
+            network,
+            None
         )?
     );
 
@@ -262,7 +270,8 @@ fn block_subsidy_for_network(network: &Network) -> Result<(), Report> {
         Amount::<NonNegative>::try_from(0)?,
         block_subsidy(
             (first_halving_height + (POST_BLOSSOM_HALVING_INTERVAL * 63)).unwrap(),
-            network
+            network,
+            None
         )?
     );
 
@@ -270,24 +279,211 @@ fn block_subsidy_for_network(network: &Network) -> Result<(), Report> {
         Amount::<NonNegative>::try_from(0)?,
         block_subsidy(
             (first_halving_height + (POST_BLOSSOM_HALVING_INTERVAL * 64)).unwrap(),
-            network
+            network,
+            None
         )?
     );
 
     assert_eq!(
         Amount::<NonNegative>::try_from(0)?,
-        block_subsidy(Height(Height::MAX_AS_U32 / 4), network)?
+        block_subsidy(Height(Height::MAX_AS_U32 / 4), network, None)?
     );
 
     assert_eq!(
         Amount::<NonNegative>::try_from(0)?,
-        block_subsidy(Height(Height::MAX_AS_U32 / 2), network)?
+        block_subsidy(Height(Height::MAX_AS_U32 / 2), network, None)?
     );
 
     assert_eq!(
         Amount::<NonNegative>::try_from(0)?,
-        block_subsidy(Height::MAX, network)?
+        block_subsidy(Height::MAX, network, None)?
     );
+
+    Ok(())
+}
+
+#[cfg(zcash_unstable = "zip234")]
+#[test]
+fn check_block_subsidy_reserve_decreases() -> Result<(), Report> {
+    use crate::{amount::MAX_MONEY, parameters::subsidy::zip234_start_height};
+
+    let network = zip234_testnet(1);
+    let mut reserve: Amount<NonNegative> = MAX_MONEY.try_into()?;
+    let first_height = zip234_start_height(&network).expect("NU7 configured");
+    let last_height = Height::MAX;
+
+    let mut heights = vec![first_height, last_height];
+    let mut h = first_height;
+    while h < last_height {
+        heights.push(h);
+        h = (h + 100_000).unwrap_or(last_height)
+    }
+
+    heights.sort_unstable();
+    heights.dedup();
+
+    let mut prev_subsidy = reserve;
+    for &height in &heights {
+        let subsidy = block_subsidy(height, &network, Some(reserve))?;
+        assert!(
+            subsidy < reserve,
+            "subsidy ({subsidy:?}) exceeds reserve ({reserve:?}) at height ({height:?})"
+        );
+
+        assert!(
+            subsidy < prev_subsidy,
+            "subsidy ({subsidy:?}) did not decrease at height ({height:?})"
+        );
+
+        prev_subsidy = subsidy;
+
+        let result = reserve.checked_sub(subsidy).expect("reserve went negative");
+        reserve = Amount::<NonNegative>::try_from(i64::from(result))
+            .expect("reserve should be non-negative");
+    }
+
+    assert!(
+        reserve >= Amount::<NonNegative>::zero(),
+        "reserve should be non-negative"
+    );
+
+    Ok(())
+}
+
+/// Testnet with NU7 at `nu7` and no funding streams.
+#[cfg(zcash_unstable = "zip234")]
+fn zip234_testnet(nu7: u32) -> Network {
+    use crate::parameters::testnet::{self, ConfiguredActivationHeights};
+    testnet::Parameters::build()
+        .with_activation_heights(ConfiguredActivationHeights {
+            nu7: Some(nu7),
+            ..Default::default()
+        })
+        .unwrap()
+        .clear_funding_streams()
+        .to_network()
+        .unwrap()
+}
+
+/// ZIP-234 start = `height_for_halving(halving(nu7) + 2, network)`.
+#[cfg(zcash_unstable = "zip234")]
+#[test]
+fn check_zip234_start_height_derivation() -> Result<(), Report> {
+    use crate::parameters::subsidy::{halving, zip234_start_height};
+
+    for nu7 in [1u32, 100, 500_000, 1_000_000] {
+        let net = zip234_testnet(nu7);
+        let nu7_height = Height(nu7);
+        let expected = height_for_halving(halving(nu7_height, &net) + 2, &net)
+            .expect("derivation should not overflow for in-range NU7");
+        assert_eq!(
+            zip234_start_height(&net),
+            Some(expected),
+            "derivation mismatch for NU7={nu7}",
+        );
+    }
+
+    Ok(())
+}
+
+/// At `start − 1`: halving path, reserve ignored. At `start`: smoothed formula.
+#[cfg(zcash_unstable = "zip234")]
+#[test]
+fn check_block_subsidy_zip234_activation_boundary() -> Result<(), Report> {
+    use crate::parameters::subsidy::zip234_start_height;
+
+    let net = zip234_testnet(1);
+    let start = zip234_start_height(&net).expect("NU7 configured");
+    let pre_activation = (start - 1).unwrap();
+
+    let pre = block_subsidy(pre_activation, &net, None)?;
+    let pre_with_reserve =
+        block_subsidy(pre_activation, &net, Some(Amount::try_from(123_456)?))?;
+    assert_eq!(pre, pre_with_reserve);
+
+    let reserve = Amount::<NonNegative>::try_from(10_000_000_000_i64)?;
+    let subsidy = block_subsidy(start, &net, Some(reserve))?;
+    assert_eq!(subsidy, Amount::<NonNegative>::try_from(4_126)?);
+
+    Ok(())
+}
+
+/// Ceiling rounding: reserve = 1 → subsidy = 1 (floor would give 0).
+#[cfg(zcash_unstable = "zip234")]
+#[test]
+fn check_block_subsidy_zip234_ceiling_at_one_zat() -> Result<(), Report> {
+    use crate::parameters::subsidy::zip234_start_height;
+
+    let net = zip234_testnet(1);
+    let height = zip234_start_height(&net).expect("NU7 configured");
+    let one = Amount::<NonNegative>::try_from(1)?;
+    assert_eq!(block_subsidy(height, &net, Some(one))?, one);
+    Ok(())
+}
+
+/// Reserve = 0 → subsidy = 0.
+#[cfg(zcash_unstable = "zip234")]
+#[test]
+fn check_block_subsidy_zip234_zero_reserve() -> Result<(), Report> {
+    use crate::parameters::subsidy::zip234_start_height;
+
+    let net = zip234_testnet(1);
+    let height = zip234_start_height(&net).expect("NU7 configured");
+    let zero = Amount::<NonNegative>::zero();
+    assert_eq!(block_subsidy(height, &net, Some(zero))?, zero);
+    Ok(())
+}
+
+/// Reserve = 10¹⁰ → subsidy = 4126 (pins the exact spec rational).
+#[cfg(zcash_unstable = "zip234")]
+#[test]
+fn check_block_subsidy_zip234_exact_fraction() -> Result<(), Report> {
+    use crate::parameters::subsidy::zip234_start_height;
+
+    let net = zip234_testnet(1);
+    let height = zip234_start_height(&net).expect("NU7 configured");
+    let reserve = Amount::<NonNegative>::try_from(10_000_000_000_i64)?;
+    let expected = Amount::<NonNegative>::try_from(4_126)?;
+    assert_eq!(block_subsidy(height, &net, Some(reserve))?, expected);
+    Ok(())
+}
+
+/// ZIP-235 burns increase money reserve by exactly the burned amount.
+#[cfg(zcash_unstable = "zip234")]
+#[test]
+fn check_zip234_money_reserve_recovers_from_burns() -> Result<(), Report> {
+    use crate::{
+        amount::NegativeAllowed, parameters::subsidy::zip234_start_height,
+        value_balance::ValueBalance,
+    };
+
+    let net = zip234_testnet(1);
+    let height = zip234_start_height(&net).expect("NU7 configured");
+
+    let initial_pool = ValueBalance::<NonNegative>::zero();
+    let initial_reserve = initial_pool.money_reserve();
+
+    let subsidy = block_subsidy(height, &net, Some(initial_reserve))?;
+    let subsidy_signed: Amount<NegativeAllowed> = subsidy.constrain()?;
+
+    let pool_without_burn = initial_pool.add_chain_value_pool_change(
+        ValueBalance::<NegativeAllowed>::from_transparent_amount(subsidy_signed),
+    )?;
+    let reserve_without_burn = pool_without_burn.money_reserve();
+
+    let burned = Amount::<NonNegative>::try_from(1_000_000_i64)?;
+    let burned_signed: Amount<NegativeAllowed> = burned.constrain()?;
+    let pool_with_burn = initial_pool.add_chain_value_pool_change(
+        ValueBalance::<NegativeAllowed>::from_transparent_amount(
+            (subsidy_signed - burned_signed)?,
+        ),
+    )?;
+    let reserve_with_burn = pool_with_burn.money_reserve();
+
+    assert!(reserve_with_burn > reserve_without_burn);
+    let recovery: Amount<NegativeAllowed> = (reserve_with_burn.constrain::<NegativeAllowed>()?
+        - reserve_without_burn.constrain::<NegativeAllowed>()?)?;
+    assert_eq!(recovery, burned_signed);
 
     Ok(())
 }

--- a/zebra-chain/src/parameters/network/tests.rs
+++ b/zebra-chain/src/parameters/network/tests.rs
@@ -351,7 +351,7 @@ fn check_block_subsidy_reserve_decreases() -> Result<(), Report> {
 }
 
 /// Testnet with NU7 at `nu7` and no funding streams.
-#[cfg(zcash_unstable = "zip234")]
+#[cfg(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt"))]
 fn zip234_testnet(nu7: u32) -> Network {
     use crate::parameters::testnet::{self, ConfiguredActivationHeights};
     testnet::Parameters::build()
@@ -484,6 +484,75 @@ fn check_zip234_money_reserve_recovers_from_burns() -> Result<(), Report> {
     let recovery: Amount<NegativeAllowed> = (reserve_with_burn.constrain::<NegativeAllowed>()?
         - reserve_without_burn.constrain::<NegativeAllowed>()?)?;
     assert_eq!(recovery, burned_signed);
+
+    Ok(())
+}
+
+#[cfg(zcash_unstable = "zip234alt")]
+#[test]
+fn check_zip234alt_zero_deficit_equals_halving() -> Result<(), Report> {
+    use crate::{
+        amount::MAX_MONEY,
+        parameters::subsidy::{cumulative_halving_subsidies, halving_subsidy_at, zip234_start_height},
+    };
+
+    let net = zip234_testnet(1);
+    let height = zip234_start_height(&net).expect("NU7 configured");
+    let parent = height.previous().unwrap();
+
+    // money_reserve corresponding to *zero* burns: actual_supply == expected_supply.
+    let expected: i64 = cumulative_halving_subsidies(&net, parent).into();
+    let money_reserve = Amount::<NonNegative>::try_from(MAX_MONEY - expected)?;
+
+    let nsmalt = block_subsidy(height, &net, Some(money_reserve))?;
+    assert_eq!(nsmalt, halving_subsidy_at(height, &net));
+
+    Ok(())
+}
+
+#[cfg(zcash_unstable = "zip234alt")]
+#[test]
+fn check_zip234alt_bonus_exact_fraction() -> Result<(), Report> {
+    use crate::{
+        amount::MAX_MONEY,
+        parameters::subsidy::{cumulative_halving_subsidies, halving_subsidy_at, zip234_start_height},
+    };
+
+    let net = zip234_testnet(1);
+    let height = zip234_start_height(&net).expect("NU7 configured");
+    let parent = height.previous().unwrap();
+
+    // Construct money_reserve so deficit == 10¹⁰ zat (denominator).
+    let expected: i64 = cumulative_halving_subsidies(&net, parent).into();
+    let actual_supply = expected - 10_000_000_000;
+    let money_reserve = Amount::<NonNegative>::try_from(MAX_MONEY - actual_supply)?;
+
+    let nsmalt = block_subsidy(height, &net, Some(money_reserve))?;
+    let bonus = (nsmalt - halving_subsidy_at(height, &net))?;
+    assert_eq!(bonus, Amount::<NonNegative>::try_from(4_126)?);
+
+    Ok(())
+}
+
+#[cfg(zcash_unstable = "zip234alt")]
+#[test]
+fn check_zip234alt_bonus_ceiling_at_one_zat_deficit() -> Result<(), Report> {
+    use crate::{
+        amount::MAX_MONEY,
+        parameters::subsidy::{cumulative_halving_subsidies, halving_subsidy_at, zip234_start_height},
+    };
+
+    let net = zip234_testnet(1);
+    let height = zip234_start_height(&net).expect("NU7 configured");
+    let parent = height.previous().unwrap();
+
+    let expected: i64 = cumulative_halving_subsidies(&net, parent).into();
+    let actual_supply = expected - 1;
+    let money_reserve = Amount::<NonNegative>::try_from(MAX_MONEY - actual_supply)?;
+
+    let nsmalt = block_subsidy(height, &net, Some(money_reserve))?;
+    let bonus = (nsmalt - halving_subsidy_at(height, &net))?;
+    assert_eq!(bonus, Amount::<NonNegative>::try_from(1)?);
 
     Ok(())
 }

--- a/zebra-chain/src/parameters/network/tests/vectors.rs
+++ b/zebra-chain/src/parameters/network/tests/vectors.rs
@@ -597,7 +597,7 @@ fn lockbox_input_value(network: &Network, height: Height) -> Amount<NonNegative>
         return Amount::zero();
     };
 
-    let total_block_subsidy = block_subsidy(height, network).unwrap();
+    let total_block_subsidy = block_subsidy(height, network, None).unwrap();
     let &deferred_amount_per_block =
         funding_stream_values(nu6_activation_height, network, total_block_subsidy)
             .expect("we always expect a funding stream hashmap response even if empty")

--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -10,7 +10,12 @@ use std::{borrow::Borrow, collections::HashMap};
 #[cfg(any(test, feature = "proptest-impl"))]
 use crate::{transaction::Transaction, transparent};
 
-#[cfg(any(test, feature = "proptest-impl", zcash_unstable = "zip234"))]
+#[cfg(any(
+    test,
+    feature = "proptest-impl",
+    zcash_unstable = "zip234",
+    zcash_unstable = "zip234alt"
+))]
 use crate::amount::MAX_MONEY;
 
 #[cfg(any(test, feature = "proptest-impl"))]
@@ -298,7 +303,7 @@ impl ValueBalance<NonNegative> {
     }
 
     /// ZIP-234 money reserve: `MAX_MONEY − IssuedSupply`.
-    #[cfg(zcash_unstable = "zip234")]
+    #[cfg(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt"))]
     pub fn money_reserve(&self) -> Amount<NonNegative> {
         let max_money = Amount::<NonNegative>::try_from(MAX_MONEY)
             .expect("MAX_MONEY must be a valid NonNegative Amount");

--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -8,7 +8,10 @@ use core::fmt;
 use std::{borrow::Borrow, collections::HashMap};
 
 #[cfg(any(test, feature = "proptest-impl"))]
-use crate::{amount::MAX_MONEY, transaction::Transaction, transparent};
+use crate::{transaction::Transaction, transparent};
+
+#[cfg(any(test, feature = "proptest-impl", zcash_unstable = "zip234"))]
+use crate::amount::MAX_MONEY;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 mod arbitrary;
@@ -292,6 +295,15 @@ impl ValueBalance<NonNegative> {
         chain_value_pool = (chain_value_pool + chain_value_pool_change)?;
 
         chain_value_pool.constrain()
+    }
+
+    /// ZIP-234 money reserve: `MAX_MONEY − IssuedSupply`.
+    #[cfg(zcash_unstable = "zip234")]
+    pub fn money_reserve(&self) -> Amount<NonNegative> {
+        let max_money = Amount::<NonNegative>::try_from(MAX_MONEY)
+            .expect("MAX_MONEY must be a valid NonNegative Amount");
+        (max_money - self.transparent - self.sprout - self.sapling - self.orchard - self.deferred)
+            .expect("result must be bounded by MAX_MONEY via consensus rules")
     }
 
     /// Create a fake value pool for testing purposes.

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -245,8 +245,42 @@ where
                 .map_err(VerifyBlockError::Time)?;
             let coinbase_tx = check::coinbase_is_first(&block)?;
 
-            let expected_block_subsidy =
-                zebra_chain::parameters::subsidy::block_subsidy(height, &network)?;
+            // After ZIP-234 activation, block subsidies require a money reserve which can be derived from the parent block's BlockInfo.
+            #[cfg(zcash_unstable = "zip234")]
+            let money_reserve = match zebra_chain::parameters::subsidy::zip234_start_height(&network)
+            {
+                Some(start) if height >= start => {
+                    let parent_hash = block.header.previous_block_hash;
+                    let zs::Response::BlockInfo(info) = state_service
+                        .ready()
+                        .await
+                        .map_err(|source| VerifyBlockError::StateService { source, hash })?
+                        .call(zs::Request::BlockInfo(parent_hash.into()))
+                        .await
+                        .map_err(|source| VerifyBlockError::StateService { source, hash })?
+                    else {
+                        unreachable!("wrong response to Request::BlockInfo");
+                    };
+
+                    Some(
+                        info.ok_or(BlockError::Other(format!(
+                            "parent block {parent_hash:?} of {hash:?} not found in any chain; \
+                             cannot derive ZIP-234 money reserve"
+                        )))?
+                        .value_pools()
+                        .money_reserve(),
+                    )
+                }
+                _ => None,
+            };
+            #[cfg(not(zcash_unstable = "zip234"))]
+            let money_reserve = None;
+
+            let expected_block_subsidy = zebra_chain::parameters::subsidy::block_subsidy(
+                height,
+                &network,
+                money_reserve,
+            )?;
 
             // See [ZIP-1015](https://zips.z.cash/zip-1015).
             let deferred_pool_balance_change =

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -246,7 +246,7 @@ where
             let coinbase_tx = check::coinbase_is_first(&block)?;
 
             // After ZIP-234 activation, block subsidies require a money reserve which can be derived from the parent block's BlockInfo.
-            #[cfg(zcash_unstable = "zip234")]
+            #[cfg(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt"))]
             let money_reserve = match zebra_chain::parameters::subsidy::zip234_start_height(&network)
             {
                 Some(start) if height >= start => {
@@ -273,7 +273,7 @@ where
                 }
                 _ => None,
             };
-            #[cfg(not(zcash_unstable = "zip234"))]
+            #[cfg(not(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt")))]
             let money_reserve = None;
 
             let expected_block_subsidy = zebra_chain::parameters::subsidy::block_subsidy(

--- a/zebra-consensus/src/block/subsidy/tests.rs
+++ b/zebra-consensus/src/block/subsidy/tests.rs
@@ -87,7 +87,8 @@ fn test_funding_stream_values() -> Result<(), Report> {
         nu6_1_fund_height_range.end,
         nu6_1_fund_height_range.end.next().unwrap(),
     ] {
-        let fsv = funding_stream_values(height, network, block_subsidy(height, network)?).unwrap();
+        let fsv =
+            funding_stream_values(height, network, block_subsidy(height, network, None)?).unwrap();
 
         if height < canopy_activation_height {
             assert!(fsv.is_empty());

--- a/zebra-consensus/src/block/tests.rs
+++ b/zebra-consensus/src/block/tests.rs
@@ -306,7 +306,7 @@ fn subsidy_is_valid_for_network(network: Network) -> Result<(), Report> {
         // TODO: first halving, second halving, third halving, and very large halvings
         if height >= canopy_activation_height {
             let expected_block_subsidy =
-                zebra_chain::parameters::subsidy::block_subsidy(height, &network)
+                zebra_chain::parameters::subsidy::block_subsidy(height, &network, None)
                     .expect("valid block subsidy");
 
             check::subsidy_is_valid(&block, &network, expected_block_subsidy)
@@ -334,6 +334,7 @@ fn coinbase_validation_failure() -> Result<(), Report> {
             .coinbase_height()
             .expect("block should have coinbase height"),
         &network,
+        None,
     )
     .expect("valid block subsidy");
 
@@ -360,6 +361,7 @@ fn coinbase_validation_failure() -> Result<(), Report> {
             .coinbase_height()
             .expect("block should have coinbase height"),
         &network,
+        None,
     )
     .expect("valid block subsidy");
 
@@ -400,6 +402,7 @@ fn coinbase_validation_failure() -> Result<(), Report> {
             .coinbase_height()
             .expect("block should have coinbase height"),
         &network,
+        None,
     )
     .expect("valid block subsidy");
 
@@ -432,7 +435,7 @@ fn funding_stream_validation_for_network(network: Network) -> Result<(), Report>
         if height >= canopy_activation_height {
             let block = Block::zcash_deserialize(&block[..]).expect("block should deserialize");
             let expected_block_subsidy =
-                zebra_chain::parameters::subsidy::block_subsidy(height, &network)
+                zebra_chain::parameters::subsidy::block_subsidy(height, &network, None)
                     .expect("valid block subsidy");
 
             // Validate
@@ -485,6 +488,7 @@ fn funding_stream_validation_failure() -> Result<(), Report> {
             .coinbase_height()
             .expect("block should have coinbase height"),
         &network,
+        None,
     )
     .expect("valid block subsidy");
 
@@ -516,7 +520,7 @@ fn miner_fees_validation_for_network(network: Network) -> Result<(), Report> {
             let block = Block::zcash_deserialize(&block[..]).expect("block should deserialize");
             let coinbase_tx = check::coinbase_is_first(&block)?;
 
-            let expected_block_subsidy = block_subsidy(height, &network)?;
+            let expected_block_subsidy = block_subsidy(height, &network, None)?;
             // See [ZIP-1015](https://zips.z.cash/zip-1015).
             let deferred_pool_balance_change =
                 match NetworkUpgrade::Canopy.activation_height(&network) {
@@ -549,7 +553,7 @@ fn miner_fees_validation_failure() -> Result<(), Report> {
     let block = Block::zcash_deserialize(&zebra_test::vectors::BLOCK_MAINNET_347499_BYTES[..])
         .expect("block should deserialize");
     let height = block.coinbase_height().expect("valid coinbase height");
-    let expected_block_subsidy = block_subsidy(height, &network)?;
+    let expected_block_subsidy = block_subsidy(height, &network, None)?;
     // See [ZIP-1015](https://zips.z.cash/zip-1015).
     let deferred_pool_balance_change = match NetworkUpgrade::Canopy.activation_height(&network) {
         Some(activation_height) if height >= activation_height => {

--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -611,9 +611,12 @@ where
         }
 
         // See [ZIP-1015](https://zips.z.cash/zip-1015).
-        let expected_deferred_amount =
-            funding_stream_values(height, &self.network, block_subsidy(height, &self.network)?)?
-                .remove(&FundingStreamReceiver::Deferred);
+        let expected_deferred_amount = funding_stream_values(
+            height,
+            &self.network,
+            block_subsidy(height, &self.network, None)?,
+        )?
+        .remove(&FundingStreamReceiver::Deferred);
 
         let deferred_pool_balance_change = expected_deferred_amount
             .unwrap_or_default()

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -2372,7 +2372,7 @@ where
                 // when the tip changes.
                 let precompute_coinbase = |network, height, params| {
                     tokio::task::spawn_blocking(move || {
-                        TransactionTemplate::new_coinbase(&network, height, &params, Amount::zero())
+                        TransactionTemplate::new_coinbase(&network, height, &params, Amount::zero(), None)
                             .expect("valid coinbase tx")
                     })
                 };
@@ -2510,6 +2510,7 @@ where
             mempool_txs,
             mempool_tx_deps,
             #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+            None,
             None,
         );
 
@@ -2796,7 +2797,34 @@ where
             None => best_chain_tip_height(&self.latest_chain_tip)?,
         };
 
-        let subsidy = block_subsidy(height, &net).map_misc_error()?;
+        #[cfg(not(zcash_unstable = "zip234"))]
+        let money_reserve = None;
+
+        #[cfg(zcash_unstable = "zip234")]
+        let money_reserve = match zebra_chain::parameters::subsidy::zip234_start_height(&net) {
+            Some(start) if height >= start => {
+                let parent =
+                    (height - 1).ok_or_misc_error("cannot get block subsidy for height 0")?;
+                let ReadResponse::BlockInfo(info) = self
+                    .read_state
+                    .clone()
+                    .oneshot(ReadRequest::BlockInfo(parent.into()))
+                    .await
+                    .map_misc_error()?
+                else {
+                    unreachable!("unmatched response for BlockInfo request")
+                };
+
+                Some(
+                    info.ok_or_misc_error("no block info available for parent height")?
+                        .value_pools()
+                        .money_reserve(),
+                )
+            }
+            _ => None,
+        };
+
+        let subsidy = block_subsidy(height, &net, money_reserve).map_misc_error()?;
 
         let (lockbox_streams, mut funding_streams): (Vec<_>, Vec<_>) =
             funding_stream_values(height, &net, subsidy)

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -2797,10 +2797,10 @@ where
             None => best_chain_tip_height(&self.latest_chain_tip)?,
         };
 
-        #[cfg(not(zcash_unstable = "zip234"))]
+        #[cfg(not(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt")))]
         let money_reserve = None;
 
-        #[cfg(zcash_unstable = "zip234")]
+        #[cfg(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt"))]
         let money_reserve = match zebra_chain::parameters::subsidy::zip234_start_height(&net) {
             Some(start) if height >= start => {
                 let parent =

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -407,7 +407,9 @@ proptest! {
                             expected_difficulty: Default::default(),
                             cur_time: DateTime32::now(),
                             min_time: DateTime32::now(),
-                            max_time: DateTime32::now()
+                            max_time: DateTime32::now(),
+                            #[cfg(zcash_unstable = "zip234")]
+                            value_pools: Default::default(),
                         }));
                 }
             };
@@ -481,7 +483,9 @@ proptest! {
                             expected_difficulty: Default::default(),
                             cur_time: DateTime32::now(),
                             min_time: DateTime32::now(),
-                            max_time: DateTime32::now()
+                            max_time: DateTime32::now(),
+                            #[cfg(zcash_unstable = "zip234")]
+                            value_pools: Default::default(),
                         }));
                 }
             };

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -408,7 +408,7 @@ proptest! {
                             cur_time: DateTime32::now(),
                             min_time: DateTime32::now(),
                             max_time: DateTime32::now(),
-                            #[cfg(zcash_unstable = "zip234")]
+                            #[cfg(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt"))]
                             value_pools: Default::default(),
                         }));
                 }
@@ -484,7 +484,7 @@ proptest! {
                             cur_time: DateTime32::now(),
                             min_time: DateTime32::now(),
                             max_time: DateTime32::now(),
-                            #[cfg(zcash_unstable = "zip234")]
+                            #[cfg(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt"))]
                             value_pools: Default::default(),
                         }));
                 }

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -1175,7 +1175,7 @@ pub async fn test_mining_rpcs<State, ReadState>(
                     min_time: fake_min_time,
                     max_time: fake_max_time,
                     chain_history_root: fake_history_tree(network).hash(),
-                    #[cfg(zcash_unstable = "zip234")]
+                    #[cfg(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt"))]
                     value_pools: Default::default(),
                 }));
         }

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -1175,6 +1175,8 @@ pub async fn test_mining_rpcs<State, ReadState>(
                     min_time: fake_min_time,
                     max_time: fake_max_time,
                     chain_history_root: fake_history_tree(network).hash(),
+                    #[cfg(zcash_unstable = "zip234")]
+                    value_pools: Default::default(),
                 }));
         }
     };

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -92,7 +92,7 @@ async fn rpc_getinfo() {
             cur_time: zebra_chain::serialization::DateTime32::now(),
             min_time: zebra_chain::serialization::DateTime32::now(),
             max_time: zebra_chain::serialization::DateTime32::now(),
-            #[cfg(zcash_unstable = "zip234")]
+            #[cfg(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt"))]
             value_pools: Default::default(),
         },
     ));
@@ -2134,7 +2134,7 @@ async fn gbt_with(net: Network, addr: ZcashAddress) {
                     min_time: fake_min_time,
                     max_time: fake_max_time,
                     chain_history_root: fake_history_tree(&Mainnet).hash(),
-                    #[cfg(zcash_unstable = "zip234")]
+                    #[cfg(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt"))]
                     value_pools: Default::default(),
                 }));
         }
@@ -2828,7 +2828,7 @@ async fn rpc_getdifficulty() {
                 min_time: fake_min_time,
                 max_time: fake_max_time,
                 chain_history_root: fake_history_tree(&Mainnet).hash(),
-                #[cfg(zcash_unstable = "zip234")]
+                #[cfg(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt"))]
                 value_pools: Default::default(),
             }));
     };
@@ -2856,7 +2856,7 @@ async fn rpc_getdifficulty() {
                 min_time: fake_min_time,
                 max_time: fake_max_time,
                 chain_history_root: fake_history_tree(&Mainnet).hash(),
-                #[cfg(zcash_unstable = "zip234")]
+                #[cfg(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt"))]
                 value_pools: Default::default(),
             }));
     };
@@ -2881,7 +2881,7 @@ async fn rpc_getdifficulty() {
                 min_time: fake_min_time,
                 max_time: fake_max_time,
                 chain_history_root: fake_history_tree(&Mainnet).hash(),
-                #[cfg(zcash_unstable = "zip234")]
+                #[cfg(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt"))]
                 value_pools: Default::default(),
             }));
     };
@@ -2906,7 +2906,7 @@ async fn rpc_getdifficulty() {
                 min_time: fake_min_time,
                 max_time: fake_max_time,
                 chain_history_root: fake_history_tree(&Mainnet).hash(),
-                #[cfg(zcash_unstable = "zip234")]
+                #[cfg(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt"))]
                 value_pools: Default::default(),
             }));
     };

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -92,6 +92,8 @@ async fn rpc_getinfo() {
             cur_time: zebra_chain::serialization::DateTime32::now(),
             min_time: zebra_chain::serialization::DateTime32::now(),
             max_time: zebra_chain::serialization::DateTime32::now(),
+            #[cfg(zcash_unstable = "zip234")]
+            value_pools: Default::default(),
         },
     ));
 
@@ -2132,6 +2134,8 @@ async fn gbt_with(net: Network, addr: ZcashAddress) {
                     min_time: fake_min_time,
                     max_time: fake_max_time,
                     chain_history_root: fake_history_tree(&Mainnet).hash(),
+                    #[cfg(zcash_unstable = "zip234")]
+                    value_pools: Default::default(),
                 }));
         }
     };
@@ -2824,6 +2828,8 @@ async fn rpc_getdifficulty() {
                 min_time: fake_min_time,
                 max_time: fake_max_time,
                 chain_history_root: fake_history_tree(&Mainnet).hash(),
+                #[cfg(zcash_unstable = "zip234")]
+                value_pools: Default::default(),
             }));
     };
 
@@ -2850,6 +2856,8 @@ async fn rpc_getdifficulty() {
                 min_time: fake_min_time,
                 max_time: fake_max_time,
                 chain_history_root: fake_history_tree(&Mainnet).hash(),
+                #[cfg(zcash_unstable = "zip234")]
+                value_pools: Default::default(),
             }));
     };
 
@@ -2873,6 +2881,8 @@ async fn rpc_getdifficulty() {
                 min_time: fake_min_time,
                 max_time: fake_max_time,
                 chain_history_root: fake_history_tree(&Mainnet).hash(),
+                #[cfg(zcash_unstable = "zip234")]
+                value_pools: Default::default(),
             }));
     };
 
@@ -2896,6 +2906,8 @@ async fn rpc_getdifficulty() {
                 min_time: fake_min_time,
                 max_time: fake_max_time,
                 chain_history_root: fake_history_tree(&Mainnet).hash(),
+                #[cfg(zcash_unstable = "zip234")]
+                value_pools: Default::default(),
             }));
     };
 

--- a/zebra-rpc/src/methods/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/types/get_block_template.rs
@@ -333,6 +333,13 @@ impl BlockTemplateResponse {
             .sum::<amount::Result<Amount<NonNegative>>>()
             .expect("mempool tx fees must be non-negative");
 
+        #[cfg(zcash_unstable = "zip234")]
+        let money_reserve = zebra_chain::parameters::subsidy::zip234_start_height(net)
+            .filter(|start| height >= *start)
+            .map(|_| chain_info.value_pools.money_reserve());
+        #[cfg(not(zcash_unstable = "zip234"))]
+        let money_reserve = None;
+
         let coinbase_txn = precomputed_coinbase.unwrap_or_else(|| {
             TransactionTemplate::new_coinbase(
                 net,
@@ -341,6 +348,7 @@ impl BlockTemplateResponse {
                 txs_fee,
                 #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
                 zip233_amount,
+                money_reserve,
             )
             .expect("valid coinbase tx")
         });

--- a/zebra-rpc/src/methods/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/types/get_block_template.rs
@@ -333,11 +333,11 @@ impl BlockTemplateResponse {
             .sum::<amount::Result<Amount<NonNegative>>>()
             .expect("mempool tx fees must be non-negative");
 
-        #[cfg(zcash_unstable = "zip234")]
+        #[cfg(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt"))]
         let money_reserve = zebra_chain::parameters::subsidy::zip234_start_height(net)
             .filter(|start| height >= *start)
             .map(|_| chain_info.value_pools.money_reserve());
-        #[cfg(not(zcash_unstable = "zip234"))]
+        #[cfg(not(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt")))]
         let money_reserve = None;
 
         let coinbase_txn = precomputed_coinbase.unwrap_or_else(|| {

--- a/zebra-rpc/src/methods/types/get_block_template/tests.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/tests.rs
@@ -83,6 +83,7 @@ fn coinbase() -> anyhow::Result<()> {
                         Amount::zero(),
                         #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
                         None,
+                        None,
                     )?
                     .data()
                     .as_ref()

--- a/zebra-rpc/src/methods/types/get_block_template/zip317.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/zip317.rs
@@ -14,7 +14,7 @@ use rand::{
 };
 
 use zebra_chain::{
-    amount::Amount,
+    amount::{Amount, NonNegative},
     block::{Height, MAX_BLOCK_BYTES},
     parameters::Network,
     transaction::{self, zip317::BLOCK_UNPAID_ACTION_LIMIT, VerifiedUnminedTx},
@@ -66,6 +66,7 @@ pub fn select_mempool_transactions(
     #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))] zip233_amount: Option<
         Amount<NonNegative>,
     >,
+    money_reserve: Option<Amount<NonNegative>>,
 ) -> Vec<SelectedMempoolTx> {
     // Use a fake coinbase transaction to break the dependency between transaction
     // selection, the miner fee, and the fee payment in the coinbase transaction.
@@ -76,6 +77,7 @@ pub fn select_mempool_transactions(
         Amount::zero(),
         #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
         zip233_amount,
+        money_reserve,
     )
     .expect("valid coinbase transaction template");
 

--- a/zebra-rpc/src/methods/types/get_block_template/zip317/tests.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/zip317/tests.rs
@@ -36,6 +36,7 @@ fn excludes_tx_with_unselected_dependencies() {
             mempool_tx_deps,
             #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             None,
+            None,
         ),
         vec![],
         "should not select any transactions when dependencies are unavailable"
@@ -76,6 +77,7 @@ fn includes_tx_with_selected_dependencies() {
         unmined_txs.clone(),
         mempool_tx_deps.clone(),
         #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+        None,
         None,
     );
 

--- a/zebra-rpc/src/methods/types/transaction.rs
+++ b/zebra-rpc/src/methods/types/transaction.rs
@@ -133,8 +133,9 @@ impl TransactionTemplate<NegativeOrZero> {
         #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))] zip233_amount: Option<
             Amount<NonNegative>,
         >,
+        money_reserve: Option<Amount<NonNegative>>,
     ) -> Result<Self, TransactionError> {
-        let block_subsidy = block_subsidy(height, net)?;
+        let block_subsidy = block_subsidy(height, net, money_reserve)?;
         let miner_reward = miner_subsidy(height, net, block_subsidy)? + txs_fee;
         let miner_reward = Zatoshis::try_from(miner_reward?)?;
 

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -914,6 +914,10 @@ pub enum Request {
     /// * [`ReadResponse::BlockAndSize(None)`](ReadResponse::BlockAndSize) otherwise.
     BlockAndSize(HashOrHeight),
 
+    /// Looks up [`BlockInfo`] in any non-finalized chain, falling back to
+    /// the finalized state. Hash queries are fork-aware.
+    BlockInfo(HashOrHeight),
+
     /// Looks up a block header by hash or height in the current best chain.
     ///
     /// Returns
@@ -1055,6 +1059,7 @@ impl Request {
             Request::AnyChainTransaction(_) => "any_chain_transaction",
             Request::UnspentBestChainUtxo { .. } => "unspent_best_chain_utxo",
             Request::Block(_) => "block",
+            Request::BlockInfo(_) => "block_info",
             Request::AnyChainBlock(_) => "any_chain_block",
             Request::BlockAndSize(_) => "block_and_size",
             Request::BlockHeader(_) => "block_header",
@@ -1099,10 +1104,8 @@ pub enum ReadRequest {
     /// with the pool values of the current best chain tip.
     TipPoolValues,
 
-    /// Looks up the block info after a block by hash or height in the current best chain.
-    ///
-    /// * [`ReadResponse::BlockInfo(Some(pool_values))`](ReadResponse::BlockInfo) if the block is in the best chain;
-    /// * [`ReadResponse::BlockInfo(None)`](ReadResponse::BlockInfo) otherwise.
+    /// Looks up [`BlockInfo`] in any non-finalized chain, falling back to
+    /// the finalized state. Hash queries are fork-aware.
     BlockInfo(HashOrHeight),
 
     /// Computes the depth in the current best chain of the block identified by the given hash.
@@ -1486,6 +1489,7 @@ impl TryFrom<Request> for ReadRequest {
                 Ok(ReadRequest::AnyChainBlock(hash_or_height))
             }
             Request::BlockAndSize(hash_or_height) => Ok(ReadRequest::BlockAndSize(hash_or_height)),
+            Request::BlockInfo(hash_or_height) => Ok(ReadRequest::BlockInfo(hash_or_height)),
             Request::BlockHeader(hash_or_height) => Ok(ReadRequest::BlockHeader(hash_or_height)),
             Request::Transaction(tx_hash) => Ok(ReadRequest::Transaction(tx_hash)),
             Request::AnyChainTransaction(tx_hash) => Ok(ReadRequest::AnyChainTransaction(tx_hash)),

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -495,7 +495,7 @@ pub struct GetBlockTemplateChainInfo {
     pub max_time: DateTime32,
 
     /// Tip's chain value pools (parent `money_reserve` for ZIP-234).
-    #[cfg(zcash_unstable = "zip234")]
+    #[cfg(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt"))]
     pub value_pools: ValueBalance<NonNegative>,
 }
 

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -70,6 +70,9 @@ pub enum Response {
     /// Response to [`Request::BlockAndSize`] with the specified block and size.
     BlockAndSize(Option<(Arc<Block>, usize)>),
 
+    /// Response to [`Request::BlockInfo`].
+    BlockInfo(Option<BlockInfo>),
+
     /// The response to a `BlockHeader` request.
     BlockHeader {
         /// The header of the requested block
@@ -490,6 +493,10 @@ pub struct GetBlockTemplateChainInfo {
     /// The maximum time the miner can use in this block.
     /// Depends on the `tip_hash`, and the local clock on testnet.
     pub max_time: DateTime32,
+
+    /// Tip's chain value pools (parent `money_reserve` for ZIP-234).
+    #[cfg(zcash_unstable = "zip234")]
+    pub value_pools: ValueBalance<NonNegative>,
 }
 
 /// Conversion from read-only [`ReadResponse`]s to read-write [`Response`]s.
@@ -507,6 +514,7 @@ impl TryFrom<ReadResponse> for Response {
 
             ReadResponse::Block(block) => Ok(Response::Block(block)),
             ReadResponse::BlockAndSize(block) => Ok(Response::BlockAndSize(block)),
+            ReadResponse::BlockInfo(info) => Ok(Response::BlockInfo(info)),
             ReadResponse::BlockHeader {
                 header,
                 hash,
@@ -536,7 +544,6 @@ impl TryFrom<ReadResponse> for Response {
 
             ReadResponse::UsageInfo(_)
             | ReadResponse::TipPoolValues { .. }
-            | ReadResponse::BlockInfo(_)
             | ReadResponse::TransactionIdsForBlock(_)
             | ReadResponse::AnyChainTransactionIdsForBlock(_)
             | ReadResponse::SaplingTree(_)

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1248,6 +1248,7 @@ impl Service<Request> for StateService {
             | Request::Block(_)
             | Request::AnyChainBlock(_)
             | Request::BlockAndSize(_)
+            | Request::BlockInfo(_)
             | Request::BlockHeader(_)
             | Request::FindBlockHashes { .. }
             | Request::FindBlockHeaders { .. }
@@ -1350,9 +1351,12 @@ impl Service<ReadRequest> for ReadStateService {
                 })
             }
 
-            // Used by getblock
             ReadRequest::BlockInfo(hash_or_height) => Ok(ReadResponse::BlockInfo(
-                read::block_info(state.latest_best_chain(), &state.db, hash_or_height),
+                read::block_info(
+                    state.latest_non_finalized_state().chain_iter(),
+                    &state.db,
+                    hash_or_height,
+                ),
             )),
 
             // Used by the StateService.
@@ -1698,7 +1702,7 @@ impl Service<ReadRequest> for ReadStateService {
                         .best_tip()
                         .and_then(|(tip_height, _)| {
                             read::block_info(
-                                state.latest_best_chain(),
+                                state.latest_non_finalized_state().chain_iter(),
                                 &state.db,
                                 tip_height.into(),
                             )

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/block_info_and_address_received.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/block_info_and_address_received.rs
@@ -178,11 +178,18 @@ impl DiskFormatUpgrade for Upgrade {
 
             // Get the deferred amount which is required to update the value pool.
             let deferred_pool_balance_change = if height > network.slow_start_interval() {
+                #[cfg(zcash_unstable = "zip234")]
+                let money_reserve = zebra_chain::parameters::subsidy::zip234_start_height(&network)
+                    .filter(|start| height >= *start)
+                    .map(|_| value_pool.money_reserve());
+                #[cfg(not(zcash_unstable = "zip234"))]
+                let money_reserve = None;
+
                 // See [ZIP-1015](https://zips.z.cash/zip-1015).
                 let deferred_pool_balance_change = funding_stream_values(
                     height,
                     &network,
-                    block_subsidy(height, &network).unwrap_or_default(),
+                    block_subsidy(height, &network, money_reserve).unwrap_or_default(),
                 )
                 .expect("should have valid funding stream values")
                 .remove(&FundingStreamReceiver::Deferred)

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade/block_info_and_address_received.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade/block_info_and_address_received.rs
@@ -178,11 +178,11 @@ impl DiskFormatUpgrade for Upgrade {
 
             // Get the deferred amount which is required to update the value pool.
             let deferred_pool_balance_change = if height > network.slow_start_interval() {
-                #[cfg(zcash_unstable = "zip234")]
+                #[cfg(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt"))]
                 let money_reserve = zebra_chain::parameters::subsidy::zip234_start_height(&network)
                     .filter(|start| height >= *start)
                     .map(|_| value_pool.money_reserve());
-                #[cfg(not(zcash_unstable = "zip234"))]
+                #[cfg(not(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt")))]
                 let money_reserve = None;
 
                 // See [ZIP-1015](https://zips.z.cash/zip-1015).

--- a/zebra-state/src/service/read/block.rs
+++ b/zebra-state/src/service/read/block.rs
@@ -342,23 +342,22 @@ pub fn any_utxo(
         .or_else(|| db.utxo(&outpoint).map(|utxo| utxo.utxo))
 }
 
-/// Returns the [`BlockInfo`] with [`block::Hash`] or
-/// [`Height`], if it exists in the non-finalized `chain` or finalized `db`.
-pub fn block_info<C>(
-    chain: Option<C>,
+/// Returns the [`BlockInfo`], searching `chains` first and falling back to
+/// the finalized `db`. Hash queries are fork-aware.
+pub fn block_info<'a, C>(
+    mut chains: impl Iterator<Item = &'a C>,
     db: &ZebraDb,
     hash_or_height: HashOrHeight,
 ) -> Option<BlockInfo>
 where
-    C: AsRef<Chain>,
+    C: AsRef<Chain> + 'a,
 {
     // # Correctness
     //
     // Since blocks are the same in the finalized and non-finalized state, we
-    // check the most efficient alternative first. (`chain` is always in memory,
-    // but `db` stores blocks on disk, with a memory cache.)
-    chain
-        .as_ref()
-        .and_then(|chain| chain.as_ref().block_info(hash_or_height))
+    // check the most efficient alternative first. (`chains` are always in
+    // memory, but `db` stores blocks on disk, with a memory cache.)
+    chains
+        .find_map(|c| c.as_ref().block_info(hash_or_height))
         .or_else(|| db.block_info(hash_or_height))
 }

--- a/zebra-state/src/service/read/difficulty.rs
+++ b/zebra-state/src/service/read/difficulty.rs
@@ -65,7 +65,7 @@ pub fn get_block_template_chain_info(
     let (best_tip_height, best_tip_hash, best_relevant_chain, best_tip_history_tree) =
         best_relevant_chain_and_history_tree_result?;
 
-    #[cfg(zcash_unstable = "zip234")]
+    #[cfg(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt"))]
     let value_pools = read::find::tip_with_value_balance(non_finalized_state.best_chain(), db)?
         .map(|(_, _, vp)| vp)
         .ok_or("tip with value balance must exist when chain tip is known")?;
@@ -76,7 +76,7 @@ pub fn get_block_template_chain_info(
         best_tip_hash,
         network,
         best_tip_history_tree,
-        #[cfg(zcash_unstable = "zip234")]
+        #[cfg(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt"))]
         value_pools,
     ))
 }
@@ -212,7 +212,7 @@ fn difficulty_time_and_history_tree(
     tip_hash: block::Hash,
     network: &Network,
     history_tree: Arc<HistoryTree>,
-    #[cfg(zcash_unstable = "zip234")] value_pools: zebra_chain::value_balance::ValueBalance<
+    #[cfg(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt"))] value_pools: zebra_chain::value_balance::ValueBalance<
         zebra_chain::amount::NonNegative,
     >,
 ) -> GetBlockTemplateChainInfo {
@@ -265,7 +265,7 @@ fn difficulty_time_and_history_tree(
         cur_time,
         min_time,
         max_time,
-        #[cfg(zcash_unstable = "zip234")]
+        #[cfg(any(zcash_unstable = "zip234", zcash_unstable = "zip234alt"))]
         value_pools,
     };
 

--- a/zebra-state/src/service/read/difficulty.rs
+++ b/zebra-state/src/service/read/difficulty.rs
@@ -65,12 +65,19 @@ pub fn get_block_template_chain_info(
     let (best_tip_height, best_tip_hash, best_relevant_chain, best_tip_history_tree) =
         best_relevant_chain_and_history_tree_result?;
 
+    #[cfg(zcash_unstable = "zip234")]
+    let value_pools = read::find::tip_with_value_balance(non_finalized_state.best_chain(), db)?
+        .map(|(_, _, vp)| vp)
+        .ok_or("tip with value balance must exist when chain tip is known")?;
+
     Ok(difficulty_time_and_history_tree(
         best_relevant_chain,
         best_tip_height,
         best_tip_hash,
         network,
         best_tip_history_tree,
+        #[cfg(zcash_unstable = "zip234")]
+        value_pools,
     ))
 }
 
@@ -205,6 +212,9 @@ fn difficulty_time_and_history_tree(
     tip_hash: block::Hash,
     network: &Network,
     history_tree: Arc<HistoryTree>,
+    #[cfg(zcash_unstable = "zip234")] value_pools: zebra_chain::value_balance::ValueBalance<
+        zebra_chain::amount::NonNegative,
+    >,
 ) -> GetBlockTemplateChainInfo {
     let relevant_data: Vec<(CompactDifficulty, DateTime<Utc>)> = relevant_chain
         .iter()
@@ -255,6 +265,8 @@ fn difficulty_time_and_history_tree(
         cur_time,
         min_time,
         max_time,
+        #[cfg(zcash_unstable = "zip234")]
+        value_pools,
     };
 
     adjust_difficulty_and_time_for_testnet(&mut result, network, tip_height, relevant_data);

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -3601,6 +3601,7 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
         Amount::zero(),
         #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
         None,
+        None,
     )
     .expect("coinbase transaction should be valid under the given parameters");
 
@@ -3667,6 +3668,7 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
         &miner_params,
         Amount::zero(),
         #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+        None,
         None,
     )
     .expect("coinbase transaction should be valid under the given parameters");


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

This PR implements [ZIP-234](https://github.com/zcash/zips/pull/914); the changes were originally part of #8948.

Additionally, it implements an alternate version of ZIP-234 that preserves halvings (behind a separate `zip234alt` cfg-flag). Only one implementation can be enabled at once; enabling both flags will cause a compilation error.

Reasoning for separate PRs is here: https://github.com/ZcashFoundation/zebra/pull/8948#issuecomment-3985616334

### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [ ] No AI tools were used in this PR
- [x] AI tools were used: <!-- tool name and what it was used for, e.g., "Claude for test boilerplate" -->
  - Claude for test boilerplate and general spec correctness

### PR Checklist

- [x] The PR name is suitable for the release notes.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
