### PR TITLE
feat(consensus): enforce NU7 shielded action limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 - Startup warning on Linux when `net.ipv4.tcp_slow_start_after_idle` is enabled (which resets TCP congestion windows between block requests and significantly reduces single-peer block-propagation throughput on long-haul links), with a "Linux TCP tuning for block propagation" troubleshooting section ([#10513](https://github.com/ZcashFoundation/zebra/pull/10513))
 - Support ZIP-213
+- Added NU7 shielded action limits for block verification, mempool admission,
+  and `getblocktemplate` transaction selection. These consensus checks only
+  activate on networks with NU7 configured, at and after the NU7 activation
+  height.
 
 ### Fixed
 

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -243,7 +243,7 @@ pub const POST_BLOSSOM_POW_TARGET_SPACING: u32 = 75;
 /// activation onwards.
 ///
 /// `OrchardBlockActionLimit` in the draft "Shorter Block Target Spacing" ZIP.
-pub const ORCHARD_BLOCK_ACTION_LIMIT: u32 = 306;
+pub const ORCHARD_BLOCK_ACTION_LIMIT: u32 = 330;
 
 /// Per-block limit on the total number of Sapling spends + outputs, applied
 /// from NU7 activation onwards.
@@ -265,7 +265,7 @@ pub const SPROUT_BLOCK_JOINSPLIT_LIMIT: u32 = 25;
 /// because each JoinSplit produces 2 shielded outputs.
 ///
 /// `GlobalShieldedBudget` in the draft "Shorter Block Target Spacing" ZIP.
-pub const GLOBAL_SHIELDED_BUDGET: u32 = 306;
+pub const GLOBAL_SHIELDED_BUDGET: u32 = 330;
 
 /// The averaging window for difficulty threshold arithmetic mean calculations.
 ///

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -239,6 +239,34 @@ const PRE_BLOSSOM_POW_TARGET_SPACING: i64 = 150;
 /// The target block spacing after Blossom activation.
 pub const POST_BLOSSOM_POW_TARGET_SPACING: u32 = 75;
 
+/// Per-block limit on the total number of Orchard actions, applied from NU7
+/// activation onwards.
+///
+/// `OrchardBlockActionLimit` in the draft "Shorter Block Target Spacing" ZIP.
+pub const ORCHARD_BLOCK_ACTION_LIMIT: u32 = 306;
+
+/// Per-block limit on the total number of Sapling spends + outputs, applied
+/// from NU7 activation onwards.
+///
+/// `SaplingBlockIOLimit` in the draft "Shorter Block Target Spacing" ZIP.
+pub const SAPLING_BLOCK_IO_LIMIT: u32 = 300;
+
+/// Per-block limit on the total number of Sprout JoinSplits, applied from NU7
+/// activation onwards.
+///
+/// `SproutBlockJoinSplitLimit` in the draft "Shorter Block Target Spacing" ZIP.
+// TODO: Remove this when disallowing
+pub const SPROUT_BLOCK_JOINSPLIT_LIMIT: u32 = 25;
+
+/// Per-block global shielded budget, applied from NU7 activation onwards.
+///
+/// Bounds the worst-case shielded sync bandwidth per block independently of
+/// which combination of pools is used. Sprout JoinSplits are weighted by 2
+/// because each JoinSplit produces 2 shielded outputs.
+///
+/// `GlobalShieldedBudget` in the draft "Shorter Block Target Spacing" ZIP.
+pub const GLOBAL_SHIELDED_BUDGET: u32 = 306;
+
 /// The averaging window for difficulty threshold arithmetic mean calculations.
 ///
 /// `PoWAveragingWindow` in the Zcash specification.
@@ -310,6 +338,19 @@ impl NetworkUpgrade {
             .map(|(_, nu)| *nu)
             .next_back()
             .expect("every height has a current network upgrade")
+    }
+
+    /// Returns `true` if NU7 is configured on `network` and active at `height`.
+    ///
+    /// NU7 has no default mainnet or testnet activation height, so this also
+    /// checks that `network` explicitly configures one before treating it as
+    /// active.
+    pub fn is_nu7_active(network: &Network, height: block::Height) -> bool {
+        let nu7_configured = network
+            .activation_list()
+            .values()
+            .any(|upgrade| *upgrade == NetworkUpgrade::Nu7);
+        nu7_configured && NetworkUpgrade::current(network, height) >= NetworkUpgrade::Nu7
     }
 
     /// Returns the next expected network upgrade after this network upgrade.

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -205,6 +205,42 @@ impl fmt::Display for Transaction {
     }
 }
 
+/// The shielded action counts of a transaction, used to enforce the per-block
+/// NU7 shielded limits from the draft "Shorter Block Target Spacing" ZIP.
+///
+/// Each count saturates at [`u32::MAX`].
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ShieldedActionCounts {
+    /// The number of Orchard actions.
+    pub orchard_actions: u32,
+    /// The number of Sapling spends plus outputs.
+    pub sapling_ios: u32,
+    /// The number of Sprout JoinSplits.
+    pub sprout_joinsplits: u32,
+}
+
+impl ShieldedActionCounts {
+    /// The total shielded cost: `orchard_actions + sapling_ios + 2 * sprout_joinsplits`.
+    ///
+    /// Sprout JoinSplits are weighted by 2 because each produces 2 shielded outputs.
+    pub fn cost(&self) -> u32 {
+        self.orchard_actions
+            .saturating_add(self.sapling_ios)
+            .saturating_add(self.sprout_joinsplits.saturating_mul(2))
+    }
+
+    /// Returns the field-wise saturating sum of `self` and `other`.
+    pub fn saturating_add(self, other: Self) -> Self {
+        Self {
+            orchard_actions: self.orchard_actions.saturating_add(other.orchard_actions),
+            sapling_ios: self.sapling_ios.saturating_add(other.sapling_ios),
+            sprout_joinsplits: self
+                .sprout_joinsplits
+                .saturating_add(other.sprout_joinsplits),
+        }
+    }
+}
+
 impl Transaction {
     // identifiers and hashes
 
@@ -1093,6 +1129,18 @@ impl Transaction {
         self.orchard_shielded_data()
             .into_iter()
             .flat_map(orchard::ShieldedData::actions)
+    }
+
+    /// Returns this transaction's [`ShieldedActionCounts`], used to enforce the
+    /// NU7 per-block shielded limits.
+    pub fn shielded_action_counts(&self) -> ShieldedActionCounts {
+        let count = |n: usize| u32::try_from(n).unwrap_or(u32::MAX);
+        ShieldedActionCounts {
+            orchard_actions: count(self.orchard_actions().count()),
+            sapling_ios: count(self.sapling_spends_per_anchor().count())
+                .saturating_add(count(self.sapling_outputs().count())),
+            sprout_joinsplits: count(self.joinsplit_count()),
+        }
     }
 
     /// Access the [`orchard::Nullifier`]s in this transaction, if there are any,

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -1098,3 +1098,58 @@ pub fn insert_fake_orchard_shielded_data(
         _ => panic!("Fake V5 transaction is not V5"),
     }
 }
+
+/// Returns an empty V5 transaction with no shielded data, for use as a base in
+/// shielded-action test fixtures.
+pub fn empty_v5_transaction() -> Transaction {
+    Transaction::V5 {
+        network_upgrade: NetworkUpgrade::Nu5,
+        lock_time: LockTime::unlocked(),
+        expiry_height: block::Height(100),
+        inputs: Vec::new(),
+        outputs: Vec::new(),
+        sapling_shielded_data: None,
+        orchard_shielded_data: None,
+    }
+}
+
+/// Returns a V5 transaction containing `count` Orchard actions.
+pub fn fake_v5_with_orchard_actions(count: usize) -> Arc<Transaction> {
+    let mut tx = empty_v5_transaction();
+    let shielded_data = insert_fake_orchard_shielded_data(&mut tx);
+    let action = shielded_data
+        .actions
+        .iter()
+        .next()
+        .expect("fake shielded data has an action")
+        .clone();
+    shielded_data.actions = at_least_one![action; count];
+    Arc::new(tx)
+}
+
+/// Returns a V5 transaction containing `count` Sapling outputs.
+pub fn fake_v5_with_sapling_outputs(count: usize) -> Arc<Transaction> {
+    let mut runner = TestRunner::default();
+    let mut shielded_data = any::<sapling::ShieldedData<sapling::SharedAnchor>>()
+        .new_tree(&mut runner)
+        .expect("sapling shielded data strategy is valid")
+        .current();
+    let output = any::<sapling::Output>()
+        .new_tree(&mut runner)
+        .expect("sapling output strategy is valid")
+        .current();
+
+    shielded_data.transfers = sapling::TransferData::JustOutputs {
+        outputs: at_least_one![output; count],
+    };
+
+    let mut tx = empty_v5_transaction();
+    match &mut tx {
+        Transaction::V5 {
+            sapling_shielded_data,
+            ..
+        } => *sapling_shielded_data = Some(shielded_data),
+        _ => unreachable!("empty_v5_transaction returns V5"),
+    }
+    Arc::new(tx)
+}

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -245,6 +245,8 @@ where
                 .map_err(VerifyBlockError::Time)?;
             let coinbase_tx = check::coinbase_is_first(&block)?;
 
+            check::shielded_action_limits_are_valid(&block.transactions, height, &network)?;
+
             let expected_block_subsidy =
                 zebra_chain::parameters::subsidy::block_subsidy(height, &network)?;
 

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -15,9 +15,10 @@ use zebra_chain::{
             founders_reward, founders_reward_address, funding_stream_values, FundingStreamReceiver,
             ParameterSubsidy, SubsidyError,
         },
-        Network, NetworkUpgrade,
+        Network, NetworkUpgrade, GLOBAL_SHIELDED_BUDGET, ORCHARD_BLOCK_ACTION_LIMIT,
+        SAPLING_BLOCK_IO_LIMIT, SPROUT_BLOCK_JOINSPLIT_LIMIT,
     },
