### PR TITLE
fix(state): increase reorg window to 1000 blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- Increased Zebra's local rollback window (`MAX_BLOCK_REORG_HEIGHT`) from 99 to
+  1000 blocks as a defence-in-depth measure against sustained consensus splits.
+
 ## [Zebra 5.1.0](https://github.com/ZcashFoundation/zebra/releases/tag/v5.1.0) - 2026-06-10
 
 This release fixes a genesis-to-tip sync stall that could cause new nodes to hang

--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -15,20 +15,15 @@ pub use zebra_chain::transparent::MIN_TRANSPARENT_COINBASE_MATURITY;
 
 /// The maximum chain reorganisation height.
 ///
-/// This threshold determines the maximum length of the best non-finalized chain.
-/// Larger reorganisations would allow double-spends of coinbase transactions.
+/// This threshold determines the maximum length of the best non-finalized
+/// chain. Once the chain grows past this height, Zebra finalizes its oldest
+/// blocks; deeper reorganisations are outside Zebra's rollback window.
 ///
-/// This threshold uses the relevant chain for the block being verified by the
-/// non-finalized state.
-///
-/// For the best chain, coinbase spends are only allowed from blocks at or below
-/// the finalized tip. For other chains, coinbase spends can use outputs from
-/// early non-finalized blocks, or finalized blocks. But if that chain becomes
-/// the best chain, all non-finalized blocks past the [`MAX_BLOCK_REORG_HEIGHT`]
-/// will be finalized. This includes all mature coinbase outputs.
+/// This is a local-only node policy; it is not part of consensus. The window is
+/// sized as a defence-in-depth measure against sustained consensus splits.
 //
 // TODO: change to HeightDiff
-pub const MAX_BLOCK_REORG_HEIGHT: u32 = MIN_TRANSPARENT_COINBASE_MATURITY - 1;
+pub const MAX_BLOCK_REORG_HEIGHT: u32 = 1000;
 
 /// The directory name used to distinguish the state database from Zebra's other databases or flat files.
 pub const STATE_DATABASE_KIND: &str = "state";
@@ -99,8 +94,8 @@ pub const MAX_LEGACY_CHAIN_BLOCKS: usize = 100_000;
 /// 100 blocks. (1 fork per 20 blocks.) When block propagation is efficient, there is around
 /// 1 fork per 300 blocks.
 ///
-/// This limits non-finalized chain memory to around:
-/// `10 forks * 100 blocks * 2 MB per block = 2 GB`
+/// This limits non-finalized chain memory, in the worst case, to around:
+/// `10 forks * 1000 blocks * 2 MB per block = 20 GB`
 pub const MAX_NON_FINALIZED_CHAIN_FORKS: usize = 10;
 
 /// The maximum number of block hashes allowed in `getblocks` responses in the Zcash network protocol.
@@ -111,8 +106,10 @@ pub const MAX_FIND_BLOCK_HEADERS_RESULTS: u32 = 160;
 
 /// The maximum number of invalidated block records.
 ///
