### PR TITLE
fix(ci): block Mergify queue on changes-requested and required-check failure

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -16,8 +16,10 @@ defaults:
     # and it does not create a draft PR if not needed
     batch_max_wait_time: "10 minutes"
     queue_conditions:
-      # Mergify automatically applies status check, approval, and conversation rules,
-      # which are the same as the GitHub main branch protection rules
+      # Mergify can auto-mirror classic branch protection, but not GitHub
+      # Rulesets. The conditions below restate the gates we actually rely on
+      # so PRs cannot be queued past failing required checks or unresolved
+      # change-requests.
       # https://docs.mergify.com/conditions/#about-branch-protection
       - base=main
       # is not in draft
@@ -26,6 +28,14 @@ defaults:
       - label!=do-not-merge
       # has at least one approving reviewer
       - "#approved-reviews-by >= 1"
+      # no reviewer has requested changes
+      - "#changes-requested-reviews-by = 0"
+      # The three required aggregator check runs must pass. After the
+      # `changes` + paths-filter refactor (#10637), each aggregator is
+      # produced by exactly one workflow, so the names below are stable.
+      - check-success=lint
+      - check-success=unit-tests
+      - check-success=test-crates
 
 
 # Allows to define the rules that reign over our merge queues


### PR DESCRIPTION
## Motivation

> ⚠️ **Depends on #10637.** This PR consumes the renamed aggregator check-run contexts (`lint`, `unit-tests`, `test-crates`) produced by that refactor. It should be merged **after** #10637, not before. If merged before, the `check-success=` strings here would never match and the queue would never accept any PR.

Mergify's queue gate currently does not respect two important signals:

1. `defaults.queue_rule.queue_conditions` requires `#approved-reviews-by >= 1` but does not require `#changes-requested-reviews-by = 0`. A PR with one approval can be queued even when another reviewer has explicitly requested changes.
2. The `pull_request_rules` entry named *"move to any queue if GitHub Rulesets are satisfied"* has `conditions: []`, so it attempts to queue every PR unconditionally. Mergify can auto-mirror **classic branch protection** requirements but cannot evaluate **GitHub Rulesets** today, so a failing required check is not detected by the queue config.

Combined, these gaps allow PRs with failing required checks or pending change requests to enter the merge queue.

## Solution

Add two explicit gates to `defaults.queue_rule.queue_conditions`:

- `"#changes-requested-reviews-by = 0"` — refuse to queue when any reviewer has explicitly requested changes.
- `check-success=` against the three aggregator check runs the required-check set rolls up into. Names follow the post-refactor scheme introduced by #10637:
  - `lint`
  - `unit-tests`
  - `test-crates`

After #10637 each aggregator is produced by exactly one workflow (mutual exclusion is enforced via `dorny/paths-filter` and `.github/path-filters.yml`), so the `check-success=` conditions are reachable on every PR.

### Tests

Validated on an equivalent private mirror with the same workflows and Mergify configuration:

- Syntax: Mergify dashboard accepts the config; no validation errors.
- Check run names: the three aggregator names match the `name:` field of the corresponding success jobs in the workflows touched by #10637.

### Specifications & References

- [Mergify — about branch protection](https://docs.mergify.com/conditions/#about-branch-protection)
- Depends on: #10637

### Follow-up Work

If a future refactor renames any of the three aggregator job names again, the `check-success=` strings here must be updated to match. The names are coupled to the GitHub Ruleset's required-check contexts, so renaming one without the other will silently break the queue gate.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude (Anthropic) — drafted the diff and the PR body; reviewed before commit.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [ ] The documentation and changelogs are up to date.