### PR TITLE
feat: expose `should_allow_unshielded_coinbase_spends` for regtest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- Added a Regtest configuration option, `should_allow_unshielded_coinbase_spends`,
+  to forbid spending coinbase outputs into transparent outputs (the inverse of
+  zcashd's `-regtestshieldcoinbase`). It defaults to allowing such spends, preserving
+  existing Regtest behavior ([#10698](https://github.com/ZcashFoundation/zebra/pull/10698))
+
 ### Changed
 
 - Opening a Zebra state read-only (for example, as a secondary instance over a

--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `parameters::testnet::RegtestParameters::should_allow_unshielded_coinbase_spends`:
+  optional override for whether Regtest allows coinbase outputs to be spent into
+  transparent outputs. Defaults to allowing them, and does not affect
+  `Network::is_regtest()`.
+
 ## [10.1.0] - 2026-06-18
 
 ### Added

--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -948,6 +948,9 @@ pub struct RegtestParameters {
     pub checkpoints: Option<ConfiguredCheckpoints>,
     /// Whether funding stream addresses should be repeated to fill all required funding stream periods.
     pub extend_funding_stream_addresses_as_required: Option<bool>,
+    /// Whether to allow coinbase spends to have transparent outputs (inverse of
+    /// zcashd's `-regtestshieldcoinbase`).
+    pub should_allow_unshielded_coinbase_spends: Option<bool>,
 }
 
 impl From<ConfiguredActivationHeights> for RegtestParameters {
@@ -1021,6 +1024,7 @@ impl Parameters {
             lockbox_disbursements,
             checkpoints,
             extend_funding_stream_addresses_as_required,
+            should_allow_unshielded_coinbase_spends,
         }: RegtestParameters,
     ) -> Result<Self, ParametersBuilderError> {
         let mut parameters = Self::build()
@@ -1028,7 +1032,9 @@ impl Parameters {
             // This value is chosen to match zcashd, see: <https://github.com/zcash/zcash/blob/master/src/chainparams.cpp#L654>
             .with_target_difficulty_limit(U256::from_big_endian(&[0x0f; 32]))?
             .with_disable_pow(true)
-            .with_unshielded_coinbase_spends(true)
+            .with_unshielded_coinbase_spends(
+                should_allow_unshielded_coinbase_spends.unwrap_or(true),
+            )
             .with_slow_start_interval(Height::MIN)
             // Like the default Testnet activation heights stripped below, the default Testnet's
             // temporary Orchard-disabling soft fork does not apply to Regtest.

--- a/zebra-chain/src/parameters/network/testnet.rs
+++ b/zebra-chain/src/parameters/network/testnet.rs
@@ -746,7 +746,8 @@ impl ParametersBuilder {
         self
     }
 
-    /// Sets the `disable_pow` flag to be used in the [`Parameters`] being built.
+    /// Sets whether coinbase outputs may be spent into transparent outputs in the
+    /// [`Parameters`] being built (the inverse of zcashd's `-regtestshieldcoinbase`).
     pub fn with_unshielded_coinbase_spends(
         mut self,
         should_allow_unshielded_coinbase_spends: bool,
@@ -1081,7 +1082,8 @@ impl Parameters {
             funding_streams: _,
             target_difficulty_limit,
             disable_pow,
-            should_allow_unshielded_coinbase_spends,
+            // Configurable on Regtest
+            should_allow_unshielded_coinbase_spends: _,
             pre_blossom_halving_interval,
             post_blossom_halving_interval,
             lockbox_disbursements: _,
@@ -1095,8 +1097,6 @@ impl Parameters {
             && self.slow_start_shift == slow_start_shift
             && self.target_difficulty_limit == target_difficulty_limit
             && self.disable_pow == disable_pow
-            && self.should_allow_unshielded_coinbase_spends
-                == should_allow_unshielded_coinbase_spends
             && self.pre_blossom_halving_interval == pre_blossom_halving_interval
             && self.post_blossom_halving_interval == post_blossom_halving_interval
     }

--- a/zebra-chain/src/parameters/network/tests/vectors.rs
+++ b/zebra-chain/src/parameters/network/tests/vectors.rs
@@ -538,6 +538,22 @@ fn check_configured_funding_stream_regtest() {
     );
 }
 
+/// Check that `should_allow_unshielded_coinbase_spends` is enabled by default on Regtest,
+/// can be disabled via `RegtestParameters`, and does not change Regtest identity.
+#[test]
+fn check_regtest_should_allow_unshielded_coinbase_spends() {
+    let default_regtest = Network::new_regtest(Default::default());
+    assert!(default_regtest.is_regtest());
+    assert!(default_regtest.should_allow_unshielded_coinbase_spends());
+
+    let shielded_regtest = Network::new_regtest(RegtestParameters {
+        should_allow_unshielded_coinbase_spends: Some(false),
+        ..Default::default()
+    });
+    assert!(shielded_regtest.is_regtest());
+    assert!(!shielded_regtest.should_allow_unshielded_coinbase_spends());
+}
+
 #[test]
 fn sum_of_one_time_lockbox_disbursements_is_correct() {
     let mut configured_activation_heights: ConfiguredActivationHeights =

--- a/zebra-network/CHANGELOG.md
+++ b/zebra-network/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added the Regtest-only network config option `should_allow_unshielded_coinbase_spends`,
+  controlling whether coinbase outputs may be spent into transparent outputs. Setting it
+  on a configured Testnet is rejected with an error
+  ([#10698](https://github.com/ZcashFoundation/zebra/pull/10698)).
+
 ## [9.0.0] - 2026-06-10
 
 ### Breaking Changes

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -901,9 +901,15 @@ where
         checkpoints,
         extend_funding_stream_addresses_as_required,
         temporary_orchard_disabling_soft_fork_height,
-        // Regtest only; ignored for configured Testnets.
-        should_allow_unshielded_coinbase_spends: _,
+        should_allow_unshielded_coinbase_spends,
     } = params;
+
+    // This is a Regtest-only consensus knob, so reject it rather than silently ignoring it.
+    if should_allow_unshielded_coinbase_spends.is_some() {
+        return Err(de::Error::custom(
+            "should_allow_unshielded_coinbase_spends is only supported on Regtest",
+        ));
+    }
 
     let mut params_builder = testnet::Parameters::build();
 

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -709,9 +709,9 @@ impl From<Arc<testnet::Parameters>> for DTestnetParameters {
             temporary_orchard_disabling_soft_fork_height: params
                 .temporary_orchard_disabling_soft_fork_height()
                 .map(|height| height.0),
-            should_allow_unshielded_coinbase_spends: Some(
-                params.should_allow_unshielded_coinbase_spends(),
-            ),
+            should_allow_unshielded_coinbase_spends: params
+                .is_regtest()
+                .then(|| params.should_allow_unshielded_coinbase_spends()),
         }
     }
 }

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -612,6 +612,8 @@ struct DTestnetParameters {
     /// If unset, the default activation height for the network is used; the soft fork
     /// cannot be disabled via configuration.
     temporary_orchard_disabling_soft_fork_height: Option<u32>,
+    /// Regtest only: whether to allow coinbase spends to have transparent outputs.
+    should_allow_unshielded_coinbase_spends: Option<bool>,
 }
 
 /// Network configuration used during deserialization.
@@ -707,6 +709,9 @@ impl From<Arc<testnet::Parameters>> for DTestnetParameters {
             temporary_orchard_disabling_soft_fork_height: params
                 .temporary_orchard_disabling_soft_fork_height()
                 .map(|height| height.0),
+            should_allow_unshielded_coinbase_spends: Some(
+                params.should_allow_unshielded_coinbase_spends(),
+            ),
         }
     }
 }
@@ -896,6 +901,8 @@ where
         checkpoints,
         extend_funding_stream_addresses_as_required,
         temporary_orchard_disabling_soft_fork_height,
+        // Regtest only; ignored for configured Testnets.
+        should_allow_unshielded_coinbase_spends: _,
     } = params;
 
     let mut params_builder = testnet::Parameters::build();
@@ -1011,6 +1018,7 @@ fn build_regtest_params(params: DTestnetParameters) -> RegtestParameters {
         lockbox_disbursements,
         checkpoints,
         extend_funding_stream_addresses_as_required,
+        should_allow_unshielded_coinbase_spends,
         ..
     } = params;
 
@@ -1030,5 +1038,6 @@ fn build_regtest_params(params: DTestnetParameters) -> RegtestParameters {
         lockbox_disbursements,
         checkpoints: Some(checkpoints),
         extend_funding_stream_addresses_as_required,
+        should_allow_unshielded_coinbase_spends,
     }
 }

--- a/zebra-network/src/config/tests/vectors.rs
+++ b/zebra-network/src/config/tests/vectors.rs
@@ -147,3 +147,33 @@ fn temporary_orchard_disabling_soft_fork_height_serialization_roundtrip() {
         Some(soft_fork_height),
     );
 }
+
+/// Checks that a Regtest configured to forbid unshielded coinbase spends survives a
+/// serialization round-trip, and that the flag does not change the network's identity.
+#[test]
+fn regtest_should_allow_unshielded_coinbase_spends_serialization_roundtrip() {
+    let _init_guard = zebra_test::init();
+
+    let config = Config {
+        network: Network::new_regtest(testnet::RegtestParameters {
+            should_allow_unshielded_coinbase_spends: Some(false),
+            ..Default::default()
+        }),
+        initial_testnet_peers: [].into(),
+        ..Config::default()
+    };
+
+    // Forbidding unshielded coinbase spends must not stop the network from being Regtest.
+    assert!(config.network.is_regtest());
+
+    let serialized = toml::to_string(&config).unwrap();
+    let deserialized: Config = toml::from_str(&serialized).unwrap();
+
+    assert_eq!(config, deserialized);
+    assert!(deserialized.network.is_regtest());
+
+    let Network::Testnet(params) = &deserialized.network else {
+        panic!("deserialized network must be Regtest");
+    };
+    assert!(!params.should_allow_unshielded_coinbase_spends());
+}

--- a/zebra-network/src/config/tests/vectors.rs
+++ b/zebra-network/src/config/tests/vectors.rs
@@ -177,3 +177,20 @@ fn regtest_should_allow_unshielded_coinbase_spends_serialization_roundtrip() {
     };
     assert!(!params.should_allow_unshielded_coinbase_spends());
 }
+
+/// Checks that the Regtest-only `should_allow_unshielded_coinbase_spends` knob is rejected
+/// on a configured Testnet rather than silently ignored.
+#[test]
+fn should_allow_unshielded_coinbase_spends_rejected_on_testnet() {
+    let _init_guard = zebra_test::init();
+
+    let toml = "network = 'Testnet'\n\n[testnet_parameters]\nshould_allow_unshielded_coinbase_spends = true\n";
+    let err = toml::from_str::<Config>(toml)
+        .expect_err("configured Testnet must reject the Regtest-only field");
+
+    assert!(
+        err.to_string()
+            .contains("should_allow_unshielded_coinbase_spends"),
+        "unexpected error: {err}"
+    );
+}


### PR DESCRIPTION
This mimick the configuration option `-regtestshieldedcoinbase` in zcashd.

The integration tests use the option `regtestshieldecoinbase` at different place. We want to be able to enforce the same behavior.
The feature had been implemented in #9085, but it hadn't been exposed as a configuration parameter until now.

Allow authorizing for regtest.