### PR TITLE
release: v4.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Zebra 4.5.3](https://github.com/ZcashFoundation/zebra/releases/tag/v4.5.3) - 2026-06-01
+
+This hotfix release adds a soft fork that temporarily disables Orchard actions in
+transactions, to mitigate a security issue. We recommend node operators update to
+4.5.3 as soon as possible.
+
+### Security
+
+- Add a soft fork that temporarily rejects transactions containing Orchard actions.
+  It activates at a fixed height on Mainnet and at a configurable height on Testnet
+  (`temporary_orchard_disabling_soft_fork_height` in the network config), and the
+  mempool is revalidated at the activation height to drop any Orchard transactions
+  accepted beforehand
+  ([GHSA-jfw5-j458-pfv6](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-jfw5-j458-pfv6)).
+
 ## [Zebra 4.5.1](https://github.com/ZcashFoundation/zebra/releases/tag/v4.5.0) - 2026-05-29
 
 This hotfix release fixes a critical security issues that was not correctly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7440,7 +7440,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "bech32",
  "bitflags 2.11.1",
@@ -7510,7 +7510,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-consensus"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7562,7 +7562,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-network"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -7701,7 +7701,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "7.0.0"
+version = "7.0.1"
 dependencies = [
  "bincode",
  "chrono",
@@ -7799,7 +7799,7 @@ dependencies = [
 
 [[package]]
 name = "zebrad"
-version = "4.5.1"
+version = "4.5.3"
 dependencies = [
  "abscissa_core",
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ cargo install --locked zebrad
 Alternatively, you can install it from GitHub:
 
 ```sh
-cargo install --git https://github.com/ZcashFoundation/zebra --tag v4.5.1 zebrad
+cargo install --git https://github.com/ZcashFoundation/zebra --tag v4.5.3 zebrad
 ```
 
 You can start Zebra by running

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-chain"
-version = "8.0.0"
+version = "8.0.1"
 authors.workspace = true
 description = "Core Zcash data structures"
 license.workspace = true

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -334,16 +334,34 @@ impl Network {
             .collect()
     }
 
-    /// Returns whether Orchard has been temporarily disabled in transactions.
-    pub fn temporary_orchard_disabling_soft_fork_active(&self, height: Height) -> bool {
-        let soft_fork_height = match self {
+    /// Returns the height at which the soft fork that temporarily disables Orchard
+    /// actions in transactions activates, if it is configured for this network.
+    pub fn temporary_orchard_disabling_soft_fork_height(&self) -> Option<Height> {
+        match self {
             Network::Mainnet => Some(MAINNET_TEMPORARY_ORCHARD_DISABLING_SOFT_FORK_HEIGHT),
             Network::Testnet(parameters) => {
                 parameters.temporary_orchard_disabling_soft_fork_height()
             }
-        };
+        }
+    }
 
-        soft_fork_height.is_some_and(|h| height >= h)
+    /// Returns whether Orchard has been temporarily disabled in transactions.
+    pub fn temporary_orchard_disabling_soft_fork_active(&self, height: Height) -> bool {
+        self.temporary_orchard_disabling_soft_fork_height()
+            .is_some_and(|h| height >= h)
+    }
+
+    /// Returns whether `height` is the first height at which the soft fork that
+    /// temporarily disables Orchard actions applies.
+    ///
+    /// This is the boundary at which the mempool must revalidate its contents, to drop
+    /// any transactions containing Orchard actions that were accepted before the soft
+    /// fork activated.
+    pub fn is_temporary_orchard_disabling_soft_fork_activation_height(
+        &self,
+        height: Height,
+    ) -> bool {
+        self.temporary_orchard_disabling_soft_fork_height() == Some(height)
     }
 }
 

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -19,7 +19,7 @@ pub mod testnet;
 #[cfg(test)]
 mod tests;
 
-const MAINNET_TEMPORARY_ORCHARD_DISABLING_SOFT_FORK_HEIGHT: Height = Height(3_364_000);
+const MAINNET_TEMPORARY_ORCHARD_DISABLING_SOFT_FORK_HEIGHT: Height = Height(3_363_366);
 
 /// An enum describing the kind of network, whether it's the production mainnet or a testnet.
 // Note: The order of these variants is important for correct bincode (de)serialization

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -19,6 +19,8 @@ pub mod testnet;
 #[cfg(test)]
 mod tests;
 
+const MAINNET_TEMPORARY_ORCHARD_DISABLING_SOFT_FORK_HEIGHT: Height = Height(3_364_000);
+
 /// An enum describing the kind of network, whether it's the production mainnet or a testnet.
 // Note: The order of these variants is important for correct bincode (de)serialization
 //       of history trees in the db format.
@@ -330,6 +332,18 @@ impl Network {
                 )
             })
             .collect()
+    }
+
+    /// Returns whether Orchard has been temporarily disabled in transactions.
+    pub fn temporary_orchard_disabling_soft_fork_active(&self, height: Height) -> bool {
+        let soft_fork_height = match self {
+            Network::Mainnet => Some(MAINNET_TEMPORARY_ORCHARD_DISABLING_SOFT_FORK_HEIGHT),
+            Network::Testnet(parameters) => {
+                parameters.temporary_orchard_disabling_soft_fork_height()
+            }
+        };
+
+        soft_fork_height.is_some_and(|h| height >= h)
     }
 }
 

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -19,7 +19,7 @@ pub mod testnet;
 #[cfg(test)]
 mod tests;
 
