### PR TITLE
fix(ci): advertise external IP on GCP-deployed nodes

### DIFF
--- a/.github/workflows/zfnd-deploy-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-nodes-gcp.yml
@@ -404,14 +404,9 @@ jobs:
             exit 0
           fi
 
-          # Bake ZEBRA_NETWORK__EXTERNAL_ADDR=<IP>:<port> into --container-env
-          # using the static IP pinned per-(network, zone) by the "Assign static
-          # IP" step below. Without this, zebrad advertises 0.0.0.0:${P2P} (the
-          # listen address) in outgoing Version messages, the address sanitizer
-          # in zebra-network/src/meta_addr.rs refuses to gossip unspecified
-          # addresses, and the node is silently undiscoverable to other peers.
-          # The IP lookup itself gates this: deploys without a reserved IP
-          # (PR/feature branches today) get an empty result and skip the env var.
+          # Inline the reserved per-zone IP as ZEBRA_NETWORK__EXTERNAL_ADDR
+          # in --container-env. The zone-suffix mapping must match the
+          # "Assign static IP" step below. Empty lookup leaves it unset.
           case "${ZONE_LETTER}" in
             b) SUFFIX="" ;;
             c) SUFFIX="-secondary" ;;

--- a/.github/workflows/zfnd-deploy-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-nodes-gcp.yml
@@ -388,6 +388,25 @@ jobs:
             --size=400 --type=pd-balanced \
             --labels="app=zebrad,environment=${ENV},network=${NETWORK},zone=${ZONE_LETTER},created_by=${{ github.event_name }},github_ref=${{ env.GITHUB_REF_SLUG_URL }},github_sha=${{ env.GITHUB_SHA_SHORT }}"
 
+      # Single source of truth for the zone-suffix to reserved-IP mapping.
+      # Gated to stable deploys so feature-branch dispatches to dev can't
+      # advertise a prod IP that isn't actually attached to the MIG.
+      - name: Resolve reserved external IP
+        if: ${{ needs.set-matrix.outputs.environment == 'prod' || github.ref_name == 'main' }}
+        env:
+          GCP_REGION: ${{ vars.GCP_REGION }}
+        run: |
+          case "${ZONE_LETTER}" in
+            b) SUFFIX="" ;;
+            c) SUFFIX="-secondary" ;;
+            d) SUFFIX="-tertiary" ;;
+          esac
+          IP_NAME="zebra-${NETWORK}${SUFFIX}"
+          IP_ADDRESS=$(gcloud compute addresses describe "${IP_NAME}" \
+            --region="${GCP_REGION}" --format='value(address)' 2>/dev/null || true)
+          echo "IP_NAME=${IP_NAME}" >> "$GITHUB_ENV"
+          echo "IP_ADDRESS=${IP_ADDRESS}" >> "$GITHUB_ENV"
+
       - name: Create instance template
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.log_file }}" ]; then
@@ -404,19 +423,8 @@ jobs:
             exit 0
           fi
 
-          # Inline the reserved per-zone IP as ZEBRA_NETWORK__EXTERNAL_ADDR
-          # in --container-env. The zone-suffix mapping must match the
-          # "Assign static IP" step below. Empty lookup leaves it unset.
-          case "${ZONE_LETTER}" in
-            b) SUFFIX="" ;;
-            c) SUFFIX="-secondary" ;;
-            d) SUFFIX="-tertiary" ;;
-          esac
-          IP_NAME="zebra-${NETWORK}${SUFFIX}"
-          IP_ADDRESS=$(gcloud compute addresses describe "${IP_NAME}" \
-            --region="${{ vars.GCP_REGION }}" --format='value(address)' 2>/dev/null || true)
           EXTERNAL_ADDR_ENV=""
-          if [ -n "${IP_ADDRESS}" ]; then
+          if [ -n "${IP_ADDRESS:-}" ]; then
             EXTERNAL_ADDR_ENV=",ZEBRA_NETWORK__EXTERNAL_ADDR=${IP_ADDRESS}:${P2P}"
           fi
 
@@ -461,27 +469,15 @@ jobs:
             --stateful-disk="device-name=${DISK_NAME},auto-delete=on-permanent-instance-deletion" \
             --zone="${ZONE}"
 