-    transaction::{self, Transaction},
+    transaction::{self, ShieldedActionCounts, Transaction},
     transparent::{Address, Output},
     work::{
         difficulty::{ExpandedDifficulty, ParameterDifficulty as _},
@@ -404,6 +405,77 @@ pub fn time_is_valid_at(
     hash: &Hash,
 ) -> Result<(), zebra_chain::block::BlockTimeError> {
     header.time_is_valid_at(now, height, hash)
+}
+
+/// Returns `Ok(())` if the per-block shielded action limits introduced by the
+/// draft "Shorter Block Target Spacing" ZIP are satisfied for the sum of
+/// `transactions` on `network` at `height`.
+///
+/// The block verifier passes every transaction in the block; the transaction
+/// verifier passes a single mempool transaction (a tx whose own counts exceed
+/// any per-block limit can never be mined, so we reject it on submission).
+///
+/// The limits apply only after NU7 activation. Before NU7 this is a no-op.
+///
+/// # Consensus
+///
+/// > For each block at height `height` where `IsNU7Activated(height)`, the
+/// > following limits MUST be satisfied:
+/// > - the total number of Orchard actions across all transactions in the
+/// >   block MUST NOT exceed `OrchardBlockActionLimit`;
+/// > - the total number of Sapling inputs and outputs across all transactions
+/// >   in the block MUST NOT exceed `SaplingBlockIOLimit`;
+/// > - the total number of Sprout JoinSplits across all transactions in the
+/// >   block MUST NOT exceed `SproutBlockJoinSplitLimit`;
+/// > - the total shielded cost across all pools MUST NOT exceed
+/// >   `GlobalShieldedBudget`, where the cost is
+/// >   `Σ orchard_actions + Σ (sapling_spends + sapling_outputs)
+/// >    + 2 * Σ joinsplits`.
+///
+/// Defined by the draft "Shorter Block Target Spacing" ZIP.
+pub fn shielded_action_limits_are_valid<'a>(
+    transactions: impl IntoIterator<Item = &'a Arc<Transaction>>,
+    height: Height,
+    network: &Network,
+) -> Result<(), TransactionError> {
+    if !NetworkUpgrade::is_nu7_active(network, height) {
+        return Ok(());
+    }
+
+    let totals = transactions
+        .into_iter()
+        .map(|tx| tx.shielded_action_counts())
+        .fold(
+            ShieldedActionCounts::default(),
+            ShieldedActionCounts::saturating_add,
+        );
+
+    if totals.orchard_actions > ORCHARD_BLOCK_ACTION_LIMIT {
+        return Err(TransactionError::OrchardActionsExceedBlockLimit {
+            actions: totals.orchard_actions,
+            limit: ORCHARD_BLOCK_ACTION_LIMIT,
+        });
+    }
+    if totals.sapling_ios > SAPLING_BLOCK_IO_LIMIT {
+        return Err(TransactionError::SaplingIOsExceedBlockLimit {
+            ios: totals.sapling_ios,
+            limit: SAPLING_BLOCK_IO_LIMIT,
+        });
+    }
+    if totals.sprout_joinsplits > SPROUT_BLOCK_JOINSPLIT_LIMIT {
+        return Err(TransactionError::SproutJoinSplitsExceedBlockLimit {
+            joinsplits: totals.sprout_joinsplits,
+            limit: SPROUT_BLOCK_JOINSPLIT_LIMIT,
+        });
+    }
+    let cost = totals.cost();
+    if cost > GLOBAL_SHIELDED_BUDGET {
+        return Err(TransactionError::ShieldedCostExceedsBlockBudget {
+            cost,
+            limit: GLOBAL_SHIELDED_BUDGET,
+        });
+    }
+    Ok(())
 }
 
 /// Check Merkle root validity.