-const MAINNET_TEMPORARY_ORCHARD_DISABLING_SOFT_FORK_HEIGHT: Height = Height(3_363_366);
+const MAINNET_TEMPORARY_ORCHARD_DISABLING_SOFT_FORK_HEIGHT: Height = Height(3_363_426);
 
 /// An enum describing the kind of network, whether it's the production mainnet or a testnet.
 // Note: The order of these variants is important for correct bincode (de)serialization

--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -911,6 +911,7 @@ impl ParametersBuilder {
             post_blossom_halving_interval,
             lockbox_disbursements,
             checkpoints: _,
+            temporary_orchard_disabling_soft_fork_height: _,
         } = Self::default();
 
         self.activation_heights == activation_heights

--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -56,6 +56,8 @@ const TESTNET_GENESIS_HASH: &str =
 /// [zcashd regtest halving interval](https://github.com/zcash/zcash/blob/v5.10.0/src/consensus/params.h#L252)
 const PRE_BLOSSOM_REGTEST_HALVING_INTERVAL: HeightDiff = 144;
 
+const TEMPORARY_ORCHARD_DISABLING_SOFT_FORK_HEIGHT: Height = Height(4_042_000);
+
 /// Configurable funding stream recipient for configured Testnets.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
@@ -477,6 +479,8 @@ pub struct ParametersBuilder {
     lockbox_disbursements: Vec<(String, Amount<NonNegative>)>,
     /// Checkpointed block hashes and heights for this network.
     checkpoints: Arc<CheckpointList>,
+    /// Height at which the soft-fork to temporarily disable Orchard in transactions activates
+    temporary_orchard_disabling_soft_fork_height: Option<Height>,
 }
 
 impl Default for ParametersBuilder {
@@ -513,6 +517,9 @@ impl Default for ParametersBuilder {
                 .map(|(addr, amount)| (addr.to_string(), *amount))
                 .collect(),
             checkpoints: TESTNET_CHECKPOINT_LIST.clone(),
+            temporary_orchard_disabling_soft_fork_height: Some(
+                TEMPORARY_ORCHARD_DISABLING_SOFT_FORK_HEIGHT,
+            ),
         }
     }
 }
@@ -810,6 +817,19 @@ impl ParametersBuilder {
         self.with_checkpoints(ConfiguredCheckpoints::Default(false))
     }
 