-      # Assign one static IP per zone, deterministically:
-      #   zone b -> primary (`zebra-${network}`)
-      #   zone c -> secondary (`zebra-${network}-secondary`)
-      #   zone d -> tertiary (`zebra-${network}-tertiary`)
-      # Skipped for feature-branch dispatches to dev (PR smoke tests use ephemeral IPs).
-      # Empirically `instance-configs create --stateful-external-ip` accepts
-      # STAGING / RUNNING-UNKNOWN instances; a short bounded poll handles the
-      # async gap between MIG-create returning and list-instances reporting.
+      # Bind the reserved IP resolved earlier to the fresh MIG instance.
+      # `instance-configs create --stateful-external-ip` accepts STAGING /
+      # RUNNING-UNKNOWN instances; the short poll handles the async gap
+      # between MIG-create returning and list-instances reporting.
       - name: Assign static IP (fresh MIG, stable deploy)
         if: ${{ steps.does-group-exist.outcome == 'failure' && (needs.set-matrix.outputs.environment == 'prod' || github.ref_name == 'main') }}
         run: |
-          case "${ZONE_LETTER}" in
-            b) SUFFIX="" ;;
-            c) SUFFIX="-secondary" ;;
-            d) SUFFIX="-tertiary" ;;
-          esac
-          IP_NAME="zebra-${NETWORK}${SUFFIX}"
-          IP_ADDRESS=$(gcloud compute addresses describe "${IP_NAME}" \
-            --region="${{ vars.GCP_REGION }}" --format='value(address)' 2>/dev/null || true)
-          if [ -z "${IP_ADDRESS}" ]; then
-            echo "::warning::${IP_NAME} not reserved; skipping"
+          if [ -z "${IP_ADDRESS:-}" ]; then
+            echo "::warning::${IP_NAME:-zebra-${NETWORK}} not reserved; skipping"
             exit 0
           fi
           for _ in $(seq 1 30); do

--- a/.github/workflows/zfnd-deploy-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-nodes-gcp.yml
@@ -403,6 +403,28 @@ jobs:
           if gcloud compute instance-templates describe "${TEMPLATE_NAME}" &>/dev/null; then
             exit 0
           fi
+
+          # Bake ZEBRA_NETWORK__EXTERNAL_ADDR=<IP>:<port> into --container-env
+          # using the static IP pinned per-(network, zone) by the "Assign static
+          # IP" step below. Without this, zebrad advertises 0.0.0.0:${P2P} (the
+          # listen address) in outgoing Version messages, the address sanitizer
+          # in zebra-network/src/meta_addr.rs refuses to gossip unspecified
+          # addresses, and the node is silently undiscoverable to other peers.
+          # The IP lookup itself gates this: deploys without a reserved IP
+          # (PR/feature branches today) get an empty result and skip the env var.
+          case "${ZONE_LETTER}" in
+            b) SUFFIX="" ;;
+            c) SUFFIX="-secondary" ;;
+            d) SUFFIX="-tertiary" ;;
+          esac
+          IP_NAME="zebra-${NETWORK}${SUFFIX}"
+          IP_ADDRESS=$(gcloud compute addresses describe "${IP_NAME}" \
+            --region="${{ vars.GCP_REGION }}" --format='value(address)' 2>/dev/null || true)
+          EXTERNAL_ADDR_ENV=""
+          if [ -n "${IP_ADDRESS}" ]; then
+            EXTERNAL_ADDR_ENV=",ZEBRA_NETWORK__EXTERNAL_ADDR=${IP_ADDRESS}:${P2P}"
+          fi
+
           gcloud compute instance-templates create-with-container "${TEMPLATE_NAME}" \
             --machine-type=${{ vars.GCP_SMALL_MACHINE }} \
             --provisioning-model=SPOT \
@@ -413,7 +435,7 @@ jobs:
             --container-mount-disk="mount-path=/home/zebra/.cache/zebra,name=${DISK_NAME},mode=rw" \
             --container-stdin --container-tty \
             --container-image="${{ vars.GAR_BASE }}/zebrad@${{ needs.build.outputs.image_digest }}" \
