### PR TITLE
fix(mempool): reduce crawler delay for NU7 block spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Startup warning on Linux when `net.ipv4.tcp_slow_start_after_idle` is enabled (which resets TCP congestion windows between block requests and significantly reduces single-peer block-propagation throughput on long-haul links), with a "Linux TCP tuning for block propagation" troubleshooting section ([#10513](https://github.com/ZcashFoundation/zebra/pull/10513))
 - Support ZIP-213
 
+### Changed
+
+- Reduced the mempool transaction crawler delay from 73 seconds to 17 seconds
+  so Zebra can crawl peer mempools within NU7's 25-second block target spacing.
+  This node-local timing change takes effect immediately.
+
 ### Fixed
 
 - Avoid panicking in the address-book ban path when `network.max_connections_per_ip > 1`. Guard the optional `most_recent_by_ip` cache instead of unwrapping it, so a ban-threshold misbehavior update no longer crashes the address-book updater and poisons the shared mutex ([#10580](https://github.com/ZcashFoundation/zebra/issues/10580))

--- a/zebra-chain/src/parameters/network/subsidy.rs
+++ b/zebra-chain/src/parameters/network/subsidy.rs
@@ -421,28 +421,33 @@ pub fn halving_divisor(height: Height, network: &Network) -> Option<u64> {
 /// [7.8]: https://zips.z.cash/protocol/protocol.pdf#subsidies
 pub fn halving(height: Height, network: &Network) -> u32 {
     let slow_start_shift = network.slow_start_shift();
-    let blossom_height = NetworkUpgrade::Blossom
-        .activation_height(network)
-        .expect("blossom activation height should be available");
+    if height < slow_start_shift {
+        return 0;
+    }
 
-    let halving_index = if height < slow_start_shift {
-        0
-    } else if height < blossom_height {
-        let pre_blossom_height = height - slow_start_shift;
-        pre_blossom_height / network.pre_blossom_halving_interval()
-    } else {
-        let pre_blossom_height = blossom_height - slow_start_shift;
-        let scaled_pre_blossom_height =
-            pre_blossom_height * HeightDiff::from(BLOSSOM_POW_TARGET_SPACING_RATIO);
+    // Each era contributes (blocks × spacing_seconds) to a running total, which
+    // we divide by (PreBlossomHalvingInterval × pre_blossom_spacing) at the end.
+    // This stays in integer arithmetic across eras with different spacings, and
+    // matches the spec's segmented-fraction sum after factoring out the
+    // common denominator.
+    let pre_blossom_spacing_seconds = NetworkUpgrade::Genesis.target_spacing().num_seconds();
+    let mut total_block_seconds: HeightDiff = 0;
 
-        let post_blossom_height = height - blossom_height;
+    let mut eras = NetworkUpgrade::target_spacings(network)
+        .filter(|(era_start, _)| *era_start <= height)
+        .peekable();
 
-        (scaled_pre_blossom_height + post_blossom_height) / network.post_blossom_halving_interval()
-    };
+    while let Some((era_start, era_spacing)) = eras.next() {
+        let era_end = eras.peek().map(|(s, _)| *s).unwrap_or(height);
+        let era_blocks = (era_end - era_start.max(slow_start_shift)).max(0);
+        total_block_seconds += era_blocks * era_spacing.num_seconds();
+    }
 
-    halving_index
+    let pre_blossom_denominator =
+        network.pre_blossom_halving_interval() * pre_blossom_spacing_seconds;
+    (total_block_seconds / pre_blossom_denominator)
         .try_into()
-        .expect("already checked for negatives")
+        .expect("halving index is non-negative and fits in u32")
 }
 
 /// `BlockSubsidy(height)` as described in [protocol specification §7.8][7.8]
@@ -466,13 +471,15 @@ pub fn block_subsidy(height: Height, net: &Network) -> Result<Amount<NonNegative
             slow_start_rate * (u64::from(height) + 1)
         }
     } else {
-        let base_subsidy = if NetworkUpgrade::current(net, height) < NetworkUpgrade::Blossom {
-            MAX_BLOCK_SUBSIDY
-        } else {
-            MAX_BLOCK_SUBSIDY / u64::from(BLOSSOM_POW_TARGET_SPACING_RATIO)
-        };
-
-        base_subsidy / halving_div
+        // Each spacing era scales the per-block subsidy by current_spacing /
+        // pre_blossom_spacing, keeping issuance per unit of wall-clock time
+        // constant across spacing changes. Casts are safe: target spacings are
+        // positive small constants.
+        let current_spacing_seconds =
+            NetworkUpgrade::target_spacing_for_height(net, height).num_seconds() as u64;
+        let pre_blossom_spacing_seconds =
+            NetworkUpgrade::Genesis.target_spacing().num_seconds() as u64;
+        MAX_BLOCK_SUBSIDY * current_spacing_seconds / pre_blossom_spacing_seconds / halving_div
     };
 
     Ok(Amount::try_from(amount)?)

--- a/zebra-chain/src/parameters/network/tests.rs
+++ b/zebra-chain/src/parameters/network/tests.rs
@@ -14,7 +14,9 @@ use crate::{
             block_subsidy, constants::POST_BLOSSOM_HALVING_INTERVAL, halving, halving_divisor,
             height_for_halving, ParameterSubsidy as _,
         },
-        NetworkUpgrade,
+        testnet::{self, ConfiguredActivationHeights},
+        NetworkUpgrade, NU7_POW_TARGET_SPACING_RATIO, POST_BLOSSOM_POW_TARGET_SPACING,
+        POST_NU7_POW_TARGET_SPACING,
     },
 };
 
@@ -287,6 +289,86 @@ fn block_subsidy_for_network(network: &Network) -> Result<(), Report> {
     assert_eq!(
         Amount::<NonNegative>::try_from(0)?,
         block_subsidy(Height::MAX, network)?
+    );
+
+    Ok(())
+}
+
+/// Tests `halving` and `block_subsidy` across the NU7 activation boundary on a
+/// configured Testnet, exercising the post-NU7 cases added by the draft
+/// "Shorter Block Target Spacing" ZIP.
+#[test]
+fn post_nu7_halving_and_subsidy() -> Result<(), Report> {
+    let _init_guard = zebra_test::init();
+
+    // Pick parameters where slow_start_shift = blossom_height, so the pre-Blossom
+    // term in the spec halving sum is exactly zero and boundaries land cleanly at
+    // multiples of the post-Blossom / post-NU7 halving intervals.
+    let blossom = 1u32;
+    let canopy = blossom + u32::try_from(POST_BLOSSOM_HALVING_INTERVAL).unwrap();
+    let nu7 = canopy + u32::try_from(POST_BLOSSOM_HALVING_INTERVAL * 2).unwrap();
+
+    let network = testnet::Parameters::build()
+        // slow_start_shift = slow_start_interval / 2 = 1, equal to Blossom height.
+        .with_slow_start_interval(Height(2))
+        .with_activation_heights(ConfiguredActivationHeights {
+            blossom: Some(blossom),
+            canopy: Some(canopy),
+            nu7: Some(nu7),
+            ..Default::default()
+        })
+        .expect("activation heights are valid")
+        .clear_funding_streams()
+        .to_network()
+        .expect("configured testnet is valid");
+
+    let nu7_height = Height(nu7);
+
+    // Target spacing shortens from the post-Blossom value to the post-NU7 value
+    // exactly at the NU7 activation height.
+    assert_eq!(
+        i64::from(POST_BLOSSOM_POW_TARGET_SPACING),
+        NetworkUpgrade::target_spacing_for_height(&network, (nu7_height - 1).unwrap())
+            .num_seconds()
+    );
+    assert_eq!(
+        i64::from(POST_NU7_POW_TARGET_SPACING),
+        NetworkUpgrade::target_spacing_for_height(&network, nu7_height).num_seconds()
+    );
+
+    // At NU7 activation, three post-Blossom halvings have elapsed:
+    //   Halving = floor(0/PreBlossom + 1 + 2) = 3
+    assert_eq!(3, halving(nu7_height, &network));
+    assert_eq!(8, halving_divisor(nu7_height, &network).unwrap());
+
+    // BlockSubsidy(NU7) = floor(MAX / (BlossomRatio * NU7Ratio * 2^Halving))
+    //                   = floor(1_250_000_000 / (2 * 3 * 8))
+    //                   = floor(1_250_000_000 / 48) = 26_041_666 zatoshi
+    assert_eq!(
+        Amount::<NonNegative>::try_from(26_041_666)?,
+        block_subsidy(nu7_height, &network)?,
+    );
+
+    // The 3rd halving boundary lands exactly at NU7 in this configuration, so the
+    // block immediately before NU7 is still in halving era 2 (post-Blossom, pre-NU7):
+    //   floor(1_250_000_000 / (2 * 4)) = 156_250_000 zatoshi.
+    assert_eq!(2, halving((nu7_height - 1).unwrap(), &network));
+    assert_eq!(
+        Amount::<NonNegative>::try_from(156_250_000)?,
+        block_subsidy((nu7_height - 1).unwrap(), &network)?,
+    );
+
+    // The halving counter does not reset at NU7. The next halving boundary is
+    // reached after one PostNU7HalvingInterval (=PostBlossomHalvingInterval * 3)
+    // of post-NU7 blocks.
+    let post_nu7_halving_interval =
+        POST_BLOSSOM_HALVING_INTERVAL * i64::from(NU7_POW_TARGET_SPACING_RATIO);
+    let next_halving = (nu7_height + post_nu7_halving_interval).unwrap();
+    assert_eq!(4, halving(next_halving, &network));
+    assert_eq!(16, halving_divisor(next_halving, &network).unwrap());
+    assert_eq!(
+        Amount::<NonNegative>::try_from(13_020_833)?,
+        block_subsidy(next_halving, &network)?,
     );
 
     Ok(())

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -239,6 +239,18 @@ const PRE_BLOSSOM_POW_TARGET_SPACING: i64 = 150;
 /// The target block spacing after Blossom activation.
 pub const POST_BLOSSOM_POW_TARGET_SPACING: u32 = 75;
 
+/// The target block spacing after NU7 activation, in seconds.
+///
+/// Defined by the draft "Shorter Block Target Spacing" ZIP, which lowers the
+/// block target spacing from 75 to 25 seconds at NU7.
+pub const POST_NU7_POW_TARGET_SPACING: u32 = 25;
+
+/// The ratio between the post-Blossom and post-NU7 block target spacings.
+///
+/// `PostBlossomPoWTargetSpacing / PostNU7PoWTargetSpacing = 75 / 25 = 3`.
+pub const NU7_POW_TARGET_SPACING_RATIO: u32 =
+    POST_BLOSSOM_POW_TARGET_SPACING / POST_NU7_POW_TARGET_SPACING;
+
 /// The averaging window for difficulty threshold arithmetic mean calculations.
 ///
 /// `PoWAveragingWindow` in the Zcash specification.
@@ -395,12 +407,13 @@ impl NetworkUpgrade {
     pub fn target_spacing(&self) -> Duration {
         let spacing_seconds = match self {
             Genesis | BeforeOverwinter | Overwinter | Sapling => PRE_BLOSSOM_POW_TARGET_SPACING,
-            Blossom | Heartwood | Canopy | Nu5 | Nu6 | Nu6_1 | Nu7 => {
+            Blossom | Heartwood | Canopy | Nu5 | Nu6 | Nu6_1 => {
                 POST_BLOSSOM_POW_TARGET_SPACING.into()
             }
+            Nu7 => POST_NU7_POW_TARGET_SPACING.into(),
 
             #[cfg(zcash_unstable = "zfuture")]
-            ZFuture => POST_BLOSSOM_POW_TARGET_SPACING.into(),
+            ZFuture => POST_NU7_POW_TARGET_SPACING.into(),
         };
 
         Duration::seconds(spacing_seconds)
@@ -423,6 +436,7 @@ impl NetworkUpgrade {
                 NetworkUpgrade::Blossom,
                 POST_BLOSSOM_POW_TARGET_SPACING.into(),
             ),
+            (NetworkUpgrade::Nu7, POST_NU7_POW_TARGET_SPACING.into()),
         ]
         .into_iter()
         .filter_map(move |(upgrade, spacing_seconds)| {

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -154,13 +154,17 @@ pub const INVENTORY_ROTATION_INTERVAL: Duration = Duration::from_secs(53);
 
 /// The default peer address crawler interval.
 ///
-/// This should be at least [`HANDSHAKE_TIMEOUT`] lower than all other crawler
-/// intervals.
+/// This should be at least [`HANDSHAKE_TIMEOUT`] lower than crawler intervals
+/// that depend on freshly connected peers.
 ///
 /// This makes the following sequence of events more likely:
 /// 1. a peer address crawl,
 /// 2. new peer connections,
 /// 3. peer requests from other crawlers.
+///
+/// The mempool transaction crawler intentionally runs more frequently after
+/// NU7's shorter block spacing so it can crawl transactions within a 25-second
+/// block target spacing. It is excluded from this ordering heuristic.
 ///
 /// Using a prime number makes sure that peer address crawls
 /// don't synchronise with other crawls.

--- a/zebrad/src/components/mempool/crawler.rs
+++ b/zebrad/src/components/mempool/crawler.rs
@@ -79,9 +79,13 @@ const FANOUT: usize = 3;
 /// This should be less than the target block interval,
 /// so that we crawl peer mempools at least once per block.
 ///
+/// This node-local cadence intentionally applies before NU7 activation: Zebra
+/// needs to be ready to crawl within the 25-second block target spacing as soon
+/// as NU7 activates.
+///
 /// Using a prime number makes sure that mempool crawler fanouts
 /// don't synchronise with other crawls.
-pub const RATE_LIMIT_DELAY: Duration = Duration::from_secs(73);
+pub const RATE_LIMIT_DELAY: Duration = Duration::from_secs(17);
 
 /// The time to wait for a peer response.
 ///

--- a/zebrad/src/components/mempool/crawler/tests/timing.rs
+++ b/zebrad/src/components/mempool/crawler/tests/timing.rs
@@ -1,24 +1,19 @@
 //! Timing tests for the mempool crawler.
 
-use zebra_chain::parameters::POST_BLOSSOM_POW_TARGET_SPACING;
-use zebra_network::constants::{DEFAULT_CRAWL_NEW_PEER_INTERVAL, HANDSHAKE_TIMEOUT};
+use zebra_chain::parameters::POST_NU7_POW_TARGET_SPACING;
+use zebra_network::constants::DEFAULT_CRAWL_NEW_PEER_INTERVAL;
 
 use crate::components::mempool::crawler::RATE_LIMIT_DELAY;
 
 #[test]
 fn ensure_timing_consistent() {
     assert!(
-        RATE_LIMIT_DELAY.as_secs() < POST_BLOSSOM_POW_TARGET_SPACING.into(),
+        RATE_LIMIT_DELAY.as_secs() < POST_NU7_POW_TARGET_SPACING.into(),
         "a mempool crawl should complete before most new blocks"
     );
 
-    // The default peer crawler interval should be at least
-    // `HANDSHAKE_TIMEOUT` lower than all other crawler intervals.
-    //
-    // See `DEFAULT_CRAWL_NEW_PEER_INTERVAL` for details.
     assert!(
-        DEFAULT_CRAWL_NEW_PEER_INTERVAL.as_secs() + HANDSHAKE_TIMEOUT.as_secs()
-            < RATE_LIMIT_DELAY.as_secs(),
-        "an address crawl and peer connections should complete before most syncer restarts"
+        RATE_LIMIT_DELAY < DEFAULT_CRAWL_NEW_PEER_INTERVAL,
+        "the mempool crawler intentionally runs more frequently than the peer address crawler"
     );
 }

--- a/zebrad/src/components/sync/tests/timing.rs
+++ b/zebrad/src/components/sync/tests/timing.rs
@@ -97,7 +97,7 @@ fn ensure_timeouts_consistent() {
     );
 
     // The default peer crawler interval should be at least
-    // `HANDSHAKE_TIMEOUT` lower than all other crawler intervals.
+    // `HANDSHAKE_TIMEOUT` lower than the sync crawler interval.
     //
     // See `DEFAULT_CRAWL_NEW_PEER_INTERVAL` for details.
     assert!(


### PR DESCRIPTION
## Motivation

With NU7's 25-second block target spacing, Zebra's old 73-second mempool transaction crawler delay is too slow to crawl peer mempools within a target block interval.

## Solution

Reduce the mempool transaction crawler delay to 17 seconds and update timing tests and docs.

This is intentionally node-local and immediate rather than NU7-gated. The crawler is not consensus behavior, and nodes need the shorter cadence before NU7 activation so they are ready to crawl transactions within the 25-second target spacing as soon as NU7 activates.

This also updates the peer address crawler documentation to remove the obsolete invariant that every other crawler interval is longer than address crawling plus handshake time. The mempool transaction crawler is now intentionally faster than the peer address crawler.

This PR is based on the NU7 target-spacing PR (#10648) so the timing test can reference the shared `POST_NU7_POW_TARGET_SPACING` constant. It is otherwise independent of the DAA, max-reorg-length, and shielded-action-limit changes.

### Tests

- `cargo fmt --all`
- `cargo test -p zebrad ensure_timing_consistent`

### Specifications & References

This is a node-timing follow-up to the draft 25-second block target spacing ZIP:

- The ZIP defines `PostNU7PoWTargetSpacing := 25 seconds`.
- Its motivation is to reduce transaction latency, with an average first confirmation around 25 seconds.
- Keeping the mempool crawler delay below 25 seconds lets Zebra refresh transaction inventory within the new target block interval.

### Follow-up Work

None in this PR.

### AI Disclosure

- [x] AI tools were used: OpenAI Codex for branch splitting, implementation review, and PR description drafting.

### PR Checklist

- [x] The PR title follows conventional commits format: `fix(mempool): reduce crawler delay for NU7 block spacing`
- [x] Test evidence is listed above.
- [x] The documentation and changelogs are up to date.