--- a/zebra-consensus/src/block/tests.rs
+++ b/zebra-consensus/src/block/tests.rs
@@ -2,8 +2,15 @@
 
 #![allow(clippy::unwrap_in_result)]
 
+use std::sync::Arc;
+
 use color_eyre::eyre::{eyre, Report};
 use once_cell::sync::Lazy;
+use proptest::{
+    arbitrary::any,
+    strategy::{Strategy, ValueTree},
+    test_runner::TestRunner,
+};
 use tower::{buffer::Buffer, util::BoxService};
 
 use zebra_chain::{
@@ -14,15 +21,24 @@ use zebra_chain::{
         },
         Block, Height,
     },
-    parameters::{subsidy::block_subsidy, NetworkUpgrade},
+    parameters::{
+        subsidy::block_subsidy, testnet, Network, NetworkUpgrade, GLOBAL_SHIELDED_BUDGET,
+        ORCHARD_BLOCK_ACTION_LIMIT, SAPLING_BLOCK_IO_LIMIT, SPROUT_BLOCK_JOINSPLIT_LIMIT,
+    },
+    primitives::Groth16Proof,
     serialization::{ZcashDeserialize, ZcashDeserializeInto},
-    transaction::{arbitrary::transaction_to_fake_v5, LockTime, Transaction},
+    transaction::{
+        arbitrary::{
+            fake_v5_with_orchard_actions, fake_v5_with_sapling_outputs, transaction_to_fake_v5,
+        },
+        JoinSplitData, LockTime, Transaction,
+    },
     work::difficulty::{ParameterDifficulty as _, INVALID_COMPACT_DIFFICULTY},
 };
 use zebra_script::Sigops;
 use zebra_test::transcript::{ExpectedTranscriptError, Transcript};
 
-use crate::{block::check::subsidy_is_valid, transaction};
+use crate::{block::check::subsidy_is_valid, error::TransactionError, transaction};
 
 use super::*;
 
