### PR TITLE
release: v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,35 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Unreleased]
+## [Zebra 5.0.0](https://github.com/ZcashFoundation/zebra/releases/tag/v5.0.0) - 2026-06-02
+
+This release activates the NU6.2 network upgrade. NU6.2 re-enables Orchard
+actions (temporarily disabled by the 4.5.3 soft fork) using the fixed Orchard
+Action circuit, which fixes a **critical** bug in the Orchard pool. NU6.2
+activates at block height 3,364,600 on Mainnet and 4,052,000 on Testnet. We
+recommend node operators update before the activation height.
+
+If the activation height has passed and your node followed a fork, you will need
+to sync from scratch. If you have a backed-up state before the activation
+height, you can sync from that.
+
+### Added
+
+- Activate the NU6.2 network upgrade (consensus branch id `0x5437f330`) at height 3,364,600
+  on Mainnet and 4,052,000 on Testnet. NU6.2 re-enables Orchard actions with the fixed
+  Orchard Action circuit and routes Orchard proofs to a per-circuit verifying key
+  (`InsecurePreNu6_2` / `FixedPostNu6_2`).
+- Advertise network protocol version 170150 for NU6.2 on Mainnet, Testnet, and Regtest.
+
+### Changed
+
+- Set the default Testnet temporary Orchard-disabling soft-fork height to 4,048,500; the
+  disable window runs until NU6.2 re-enables Orchard actions at height 4,052,000.
 
 ### Security
 
 - Add a consensus rule that rejects Orchard bundles whose proof has a non-canonical size,
-  effective from the NU6.2 network upgrade (GHSA-2x4w-pxqw-58v9). The rule is inert until
-  NU6.2 is assigned an activation height.
-
-### Added
-
-- Add NU6.2 network-upgrade scaffolding (consensus branch id `0x5437f330`). NU6.2 re-enables
-  Orchard actions with the fixed Orchard Action circuit and routes Orchard proofs to a
-  per-circuit verifying key (`InsecurePreNu6_2` / `FixedPostNu6_2`). NU6.2 has no committed
-  Mainnet activation height yet, so the re-enable and the proof-size rule remain inert.
+  effective from the NU6.2 network upgrade (GHSA-2x4w-pxqw-58v9).
 
 ## [Zebra 4.5.3](https://github.com/ZcashFoundation/zebra/releases/tag/v4.5.3) - 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+
+### Security
+
+- Add a consensus rule that rejects Orchard bundles whose proof has a non-canonical size,
+  effective from the NU6.2 network upgrade (GHSA-2x4w-pxqw-58v9). The rule is inert until
+  NU6.2 is assigned an activation height.
+
+### Added
+
+- Add NU6.2 network-upgrade scaffolding (consensus branch id `0x5437f330`). NU6.2 re-enables
+  Orchard actions with the fixed Orchard Action circuit and routes Orchard proofs to a
+  per-circuit verifying key (`InsecurePreNu6_2` / `FixedPostNu6_2`). NU6.2 has no committed
+  Mainnet activation height yet, so the re-enable and the proof-size rule remain inert.
+
 ## [Zebra 4.5.3](https://github.com/ZcashFoundation/zebra/releases/tag/v4.5.3) - 2026-06-01
 
 This hotfix release adds a soft fork that temporarily disables Orchard actions in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ height, you can sync from that.
 ### Security
 
 - Add a consensus rule that rejects Orchard bundles whose proof has a non-canonical size,