+    /// Sets the height for this network at which the soft fork that temporarily disables
+    /// Orchard transactions will activate.
+    pub fn with_temporary_orchard_disabling_soft_fork_height(mut self, height: Height) -> Self {
+        self.temporary_orchard_disabling_soft_fork_height = Some(height);
+        self
+    }
+
+    /// Disables the soft fork that would temporarily disable Orchard transactions.
+    pub fn disable_temporary_orchard_disabling_soft_fork(mut self) -> Self {
+        self.temporary_orchard_disabling_soft_fork_height = None;
+        self
+    }
+
     /// Converts the builder to a [`Parameters`] struct
     fn finish(self) -> Parameters {
         let Self {
@@ -827,6 +847,7 @@ impl ParametersBuilder {
             post_blossom_halving_interval,
             lockbox_disbursements,
             checkpoints,
+            temporary_orchard_disabling_soft_fork_height,
         } = self;
         Parameters {
             network_name,
@@ -843,6 +864,7 @@ impl ParametersBuilder {
             post_blossom_halving_interval,
             lockbox_disbursements,
             checkpoints,
+            temporary_orchard_disabling_soft_fork_height,
         }
     }
 
@@ -962,6 +984,8 @@ pub struct Parameters {
     lockbox_disbursements: Vec<(String, Amount<NonNegative>)>,
     /// List of checkpointed block heights and hashes
     checkpoints: Arc<CheckpointList>,
+    /// Height at which the soft-fork to temporarily disable Orchard in transactions activates
+    temporary_orchard_disabling_soft_fork_height: Option<Height>,
 }
 
 impl Default for Parameters {
@@ -1046,6 +1070,7 @@ impl Parameters {
             post_blossom_halving_interval,
             lockbox_disbursements: _,
             checkpoints: _,
+            temporary_orchard_disabling_soft_fork_height: _,
         } = Self::new_regtest(Default::default()).expect("default regtest parameters are valid");
 
         self.network_name == network_name
@@ -1146,6 +1171,12 @@ impl Parameters {
     /// Returns the checkpoints for this network.
     pub fn checkpoints(&self) -> Arc<CheckpointList> {
         self.checkpoints.clone()
+    }
+
+    /// Returns the height at which the soft-fork to temporarily disable Orchard in
+    /// transactions activates.
+    pub fn temporary_orchard_disabling_soft_fork_height(&self) -> Option<Height> {
+        self.temporary_orchard_disabling_soft_fork_height
     }
 }
 

--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -56,8 +56,6 @@ const TESTNET_GENESIS_HASH: &str =
 /// [zcashd regtest halving interval](https://github.com/zcash/zcash/blob/v5.10.0/src/consensus/params.h#L252)
 const PRE_BLOSSOM_REGTEST_HALVING_INTERVAL: HeightDiff = 144;
 
-const TEMPORARY_ORCHARD_DISABLING_SOFT_FORK_HEIGHT: Height = Height(4_042_000);
-
 /// Configurable funding stream recipient for configured Testnets.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
@@ -517,9 +515,7 @@ impl Default for ParametersBuilder {
                 .map(|(addr, amount)| (addr.to_string(), *amount))
                 .collect(),
             checkpoints: TESTNET_CHECKPOINT_LIST.clone(),
-            temporary_orchard_disabling_soft_fork_height: Some(
-                TEMPORARY_ORCHARD_DISABLING_SOFT_FORK_HEIGHT,
-            ),
+            temporary_orchard_disabling_soft_fork_height: None,
         }
     }
 }

--- a/zebra-chain/src/parameters/network/tests/vectors.rs
+++ b/zebra-chain/src/parameters/network/tests/vectors.rs
@@ -696,7 +696,7 @@ fn temporary_orchard_disabling_soft_fork_heights() {
     let _init_guard = zebra_test::init();
 
     // Mainnet uses a fixed activation height.
-    let mainnet_height = Height(3_363_366);
+    let mainnet_height = Height(3_363_426);
     assert_eq!(
         Network::Mainnet.temporary_orchard_disabling_soft_fork_height(),
         Some(mainnet_height),

--- a/zebra-chain/src/parameters/network/tests/vectors.rs
+++ b/zebra-chain/src/parameters/network/tests/vectors.rs
@@ -696,7 +696,7 @@ fn temporary_orchard_disabling_soft_fork_heights() {
     let _init_guard = zebra_test::init();
 
     // Mainnet uses a fixed activation height.
-    let mainnet_height = Height(3_364_000);
+    let mainnet_height = Height(3_363_366);
     assert_eq!(
         Network::Mainnet.temporary_orchard_disabling_soft_fork_height(),
         Some(mainnet_height),

--- a/zebra-chain/src/parameters/network/tests/vectors.rs
+++ b/zebra-chain/src/parameters/network/tests/vectors.rs
@@ -688,3 +688,55 @@ fn funding_streams_default_values() {
         1
     );
 }
+
+/// Checks the temporary Orchard-disabling soft fork height accessors, including the
+/// activation-height boundary used to trigger a mempool reset.
+#[test]
+fn temporary_orchard_disabling_soft_fork_heights() {
+    let _init_guard = zebra_test::init();
+
+    // Mainnet uses a fixed activation height.
+    let mainnet_height = Height(3_364_000);
+    assert_eq!(
+        Network::Mainnet.temporary_orchard_disabling_soft_fork_height(),
+        Some(mainnet_height),
+    );
+    assert!(!Network::Mainnet
+        .temporary_orchard_disabling_soft_fork_active((mainnet_height - 1).unwrap()),);
+    assert!(Network::Mainnet.temporary_orchard_disabling_soft_fork_active(mainnet_height));
+    // Only the exact activation height is the boundary that triggers a reset.
+    assert!(!Network::Mainnet
+        .is_temporary_orchard_disabling_soft_fork_activation_height((mainnet_height - 1).unwrap()));
+    assert!(
+        Network::Mainnet.is_temporary_orchard_disabling_soft_fork_activation_height(mainnet_height)
+    );
+    assert!(!Network::Mainnet
+        .is_temporary_orchard_disabling_soft_fork_activation_height((mainnet_height + 1).unwrap()));
+
+    // A configured Testnet uses its configured height.
+    let testnet_height = Height(2_000_000);
+    let configured = testnet::Parameters::build()
+        .with_temporary_orchard_disabling_soft_fork_height(testnet_height)
+        .to_network()
+        .expect("failed to build configured network");
+
+    assert_eq!(
+        configured.temporary_orchard_disabling_soft_fork_height(),
+        Some(testnet_height),
+    );
+    assert!(configured.is_temporary_orchard_disabling_soft_fork_activation_height(testnet_height));
+    assert!(!configured
+        .is_temporary_orchard_disabling_soft_fork_activation_height((testnet_height + 1).unwrap()));
+
+    // A Testnet with the soft fork disabled has no activation height.
+    let disabled = testnet::Parameters::build()
+        .disable_temporary_orchard_disabling_soft_fork()
+        .to_network()
+        .expect("failed to build configured network");
+
+    assert_eq!(
+        disabled.temporary_orchard_disabling_soft_fork_height(),
+        None,
+    );
+    assert!(!disabled.is_temporary_orchard_disabling_soft_fork_activation_height(testnet_height));
+}

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-consensus"
-version = "7.0.0"
+version = "7.0.1"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks"
 license.workspace = true
@@ -71,9 +71,9 @@ tower-fallback = { path = "../tower-fallback/", version = "0.2.41" }
 tower-batch-control = { path = "../tower-batch-control/", version = "1.0.1" }
 
 zebra-script = { path = "../zebra-script", version = "7.0.1" }
-zebra-state = { path = "../zebra-state", version = "7.0.0" }
+zebra-state = { path = "../zebra-state", version = "7.0.1" }
 zebra-node-services = { path = "../zebra-node-services", version = "6.0.0" }
-zebra-chain = { path = "../zebra-chain", version = "8.0.0" }
+zebra-chain = { path = "../zebra-chain", version = "8.0.1" }
 
 zcash_protocol.workspace = true
 
@@ -97,8 +97,8 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zebra-state = { path = "../zebra-state", version = "7.0.0", features = ["proptest-impl"] }
-zebra-chain = { path = "../zebra-chain", version = "8.0.0", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", version = "7.0.1", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "8.0.1", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/", version = "3.0.0" }
 
 criterion = { workspace = true, features = ["html_reports"] }

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -406,6 +406,18 @@ where
             check::has_enough_orchard_flags(&tx)?;
             check::consensus_branch_id(&tx, req.height(), &network)?;
 
+            // Soft fork: temporarily require transactions to not contain Orchard actions.
+            //
+            // This soft fork was added while NU 6.1 was the active epoch on the Zcash
+            // chain, but we apply it uniformly even if NU 6.1 is not active in case it is
+            // ported to other chains with a different sequence of NUs.
+            //
+            // This will be treated as "Rules that apply generally before the next NU"
+            // when we add the NU that re-enables Orchard actions.
+            if network.temporary_orchard_disabling_soft_fork_active(req.height()) && tx.orchard_shielded_data().is_some() {
+                return Err(TransactionError::Other("transaction has Orchard actions (temporarily disabled)".into()));
+            }
+
             // Validate the coinbase input consensus rules
             if req.is_mempool() && tx.is_coinbase() {
                 return Err(TransactionError::CoinbaseInMempool);

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -2896,13 +2896,13 @@ fn orchard_disabling_soft_fork_activation_boundary() {
         "a disabled soft fork must never be active",
     );
 
-    // Mainnet uses a fixed activation height (3_364_000).
+    // Mainnet uses a fixed activation height (3_363_366).
     assert!(
-        !Network::Mainnet.temporary_orchard_disabling_soft_fork_active(Height(3_363_999)),
+        !Network::Mainnet.temporary_orchard_disabling_soft_fork_active(Height(3_363_365)),
         "Mainnet soft fork must be inactive below its fixed height",
     );
     assert!(
-        Network::Mainnet.temporary_orchard_disabling_soft_fork_active(Height(3_364_000)),
+        Network::Mainnet.temporary_orchard_disabling_soft_fork_active(Height(3_363_366)),
         "Mainnet soft fork must be active at its fixed height",
     );
 }

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -2993,6 +2993,204 @@ async fn orchard_disabling_soft_fork_rejects_orchard_actions_in_blocks_and_mempo
     );
 }
 
+/// Negative control mirroring the zcashd test: a transaction without Orchard
+/// actions is unaffected by the soft fork and is still accepted while it is
+/// active.
+#[tokio::test]
+async fn orchard_disabling_soft_fork_accepts_non_orchard_transactions() {
+    let _init_guard = zebra_test::init();
+
+    // A Testnet with the Orchard-disabling soft fork active from height 1.
+    let network = Parameters::build()
+        .with_temporary_orchard_disabling_soft_fork_height(Height(1))
+        .to_network()
+        .expect("failed to build configured network");
+
+    let mut state: MockService<_, _, _, _> = MockService::build().for_prop_tests();
+
+    let canopy_activation_height = NetworkUpgrade::Canopy
+        .activation_height(&network)
+        .expect("Canopy activation height is specified");
+
+    let transaction_block_height =
+        (canopy_activation_height + 10).expect("transaction block height is too large");
+    let fake_source_fund_height =
+        (transaction_block_height - 1).expect("fake source fund block height is too small");
+
+    assert!(
+        network.temporary_orchard_disabling_soft_fork_active(transaction_block_height),
+        "soft fork must be active at the transaction's height",
+    );
+
+    // A transparent transfer has no Orchard actions, so the soft fork must not
+    // affect it. The input must exceed the output by enough to pay the ZIP-317
+    // conventional fee, so the transaction is otherwise valid.
+    let (input, output, known_utxos) = mock_transparent_transfer(
+        fake_source_fund_height,
+        true,
+        0,
+        Amount::try_from(10001).expect("valid amount"),
+    );
+
+    let transaction = Transaction::V4 {
+        inputs: vec![input],
+        outputs: vec![output],
+        lock_time: LockTime::Height(block::Height(0)),
+        expiry_height: (transaction_block_height + 1).expect("expiry height is too large"),
+        joinsplit_data: None,
+        sapling_shielded_data: None,
+    };
+
+    let input_outpoint = match transaction.inputs()[0] {
+        transparent::Input::PrevOut { outpoint, .. } => outpoint,
+        transparent::Input::Coinbase { .. } => panic!("requires a non-coinbase transaction"),
+    };
+
+    let verifier = Verifier::new_for_tests(&network, state.clone());
+
+    tokio::spawn(async move {
+        state
+            .expect_request(zebra_state::Request::UnspentBestChainUtxo(input_outpoint))
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zebra_state::Response::UnspentBestChainUtxo(
+                known_utxos
+                    .get(&input_outpoint)
+                    .map(|utxo| utxo.utxo.clone()),
+            ));
+
+        state
+            .expect_request_that(|req| {
+                matches!(
+                    req,
+                    zebra_state::Request::CheckBestChainTipNullifiersAndAnchors(_)
+                )
+            })
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zebra_state::Response::ValidBestChainTipNullifiersAndAnchors);
+    });
+
+    let response = verifier
+        .oneshot(Request::Mempool {
+            transaction: transaction.into(),
+            height: transaction_block_height,
+        })
+        .await;
+
+    assert!(
+        response.is_ok(),
+        "non-Orchard transaction must be accepted while the soft fork is active, got: {response:?}",
+    );
+}
+
+/// Mirrors the zcashd boundary test: the soft fork must accept an Orchard
+/// transaction one block below its activation height but reject the same
+/// transaction at the activation height.
+#[tokio::test]
+async fn orchard_disabling_soft_fork_accepts_orchard_actions_below_activation_height() {
+    let _init_guard = zebra_test::init();
+
+    // Use an unmodified Orchard-only V5 transaction from the test vectors so its
+    // proofs remain valid for the acceptance path.
+    let default_testnet = Network::new_default_testnet();
+    let tx = v5_transactions(default_testnet.block_iter())
+        .rev()
+        .find(|transaction| {
+            transaction.inputs().is_empty()
+                && transaction.outputs().is_empty()
+                && transaction.sapling_spends_per_anchor().next().is_none()
+                && transaction.sapling_outputs().next().is_none()
+                && transaction.joinsplit_count() == 0
+        })
+        .expect("V5 tx with only Orchard actions");
+
+    assert!(
+        tx.orchard_shielded_data().is_some(),
+        "test transaction must contain Orchard actions",
+    );
+
+    let height = tx.expiry_height().expect("V5 tx has an expiry height");
+
+    // The soft fork activates one block above the transaction's height, so it is
+    // inactive for this transaction and verification proceeds normally.
+    let accepting_network = Parameters::build()
+        .with_temporary_orchard_disabling_soft_fork_height(
+            (height + 1).expect("height is too large"),
+        )
+        .to_network()
+        .expect("failed to build configured network");
+
+    assert!(
+        !accepting_network.temporary_orchard_disabling_soft_fork_active(height),
+        "soft fork must be inactive below its activation height",
+    );
+
+    // The only state request for an Orchard-only transaction verified as part of
+    // a block is the nullifier and anchor check.
+    let mut state: MockService<zebra_state::Request, zebra_state::Response, _, _> =
+        MockService::build().for_prop_tests();
+    let accept_verifier = Verifier::new_for_tests(&accepting_network, state.clone());
+
+    tokio::spawn(async move {
+        state
+            .expect_request_that(|req| {
+                matches!(
+                    req,
+                    zebra_state::Request::CheckBestChainTipNullifiersAndAnchors(_)
+                )
+            })
+            .await
+            .expect("verifier should call mock state service with correct request")
+            .respond(zebra_state::Response::ValidBestChainTipNullifiersAndAnchors);
+    });
+
+    let accept_response = accept_verifier
+        .oneshot(Request::Block {
+            transaction_hash: tx.hash(),
+            transaction: Arc::new(tx.clone()),
+            known_utxos: Arc::new(HashMap::new()),
+            known_outpoint_hashes: Arc::new(HashSet::new()),
+            height,
+            time: DateTime::<Utc>::MAX_UTC,
+        })
+        .await;
+
+    assert!(
+        accept_response.is_ok(),
+        "Orchard transaction must be accepted below the soft fork height, got: {accept_response:?}",
+    );
+
+    // At the activation height the same transaction is rejected. The soft-fork
+    // check runs before any state query, so the state service is never called.
+    let rejecting_network = Parameters::build()
+        .with_temporary_orchard_disabling_soft_fork_height(height)
+        .to_network()
+        .expect("failed to build configured network");
+
+    let reject_response = Verifier::new_for_tests(
+        &rejecting_network,
+        service_fn(|_| async { unreachable!("state service should not be called") }),
+    )
+    .oneshot(Request::Block {
+        transaction_hash: tx.hash(),
+        transaction: Arc::new(tx),
+        known_utxos: Arc::new(HashMap::new()),
+        known_outpoint_hashes: Arc::new(HashSet::new()),
+        height,
+        time: DateTime::<Utc>::MAX_UTC,
+    })
+    .await;
+
+    assert_eq!(
+        reject_response,
+        Err(TransactionError::Other(
+            "transaction has Orchard actions (temporarily disabled)".into()
+        )),
+        "Orchard transaction must be rejected at the soft fork height",
+    );
+}
+
 /// Checks that the tx verifier handles consensus branch ids in V5 txs correctly.
 #[tokio::test]
 async fn v5_consensus_branch_ids() {

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -2896,13 +2896,13 @@ fn orchard_disabling_soft_fork_activation_boundary() {
         "a disabled soft fork must never be active",
     );
 
-    // Mainnet uses a fixed activation height (3_363_366).
+    // Mainnet uses a fixed activation height (3_363_426).
     assert!(
-        !Network::Mainnet.temporary_orchard_disabling_soft_fork_active(Height(3_363_365)),
+        !Network::Mainnet.temporary_orchard_disabling_soft_fork_active(Height(3_363_425)),
         "Mainnet soft fork must be inactive below its fixed height",
     );
     assert!(
-        Network::Mainnet.temporary_orchard_disabling_soft_fork_active(Height(3_363_366)),
+        Network::Mainnet.temporary_orchard_disabling_soft_fork_active(Height(3_363_426)),
         "Mainnet soft fork must be active at its fixed height",
     );
 }

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -21,7 +21,10 @@ use zebra_chain::{
     amount::{Amount, NonNegative},
     block::{self, Block, Height},
     orchard::{Action, AuthorizedAction, Flags},
-    parameters::{testnet::ConfiguredActivationHeights, Network, NetworkUpgrade},
+    parameters::{
+        testnet::{ConfiguredActivationHeights, Parameters},
+        Network, NetworkUpgrade,
+    },
     primitives::{ed25519, x25519, Groth16Proof},
     sapling,
     serialization::{AtLeastOne, DateTime32, ZcashDeserialize, ZcashDeserializeInto},
@@ -2852,6 +2855,142 @@ async fn v5_with_duplicate_orchard_action() {
             ))
         );
     }