@@ -760,6 +776,224 @@ fn miner_fees_validation_fails_when_zip233_amount_is_incorrect() -> Result<(), R
     );
 
     Ok(())
+}
+
+/// Smoke test for the per-block shielded action limits introduced by the draft
+/// "Shorter Block Target Spacing" ZIP. The limits only apply at and after NU7
+/// activation; pre-NU7 the check is a no-op, so historical block test vectors
+/// must all pass, and a (very small) historical block treated as if it were at
+/// NU7 activation must still pass because its shielded counts are all zero or
+/// well below the limits.
+#[test]
+fn shielded_action_limits_smoke() -> Result<(), Report> {
+    let _init_guard = zebra_test::init();
+
+    // Pre-NU7: the function is a no-op, so every historical block must pass.
+    for block in zebra_test::vectors::BLOCKS.iter() {
+        let block = block
+            .zcash_deserialize_into::<Block>()
+            .expect("block is structurally valid");
+        check::shielded_action_limits_are_valid(
+            &block.transactions,
+            block.coinbase_height().unwrap(),
+            &Network::Mainnet,
+        )
+        .expect("historical pre-NU7 block must satisfy the shielded action limits");
+    }
+
+    // Post-NU7: on a testnet with NU7 active at height 1, the mainnet genesis
+    // block (no shielded data) evaluated "as if" at NU7 activation must pass,
+    // because its action counts are all zero.
+    let nu7_testnet = nu7_active_testnet();
+    let block = Block::zcash_deserialize(&zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES[..])
+        .expect("mainnet genesis deserializes");
+
+    check::shielded_action_limits_are_valid(&block.transactions, Height(1), &nu7_testnet)
+        .expect("a block with no shielded data must satisfy the post-NU7 limits");
+
+    Ok(())
+}
+
+#[test]
+fn shielded_action_limits_activate_at_nu7_height() {
+    let network = nu7_activation_testnet(2);
+    let over_limit_tx = fake_v5_with_orchard_actions(limit_plus_one(ORCHARD_BLOCK_ACTION_LIMIT));
+
+    check::shielded_action_limits_are_valid([over_limit_tx.clone()].iter(), Height(1), &network)
+        .expect("pre-NU7 shielded action limits are not active");
+
+    let err = check::shielded_action_limits_are_valid([over_limit_tx].iter(), Height(2), &network)
+        .expect_err("NU7 activation height must enforce shielded action limits");
+
+    assert_eq!(
+        err,
+        TransactionError::OrchardActionsExceedBlockLimit {
+            actions: ORCHARD_BLOCK_ACTION_LIMIT.saturating_add(1),
+            limit: ORCHARD_BLOCK_ACTION_LIMIT,
+        }
+    );
+}
+
+#[test]
+fn shielded_action_limits_accept_per_pool_limits() {
+    check::shielded_action_limits_are_valid(
+        [fake_v5_with_orchard_actions(
+            usize::try_from(ORCHARD_BLOCK_ACTION_LIMIT).expect("limit fits in usize"),
+        )]
+        .iter(),
+        Height(1),
+        &nu7_active_testnet(),
+    )
+    .expect("Orchard actions exactly at the NU7 limit must pass");
+
+    check::shielded_action_limits_are_valid(
+        [fake_v5_with_sapling_outputs(
+            usize::try_from(SAPLING_BLOCK_IO_LIMIT).expect("limit fits in usize"),
+        )]
+        .iter(),
+        Height(1),
+        &nu7_active_testnet(),
+    )
+    .expect("Sapling inputs and outputs exactly at the NU7 limit must pass");
+
+    check::shielded_action_limits_are_valid(
+        [fake_v4_with_sprout_joinsplits(
+            usize::try_from(SPROUT_BLOCK_JOINSPLIT_LIMIT).expect("limit fits in usize"),
+        )]
+        .iter(),
+        Height(1),
+        &nu7_active_testnet(),
+    )
+    .expect("Sprout JoinSplits exactly at the NU7 limit must pass");
+}
+
+#[test]
+fn shielded_action_limits_accept_global_budget_limit() {
+    let orchard_actions = usize::try_from(
+        GLOBAL_SHIELDED_BUDGET
+            .checked_sub(2)
+            .expect("global shielded budget is at least one JoinSplit cost"),
+    )
+    .expect("limit fits in usize");
+
+    check::shielded_action_limits_are_valid(
+        [
+            fake_v5_with_orchard_actions(orchard_actions),
+            fake_v4_with_sprout_joinsplits(1),
+        ]
+        .iter(),
+        Height(1),
+        &nu7_active_testnet(),
+    )
+    .expect("combined shielded cost exactly at the NU7 global budget must pass");
+}
+
+#[test]
+fn shielded_action_limits_reject_sapling_over_limit() {
+    let count = limit_plus_one(SAPLING_BLOCK_IO_LIMIT);
+    let err = check::shielded_action_limits_are_valid(
+        [fake_v5_with_sapling_outputs(count)].iter(),
+        Height(1),
+        &nu7_active_testnet(),
+    )
+    .expect_err("Sapling spends and outputs above the NU7 per-block limit must fail");
+
+    assert_eq!(
+        err,
+        TransactionError::SaplingIOsExceedBlockLimit {
+            ios: SAPLING_BLOCK_IO_LIMIT + 1,
+            limit: SAPLING_BLOCK_IO_LIMIT,
+        }
+    );
+}
+
+#[test]
+fn shielded_action_limits_reject_sprout_over_limit() {
+    let count = limit_plus_one(SPROUT_BLOCK_JOINSPLIT_LIMIT);
+    let err = check::shielded_action_limits_are_valid(
+        [fake_v4_with_sprout_joinsplits(count)].iter(),
+        Height(1),
+        &nu7_active_testnet(),
+    )
+    .expect_err("Sprout JoinSplits above the NU7 per-block limit must fail");
+
+    assert_eq!(
+        err,
+        TransactionError::SproutJoinSplitsExceedBlockLimit {
+            joinsplits: SPROUT_BLOCK_JOINSPLIT_LIMIT + 1,
+            limit: SPROUT_BLOCK_JOINSPLIT_LIMIT,
+        }
+    );
+}
+
+#[test]
+fn shielded_action_limits_reject_global_budget_over_limit() {
+    let err = check::shielded_action_limits_are_valid(
+        [
+            fake_v5_with_orchard_actions(
+                usize::try_from(ORCHARD_BLOCK_ACTION_LIMIT).expect("limit fits in usize"),
+            ),
+            fake_v5_with_sapling_outputs(1),
+        ]
+        .iter(),
+        Height(1),
+        &nu7_active_testnet(),
+    )
+    .expect_err("combined shielded cost above the NU7 global budget must fail");
+
+    assert_eq!(
+        err,
+        TransactionError::ShieldedCostExceedsBlockBudget {
+            cost: GLOBAL_SHIELDED_BUDGET + 1,
+            limit: GLOBAL_SHIELDED_BUDGET,
+        }
+    );
+}
+
+fn nu7_active_testnet() -> Network {
+    nu7_activation_testnet(1)
+}
+
+fn nu7_activation_testnet(nu7_activation_height: u32) -> Network {
+    testnet::Parameters::build()
+        .with_slow_start_interval(Height(0))
+        .with_activation_heights(testnet::ConfiguredActivationHeights {
+            nu7: Some(nu7_activation_height),
+            ..Default::default()
+        })
+        .expect("activation heights are valid")
+        .clear_funding_streams()
+        .to_network()
+        .expect("configured testnet is valid")
+}
+
+fn limit_plus_one(limit: u32) -> usize {
+    limit
+        .checked_add(1)
+        .expect("test limit plus one fits in u32")
+        .try_into()
+        .expect("test limit fits in usize")
+}
+
+fn fake_v4_with_sprout_joinsplits(count: usize) -> Arc<Transaction> {
+    let mut runner = TestRunner::default();
+    let mut joinsplit_data = any::<JoinSplitData<Groth16Proof>>()
+        .new_tree(&mut runner)
+        .expect("sprout JoinSplit data strategy is valid")
+        .current();
+    let rest_len = count
+        .checked_sub(1)
+        .expect("sprout JoinSplit test count is at least one");
+    joinsplit_data.rest = vec![joinsplit_data.first.clone(); rest_len];
+
+    Arc::new(Transaction::V4 {
+        inputs: Vec::new(),
+        outputs: Vec::new(),
+        lock_time: LockTime::unlocked(),
+        expiry_height: Height(100),
+        joinsplit_data: Some(joinsplit_data),
+        sapling_shielded_data: None,
+    })
 }
 
 #[test]

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -230,6 +230,22 @@ pub enum TransactionError {
     #[error("wrong tx format: tx version is ≥ 5, but `nConsensusBranchId` is missing")]
     MissingConsensusBranchId,
 
+    #[error("Orchard action count {actions} exceeds the per-block limit of {limit}")]
+    OrchardActionsExceedBlockLimit { actions: u32, limit: u32 },
+
+    #[error("Sapling spends + outputs count {ios} exceeds the per-block limit of {limit}")]
+    SaplingIOsExceedBlockLimit { ios: u32, limit: u32 },
+
+    #[error("Sprout JoinSplit count {joinsplits} exceeds the per-block limit of {limit}")]
+    SproutJoinSplitsExceedBlockLimit { joinsplits: u32, limit: u32 },
+
+    #[error(
+        "shielded cost {cost} \
+         (Orchard actions + Sapling spends + Sapling outputs + 2 * Sprout JoinSplits) \
+         exceeds the per-block global shielded budget of {limit}"
+    )]
+    ShieldedCostExceedsBlockBudget { cost: u32, limit: u32 },
+
     #[error("input/output error")]
     Io(String),
 