-/// This limits the memory use to around:
-/// `100 entries * up to 99 blocks * 2 MB per block = 20 GB`
+/// Each record can hold a chain of invalidated descendants up to the rollback
+/// window ([`MAX_BLOCK_REORG_HEIGHT`]) deep, so this limits the memory use, in
+/// the worst case, to around:
+/// `100 entries * up to 1000 blocks * 2 MB per block = 200 GB`
 pub const MAX_INVALIDATED_BLOCKS: usize = 100;
 
 lazy_static! {

--- a/zebra-state/src/service/read/find/tests/vectors.rs
+++ b/zebra-state/src/service/read/find/tests/vectors.rs
@@ -4,17 +4,20 @@ use zebra_chain::block::Height;
 
 use crate::{constants, service::read::find::block_locator_heights};
 
-/// Block heights, and the expected minimum block locator height
+/// Block heights, and the expected minimum block locator height.
+///
+/// Cases are computed against [`constants::MAX_BLOCK_REORG_HEIGHT`].
 static BLOCK_LOCATOR_CASES: &[(u32, u32)] = &[
     (0, 0),
     (1, 0),
     (10, 0),
-    (98, 0),
     (99, 0),
-    (100, 1),
-    (101, 2),
-    (1000, 901),
-    (10000, 9901),
+    (100, 0),
+    (999, 0),
+    (1000, 0),
+    (1001, 1),
+    (2000, 1000),
+    (10000, 9000),
 ];
 
 /// Check that the block locator heights are sensible.
@@ -54,7 +57,7 @@ fn test_block_locator_heights() {
         );
         assert!(
             height - final_height.0 <= constants::MAX_BLOCK_REORG_HEIGHT,
-            "locator for {} must not be more than the maximum reorg height {} below the tip, \
+            "locator for {} must not be more than MAX_BLOCK_REORG_HEIGHT ({}) below the tip, \
              but {} is {} blocks below the tip",
             height,
             constants::MAX_BLOCK_REORG_HEIGHT,


### PR DESCRIPTION
## Motivation

This is a defence-in-depth change against sustained consensus splits. The recent [Litecoin MWEB security incident](https://litecoin.com/news/litecoin-mweb-security-incident-postmortem) produced a ~3 hour reorg after patched miners were DoS'd and unpatched hashpower built the heavier chain, and Zcash has had multiple recent consensus-split and remote-crash patches, so mixed patch deployment is a realistic risk.

Zebra's local rollback window was 99 blocks (`MIN_TRANSPARENT_COINBASE_MATURITY - 1`). Once a heavier valid chain diverges past that window, Zebra finalizes its older chain and can no longer follow the heavier one. Increasing the window to 1000 blocks gives operators more time to detect and recover before finalization locks the node onto the wrong chain. This is a local-only node policy, not a consensus rule, and is intentionally not activation-gated.

## Solution

- Increase `MAX_BLOCK_REORG_HEIGHT` from 99 to 1000.
- Update the dependent block-locator and acceptance tests, and the memory-bound comments.
- Make `zebra-checkpoints` use `MAX_BLOCK_REORG_HEIGHT` as its settlement margin instead of the fixed 100-block maturity value, so a reorg the node would now follow cannot orphan a shipped checkpoint. A compile-time assertion keeps the margin from ever dropping below the rollback window.
- Update stale "~100 most recent blocks" doc comments on the state service.

### Maturity vs. rollback window

Coinbase maturity (`MIN_TRANSPARENT_COINBASE_MATURITY` = 100) is a consensus rule and is unchanged. It is enforced per-spend by block height, independent of the rollback window, so the two constants need not be equal (they were only incidentally so). The only behavioural change is that mature coinbase spends stay reversible within the larger window, which is the intended trade and does not affect consensus validity.

### Resource ceilings (intentional)

The larger window raises worst-case in-memory bounds, and this PR deliberately adds no new cap. Non-finalized chain memory is ~20 GB worst case (`10 forks × 1000 blocks × 2 MB`), reachable only with substantial valid PoW. The invalidated-block cache is ~200 GB worst case (`100 entries × up to 1000 blocks × 2 MB`), reachable only via the operator-triggered `invalidateblock` RPC. The documented bounds in `zebra-state/src/constants.rs` are updated to match.

### zcashd compatibility

Zebra and zcashd use their max-reorg constants differently. In Zebra, `MAX_BLOCK_REORG_HEIGHT` controls the local non-finalized rollback window, whereas zcashd's `MAX_REORG_LENGTH` triggers a shutdown/alert. This change is Zebra-local and is not a network-wide reorg rule change.

### Tests

- `cargo fmt --all -- --check`
- `cargo test -p zebra-state test_block_locator_heights`
- `cargo clippy -p zebra-utils --features zebra-checkpoints --all-targets -- -D warnings`
- `cargo check -p zebrad --test acceptance --features indexer,zebra-checkpoints`

The affected acceptance/checkpoint integration tests (`has_spending_transaction_ids`, `generate_checkpoints_*`) are `#[ignore]` and need a near-tip cached state, so they are type-checked here rather than run.

### AI Disclosure

- [x] AI tools were used: Claude Code (Anthropic) for the implementation, test/comment updates, the checkpoint-generator fix, and this PR description. The contributor is the responsible author.

### PR Checklist

- [x] The PR title follows conventional commits format: `fix(state): increase reorg window to 1000 blocks`
- [x] Test evidence is listed above.
- [x] The documentation and changelogs are up to date.
