### PR TITLE
feat(consensus): add NU7 difficulty adjustment parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Startup warning on Linux when `net.ipv4.tcp_slow_start_after_idle` is enabled (which resets TCP congestion windows between block requests and significantly reduces single-peer block-propagation throughput on long-haul links), with a "Linux TCP tuning for block propagation" troubleshooting section ([#10513](https://github.com/ZcashFoundation/zebra/pull/10513))
 - Support ZIP-213
 
+### Changed
+
+- Added NU7 difficulty adjustment parameters so Testnet difficulty uses a
+  102-block averaging window at and after NU7 activation.
+
 ### Fixed
 
 - Avoid panicking in the address-book ban path when `network.max_connections_per_ip > 1`. Guard the optional `most_recent_by_ip` cache instead of unwrapping it, so a ban-threshold misbehavior update no longer crashes the address-book updater and poisons the shared mutex ([#10580](https://github.com/ZcashFoundation/zebra/issues/10580))

--- a/zebra-chain/src/parameters/network/subsidy.rs
+++ b/zebra-chain/src/parameters/network/subsidy.rs
@@ -421,28 +421,33 @@ pub fn halving_divisor(height: Height, network: &Network) -> Option<u64> {
 /// [7.8]: https://zips.z.cash/protocol/protocol.pdf#subsidies
 pub fn halving(height: Height, network: &Network) -> u32 {
     let slow_start_shift = network.slow_start_shift();
-    let blossom_height = NetworkUpgrade::Blossom
-        .activation_height(network)
-        .expect("blossom activation height should be available");
+    if height < slow_start_shift {
+        return 0;
+    }
 
-    let halving_index = if height < slow_start_shift {
-        0
-    } else if height < blossom_height {
-        let pre_blossom_height = height - slow_start_shift;
-        pre_blossom_height / network.pre_blossom_halving_interval()
-    } else {
-        let pre_blossom_height = blossom_height - slow_start_shift;
-        let scaled_pre_blossom_height =
-            pre_blossom_height * HeightDiff::from(BLOSSOM_POW_TARGET_SPACING_RATIO);
+    // Each era contributes (blocks × spacing_seconds) to a running total, which
+    // we divide by (PreBlossomHalvingInterval × pre_blossom_spacing) at the end.
+    // This stays in integer arithmetic across eras with different spacings, and
+    // matches the spec's segmented-fraction sum after factoring out the
+    // common denominator.
+    let pre_blossom_spacing_seconds = NetworkUpgrade::Genesis.target_spacing().num_seconds();
+    let mut total_block_seconds: HeightDiff = 0;
 
-        let post_blossom_height = height - blossom_height;
+    let mut eras = NetworkUpgrade::target_spacings(network)
+        .filter(|(era_start, _)| *era_start <= height)
+        .peekable();
 
-        (scaled_pre_blossom_height + post_blossom_height) / network.post_blossom_halving_interval()
-    };
+    while let Some((era_start, era_spacing)) = eras.next() {
+        let era_end = eras.peek().map(|(s, _)| *s).unwrap_or(height);
+        let era_blocks = (era_end - era_start.max(slow_start_shift)).max(0);
+        total_block_seconds += era_blocks * era_spacing.num_seconds();
+    }
 
-    halving_index
+    let pre_blossom_denominator =
+        network.pre_blossom_halving_interval() * pre_blossom_spacing_seconds;
+    (total_block_seconds / pre_blossom_denominator)
         .try_into()
-        .expect("already checked for negatives")
+        .expect("halving index is non-negative and fits in u32")
 }
 
 /// `BlockSubsidy(height)` as described in [protocol specification §7.8][7.8]
@@ -466,13 +471,15 @@ pub fn block_subsidy(height: Height, net: &Network) -> Result<Amount<NonNegative
             slow_start_rate * (u64::from(height) + 1)
         }
     } else {
-        let base_subsidy = if NetworkUpgrade::current(net, height) < NetworkUpgrade::Blossom {
-            MAX_BLOCK_SUBSIDY
-        } else {
-            MAX_BLOCK_SUBSIDY / u64::from(BLOSSOM_POW_TARGET_SPACING_RATIO)
-        };
-
-        base_subsidy / halving_div
+        // Each spacing era scales the per-block subsidy by current_spacing /
+        // pre_blossom_spacing, keeping issuance per unit of wall-clock time
+        // constant across spacing changes. Casts are safe: target spacings are
+        // positive small constants.
+        let current_spacing_seconds =
+            NetworkUpgrade::target_spacing_for_height(net, height).num_seconds() as u64;
+        let pre_blossom_spacing_seconds =
+            NetworkUpgrade::Genesis.target_spacing().num_seconds() as u64;
+        MAX_BLOCK_SUBSIDY * current_spacing_seconds / pre_blossom_spacing_seconds / halving_div
     };
 
     Ok(Amount::try_from(amount)?)

--- a/zebra-chain/src/parameters/network/tests.rs
+++ b/zebra-chain/src/parameters/network/tests.rs
@@ -16,9 +16,40 @@ use crate::{
         },
         testnet::{self, ConfiguredActivationHeights},
         NetworkUpgrade, NU7_POW_TARGET_SPACING_RATIO, POST_BLOSSOM_POW_TARGET_SPACING,
-        POST_NU7_POW_TARGET_SPACING,
+        POST_NU7_POW_AVERAGING_WINDOW, POST_NU7_POW_TARGET_SPACING, PRE_NU7_POW_AVERAGING_WINDOW,
     },
 };
+
+#[test]
+fn averaging_window_changes_at_nu7_activation_height() -> Result<(), Report> {
+    let network = testnet::Parameters::build()
+        .with_activation_heights(ConfiguredActivationHeights {
+            blossom: Some(1),
+            nu7: Some(10),
+            ..Default::default()
+        })
+        .expect("activation heights are valid")
+        .clear_funding_streams()
+        .to_network()
+        .expect("configured testnet is valid");
+
+    assert_eq!(
+        PRE_NU7_POW_AVERAGING_WINDOW,
+        NetworkUpgrade::averaging_window_for_height(&network, Height(9))
+    );
+
+    assert_eq!(
+        POST_NU7_POW_AVERAGING_WINDOW,
+        NetworkUpgrade::averaging_window_for_height(&network, Height(10))
+    );
+
+    assert_eq!(
+        POST_NU7_POW_AVERAGING_WINDOW,
+        NetworkUpgrade::averaging_window_for_height(&network, Height(11))
+    );
+
+    Ok(())
+}
 
 #[test]
 fn halving_test() -> Result<(), Report> {

--- a/zebra-chain/src/parameters/network/tests.rs
+++ b/zebra-chain/src/parameters/network/tests.rs
@@ -14,7 +14,9 @@ use crate::{
             block_subsidy, constants::POST_BLOSSOM_HALVING_INTERVAL, halving, halving_divisor,
             height_for_halving, ParameterSubsidy as _,
         },
-        NetworkUpgrade,
+        testnet::{self, ConfiguredActivationHeights},
+        NetworkUpgrade, NU7_POW_TARGET_SPACING_RATIO, POST_BLOSSOM_POW_TARGET_SPACING,
+        POST_NU7_POW_TARGET_SPACING,
     },
 };
 