@@ -357,7 +373,11 @@ impl TransactionError {
             | DisabledAddToSproutPool
             | NotEnoughFlags
             | WrongConsensusBranchId
-            | MissingConsensusBranchId => 100,
+            | MissingConsensusBranchId
+            | OrchardActionsExceedBlockLimit { .. }
+            | SaplingIOsExceedBlockLimit { .. }
+            | SproutJoinSplitsExceedBlockLimit { .. }
+            | ShieldedCostExceedsBlockBudget { .. } => 100,
 
             _other => 0,
         }

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -405,6 +405,11 @@ where
             check::has_inputs_and_outputs(&tx)?;
             check::has_enough_orchard_flags(&tx)?;
             check::consensus_branch_id(&tx, req.height(), &network)?;
+            crate::block::check::shielded_action_limits_are_valid(
+                std::iter::once(&tx),
+                req.height(),
+                &network,
+            )?;
 
             // Validate the coinbase input consensus rules
             if req.is_mempool() && tx.is_coinbase() {

--- a/zebra-rpc/src/methods/types/get_block_template/zip317.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/zip317.rs
@@ -16,7 +16,10 @@ use rand::{
 use zebra_chain::{
     amount::Amount,
     block::{Height, MAX_BLOCK_BYTES},
-    parameters::Network,
+    parameters::{
+        Network, NetworkUpgrade, GLOBAL_SHIELDED_BUDGET, ORCHARD_BLOCK_ACTION_LIMIT,
+        SAPLING_BLOCK_IO_LIMIT, SPROUT_BLOCK_JOINSPLIT_LIMIT,
+    },
     transaction::{self, zip317::BLOCK_UNPAID_ACTION_LIMIT, VerifiedUnminedTx},
 };
 use zebra_consensus::MAX_BLOCK_SIGOPS;
@@ -93,14 +96,7 @@ pub fn select_mempool_transactions(
 
     let mut selected_txs = Vec::new();
 
-    // Set up limit tracking
-    let mut remaining_block_bytes: usize = MAX_BLOCK_BYTES.try_into().expect("fits in memory");
-    let mut remaining_block_sigops = MAX_BLOCK_SIGOPS;
-    let mut remaining_block_unpaid_actions: u32 = BLOCK_UNPAID_ACTION_LIMIT;
-
-    // Adjust the limits based on the coinbase transaction
-    remaining_block_bytes -= fake_coinbase_tx.data.as_ref().len();
-    remaining_block_sigops -= fake_coinbase_tx.sigops;
+    let mut limits = BlockTemplateLimits::initial(net, height, &fake_coinbase_tx);
 
     // > Repeat while there is any candidate transaction
     // > that pays at least the conventional fee:
@@ -113,11 +109,7 @@ pub fn select_mempool_transactions(
             tx_weights,
             &mut selected_txs,
             &mempool_tx_deps,
-            &mut remaining_block_bytes,
-            &mut remaining_block_sigops,
-            // The number of unpaid actions is always zero for transactions that pay the
-            // conventional fee, so this check and limit is effectively ignored.
-            &mut remaining_block_unpaid_actions,
+            &mut limits,
         );
     }
 
@@ -131,13 +123,102 @@ pub fn select_mempool_transactions(
             tx_weights,
             &mut selected_txs,
             &mempool_tx_deps,
-            &mut remaining_block_bytes,
-            &mut remaining_block_sigops,
-            &mut remaining_block_unpaid_actions,
+            &mut limits,
         );
     }
 
     selected_txs
+}
+
+/// Tracks the remaining capacity of a block template against every limit a
+/// candidate mempool transaction might exhaust: ZIP-317 byte/sigop/unpaid-action
+/// limits and, post-NU7, the per-pool shielded action limits and the global
+/// shielded budget defined by the draft "Shorter Block Target Spacing" ZIP.
+///
+/// Pre-NU7 the shielded fields are initialised to `u32::MAX` so the new limits
+/// have no effect.
+struct BlockTemplateLimits {
+    remaining_bytes: usize,
+    remaining_sigops: u32,
+    remaining_unpaid_actions: u32,
+    remaining_orchard_actions: u32,
+    remaining_sapling_ios: u32,
+    remaining_sprout_joinsplits: u32,
+    remaining_shielded_cost: u32,
+}
+
+impl BlockTemplateLimits {
+    /// Returns the initial limits for a block template at `height`, already
+    /// adjusted for `fake_coinbase_tx`'s contribution to the byte and sigop
+    /// limits.
+    fn initial<FeeConstraint>(
+        network: &Network,
+        height: Height,
+        fake_coinbase_tx: &TransactionTemplate<FeeConstraint>,
+    ) -> Self
+    where
+        FeeConstraint: zebra_chain::amount::Constraint + Clone + Copy,
+    {
+        let nu7_active = NetworkUpgrade::is_nu7_active(network, height);
+
+        let (orchard, sapling_io, sprout_jss, shielded_cost) = if nu7_active {
+            (
+                ORCHARD_BLOCK_ACTION_LIMIT,
+                SAPLING_BLOCK_IO_LIMIT,
+                SPROUT_BLOCK_JOINSPLIT_LIMIT,
+                GLOBAL_SHIELDED_BUDGET,
+            )
+        } else {
+            (u32::MAX, u32::MAX, u32::MAX, u32::MAX)
+        };
+
+        let max_bytes: usize = MAX_BLOCK_BYTES.try_into().expect("fits in memory");
+        Self {
+            remaining_bytes: max_bytes.saturating_sub(fake_coinbase_tx.data.as_ref().len()),
+            remaining_sigops: MAX_BLOCK_SIGOPS.saturating_sub(fake_coinbase_tx.sigops),
+            remaining_unpaid_actions: BLOCK_UNPAID_ACTION_LIMIT,
+            remaining_orchard_actions: orchard,
+            remaining_sapling_ios: sapling_io,
+            remaining_sprout_joinsplits: sprout_jss,
+            remaining_shielded_cost: shielded_cost,
+        }
+    }
+
+    /// Tries to add `tx` to the block template. Returns `true` and decrements
+    /// the remaining capacity if it fits within every limit; otherwise returns
+    /// `false` and leaves `self` unchanged.
+    fn try_add(&mut self, tx: &VerifiedUnminedTx) -> bool {
+        let counts = tx.transaction.transaction.shielded_action_counts();
+        let cost = counts.cost();
+        let tx_block_sigops = tx.block_sigop_count();
+
+        // > If the block template with this transaction included
+        // > would be within the block size limit and block sigop limit,
+        // > and block_unpaid_actions <= block_unpaid_action_limit,
+        // > add the transaction to the block template
+        //
+        // Unpaid actions are always zero for transactions that pay the conventional fee,
+        // so the unpaid action check always passes for those transactions.
+        if tx.transaction.size > self.remaining_bytes
+            || tx_block_sigops > self.remaining_sigops
+            || tx.unpaid_actions > self.remaining_unpaid_actions
+            || counts.orchard_actions > self.remaining_orchard_actions
+            || counts.sapling_ios > self.remaining_sapling_ios
+            || counts.sprout_joinsplits > self.remaining_sprout_joinsplits
+            || cost > self.remaining_shielded_cost
+        {
+            return false;
+        }
+
+        self.remaining_bytes -= tx.transaction.size;
+        self.remaining_sigops -= tx_block_sigops;
+        self.remaining_unpaid_actions -= tx.unpaid_actions;
+        self.remaining_orchard_actions -= counts.orchard_actions;
+        self.remaining_sapling_ios -= counts.sapling_ios;
+        self.remaining_sprout_joinsplits -= counts.sprout_joinsplits;
+        self.remaining_shielded_cost -= cost;
+        true
+    }
 }
 
 /// Returns a fee-weighted index and the total weight of `transactions`.