+}
+
+/// Checks the activation boundary of the temporary Orchard-disabling soft fork:
+/// it is inactive below the configured height and active at and above it, can be
+/// disabled entirely, and Mainnet uses its fixed activation height.
+#[test]
+fn orchard_disabling_soft_fork_activation_boundary() {
+    let _init_guard = zebra_test::init();
+
+    let soft_fork_height = Height(2_000_000);
+
+    // A Testnet with the soft fork configured to activate at `soft_fork_height`.
+    let network = Parameters::build()
+        .with_temporary_orchard_disabling_soft_fork_height(soft_fork_height)
+        .to_network()
+        .expect("failed to build configured network");
+
+    assert!(
+        !network.temporary_orchard_disabling_soft_fork_active(Height(1_999_999)),
+        "soft fork must be inactive below the configured height",
+    );
+    assert!(
+        network.temporary_orchard_disabling_soft_fork_active(soft_fork_height),
+        "soft fork must be active at the configured height",
+    );
+    assert!(
+        network.temporary_orchard_disabling_soft_fork_active(Height(2_000_001)),
+        "soft fork must be active above the configured height",
+    );
+
+    // A Testnet with the soft fork disabled is never active.
+    let disabled = Parameters::build()
+        .disable_temporary_orchard_disabling_soft_fork()
+        .to_network()
+        .expect("failed to build configured network");
+
+    assert!(
+        !disabled.temporary_orchard_disabling_soft_fork_active(Height(4_042_000)),
+        "a disabled soft fork must never be active",
+    );
+
+    // Mainnet uses a fixed activation height (3_364_000).
+    assert!(
+        !Network::Mainnet.temporary_orchard_disabling_soft_fork_active(Height(3_363_999)),
+        "Mainnet soft fork must be inactive below its fixed height",
+    );
+    assert!(
+        Network::Mainnet.temporary_orchard_disabling_soft_fork_active(Height(3_364_000)),
+        "Mainnet soft fork must be active at its fixed height",
+    );
+}
+
+/// The temporary Orchard-disabling soft fork must reject transactions that
+/// contain Orchard actions once it is active, in both block and mempool
+/// verification contexts.
+#[tokio::test]
+async fn orchard_disabling_soft_fork_rejects_orchard_actions_in_blocks_and_mempool() {
+    let _init_guard = zebra_test::init();
+
+    // Find a V5 transaction whose only shielded data is Orchard, so it both
+    // contains Orchard actions and can pass `has_inputs_and_outputs` once the
+    // Orchard flags are set below.
+    let default_testnet = Network::new_default_testnet();
+    let mut tx = v5_transactions(default_testnet.block_iter())
+        .rev()
+        .find(|transaction| {
+            transaction.inputs().is_empty()
+                && transaction.outputs().is_empty()
+                && transaction.sapling_spends_per_anchor().next().is_none()
+                && transaction.sapling_outputs().next().is_none()
+                && transaction.joinsplit_count() == 0
+        })
+        .expect("V5 tx with only Orchard actions");
+
+    // Enable spends and outputs so the transaction passes `has_inputs_and_outputs`
+    // and `has_enough_orchard_flags`, reaching the soft-fork check.
+    tx.orchard_shielded_data_mut()
+        .expect("tx without transparent, Sprout, or Sapling data must have Orchard actions")
+        .flags = Flags::ENABLE_SPENDS | Flags::ENABLE_OUTPUTS;
+
+    // Verify at the transaction's own expiry height, where its NU5 consensus
+    // branch id is valid on the default Testnet activation schedule.
+    let height = tx.expiry_height().expect("V5 tx has an expiry height");
+
+    // Configure a Testnet identical to the default public Testnet except that the
+    // Orchard-disabling soft fork activates at `height`, so it is active for this
+    // transaction.
+    let network = Parameters::build()
+        .with_temporary_orchard_disabling_soft_fork_height(height)
+        .to_network()
+        .expect("failed to build configured network");
+
+    assert!(
+        network.temporary_orchard_disabling_soft_fork_active(height),
+        "soft fork must be active at the transaction's height",
+    );
+
+    let expected = Err(TransactionError::Other(
+        "transaction has Orchard actions (temporarily disabled)".into(),
+    ));
+
+    // The soft-fork check runs before any state-service query, so the state
+    // service must never be called.
+    let block_response = Verifier::new_for_tests(
+        &network,
+        service_fn(|_| async { unreachable!("state service should not be called") }),
+    )
+    .oneshot(Request::Block {
+        transaction_hash: tx.hash(),
+        transaction: Arc::new(tx.clone()),
+        known_utxos: Arc::new(HashMap::new()),
+        known_outpoint_hashes: Arc::new(HashSet::new()),
+        height,
+        time: DateTime::<Utc>::MAX_UTC,
+    })
+    .await;
+
+    assert_eq!(
+        block_response, expected,
+        "block verification must reject a transaction with Orchard actions after the soft fork",
+    );
+
+    let mempool_response = Verifier::new_for_tests(
+        &network,
+        service_fn(|_| async { unreachable!("state service should not be called") }),
+    )
+    .oneshot(Request::Mempool {
+        transaction: tx.into(),
+        height,
+    })
+    .await;
+
+    assert_eq!(
+        mempool_response, expected,
+        "mempool verification must reject a transaction with Orchard actions after the soft fork",
+    );
 }
 
 /// Checks that the tx verifier handles consensus branch ids in V5 txs correctly.

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-network"
-version = "7.0.0"
+version = "7.0.1"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Networking code for Zebra"
 # # Legal