-  effective from the NU6.2 network upgrade (GHSA-2x4w-pxqw-58v9).
+  effective from the NU6.2 network upgrade (GHSA-jfw5-j458-pfv6).
 
 ## [Zebra 4.5.3](https://github.com/ZcashFoundation/zebra/releases/tag/v4.5.3) - 2026-06-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,7 +1592,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=2501696f47b322e1dbeb1e59910b89d87a1dd7f5#2501696f47b322e1dbeb1e59910b89d87a1dd7f5"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=646f65deeafe755d82dfe9f2e554b499fdd59562#646f65deeafe755d82dfe9f2e554b499fdd59562"
 dependencies = [
  "blake2b_simd",
  "cc",
@@ -1640,7 +1640,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=2501696f47b322e1dbeb1e59910b89d87a1dd7f5#2501696f47b322e1dbeb1e59910b89d87a1dd7f5"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=646f65deeafe755d82dfe9f2e554b499fdd59562#646f65deeafe755d82dfe9f2e554b499fdd59562"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3624,7 +3624,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.13.1"
-source = "git+https://github.com/zodl-inc/orchard-security-fixes.git?rev=6e76352618b6b4a7448645f0f8afae18855d5fa1#6e76352618b6b4a7448645f0f8afae18855d5fa1"
+source = "git+https://github.com/zodl-inc/orchard-security-fixes.git?rev=9c1b5af87a04a4b5c4d9616c359ebcee341a37b3#9c1b5af87a04a4b5c4d9616c359ebcee341a37b3"
 dependencies = [
  "aes",
  "bitvec",
@@ -7240,7 +7240,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.11.0"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=2501696f47b322e1dbeb1e59910b89d87a1dd7f5#2501696f47b322e1dbeb1e59910b89d87a1dd7f5"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=646f65deeafe755d82dfe9f2e554b499fdd59562#646f65deeafe755d82dfe9f2e554b499fdd59562"
 dependencies = [
  "bech32",
  "bs58",
@@ -7253,7 +7253,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=2501696f47b322e1dbeb1e59910b89d87a1dd7f5#2501696f47b322e1dbeb1e59910b89d87a1dd7f5"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=646f65deeafe755d82dfe9f2e554b499fdd59562#646f65deeafe755d82dfe9f2e554b499fdd59562"
 dependencies = [
  "corez",
  "hex",
@@ -7263,7 +7263,8 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.4.0"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=2501696f47b322e1dbeb1e59910b89d87a1dd7f5#2501696f47b322e1dbeb1e59910b89d87a1dd7f5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fde17bf53792f9c756b313730da14880257d7661b5bfc69d0571c3a7c11a76d"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -7273,8 +7274,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b340e2bc20698c4d784d920dcda1f270d076bef2b0726b732ca9ca7574d61241"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=646f65deeafe755d82dfe9f2e554b499fdd59562#646f65deeafe755d82dfe9f2e554b499fdd59562"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -7314,7 +7314,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.27.1"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=2501696f47b322e1dbeb1e59910b89d87a1dd7f5#2501696f47b322e1dbeb1e59910b89d87a1dd7f5"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=646f65deeafe755d82dfe9f2e554b499fdd59562#646f65deeafe755d82dfe9f2e554b499fdd59562"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7344,7 +7344,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.27.0"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=2501696f47b322e1dbeb1e59910b89d87a1dd7f5#2501696f47b322e1dbeb1e59910b89d87a1dd7f5"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=646f65deeafe755d82dfe9f2e554b499fdd59562#646f65deeafe755d82dfe9f2e554b499fdd59562"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7366,7 +7366,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.8.0"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=2501696f47b322e1dbeb1e59910b89d87a1dd7f5#2501696f47b322e1dbeb1e59910b89d87a1dd7f5"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=646f65deeafe755d82dfe9f2e554b499fdd59562#646f65deeafe755d82dfe9f2e554b499fdd59562"
 dependencies = [
  "corez",
  "document-features",
@@ -7404,7 +7404,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.7.0"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=2501696f47b322e1dbeb1e59910b89d87a1dd7f5#2501696f47b322e1dbeb1e59910b89d87a1dd7f5"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=646f65deeafe755d82dfe9f2e554b499fdd59562#646f65deeafe755d82dfe9f2e554b499fdd59562"
 dependencies = [
  "bip32",
  "bs58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -176,7 +176,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1428,7 +1428,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1592,7 +1592,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=646f65deeafe755d82dfe9f2e554b499fdd59562#646f65deeafe755d82dfe9f2e554b499fdd59562"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=a4bc18408935df58db686e1834c23bcc8c5680e0#a4bc18408935df58db686e1834c23bcc8c5680e0"
 dependencies = [
  "blake2b_simd",
  "cc",
@@ -1624,7 +1624,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1640,7 +1640,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=646f65deeafe755d82dfe9f2e554b499fdd59562#646f65deeafe755d82dfe9f2e554b499fdd59562"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=a4bc18408935df58db686e1834c23bcc8c5680e0#a4bc18408935df58db686e1834c23bcc8c5680e0"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2007,8 +2007,8 @@ dependencies = [
 
 [[package]]
 name = "halo2_gadgets"
-version = "0.4.0"
-source = "git+https://github.com/zodl-inc/halo2-security-fixes.git?rev=a101adb907869062593242a1946a7d6157d11899#a101adb907869062593242a1946a7d6157d11899"
+version = "0.5.0"
+source = "git+https://github.com/zodl-inc/halo2-security-fixes.git?rev=d751768afe0d2105b349dd93f73fde7f2eade088#d751768afe0d2105b349dd93f73fde7f2eade088"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -2033,7 +2033,7 @@ checksum = "47716fe1ae67969c5e0b2ef826f32db8c3be72be325e1aa3c1951d06b5575ec5"
 [[package]]
 name = "halo2_poseidon"
 version = "0.1.0"
-source = "git+https://github.com/zodl-inc/halo2-security-fixes.git?rev=a101adb907869062593242a1946a7d6157d11899#a101adb907869062593242a1946a7d6157d11899"
+source = "git+https://github.com/zodl-inc/halo2-security-fixes.git?rev=d751768afe0d2105b349dd93f73fde7f2eade088#d751768afe0d2105b349dd93f73fde7f2eade088"
 dependencies = [
  "bitvec",
  "ff",
@@ -2044,7 +2044,7 @@ dependencies = [
 [[package]]
 name = "halo2_proofs"
 version = "0.3.2"
-source = "git+https://github.com/zodl-inc/halo2-security-fixes.git?rev=a101adb907869062593242a1946a7d6157d11899#a101adb907869062593242a1946a7d6157d11899"
+source = "git+https://github.com/zodl-inc/halo2-security-fixes.git?rev=d751768afe0d2105b349dd93f73fde7f2eade088#d751768afe0d2105b349dd93f73fde7f2eade088"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -2663,7 +2663,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2903,7 +2903,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3245,7 +3245,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3623,8 +3623,8 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.13.1"
-source = "git+https://github.com/zodl-inc/orchard-security-fixes.git?rev=9c1b5af87a04a4b5c4d9616c359ebcee341a37b3#9c1b5af87a04a4b5c4d9616c359ebcee341a37b3"
+version = "0.14.0"
+source = "git+https://github.com/zodl-inc/orchard-security-fixes.git?rev=994dad2f7bb8c85e7c8ea336dcc2a814a94bc9fd#994dad2f7bb8c85e7c8ea336dcc2a814a94bc9fd"
 dependencies = [
  "aes",
  "bitvec",
@@ -4786,7 +4786,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4845,7 +4845,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5408,7 +5408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5625,7 +5625,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6827,7 +6827,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7239,8 +7239,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.11.0"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=646f65deeafe755d82dfe9f2e554b499fdd59562#646f65deeafe755d82dfe9f2e554b499fdd59562"
+version = "0.12.0"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=a4bc18408935df58db686e1834c23bcc8c5680e0#a4bc18408935df58db686e1834c23bcc8c5680e0"
 dependencies = [
  "bech32",
  "bs58",
@@ -7253,7 +7253,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=646f65deeafe755d82dfe9f2e554b499fdd59562#646f65deeafe755d82dfe9f2e554b499fdd59562"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=a4bc18408935df58db686e1834c23bcc8c5680e0#a4bc18408935df58db686e1834c23bcc8c5680e0"
 dependencies = [
  "corez",
  "hex",
@@ -7273,8 +7273,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.13.0"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=646f65deeafe755d82dfe9f2e554b499fdd59562#646f65deeafe755d82dfe9f2e554b499fdd59562"
+version = "0.14.0"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=a4bc18408935df58db686e1834c23bcc8c5680e0#a4bc18408935df58db686e1834c23bcc8c5680e0"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -7313,8 +7313,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.27.1"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=646f65deeafe755d82dfe9f2e554b499fdd59562#646f65deeafe755d82dfe9f2e554b499fdd59562"
+version = "0.28.0"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=a4bc18408935df58db686e1834c23bcc8c5680e0#a4bc18408935df58db686e1834c23bcc8c5680e0"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7343,8 +7343,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.27.0"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=646f65deeafe755d82dfe9f2e554b499fdd59562#646f65deeafe755d82dfe9f2e554b499fdd59562"
+version = "0.28.0"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=a4bc18408935df58db686e1834c23bcc8c5680e0#a4bc18408935df58db686e1834c23bcc8c5680e0"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7365,8 +7365,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.8.0"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=646f65deeafe755d82dfe9f2e554b499fdd59562#646f65deeafe755d82dfe9f2e554b499fdd59562"
+version = "0.9.0"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=a4bc18408935df58db686e1834c23bcc8c5680e0#a4bc18408935df58db686e1834c23bcc8c5680e0"
 dependencies = [
  "corez",
  "document-features",
@@ -7403,8 +7403,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.7.0"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=646f65deeafe755d82dfe9f2e554b499fdd59562#646f65deeafe755d82dfe9f2e554b499fdd59562"
+version = "0.8.0"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=a4bc18408935df58db686e1834c23bcc8c5680e0#a4bc18408935df58db686e1834c23bcc8c5680e0"
 dependencies = [
  "bip32",
  "bs58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,15 +263,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -270,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -339,6 +348,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,7 +413,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -408,7 +423,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash 1.1.0",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.117",
 ]
 
@@ -418,7 +433,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -426,7 +441,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash 2.1.2",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.117",
 ]
 
@@ -469,9 +484,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 dependencies = [
  "serde_core",
 ]
@@ -482,7 +497,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b64e60c28b6d25ad92e8b367801ff9aa12b41d05fc8798055d296bace4a60cc"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "serde",
 ]
 
@@ -582,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-slice-cast"
@@ -676,14 +691,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -857,6 +872,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "color-eyre"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,9 +943,9 @@ checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "config"
-version = "0.15.22"
+version = "0.15.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68cfe19cd7d23ffde002c24ffa5cda73931913ef394d5eaaa32037dc940c0c"
+checksum = "f316c6237b2d38be61949ecd15268a4c6ca32570079394a2444d9ce2c72a72d8"
 dependencies = [
  "async-trait",
  "convert_case 0.6.0",
@@ -1000,6 +1024,12 @@ dependencies = [
  "tracing-core",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "const-crc32-nostd"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808ac43170e95b11dd23d78aa9eaac5bea45776a602955552c4e833f3f0f823d"
 
 [[package]]
 name = "const-oid"
@@ -1149,6 +1179,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,12 +1283,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -1271,11 +1307,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -1296,11 +1331,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -1437,15 +1472,15 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "objc2",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1538,9 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elasticsearch"
@@ -1563,6 +1598,18 @@ dependencies = [
  "url",
  "void",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -1592,7 +1639,8 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=a4bc18408935df58db686e1834c23bcc8c5680e0#a4bc18408935df58db686e1834c23bcc8c5680e0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
 dependencies = [
  "blake2b_simd",
  "cc",
@@ -1640,7 +1688,8 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=a4bc18408935df58db686e1834c23bcc8c5680e0#a4bc18408935df58db686e1834c23bcc8c5680e0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1754,6 +1803,41 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "frost-core"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81ef2787af391c7e8bedc037a3b9ea03dde803fbd93e778e6bb369547800e5cd"
+dependencies = [
+ "byteorder",
+ "const-crc32-nostd",
+ "derive-getters",
+ "document-features",
+ "hex",
+ "itertools 0.14.0",
+ "postcard",
+ "rand_core 0.6.4",
+ "serde",
+ "serdect",
+ "thiserror 2.0.18",
+ "visibility",
+ "zeroize",
+ "zeroize_derive",
+]
+
+[[package]]
+name = "frost-rerandomized"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4c5cedd2426728adef2c0b1720f57676354c473836d1ccc50d0f0d1c91942b"
+dependencies = [
+ "derive-getters",
+ "document-features",
+ "frost-core",
+ "hex",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1950,7 +2034,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -1977,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2008,7 +2092,8 @@ dependencies = [
 [[package]]
 name = "halo2_gadgets"
 version = "0.5.0"
-source = "git+https://github.com/zodl-inc/halo2-security-fixes.git?rev=d751768afe0d2105b349dd93f73fde7f2eade088#d751768afe0d2105b349dd93f73fde7f2eade088"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb2a697cad929f706b7987fe804ad57d43622cd37463ba7e4d662a926fdcfea3"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -2033,7 +2118,8 @@ checksum = "47716fe1ae67969c5e0b2ef826f32db8c3be72be325e1aa3c1951d06b5575ec5"
 [[package]]
 name = "halo2_poseidon"
 version = "0.1.0"
-source = "git+https://github.com/zodl-inc/halo2-security-fixes.git?rev=d751768afe0d2105b349dd93f73fde7f2eade088#d751768afe0d2105b349dd93f73fde7f2eade088"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa3da60b81f02f9b33ebc6252d766f843291fb4d2247a07ae73d20b791fc56f"
 dependencies = [
  "bitvec",
  "ff",
@@ -2044,7 +2130,8 @@ dependencies = [
 [[package]]
 name = "halo2_proofs"
 version = "0.3.2"
-source = "git+https://github.com/zodl-inc/halo2-security-fixes.git?rev=d751768afe0d2105b349dd93f73fde7f2eade088#d751768afe0d2105b349dd93f73fde7f2eade088"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05713f117155643ce10975e0bee44a274bcda2f4bb5ef29a999ad67c1fa8d4d3"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -2055,6 +2142,15 @@ dependencies = [
  "pasta_curves",
  "rand_core 0.6.4",
  "tracing",
+]
+
+[[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -2091,17 +2187,17 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2115,6 +2211,20 @@ dependencies = [
  "flate2",
  "nom",
  "num-traits",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2173,11 +2283,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2204,9 +2314,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2280,9 +2390,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2378,21 +2488,23 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
+ "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2402,96 +2514,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
- "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
+ "icu_locale_core",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -2508,9 +2582,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -2519,9 +2593,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2580,7 +2654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2644,16 +2718,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is-terminal"
@@ -2775,9 +2839,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2798,9 +2862,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e281ae70cc3b98dac15fced3366a880949e65fc66e345ce857a5682d152f3e62"
+checksum = "72c4b1f204b655b36b24dc4939af20366c649431d4711863bbbae5c495f3eeb4"
 dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-server",
@@ -2810,9 +2874,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348ee569eaed52926b5e740aae20863762b16596476e943c9e415a6479021622"
+checksum = "f49bfa9334963e1c85866b39dff3ffcc81f1c286eb23334267c5cb97677543a4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2833,9 +2897,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7398cddf5013cca4702862a2692b66c48a3bd6cf6ec681a47453c93d63cf8de5"
+checksum = "f5248249c016692f1465a753057ae8347681995dd490c2cb65c48b14b46215a8"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-crate",
@@ -2846,9 +2910,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21429bcdda37dcf2d43b68621b994adede0e28061f816b038b0f18c70c143d51"
+checksum = "c625c78b8d545478370b6e7a2a191b0d921f831a9eef38dc1e7efb57e7a5472f"
 dependencies = [
  "futures-util",
  "http",
@@ -2873,9 +2937,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.24.10"
+version = "0.24.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f05e0028e55b15dbd2107163b3c744cd3bb4474f193f95d9708acbf5677e44"
+checksum = "41d86fc943f81dab0ecdd6c0240b6e0f55ad57a2ea9ad8ad7efe8456fb9cc7a4"
 dependencies = [
  "http",
  "serde",
@@ -2950,9 +3014,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.5+1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
 dependencies = [
  "cc",
  "libc",
@@ -2978,9 +3042,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -3002,9 +3066,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.28"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "libc",
@@ -3033,9 +3097,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -3054,9 +3118,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "lru-slab"
@@ -3101,9 +3165,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memuse"
@@ -3181,9 +3245,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -3217,7 +3281,19 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.12.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3260,9 +3336,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-format"
@@ -3332,7 +3408,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -3353,7 +3429,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "dispatch2",
  "objc2",
 ]
@@ -3364,7 +3440,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -3397,7 +3473,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -3415,7 +3491,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "block2",
  "libc",
  "objc2",
@@ -3428,7 +3504,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3439,7 +3515,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -3451,7 +3527,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -3624,7 +3700,8 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.14.0"
-source = "git+https://github.com/zodl-inc/orchard-security-fixes.git?rev=994dad2f7bb8c85e7c8ea336dcc2a814a94bc9fd#994dad2f7bb8c85e7c8ea336dcc2a814a94bc9fd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a54f8d29bfb1e76a9d4e868a1a08cce2e57dd2bdc66232982822ad3114b91ab3"
 dependencies = [
  "aes",
  "bitvec",
@@ -3678,13 +3755,13 @@ dependencies = [
 
 [[package]]
 name = "os_info"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
 dependencies = [
  "android_system_properties",
  "log",
- "nix",
+ "nix 0.31.3",
  "objc2",
  "objc2-foundation",
  "objc2-ui-kit",
@@ -3893,18 +3970,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3977,6 +4054,28 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -4086,7 +4185,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -4163,11 +4262,11 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "memchr",
  "unicase",
 ]
@@ -4204,9 +4303,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -4450,7 +4549,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -4475,19 +4574,20 @@ dependencies = [
 
 [[package]]
 name = "reddsa"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a5191930e84973293aa5f532b513404460cd2216c1cfb76d08748c15b40b02"
+checksum = "4784b85c8bfd17b36b86e664e6e504ecdb586001086ee23749e4a633bbb84832"
 dependencies = [
  "blake2b_simd",
  "byteorder",
+ "frost-rerandomized",
  "group",
  "hex",
  "jubjub",
  "pasta_curves",
  "rand_core 0.6.4",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "zeroize",
 ]
 
@@ -4510,7 +4610,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -4615,9 +4715,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4719,7 +4819,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "once_cell",
  "serde",
  "serde_derive",
@@ -4782,7 +4882,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4807,9 +4907,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -5019,7 +5119,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -5054,7 +5154,7 @@ checksum = "eb25f439f97d26fea01d717fa626167ceffcd981addaa670001e70505b72acbb"
 dependencies = [
  "cfg_aliases",
  "httpdate",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "rustls",
  "sentry-backtrace",
  "sentry-contexts",
@@ -5108,7 +5208,7 @@ version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "235865e639f1d72414fa5d35374e105c292e2ee3a2f90919d961bbb486626ee6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "log",
  "sentry-core",
 ]
@@ -5119,7 +5219,7 @@ version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27701acc51e68db5281802b709010395bfcbcb128b1d0a4e5873680d3b47ff0c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "sentry-backtrace",
  "sentry-core",
  "tracing-core",
@@ -5207,9 +5307,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -5242,11 +5342,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5261,14 +5362,24 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
 ]
 
 [[package]]
@@ -5318,6 +5429,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -5379,9 +5496,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -5403,9 +5520,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -5482,9 +5599,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str_stack"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+checksum = "7f446288b699d66d0fd2e30d1cfe7869194312524b3b9252594868ed26ef056a"
 
 [[package]]
 name = "strsim"
@@ -5692,7 +5809,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe075d7053dae61ac5413a34ea7d4913b6e6207844fd726bdd858b37ff72bf5"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "cfg-if",
  "libc",
  "log",
@@ -5753,9 +5870,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -5788,9 +5905,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -5897,9 +6014,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
@@ -5924,9 +6041,9 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
@@ -5953,9 +6070,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -5965,9 +6082,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
@@ -5976,9 +6093,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -5992,9 +6109,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-reflection"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf0685a51e6d02b502ba0764002e766b7f3042aed13d9234925b6ffbfa3fca7"
+checksum = "acccd136a4bf19810a1fde9c74edc6129b42a66b44d0c1c8aaa67aeb49a146a7"
 dependencies = [
  "prost",
  "prost-types",
@@ -6077,25 +6194,25 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "bytes",
  "futures-core",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
- "iri-string",
  "pin-project-lite",
  "tokio",
  "tokio-util",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -6303,9 +6420,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -6366,9 +6483,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -6434,21 +6551,16 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8-zero"
@@ -6470,9 +6582,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "js-sys",
  "serde_core",
@@ -6671,9 +6783,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6684,9 +6796,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6694,9 +6806,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6704,9 +6816,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6717,9 +6829,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -6752,7 +6864,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -6760,9 +6872,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7062,9 +7174,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -7133,7 +7245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -7164,16 +7276,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -7204,9 +7310,9 @@ checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "yaml-rust2"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
+checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
 dependencies = [
  "arraydeque",
  "encoding_rs",
@@ -7215,11 +7321,10 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -7227,9 +7332,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7240,7 +7345,8 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.12.0"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=a4bc18408935df58db686e1834c23bcc8c5680e0#a4bc18408935df58db686e1834c23bcc8c5680e0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58342d0aaa8e2fa98849636f52800ac4bf020574c944c974742fc933db58cac2"
 dependencies = [
  "bech32",
  "bs58",
@@ -7253,7 +7359,8 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=a4bc18408935df58db686e1834c23bcc8c5680e0#a4bc18408935df58db686e1834c23bcc8c5680e0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
 dependencies = [
  "corez",
  "hex",
@@ -7274,7 +7381,8 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.14.0"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=a4bc18408935df58db686e1834c23bcc8c5680e0#a4bc18408935df58db686e1834c23bcc8c5680e0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbcdfbb5c8edb247439d72a397abaae9b7dd14a1c070e7e4fc3536924f9065f"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -7314,7 +7422,8 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.28.0"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=a4bc18408935df58db686e1834c23bcc8c5680e0#a4bc18408935df58db686e1834c23bcc8c5680e0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c69e07f5eb3f682a6467b4b08ee4956f1acd1e886d70b21c4766953b3a1beba2"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7344,7 +7453,8 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.28.0"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=a4bc18408935df58db686e1834c23bcc8c5680e0#a4bc18408935df58db686e1834c23bcc8c5680e0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3de6b0ca82e08a9d38b1121f87c5b180b5feac19fecba074cb582882210d2371"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7366,7 +7476,8 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.9.0"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=a4bc18408935df58db686e1834c23bcc8c5680e0#a4bc18408935df58db686e1834c23bcc8c5680e0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bec496a0bd62dae98c4b26f51c5dab112d0c5350bbc2ccfdfd05bb3454f714d"
 dependencies = [
  "corez",
  "document-features",
@@ -7382,7 +7493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f872800287d118be71bdf6fe8c869c6a6ff6fb0a5762f68fb2af54c97edf0f2"
 dependencies = [
  "bip32",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "bounded-vec",
  "hex",
  "ripemd 0.1.3",
@@ -7404,7 +7515,8 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.8.0"
-source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=a4bc18408935df58db686e1834c23bcc8c5680e0#a4bc18408935df58db686e1834c23bcc8c5680e0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15df1908b428d4edeb7c7caae5692e05e2e92e5c38007a40b20ac098efdffd96"
 dependencies = [
  "bip32",
  "bs58",
@@ -7430,7 +7542,7 @@ name = "zebra-chain"
 version = "9.0.0"
 dependencies = [
  "bech32",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "bitflags-serde-legacy",
  "bitvec",
  "blake2b_simd",
@@ -7551,7 +7663,7 @@ dependencies = [
 name = "zebra-network"
 version = "8.0.0"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -7626,7 +7738,7 @@ dependencies = [
  "jsonrpsee-types",
  "lazy_static",
  "metrics",
- "nix",
+ "nix 0.30.1",
  "openrpsee",
  "orchard",
  "phf",
@@ -7868,18 +7980,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7888,9 +8000,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -7928,10 +8040,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -7940,9 +8063,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7427,7 +7427,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "8.0.1"
+version = "9.0.0"
 dependencies = [
  "bech32",
  "bitflags 2.11.1",
@@ -7497,7 +7497,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-consensus"
-version = "7.0.1"
+version = "8.0.0"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7549,7 +7549,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-network"
-version = "7.0.1"
+version = "8.0.0"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -7591,7 +7591,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-node-services"
-version = "6.0.0"
+version = "7.0.0"
 dependencies = [
  "color-eyre",
  "jsonrpsee-types",
@@ -7605,7 +7605,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "8.0.0"
+version = "9.0.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7670,7 +7670,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-script"
-version = "7.0.1"
+version = "8.0.0"
 dependencies = [
  "hex",
  "lazy_static",
@@ -7688,7 +7688,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "7.0.1"
+version = "8.0.0"
 dependencies = [
  "bincode",
  "chrono",
@@ -7764,7 +7764,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-utils"
-version = "6.0.0"
+version = "7.0.0"
 dependencies = [
  "color-eyre",
  "hex",
@@ -7786,7 +7786,7 @@ dependencies = [
 
 [[package]]
 name = "zebrad"
-version = "4.5.3"
+version = "5.0.0"
 dependencies = [
  "abscissa_core",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,8 +1592,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=2501696f47b322e1dbeb1e59910b89d87a1dd7f5#2501696f47b322e1dbeb1e59910b89d87a1dd7f5"
 dependencies = [
  "blake2b_simd",
  "cc",
@@ -1641,8 +1640,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=2501696f47b322e1dbeb1e59910b89d87a1dd7f5#2501696f47b322e1dbeb1e59910b89d87a1dd7f5"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2010,8 +2008,7 @@ dependencies = [
 [[package]]
 name = "halo2_gadgets"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45824ce0dd12e91ec0c68ebae2a7ed8ae19b70946624c849add59f1d1a62a143"
+source = "git+https://github.com/zodl-inc/halo2-security-fixes.git?rev=a101adb907869062593242a1946a7d6157d11899#a101adb907869062593242a1946a7d6157d11899"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -2036,8 +2033,7 @@ checksum = "47716fe1ae67969c5e0b2ef826f32db8c3be72be325e1aa3c1951d06b5575ec5"
 [[package]]
 name = "halo2_poseidon"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa3da60b81f02f9b33ebc6252d766f843291fb4d2247a07ae73d20b791fc56f"
+source = "git+https://github.com/zodl-inc/halo2-security-fixes.git?rev=a101adb907869062593242a1946a7d6157d11899#a101adb907869062593242a1946a7d6157d11899"
 dependencies = [
  "bitvec",
  "ff",
@@ -2048,8 +2044,7 @@ dependencies = [
 [[package]]
 name = "halo2_proofs"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05713f117155643ce10975e0bee44a274bcda2f4bb5ef29a999ad67c1fa8d4d3"
+source = "git+https://github.com/zodl-inc/halo2-security-fixes.git?rev=a101adb907869062593242a1946a7d6157d11899#a101adb907869062593242a1946a7d6157d11899"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -3629,8 +3624,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "orchard"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497e74492624a1d1cc8c9675a7afb17b430d32fd9efc171513d0840140b5f0c7"
+source = "git+https://github.com/zodl-inc/orchard-security-fixes.git?rev=6e76352618b6b4a7448645f0f8afae18855d5fa1#6e76352618b6b4a7448645f0f8afae18855d5fa1"
 dependencies = [
  "aes",
  "bitvec",
@@ -7246,8 +7240,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355f3db1087875052b5ad0f9e7179a7e7794f0ae9cb1d6ab2b7db29f7b9a9b0b"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=2501696f47b322e1dbeb1e59910b89d87a1dd7f5#2501696f47b322e1dbeb1e59910b89d87a1dd7f5"
 dependencies = [
  "bech32",
  "bs58",
@@ -7260,8 +7253,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=2501696f47b322e1dbeb1e59910b89d87a1dd7f5#2501696f47b322e1dbeb1e59910b89d87a1dd7f5"
 dependencies = [
  "corez",
  "hex",
@@ -7271,8 +7263,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fde17bf53792f9c756b313730da14880257d7661b5bfc69d0571c3a7c11a76d"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=2501696f47b322e1dbeb1e59910b89d87a1dd7f5#2501696f47b322e1dbeb1e59910b89d87a1dd7f5"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -7322,9 +7313,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a59f418f8b1274a526d57dfa3b1a7b3724f04926c84712a27c1602e4b44bfacd"
+version = "0.27.1"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=2501696f47b322e1dbeb1e59910b89d87a1dd7f5#2501696f47b322e1dbeb1e59910b89d87a1dd7f5"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7354,8 +7344,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c6749aeaf49a56874d915482bc03e4afb9f6e561ed476b7c906e6d9de3ef74"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=2501696f47b322e1dbeb1e59910b89d87a1dd7f5#2501696f47b322e1dbeb1e59910b89d87a1dd7f5"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7377,8 +7366,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ef3de16a4464a574591aa3e4ea875116372638307d7ae04415279ec187ba88"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=2501696f47b322e1dbeb1e59910b89d87a1dd7f5#2501696f47b322e1dbeb1e59910b89d87a1dd7f5"
 dependencies = [
  "corez",
  "document-features",
@@ -7416,8 +7404,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9ad72051b49432acd56d44ab301bb6467bd70eb23faab3f35539e4ecf2733d"
+source = "git+https://github.com/zodl-inc/librustzcash-security-fixes.git?rev=2501696f47b322e1dbeb1e59910b89d87a1dd7f5#2501696f47b322e1dbeb1e59910b89d87a1dd7f5"
 dependencies = [
  "bip32",
  "bs58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,15 +236,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,15 +254,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -279,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -348,12 +339,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,7 +398,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -423,7 +408,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash 1.1.0",
- "shlex 1.3.0",
+ "shlex",
  "syn 2.0.117",
 ]
 
@@ -433,7 +418,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -441,7 +426,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash 2.1.2",
- "shlex 1.3.0",
+ "shlex",
  "syn 2.0.117",
 ]
 
@@ -484,9 +469,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -497,7 +482,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b64e60c28b6d25ad92e8b367801ff9aa12b41d05fc8798055d296bace4a60cc"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "serde",
 ]
 
@@ -597,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.3"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byte-slice-cast"
@@ -691,14 +676,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex 2.0.1",
+ "shlex",
 ]
 
 [[package]]
@@ -872,15 +857,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cobs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
-dependencies = [
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "color-eyre"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,9 +919,9 @@ checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "config"
-version = "0.15.23"
+version = "0.15.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f316c6237b2d38be61949ecd15268a4c6ca32570079394a2444d9ce2c72a72d8"
+checksum = "8e68cfe19cd7d23ffde002c24ffa5cda73931913ef394d5eaaa32037dc940c0c"
 dependencies = [
  "async-trait",
  "convert_case 0.6.0",
@@ -1024,12 +1000,6 @@ dependencies = [
  "tracing-core",
  "tracing-subscriber",
 ]
-
-[[package]]
-name = "const-crc32-nostd"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808ac43170e95b11dd23d78aa9eaac5bea45776a602955552c4e833f3f0f823d"
 
 [[package]]
 name = "const-oid"
@@ -1179,12 +1149,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1283,12 +1247,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -1307,10 +1271,11 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
+ "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -1331,11 +1296,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.117",
 ]
@@ -1472,15 +1437,15 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "objc2",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1573,9 +1538,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elasticsearch"
@@ -1598,18 +1563,6 @@ dependencies = [
  "url",
  "void",
 ]
-
-[[package]]
-name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -1806,41 +1759,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "frost-core"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ef2787af391c7e8bedc037a3b9ea03dde803fbd93e778e6bb369547800e5cd"
-dependencies = [
- "byteorder",
- "const-crc32-nostd",
- "derive-getters",
- "document-features",
- "hex",
- "itertools 0.14.0",
- "postcard",
- "rand_core 0.6.4",
- "serde",
- "serdect",
- "thiserror 2.0.18",
- "visibility",
- "zeroize",
- "zeroize_derive",
-]
-
-[[package]]
-name = "frost-rerandomized"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4c5cedd2426728adef2c0b1720f57676354c473836d1ccc50d0f0d1c91942b"
-dependencies = [
- "derive-getters",
- "document-features",
- "frost-core",
- "hex",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "fs-err"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2034,7 +1952,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -2061,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2145,15 +2063,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,17 +2096,17 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2211,20 +2120,6 @@ dependencies = [
  "flate2",
  "nom",
  "num-traits",
-]
-
-[[package]]
-name = "heapless"
-version = "0.7.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
-dependencies = [
- "atomic-polyfill",
- "hash32",
- "rustc_version",
- "serde",
- "spin",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -2283,11 +2178,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.12"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2314,9 +2209,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
  "itoa",
@@ -2390,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2488,23 +2383,21 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
  "displaydoc",
- "potential_utf",
- "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locale_core"
-version = "2.2.0"
+name = "icu_locid"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2514,58 +2407,96 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_normalizer"
-version = "2.2.0"
+name = "icu_locid_transform"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
 dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
  "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
 dependencies = [
+ "displaydoc",
  "icu_collections",
- "icu_locale_core",
+ "icu_locid_transform",
  "icu_properties_data",
  "icu_provider",
- "zerotrie",
+ "tinystr",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
 dependencies = [
  "displaydoc",
- "icu_locale_core",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
- "zerotrie",
  "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2582,9 +2513,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.1.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -2593,9 +2524,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2654,7 +2585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -2718,6 +2649,16 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is-terminal"
@@ -2839,9 +2780,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2862,9 +2803,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.24.11"
+version = "0.24.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c4b1f204b655b36b24dc4939af20366c649431d4711863bbbae5c495f3eeb4"
+checksum = "e281ae70cc3b98dac15fced3366a880949e65fc66e345ce857a5682d152f3e62"
 dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-server",
@@ -2874,9 +2815,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.24.11"
+version = "0.24.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49bfa9334963e1c85866b39dff3ffcc81f1c286eb23334267c5cb97677543a4"
+checksum = "348ee569eaed52926b5e740aae20863762b16596476e943c9e415a6479021622"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2897,9 +2838,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.24.11"
+version = "0.24.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5248249c016692f1465a753057ae8347681995dd490c2cb65c48b14b46215a8"
+checksum = "7398cddf5013cca4702862a2692b66c48a3bd6cf6ec681a47453c93d63cf8de5"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-crate",
@@ -2910,9 +2851,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.24.11"
+version = "0.24.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c625c78b8d545478370b6e7a2a191b0d921f831a9eef38dc1e7efb57e7a5472f"
+checksum = "21429bcdda37dcf2d43b68621b994adede0e28061f816b038b0f18c70c143d51"
 dependencies = [
  "futures-util",
  "http",
@@ -2937,9 +2878,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.24.11"
+version = "0.24.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d86fc943f81dab0ecdd6c0240b6e0f55ad57a2ea9ad8ad7efe8456fb9cc7a4"
+checksum = "b0f05e0028e55b15dbd2107163b3c744cd3bb4474f193f95d9708acbf5677e44"
 dependencies = [
  "http",
  "serde",
@@ -3014,9 +2955,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.5+1.9.4"
+version = "0.18.3+1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
+checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
 dependencies = [
  "cc",
  "libc",
@@ -3042,9 +2983,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
@@ -3066,9 +3007,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.29"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
 dependencies = [
  "cc",
  "libc",
@@ -3097,9 +3038,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litrs"
@@ -3118,9 +3059,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.31"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru-slab"
@@ -3165,9 +3106,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memuse"
@@ -3245,9 +3186,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -3281,19 +3222,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.12.1",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.31.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
-dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3336,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-format"
@@ -3408,7 +3337,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -3429,7 +3358,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "dispatch2",
  "objc2",
 ]
@@ -3440,7 +3369,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -3473,7 +3402,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -3491,7 +3420,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "block2",
  "libc",
  "objc2",
@@ -3504,7 +3433,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3515,7 +3444,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -3527,7 +3456,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -3755,13 +3684,13 @@ dependencies = [
 
 [[package]]
 name = "os_info"
-version = "3.15.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
 dependencies = [
  "android_system_properties",
  "log",
- "nix 0.31.3",
+ "nix",
  "objc2",
  "objc2-foundation",
  "objc2-ui-kit",
@@ -3970,18 +3899,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.13"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.13"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4054,28 +3983,6 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "postcard"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
-dependencies = [
- "cobs",
- "embedded-io 0.4.0",
- "embedded-io 0.6.1",
- "heapless",
- "serde",
-]
-
-[[package]]
-name = "potential_utf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
-dependencies = [
- "zerovec",
-]
 
 [[package]]
 name = "powerfmt"
@@ -4185,7 +4092,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -4262,11 +4169,11 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.4"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "memchr",
  "unicase",
 ]
@@ -4303,9 +4210,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
 ]
@@ -4549,7 +4456,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -4574,20 +4481,19 @@ dependencies = [
 
 [[package]]
 name = "reddsa"
-version = "0.5.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4784b85c8bfd17b36b86e664e6e504ecdb586001086ee23749e4a633bbb84832"
+checksum = "78a5191930e84973293aa5f532b513404460cd2216c1cfb76d08748c15b40b02"
 dependencies = [
  "blake2b_simd",
  "byteorder",
- "frost-rerandomized",
  "group",
  "hex",
  "jubjub",
  "pasta_curves",
  "rand_core 0.6.4",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -4610,7 +4516,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -4715,9 +4621,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.4"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4819,7 +4725,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "once_cell",
  "serde",
  "serde_derive",
@@ -4882,7 +4788,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4907,9 +4813,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -5119,7 +5025,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -5154,7 +5060,7 @@ checksum = "eb25f439f97d26fea01d717fa626167ceffcd981addaa670001e70505b72acbb"
 dependencies = [
  "cfg_aliases",
  "httpdate",
- "reqwest 0.13.4",
+ "reqwest 0.13.3",
  "rustls",
  "sentry-backtrace",
  "sentry-contexts",
@@ -5208,7 +5114,7 @@ version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "235865e639f1d72414fa5d35374e105c292e2ee3a2f90919d961bbb486626ee6"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "log",
  "sentry-core",
 ]
@@ -5219,7 +5125,7 @@ version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27701acc51e68db5281802b709010395bfcbcb128b1d0a4e5873680d3b47ff0c"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "sentry-backtrace",
  "sentry-core",
  "tracing-core",
@@ -5307,9 +5213,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -5342,12 +5248,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
  "base64 0.22.1",
- "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5362,24 +5267,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "serdect"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
-dependencies = [
- "base16ct",
- "serde",
 ]
 
 [[package]]
@@ -5429,12 +5324,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "shlex"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -5496,9 +5385,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -5520,9 +5409,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -5599,9 +5488,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str_stack"
-version = "0.1.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f446288b699d66d0fd2e30d1cfe7869194312524b3b9252594868ed26ef056a"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
 
 [[package]]
 name = "strsim"
@@ -5809,7 +5698,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe075d7053dae61ac5413a34ea7d4913b6e6207844fd726bdd858b37ff72bf5"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "cfg-if",
  "libc",
  "log",
@@ -5870,9 +5759,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -5905,9 +5794,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -6014,9 +5903,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
@@ -6041,9 +5930,9 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.14.6"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum",
@@ -6070,9 +5959,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.6"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
+checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -6082,9 +5971,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.6"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
  "prost",
@@ -6093,9 +5982,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.6"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
+checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -6109,9 +5998,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-reflection"
-version = "0.14.6"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acccd136a4bf19810a1fde9c74edc6129b42a66b44d0c1c8aaa67aeb49a146a7"
+checksum = "aaf0685a51e6d02b502ba0764002e766b7f3042aed13d9234925b6ffbfa3fca7"
 dependencies = [
  "prost",
  "prost-types",
@@ -6194,25 +6083,25 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.11"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "bytes",
  "futures-core",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
+ "iri-string",
  "pin-project-lite",
  "tokio",
  "tokio-util",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
- "url",
 ]
 
 [[package]]
@@ -6420,9 +6309,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.1"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -6483,9 +6372,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.3"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -6551,16 +6440,21 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.8"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
- "serde_derive",
 ]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8-zero"
@@ -6582,9 +6476,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "js-sys",
  "serde_core",
@@ -6783,9 +6677,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6796,9 +6690,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6806,9 +6700,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6816,9 +6710,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6829,9 +6723,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -6864,7 +6758,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -6872,9 +6766,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7174,9 +7068,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -7245,7 +7139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -7276,10 +7170,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "writeable"
-version = "0.6.3"
+name = "write16"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "wyz"
@@ -7310,9 +7210,9 @@ checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "yaml-rust2"
-version = "0.11.0"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
+checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
 dependencies = [
  "arraydeque",
  "encoding_rs",
@@ -7321,10 +7221,11 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
+ "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -7332,9 +7233,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.2"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7493,7 +7394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f872800287d118be71bdf6fe8c869c6a6ff6fb0a5762f68fb2af54c97edf0f2"
 dependencies = [
  "bip32",
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "bounded-vec",
  "hex",
  "ripemd 0.1.3",
@@ -7542,7 +7443,7 @@ name = "zebra-chain"
 version = "9.0.0"
 dependencies = [
  "bech32",
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "bitflags-serde-legacy",
  "bitvec",
  "blake2b_simd",
@@ -7663,7 +7564,7 @@ dependencies = [
 name = "zebra-network"
 version = "8.0.0"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.11.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -7738,7 +7639,7 @@ dependencies = [
  "jsonrpsee-types",
  "lazy_static",
  "metrics",
- "nix 0.30.1",
+ "nix",
  "openrpsee",
  "orchard",
  "phf",
@@ -7980,18 +7881,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8000,9 +7901,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.8"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -8040,21 +7941,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerotrie"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -8063,9 +7953,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,16 +30,16 @@ edition = "2021"
 
 [workspace.dependencies]
 incrementalmerkletree = { version = "0.8.2", features = ["legacy-api"] }
-orchard = "0.13"
+orchard = "0.14"
 sapling-crypto = "0.7"
-zcash_address = "0.11"
+zcash_address = "0.12"
 zcash_encoding = "0.4"
 zcash_history = "0.4"
-zcash_keys = "0.13"
-zcash_primitives = "0.27"
-zcash_proofs = "0.27"
-zcash_transparent = "0.7"
-zcash_protocol = "0.8"
+zcash_keys = "0.14"
+zcash_primitives = "0.28"
+zcash_proofs = "0.28"
+zcash_transparent = "0.8"
+zcash_protocol = "0.9"
 zip32 = "0.2"
 abscissa_core = "0.7"
 base64 = "0.22.1"
@@ -182,18 +182,18 @@ which = "8.0.0"
 # checkouts), pinned to the git revisions used by zodl-inc/librustzcash-security-fixes#6
 # (branch `orchard-update`). Drop this block once the dependencies are published.
 [patch.crates-io]
-equihash = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "646f65deeafe755d82dfe9f2e554b499fdd59562" }
-halo2_gadgets = { package = "halo2_gadgets", git = "https://github.com/zodl-inc/halo2-security-fixes.git", rev = "a101adb907869062593242a1946a7d6157d11899" }
-halo2_proofs = { package = "halo2_proofs", git = "https://github.com/zodl-inc/halo2-security-fixes.git", rev = "a101adb907869062593242a1946a7d6157d11899" }
-poseidon = { package = "halo2_poseidon", git = "https://github.com/zodl-inc/halo2-security-fixes.git", rev = "a101adb907869062593242a1946a7d6157d11899" }
-orchard = { package = "orchard", git = "https://github.com/zodl-inc/orchard-security-fixes.git", rev = "9c1b5af87a04a4b5c4d9616c359ebcee341a37b3" }
-zcash_transparent = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "646f65deeafe755d82dfe9f2e554b499fdd59562" }
-zcash_address = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "646f65deeafe755d82dfe9f2e554b499fdd59562" }
-zcash_encoding = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "646f65deeafe755d82dfe9f2e554b499fdd59562" }
-zcash_keys = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "646f65deeafe755d82dfe9f2e554b499fdd59562" }
-zcash_primitives = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "646f65deeafe755d82dfe9f2e554b499fdd59562" }
-zcash_proofs = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "646f65deeafe755d82dfe9f2e554b499fdd59562" }
-zcash_protocol = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "646f65deeafe755d82dfe9f2e554b499fdd59562" }
+equihash = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "a4bc18408935df58db686e1834c23bcc8c5680e0" }
+halo2_gadgets = { package = "halo2_gadgets", git = "https://github.com/zodl-inc/halo2-security-fixes.git", rev = "d751768afe0d2105b349dd93f73fde7f2eade088" }
+halo2_proofs = { package = "halo2_proofs", git = "https://github.com/zodl-inc/halo2-security-fixes.git", rev = "d751768afe0d2105b349dd93f73fde7f2eade088" }
+poseidon = { package = "halo2_poseidon", git = "https://github.com/zodl-inc/halo2-security-fixes.git", rev = "d751768afe0d2105b349dd93f73fde7f2eade088" }
+orchard = { git = "https://github.com/zodl-inc/orchard-security-fixes.git", rev = "994dad2f7bb8c85e7c8ea336dcc2a814a94bc9fd" }
+zcash_transparent = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "a4bc18408935df58db686e1834c23bcc8c5680e0" }
+zcash_address = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "a4bc18408935df58db686e1834c23bcc8c5680e0" }
+zcash_encoding = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "a4bc18408935df58db686e1834c23bcc8c5680e0" }
+zcash_keys = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "a4bc18408935df58db686e1834c23bcc8c5680e0" }
+zcash_primitives = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "a4bc18408935df58db686e1834c23bcc8c5680e0" }
+zcash_proofs = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "a4bc18408935df58db686e1834c23bcc8c5680e0" }
+zcash_protocol = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "a4bc18408935df58db686e1834c23bcc8c5680e0" }
 
 [workspace.metadata.release]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,6 +175,26 @@ zcash_script = "0.4.5"
 config = { version = "0.15.14", features = ["toml"] }
 which = "8.0.0"
 
+# TEMPORARY: git patches to the NU6.2 security-fix crates — the fixed Orchard
+# variable-base scalar-multiplication circuit (the bug that disabled Orchard) and
+# `orchard::Proof::expected_proof_size` — pending public releases. This is the same set
+# of crates zcashd patched in zodl-inc/zcash-security-fixes#176 (which used local path
+# checkouts), pinned to the git revisions used by zodl-inc/librustzcash-security-fixes#6
+# (branch `orchard-update`). Drop this block once the dependencies are published.
+[patch.crates-io]
+orchard = { git = "https://github.com/zodl-inc/orchard-security-fixes.git", rev = "6e76352618b6b4a7448645f0f8afae18855d5fa1" }
+halo2_proofs = { git = "https://github.com/zodl-inc/halo2-security-fixes.git", rev = "a101adb907869062593242a1946a7d6157d11899" }
+halo2_gadgets = { git = "https://github.com/zodl-inc/halo2-security-fixes.git", rev = "a101adb907869062593242a1946a7d6157d11899" }
+halo2_poseidon = { git = "https://github.com/zodl-inc/halo2-security-fixes.git", rev = "a101adb907869062593242a1946a7d6157d11899" }
+equihash = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "2501696f47b322e1dbeb1e59910b89d87a1dd7f5" }
+zcash_address = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "2501696f47b322e1dbeb1e59910b89d87a1dd7f5" }
+zcash_encoding = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "2501696f47b322e1dbeb1e59910b89d87a1dd7f5" }
+zcash_history = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "2501696f47b322e1dbeb1e59910b89d87a1dd7f5" }
+zcash_primitives = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "2501696f47b322e1dbeb1e59910b89d87a1dd7f5" }
+zcash_proofs = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "2501696f47b322e1dbeb1e59910b89d87a1dd7f5" }
+zcash_protocol = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "2501696f47b322e1dbeb1e59910b89d87a1dd7f5" }
+zcash_transparent = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "2501696f47b322e1dbeb1e59910b89d87a1dd7f5" }
+
 [workspace.metadata.release]
 
 # We always do releases from the main branch

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,18 +182,18 @@ which = "8.0.0"
 # checkouts), pinned to the git revisions used by zodl-inc/librustzcash-security-fixes#6
 # (branch `orchard-update`). Drop this block once the dependencies are published.
 [patch.crates-io]
-orchard = { git = "https://github.com/zodl-inc/orchard-security-fixes.git", rev = "6e76352618b6b4a7448645f0f8afae18855d5fa1" }
-halo2_proofs = { git = "https://github.com/zodl-inc/halo2-security-fixes.git", rev = "a101adb907869062593242a1946a7d6157d11899" }
-halo2_gadgets = { git = "https://github.com/zodl-inc/halo2-security-fixes.git", rev = "a101adb907869062593242a1946a7d6157d11899" }
-halo2_poseidon = { git = "https://github.com/zodl-inc/halo2-security-fixes.git", rev = "a101adb907869062593242a1946a7d6157d11899" }
-equihash = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "2501696f47b322e1dbeb1e59910b89d87a1dd7f5" }
-zcash_address = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "2501696f47b322e1dbeb1e59910b89d87a1dd7f5" }
-zcash_encoding = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "2501696f47b322e1dbeb1e59910b89d87a1dd7f5" }
-zcash_history = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "2501696f47b322e1dbeb1e59910b89d87a1dd7f5" }
-zcash_primitives = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "2501696f47b322e1dbeb1e59910b89d87a1dd7f5" }
-zcash_proofs = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "2501696f47b322e1dbeb1e59910b89d87a1dd7f5" }
-zcash_protocol = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "2501696f47b322e1dbeb1e59910b89d87a1dd7f5" }
-zcash_transparent = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "2501696f47b322e1dbeb1e59910b89d87a1dd7f5" }
+equihash = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "646f65deeafe755d82dfe9f2e554b499fdd59562" }
+halo2_gadgets = { package = "halo2_gadgets", git = "https://github.com/zodl-inc/halo2-security-fixes.git", rev = "a101adb907869062593242a1946a7d6157d11899" }
+halo2_proofs = { package = "halo2_proofs", git = "https://github.com/zodl-inc/halo2-security-fixes.git", rev = "a101adb907869062593242a1946a7d6157d11899" }
+poseidon = { package = "halo2_poseidon", git = "https://github.com/zodl-inc/halo2-security-fixes.git", rev = "a101adb907869062593242a1946a7d6157d11899" }
+orchard = { package = "orchard", git = "https://github.com/zodl-inc/orchard-security-fixes.git", rev = "9c1b5af87a04a4b5c4d9616c359ebcee341a37b3" }
+zcash_transparent = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "646f65deeafe755d82dfe9f2e554b499fdd59562" }
+zcash_address = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "646f65deeafe755d82dfe9f2e554b499fdd59562" }
+zcash_encoding = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "646f65deeafe755d82dfe9f2e554b499fdd59562" }
+zcash_keys = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "646f65deeafe755d82dfe9f2e554b499fdd59562" }
+zcash_primitives = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "646f65deeafe755d82dfe9f2e554b499fdd59562" }
+zcash_proofs = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "646f65deeafe755d82dfe9f2e554b499fdd59562" }
+zcash_protocol = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "646f65deeafe755d82dfe9f2e554b499fdd59562" }
 
 [workspace.metadata.release]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,26 +175,6 @@ zcash_script = "0.4.5"
 config = { version = "0.15.14", features = ["toml"] }
 which = "8.0.0"
 
-# TEMPORARY: git patches to the NU6.2 security-fix crates — the fixed Orchard
-# variable-base scalar-multiplication circuit (the bug that disabled Orchard) and
-# `orchard::Proof::expected_proof_size` — pending public releases. This is the same set
-# of crates zcashd patched in zodl-inc/zcash-security-fixes#176 (which used local path
-# checkouts), pinned to the git revisions used by zodl-inc/librustzcash-security-fixes#6
-# (branch `orchard-update`). Drop this block once the dependencies are published.
-[patch.crates-io]
-equihash = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "a4bc18408935df58db686e1834c23bcc8c5680e0" }
-halo2_gadgets = { package = "halo2_gadgets", git = "https://github.com/zodl-inc/halo2-security-fixes.git", rev = "d751768afe0d2105b349dd93f73fde7f2eade088" }
-halo2_proofs = { package = "halo2_proofs", git = "https://github.com/zodl-inc/halo2-security-fixes.git", rev = "d751768afe0d2105b349dd93f73fde7f2eade088" }
-poseidon = { package = "halo2_poseidon", git = "https://github.com/zodl-inc/halo2-security-fixes.git", rev = "d751768afe0d2105b349dd93f73fde7f2eade088" }
-orchard = { git = "https://github.com/zodl-inc/orchard-security-fixes.git", rev = "994dad2f7bb8c85e7c8ea336dcc2a814a94bc9fd" }
-zcash_transparent = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "a4bc18408935df58db686e1834c23bcc8c5680e0" }
-zcash_address = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "a4bc18408935df58db686e1834c23bcc8c5680e0" }
-zcash_encoding = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "a4bc18408935df58db686e1834c23bcc8c5680e0" }
-zcash_keys = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "a4bc18408935df58db686e1834c23bcc8c5680e0" }
-zcash_primitives = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "a4bc18408935df58db686e1834c23bcc8c5680e0" }
-zcash_proofs = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "a4bc18408935df58db686e1834c23bcc8c5680e0" }
-zcash_protocol = { git = "https://github.com/zodl-inc/librustzcash-security-fixes.git", rev = "a4bc18408935df58db686e1834c23bcc8c5680e0" }
-
 [workspace.metadata.release]
 
 # We always do releases from the main branch

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -642,7 +642,7 @@ version = "2.7.1"
 criteria = "safe-to-run"
 
 [[exemptions.halo2_gadgets]]
-version = "0.4.0"
+version = "0.5.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.halo2_legacy_pdqsort]]
@@ -1088,7 +1088,7 @@ version = "0.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.orchard]]
-version = "0.13.1"
+version = "0.14.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.ordered-map]]
@@ -2112,7 +2112,7 @@ version = "0.10.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_address]]
-version = "0.11.0"
+version = "0.12.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_encoding]]
@@ -2124,19 +2124,19 @@ version = "0.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_keys]]
-version = "0.13.0"
+version = "0.14.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_primitives]]
-version = "0.27.0"
+version = "0.28.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_proofs]]
-version = "0.27.0"
+version = "0.28.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_protocol]]
-version = "0.8.0"
+version = "0.9.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_script]]
@@ -2148,35 +2148,35 @@ version = "0.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.zcash_transparent]]
-version = "0.7.0"
+version = "0.8.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-chain]]
-version = "8.0.0"
+version = "9.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-consensus]]
-version = "7.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-network]]
-version = "7.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-node-services]]
-version = "6.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-rpc]]
 version = "8.0.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.zebra-script]]
+[[exemptions.zebra-network]]
+version = "8.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.zebra-node-services]]
 version = "7.0.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.zebra-rpc]]
+version = "9.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.zebra-script]]
+version = "8.0.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.zebra-state]]
-version = "7.0.0"
+version = "8.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-test]]
@@ -2184,11 +2184,11 @@ version = "3.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-utils]]
-version = "6.0.0"
+version = "7.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebrad]]
-version = "4.5.0"
+version = "5.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,14 +1,6 @@
 
 # cargo-vet imports lock
 
-[[unpublished.zebra-script]]
-version = "7.0.1"
-audited_as = "7.0.0"
-
-[[unpublished.zebrad]]
-version = "4.5.1"
-audited_as = "4.5.0"
-
 [[publisher.bumpalo]]
 version = "3.20.2"
 when = "2026-02-19"

--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.0.0] - 2026-06-02
+
+### Added
+
+- `NetworkUpgrade::Nu6_2` (consensus branch id `0x5437f330`), with activation heights
+  3,364,600 on Mainnet and 4,052,000 on Testnet.
+- `OrchardShieldedData::proof_size_is_canonical()`.
+- `Network::orchard_canonical_proof_size_rule_active()` and
+  `Network::is_orchard_temporarily_disabled()`.
+- A configurable NU6.2 activation height for Testnets (`ConfiguredActivationHeights::nu6_2`).
+
+### Changed
+
+- The default Testnet's temporary Orchard-disabling soft-fork height now defaults to
+  4,048,500; Regtest leaves it unset.
+
 ## [8.0.0] - 2026-05-28
 
 ### Removed

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-chain"
-version = "8.0.1"
+version = "9.0.0"
 authors.workspace = true
 description = "Core Zcash data structures"
 license.workspace = true

--- a/zebra-chain/src/block/commitment.rs
+++ b/zebra-chain/src/block/commitment.rs
@@ -139,7 +139,7 @@ impl Commitment {
                 }
             }
             (Heartwood | Canopy, _) => Ok(ChainHistoryRoot(ChainHistoryMmrRootHash(bytes))),
-            (Nu5 | Nu6 | Nu6_1 | Nu7, _) => Ok(ChainHistoryBlockTxAuthCommitment(
+            (Nu5 | Nu6 | Nu6_1 | Nu6_2 | Nu7, _) => Ok(ChainHistoryBlockTxAuthCommitment(
                 ChainHistoryBlockTxAuthCommitmentHash(bytes),
             )),
 

--- a/zebra-chain/src/history_tree.rs
+++ b/zebra-chain/src/history_tree.rs
@@ -105,6 +105,7 @@ impl NonEmptyHistoryTree {
             NetworkUpgrade::Nu5
             | NetworkUpgrade::Nu6
             | NetworkUpgrade::Nu6_1
+            | NetworkUpgrade::Nu6_2
             | NetworkUpgrade::Nu7 => {
                 let tree = Tree::<OrchardOnward>::new_from_cache(
                     network,
@@ -174,6 +175,7 @@ impl NonEmptyHistoryTree {
             NetworkUpgrade::Nu5
             | NetworkUpgrade::Nu6
             | NetworkUpgrade::Nu6_1
+            | NetworkUpgrade::Nu6_2
             | NetworkUpgrade::Nu7 => {
                 let (tree, entry) = Tree::<OrchardOnward>::new_from_block(
                     network,

--- a/zebra-chain/src/orchard/shielded_data.rs
+++ b/zebra-chain/src/orchard/shielded_data.rs
@@ -20,6 +20,34 @@ use crate::{
     },
 };
 
+/// The number of bytes a canonical Orchard proof grows by for each additional action.
+///
+/// An Orchard proof is a Halo2 proof whose length is exactly linear in the number of
+/// actions (circuit instances). This constant and [`ORCHARD_PROOF_BASE_BYTES`] are
+/// derived from the Orchard circuit's `halo2_proofs` `CircuitCost`, which gives a proof
+/// size of 4992 bytes for 1 action and 7264 bytes for 2 actions, i.e. a slope of
+/// `7264 - 4992 = 2272` bytes per action.
+//
+// TODO: replace these constants and `expected_proof_size` with
+// `orchard::Proof::expected_proof_size` once Zebra upgrades to an `orchard` release
+// that exposes it (0.14+).
+const ORCHARD_PROOF_BYTES_PER_ACTION: usize = 2272;
+
+/// The size in bytes of the fixed portion of a canonical Orchard proof.
+///
+/// See [`ORCHARD_PROOF_BYTES_PER_ACTION`] for the derivation: with a slope of 2272
+/// bytes per action and a proof size of 4992 bytes for 1 action, the fixed portion is
+/// `4992 - 2272 = 2720` bytes.
+const ORCHARD_PROOF_BASE_BYTES: usize = 2720;
+
+/// Returns the canonical size in bytes of an Orchard proof for `num_actions` actions.
+pub(crate) fn expected_proof_size(num_actions: usize) -> usize {
+    // Saturating arithmetic: this feeds an untrusted-input consensus check, so avoid any
+    // possibility of an overflow panic even though `num_actions` is bounded on parse.
+    ORCHARD_PROOF_BASE_BYTES
+        .saturating_add(ORCHARD_PROOF_BYTES_PER_ACTION.saturating_mul(num_actions))
+}
+
 /// A bundle of [`Action`] descriptions and signature data.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ShieldedData {
@@ -64,6 +92,17 @@ impl ShieldedData {
     /// transaction, in the order they appear in it.
     pub fn actions(&self) -> impl Iterator<Item = &Action> {
         self.actions.actions()
+    }
+
+    /// Returns whether the proof has the canonical length for its number of actions.
+    ///
+    /// An Orchard proof is stored as an unbounded byte sequence, so a proof that is
+    /// present but not canonically sized can be padded with arbitrary trailing data
+    /// without affecting its validity. Bundles are parsed leniently (so that historical
+    /// transactions remain deserializable), so this is enforced separately as a
+    /// height-gated consensus rule. See `GHSA-2x4w-pxqw-58v9`.
+    pub fn proof_size_is_canonical(&self) -> bool {
+        self.proof.0.len() == expected_proof_size(self.actions.len())
     }
 
     /// Collect the [`Nullifier`]s for this transaction.

--- a/zebra-chain/src/orchard/shielded_data.rs
+++ b/zebra-chain/src/orchard/shielded_data.rs
@@ -85,7 +85,7 @@ impl ShieldedData {
     /// present but not canonically sized can be padded with arbitrary trailing data
     /// without affecting its validity. Bundles are parsed leniently (so that historical
     /// transactions remain deserializable), so this is enforced separately as a
-    /// height-gated consensus rule. See `GHSA-2x4w-pxqw-58v9`.
+    /// height-gated consensus rule. See `GHSA-jfw5-j458-pfv6`.
     pub fn proof_size_is_canonical(&self) -> bool {
         self.proof.0.len() == expected_proof_size(self.actions.len())
     }

--- a/zebra-chain/src/orchard/shielded_data.rs
+++ b/zebra-chain/src/orchard/shielded_data.rs
@@ -20,32 +20,17 @@ use crate::{
     },
 };
 
-/// The number of bytes a canonical Orchard proof grows by for each additional action.
+/// Returns the canonical size in bytes of an Orchard proof for `num_actions` actions.
 ///
 /// An Orchard proof is a Halo2 proof whose length is exactly linear in the number of
-/// actions (circuit instances). This constant and [`ORCHARD_PROOF_BASE_BYTES`] are
-/// derived from the Orchard circuit's `halo2_proofs` `CircuitCost`, which gives a proof
-/// size of 4992 bytes for 1 action and 7264 bytes for 2 actions, i.e. a slope of
-/// `7264 - 4992 = 2272` bytes per action.
-//
-// TODO: replace these constants and `expected_proof_size` with
-// `orchard::Proof::expected_proof_size` once Zebra upgrades to an `orchard` release
-// that exposes it (0.14+).
-const ORCHARD_PROOF_BYTES_PER_ACTION: usize = 2272;
-
-/// The size in bytes of the fixed portion of a canonical Orchard proof.
-///
-/// See [`ORCHARD_PROOF_BYTES_PER_ACTION`] for the derivation: with a slope of 2272
-/// bytes per action and a proof size of 4992 bytes for 1 action, the fixed portion is
-/// `4992 - 2272 = 2720` bytes.
-const ORCHARD_PROOF_BASE_BYTES: usize = 2720;
-
-/// Returns the canonical size in bytes of an Orchard proof for `num_actions` actions.
+/// actions (circuit instances): 4992 bytes for 1 action and 7264 bytes for 2 actions,
+/// i.e. a fixed base plus 2272 bytes per action. The exact constants are owned by the
+/// `orchard` crate, which derives them from the action circuit's `halo2_proofs`
+/// `CircuitCost` and cross-checks them in its circuit tests, so we delegate to
+/// [`orchard::Proof::expected_proof_size`] rather than re-deriving them here. The
+/// `expected_proof_size_known_values` guard test cross-checks the returned values.
 pub(crate) fn expected_proof_size(num_actions: usize) -> usize {
-    // Saturating arithmetic: this feeds an untrusted-input consensus check, so avoid any
-    // possibility of an overflow panic even though `num_actions` is bounded on parse.
-    ORCHARD_PROOF_BASE_BYTES
-        .saturating_add(ORCHARD_PROOF_BYTES_PER_ACTION.saturating_mul(num_actions))
+    orchard::Proof::expected_proof_size(num_actions)
 }
 
 /// A bundle of [`Action`] descriptions and signature data.

--- a/zebra-chain/src/orchard/tests.rs
+++ b/zebra-chain/src/orchard/tests.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::unwrap_in_result)]
 
 mod preallocate;
+mod proof_size;
 mod prop;
 mod tree;
 pub(crate) mod vectors;

--- a/zebra-chain/src/orchard/tests/proof_size.rs
+++ b/zebra-chain/src/orchard/tests/proof_size.rs
@@ -1,0 +1,14 @@
+//! Tests for canonical Orchard proof sizes.
+
+use crate::orchard::shielded_data::expected_proof_size;
+
+/// The canonical Orchard proof size for `n` actions is `2272·n + 2720` bytes, matching
+/// the Orchard circuit's `halo2_proofs` `CircuitCost` (4992 bytes for 1 action, 7264 for
+/// 2 actions). These values are consensus-critical, so pin them here.
+#[test]
+fn expected_proof_size_known_values() {
+    assert_eq!(expected_proof_size(0), 2720);
+    assert_eq!(expected_proof_size(1), 4992);
+    assert_eq!(expected_proof_size(2), 7264);
+    assert_eq!(expected_proof_size(3), 9536);
+}

--- a/zebra-chain/src/parameters/constants.rs
+++ b/zebra-chain/src/parameters/constants.rs
@@ -52,6 +52,8 @@ pub mod activation_heights {
         pub const NU6: Height = Height(2_976_000);
         /// The block height at which `NU6.1` activates on Testnet.
         pub const NU6_1: Height = Height(3_536_500);
+        /// The block height at which `NU6.2` activates on Testnet.
+        pub const NU6_2: Height = Height(4_052_000);
     }
 
     /// Network upgrade activation heights for Mainnet.
@@ -76,5 +78,7 @@ pub mod activation_heights {
         pub const NU6: Height = Height(2_726_400);
         /// The block height at which `NU6.1` activates on Mainnet.
         pub const NU6_1: Height = Height(3_146_400);
+        /// The block height at which `NU6.2` activates on Mainnet.
+        pub const NU6_2: Height = Height(3_364_600);
     }
 }

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -19,6 +19,7 @@ pub mod testnet;
 #[cfg(test)]
 mod tests;
 
+// TODO(NU6.2): reconcile with zcashd PR #176 (3_364_000)
 const MAINNET_TEMPORARY_ORCHARD_DISABLING_SOFT_FORK_HEIGHT: Height = Height(3_363_426);
 
 /// An enum describing the kind of network, whether it's the production mainnet or a testnet.
@@ -351,6 +352,19 @@ impl Network {
             .is_some_and(|h| height >= h)
     }
 
+    /// Returns whether Orchard is temporarily disabled in transactions at `height`.
+    ///
+    /// The temporary-disable soft fork is bounded above by NU6.2, which re-enables
+    /// Orchard actions: once NU6.2 is active the temporary-disable rule no longer
+    /// applies. While NU6.2 is unscheduled this matches
+    /// [`Self::temporary_orchard_disabling_soft_fork_active`].
+    pub fn is_orchard_temporarily_disabled(&self, height: Height) -> bool {
+        self.temporary_orchard_disabling_soft_fork_active(height)
+            && NetworkUpgrade::Nu6_2
+                .activation_height(self)
+                .is_none_or(|nu6_2| height < nu6_2)
+    }
+
     /// Returns whether `height` is the first height at which the soft fork that
     /// temporarily disables Orchard actions applies.
     ///
@@ -368,17 +382,14 @@ impl Network {
     /// is active at `height`.
     ///
     /// This rule activates with the network upgrade that re-enables Orchard actions
-    /// (NU6.2), which is not yet defined; until an activation height is set it is always
-    /// inactive. It is a constricting rule, so it must not become active without a height
-    /// gate, or it would reject historical Orchard actions mined before the soft fork
-    /// that temporarily disabled them, and prevent syncing.
-    //
-    // TODO: once NU6.2 is defined, resolve its activation height per network — mirroring
-    // `temporary_orchard_disabling_soft_fork_height` (including Testnet configurability) —
-    // instead of always returning `None`.
+    /// (NU6.2). While NU6.2 is unscheduled the rule is always inactive. It is a
+    /// constricting rule, so it must stay height-gated, or it would reject historical
+    /// Orchard actions mined before the soft fork that temporarily disabled them, and
+    /// prevent syncing.
     pub fn orchard_canonical_proof_size_rule_active(&self, height: Height) -> bool {
-        let activation_height: Option<Height> = None;
-        activation_height.is_some_and(|h| height >= h)
+        NetworkUpgrade::Nu6_2
+            .activation_height(self)
+            .is_some_and(|h| height >= h)
     }
 }
 

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -20,10 +20,15 @@ pub mod testnet;
 mod tests;
 
 // Mainnet temporary Orchard-disabling soft-fork height, shipped publicly in Zebra v4.5.3.
-// This is DISTINCT from the NU6.2 *activation* (re-enable) height (provisionally 3_364_000,
-// see `network_upgrade.rs`), which lands ~574 blocks later. Do NOT change this value: it is
+// This is DISTINCT from the NU6.2 *activation* (re-enable) height (3_364_600, see
+// `network_upgrade.rs`), which lands 1_174 blocks later. Do NOT change this value: it is
 // already deployed, so changing it would fork from live v4.5.3 nodes in the disable window.
 const MAINNET_TEMPORARY_ORCHARD_DISABLING_SOFT_FORK_HEIGHT: Height = Height(3_363_426);
+
+// Default Testnet temporary Orchard-disabling soft-fork height. As on Mainnet, this is DISTINCT
+// from the NU6.2 *activation* (re-enable) height (4_052_000, see `network_upgrade.rs`), which
+// lands 3_500 blocks later.
+const TESTNET_TEMPORARY_ORCHARD_DISABLING_SOFT_FORK_HEIGHT: Height = Height(4_048_500);
 
 /// An enum describing the kind of network, whether it's the production mainnet or a testnet.
 // Note: The order of these variants is important for correct bincode (de)serialization
@@ -359,7 +364,7 @@ impl Network {
     ///
     /// The temporary-disable soft fork is bounded above by NU6.2, which re-enables
     /// Orchard actions: once NU6.2 is active the temporary-disable rule no longer
-    /// applies. While NU6.2 is unscheduled this matches
+    /// applies. On networks where NU6.2 is unscheduled this matches
     /// [`Self::temporary_orchard_disabling_soft_fork_active`].
     pub fn is_orchard_temporarily_disabled(&self, height: Height) -> bool {
         self.temporary_orchard_disabling_soft_fork_active(height)
@@ -385,7 +390,7 @@ impl Network {
     /// is active at `height`.
     ///
     /// This rule activates with the network upgrade that re-enables Orchard actions
-    /// (NU6.2). While NU6.2 is unscheduled the rule is always inactive. It is a
+    /// (NU6.2). On networks where NU6.2 is unscheduled the rule is always inactive. It is a
     /// constricting rule, so it must stay height-gated, or it would reject historical
     /// Orchard actions mined before the soft fork that temporarily disabled them, and
     /// prevent syncing.

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -19,7 +19,10 @@ pub mod testnet;
 #[cfg(test)]
 mod tests;
 
-// TODO(NU6.2): reconcile with zcashd PR #176 (3_364_000)
+// Mainnet temporary Orchard-disabling soft-fork height, shipped publicly in Zebra v4.5.3.
+// This is DISTINCT from the NU6.2 *activation* (re-enable) height (provisionally 3_364_000,
+// see `network_upgrade.rs`), which lands ~574 blocks later. Do NOT change this value: it is
+// already deployed, so changing it would fork from live v4.5.3 nodes in the disable window.
 const MAINNET_TEMPORARY_ORCHARD_DISABLING_SOFT_FORK_HEIGHT: Height = Height(3_363_426);
 
 /// An enum describing the kind of network, whether it's the production mainnet or a testnet.

--- a/zebra-chain/src/parameters/network.rs
+++ b/zebra-chain/src/parameters/network.rs
@@ -363,6 +363,23 @@ impl Network {
     ) -> bool {
         self.temporary_orchard_disabling_soft_fork_height() == Some(height)
     }
+
+    /// Returns whether the consensus rule requiring a canonically-sized Orchard proof
+    /// is active at `height`.
+    ///
+    /// This rule activates with the network upgrade that re-enables Orchard actions
+    /// (NU6.2), which is not yet defined; until an activation height is set it is always
+    /// inactive. It is a constricting rule, so it must not become active without a height
+    /// gate, or it would reject historical Orchard actions mined before the soft fork
+    /// that temporarily disabled them, and prevent syncing.
+    //
+    // TODO: once NU6.2 is defined, resolve its activation height per network — mirroring
+    // `temporary_orchard_disabling_soft_fork_height` (including Testnet configurability) —
+    // instead of always returning `None`.
+    pub fn orchard_canonical_proof_size_rule_active(&self, height: Height) -> bool {
+        let activation_height: Option<Height> = None;
+        activation_height.is_some_and(|h| height >= h)
+    }
 }
 
 // This is used for parsing a command-line argument for the `TipHeight` command in zebrad.

--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -521,7 +521,9 @@ impl Default for ParametersBuilder {
                 .map(|(addr, amount)| (addr.to_string(), *amount))
                 .collect(),
             checkpoints: TESTNET_CHECKPOINT_LIST.clone(),
-            temporary_orchard_disabling_soft_fork_height: None,
+            temporary_orchard_disabling_soft_fork_height: Some(
+                super::TESTNET_TEMPORARY_ORCHARD_DISABLING_SOFT_FORK_HEIGHT,
+            ),
         }
     }
 }
@@ -1028,6 +1030,9 @@ impl Parameters {
             .with_disable_pow(true)
             .with_unshielded_coinbase_spends(true)
             .with_slow_start_interval(Height::MIN)
+            // Like the default Testnet activation heights stripped below, the default Testnet's
+            // temporary Orchard-disabling soft fork does not apply to Regtest.
+            .disable_temporary_orchard_disabling_soft_fork()
             // Removes default Testnet activation heights if not configured,
             // most network upgrades are disabled by default for Regtest in zcashd
             .with_activation_heights(activation_heights.for_regtest())?

--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -189,6 +189,7 @@ impl From<&BTreeMap<Height, NetworkUpgrade>> for ConfiguredActivationHeights {
                 NetworkUpgrade::Nu5 => &mut configured_activation_heights.nu5,
                 NetworkUpgrade::Nu6 => &mut configured_activation_heights.nu6,
                 NetworkUpgrade::Nu6_1 => &mut configured_activation_heights.nu6_1,
+                NetworkUpgrade::Nu6_2 => &mut configured_activation_heights.nu6_2,
                 NetworkUpgrade::Nu7 => &mut configured_activation_heights.nu7,
                 #[cfg(zcash_unstable = "zfuture")]
                 NetworkUpgrade::ZFuture => &mut configured_activation_heights.zfuture,
@@ -362,6 +363,9 @@ pub struct ConfiguredActivationHeights {
     /// Activation height for `NU6.1` network upgrade.
     #[serde(rename = "NU6.1")]
     pub nu6_1: Option<u32>,
+    /// Activation height for `NU6.2` network upgrade.
+    #[serde(rename = "NU6.2")]
+    pub nu6_2: Option<u32>,
     /// Activation height for `NU7` network upgrade.
     #[serde(rename = "NU7")]
     pub nu7: Option<u32>,
@@ -385,6 +389,7 @@ impl ConfiguredActivationHeights {
             nu5,
             nu6,
             nu6_1,
+            nu6_2,
             nu7,
             #[cfg(zcash_unstable = "zfuture")]
             zfuture,
@@ -406,6 +411,7 @@ impl ConfiguredActivationHeights {
             nu5,
             nu6,
             nu6_1,
+            nu6_2,
             nu7,
             #[cfg(zcash_unstable = "zfuture")]
             zfuture,
@@ -596,6 +602,7 @@ impl ParametersBuilder {
             nu5,
             nu6,
             nu6_1,
+            nu6_2,
             nu7,
             #[cfg(zcash_unstable = "zfuture")]
             zfuture,
@@ -623,6 +630,7 @@ impl ParametersBuilder {
                 .chain(nu5.into_iter().map(|h| (h, Nu5)))
                 .chain(nu6.into_iter().map(|h| (h, Nu6)))
                 .chain(nu6_1.into_iter().map(|h| (h, Nu6_1)))
+                .chain(nu6_2.into_iter().map(|h| (h, Nu6_2)))
                 .chain(nu7.into_iter().map(|h| (h, Nu7)));
 
             #[cfg(zcash_unstable = "zfuture")]

--- a/zebra-chain/src/parameters/network/tests/vectors.rs
+++ b/zebra-chain/src/parameters/network/tests/vectors.rs
@@ -713,6 +713,19 @@ fn temporary_orchard_disabling_soft_fork_heights() {
     assert!(!Network::Mainnet
         .is_temporary_orchard_disabling_soft_fork_activation_height((mainnet_height + 1).unwrap()));
 
+    // The default Testnet uses a fixed activation height, below its NU6.2 activation height.
+    let testnet_default_height = Height(4_048_500);
+    assert_eq!(
+        Network::new_default_testnet().temporary_orchard_disabling_soft_fork_height(),
+        Some(testnet_default_height),
+    );
+
+    // Regtest does not apply the temporary Orchard-disabling soft fork.
+    assert_eq!(
+        Network::new_regtest(Default::default()).temporary_orchard_disabling_soft_fork_height(),
+        None,
+    );
+
     // A configured Testnet uses its configured height.
     let testnet_height = Height(2_000_000);
     let configured = testnet::Parameters::build()

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -58,6 +58,9 @@ pub enum NetworkUpgrade {
     /// The Zcash protocol after the NU6.1 upgrade.
     #[serde(rename = "NU6.1")]
     Nu6_1,
+    /// The Zcash protocol after the NU6.2 upgrade.
+    #[serde(rename = "NU6.2")]
+    Nu6_2,
     /// The Zcash protocol after the NU7 upgrade.
     #[serde(rename = "NU7")]
     Nu7,
@@ -108,6 +111,9 @@ pub(super) const MAINNET_ACTIVATION_HEIGHTS: &[(block::Height, NetworkUpgrade)] 
         (NU5, Nu5),
         (NU6, Nu6),
         (NU6_1, Nu6_1),
+        // NU6.2 is left UNSCHEDULED on Mainnet so it stays inert until a height is committed.
+        // Provisional Mainnet activation height (per zcashd PR #176): 3_364_000.
+        // TODO(NU6.2): add (NU6_2, Nu6_2) once the activation height is finalized.
     ]
 };
 /// Testnet network upgrade activation heights.
@@ -133,6 +139,9 @@ pub(super) const TESTNET_ACTIVATION_HEIGHTS: &[(block::Height, NetworkUpgrade)] 
         (NU5, Nu5),
         (NU6, Nu6),
         (NU6_1, Nu6_1),
+        // NU6.2 is left UNSCHEDULED on default Testnet so it stays inert until a height is committed.
+        // Provisional Testnet activation height (per zcashd PR #176): 4_042_000.
+        // TODO(NU6.2): add (NU6_2, Nu6_2) once the activation height is finalized.
     ]
 };
 
@@ -226,6 +235,7 @@ pub(crate) const CONSENSUS_BRANCH_IDS: &[(NetworkUpgrade, ConsensusBranchId)] = 
     (Nu5, ConsensusBranchId(0xc2d6d0b4)),
     (Nu6, ConsensusBranchId(0xc8e71055)),
     (Nu6_1, ConsensusBranchId(0x4dec4df0)),
+    (Nu6_2, ConsensusBranchId(0x5437f330)),
     // TODO: set below to (Nu7, ConsensusBranchId(0x77190ad8)), once the same value is set in librustzcash
     #[cfg(any(test, feature = "zebra-test"))]
     (Nu7, ConsensusBranchId(0xffffffff)),
@@ -395,7 +405,7 @@ impl NetworkUpgrade {
     pub fn target_spacing(&self) -> Duration {
         let spacing_seconds = match self {
             Genesis | BeforeOverwinter | Overwinter | Sapling => PRE_BLOSSOM_POW_TARGET_SPACING,
-            Blossom | Heartwood | Canopy | Nu5 | Nu6 | Nu6_1 | Nu7 => {
+            Blossom | Heartwood | Canopy | Nu5 | Nu6 | Nu6_1 | Nu6_2 | Nu7 => {
                 POST_BLOSSOM_POW_TARGET_SPACING.into()
             }
 

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -111,9 +111,7 @@ pub(super) const MAINNET_ACTIVATION_HEIGHTS: &[(block::Height, NetworkUpgrade)] 
         (NU5, Nu5),
         (NU6, Nu6),
         (NU6_1, Nu6_1),
-        // NU6.2 is left UNSCHEDULED on Mainnet so it stays inert until a height is committed.
-        // Provisional Mainnet activation height (per zcashd PR #176): 3_364_000.
-        // TODO(NU6.2): add (NU6_2, Nu6_2) once the activation height is finalized.
+        (NU6_2, Nu6_2),
     ]
 };
 /// Testnet network upgrade activation heights.
@@ -139,9 +137,7 @@ pub(super) const TESTNET_ACTIVATION_HEIGHTS: &[(block::Height, NetworkUpgrade)] 
         (NU5, Nu5),
         (NU6, Nu6),
         (NU6_1, Nu6_1),
-        // NU6.2 is left UNSCHEDULED on default Testnet so it stays inert until a height is committed.
-        // Provisional Testnet activation height (per zcashd PR #176): 4_042_000.
-        // TODO(NU6.2): add (NU6_2, Nu6_2) once the activation height is finalized.
+        (NU6_2, Nu6_2),
     ]
 };
 

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -530,6 +530,7 @@ impl From<zcash_protocol::consensus::NetworkUpgrade> for NetworkUpgrade {
             zcash_protocol::consensus::NetworkUpgrade::Nu5 => Self::Nu5,
             zcash_protocol::consensus::NetworkUpgrade::Nu6 => Self::Nu6,
             zcash_protocol::consensus::NetworkUpgrade::Nu6_1 => Self::Nu6_1,
+            zcash_protocol::consensus::NetworkUpgrade::Nu6_2 => Self::Nu6_2,
             #[cfg(zcash_unstable = "nu7")]
             zcash_protocol::consensus::NetworkUpgrade::Nu7 => Self::Nu7,
             #[cfg(zcash_unstable = "zfuture")]

--- a/zebra-chain/src/parameters/tests.rs
+++ b/zebra-chain/src/parameters/tests.rs
@@ -270,6 +270,7 @@ const NETWORK_UPGRADES_IN_ORDER: &[NetworkUpgrade] = &[
     Nu5,
     Nu6,
     Nu6_1,
+    Nu6_2,
     #[cfg(any(test, feature = "zebra-test"))]
     Nu7,
 ];
@@ -287,6 +288,7 @@ fn full_activation_list_contains_all_upgrades() {
     let network = Network::Mainnet;
     let full_list = network.full_activation_list();
 
-    // NU7 is only included in tests; on Mainnet, NU7 isn’t live yet, so we subtract 1 here.
-    assert_eq!(full_list.len(), NetworkUpgrade::iter().count() - 1);
+    // NU6.2 and NU7 are both unscheduled on Mainnet (no activation height committed), so they
+    // are absent from the full activation list even though they are always present in the iter.
+    assert_eq!(full_list.len(), NetworkUpgrade::iter().count() - 2);
 }

--- a/zebra-chain/src/parameters/tests.rs
+++ b/zebra-chain/src/parameters/tests.rs
@@ -288,7 +288,7 @@ fn full_activation_list_contains_all_upgrades() {
     let network = Network::Mainnet;
     let full_list = network.full_activation_list();
 
-    // NU6.2 and NU7 are both unscheduled on Mainnet (no activation height committed), so they
-    // are absent from the full activation list even though they are always present in the iter.
-    assert_eq!(full_list.len(), NetworkUpgrade::iter().count() - 2);
+    // NU7 is unscheduled on Mainnet (no activation height committed), so it is absent from the
+    // full activation list even though it is always present in the iter.
+    assert_eq!(full_list.len(), NetworkUpgrade::iter().count() - 1);
 }

--- a/zebra-chain/src/primitives/zcash_history.rs
+++ b/zebra-chain/src/primitives/zcash_history.rs
@@ -278,6 +278,7 @@ impl Version for zcash_history::V1 {
             | NetworkUpgrade::Nu5
             | NetworkUpgrade::Nu6
             | NetworkUpgrade::Nu6_1
+            | NetworkUpgrade::Nu6_2
             | NetworkUpgrade::Nu7 => {}
             #[cfg(zcash_unstable = "zfuture")]
             NetworkUpgrade::ZFuture => {}

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -781,6 +781,7 @@ impl Arbitrary for Transaction {
             NetworkUpgrade::Nu5
             | NetworkUpgrade::Nu6
             | NetworkUpgrade::Nu6_1
+            | NetworkUpgrade::Nu6_2
             | NetworkUpgrade::Nu7 => prop_oneof![
                 Self::v4_strategy(ledger_state.clone()),
                 Self::v5_strategy(ledger_state)

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -705,13 +705,29 @@ impl Arbitrary for orchard::ShieldedData {
             any::<orchard::shielded_data::Flags>(),
             any::<Amount>(),
             any::<orchard::tree::Root>(),
-            any::<Halo2Proof>(),
             vec(
                 any::<orchard::shielded_data::AuthorizedAction>(),
                 1..MAX_ARBITRARY_ITEMS,
             ),
             any::<BindingSignature>(),
         )
+            .prop_flat_map(|(flags, value_balance, shared_anchor, actions, binding_sig)| {
+                // Since NU6.2, an Orchard proof must have the canonical length for its number of
+                // actions (`2272 * num_actions + 2720` bytes), otherwise it is rejected as
+                // non-canonical (GHSA-2x4w-pxqw-58v9). The V5 txid is computed by round-tripping
+                // through `librustzcash`, which enforces this length, so a proof of any other
+                // size makes the round-trip (and thus `Transaction::hash`) fail. Generate a proof
+                // of exactly the expected length, which depends on the number of actions.
+                let proof_size = orchard::shielded_data::expected_proof_size(actions.len());
+                (
+                    Just(flags),
+                    Just(value_balance),
+                    Just(shared_anchor),
+                    vec(any::<u8>(), proof_size).prop_map(Halo2Proof),
+                    Just(actions),
+                    Just(binding_sig),
+                )
+            })
             .prop_map(
                 |(flags, value_balance, shared_anchor, proof, actions, binding_sig)| Self {
                     flags,

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -711,23 +711,25 @@ impl Arbitrary for orchard::ShieldedData {
             ),
             any::<BindingSignature>(),
         )
-            .prop_flat_map(|(flags, value_balance, shared_anchor, actions, binding_sig)| {
-                // Since NU6.2, an Orchard proof must have the canonical length for its number of
-                // actions (`2272 * num_actions + 2720` bytes), otherwise it is rejected as
-                // non-canonical (GHSA-jfw5-j458-pfv6). The V5 txid is computed by round-tripping
-                // through `librustzcash`, which enforces this length, so a proof of any other
-                // size makes the round-trip (and thus `Transaction::hash`) fail. Generate a proof
-                // of exactly the expected length, which depends on the number of actions.
-                let proof_size = orchard::shielded_data::expected_proof_size(actions.len());
-                (
-                    Just(flags),
-                    Just(value_balance),
-                    Just(shared_anchor),
-                    vec(any::<u8>(), proof_size).prop_map(Halo2Proof),
-                    Just(actions),
-                    Just(binding_sig),
-                )
-            })
+            .prop_flat_map(
+                |(flags, value_balance, shared_anchor, actions, binding_sig)| {
+                    // Since NU6.2, an Orchard proof must have the canonical length for its number of
+                    // actions (`2272 * num_actions + 2720` bytes), otherwise it is rejected as
+                    // non-canonical (GHSA-jfw5-j458-pfv6). The V5 txid is computed by round-tripping
+                    // through `librustzcash`, which enforces this length, so a proof of any other
+                    // size makes the round-trip (and thus `Transaction::hash`) fail. Generate a proof
+                    // of exactly the expected length, which depends on the number of actions.
+                    let proof_size = orchard::shielded_data::expected_proof_size(actions.len());
+                    (
+                        Just(flags),
+                        Just(value_balance),
+                        Just(shared_anchor),
+                        vec(any::<u8>(), proof_size).prop_map(Halo2Proof),
+                        Just(actions),
+                        Just(binding_sig),
+                    )
+                },
+            )
             .prop_map(
                 |(flags, value_balance, shared_anchor, proof, actions, binding_sig)| Self {
                     flags,

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -714,7 +714,7 @@ impl Arbitrary for orchard::ShieldedData {
             .prop_flat_map(|(flags, value_balance, shared_anchor, actions, binding_sig)| {
                 // Since NU6.2, an Orchard proof must have the canonical length for its number of
                 // actions (`2272 * num_actions + 2720` bytes), otherwise it is rejected as
-                // non-canonical (GHSA-2x4w-pxqw-58v9). The V5 txid is computed by round-tripping
+                // non-canonical (GHSA-jfw5-j458-pfv6). The V5 txid is computed by round-tripping
                 // through `librustzcash`, which enforces this length, so a proof of any other
                 // size makes the round-trip (and thus `Transaction::hash`) fail. Generate a proof
                 // of exactly the expected length, which depends on the number of actions.

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -844,7 +844,7 @@ fn zip244_sighash() -> Result<()> {
 }
 
 /// Real Orchard proofs from mined transactions must have the canonical size, and padding
-/// a proof with trailing bytes must make it non-canonical (GHSA-2x4w-pxqw-58v9). This
+/// a proof with trailing bytes must make it non-canonical (GHSA-jfw5-j458-pfv6). This
 /// also cross-checks `expected_proof_size` against real proofs produced by the chain.
 #[test]
 fn orchard_proof_size_is_canonical() {

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -843,6 +843,43 @@ fn zip244_sighash() -> Result<()> {
     Ok(())
 }
 
+/// Real Orchard proofs from mined transactions must have the canonical size, and padding
+/// a proof with trailing bytes must make it non-canonical (GHSA-2x4w-pxqw-58v9). This
+/// also cross-checks `expected_proof_size` against real proofs produced by the chain.
+#[test]
+fn orchard_proof_size_is_canonical() {
+    let mut checked = 0;
+
+    for net in Network::iter() {
+        for tx in v5_transactions(net.block_iter()) {
+            let Some(shielded_data) = tx.orchard_shielded_data() else {
+                continue;
+            };
+
+            // A real, mined Orchard proof has the canonical length for its actions.
+            assert!(
+                shielded_data.proof_size_is_canonical(),
+                "a real Orchard proof should be canonically sized"
+            );
+
+            // Padding the proof with trailing data must break canonicity.
+            let mut padded = shielded_data.clone();
+            padded.proof.0.push(0);
+            assert!(
+                !padded.proof_size_is_canonical(),
+                "a padded Orchard proof must not be considered canonical"
+            );
+
+            checked += 1;
+        }
+    }
+
+    assert!(
+        checked > 0,
+        "expected at least one Orchard transaction in the test vectors"
+    );
+}
+
 #[test]
 fn consensus_branch_id() {
     for net in Network::iter() {

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.0.0] - 2026-06-02
+
+### Added
+
+- `error::TransactionError::OrchardProofSize`.
+- Per-Orchard-circuit verifying keys and batch verifiers: `VERIFYING_KEY_PRE_NU6_2`,
+  `VERIFYING_KEY_POST_NU6_2`, `VERIFIER_PRE_NU6_2`, `VERIFIER_POST_NU6_2`, and `verifier_for()`
+  to select the verifier for a network upgrade.
+
+### Removed
+
+- `VERIFYING_KEY` and `VERIFIER`; replaced by the per-circuit pairs above.
+
+### Changed
+
+- Enforce a canonical Orchard proof size from the NU6.2 network upgrade, and verify Orchard
+  proofs against the fixed circuit's verifying key from NU6.2 onward.
+
 ## [7.0.0] - 2026-05-28
 
 ### Added

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-consensus"
-version = "7.0.1"
+version = "8.0.0"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks"
 license.workspace = true
@@ -70,10 +70,10 @@ zcash_primitives = { workspace = true }
 tower-fallback = { path = "../tower-fallback/", version = "0.2.41" }
 tower-batch-control = { path = "../tower-batch-control/", version = "1.0.1" }
 
-zebra-script = { path = "../zebra-script", version = "7.0.1" }
-zebra-state = { path = "../zebra-state", version = "7.0.1" }
-zebra-node-services = { path = "../zebra-node-services", version = "6.0.0" }
-zebra-chain = { path = "../zebra-chain", version = "8.0.1" }
+zebra-script = { path = "../zebra-script", version = "8.0.0" }
+zebra-state = { path = "../zebra-state", version = "8.0.0" }
+zebra-node-services = { path = "../zebra-node-services", version = "7.0.0" }
+zebra-chain = { path = "../zebra-chain", version = "9.0.0" }
 
 zcash_protocol.workspace = true
 
@@ -97,8 +97,8 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zebra-state = { path = "../zebra-state", version = "7.0.1", features = ["proptest-impl"] }
-zebra-chain = { path = "../zebra-chain", version = "8.0.1", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", version = "8.0.0", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "9.0.0", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/", version = "3.0.0" }
 
 criterion = { workspace = true, features = ["html_reports"] }

--- a/zebra-consensus/benches/halo2.rs
+++ b/zebra-consensus/benches/halo2.rs
@@ -38,7 +38,7 @@ use zebra_chain::{
 };
 
 use tower_batch_control::RequestWeight;
-use zebra_consensus::halo2::{Item, VERIFYING_KEY};
+use zebra_consensus::halo2::{Item, OrchardEra};
 
 /// Extracts valid Halo2 items (Orchard bundles + sighashes) from NU5+ mainnet
 /// test blocks.
@@ -74,7 +74,9 @@ fn extract_halo2_items_from_blocks() -> Vec<Item> {
 
             let sighash = sighasher.sighash(zebra_chain::transaction::HashType::ALL, None);
 
-            items.push(Item::new(bundle, sighash));
+            // These mainnet test blocks are NU5-era Orchard history (mined before NU6.2),
+            // so they verify under the pre-NU6.2 verifying key.
+            items.push(Item::new(bundle, sighash, OrchardEra::PreNu6_2));
         }
     }
 
@@ -87,7 +89,6 @@ fn extract_halo2_items_from_blocks() -> Vec<Item> {
 }
 
 fn bench_halo2_verify(c: &mut Criterion) {
-    let vk = &*VERIFYING_KEY;
     let source_items = extract_halo2_items_from_blocks();
 
     let mut group = c.benchmark_group("halo2");
@@ -96,7 +97,7 @@ fn bench_halo2_verify(c: &mut Criterion) {
     group.bench_function("single bundle", |b| {
         let item = source_items[0].clone();
         b.iter(|| {
-            assert!(item.clone().verify_single(vk));
+            assert!(item.clone().verify_single());
         })
     });
 
@@ -113,7 +114,7 @@ fn bench_halo2_verify(c: &mut Criterion) {
             |b, items: &Vec<Item>| {
                 b.iter(|| {
                     for item in items {
-                        assert!(item.clone().verify_single(vk));
+                        assert!(item.clone().verify_single());
                     }
                 })
             },

--- a/zebra-consensus/benches/halo2.rs
+++ b/zebra-consensus/benches/halo2.rs
@@ -38,7 +38,7 @@ use zebra_chain::{
 };
 
 use tower_batch_control::RequestWeight;
-use zebra_consensus::halo2::{Item, OrchardEra};
+use zebra_consensus::halo2::{Item, VERIFYING_KEY_PRE_NU6_2};
 
 /// Extracts valid Halo2 items (Orchard bundles + sighashes) from NU5+ mainnet
 /// test blocks.
@@ -75,8 +75,9 @@ fn extract_halo2_items_from_blocks() -> Vec<Item> {
             let sighash = sighasher.sighash(zebra_chain::transaction::HashType::ALL, None);
 
             // These mainnet test blocks are NU5-era Orchard history (mined before NU6.2),
-            // so they verify under the pre-NU6.2 verifying key.
-            items.push(Item::new(bundle, sighash, OrchardEra::PreNu6_2));
+            // so they verify under the pre-NU6.2 verifying key (see the `verify_single` calls
+            // below, which pass `VERIFYING_KEY_PRE_NU6_2`).
+            items.push(Item::new(bundle, sighash));
         }
     }
 
@@ -97,7 +98,7 @@ fn bench_halo2_verify(c: &mut Criterion) {
     group.bench_function("single bundle", |b| {
         let item = source_items[0].clone();
         b.iter(|| {
-            assert!(item.clone().verify_single());
+            assert!(item.clone().verify_single(&VERIFYING_KEY_PRE_NU6_2));
         })
     });
 
@@ -114,7 +115,7 @@ fn bench_halo2_verify(c: &mut Criterion) {
             |b, items: &Vec<Item>| {
                 b.iter(|| {
                     for item in items {
-                        assert!(item.clone().verify_single());
+                        assert!(item.clone().verify_single(&VERIFYING_KEY_PRE_NU6_2));
                     }
                 })
             },

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -242,6 +242,9 @@ pub enum TransactionError {
     #[error("invalid balance")]
     Balance(String),
 
+    #[error("Orchard proof has a non-canonical size")]
+    OrchardProofSize,
+
     #[error("unexpected error")]
     Other(String),
 }

--- a/zebra-consensus/src/primitives/halo2.rs
+++ b/zebra-consensus/src/primitives/halo2.rs
@@ -52,7 +52,7 @@ pub type ItemVerifyingKey = VerifyingKey;
 
 // NU6.2 re-enables Orchard actions and ships the *fixed* variable-base
 // scalar-multiplication Orchard circuit (the circuit bug that caused Orchard to be temporarily
-// disabled; see GHSA-2x4w-pxqw-58v9). The fix changes the Orchard Action circuit, and therefore
+// disabled; see GHSA-jfw5-j458-pfv6). The fix changes the Orchard Action circuit, and therefore
 // its verifying key: a proof produced under one circuit version does not verify under the other
 // key. So we keep BOTH keys, each in its own dedicated verifier, and route each bundle to the
 // correct verifier by the block's network upgrade (see [`verifier_for`]):
@@ -240,7 +240,7 @@ pub static VERIFIER_POST_NU6_2: Lazy<VerifierService> =
 /// Returns the global Halo2 verifier for Orchard bundles in blocks at `network_upgrade`.
 ///
 /// The Orchard Action circuit — and therefore its verifying key — changed at NU6.2 (the fixed
-/// variable-base scalar-multiplication circuit; see GHSA-2x4w-pxqw-58v9), and a proof produced
+/// variable-base scalar-multiplication circuit; see GHSA-jfw5-j458-pfv6), and a proof produced
 /// under one circuit does not verify under the other key. So each bundle must be checked against
 /// the key for the upgrade of the block it appears in:
 ///

--- a/zebra-consensus/src/primitives/halo2.rs
+++ b/zebra-consensus/src/primitives/halo2.rs
@@ -46,11 +46,6 @@ type VerifyResult = bool;
 /// The type of the batch sender channel.
 type Sender = watch::Sender<Option<VerifyResult>>;
 
-/// Temporary substitute type for fake batch verification.
-///
-/// TODO: implement batch verification
-pub type BatchVerifyingKey = ItemVerifyingKey;
-
 /// The type of a prepared verifying key.
 /// This is the key used to verify individual items.
 pub type ItemVerifyingKey = VerifyingKey;

--- a/zebra-consensus/src/primitives/halo2.rs
+++ b/zebra-consensus/src/primitives/halo2.rs
@@ -269,6 +269,13 @@ pub fn verifier_for(network_upgrade: NetworkUpgrade) -> &'static VerifierService
         // NU6.2 ships the fixed circuit, and every upgrade after it inherits that fixed circuit,
         // so all of them verify under the fixed key.
         Nu6_2 | Nu7 => &VERIFIER_POST_NU6_2,
+
+        // `ZFuture` only exists under the `zcash_unstable = "zfuture"` cfg. It is a post-NU6.2
+        // upgrade, so it inherits the fixed circuit and is bound to the fixed key here on purpose
+        // (rather than via a wildcard) to keep this match exhaustive and fail-closed under every
+        // build configuration.
+        #[cfg(zcash_unstable = "zfuture")]
+        ZFuture => &VERIFIER_POST_NU6_2,
     }
 }
 

--- a/zebra-consensus/src/primitives/halo2.rs
+++ b/zebra-consensus/src/primitives/halo2.rs
@@ -12,7 +12,7 @@ use futures::{future::BoxFuture, FutureExt};
 use once_cell::sync::Lazy;
 use orchard::{
     bundle::BatchValidator,
-    circuit::{FixedPostNu6_2, InsecurePreNu6_2, VerifyingKey},
+    circuit::{OrchardCircuitVersion, VerifyingKey},
 };
 use rand::thread_rng;
 use zcash_protocol::value::ZatBalance;
@@ -75,7 +75,7 @@ lazy_static::lazy_static! {
     /// MUST be retained to re-verify pre-NU6.2 history on resync. It must never be used to verify
     /// post-NU6.2 bundles.
     pub static ref VERIFYING_KEY_PRE_NU6_2: ItemVerifyingKey =
-        ItemVerifyingKey::build::<InsecurePreNu6_2>();
+        ItemVerifyingKey::build_for_version(OrchardCircuitVersion::InsecurePreNu6_2);
 
     /// The Orchard Action verifying key for the **NU6.2+** (fixed) circuit.
     ///
@@ -83,7 +83,7 @@ lazy_static::lazy_static! {
     /// NU6.2. Bundles mined at or after the NU6.2 activation height commit to this circuit and
     /// only verify under this key. See [`VERIFYING_KEY_PRE_NU6_2`] for the era split.
     pub static ref VERIFYING_KEY_POST_NU6_2: ItemVerifyingKey =
-        ItemVerifyingKey::build::<FixedPostNu6_2>();
+        ItemVerifyingKey::build();
 }
 
 /// A Halo2 verification item, used as the request type of the service.

--- a/zebra-consensus/src/primitives/halo2.rs
+++ b/zebra-consensus/src/primitives/halo2.rs
@@ -16,16 +16,19 @@ use orchard::{
 };
 use rand::thread_rng;
 use zcash_protocol::value::ZatBalance;
-use zebra_chain::transaction::SigHash;
+use zebra_chain::{parameters::NetworkUpgrade, transaction::SigHash};
 
 use crate::BoxError;
 use thiserror::Error;
 use tokio::sync::watch;
-use tower::{util::ServiceFn, Service};
+use tower::Service;
 use tower_batch_control::{Batch, BatchControl, RequestWeight};
 use tower_fallback::Fallback;
 
 use super::spawn_fifo;
+
+#[cfg(test)]
+mod tests;
 
 /// Adjusted batch size for halo2 batches.
 ///
@@ -53,80 +56,50 @@ pub type BatchVerifyingKey = ItemVerifyingKey;
 pub type ItemVerifyingKey = VerifyingKey;
 
 // NU6.2 re-enables Orchard actions and ships the *fixed* variable-base
-// scalar-multiplication Orchard circuit (the circuit bug that caused Orchard to be
-// temporarily disabled; see GHSA-2x4w-pxqw-58v9). The fix changes the Orchard Action
-// circuit, and therefore its verifying key: a proof produced under one circuit version
-// does not verify under the other key. So we must keep BOTH keys and select per bundle by
-// the block's network upgrade (era):
+// scalar-multiplication Orchard circuit (the circuit bug that caused Orchard to be temporarily
+// disabled; see GHSA-2x4w-pxqw-58v9). The fix changes the Orchard Action circuit, and therefore
+// its verifying key: a proof produced under one circuit version does not verify under the other
+// key. So we keep BOTH keys, each in its own dedicated verifier, and route each bundle to the
+// correct verifier by the block's network upgrade (see [`verifier_for`]):
 //
-//   * Orchard bundles mined before NU6.2 (NU5..NU6.2) were produced by the historical,
-//     insecure circuit and only verify under the [`InsecurePreNu6_2`] key. These must keep
-//     verifying so that nodes can re-sync and reindex pre-soft-fork Orchard history.
+//   * Orchard bundles mined before NU6.2 (NU5..NU6.2) were produced by the historical, insecure
+//     circuit and only verify under the [`InsecurePreNu6_2`] key. These must keep verifying so
+//     that nodes can re-sync and reindex pre-soft-fork Orchard history.
 //
-//   * Orchard bundles mined at NU6.2 onward are produced by the fixed circuit and only
-//     verify under the [`FixedPostNu6_2`] key.
+//   * Orchard bundles mined at NU6.2 onward are produced by the fixed circuit and only verify
+//     under the [`FixedPostNu6_2`] key.
 //
-// The era is threaded in from transaction verification
-// (`zebra-consensus/src/transaction.rs`, via `request.upgrade(network)`) through
-// [`Item`] into the [`Verifier`], which keeps a separate batch per era and validates each
-// batch against the matching key.
-//
-// NOTE: this deliberately does NOT copy zcashd PR #176's WIP shortcut of validating
-// everything against the fixed key; that is incorrect for re-syncing pre-soft-fork Orchard
-// blocks, whose proofs only verify under the insecure key.
+// NOTE: this deliberately does NOT copy zcashd PR #176's WIP shortcut of validating everything
+// against the fixed key; that is incorrect for re-syncing pre-soft-fork Orchard blocks, whose
+// proofs only verify under the insecure key.
 lazy_static::lazy_static! {
-    /// The fixed (post-NU6.2) halo2 proof verifying key.
-    ///
-    /// Built from the fixed variable-base scalar-multiplication Orchard Action circuit
-    /// shipped in NU6.2. Use this for Orchard bundles in blocks at or after the NU6.2
-    /// activation height.
-    pub static ref VERIFYING_KEY_POST_NU6_2: ItemVerifyingKey =
-        ItemVerifyingKey::build::<FixedPostNu6_2>();
-
-    /// The historical, insecure (pre-NU6.2) halo2 proof verifying key.
+    /// The Orchard Action verifying key for the **pre-NU6.2** (insecure) circuit.
     ///
     /// Reconstructs the verifying key of the original (NU5..NU6.2) Orchard Action circuit.
-    /// Use this ONLY to verify Orchard bundles in blocks mined before the NU6.2 activation
-    /// height, so that pre-soft-fork Orchard history can be re-synced and reindexed. It must
-    /// never be used to verify post-NU6.2 bundles.
+    /// Bundles mined before NU6.2 committed to this circuit and only verify under this key, so it
+    /// MUST be retained to re-verify pre-NU6.2 history on resync. It must never be used to verify
+    /// post-NU6.2 bundles.
     pub static ref VERIFYING_KEY_PRE_NU6_2: ItemVerifyingKey =
         ItemVerifyingKey::build::<InsecurePreNu6_2>();
-}
 
-/// The Orchard circuit era of a bundle, which selects the verifying key it is checked
-/// against.
-///
-/// The Orchard Action circuit — and therefore its verifying key — changed at NU6.2 (the
-/// fixed variable-base scalar-multiplication circuit; see GHSA-2x4w-pxqw-58v9). A proof
-/// produced under one era does not verify under the other era's key, so each bundle must be
-/// checked against the key for the era of the block it appears in.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub enum OrchardEra {
-    /// Blocks before the NU6.2 activation height, verified with [`VERIFYING_KEY_PRE_NU6_2`].
-    PreNu6_2,
-    /// Blocks at or after the NU6.2 activation height, verified with
-    /// [`VERIFYING_KEY_POST_NU6_2`].
-    PostNu6_2,
-}
-
-impl OrchardEra {
-    /// Returns the verifying key for this era.
-    fn verifying_key(self) -> &'static ItemVerifyingKey {
-        match self {
-            OrchardEra::PreNu6_2 => &VERIFYING_KEY_PRE_NU6_2,
-            OrchardEra::PostNu6_2 => &VERIFYING_KEY_POST_NU6_2,
-        }
-    }
+    /// The Orchard Action verifying key for the **NU6.2+** (fixed) circuit.
+    ///
+    /// Built from the fixed variable-base scalar-multiplication Orchard Action circuit shipped in
+    /// NU6.2. Bundles mined at or after the NU6.2 activation height commit to this circuit and
+    /// only verify under this key. See [`VERIFYING_KEY_PRE_NU6_2`] for the era split.
+    pub static ref VERIFYING_KEY_POST_NU6_2: ItemVerifyingKey =
+        ItemVerifyingKey::build::<FixedPostNu6_2>();
 }
 
 /// A Halo2 verification item, used as the request type of the service.
+///
+/// An [`Item`] is key-agnostic: it carries only the bundle and sighash. The verifying key (pre-
+/// vs post-NU6.2) is supplied by whichever [`Verifier`] processes the item, so an item is always
+/// validated against exactly one key and eras are never mixed within a batch.
 #[derive(Clone, Debug)]
 pub struct Item {
     bundle: orchard::bundle::Bundle<orchard::bundle::Authorized, ZatBalance>,
     sighash: SigHash,
-    /// The Orchard circuit era of the block this bundle appears in, which selects the
-    /// verifying key. See [`OrchardEra`].
-    era: OrchardEra,
 }
 
 impl RequestWeight for Item {
@@ -136,31 +109,20 @@ impl RequestWeight for Item {
 }
 
 impl Item {
-    /// Creates a new [`Item`] from a bundle, sighash, and the Orchard circuit era of the
-    /// block the bundle appears in.
+    /// Creates a new [`Item`] from a bundle and sighash.
     pub fn new(
         bundle: orchard::bundle::Bundle<orchard::bundle::Authorized, ZatBalance>,
         sighash: SigHash,
-        era: OrchardEra,
     ) -> Self {
-        Self {
-            bundle,
-            sighash,
-            era,
-        }
+        Self { bundle, sighash }
     }
 
-    /// The Orchard circuit era of this item.
-    pub fn era(&self) -> OrchardEra {
-        self.era
-    }
-
-    /// Perform non-batched verification of this [`Item`] against its era's verifying key.
+    /// Perform non-batched verification of this [`Item`] against `vk`.
     ///
     /// This is useful (in combination with `Item::clone`) for implementing
-    /// fallback logic when batch verification fails.
-    pub fn verify_single(self) -> bool {
-        let vk = self.era.verifying_key();
+    /// fallback logic when batch verification fails. The caller supplies the
+    /// verifying key for the item's era.
+    pub fn verify_single(self, vk: &ItemVerifyingKey) -> bool {
         let mut batch = BatchValidator::default();
         batch.queue(self);
         batch.validate(vk, thread_rng())
@@ -172,12 +134,7 @@ trait QueueBatchVerify {
 }
 
 impl QueueBatchVerify for BatchValidator {
-    fn queue(
-        &mut self,
-        Item {
-            bundle, sighash, ..
-        }: Item,
-    ) {
+    fn queue(&mut self, Item { bundle, sighash }: Item) {
         self.add_bundle(&bundle, sighash.0);
     }
 }
@@ -207,65 +164,128 @@ impl From<halo2::plonk::Error> for Halo2Error {
     }
 }
 
-/// Global batch verification context for Halo2 proofs of Action statements.
+/// The single-item fallback service for one Orchard circuit era.
 ///
-/// This service transparently batches contemporaneous proof verifications,
-/// handling batch failures by falling back to individual verification.
+/// When a batch fails, [`Fallback`] re-runs each item individually through this service. It holds
+/// the *same* verifying key as the batch it backs, so the fallback can never validate an item
+/// against a different era's key than the batch did. The key is named once, when the verifier is
+/// built (see [`batch_verifier`]).
 ///
-/// Note that making a `Service` call requires mutable access to the service, so
-/// you should call `.clone()` on the global handle to create a local, mutable
-/// handle.
-pub static VERIFIER: Lazy<
-    Fallback<
-        Batch<Verifier, Item>,
-        ServiceFn<fn(Item) -> BoxFuture<'static, Result<(), BoxError>>>,
-    >,
-> = Lazy::new(|| {
+/// This is a tiny named service rather than a `service_fn` closure because the closure would have
+/// to capture `vk`, and a capturing closure has an unnameable, non-`Clone` type — but the global
+/// verifier must be `Clone` to hand out per-call handles. A `&'static` field keeps this `Copy`.
+#[derive(Clone, Copy)]
+pub struct OrchardFallback {
+    /// The verifying key for this era, shared with the batch verifier it backs.
+    vk: &'static ItemVerifyingKey,
+}
+
+impl Service<Item> for OrchardFallback {
+    type Response = ();
+    type Error = BoxError;
+    type Future = BoxFuture<'static, Result<(), BoxError>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, item: Item) -> Self::Future {
+        Verifier::verify_single_spawning(item, self.vk).boxed()
+    }
+}
+
+/// The concrete type of a global Halo2 verification service.
+///
+/// Each Orchard circuit era gets its own instance — see [`VERIFIER_PRE_NU6_2`] and
+/// [`VERIFIER_POST_NU6_2`] — so that batches, fallbacks, and verifying keys are fully separated
+/// per era.
+type VerifierService = Fallback<Batch<Verifier, Item>, OrchardFallback>;
+
+/// Builds a global Halo2 verifier that validates every item against `vk`.
+///
+/// The returned service batches contemporaneous proof verifications and, if a batch fails, falls
+/// back to verifying each item individually. The batch and its fallback share the single `vk`
+/// passed here, so an item built by this verifier is always checked against exactly one era's key.
+/// Callers select the correct era's key by which `VERIFYING_KEY_*` they pass (see the two statics
+/// below); there is no runtime key resolution.
+fn batch_verifier(vk: &'static ItemVerifyingKey) -> VerifierService {
     Fallback::new(
         Batch::new(
-            Verifier::new(),
+            Verifier::new(vk),
             HALO2_MAX_BATCH_SIZE,
             None,
             super::MAX_BATCH_LATENCY,
         ),
-        // We want to fallback to individual verification if batch verification fails,
-        // so we need a Service to use.
-        //
-        // Because we have to specify the type of a static, we need to be able to
-        // write the type of the closure and its return value. But both closures and
-        // async blocks have unnameable types. So instead we cast the closure to a function
-        // (which is possible because it doesn't capture any state), and use a BoxFuture
-        // to erase the result type.
-        // (We can't use BoxCloneService to erase the service type, because it is !Sync.)
-        //
-        // The fallback verifies each item against its own era's verifying key (see
-        // [`Item::verify_single`]).
-        tower::service_fn(
-            (|item: Item| Verifier::verify_single_spawning(item).boxed()) as fn(_) -> _,
-        ),
+        OrchardFallback { vk },
     )
-});
+}
+
+/// Global batch verification context for **pre-NU6.2** Halo2 Action proofs.
+///
+/// Items routed here are verified against [`VERIFYING_KEY_PRE_NU6_2`] (the insecure circuit
+/// retained for historical blocks). This service transparently batches contemporaneous proof
+/// verifications, handling batch failures by falling back to individual verification.
+///
+/// Note that making a `Service` call requires mutable access to the service, so you should call
+/// `.clone()` on the global handle to create a local, mutable handle.
+pub static VERIFIER_PRE_NU6_2: Lazy<VerifierService> =
+    Lazy::new(|| batch_verifier(&VERIFYING_KEY_PRE_NU6_2));
+
+/// Global batch verification context for **NU6.2+** Halo2 Action proofs.
+///
+/// Items routed here are verified against [`VERIFYING_KEY_POST_NU6_2`] (the fixed circuit). This
+/// service transparently batches contemporaneous proof verifications, handling batch failures by
+/// falling back to individual verification.
+///
+/// Note that making a `Service` call requires mutable access to the service, so you should call
+/// `.clone()` on the global handle to create a local, mutable handle.
+pub static VERIFIER_POST_NU6_2: Lazy<VerifierService> =
+    Lazy::new(|| batch_verifier(&VERIFYING_KEY_POST_NU6_2));
+
+/// Returns the global Halo2 verifier for Orchard bundles in blocks at `network_upgrade`.
+///
+/// The Orchard Action circuit — and therefore its verifying key — changed at NU6.2 (the fixed
+/// variable-base scalar-multiplication circuit; see GHSA-2x4w-pxqw-58v9), and a proof produced
+/// under one circuit does not verify under the other key. So each bundle must be checked against
+/// the key for the upgrade of the block it appears in:
+///
+///   * upgrades before NU6.2 are routed to [`VERIFIER_PRE_NU6_2`] (the historical insecure key),
+///     so pre-soft-fork Orchard history still verifies on re-sync;
+///   * NU6.2 and every later upgrade are routed to [`VERIFIER_POST_NU6_2`] (the fixed key).
+///
+/// The mapping is an explicit, exhaustive `match` on every [`NetworkUpgrade`] variant: there is
+/// no version-comparison fallthrough and no default-to-insecure arm, so adding a future upgrade
+/// is a compile error here until it is bound to a key on purpose.
+pub fn verifier_for(network_upgrade: NetworkUpgrade) -> &'static VerifierService {
+    use NetworkUpgrade::*;
+
+    match network_upgrade {
+        // Orchard did not exist before NU5, so these upgrades never carry Orchard bundles. They
+        // are bound to the pre-NU6.2 (insecure) verifier because that is the only key under which
+        // any Orchard history before NU6.2 verifies; routing them anywhere else cannot be correct.
+        Genesis | BeforeOverwinter | Overwinter | Sapling | Blossom | Heartwood | Canopy | Nu5
+        | Nu6 | Nu6_1 => &VERIFIER_PRE_NU6_2,
+
+        // NU6.2 ships the fixed circuit, and every upgrade after it inherits that fixed circuit,
+        // so all of them verify under the fixed key.
+        Nu6_2 | Nu7 => &VERIFIER_POST_NU6_2,
+    }
+}
 
 /// Halo2 proof verifier implementation
 ///
 /// This is the core implementation for the batch verification logic of the
 /// Halo2 verifier. It handles batching incoming requests, driving batches to
 /// completion, and reporting results.
+///
+/// Each verifier validates against a single, fixed [`ItemVerifyingKey`]; the two Orchard circuit
+/// eras are served by two independent verifiers, so a batch never mixes pre- and post-NU6.2
+/// proofs.
 pub struct Verifier {
-    /// The per-era synchronous Halo2 batch validators.
-    ///
-    /// Orchard's verifying key changed at NU6.2 (see [`OrchardEra`]), and a single
-    /// [`BatchValidator`] is validated against exactly one verifying key. So we keep a
-    /// separate batch per era and route each incoming [`Item`] into the batch for its era,
-    /// flushing each batch against the matching key. This keeps the batching optimization
-    /// while never mixing proofs from different circuit eras into a single batch.
-    pre_nu6_2: EraBatch,
-    post_nu6_2: EraBatch,
-}
+    /// The verifying key that every batch and fallback from this verifier uses.
+    vk: &'static ItemVerifyingKey,
 
-/// A single-era batch and its result-broadcast channel.
-struct EraBatch {
-    /// The synchronous Halo2 batch validator for this era.
+    /// The synchronous Halo2 batch validator.
     batch: BatchValidator,
 
     /// A channel for broadcasting the result of a batch to the futures for each batch item.
@@ -275,69 +295,51 @@ struct EraBatch {
     tx: Sender,
 }
 
-impl Default for EraBatch {
-    fn default() -> Self {
+impl Verifier {
+    /// Creates a verifier that validates every item against `vk`.
+    fn new(vk: &'static ItemVerifyingKey) -> Self {
         let (tx, _) = watch::channel(None);
         Self {
+            vk,
             batch: BatchValidator::default(),
             tx,
         }
     }
-}
 
-impl Verifier {
-    fn new() -> Self {
-        Self {
-            pre_nu6_2: EraBatch::default(),
-            post_nu6_2: EraBatch::default(),
-        }
-    }
-
-    /// Returns a mutable reference to the [`EraBatch`] for `era`.
-    fn era_batch(&mut self, era: OrchardEra) -> &mut EraBatch {
-        match era {
-            OrchardEra::PreNu6_2 => &mut self.pre_nu6_2,
-            OrchardEra::PostNu6_2 => &mut self.post_nu6_2,
-        }
-    }
-
-    /// Returns the batch verifier, verifying key, and channel sender for `era`,
+    /// Returns the batch verifier and channel sender,
     /// replacing the batch and channel with new empty ones.
-    fn take(&mut self, era: OrchardEra) -> (BatchValidator, &'static BatchVerifyingKey, Sender) {
-        let vk = era.verifying_key();
-        let era_batch = self.era_batch(era);
-
+    fn take(&mut self) -> (BatchValidator, Sender) {
         // Use a new verifier and channel for each batch.
-        let batch = mem::take(&mut era_batch.batch);
+        let batch = mem::take(&mut self.batch);
         let (tx, _) = watch::channel(None);
-        let tx = mem::replace(&mut era_batch.tx, tx);
+        let tx = mem::replace(&mut self.tx, tx);
 
-        (batch, vk, tx)
+        (batch, tx)
     }
 
-    /// Synchronously process the batch, and send the result using the channel sender.
-    /// This function blocks until the batch is completed.
-    fn verify(batch: BatchValidator, vk: &'static BatchVerifyingKey, tx: Sender) {
+    /// Synchronously process the batch against `vk`, and send the result using
+    /// the channel sender. This function blocks until the batch is completed.
+    fn verify(batch: BatchValidator, vk: &'static ItemVerifyingKey, tx: Sender) {
         let result = batch.validate(vk, thread_rng());
         let _ = tx.send(Some(result));
     }
 
-    /// Flush all per-era batches using a thread pool, sending each result via its channel.
-    /// This returns immediately, usually before the batches are completed.
+    /// Flush the batch using a thread pool, sending the result via the channel.
+    /// This returns immediately, usually before the batch is completed.
     fn flush_blocking(&mut self) {
-        for era in [OrchardEra::PreNu6_2, OrchardEra::PostNu6_2] {
-            let (batch, vk, tx) = self.take(era);
+        let vk = self.vk;
+        let (batch, tx) = self.take();
 
-            // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
-            //
-            // We don't care about execution order here, because this method is only called on drop.
-            tokio::task::block_in_place(|| rayon::spawn_fifo(move || Self::verify(batch, vk, tx)));
-        }
+        // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
+        //
+        // We don't care about execution order here, because this method is only called on drop.
+        tokio::task::block_in_place(|| rayon::spawn_fifo(move || Self::verify(batch, vk, tx)));
     }
 
-    /// Flush the batch using a thread pool, and return the result via the channel.
-    /// This function returns a future that becomes ready when the batch is completed.
-    async fn flush_spawning(batch: BatchValidator, vk: &'static BatchVerifyingKey, tx: Sender) {
+    /// Flush the batch using a thread pool, validating against `vk` and
+    /// returning the result via the channel. This function returns a future that
+    /// becomes ready when the batch is completed.
+    async fn flush_spawning(batch: BatchValidator, vk: &'static ItemVerifyingKey, tx: Sender) {
         // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
         let start = std::time::Instant::now();
         let result = spawn_fifo(move || batch.validate(vk, thread_rng())).await;
@@ -357,12 +359,13 @@ impl Verifier {
         let _ = tx.send(result.ok());
     }
 
-    /// Verify a single item using a thread pool, and return the result.
-    ///
-    /// The item is verified against its own era's verifying key (see [`Item::verify_single`]).
-    async fn verify_single_spawning(item: Item) -> Result<(), BoxError> {
+    /// Verify a single item against `vk` using a thread pool, and return the result.
+    async fn verify_single_spawning(
+        item: Item,
+        vk: &'static ItemVerifyingKey,
+    ) -> Result<(), BoxError> {
         // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
-        if spawn_fifo(move || item.verify_single()).await? {
+        if spawn_fifo(move || item.verify_single(vk)).await? {
             Ok(())
         } else {
             Err("could not validate orchard proof".into())
@@ -373,10 +376,7 @@ impl Verifier {
 impl fmt::Debug for Verifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = "Verifier";
-        f.debug_struct(name)
-            .field("pre_nu6_2", &"..")
-            .field("post_nu6_2", &"..")
-            .finish()
+        f.debug_struct(name).field("batch", &"..").finish()
     }
 }
 
@@ -392,14 +392,9 @@ impl Service<BatchControl<Item>> for Verifier {
     fn call(&mut self, req: BatchControl<Item>) -> Self::Future {
         match req {
             BatchControl::Item(item) => {
-                let era = item.era();
-                tracing::trace!(?era, "got item");
-                // Route the item into the batch for its era, and subscribe its future to
-                // that era's result channel, so each item is verified against the verifying
-                // key for the circuit era of its block.
-                let era_batch = self.era_batch(era);
-                era_batch.batch.queue(item);
-                let mut rx = era_batch.tx.subscribe();
+                tracing::trace!("got item");
+                self.batch.queue(item);
+                let mut rx = self.tx.subscribe();
                 Box::pin(async move {
                     match rx.changed().await {
                         Ok(()) => {
@@ -428,18 +423,10 @@ impl Service<BatchControl<Item>> for Verifier {
             BatchControl::Flush => {
                 tracing::trace!("got halo2 flush command");
 
-                // Flush both era batches, each against its own verifying key. The future is
-                // ready only once both batches have completed and broadcast their results.
-                let (pre_batch, pre_vk, pre_tx) = self.take(OrchardEra::PreNu6_2);
-                let (post_batch, post_vk, post_tx) = self.take(OrchardEra::PostNu6_2);
+                let vk = self.vk;
+                let (batch, tx) = self.take();
 
-                Box::pin(
-                    futures::future::join(
-                        Self::flush_spawning(pre_batch, pre_vk, pre_tx),
-                        Self::flush_spawning(post_batch, post_vk, post_tx),
-                    )
-                    .map(|((), ())| Ok(())),
-                )
+                Box::pin(Self::flush_spawning(batch, vk, tx).map(|()| Ok(())))
             }
         }
     }

--- a/zebra-consensus/src/primitives/halo2.rs
+++ b/zebra-consensus/src/primitives/halo2.rs
@@ -10,7 +10,10 @@ use std::{
 
 use futures::{future::BoxFuture, FutureExt};
 use once_cell::sync::Lazy;
-use orchard::{bundle::BatchValidator, circuit::VerifyingKey};
+use orchard::{
+    bundle::BatchValidator,
+    circuit::{FixedPostNu6_2, InsecurePreNu6_2, VerifyingKey},
+};
 use rand::thread_rng;
 use zcash_protocol::value::ZatBalance;
 use zebra_chain::transaction::SigHash;
@@ -49,40 +52,71 @@ pub type BatchVerifyingKey = ItemVerifyingKey;
 /// This is the key used to verify individual items.
 pub type ItemVerifyingKey = VerifyingKey;
 
-// TODO(NU6.2): post-NU6.2 Orchard verification cannot be implemented here yet.
-//
 // NU6.2 re-enables Orchard actions and ships the *fixed* variable-base
-// scalar-multiplication Orchard circuit (the circuit bug that caused Orchard to
-// be temporarily disabled; see GHSA-2x4w-pxqw-58v9). Correctly verifying both
-// eras requires changes that depend entirely on UNRELEASED crates and APIs that
-// do not exist in the currently pinned `orchard 0.13`:
+// scalar-multiplication Orchard circuit (the circuit bug that caused Orchard to be
+// temporarily disabled; see GHSA-2x4w-pxqw-58v9). The fix changes the Orchard Action
+// circuit, and therefore its verifying key: a proof produced under one circuit version
+// does not verify under the other key. So we must keep BOTH keys and select per bundle by
+// the block's network upgrade (era):
 //
-//   1. Dependency bump (blocked): the fixed circuit and the new verifying-key
-//      construction API (`VerifyingKey::build::<C>()` with circuit type params)
-//      live only in an unreleased `orchard`/`halo2`/`librustzcash` release.
-//      `orchard 0.13` exposes only the parameterless `VerifyingKey::build()`
-//      used below, so this cannot be changed without breaking the build.
+//   * Orchard bundles mined before NU6.2 (NU5..NU6.2) were produced by the historical,
+//     insecure circuit and only verify under the [`InsecurePreNu6_2`] key. These must keep
+//     verifying so that nodes can re-sync and reindex pre-soft-fork Orchard history.
 //
-//   2. Two verifying keys (blocked on 1): the verifying key changes at NU6.2 and
-//      one key cannot verify both eras. This static must become TWO keys — an
-//      insecure pre-NU6.2 key and the fixed post-NU6.2 key — once the typed
-//      `build::<C>()` API is available.
+//   * Orchard bundles mined at NU6.2 onward are produced by the fixed circuit and only
+//     verify under the [`FixedPostNu6_2`] key.
 //
-//   3. Height/era-based key selection (blocked on 1 & 2): pre-NU6.2 bundles must
-//      verify under the insecure key and NU6.2+ bundles under the fixed key.
-//      No height/era is currently threaded into halo2 verification, so the
-//      activation height (`NetworkUpgrade::Nu6_2.activation_height(network)`)
-//      must be plumbed from transaction verification
-//      (`zebra-consensus/src/transaction.rs`) through `Item`/`Verifier` into the
-//      key selection here, before `BatchValidator::validate`. NOTE: do NOT copy
-//      zcashd PR #176's shortcut of validating everything against the fixed key;
-//      that is incorrect for re-syncing pre-soft-fork Orchard blocks.
+// The era is threaded in from transaction verification
+// (`zebra-consensus/src/transaction.rs`, via `request.upgrade(network)`) through
+// [`Item`] into the [`Verifier`], which keeps a separate batch per era and validates each
+// batch against the matching key.
 //
-// See /tmp/nu6.2-gap-analysis.md blockers B1, B2, B3 for full detail. Until the
-// fixed-circuit crates are released, only the single key below is available.
+// NOTE: this deliberately does NOT copy zcashd PR #176's WIP shortcut of validating
+// everything against the fixed key; that is incorrect for re-syncing pre-soft-fork Orchard
+// blocks, whose proofs only verify under the insecure key.
 lazy_static::lazy_static! {
-    /// The halo2 proof verifying key.
-    pub static ref VERIFYING_KEY: ItemVerifyingKey = ItemVerifyingKey::build();
+    /// The fixed (post-NU6.2) halo2 proof verifying key.
+    ///
+    /// Built from the fixed variable-base scalar-multiplication Orchard Action circuit
+    /// shipped in NU6.2. Use this for Orchard bundles in blocks at or after the NU6.2
+    /// activation height.
+    pub static ref VERIFYING_KEY_POST_NU6_2: ItemVerifyingKey =
+        ItemVerifyingKey::build::<FixedPostNu6_2>();
+
+    /// The historical, insecure (pre-NU6.2) halo2 proof verifying key.
+    ///
+    /// Reconstructs the verifying key of the original (NU5..NU6.2) Orchard Action circuit.
+    /// Use this ONLY to verify Orchard bundles in blocks mined before the NU6.2 activation
+    /// height, so that pre-soft-fork Orchard history can be re-synced and reindexed. It must
+    /// never be used to verify post-NU6.2 bundles.
+    pub static ref VERIFYING_KEY_PRE_NU6_2: ItemVerifyingKey =
+        ItemVerifyingKey::build::<InsecurePreNu6_2>();
+}
+
+/// The Orchard circuit era of a bundle, which selects the verifying key it is checked
+/// against.
+///
+/// The Orchard Action circuit — and therefore its verifying key — changed at NU6.2 (the
+/// fixed variable-base scalar-multiplication circuit; see GHSA-2x4w-pxqw-58v9). A proof
+/// produced under one era does not verify under the other era's key, so each bundle must be
+/// checked against the key for the era of the block it appears in.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum OrchardEra {
+    /// Blocks before the NU6.2 activation height, verified with [`VERIFYING_KEY_PRE_NU6_2`].
+    PreNu6_2,
+    /// Blocks at or after the NU6.2 activation height, verified with
+    /// [`VERIFYING_KEY_POST_NU6_2`].
+    PostNu6_2,
+}
+
+impl OrchardEra {
+    /// Returns the verifying key for this era.
+    fn verifying_key(self) -> &'static ItemVerifyingKey {
+        match self {
+            OrchardEra::PreNu6_2 => &VERIFYING_KEY_PRE_NU6_2,
+            OrchardEra::PostNu6_2 => &VERIFYING_KEY_POST_NU6_2,
+        }
+    }
 }
 
 /// A Halo2 verification item, used as the request type of the service.
@@ -90,6 +124,9 @@ lazy_static::lazy_static! {
 pub struct Item {
     bundle: orchard::bundle::Bundle<orchard::bundle::Authorized, ZatBalance>,
     sighash: SigHash,
+    /// The Orchard circuit era of the block this bundle appears in, which selects the
+    /// verifying key. See [`OrchardEra`].
+    era: OrchardEra,
 }
 
 impl RequestWeight for Item {
@@ -99,19 +136,31 @@ impl RequestWeight for Item {
 }
 
 impl Item {
-    /// Creates a new [`Item`] from a bundle and sighash.
+    /// Creates a new [`Item`] from a bundle, sighash, and the Orchard circuit era of the
+    /// block the bundle appears in.
     pub fn new(
         bundle: orchard::bundle::Bundle<orchard::bundle::Authorized, ZatBalance>,
         sighash: SigHash,
+        era: OrchardEra,
     ) -> Self {
-        Self { bundle, sighash }
+        Self {
+            bundle,
+            sighash,
+            era,
+        }
     }
 
-    /// Perform non-batched verification of this [`Item`].
+    /// The Orchard circuit era of this item.
+    pub fn era(&self) -> OrchardEra {
+        self.era
+    }
+
+    /// Perform non-batched verification of this [`Item`] against its era's verifying key.
     ///
     /// This is useful (in combination with `Item::clone`) for implementing
     /// fallback logic when batch verification fails.
-    pub fn verify_single(self, vk: &ItemVerifyingKey) -> bool {
+    pub fn verify_single(self) -> bool {
+        let vk = self.era.verifying_key();
         let mut batch = BatchValidator::default();
         batch.queue(self);
         batch.validate(vk, thread_rng())
@@ -123,7 +172,12 @@ trait QueueBatchVerify {
 }
 
 impl QueueBatchVerify for BatchValidator {
-    fn queue(&mut self, Item { bundle, sighash }: Item) {
+    fn queue(
+        &mut self,
+        Item {
+            bundle, sighash, ..
+        }: Item,
+    ) {
         self.add_bundle(&bundle, sighash.0);
     }
 }
@@ -169,7 +223,7 @@ pub static VERIFIER: Lazy<
 > = Lazy::new(|| {
     Fallback::new(
         Batch::new(
-            Verifier::new(&VERIFYING_KEY),
+            Verifier::new(),
             HALO2_MAX_BATCH_SIZE,
             None,
             super::MAX_BATCH_LATENCY,
@@ -183,9 +237,11 @@ pub static VERIFIER: Lazy<
         // (which is possible because it doesn't capture any state), and use a BoxFuture
         // to erase the result type.
         // (We can't use BoxCloneService to erase the service type, because it is !Sync.)
+        //
+        // The fallback verifies each item against its own era's verifying key (see
+        // [`Item::verify_single`]).
         tower::service_fn(
-            (|item: Item| Verifier::verify_single_spawning(item, &VERIFYING_KEY).boxed())
-                as fn(_) -> _,
+            (|item: Item| Verifier::verify_single_spawning(item).boxed()) as fn(_) -> _,
         ),
     )
 });
@@ -196,13 +252,21 @@ pub static VERIFIER: Lazy<
 /// Halo2 verifier. It handles batching incoming requests, driving batches to
 /// completion, and reporting results.
 pub struct Verifier {
-    /// The synchronous Halo2 batch validator.
-    batch: BatchValidator,
-
-    /// The halo2 proof verification key.
+    /// The per-era synchronous Halo2 batch validators.
     ///
-    /// Making this 'static makes managing lifetimes much easier.
-    vk: &'static ItemVerifyingKey,
+    /// Orchard's verifying key changed at NU6.2 (see [`OrchardEra`]), and a single
+    /// [`BatchValidator`] is validated against exactly one verifying key. So we keep a
+    /// separate batch per era and route each incoming [`Item`] into the batch for its era,
+    /// flushing each batch against the matching key. This keeps the batching optimization
+    /// while never mixing proofs from different circuit eras into a single batch.
+    pre_nu6_2: EraBatch,
+    post_nu6_2: EraBatch,
+}
+
+/// A single-era batch and its result-broadcast channel.
+struct EraBatch {
+    /// The synchronous Halo2 batch validator for this era.
+    batch: BatchValidator,
 
     /// A channel for broadcasting the result of a batch to the futures for each batch item.
     ///
@@ -211,23 +275,44 @@ pub struct Verifier {
     tx: Sender,
 }
 
-impl Verifier {
-    fn new(vk: &'static ItemVerifyingKey) -> Self {
-        let batch = BatchValidator::default();
+impl Default for EraBatch {
+    fn default() -> Self {
         let (tx, _) = watch::channel(None);
-        Self { batch, vk, tx }
+        Self {
+            batch: BatchValidator::default(),
+            tx,
+        }
+    }
+}
+
+impl Verifier {
+    fn new() -> Self {
+        Self {
+            pre_nu6_2: EraBatch::default(),
+            post_nu6_2: EraBatch::default(),
+        }
     }
 
-    /// Returns the batch verifier and channel sender from `self`,
-    /// replacing them with a new empty batch.
-    fn take(&mut self) -> (BatchValidator, &'static BatchVerifyingKey, Sender) {
+    /// Returns a mutable reference to the [`EraBatch`] for `era`.
+    fn era_batch(&mut self, era: OrchardEra) -> &mut EraBatch {
+        match era {
+            OrchardEra::PreNu6_2 => &mut self.pre_nu6_2,
+            OrchardEra::PostNu6_2 => &mut self.post_nu6_2,
+        }
+    }
+
+    /// Returns the batch verifier, verifying key, and channel sender for `era`,
+    /// replacing the batch and channel with new empty ones.
+    fn take(&mut self, era: OrchardEra) -> (BatchValidator, &'static BatchVerifyingKey, Sender) {
+        let vk = era.verifying_key();
+        let era_batch = self.era_batch(era);
+
         // Use a new verifier and channel for each batch.
-        let batch = mem::take(&mut self.batch);
-
+        let batch = mem::take(&mut era_batch.batch);
         let (tx, _) = watch::channel(None);
-        let tx = mem::replace(&mut self.tx, tx);
+        let tx = mem::replace(&mut era_batch.tx, tx);
 
-        (batch, self.vk, tx)
+        (batch, vk, tx)
     }
 
     /// Synchronously process the batch, and send the result using the channel sender.
@@ -237,15 +322,17 @@ impl Verifier {
         let _ = tx.send(Some(result));
     }
 
-    /// Flush the batch using a thread pool, and return the result via the channel.
-    /// This returns immediately, usually before the batch is completed.
+    /// Flush all per-era batches using a thread pool, sending each result via its channel.
+    /// This returns immediately, usually before the batches are completed.
     fn flush_blocking(&mut self) {
-        let (batch, vk, tx) = self.take();
+        for era in [OrchardEra::PreNu6_2, OrchardEra::PostNu6_2] {
+            let (batch, vk, tx) = self.take(era);
 
-        // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
-        //
-        // We don't care about execution order here, because this method is only called on drop.
-        tokio::task::block_in_place(|| rayon::spawn_fifo(|| Self::verify(batch, vk, tx)));
+            // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
+            //
+            // We don't care about execution order here, because this method is only called on drop.
+            tokio::task::block_in_place(|| rayon::spawn_fifo(move || Self::verify(batch, vk, tx)));
+        }
     }
 
     /// Flush the batch using a thread pool, and return the result via the channel.
@@ -271,13 +358,11 @@ impl Verifier {
     }
 
     /// Verify a single item using a thread pool, and return the result.
-    async fn verify_single_spawning(
-        item: Item,
-        pvk: &'static ItemVerifyingKey,
-    ) -> Result<(), BoxError> {
-        // TODO: Restore code for verifying single proofs or return a result from batch.validate()
+    ///
+    /// The item is verified against its own era's verifying key (see [`Item::verify_single`]).
+    async fn verify_single_spawning(item: Item) -> Result<(), BoxError> {
         // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
-        if spawn_fifo(move || item.verify_single(pvk)).await? {
+        if spawn_fifo(move || item.verify_single()).await? {
             Ok(())
         } else {
             Err("could not validate orchard proof".into())
@@ -289,9 +374,8 @@ impl fmt::Debug for Verifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = "Verifier";
         f.debug_struct(name)
-            .field("batch", &"..")
-            .field("vk", &"..")
-            .field("tx", &self.tx)
+            .field("pre_nu6_2", &"..")
+            .field("post_nu6_2", &"..")
             .finish()
     }
 }
@@ -308,9 +392,14 @@ impl Service<BatchControl<Item>> for Verifier {
     fn call(&mut self, req: BatchControl<Item>) -> Self::Future {
         match req {
             BatchControl::Item(item) => {
-                tracing::trace!("got item");
-                self.batch.queue(item);
-                let mut rx = self.tx.subscribe();
+                let era = item.era();
+                tracing::trace!(?era, "got item");
+                // Route the item into the batch for its era, and subscribe its future to
+                // that era's result channel, so each item is verified against the verifying
+                // key for the circuit era of its block.
+                let era_batch = self.era_batch(era);
+                era_batch.batch.queue(item);
+                let mut rx = era_batch.tx.subscribe();
                 Box::pin(async move {
                     match rx.changed().await {
                         Ok(()) => {
@@ -339,9 +428,18 @@ impl Service<BatchControl<Item>> for Verifier {
             BatchControl::Flush => {
                 tracing::trace!("got halo2 flush command");
 
-                let (batch, vk, tx) = self.take();
+                // Flush both era batches, each against its own verifying key. The future is
+                // ready only once both batches have completed and broadcast their results.
+                let (pre_batch, pre_vk, pre_tx) = self.take(OrchardEra::PreNu6_2);
+                let (post_batch, post_vk, post_tx) = self.take(OrchardEra::PostNu6_2);
 
-                Box::pin(Self::flush_spawning(batch, vk, tx).map(Ok))
+                Box::pin(
+                    futures::future::join(
+                        Self::flush_spawning(pre_batch, pre_vk, pre_tx),
+                        Self::flush_spawning(post_batch, post_vk, post_tx),
+                    )
+                    .map(|((), ())| Ok(())),
+                )
             }
         }
     }

--- a/zebra-consensus/src/primitives/halo2.rs
+++ b/zebra-consensus/src/primitives/halo2.rs
@@ -49,6 +49,37 @@ pub type BatchVerifyingKey = ItemVerifyingKey;
 /// This is the key used to verify individual items.
 pub type ItemVerifyingKey = VerifyingKey;
 
+// TODO(NU6.2): post-NU6.2 Orchard verification cannot be implemented here yet.
+//
+// NU6.2 re-enables Orchard actions and ships the *fixed* variable-base
+// scalar-multiplication Orchard circuit (the circuit bug that caused Orchard to
+// be temporarily disabled; see GHSA-2x4w-pxqw-58v9). Correctly verifying both
+// eras requires changes that depend entirely on UNRELEASED crates and APIs that
+// do not exist in the currently pinned `orchard 0.13`:
+//
+//   1. Dependency bump (blocked): the fixed circuit and the new verifying-key
+//      construction API (`VerifyingKey::build::<C>()` with circuit type params)
+//      live only in an unreleased `orchard`/`halo2`/`librustzcash` release.
+//      `orchard 0.13` exposes only the parameterless `VerifyingKey::build()`
+//      used below, so this cannot be changed without breaking the build.
+//
+//   2. Two verifying keys (blocked on 1): the verifying key changes at NU6.2 and
+//      one key cannot verify both eras. This static must become TWO keys — an
+//      insecure pre-NU6.2 key and the fixed post-NU6.2 key — once the typed
+//      `build::<C>()` API is available.
+//
+//   3. Height/era-based key selection (blocked on 1 & 2): pre-NU6.2 bundles must
+//      verify under the insecure key and NU6.2+ bundles under the fixed key.
+//      No height/era is currently threaded into halo2 verification, so the
+//      activation height (`NetworkUpgrade::Nu6_2.activation_height(network)`)
+//      must be plumbed from transaction verification
+//      (`zebra-consensus/src/transaction.rs`) through `Item`/`Verifier` into the
+//      key selection here, before `BatchValidator::validate`. NOTE: do NOT copy
+//      zcashd PR #176's shortcut of validating everything against the fixed key;
+//      that is incorrect for re-syncing pre-soft-fork Orchard blocks.
+//
+// See /tmp/nu6.2-gap-analysis.md blockers B1, B2, B3 for full detail. Until the
+// fixed-circuit crates are released, only the single key below is available.
 lazy_static::lazy_static! {
     /// The halo2 proof verifying key.
     pub static ref VERIFYING_KEY: ItemVerifyingKey = ItemVerifyingKey::build();

--- a/zebra-consensus/src/primitives/halo2/tests.rs
+++ b/zebra-consensus/src/primitives/halo2/tests.rs
@@ -1,0 +1,128 @@
+//! Tests for the Halo2 Orchard Action verifier.
+//!
+//! The key correctness property of this module is the **era split**: the Orchard Action circuit
+//! (and therefore its verifying key) changed at NU6.2 to fix a variable-base scalar-multiplication
+//! soundness bug (GHSA-2x4w-pxqw-58v9). A proof produced under one circuit does not verify under
+//! the other key. These tests guard that:
+//!
+//!   * a real pre-NU6.2 Orchard proof verifies under the pre-NU6.2 (insecure) key, so historical
+//!     blocks still re-sync;
+//!   * the same proof is **rejected** by the post-NU6.2 (fixed) key, so the verifier is not
+//!     "fail-open" — it does not accept whatever it is handed regardless of era; and
+//!   * [`verifier_for`] routes each network upgrade to the service holding the matching key,
+//!     with NU6.2 and every later upgrade going to the fixed-key verifier.
+
+use std::sync::Arc;
+
+use orchard::bundle::{Authorized, Bundle};
+use zcash_protocol::value::ZatBalance;
+use zebra_chain::{
+    block::Block,
+    parameters::NetworkUpgrade,
+    serialization::ZcashDeserializeInto,
+    transaction::{HashType, SigHash},
+    transparent,
+};
+
+use super::{
+    verifier_for, Item, VERIFIER_POST_NU6_2, VERIFIER_PRE_NU6_2, VERIFYING_KEY_POST_NU6_2,
+    VERIFYING_KEY_PRE_NU6_2,
+};
+
+/// Returns one real pre-NU6.2 Orchard bundle and its sighash, extracted from the mainnet test
+/// blocks.
+///
+/// These mainnet blocks are NU5-era Orchard history, mined long before NU6.2, so their proofs
+/// were produced by the historical (insecure) circuit and only verify under
+/// [`VERIFYING_KEY_PRE_NU6_2`]. Transactions with transparent inputs are skipped because their
+/// sighash needs the previous outputs they spend, which are not in the test vectors.
+fn pre_nu6_2_bundle_and_sighash() -> (Bundle<Authorized, ZatBalance>, SigHash) {
+    for bytes in zebra_test::vectors::MAINNET_BLOCKS.values() {
+        let block: Block = bytes
+            .zcash_deserialize_into()
+            .expect("hard-coded test vector must deserialize");
+
+        for tx in &block.transactions {
+            if tx.orchard_shielded_data().is_none() || !tx.inputs().is_empty() {
+                continue;
+            }
+
+            let all_previous_outputs: Arc<Vec<transparent::Output>> = Arc::new(Vec::new());
+            let Ok(sighasher) = tx.sighasher(NetworkUpgrade::Nu5, all_previous_outputs) else {
+                continue;
+            };
+            let Some(bundle) = sighasher.orchard_bundle() else {
+                continue;
+            };
+
+            let sighash = sighasher.sighash(HashType::ALL, None);
+            return (bundle, sighash);
+        }
+    }
+
+    panic!("mainnet test blocks must contain a transparent-input-free Orchard transaction");
+}
+
+/// A real pre-NU6.2 Orchard proof verifies under the pre-NU6.2 key and is rejected by the
+/// post-NU6.2 key.
+///
+/// This is the core guard for the era split: it proves the two keys are genuinely different and
+/// that selecting the wrong era's key causes a hard verification failure. If the verifier ever
+/// "fails open" (e.g. validates everything against a single key, like the rejected zcashd WIP
+/// shortcut), the wrong-key assertion below would fail.
+#[test]
+fn pre_nu6_2_proof_only_verifies_under_pre_nu6_2_key() {
+    let (bundle, sighash) = pre_nu6_2_bundle_and_sighash();
+
+    // Correct era key: the historical proof must verify, so pre-NU6.2 history still re-syncs.
+    assert!(
+        Item::new(bundle.clone(), sighash).verify_single(&VERIFYING_KEY_PRE_NU6_2),
+        "a real pre-NU6.2 Orchard proof must verify under the pre-NU6.2 (insecure) key"
+    );
+
+    // Wrong era key: the same proof must be rejected. This is the not-fail-open guarantee.
+    assert!(
+        !Item::new(bundle, sighash).verify_single(&VERIFYING_KEY_POST_NU6_2),
+        "a pre-NU6.2 Orchard proof must be REJECTED by the post-NU6.2 (fixed) key; \
+         verifying it would mean the era selection is fail-open"
+    );
+}
+
+/// [`verifier_for`] routes each upgrade to the service that holds the correct era key.
+///
+/// We compare service identity by pointer: `verifier_for` returns a borrow of one of the two
+/// global `Lazy` services, so the pre-NU6.2 upgrades must alias [`VERIFIER_PRE_NU6_2`] and NU6.2+
+/// must alias [`VERIFIER_POST_NU6_2`]. Because the pre/post split is what binds an item to a key,
+/// routing to the wrong service is exactly routing to the wrong key.
+///
+/// This is an async test because forcing the global `Lazy` verifiers builds their `Batch` layer,
+/// which spawns a worker task and therefore needs a Tokio runtime.
+#[tokio::test(flavor = "multi_thread")]
+async fn verifier_for_routes_each_upgrade_to_the_correct_key() {
+    // Deref each `Lazy` to the inner service it guards, matching what `verifier_for` returns, so
+    // the pointer comparisons below compare the same service type.
+    let pre: &'static super::VerifierService = &VERIFIER_PRE_NU6_2;
+    let post: &'static super::VerifierService = &VERIFIER_POST_NU6_2;
+
+    // Everything before NU6.2 (including upgrades from before Orchard existed) routes to the
+    // insecure key, which is the only key any pre-NU6.2 Orchard history verifies under.
+    for nu in [
+        NetworkUpgrade::Nu5,
+        NetworkUpgrade::Nu6,
+        NetworkUpgrade::Nu6_1,
+    ] {
+        assert!(
+            std::ptr::eq(verifier_for(nu), pre),
+            "{nu:?} must route to the pre-NU6.2 (insecure) verifier"
+        );
+    }
+
+    // NU6.2 and every later upgrade route to the fixed key. Nu7 guards that "NU6.2 and later"
+    // does not silently fall back to the insecure verifier for future upgrades.
+    for nu in [NetworkUpgrade::Nu6_2, NetworkUpgrade::Nu7] {
+        assert!(
+            std::ptr::eq(verifier_for(nu), post),
+            "{nu:?} must route to the post-NU6.2 (fixed) verifier"
+        );
+    }
+}

--- a/zebra-consensus/src/primitives/halo2/tests.rs
+++ b/zebra-consensus/src/primitives/halo2/tests.rs
@@ -2,7 +2,7 @@
 //!
 //! The key correctness property of this module is the **era split**: the Orchard Action circuit
 //! (and therefore its verifying key) changed at NU6.2 to fix a variable-base scalar-multiplication
-//! soundness bug (GHSA-2x4w-pxqw-58v9). A proof produced under one circuit does not verify under
+//! soundness bug (GHSA-jfw5-j458-pfv6). A proof produced under one circuit does not verify under
 //! the other key. These tests guard that:
 //!
 //!   * a real pre-NU6.2 Orchard proof verifies under the pre-NU6.2 (insecure) key, so historical

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -418,6 +418,30 @@ where
                 return Err(TransactionError::Other("transaction has Orchard actions (temporarily disabled)".into()));
             }
 
+            // From the network upgrade that re-enables Orchard actions (NU6.2), require
+            // that any Orchard proof has the canonical length for its number of actions.
+            // A proof that is present but not canonically sized can be padded with
+            // arbitrary trailing data without affecting its validity, allowing excess
+            // bandwidth and storage costs to be imposed while paying only fees sized to a
+            // canonical proof (GHSA-2x4w-pxqw-58v9).
+            //
+            // This is a constricting rule, so it is gated on that network upgrade:
+            // Orchard actions mined before it, under earlier rules that did not enforce
+            // the proof size, must remain valid so that nodes can sync and reindex the
+            // chain before the soft fork that temporarily disabled Orchard. Orchard
+            // bundles are deserialized leniently, so the size is checked here, where the
+            // block height is available, rather than during parsing.
+            //
+            // The gate is currently inert pending the definition of NU6.2; see
+            // `Network::orchard_canonical_proof_size_rule_active`.
+            if network.orchard_canonical_proof_size_rule_active(req.height()) {
+                if let Some(orchard_shielded_data) = tx.orchard_shielded_data() {
+                    if !orchard_shielded_data.proof_size_is_canonical() {
+                        return Err(TransactionError::OrchardProofSize);
+                    }
+                }
+            }
+
             // Validate the coinbase input consensus rules
             if req.is_mempool() && tx.is_coinbase() {
                 return Err(TransactionError::CoinbaseInMempool);

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -423,7 +423,7 @@ where
             // A proof that is present but not canonically sized can be padded with
             // arbitrary trailing data without affecting its validity, allowing excess
             // bandwidth and storage costs to be imposed while paying only fees sized to a
-            // canonical proof (GHSA-2x4w-pxqw-58v9).
+            // canonical proof (GHSA-jfw5-j458-pfv6).
             //
             // This is a constricting rule, so it is gated on that network upgrade:
             // Orchard actions mined before it, under earlier rules that did not enforce
@@ -1196,7 +1196,7 @@ where
     /// `network_upgrade` is the network upgrade active at the verified transaction's block
     /// height. It selects the Orchard verifier: the Orchard Action circuit (and its verifying
     /// key) changed at NU6.2 to fix the variable-base scalar-multiplication bug
-    /// (GHSA-2x4w-pxqw-58v9), so pre-NU6.2 bundles must be verified against the historical
+    /// (GHSA-jfw5-j458-pfv6), so pre-NU6.2 bundles must be verified against the historical
     /// (insecure) key and NU6.2+ bundles against the fixed key. A proof from one era does not
     /// verify under the other era's key. [`primitives::halo2::verifier_for`] maps the upgrade to
     /// the verifier holding the matching key; the two verifiers keep separate batches, so eras

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -414,7 +414,7 @@ where
             //
             // This will be treated as "Rules that apply generally before the next NU"
             // when we add the NU that re-enables Orchard actions.
-            if network.temporary_orchard_disabling_soft_fork_active(req.height()) && tx.orchard_shielded_data().is_some() {
+            if network.is_orchard_temporarily_disabled(req.height()) && tx.orchard_shielded_data().is_some() {
                 return Err(TransactionError::Other("transaction has Orchard actions (temporarily disabled)".into()));
             }
 
@@ -909,7 +909,8 @@ where
             | NetworkUpgrade::Canopy
             | NetworkUpgrade::Nu5
             | NetworkUpgrade::Nu6
-            | NetworkUpgrade::Nu6_1 => Ok(()),
+            | NetworkUpgrade::Nu6_1
+            | NetworkUpgrade::Nu6_2 => Ok(()),
 
             #[cfg(zcash_unstable = "zfuture")]
             NetworkUpgrade::ZFuture => Ok(()),
@@ -993,6 +994,7 @@ where
             NetworkUpgrade::Nu5
             | NetworkUpgrade::Nu6
             | NetworkUpgrade::Nu6_1
+            | NetworkUpgrade::Nu6_2
             | NetworkUpgrade::Nu7 => Ok(()),
 
             #[cfg(zcash_unstable = "zfuture")]

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -1193,11 +1193,13 @@ where
     /// Verifies a transaction's Orchard shielded data.
     ///
     /// `network_upgrade` is the network upgrade active at the verified transaction's block
-    /// height. It selects the Orchard verifying key: the Orchard Action circuit (and its
-    /// verifying key) changed at NU6.2 to fix the variable-base scalar-multiplication bug
+    /// height. It selects the Orchard verifier: the Orchard Action circuit (and its verifying
+    /// key) changed at NU6.2 to fix the variable-base scalar-multiplication bug
     /// (GHSA-2x4w-pxqw-58v9), so pre-NU6.2 bundles must be verified against the historical
-    /// (insecure) key and NU6.2+ bundles against the fixed key. A proof from one era does
-    /// not verify under the other era's key.
+    /// (insecure) key and NU6.2+ bundles against the fixed key. A proof from one era does not
+    /// verify under the other era's key. [`primitives::halo2::verifier_for`] maps the upgrade to
+    /// the verifier holding the matching key; the two verifiers keep separate batches, so eras
+    /// are never mixed.
     fn verify_orchard_bundle(
         bundle: Option<::orchard::bundle::Bundle<::orchard::bundle::Authorized, ZatBalance>>,
         sighash: &SigHash,
@@ -1206,12 +1208,6 @@ where
         let mut async_checks = AsyncChecks::new();
 
         if let Some(bundle) = bundle {
-            let era = if network_upgrade >= NetworkUpgrade::Nu6_2 {
-                primitives::halo2::OrchardEra::PostNu6_2
-            } else {
-                primitives::halo2::OrchardEra::PreNu6_2
-            };
-
             // # Consensus
             //
             // > The proof 𝜋 MUST be valid given a primary input (cv, rt^{Orchard},
@@ -1223,10 +1219,13 @@ where
             // aggregated Halo2 proof per transaction, even with multiple
             // Actions in one transaction. So we queue it for verification
             // only once instead of queuing it up for every Action description.
+            //
+            // Route the bundle to the verifier for its circuit era: pre-NU6.2 bundles only
+            // verify under the insecure key, NU6.2+ bundles only under the fixed key.
             async_checks.push(
-                primitives::halo2::VERIFIER
+                primitives::halo2::verifier_for(network_upgrade)
                     .clone()
-                    .oneshot(primitives::halo2::Item::new(bundle, *sighash, era)),
+                    .oneshot(primitives::halo2::Item::new(bundle, *sighash)),
             );
         }
 

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -432,9 +432,8 @@ where
             // bundles are deserialized leniently, so the size is checked here, where the
             // block height is available, rather than during parsing.
             //
-            // The gate is currently inert because NU6.2 has no committed activation height on
-            // Mainnet or the default Testnet; it activates automatically once that height is
-            // added to MAINNET/TESTNET_ACTIVATION_HEIGHTS. See
+            // The gate activates at the NU6.2 activation height committed in
+            // MAINNET/TESTNET_ACTIVATION_HEIGHTS. See
             // `Network::orchard_canonical_proof_size_rule_active`.
             if network.orchard_canonical_proof_size_rule_active(req.height()) {
                 if let Some(orchard_shielded_data) = tx.orchard_shielded_data() {

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -432,7 +432,9 @@ where
             // bundles are deserialized leniently, so the size is checked here, where the
             // block height is available, rather than during parsing.
             //
-            // The gate is currently inert pending the definition of NU6.2; see
+            // The gate is currently inert because NU6.2 has no committed activation height on
+            // Mainnet or the default Testnet; it activates automatically once that height is
+            // added to MAINNET/TESTNET_ACTIVATION_HEIGHTS. See
             // `Network::orchard_canonical_proof_size_rule_active`.
             if network.orchard_canonical_proof_size_rule_active(req.height()) {
                 if let Some(orchard_shielded_data) = tx.orchard_shielded_data() {

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -970,7 +970,7 @@ where
             cached_ffi_transaction,
         )?
         .and(Self::verify_sapling_bundle(sapling_bundle, &sighash))
-        .and(Self::verify_orchard_bundle(orchard_bundle, &sighash)))
+        .and(Self::verify_orchard_bundle(orchard_bundle, &sighash, nu)))
     }
 
     /// Verifies if a V5 `transaction` is supported by `network_upgrade`.
@@ -1191,13 +1191,27 @@ where
     }
 
     /// Verifies a transaction's Orchard shielded data.
+    ///
+    /// `network_upgrade` is the network upgrade active at the verified transaction's block
+    /// height. It selects the Orchard verifying key: the Orchard Action circuit (and its
+    /// verifying key) changed at NU6.2 to fix the variable-base scalar-multiplication bug
+    /// (GHSA-2x4w-pxqw-58v9), so pre-NU6.2 bundles must be verified against the historical
+    /// (insecure) key and NU6.2+ bundles against the fixed key. A proof from one era does
+    /// not verify under the other era's key.
     fn verify_orchard_bundle(
         bundle: Option<::orchard::bundle::Bundle<::orchard::bundle::Authorized, ZatBalance>>,
         sighash: &SigHash,
+        network_upgrade: NetworkUpgrade,
     ) -> AsyncChecks {
         let mut async_checks = AsyncChecks::new();
 
         if let Some(bundle) = bundle {
+            let era = if network_upgrade >= NetworkUpgrade::Nu6_2 {
+                primitives::halo2::OrchardEra::PostNu6_2
+            } else {
+                primitives::halo2::OrchardEra::PreNu6_2
+            };
+
             // # Consensus
             //
             // > The proof 𝜋 MUST be valid given a primary input (cv, rt^{Orchard},
@@ -1212,7 +1226,7 @@ where
             async_checks.push(
                 primitives::halo2::VERIFIER
                     .clone()
-                    .oneshot(primitives::halo2::Item::new(bundle, *sighash)),
+                    .oneshot(primitives::halo2::Item::new(bundle, *sighash, era)),
             );
         }
 

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -2249,7 +2249,7 @@ async fn v5_transaction_with_exceeding_expiry_height() {
         expiry_height,
         sapling_shielded_data: None,
         orchard_shielded_data: None,
-        network_upgrade: NetworkUpgrade::Nu6_1,
+        network_upgrade: NetworkUpgrade::Nu6_2,
     };
 
     let transaction_hash = transaction.hash();

--- a/zebra-consensus/src/transaction/tests/prop.rs
+++ b/zebra-consensus/src/transaction/tests/prop.rs
@@ -362,7 +362,7 @@ fn sanitize_transaction_version(
             Overwinter => 3,
             Sapling | Blossom | Heartwood | Canopy => 4,
             // FIXME: Use 6 for Nu7
-            Nu5 | Nu6 | Nu6_1 | Nu7 => 5,
+            Nu5 | Nu6 | Nu6_1 | Nu6_2 | Nu7 => 5,
 
             #[cfg(zcash_unstable = "zfuture")]
             NetworkUpgrade::ZFuture => u8::MAX,

--- a/zebra-network/CHANGELOG.md
+++ b/zebra-network/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.0.0] - 2026-06-02
+
+### Changed
+
+- Require network protocol version 170150 for NU6.2 on Mainnet, Testnet, and Regtest.
+- Bump `CURRENT_NETWORK_PROTOCOL_VERSION` to 170150.
+
 ## [7.0.0] - 2026-05-28
 
 This release fixes three network security issues:

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-network"
-version = "7.0.1"
+version = "8.0.0"
 authors = ["Zcash Foundation <zebra@zfnd.org>", "Tower Maintainers <team@tower-rs.com>"]
 description = "Networking code for Zebra"
 # # Legal
@@ -85,7 +85,7 @@ howudoin = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "8.0.1", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "9.0.0", features = ["async-error"] }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -341,9 +341,9 @@ pub const TIMESTAMP_TRUNCATION_SECONDS: u32 = 30 * 60;
 /// This version of Zebra draws the current network protocol version from
 /// [ZIP-255](https://zips.z.cash/zip-0255).
 // TODO: Update this constant to the correct value after NU7 activation (see NU deployment ZIPs),
-pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_140);
-// pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_150); // NU7 Testnet.
-// pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_160); // NU7 Mainnet.
+pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_150); // NU6.2 (Mainnet + Testnet).
+// pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_160); // NU7 Testnet.
+// pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_170); // NU7 Mainnet.
 
 /// The default RTT estimate for peer responses.
 ///

--- a/zebra-network/src/constants.rs
+++ b/zebra-network/src/constants.rs
@@ -342,8 +342,8 @@ pub const TIMESTAMP_TRUNCATION_SECONDS: u32 = 30 * 60;
 /// [ZIP-255](https://zips.z.cash/zip-0255).
 // TODO: Update this constant to the correct value after NU7 activation (see NU deployment ZIPs),
 pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_150); // NU6.2 (Mainnet + Testnet).
-// pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_160); // NU7 Testnet.
-// pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_170); // NU7 Mainnet.
+                                                                        // pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_160); // NU7 Testnet.
+                                                                        // pub const CURRENT_NETWORK_PROTOCOL_VERSION: Version = Version(170_170); // NU7 Mainnet.
 
 /// The default RTT estimate for peer responses.
 ///

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -229,7 +229,7 @@ mod test {
 
         let highest_network_upgrade = NetworkUpgrade::current(network, block::Height::MAX);
         assert!(
-            matches!(highest_network_upgrade, Nu6 | Nu6_1 | Nu7),
+            matches!(highest_network_upgrade, Nu6 | Nu6_1 | Nu6_2 | Nu7),
             "expected coverage of all network upgrades: \
             add the new network upgrade to the list in this test"
         );
@@ -244,6 +244,7 @@ mod test {
             Nu5,
             Nu6,
             Nu6_1,
+            Nu6_2,
             Nu7,
         ] {
             let height = network_upgrade.activation_height(network);

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -116,8 +116,14 @@ impl Version {
                 170_130
             }
             (Mainnet, Nu6_1) => 170_140,
-            (Testnet(params), Nu7) if params.is_default_testnet() || params.is_regtest() => 170_150,
-            (Mainnet, Nu7) => 170_160,
+            (Testnet(params), Nu6_2) if params.is_default_testnet() || params.is_regtest() => {
+                170_150
+            }
+            (Mainnet, Nu6_2) => 170_160,
+            // TODO(NU6.2): these Nu7 protocol versions are provisional, bumped above Nu6_2's
+            // 170_150/170_160. Update them when the real Nu7 values are specified.
+            (Testnet(params), Nu7) if params.is_default_testnet() || params.is_regtest() => 170_160,
+            (Mainnet, Nu7) => 170_170,
 
             // It should be fine to reject peers with earlier network protocol versions on custom testnets for now.
             (Testnet(_), _) => CURRENT_NETWORK_PROTOCOL_VERSION.0,

--- a/zebra-network/src/protocol/external/types.rs
+++ b/zebra-network/src/protocol/external/types.rs
@@ -119,9 +119,9 @@ impl Version {
             (Testnet(params), Nu6_2) if params.is_default_testnet() || params.is_regtest() => {
                 170_150
             }
-            (Mainnet, Nu6_2) => 170_160,
+            (Mainnet, Nu6_2) => 170_150,
             // TODO(NU6.2): these Nu7 protocol versions are provisional, bumped above Nu6_2's
-            // 170_150/170_160. Update them when the real Nu7 values are specified.
+            // 170_150. Update them when the real Nu7 values are specified.
             (Testnet(params), Nu7) if params.is_default_testnet() || params.is_regtest() => 170_160,
             (Mainnet, Nu7) => 170_170,
 

--- a/zebra-node-services/CHANGELOG.md
+++ b/zebra-node-services/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.0] - 2026-06-02
+
+### Changed
+
+- Update to `zebra-chain` 9.0.0 (NU6.2 support). No other changes to this crate.
+
 ## [6.0.0] - 2026-05-28
 
 ### Added

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-node-services"
-version = "6.0.0"
+version = "7.0.0"
 authors.workspace = true
 description = "The interfaces of some Zebra node services"
 license.workspace = true
@@ -31,7 +31,7 @@ rpc-client = [
 ]
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain" , version = "8.0.1" }
+zebra-chain = { path = "../zebra-chain" , version = "9.0.0" }
 tower = { workspace = true }
 
 # Optional dependencies

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.0.0] - 2026-06-02
+
+### Changed
+
+- `getblocktemplate` block proposals now support the NU6.2 network upgrade.
+
 ## [8.0.0] - 2026-05-28
 
 This release fixes two RPC security issues:

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-rpc"
-version = "8.0.0"
+version = "9.0.0"
 authors.workspace = true
 description = "A Zebra JSON Remote Procedure Call (JSON-RPC) interface"
 license.workspace = true
@@ -109,16 +109,16 @@ zcash_transparent = { workspace = true }
 # Test-only feature proptest-impl
 proptest = { workspace = true, optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "8.0.1", features = [
+zebra-chain = { path = "../zebra-chain", version = "9.0.0", features = [
     "json-conversion",
 ] }
-zebra-consensus = { path = "../zebra-consensus", version = "7.0.1" }
-zebra-network = { path = "../zebra-network", version = "7.0.1" }
-zebra-node-services = { path = "../zebra-node-services", version = "6.0.0", features = [
+zebra-consensus = { path = "../zebra-consensus", version = "8.0.0" }
+zebra-network = { path = "../zebra-network", version = "8.0.0" }
+zebra-node-services = { path = "../zebra-node-services", version = "7.0.0", features = [
     "rpc-client",
 ] }
-zebra-script = { path = "../zebra-script", version = "7.0.1" }
-zebra-state = { path = "../zebra-state", version = "7.0.1" }
+zebra-script = { path = "../zebra-script", version = "8.0.0" }
+zebra-state = { path = "../zebra-state", version = "8.0.0" }
 
 [build-dependencies]
 openrpsee = { workspace = true }
@@ -136,16 +136,16 @@ proptest = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zebra-chain = { path = "../zebra-chain", version = "8.0.1", features = [
+zebra-chain = { path = "../zebra-chain", version = "9.0.0", features = [
     "proptest-impl",
 ] }
-zebra-consensus = { path = "../zebra-consensus", version = "7.0.1", features = [
+zebra-consensus = { path = "../zebra-consensus", version = "8.0.0", features = [
     "proptest-impl",
 ] }
-zebra-network = { path = "../zebra-network", version = "7.0.1", features = [
+zebra-network = { path = "../zebra-network", version = "8.0.0", features = [
     "proptest-impl",
 ] }
-zebra-state = { path = "../zebra-state", version = "7.0.1", features = [
+zebra-state = { path = "../zebra-state", version = "8.0.0", features = [
     "proptest-impl",
 ] }
 

--- a/zebra-rpc/src/methods/tests/snapshots/get_blockchain_info@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_blockchain_info@mainnet_10.snap
@@ -91,6 +91,11 @@ expression: info
       "name": "NU6.1",
       "activationheight": 3146400,
       "status": "pending"
+    },
+    "5437f330": {
+      "name": "NU6.2",
+      "activationheight": 3364600,
+      "status": "pending"
     }
   },
   "consensus": {

--- a/zebra-rpc/src/methods/tests/snapshots/get_blockchain_info@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_blockchain_info@testnet_10.snap
@@ -91,6 +91,11 @@ expression: info
       "name": "NU6.1",
       "activationheight": 3536500,
       "status": "pending"
+    },
+    "5437f330": {
+      "name": "NU6.2",
+      "activationheight": 4052000,
+      "status": "pending"
     }
   },
   "consensus": {

--- a/zebra-rpc/src/methods/tests/snapshots/get_info@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_info@mainnet_10.snap
@@ -6,7 +6,7 @@ expression: info
   "version": 100,
   "build": "v0.0.1",
   "subversion": "[SubVersion]",
-  "protocolversion": 170140,
+  "protocolversion": 170150,
   "blocks": 10,
   "connections": 0,
   "difficulty": 1.0,

--- a/zebra-rpc/src/methods/tests/snapshots/get_info@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_info@testnet_10.snap
@@ -6,7 +6,7 @@ expression: info
   "version": 100,
   "build": "v0.0.1",
   "subversion": "[SubVersion]",
-  "protocolversion": 170140,
+  "protocolversion": 170150,
   "blocks": 10,
   "connections": 0,
   "difficulty": 1.0,

--- a/zebra-rpc/src/methods/tests/snapshots/get_network_info@mainnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_network_info@mainnet_10.snap
@@ -5,7 +5,7 @@ expression: get_network_info
 {
   "version": 100,
   "subversion": "RPC test",
-  "protocolversion": 170140,
+  "protocolversion": 170150,
   "localservices": "0000000000000001",
   "timeoffset": 0,
   "connections": 1,

--- a/zebra-rpc/src/methods/tests/snapshots/get_network_info@testnet_10.snap
+++ b/zebra-rpc/src/methods/tests/snapshots/get_network_info@testnet_10.snap
@@ -5,7 +5,7 @@ expression: get_network_info
 {
   "version": 100,
   "subversion": "RPC test",
-  "protocolversion": 170140,
+  "protocolversion": 170150,
   "localservices": "0000000000000001",
   "timeoffset": 0,
   "connections": 1,

--- a/zebra-rpc/src/methods/types/get_block_template/proposal.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/proposal.rs
@@ -212,9 +212,11 @@ pub fn proposal_block_from_template(
 
     let commitment_bytes = match NetworkUpgrade::current(net, height) {
         NetworkUpgrade::Canopy => chain_history_root.bytes_in_serialized_order(),
-        NetworkUpgrade::Nu5 | NetworkUpgrade::Nu6 | NetworkUpgrade::Nu6_1 | NetworkUpgrade::Nu7 => {
-            block_commitments_hash.bytes_in_serialized_order()
-        }
+        NetworkUpgrade::Nu5
+        | NetworkUpgrade::Nu6
+        | NetworkUpgrade::Nu6_1
+        | NetworkUpgrade::Nu6_2
+        | NetworkUpgrade::Nu7 => block_commitments_hash.bytes_in_serialized_order(),
         _ => Err(SerializationError::Parse(
             "Zebra does not support generating pre-Canopy block templates",
         ))?,

--- a/zebra-script/CHANGELOG.md
+++ b/zebra-script/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.0.0] - 2026-06-02
+
+### Changed
+
+- Update to `zebra-chain` 9.0.0 (NU6.2 support). No other changes to this crate.
+
 ## [7.0.1] - 2026-05-29
 
 This release fixes one consensus security issue:

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-script"
-version = "7.0.1"
+version = "8.0.0"
 authors.workspace = true
 description = "Zebra script verification wrapping zcashd's zcash_script library"
 license.workspace = true
@@ -26,7 +26,7 @@ comparison-interpreter = []
 libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
-zebra-chain = { path = "../zebra-chain", version = "8.0.1" }
+zebra-chain = { path = "../zebra-chain", version = "9.0.0" }
 
 rand = { workspace = true }
 thiserror = { workspace = true }

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.0.0] - 2026-06-02
+
+### Changed
+
+- Release for NU6.2 support (updates `zebra-chain` to 9.0.0). Internal refactor of the
+  chain-tip mempool-reset height computation; no public API or behavior change.
+
 ## [7.0.0] - 2026-05-28
 
 This release fixes four state security issues:

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-state"
-version = "7.0.1"
+version = "8.0.0"
 authors.workspace = true
 description = "State contextual verification and storage code for Zebra"
 license.workspace = true
@@ -78,8 +78,8 @@ sapling-crypto = { workspace = true }
 elasticsearch = { workspace = true, features = ["rustls-tls"], optional = true }
 serde_json = { workspace = true, optional = true }
 
-zebra-node-services = { path = "../zebra-node-services", version = "6.0.0" }
-zebra-chain = { path = "../zebra-chain", version = "8.0.1", features = ["async-error"] }
+zebra-node-services = { path = "../zebra-node-services", version = "7.0.0" }
+zebra-chain = { path = "../zebra-chain", version = "9.0.0", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { workspace = true, optional = true }
@@ -109,7 +109,7 @@ jubjub = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zebra-chain = { path = "../zebra-chain", version = "8.0.1", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "9.0.0", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/", version = "3.0.0" }
 
 [lints]

--- a/zebra-state/src/service/chain_tip.rs
+++ b/zebra-state/src/service/chain_tip.rs
@@ -600,13 +600,20 @@ impl ChainTipChange {
         // upgrade, but it has the same memory-pool requirement: once the chain tip
         // reaches its activation height, the mempool must drop any transactions
         // that are no longer valid under the new rule. So we also reset there.
+        // The next height is what the mempool verifies against; it always exists because the
+        // chain tip height is far below `Height::MAX`.
+        // TODO: confirm whether resetting at `activation_height - 1` (the `.next()` semantics
+        // below) is intended for every network upgrade, or only for the temporary-disable soft
+        // fork; ZIP-200 phrases the reset as "when the tip reaches ACTIVATION_HEIGHT".
+        let next_height = block
+            .height
+            .next()
+            .expect("chain tip height is far below Height::MAX");
         if Some(block.previous_block_hash) != self.last_change_hash
-            || NetworkUpgrade::is_activation_height(&self.network, block.height.next().unwrap())
+            || NetworkUpgrade::is_activation_height(&self.network, next_height)
             || self
                 .network
-                .is_temporary_orchard_disabling_soft_fork_activation_height(
-                    block.height.next().unwrap(),
-                )
+                .is_temporary_orchard_disabling_soft_fork_activation_height(next_height)
         {
             TipAction::reset_with(block)
         } else {

--- a/zebra-state/src/service/chain_tip/tests/prop.rs
+++ b/zebra-state/src/service/chain_tip/tests/prop.rs
@@ -128,11 +128,22 @@ proptest! {
             let old_last_change_hash = chain_tip_change.last_change_hash;
 
             let new_action = expected_tip.and_then(|(chain_tip, block)| {
+                // Mirror `ChainTipChange::action`: the mempool verifies against the *next*
+                // height, so a reset happens at `activation_height - 1`, and also at the
+                // temporary-Orchard-disabling soft fork's activation height (see commit
+                // 548672c5e). `next` always succeeds because the tip is far below `Height::MAX`.
+                let next_height = chain_tip
+                    .height
+                    .next()
+                    .expect("chain tip height is far below Height::MAX");
+
                 if Some(chain_tip.hash) == old_last_change_hash {
                     // some updates don't do anything, so there's no new action
                     None
                 } else if Some(chain_tip.previous_block_hash) != old_last_change_hash
-                    || NetworkUpgrade::is_activation_height(&network, chain_tip.height)
+                    || NetworkUpgrade::is_activation_height(&network, next_height)
+                    || network
+                        .is_temporary_orchard_disabling_soft_fork_activation_height(next_height)
                 {
                     Some(TipAction::reset_with(block.0.into()))
                 } else {

--- a/zebra-state/src/service/finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/finalized_state/tests/prop.rs
@@ -73,6 +73,7 @@ fn all_upgrades_and_wrong_commitments_with_fake_activation_heights() -> Result<(
             nu5: Some(35),
             nu6: Some(40),
             nu6_1: Some(45),
+            nu6_2: Some(47),
             nu7: Some(50),
         })
         .expect("failed to set activation heights")

--- a/zebra-utils/CHANGELOG.md
+++ b/zebra-utils/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.0] - 2026-06-02
+
+### Changed
+
+- Update to `zebra-chain` 9.0.0, `zebra-rpc` 9.0.0, and `zebra-node-services` 7.0.0
+  (NU6.2 support). No other changes to this crate.
+
 ## [6.0.0] - 2026-05-01
 
 ### Changed

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-utils"
-version = "6.0.0"
+version = "7.0.0"
 authors.workspace = true
 description = "Developer tools for Zebra maintenance and testing"
 license.workspace = true
@@ -60,11 +60,11 @@ tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 
-zebra-node-services = { path = "../zebra-node-services", version = "6.0.0" }
-zebra-chain = { path = "../zebra-chain", version = "8.0.1" }
+zebra-node-services = { path = "../zebra-node-services", version = "7.0.0" }
+zebra-chain = { path = "../zebra-chain", version = "9.0.0" }
 
 # These crates are needed for the block-template-to-proposal binary
-zebra-rpc = { path = "../zebra-rpc", version = "8.0.0" }
+zebra-rpc = { path = "../zebra-rpc", version = "9.0.0" }
 
 # These crates are needed for the zebra-checkpoints binary
 itertools = { workspace = true, optional = true }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate metadata
 name = "zebrad"
-version = "4.5.3"
+version = "5.0.0"
 authors.workspace = true
 description = "The Zcash Foundation's independent, consensus-compatible implementation of a Zcash node"
 license.workspace = true
@@ -148,20 +148,20 @@ tx_v6 = ["zebra-chain/tx_v6", "zebra-state/tx_v6", "zebra-consensus/tx_v6", "zeb
 comparison-interpreter = ["zebra-script/comparison-interpreter"]
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain", version = "8.0.1" }
-zebra-consensus = { path = "../zebra-consensus", version = "7.0.1" }
-zebra-network = { path = "../zebra-network", version = "7.0.1" }
-zebra-node-services = { path = "../zebra-node-services", version = "6.0.0", features = ["rpc-client"] }
-zebra-rpc = { path = "../zebra-rpc", version = "8.0.0" }
-zebra-state = { path = "../zebra-state", version = "7.0.1" }
+zebra-chain = { path = "../zebra-chain", version = "9.0.0" }
+zebra-consensus = { path = "../zebra-consensus", version = "8.0.0" }
+zebra-network = { path = "../zebra-network", version = "8.0.0" }
+zebra-node-services = { path = "../zebra-node-services", version = "7.0.0", features = ["rpc-client"] }
+zebra-rpc = { path = "../zebra-rpc", version = "9.0.0" }
+zebra-state = { path = "../zebra-state", version = "8.0.0" }
 # zebra-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
 # enabling it in the other imports of zcash-script.)
-zebra-script = { path = "../zebra-script", version = "7.0.1" }
+zebra-script = { path = "../zebra-script", version = "8.0.0" }
 zcash_script = { workspace = true }
 
 # Required for crates.io publishing, but it's only used in tests
-zebra-utils = { path = "../zebra-utils", version = "6.0.0", optional = true }
+zebra-utils = { path = "../zebra-utils", version = "7.0.0", optional = true }
 
 abscissa_core = { workspace = true }
 clap = { workspace = true, features = ["cargo"] }
@@ -293,10 +293,10 @@ proptest-derive = { workspace = true }
 # enable span traces and track caller in tests
 color-eyre = { workspace = true }
 
-zebra-chain = { path = "../zebra-chain", version = "8.0.1", features = ["proptest-impl"] }
-zebra-consensus = { path = "../zebra-consensus", version = "7.0.1", features = ["proptest-impl"] }
-zebra-network = { path = "../zebra-network", version = "7.0.1", features = ["proptest-impl"] }
-zebra-state = { path = "../zebra-state", version = "7.0.1", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "9.0.0", features = ["proptest-impl"] }
+zebra-consensus = { path = "../zebra-consensus", version = "8.0.0", features = ["proptest-impl"] }
+zebra-network = { path = "../zebra-network", version = "8.0.0", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", version = "8.0.0", features = ["proptest-impl"] }
 
 zebra-test = { path = "../zebra-test", version = "3.0.0" }
 
@@ -309,7 +309,7 @@ zebra-test = { path = "../zebra-test", version = "3.0.0" }
 # When `-Z bindeps` is stabilised, enable this binary dependency instead:
 # https://github.com/rust-lang/cargo/issues/9096
 # zebra-utils { path = "../zebra-utils", artifact = "bin:zebra-checkpoints" }
-zebra-utils = { path = "../zebra-utils", version = "6.0.0" }
+zebra-utils = { path = "../zebra-utils", version = "7.0.0" }
 
 [package.metadata.cargo-udeps.ignore]
 # These dependencies are false positives - they are actually used


### PR DESCRIPTION
## Motivation

Deploy the **NU6.2** network upgrade, which re-enables Orchard actions — temporarily disabled by the v4.5.3 soft fork — using the **fixed** Orchard Action circuit, and adds the canonical Orchard proof-size consensus rule. NU6.2 fixes a critical issue in the Orchard pool (GHSA-jfw5-j458-pfv6).

NU6.2 activates at **Mainnet height 3,364,600** and **Testnet height 4,052,000**.

## Solution

- Add `NetworkUpgrade::Nu6_2` (consensus branch id `0x5437f330`, protocol version `170150` on Mainnet/Testnet/Regtest).
- Re-enable Orchard actions at NU6.2, upper-bounding the v4.5.3 temporary-disable soft fork (Mainnet `3,363,426` / Testnet `4,048,500`).
- Add the canonical Orchard proof-size consensus rule, gated on NU6.2: delegates to `orchard::Proof::expected_proof_size` and rejects a non-canonically-sized proof with `TransactionError::OrchardProofSize`.
- Route Orchard proof verification to a per-circuit Halo2 verifying key (`InsecurePreNu6_2` / `FixedPostNu6_2`) by network-upgrade era (fail-closed), so pre-NU6.2 history still verifies on resync.
- Depend on the **published crates.io releases** of the fixed dependencies (orchard 0.14.0, zcash_primitives 0.28.0, halo2_gadgets 0.5.0, …) — no git or vendored sources.

## Test evidence

- `cargo build --workspace --locked` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅
- `cargo test -p zebra-chain -p zebra-consensus` ✅ (zebra-chain 251, zebra-consensus 113)

Consensus parity with zcashd `release-v6.20.0` was independently verified — activation heights, consensus branch id, protocol version, proof-size rule, and dual verifying-key selection all match — and the published `orchard 0.14.0` was byte-verified to carry the audited Action-circuit fix.

## Follow-up test coverage

Consensus-critical paths currently lacking direct coverage, tracked separately:
- #10670 — end-to-end `OrchardProofSize` rejection through the verifier
- #10671 — `is_orchard_temporarily_disabled` NU6.2 re-enable upper bound
- #10672 — positive fixed-circuit proof verification under the post-NU6.2 key

## Security

Fixes GHSA-jfw5-j458-pfv6.

## AI disclosure

The NU6.2 implementation, the de-vendoring to published crates, the consensus/dependency-parity auditing, and this PR description were produced with Claude Code (Anthropic). The author is the sole responsible author for all changes.