-            --container-env="ZEBRA_NETWORK__NETWORK=${{ matrix.network }},ZEBRA_NETWORK__LISTEN_ADDR=0.0.0.0:${P2P},LOG_FILE=${LOG_FILE},SENTRY_DSN=${{ vars.SENTRY_DSN }},SENTRY_ENVIRONMENT=${{ needs.set-matrix.outputs.environment }},GITHUB_ACTIONS=${GITHUB_ACTIONS},GITHUB_EVENT_NAME=${GITHUB_EVENT_NAME},GITHUB_REF_POINT_SLUG_URL=${GITHUB_REF_POINT_SLUG_URL},GITHUB_SHA=${GITHUB_SHA},GITHUB_RUN_ID=${GITHUB_RUN_ID},GITHUB_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT},GITHUB_WORKFLOW=${GITHUB_WORKFLOW},GITHUB_JOB=${GITHUB_JOB},CI_PR_NUMBER=${{ github.event.pull_request.number || '' }},ZEBRA_HEALTH__LISTEN_ADDR=0.0.0.0:8080,ZEBRA_HEALTH__MIN_CONNECTED_PEERS=1,ZEBRA_RPC__LISTEN_ADDR=0.0.0.0:${RPC}" \
+            --container-env="ZEBRA_NETWORK__NETWORK=${{ matrix.network }},ZEBRA_NETWORK__LISTEN_ADDR=0.0.0.0:${P2P},LOG_FILE=${LOG_FILE},SENTRY_DSN=${{ vars.SENTRY_DSN }},SENTRY_ENVIRONMENT=${{ needs.set-matrix.outputs.environment }},GITHUB_ACTIONS=${GITHUB_ACTIONS},GITHUB_EVENT_NAME=${GITHUB_EVENT_NAME},GITHUB_REF_POINT_SLUG_URL=${GITHUB_REF_POINT_SLUG_URL},GITHUB_SHA=${GITHUB_SHA},GITHUB_RUN_ID=${GITHUB_RUN_ID},GITHUB_RUN_ATTEMPT=${GITHUB_RUN_ATTEMPT},GITHUB_WORKFLOW=${GITHUB_WORKFLOW},GITHUB_JOB=${GITHUB_JOB},CI_PR_NUMBER=${{ github.event.pull_request.number || '' }},ZEBRA_HEALTH__LISTEN_ADDR=0.0.0.0:8080,ZEBRA_HEALTH__MIN_CONNECTED_PEERS=1,ZEBRA_RPC__LISTEN_ADDR=0.0.0.0:${RPC}${EXTERNAL_ADDR_ENV}" \
             --service-account=${{ vars.GCP_DEPLOYMENTS_SA }} --scopes=cloud-platform \
             --metadata=google-logging-enabled=true,google-logging-use-fluentbit=true,google-monitoring-enabled=true \
             --labels="app=zebrad,environment=${{ needs.set-matrix.outputs.environment }},network=${NETWORK},zone=${ZONE_LETTER},created_by=${{ github.event_name }},github_ref=${{ env.GITHUB_REF_SLUG_URL }},github_sha=${{ env.GITHUB_SHA_SHORT }}" \


### PR DESCRIPTION
## Motivation

Deployed nodes on GCP have been silently invisible to peer discovery. Without `network.external_addr`, a node advertises `[::]:8233` in its outgoing `Version` messages. Every recipient drops unspecified IPs from `addr` / `addrv2` responses, so the node never propagates through gossip or DNS-seeder crawls. Inbound connections still work; the node is just absent from every other operator's peer pool.

## Solution

The deploy workflow now resolves the per-(network, zone) static IP reserved by the "Assign static IP" step. It inlines that IP as `ZEBRA_NETWORK__EXTERNAL_ADDR=<ip>:<p2p>` in the new MIG template's `--container-env`. Deploys without a reserved IP (PR / feature-branch dispatches to dev) skip the env var: the lookup returns empty and short-circuits the addition.

### Follow-up Work

The underlying gap in Zebra itself (silent undiscoverability for any operator who does not set `external_addr`) is tracked at #1893.

### AI Disclosure

- [x] AI tools were used: Claude for the workflow edit, this PR description, and the deployment-side cleanup.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: \`type(scope): description\`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [ ] The documentation and changelogs are up to date.