@@ -85,7 +85,7 @@ howudoin = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "8.0.0", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "8.0.1", features = ["async-error"] }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -607,6 +607,11 @@ struct DTestnetParameters {
     /// If `true`, automatically repeats configured funding stream addresses to fill
     /// all required periods.
     extend_funding_stream_addresses_as_required: Option<bool>,
+    /// Height at which the soft fork that temporarily disables Orchard actions activates.
+    ///
+    /// If unset, the default activation height for the network is used; the soft fork
+    /// cannot be disabled via configuration.
+    temporary_orchard_disabling_soft_fork_height: Option<u32>,
 }
 
 /// Network configuration used during deserialization.
@@ -699,6 +704,9 @@ impl From<Arc<testnet::Parameters>> for DTestnetParameters {
                 params.checkpoints().into()
             },
             extend_funding_stream_addresses_as_required: None,
+            temporary_orchard_disabling_soft_fork_height: params
+                .temporary_orchard_disabling_soft_fork_height()
+                .map(|height| height.0),
         }
     }
 }
@@ -887,6 +895,7 @@ where
         lockbox_disbursements,
         checkpoints,
         extend_funding_stream_addresses_as_required,
+        temporary_orchard_disabling_soft_fork_height,
     } = params;
 
     let mut params_builder = testnet::Parameters::build();