@@ -225,20 +306,14 @@ fn checked_add_transaction_weighted_random(
     tx_weights: WeightedIndex<f32>,
     selected_txs: &mut Vec<SelectedMempoolTx>,
     mempool_tx_deps: &TransactionDependencies,
-    remaining_block_bytes: &mut usize,
-    remaining_block_sigops: &mut u32,
-    remaining_block_unpaid_actions: &mut u32,
+    limits: &mut BlockTemplateLimits,
 ) -> Option<WeightedIndex<f32>> {
     // > Pick one of those transactions at random with probability in direct proportion
     // > to its weight_ratio, and remove it from the set of candidate transactions
     let (new_tx_weights, candidate_tx) =
         choose_transaction_weighted_random(candidate_txs, tx_weights);
 
-    if !candidate_tx.try_update_block_template_limits(
-        remaining_block_bytes,
-        remaining_block_sigops,
-        remaining_block_unpaid_actions,
-    ) {
+    if !limits.try_add(&candidate_tx) {
         return new_tx_weights;
     }
 
@@ -279,11 +354,7 @@ fn checked_add_transaction_weighted_random(
                     continue;
                 }
 
-                if !candidate_tx.try_update_block_template_limits(
-                    remaining_block_bytes,
-                    remaining_block_sigops,
-                    remaining_block_unpaid_actions,
-                ) {
+                if !limits.try_add(&candidate_tx) {
                     continue;
                 }
 
@@ -304,55 +375,6 @@ fn checked_add_transaction_weighted_random(
     }
 
     new_tx_weights
-}
-
-trait TryUpdateBlockLimits {
-    /// Checks if a transaction fits within the provided remaining block bytes,
-    /// sigops, and unpaid actions limits.
-    ///
-    /// Updates the limits and returns true if the transaction does fit, or
-    /// returns false otherwise.
-    fn try_update_block_template_limits(
-        &self,
-        remaining_block_bytes: &mut usize,
-        remaining_block_sigops: &mut u32,
-        remaining_block_unpaid_actions: &mut u32,
-    ) -> bool;
-}
-
-impl TryUpdateBlockLimits for VerifiedUnminedTx {
-    fn try_update_block_template_limits(
-        &self,
-        remaining_block_bytes: &mut usize,
-        remaining_block_sigops: &mut u32,
-        remaining_block_unpaid_actions: &mut u32,
-    ) -> bool {
-        // > If the block template with this transaction included
-        // > would be within the block size limit and block sigop limit,
-        // > and block_unpaid_actions <=  block_unpaid_action_limit,
-        // > add the transaction to the block template
-        //
-        // Unpaid actions are always zero for transactions that pay the conventional fee, so the
-        // unpaid action check always passes for those transactions. Use the full block-level sigop
-        // count (legacy + P2SH) so template selection cannot produce blocks that the block verifier
-        // would reject for exceeding `MAX_BLOCK_SIGOPS`.
-        let tx_block_sigops = self.block_sigop_count();
-        if self.transaction.size <= *remaining_block_bytes
-            && tx_block_sigops <= *remaining_block_sigops
-            && self.unpaid_actions <= *remaining_block_unpaid_actions
-        {
-            *remaining_block_bytes -= self.transaction.size;
-            *remaining_block_sigops -= tx_block_sigops;
-
-            // Unpaid actions are always zero for transactions that pay the conventional fee,
-            // so this limit always remains the same after they are added.
-            *remaining_block_unpaid_actions -= self.unpaid_actions;
-
-            true
-        } else {
-            false
-        }
-    }
 }
 
 /// Choose a transaction from `transactions`, using the previously set up `weighted_index`.

--- a/zebra-rpc/src/methods/types/get_block_template/zip317/tests.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/zip317/tests.rs
@@ -2,15 +2,29 @@
 
 #![allow(clippy::unwrap_in_result)]
 
+use std::sync::Arc;
+
 use zcash_keys::address::Address;
 use zcash_transparent::address::TransparentAddress;
 
-use zebra_chain::{block::Height, parameters::Network, transaction, transparent::OutPoint};
+use zebra_chain::{
+    block::Height,
+    parameters::{
+        Network, GLOBAL_SHIELDED_BUDGET, ORCHARD_BLOCK_ACTION_LIMIT, SAPLING_BLOCK_IO_LIMIT,
+        SPROUT_BLOCK_JOINSPLIT_LIMIT,
+    },
+    transaction::{
+        self,
+        arbitrary::{fake_v5_with_orchard_actions, fake_v5_with_sapling_outputs},
+        Transaction, UnminedTx, VerifiedUnminedTx,
+    },
+    transparent::OutPoint,
+};
 use zebra_node_services::mempool::TransactionDependencies;
 
 use crate::methods::types::get_block_template::MinerParams;
 
-use super::select_mempool_transactions;
+use super::{select_mempool_transactions, BlockTemplateLimits};
 
 #[test]
 fn excludes_tx_with_unselected_dependencies() {
@@ -40,6 +54,38 @@ fn excludes_tx_with_unselected_dependencies() {
         vec![],
         "should not select any transactions when dependencies are unavailable"
     );
+}
+
+#[test]
+fn template_limits_selection_to_global_shielded_budget_after_nu7() {
+    let mut limits = nu7_block_template_limits();
+    let orchard_tx = verified_unmined_tx(fake_v5_with_orchard_actions(
+        usize::try_from(ORCHARD_BLOCK_ACTION_LIMIT).expect("limit fits in usize"),
+    ));
+    let sapling_tx = verified_unmined_tx(fake_v5_with_sapling_outputs(1));
+
+    assert!(limits.try_add(&orchard_tx));
+    assert!(!limits.try_add(&sapling_tx));
+}
+
+fn nu7_block_template_limits() -> BlockTemplateLimits {
+    BlockTemplateLimits {
+        remaining_bytes: usize::MAX,
+        remaining_sigops: u32::MAX,
+        remaining_unpaid_actions: u32::MAX,
+        remaining_orchard_actions: ORCHARD_BLOCK_ACTION_LIMIT,
+        remaining_sapling_ios: SAPLING_BLOCK_IO_LIMIT,
+        remaining_sprout_joinsplits: SPROUT_BLOCK_JOINSPLIT_LIMIT,
+        remaining_shielded_cost: GLOBAL_SHIELDED_BUDGET,
+    }
+}
+
+fn verified_unmined_tx(transaction: Arc<Transaction>) -> VerifiedUnminedTx {
+    let unmined_tx = UnminedTx::from(transaction);
+    let miner_fee = unmined_tx.conventional_fee;
+
+    VerifiedUnminedTx::new(unmined_tx, miner_fee, 0, 0, Arc::new(Vec::new()))
+        .expect("fake transaction pays the conventional fee")
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

This PR is targeting the nu7 candidate zip [218](https://zips.z.cash/zip-0218) https://zips.z.cash/#nu7-candidate-zips.

NU7's 25-second block target spacing increases block frequency. The NU7 block-spacing proposal pairs that with shielded action limits to bound worst-case shielded sync and validation costs.

## Solution

Add NU7 shielded action limit constants and enforce them in:

- block verification,
- mempool transaction admission, and
- `getblocktemplate` transaction selection.

The checks only activate on networks that explicitly configure NU7, at and after the NU7 activation height. Pre-NU7 behavior remains a no-op for these limits.

This branch follows the NU7 testnet source branch constants:

- Orchard actions: 330
- Sapling spends plus outputs: 300
- Sprout JoinSplits: 25
- Global shielded budget: 330

The count and cost arithmetic is saturating so malformed or future oversized data cannot overflow local accounting.

### Tests

- `cargo fmt --all`
- `cargo test -p zebra-consensus shielded_action_limits_`

### Specifications & References

This implements the shielded action-limit structure from the draft 25-second block target spacing ZIP:

- The ZIP applies the limits only where `IsNU7Activated(height)` is true.
- It defines per-pool limits for Orchard actions, Sapling inputs plus outputs, and Sprout JoinSplits.
- It defines a global shielded budget across all pools.
- It defines shielded cost as Orchard actions plus Sapling spends and outputs plus two units per Sprout JoinSplit.
- It states these limits do not apply to transparent transaction components and the existing 2 MB block size limit still applies.

### Follow-up Work

None in this PR.

### AI Disclosure

- [x] AI tools were used: OpenAI Codex for branch splitting, implementation review, and PR description drafting.

### PR Checklist

- [x] The PR title follows conventional commits format: `feat(consensus): enforce NU7 shielded action limits`
- [x] Test evidence is listed above.
- [x] The documentation and changelogs are up to date.