@@ -287,6 +289,86 @@ fn block_subsidy_for_network(network: &Network) -> Result<(), Report> {
     assert_eq!(
         Amount::<NonNegative>::try_from(0)?,
         block_subsidy(Height::MAX, network)?
+    );
+
+    Ok(())
+}
+
+/// Tests `halving` and `block_subsidy` across the NU7 activation boundary on a
+/// configured Testnet, exercising the post-NU7 cases added by the draft
+/// "Shorter Block Target Spacing" ZIP.
+#[test]
+fn post_nu7_halving_and_subsidy() -> Result<(), Report> {
+    let _init_guard = zebra_test::init();
+
+    // Pick parameters where slow_start_shift = blossom_height, so the pre-Blossom
+    // term in the spec halving sum is exactly zero and boundaries land cleanly at
+    // multiples of the post-Blossom / post-NU7 halving intervals.
+    let blossom = 1u32;
+    let canopy = blossom + u32::try_from(POST_BLOSSOM_HALVING_INTERVAL).unwrap();
+    let nu7 = canopy + u32::try_from(POST_BLOSSOM_HALVING_INTERVAL * 2).unwrap();
+
+    let network = testnet::Parameters::build()
+        // slow_start_shift = slow_start_interval / 2 = 1, equal to Blossom height.
+        .with_slow_start_interval(Height(2))
+        .with_activation_heights(ConfiguredActivationHeights {
+            blossom: Some(blossom),
+            canopy: Some(canopy),
+            nu7: Some(nu7),
+            ..Default::default()
+        })
+        .expect("activation heights are valid")
+        .clear_funding_streams()
+        .to_network()
+        .expect("configured testnet is valid");
+
+    let nu7_height = Height(nu7);
+
+    // Target spacing shortens from the post-Blossom value to the post-NU7 value
+    // exactly at the NU7 activation height.
+    assert_eq!(
+        i64::from(POST_BLOSSOM_POW_TARGET_SPACING),
+        NetworkUpgrade::target_spacing_for_height(&network, (nu7_height - 1).unwrap())
+            .num_seconds()
+    );
+    assert_eq!(
+        i64::from(POST_NU7_POW_TARGET_SPACING),
+        NetworkUpgrade::target_spacing_for_height(&network, nu7_height).num_seconds()
+    );
+
+    // At NU7 activation, three post-Blossom halvings have elapsed:
+    //   Halving = floor(0/PreBlossom + 1 + 2) = 3
+    assert_eq!(3, halving(nu7_height, &network));
+    assert_eq!(8, halving_divisor(nu7_height, &network).unwrap());
+
+    // BlockSubsidy(NU7) = floor(MAX / (BlossomRatio * NU7Ratio * 2^Halving))
+    //                   = floor(1_250_000_000 / (2 * 3 * 8))
+    //                   = floor(1_250_000_000 / 48) = 26_041_666 zatoshi
+    assert_eq!(
+        Amount::<NonNegative>::try_from(26_041_666)?,
+        block_subsidy(nu7_height, &network)?,
+    );
+
+    // The 3rd halving boundary lands exactly at NU7 in this configuration, so the
+    // block immediately before NU7 is still in halving era 2 (post-Blossom, pre-NU7):
+    //   floor(1_250_000_000 / (2 * 4)) = 156_250_000 zatoshi.
+    assert_eq!(2, halving((nu7_height - 1).unwrap(), &network));
+    assert_eq!(
+        Amount::<NonNegative>::try_from(156_250_000)?,
+        block_subsidy((nu7_height - 1).unwrap(), &network)?,
+    );
+
+    // The halving counter does not reset at NU7. The next halving boundary is
+    // reached after one PostNU7HalvingInterval (=PostBlossomHalvingInterval * 3)
+    // of post-NU7 blocks.
+    let post_nu7_halving_interval =
+        POST_BLOSSOM_HALVING_INTERVAL * i64::from(NU7_POW_TARGET_SPACING_RATIO);
+    let next_halving = (nu7_height + post_nu7_halving_interval).unwrap();
+    assert_eq!(4, halving(next_halving, &network));
+    assert_eq!(16, halving_divisor(next_halving, &network).unwrap());
+    assert_eq!(
+        Amount::<NonNegative>::try_from(13_020_833)?,
+        block_subsidy(next_halving, &network)?,
     );
 
     Ok(())

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -251,10 +251,23 @@ pub const POST_NU7_POW_TARGET_SPACING: u32 = 25;
 pub const NU7_POW_TARGET_SPACING_RATIO: u32 =
     POST_BLOSSOM_POW_TARGET_SPACING / POST_NU7_POW_TARGET_SPACING;
 
-/// The averaging window for difficulty threshold arithmetic mean calculations.
+/// Alias of [`PRE_NU7_POW_AVERAGING_WINDOW`], retained for pre-NU7 call sites.
+///
+/// Prefer [`NetworkUpgrade::averaging_window`] or
+/// [`NetworkUpgrade::averaging_window_for_height`] for the active network value.
+pub const POW_AVERAGING_WINDOW: usize = PRE_NU7_POW_AVERAGING_WINDOW;
+
+/// The averaging window for difficulty threshold arithmetic mean calculations before NU7.
 ///
 /// `PoWAveragingWindow` in the Zcash specification.
-pub const POW_AVERAGING_WINDOW: usize = 17;
+pub const PRE_NU7_POW_AVERAGING_WINDOW: usize = 17;
+
+/// The averaging window for difficulty threshold arithmetic mean calculations from NU7 onward.
+///
+/// Scaled so that the wall-clock timespan of the averaging window matches a
+/// reference of 17 blocks at 150 s per block (2550 s), which at the post-NU7
+/// 25 s target spacing equals `17 * (150 / 25) = 102` blocks.
+pub const POST_NU7_POW_AVERAGING_WINDOW: usize = 102;
 
 /// The multiplier used to derive the testnet minimum difficulty block time gap
 /// threshold.
@@ -504,7 +517,21 @@ impl NetworkUpgrade {
     ///
     /// `AveragingWindowTimespan` from the Zcash specification.
     pub fn averaging_window_timespan(&self) -> Duration {
-        self.target_spacing() * POW_AVERAGING_WINDOW.try_into().expect("fits in i32")
+        self.target_spacing() * self.averaging_window().try_into().expect("fits in i32")
+    }
+
+    /// Returns the averaging window for difficulty threshold arithmetic mean calculations.
+    ///
+    /// `PoWAveragingWindow` from the Zcash specification.
+    pub fn averaging_window(&self) -> usize {
+        match self {
+            Genesis | BeforeOverwinter | Overwinter | Sapling | Blossom | Heartwood | Canopy
+            | Nu5 | Nu6 | Nu6_1 => PRE_NU7_POW_AVERAGING_WINDOW,
+            Nu7 => POST_NU7_POW_AVERAGING_WINDOW,
+
+            #[cfg(zcash_unstable = "zfuture")]
+            ZFuture => POST_NU7_POW_AVERAGING_WINDOW,
+        }
     }
 
     /// Returns the averaging window timespan for `network` and `height`.
@@ -515,6 +542,13 @@ impl NetworkUpgrade {
         height: block::Height,
     ) -> Duration {
         NetworkUpgrade::current(network, height).averaging_window_timespan()
+    }
+
+    /// Returns the averaging window for `network` and `height`.
+    ///
+    /// See [`NetworkUpgrade::averaging_window`] for details.
+    pub fn averaging_window_for_height(network: &Network, height: block::Height) -> usize {
+        NetworkUpgrade::current(network, height).averaging_window()
     }
 
     /// Returns an iterator over [`NetworkUpgrade`] variants.

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -239,6 +239,18 @@ const PRE_BLOSSOM_POW_TARGET_SPACING: i64 = 150;
 /// The target block spacing after Blossom activation.
 pub const POST_BLOSSOM_POW_TARGET_SPACING: u32 = 75;
 
+/// The target block spacing after NU7 activation, in seconds.
+///
+/// Defined by the draft "Shorter Block Target Spacing" ZIP, which lowers the
+/// block target spacing from 75 to 25 seconds at NU7.
+pub const POST_NU7_POW_TARGET_SPACING: u32 = 25;
+
+/// The ratio between the post-Blossom and post-NU7 block target spacings.
+///
+/// `PostBlossomPoWTargetSpacing / PostNU7PoWTargetSpacing = 75 / 25 = 3`.
+pub const NU7_POW_TARGET_SPACING_RATIO: u32 =
+    POST_BLOSSOM_POW_TARGET_SPACING / POST_NU7_POW_TARGET_SPACING;
+
 /// The averaging window for difficulty threshold arithmetic mean calculations.
 ///
 /// `PoWAveragingWindow` in the Zcash specification.
@@ -395,12 +407,13 @@ impl NetworkUpgrade {
     pub fn target_spacing(&self) -> Duration {
         let spacing_seconds = match self {
             Genesis | BeforeOverwinter | Overwinter | Sapling => PRE_BLOSSOM_POW_TARGET_SPACING,
-            Blossom | Heartwood | Canopy | Nu5 | Nu6 | Nu6_1 | Nu7 => {
+            Blossom | Heartwood | Canopy | Nu5 | Nu6 | Nu6_1 => {
                 POST_BLOSSOM_POW_TARGET_SPACING.into()
             }
+            Nu7 => POST_NU7_POW_TARGET_SPACING.into(),
 
             #[cfg(zcash_unstable = "zfuture")]
-            ZFuture => POST_BLOSSOM_POW_TARGET_SPACING.into(),
+            ZFuture => POST_NU7_POW_TARGET_SPACING.into(),
         };
 
         Duration::seconds(spacing_seconds)
@@ -423,6 +436,7 @@ impl NetworkUpgrade {
                 NetworkUpgrade::Blossom,
                 POST_BLOSSOM_POW_TARGET_SPACING.into(),
             ),
+            (NetworkUpgrade::Nu7, POST_NU7_POW_TARGET_SPACING.into()),
         ]
         .into_iter()
         .filter_map(move |(upgrade, spacing_seconds)| {

--- a/zebra-state/src/service/check.rs
+++ b/zebra-state/src/service/check.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
 
 use crate::{
     service::{
-        block_iter::any_ancestor_blocks, check::difficulty::POW_ADJUSTMENT_BLOCK_SPAN,
+        block_iter::any_ancestor_blocks, check::difficulty::pow_adjustment_block_span_for_height,
         finalized_state::ZebraDb, non_finalized_state::NonFinalizedState,
     },
     BoxError, SemanticallyVerifiedBlock, ValidateContextError,
@@ -62,9 +62,12 @@ where
         .expect("finalized state must contain at least one block to do contextual validation");
     check::block_is_not_orphaned(finalized_tip_height, semantically_verified.height)?;
 
+    let pow_adjustment_block_span =
+        pow_adjustment_block_span_for_height(network, semantically_verified.height);
+
     let relevant_chain: Vec<_> = relevant_chain
         .into_iter()
-        .take(POW_ADJUSTMENT_BLOCK_SPAN)
+        .take(pow_adjustment_block_span)
         .collect();
 
     let Some(parent_block) = relevant_chain.first() else {
@@ -89,7 +92,7 @@ where
     //
     // TODO: accept a NotReadyToBeCommitted error in those tests instead
     #[cfg(test)]
-    if relevant_chain.len() < POW_ADJUSTMENT_BLOCK_SPAN {
+    if relevant_chain.len() < pow_adjustment_block_span {
         return Ok(());
     }
 
@@ -101,11 +104,11 @@ where
     // verified blocks, so there will be at least 1 million blocks in the state when it is
     // called. So this error should never happen on Mainnet or the default Testnet.
     //
-    // It's okay to use a relevant chain of fewer than `POW_ADJUSTMENT_BLOCK_SPAN` blocks, because
+    // It's okay to use a relevant chain of fewer than `PoWAveragingWindow + PoWMedianBlockSpan` blocks, because
     // the MedianTime function uses height 0 if passed a negative height by the ActualTimespan function:
     // > ActualTimespan(height : N) := MedianTime(height) − MedianTime(height − PoWAveragingWindow)
     // > MedianTime(height : N) := median([[ nTime(𝑖) for 𝑖 from max(0, height − PoWMedianBlockSpan) up to height − 1 ]])
-    // and the MeanTarget function only requires the past `PoWAveragingWindow` (17) blocks for heights above 17,
+    // and the MeanTarget function only requires the past `PoWAveragingWindow` blocks for heights above that window,
     // > PoWLimit, if height ≤ PoWAveragingWindow
     // > ([ToTarget(nBits(𝑖)) for 𝑖 from height−PoWAveragingWindow up to height−1]) otherwise
     //

--- a/zebra-state/src/service/check/difficulty.rs
+++ b/zebra-state/src/service/check/difficulty.rs
@@ -11,21 +11,25 @@ use chrono::{DateTime, Duration, Utc};
 
 use zebra_chain::{
     block::{self, Block},
-    parameters::{Network, NetworkUpgrade, POW_AVERAGING_WINDOW},
+    parameters::{Network, NetworkUpgrade, POST_NU7_POW_AVERAGING_WINDOW},
     work::difficulty::{CompactDifficulty, ExpandedDifficulty, ParameterDifficulty as _, U256},
     BoundedVec,
 };
 
 /// The median block span for time median calculations.
 ///
-/// `PoWMedianBlockSpan` in the Zcash specification.
+/// `PoWMedianBlockSpan` in the Zcash specification. Per ZIP, this value is a
+/// number of blocks and does not change at network upgrade activations.
 pub const POW_MEDIAN_BLOCK_SPAN: usize = 11;
 
-/// The overall block span used for adjusting Zcash block difficulty.
+/// The maximum overall block span used for adjusting Zcash block difficulty.
 ///
 /// `PoWAveragingWindow + PoWMedianBlockSpan` in the Zcash specification based on
 /// > ActualTimespan(height : N) := MedianTime(height) − MedianTime(height − PoWAveragingWindow)
-pub const POW_ADJUSTMENT_BLOCK_SPAN: usize = POW_AVERAGING_WINDOW + POW_MEDIAN_BLOCK_SPAN;
+///
+/// Sized for the largest active averaging window so that the [`BoundedVec`]
+/// capacities accommodate any height.
+pub const POW_ADJUSTMENT_BLOCK_SPAN: usize = POST_NU7_POW_AVERAGING_WINDOW + POW_MEDIAN_BLOCK_SPAN;
 
 /// The damping factor for median timespan variance.
 ///
@@ -60,15 +64,14 @@ pub(crate) struct AdjustedDifficulty {
     /// The configured network
     network: Network,
     /// The `header.difficulty_threshold`s from the previous
-    /// `PoWAveragingWindow + PoWMedianBlockSpan` (28) blocks, in reverse height
+    /// `PoWAveragingWindow + PoWMedianBlockSpan` blocks, in reverse height
     /// order.
     relevant_difficulty_thresholds: BoundedVec<CompactDifficulty, 1, POW_ADJUSTMENT_BLOCK_SPAN>,
-    /// The `header.time`s from the previous
-    /// `PoWAveragingWindow + PoWMedianBlockSpan` (28) blocks, in reverse height
-    /// order.
+    /// The `header.time`s from the previous `PoWAveragingWindow + PoWMedianBlockSpan`
+    /// blocks, in reverse height order.
     ///
-    /// Only the first and last `PoWMedianBlockSpan` times are used. Times
-    /// `11..=16` are ignored.
+    /// Only the first and last `PoWMedianBlockSpan` times are used. Any times
+    /// between those spans are ignored.
     relevant_times: BoundedVec<DateTime<Utc>, 1, POW_ADJUSTMENT_BLOCK_SPAN>,
 }
 
@@ -76,10 +79,9 @@ impl AdjustedDifficulty {
     /// Initialise and return a new `AdjustedDifficulty` using a `candidate_block`,
     /// `network`, and a `context`.
     ///
-    /// The `context` contains the previous
-    /// `PoWAveragingWindow + PoWMedianBlockSpan` (28) `difficulty_threshold`s and
-    /// `time`s from the relevant chain for `candidate_block`, in reverse height
-    /// order, starting with the previous block.
+    /// The `context` contains the previous `PoWAveragingWindow + PoWMedianBlockSpan`
+    /// `difficulty_threshold`s and `time`s from the relevant chain for
+    /// `candidate_block`, in reverse height order, starting with the previous block.
     ///
     /// Note that the `time`s might not be in reverse chronological order, because
     /// block times are supplied by miners.
@@ -126,7 +128,6 @@ impl AdjustedDifficulty {
     /// - The next block height is invalid.
     /// - The `context` iterator is empty, because at least one difficulty threshold
     ///   and block time are required to construct the `Bounded` vectors.
-    /// - The context iterator is empty, because at least one difficulty threshold and block time are required.
     pub fn new_from_header_time<C>(
         candidate_header_time: DateTime<Utc>,
         previous_block_height: block::Height,
@@ -138,9 +139,12 @@ impl AdjustedDifficulty {
     {
         let candidate_height = (previous_block_height + 1).expect("next block height is valid");
 
+        let pow_adjustment_block_span =
+            pow_adjustment_block_span_for_height(network, candidate_height);
+
         let (thresholds, times) = context
             .into_iter()
-            .take(POW_ADJUSTMENT_BLOCK_SPAN)
+            .take(pow_adjustment_block_span)
             .unzip::<_, _, Vec<_>, Vec<_>>();
 
         let relevant_difficulty_thresholds: BoundedVec<
@@ -181,7 +185,7 @@ impl AdjustedDifficulty {
     /// Calculate the expected `difficulty_threshold` for a candidate block, based
     /// on the `candidate_time`, `candidate_height`, `network`, and the
     /// `difficulty_threshold`s and `time`s from the previous
-    /// `PoWAveragingWindow + PoWMedianBlockSpan` (28) blocks in the relevant chain.
+    /// `PoWAveragingWindow + PoWMedianBlockSpan` blocks in the relevant chain.
     ///
     /// Implements `ThresholdBits` from the Zcash specification, and the Testnet
     /// minimum difficulty adjustment from ZIPs 205 and 208.
@@ -224,43 +228,49 @@ impl AdjustedDifficulty {
     }
 
     /// Calculate the arithmetic mean of the averaging window thresholds: the
-    /// expanded `difficulty_threshold`s from the previous `PoWAveragingWindow` (17)
+    /// expanded `difficulty_threshold`s from the previous `PoWAveragingWindow`
     /// blocks in the relevant chain.
     ///
     /// Implements `MeanTarget` from the Zcash specification.
     fn mean_target_difficulty(&self) -> ExpandedDifficulty {
         // In Zebra, contextual validation starts after Canopy activation, so we
-        // can assume that the relevant chain contains at least 17 blocks.
+        // can assume that the relevant chain contains at least `PoWAveragingWindow` blocks.
         // Therefore, the `PoWLimit` case of `MeanTarget()` from the Zcash
         // specification is unreachable.
+        let averaging_window =
+            NetworkUpgrade::averaging_window_for_height(&self.network, self.candidate_height);
 
         let averaging_window_thresholds =
-            if self.relevant_difficulty_thresholds.len() >= POW_AVERAGING_WINDOW {
-                &self.relevant_difficulty_thresholds.as_slice()[0..POW_AVERAGING_WINDOW]
+            if self.relevant_difficulty_thresholds.len() >= averaging_window {
+                &self.relevant_difficulty_thresholds.as_slice()[0..averaging_window]
             } else {
                 return self.network.target_difficulty_limit();
             };
 
-        // Since the PoWLimits are `2^251 − 1` for Testnet, and `2^243 − 1` for
-        // Mainnet, the sum of 17 `ExpandedDifficulty` will be less than or equal
-        // to: `(2^251 − 1) * 17 = 2^255 + 2^251 - 17`. Therefore, the sum can
-        // not overflow a u256 value.
-        let total: ExpandedDifficulty = averaging_window_thresholds
-            .iter()
-            .map(|compact| {
-                compact
+        let divisor: U256 = averaging_window.into();
+        // The post-NU7 sum of Testnet PoWLimit thresholds can exceed 256 bits, so
+        // average the quotient and remainder parts separately.
+        let (quotient_total, remainder_total) = averaging_window_thresholds.iter().fold(
+            (U256::zero(), U256::zero()),
+            |(quotient_total, remainder_total), compact| {
+                let threshold: U256 = compact
                     .to_expanded()
                     .expect("difficulty thresholds in previously verified blocks are valid")
-            })
-            .sum();
+                    .into();
 
-        let divisor: U256 = POW_AVERAGING_WINDOW.into();
-        total / divisor
+                (
+                    quotient_total + threshold / divisor,
+                    remainder_total + threshold % divisor,
+                )
+            },
+        );
+
+        ExpandedDifficulty::from(quotient_total + remainder_total / divisor)
     }
 
     /// Calculate the bounded median timespan. The median timespan is the
     /// difference of medians of the timespan times, which are the `time`s from
-    /// the previous `PoWAveragingWindow + PoWMedianBlockSpan` (28) blocks in the
+    /// the previous `PoWAveragingWindow + PoWMedianBlockSpan` blocks in the
     /// relevant chain.
     ///
     /// Uses the candidate block's `height' and `network` to calculate the
@@ -271,8 +281,8 @@ impl AdjustedDifficulty {
     ///
     /// Implements `ActualTimespanBounded` from the Zcash specification.
     ///
-    /// Note: This calculation only uses `PoWMedianBlockSpan` (11) times at the
-    /// start and end of the timespan times. timespan times `[11..=16]` are ignored.
+    /// Note: This calculation only uses `PoWMedianBlockSpan` times at the
+    /// start and end of the timespan times. Any times between those spans are ignored.
     fn median_timespan_bounded(&self) -> Duration {
         let averaging_window_timespan = NetworkUpgrade::averaging_window_timespan_for_height(
             &self.network,
@@ -302,20 +312,22 @@ impl AdjustedDifficulty {
 
     /// Calculate the median timespan. The median timespan is the difference of
     /// medians of the timespan times, which are the `time`s from the previous
-    /// `PoWAveragingWindow + PoWMedianBlockSpan` (28) blocks in the relevant chain.
+    /// `PoWAveragingWindow + PoWMedianBlockSpan` blocks in the relevant chain.
     ///
     /// Implements `ActualTimespan` from the Zcash specification.
     ///
     /// See [`Self::median_timespan_bounded`] for details.
     fn median_timespan(&self) -> Duration {
         let newer_median = self.median_time_past();
+        let averaging_window =
+            NetworkUpgrade::averaging_window_for_height(&self.network, self.candidate_height);
 
         // MedianTime(height : N) := median([ nTime(𝑖) for 𝑖 from max(0, height − PoWMedianBlockSpan) up to max(0, height − 1) ])
-        let older_median = if self.relevant_times.len() > POW_AVERAGING_WINDOW {
+        let older_median = if self.relevant_times.len() > averaging_window {
             let older_times: Vec<_> = self
                 .relevant_times
                 .iter()
-                .skip(POW_AVERAGING_WINDOW)
+                .skip(averaging_window)
                 .cloned()
                 .take(POW_MEDIAN_BLOCK_SPAN)
                 .collect();
@@ -330,7 +342,7 @@ impl AdjustedDifficulty {
     }
 
     /// Calculate the median of the `time`s from the previous
-    /// `PoWMedianBlockSpan` (11) blocks in the relevant chain.
+    /// `PoWMedianBlockSpan` blocks in the relevant chain.
     ///
     /// Implements `median-time-past` and `MedianTime(candidate_height)` from the
     /// Zcash specification. (These functions are identical, but they are
@@ -347,7 +359,7 @@ impl AdjustedDifficulty {
     }
 
     /// Calculate the median of the `median_block_span_times`: the `time`s from a
-    /// Vec of `PoWMedianBlockSpan` (11) or fewer blocks in the relevant chain.
+    /// Vec of `PoWMedianBlockSpan` or fewer blocks in the relevant chain.
     ///
     /// Implements `MedianTime` from the Zcash specification.
     ///
@@ -361,5 +373,114 @@ impl AdjustedDifficulty {
         // <https://zips.z.cash/protocol/protocol.pdf>, section 7.7.3, Difficulty Adjustment (p. 132)
         let median_idx = median_block_span_times.len() / 2;
         median_block_span_times[median_idx]
+    }
+}
+
+/// Returns the difficulty adjustment block span for `network` and `height`.
+pub fn pow_adjustment_block_span_for_height(network: &Network, height: block::Height) -> usize {
+    NetworkUpgrade::averaging_window_for_height(network, height) + POW_MEDIAN_BLOCK_SPAN
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use hex::FromHex;
+    use zebra_chain::{
+        block::Height,
+        parameters::{
+            testnet, POST_BLOSSOM_POW_TARGET_SPACING, POST_NU7_POW_AVERAGING_WINDOW,
+            POST_NU7_POW_TARGET_SPACING, PRE_NU7_POW_AVERAGING_WINDOW,
+        },
+        work::difficulty::ParameterDifficulty,
+    };
+
+    /// Builds a Testnet that activates Blossom at height 1 and NU7 at `nu7_height`.
+    fn nu7_testnet(nu7_height: u32) -> Network {
+        testnet::Parameters::build()
+            .with_activation_heights(testnet::ConfiguredActivationHeights {
+                blossom: Some(1),
+                nu7: Some(nu7_height),
+                ..Default::default()
+            })
+            .expect("activation heights are valid")
+            .clear_funding_streams()
+            .to_network()
+            .expect("configured testnet is valid")
+    }
+
+    /// Returns the expected difficulty threshold for a candidate block at height
+    /// 100, preceded by a chain of blocks all at the PoW limit and spaced
+    /// `target_spacing` seconds apart, ending at `candidate_secs`.
+    fn min_pow_limit_threshold(
+        network: &Network,
+        target_spacing: i64,
+        candidate_secs: i64,
+    ) -> CompactDifficulty {
+        let previous_block_height = Height(99);
+        let candidate_block_height = (previous_block_height + 1).expect("next height is valid");
+
+        let difficulty = network.target_difficulty_limit().to_compact();
+        let candidate_time =
+            DateTime::from_timestamp(candidate_secs, 0).expect("test timestamp is in-range");
+
+        let relevant_data =
+            (0..pow_adjustment_block_span_for_height(network, candidate_block_height)).map(
+                |offset| {
+                    let offset = i64::try_from(offset).expect("test offset fits in i64");
+                    (
+                        difficulty,
+                        candidate_time - Duration::seconds((offset + 1) * target_spacing),
+                    )
+                },
+            );
+
+        AdjustedDifficulty::new_from_header_time(
+            candidate_time,
+            previous_block_height,
+            network,
+            relevant_data,
+        )
+        .expected_difficulty_threshold()
+    }
+
+    /// Before NU7 the difficulty calculation still uses the legacy 17-block
+    /// averaging window, producing the same threshold as the pre-NU7 code.
+    ///
+    /// The threshold sits one ULP below `PoWLimit`: even with on-target spacing,
+    /// `(mean_target / target_timespan) * actual_timespan` truncates downwards.
+    #[test]
+    fn pre_nu7_difficulty_vector_matches_legacy_averaging_window() {
+        let network = nu7_testnet(1_000);
+
+        assert_eq!(
+            PRE_NU7_POW_AVERAGING_WINDOW,
+            NetworkUpgrade::averaging_window_for_height(&network, Height(100))
+        );
+
+        assert_eq!(
+            CompactDifficulty::from_hex("2007fffe").expect("hard-coded difficulty is valid"),
+            min_pow_limit_threshold(&network, i64::from(POST_BLOSSOM_POW_TARGET_SPACING), 7_500),
+        );
+    }
+
+    /// The wider 102-block NU7 window must not overflow the `mean_target` sum.
+    #[test]
+    fn mean_target_uses_nu7_averaging_window_without_overflow() {
+        let network = nu7_testnet(100);
+
+        assert_eq!(
+            PRE_NU7_POW_AVERAGING_WINDOW,
+            NetworkUpgrade::averaging_window_for_height(&network, Height(99))
+        );
+        assert_eq!(
+            POST_NU7_POW_AVERAGING_WINDOW,
+            NetworkUpgrade::averaging_window_for_height(&network, Height(100))
+        );
+
+        assert_eq!(
+            CompactDifficulty::from_hex("2007fffe").expect("hard-coded difficulty is valid"),
+            min_pow_limit_threshold(&network, i64::from(POST_NU7_POW_TARGET_SPACING), 2_500),
+        );
     }
 }

--- a/zebra-state/src/service/read/difficulty.rs
+++ b/zebra-state/src/service/read/difficulty.rs
@@ -275,6 +275,8 @@ fn adjust_difficulty_and_time_for_testnet(
         return;
     }
 
+    let candidate_block_height = (previous_block_height + 1).expect("next block height is valid");
+
     // On testnet, changing the block time can also change the difficulty,
     // due to the minimum difficulty consensus rule:
     // > if the block time of a block at height `height ≥ 299188`
@@ -303,7 +305,7 @@ fn adjust_difficulty_and_time_for_testnet(
         .expect("valid blocks have in-range times");
 
     let Some(minimum_difficulty_spacing) =
-        NetworkUpgrade::minimum_difficulty_spacing_for_height(network, previous_block_height)
+        NetworkUpgrade::minimum_difficulty_spacing_for_height(network, candidate_block_height)
     else {
         // Returns early if the testnet minimum difficulty consensus rule is not active
         return;
@@ -363,5 +365,63 @@ fn adjust_difficulty_and_time_for_testnet(
             relevant_data.iter().cloned(),
         )
         .expected_difficulty_threshold();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use zebra_chain::{
+        block, parameters::testnet, serialization::Duration32,
+        work::difficulty::ParameterDifficulty,
+    };
+
+    #[test]
+    fn get_block_template_testnet_min_difficulty_uses_candidate_height_spacing() {
+        let previous_block_height = Height(2_999_999);
+        let candidate_block_height = (previous_block_height + 1).unwrap();
+        let previous_block_time = DateTime32::from(1_000u32);
+
+        let network = testnet::Parameters::build()
+            .with_activation_heights(testnet::ConfiguredActivationHeights {
+                nu7: Some(candidate_block_height.0),
+                ..Default::default()
+            })
+            .expect("activation heights are valid")
+            .clear_funding_streams()
+            .to_network()
+            .expect("configured testnet is valid");
+
+        let difficulty = network.target_difficulty_limit().to_compact();
+        let mut result = GetBlockTemplateChainInfo {
+            tip_hash: block::Hash([0; 32]),
+            tip_height: previous_block_height,
+            chain_history_root: None,
+            expected_difficulty: difficulty,
+            cur_time: previous_block_time
+                .checked_add(Duration32::from_seconds(151))
+                .expect("test time is in-range"),
+            min_time: previous_block_time
+                .checked_add(Duration32::from_seconds(1))
+                .expect("test time is in-range"),
+            max_time: previous_block_time
+                .checked_add(Duration32::from_seconds(2_000))
+                .expect("test time is in-range"),
+        };
+
+        adjust_difficulty_and_time_for_testnet(
+            &mut result,
+            &network,
+            previous_block_height,
+            vec![(difficulty, previous_block_time.to_chrono())],
+        );
+
+        assert_eq!(
+            previous_block_time
+                .checked_add(Duration32::from_seconds(151))
+                .expect("test time is in-range"),
+            result.min_time
+        );
     }
 }


### PR DESCRIPTION
## Motivation

This PR is targeting the nu7 candidate zip [218](https://zips.z.cash/zip-0218) https://zips.z.cash/#nu7-candidate-zips.

and also this post https://x.com/zkDragon/status/2056990016203796749

NU7's 25-second block target spacing changes the time represented by a fixed number of blocks. Zebra's difficulty adjustment code needs height-dependent averaging-window parameters while preserving pre-NU7 behavior exactly.

## Solution

Add pre- and post-NU7 averaging-window constants and make the active averaging window depend on the candidate block height. Resize the contextual DAA history buffer for the largest active window.

The mean-target calculation now avoids overflowing when summing large post-NU7 Testnet thresholds by averaging quotient and remainder parts separately. Testnet minimum-difficulty decisions use the candidate height so the 25-second spacing activates at the right boundary.

This PR is stacked on the NU7 target-spacing PR (#10648) because the DAA transition uses the height-dependent target-spacing API from that branch. It no longer depends on the max-reorg-length change (#10650), which is now a separate local-policy PR.

### Tests

- `cargo fmt --all`
- `cargo test -p zebra-chain averaging_window_changes_at_nu7_activation_height`
- `cargo test -p zebra-state mean_target_uses_nu7_averaging_window_without_overflow`

### Specifications & References

This implements the DAA parameter pieces of the draft 25-second block target spacing ZIP:

- The ZIP makes `PoWAveragingWindow(height)` height-dependent.
- It says all other references to `PoWAveragingWindow` in difficulty adjustment use the value for the height of the block under consideration.
- The branch follows the NU7 testnet source branch final value `POST_NU7_POW_AVERAGING_WINDOW = 102`, which keeps the historical 17-block, 150-second averaging period as 102 blocks at 25 seconds.
- The ZIP also redefines `PoWTargetSpacing(height)`, which this branch consumes from the target-spacing PR for timespan and Testnet minimum-difficulty decisions.

### Follow-up Work

None in this PR.

### AI Disclosure

- [x] AI tools were used: OpenAI Codex for branch splitting, implementation review, and PR description drafting.

### PR Checklist

- [x] The PR title follows conventional commits format: `feat(consensus): add NU7 difficulty adjustment parameters`
- [x] Test evidence is listed above.
- [x] The documentation and changelogs are up to date.