@@ -966,6 +975,13 @@ where
 
     if let Some(true) = extend_funding_stream_addresses_as_required {
         params_builder = params_builder.extend_funding_streams();
+    }
+
+    // Retain the default soft-fork activation height unless one is configured.
+    if let Some(height) = temporary_orchard_disabling_soft_fork_height {
+        params_builder = params_builder.with_temporary_orchard_disabling_soft_fork_height(
+            height.try_into().map_err(de::Error::custom)?,
+        );
     }
 
     // Return an error if the initial testnet peers includes any of the default initial Mainnet or Testnet

--- a/zebra-network/src/config/tests/vectors.rs
+++ b/zebra-network/src/config/tests/vectors.rs
@@ -1,7 +1,13 @@
 //! Fixed test vectors for zebra-network configuration.
 
 use static_assertions::const_assert;
-use zebra_chain::parameters::testnet::{self, ConfiguredFundingStreams};
+use zebra_chain::{
+    block::Height,
+    parameters::{
+        testnet::{self, ConfiguredFundingStreams},
+        Network,
+    },
+};
 
 use crate::{
     constants::{INBOUND_PEER_LIMIT_MULTIPLIER, OUTBOUND_PEER_LIMIT_MULTIPLIER},
@@ -108,4 +114,36 @@ fn funding_streams_serialization_roundtrip() {
     let deserialized: Config = toml::from_str(&serialized).unwrap();
 
     assert_eq!(config, deserialized);
+}
+
+/// Checks that a configured Testnet's temporary Orchard-disabling soft fork height
+/// survives a serialization round-trip.
+#[test]
+fn temporary_orchard_disabling_soft_fork_height_serialization_roundtrip() {
+    let _init_guard = zebra_test::init();
+
+    let soft_fork_height = Height(2_000_000);
+
+    let config = Config {
+        network: testnet::Parameters::build()
+            .with_temporary_orchard_disabling_soft_fork_height(soft_fork_height)
+            .to_network()
+            .expect("failed to build configured network"),
+        initial_testnet_peers: [].into(),
+        ..Config::default()
+    };
+
+    let serialized = toml::to_string(&config).unwrap();
+    let deserialized: Config = toml::from_str(&serialized).unwrap();
+
+    assert_eq!(config, deserialized);
+
+    // The configured height must be preserved through the round-trip.
+    let Network::Testnet(params) = &deserialized.network else {
+        panic!("deserialized network must be a Testnet");
+    };
+    assert_eq!(
+        params.temporary_orchard_disabling_soft_fork_height(),
+        Some(soft_fork_height),
+    );
 }

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -31,7 +31,7 @@ rpc-client = [
 ]
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain" , version = "8.0.0" }
+zebra-chain = { path = "../zebra-chain" , version = "8.0.1" }
 tower = { workspace = true }
 
 # Optional dependencies

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -109,16 +109,16 @@ zcash_transparent = { workspace = true }
 # Test-only feature proptest-impl
 proptest = { workspace = true, optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "8.0.0", features = [
+zebra-chain = { path = "../zebra-chain", version = "8.0.1", features = [
     "json-conversion",
 ] }
-zebra-consensus = { path = "../zebra-consensus", version = "7.0.0" }
-zebra-network = { path = "../zebra-network", version = "7.0.0" }
+zebra-consensus = { path = "../zebra-consensus", version = "7.0.1" }
+zebra-network = { path = "../zebra-network", version = "7.0.1" }
 zebra-node-services = { path = "../zebra-node-services", version = "6.0.0", features = [
     "rpc-client",
 ] }
 zebra-script = { path = "../zebra-script", version = "7.0.1" }
-zebra-state = { path = "../zebra-state", version = "7.0.0" }
+zebra-state = { path = "../zebra-state", version = "7.0.1" }
 
 [build-dependencies]
 openrpsee = { workspace = true }
@@ -136,16 +136,16 @@ proptest = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zebra-chain = { path = "../zebra-chain", version = "8.0.0", features = [
+zebra-chain = { path = "../zebra-chain", version = "8.0.1", features = [
     "proptest-impl",
 ] }
-zebra-consensus = { path = "../zebra-consensus", version = "7.0.0", features = [
+zebra-consensus = { path = "../zebra-consensus", version = "7.0.1", features = [
     "proptest-impl",
 ] }
-zebra-network = { path = "../zebra-network", version = "7.0.0", features = [
+zebra-network = { path = "../zebra-network", version = "7.0.1", features = [
     "proptest-impl",
 ] }
-zebra-state = { path = "../zebra-state", version = "7.0.0", features = [
+zebra-state = { path = "../zebra-state", version = "7.0.1", features = [
     "proptest-impl",
 ] }
 

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -26,7 +26,7 @@ comparison-interpreter = []
 libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
-zebra-chain = { path = "../zebra-chain", version = "8.0.0" }
+zebra-chain = { path = "../zebra-chain", version = "8.0.1" }
 
 rand = { workspace = true }
 thiserror = { workspace = true }

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-state"
-version = "7.0.0"
+version = "7.0.1"
 authors.workspace = true
 description = "State contextual verification and storage code for Zebra"
 license.workspace = true
@@ -79,7 +79,7 @@ elasticsearch = { workspace = true, features = ["rustls-tls"], optional = true }
 serde_json = { workspace = true, optional = true }
 
 zebra-node-services = { path = "../zebra-node-services", version = "6.0.0" }
-zebra-chain = { path = "../zebra-chain", version = "8.0.0", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "8.0.1", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { workspace = true, optional = true }
@@ -109,7 +109,7 @@ jubjub = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zebra-chain = { path = "../zebra-chain", version = "8.0.0", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "8.0.1", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/", version = "3.0.0" }
 
 [lints]

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -595,8 +595,18 @@ impl ChainTipChange {
         // Skipped blocks can include network upgrade activation blocks.
         // Fork changes can activate or deactivate a network upgrade.
         // So we must perform the same actions for network upgrades and skipped blocks.
+        //
+        // The soft fork that temporarily disables Orchard actions is not a network
+        // upgrade, but it has the same memory-pool requirement: once the chain tip
+        // reaches its activation height, the mempool must drop any transactions
+        // that are no longer valid under the new rule. So we also reset there.
         if Some(block.previous_block_hash) != self.last_change_hash
-            || NetworkUpgrade::is_activation_height(&self.network, block.height)
+            || NetworkUpgrade::is_activation_height(&self.network, block.height.next().unwrap())
+            || self
+                .network
+                .is_temporary_orchard_disabling_soft_fork_activation_height(
+                    block.height.next().unwrap(),
+                )
         {
             TipAction::reset_with(block)
         } else {

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -61,7 +61,7 @@ tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 
 zebra-node-services = { path = "../zebra-node-services", version = "6.0.0" }
-zebra-chain = { path = "../zebra-chain", version = "8.0.0" }
+zebra-chain = { path = "../zebra-chain", version = "8.0.1" }
 
 # These crates are needed for the block-template-to-proposal binary
 zebra-rpc = { path = "../zebra-rpc", version = "8.0.0" }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate metadata
 name = "zebrad"
-version = "4.5.1"
+version = "4.5.3"
 authors.workspace = true
 description = "The Zcash Foundation's independent, consensus-compatible implementation of a Zcash node"
 license.workspace = true
@@ -148,12 +148,12 @@ tx_v6 = ["zebra-chain/tx_v6", "zebra-state/tx_v6", "zebra-consensus/tx_v6", "zeb
 comparison-interpreter = ["zebra-script/comparison-interpreter"]
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain", version = "8.0.0" }
-zebra-consensus = { path = "../zebra-consensus", version = "7.0.0" }
-zebra-network = { path = "../zebra-network", version = "7.0.0" }
+zebra-chain = { path = "../zebra-chain", version = "8.0.1" }
+zebra-consensus = { path = "../zebra-consensus", version = "7.0.1" }
+zebra-network = { path = "../zebra-network", version = "7.0.1" }
 zebra-node-services = { path = "../zebra-node-services", version = "6.0.0", features = ["rpc-client"] }
 zebra-rpc = { path = "../zebra-rpc", version = "8.0.0" }
-zebra-state = { path = "../zebra-state", version = "7.0.0" }
+zebra-state = { path = "../zebra-state", version = "7.0.1" }
 # zebra-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
 # enabling it in the other imports of zcash-script.)
@@ -293,10 +293,10 @@ proptest-derive = { workspace = true }
 # enable span traces and track caller in tests
 color-eyre = { workspace = true }
 
-zebra-chain = { path = "../zebra-chain", version = "8.0.0", features = ["proptest-impl"] }
-zebra-consensus = { path = "../zebra-consensus", version = "7.0.0", features = ["proptest-impl"] }
-zebra-network = { path = "../zebra-network", version = "7.0.0", features = ["proptest-impl"] }
-zebra-state = { path = "../zebra-state", version = "7.0.0", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "8.0.1", features = ["proptest-impl"] }
+zebra-consensus = { path = "../zebra-consensus", version = "7.0.1", features = ["proptest-impl"] }
+zebra-network = { path = "../zebra-network", version = "7.0.1", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", version = "7.0.1", features = ["proptest-impl"] }
 
 zebra-test = { path = "../zebra-test", version = "3.0.0" }
 


### PR DESCRIPTION
Hotfix release **Zebra 4.5.3**.

Adds a soft fork that temporarily disables Orchard actions in transactions to mitigate a security issue ([GHSA-jfw5-j458-pfv6](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-jfw5-j458-pfv6)), activating at Mainnet height **3,363,426**.

- Version bumps: `zebra-chain` 8.0.1, `zebra-consensus`/`zebra-network`/`zebra-state` 7.0.1, `zebrad` 4.5.3.
- CHANGELOG + README updated.
- Checkpoints/end-of-support intentionally not refreshed: v4.5.1 shipped 3 days ago, and the activation height (3,363,426) is above the highest checkpoint (3,358,006), so the rule is enforced via semantic verification.

Release is performed from this branch per the hotfix checklist.