### PR TITLE
fix(ci): unbreak main branch CI checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,7 +277,6 @@ Zebra versions are vulnerable to these issues.
   ([#10464](https://github.com/ZcashFoundation/zebra/pull/10464)).
 
 ## [Zebra 4.3.0](https://github.com/ZcashFoundation/zebra/releases/tag/v4.3.0) - 2026-03-12
-## [Zebra 4.3.0](https://github.com/ZcashFoundation/zebra/releases/tag/v4.3.0) - 2026-03-12
 
 This release fixes **two important security issues**:
 

--- a/deny.toml
+++ b/deny.toml
@@ -16,6 +16,7 @@ ignore = [
     "RUSTSEC-2024-0375", # atty (unmaintained) — transitive via abscissa_core -> structopt
     "RUSTSEC-2021-0145", # atty (unsound) — transitive via abscissa_core -> structopt
     "RUSTSEC-2024-0370", # proc-macro-error — transitive via abscissa_core -> structopt
+    "RUSTSEC-2026-0173", # proc-macro-error2 (unmaintained fork of proc-macro-error) — transitive via abscissa_core -> structopt
     "RUSTSEC-2025-0119", # number_prefix — transitive via indicatif
     "RUSTSEC-2025-0141", # bincode — direct dependency
 ]

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -24,7 +24,7 @@ use zebra_chain::{
     },
     serialization::{DateTime32, ZcashDeserializeInto, ZcashSerialize},
     transaction::{zip317, UnminedTxId, VerifiedUnminedTx},
-    work::difficulty::{CompactDifficulty, ExpandedDifficulty, ParameterDifficulty as _, U256},
+    work::difficulty::{CompactDifficulty, ExpandedDifficulty, U256},
 };
 use zebra_consensus::MAX_BLOCK_SIGOPS;
 use zebra_network::{


### PR DESCRIPTION
Three checks are red on `main`, each an independent cause:

- **markdownlint** (MD022): duplicated `Zebra 4.3.0` heading in `CHANGELOG.md`.
- **cargo-udeps**: redundant `ParameterDifficulty` trait import in a zebra-rpc test. The trait is already in scope via the module glob; newer nightly rejects the duplicate.
- **deny advisories**: `proc-macro-error2` is now unmaintained (RUSTSEC-2026-0173). Added to the ignore list beside its predecessor.

Each verified locally against its exact CI command.

AI: drafted and verified with Claude Code.