### PR TITLE
fix(ci): temporarily allow lint workflow on v4.2.0-dev

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,11 @@ name: Lint
 
 on:
   pull_request:
-    branches: [main]
+    # Temporarily allow CI on the QEDIT integration branch.
+    # TODO: Remove v4.2.0-dev before merging upstream.
+    branches:
+      - main
+      - v4.2.0-dev
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"
@@ -12,7 +16,11 @@ on:
       - .github/workflows/lint.yml
 
   push:
-    branches: [main]
+    # Temporarily allow CI on the QEDIT integration branch.
+    # TODO: Remove v4.2.0-dev before merging upstream.
+    branches:
+      - main
+      - v4.2.0-dev
     paths:
       - "**/*.rs"
       - "**/Cargo.toml"


### PR DESCRIPTION
This is a technical follow-up PR targeting `zsa-support` to test whether the `lint` workflow is triggered when `v4.2.0-dev` is added to the allowed branches in `.github/workflows/lint.yml`.

## Motivation

The ZSA draft PR needs full upstream CI coverage for follow-up changes targeting `v4.2.0-dev`.

Currently, the `lint` workflow (for example) only allows PRs and pushes targeting `main`, so we want to verify whether adding `v4.2.0-dev` to the workflow branch allowlist is enough to trigger the lint CI in the ZcashFoundation environment.

## Solution

This PR updates the `lint` workflow to:

* allow `pull_request` runs targeting `v4.2.0-dev`;
* allow `push` runs on `v4.2.0-dev`;
* keep the existing `main` behavior unchanged.

## Notes

This PR is intended as a CI-only follow-up to validate the workflow trigger behavior before applying the same temporary branch allowlist change to other required CI workflows.

This change should be removed before merging upstream.

### AI Disclosure

* [x] AI tools were used: ChatGPT was used for wording and CI review assistance.
