### PR TITLE
fix(zebrad): retry block proposal on tip race in getblocktemplate test

### DIFF
--- a/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
+++ b/zebrad/tests/common/get_block_template_rpcs/get_block_template.rs
@@ -258,6 +258,8 @@ async fn try_validate_block_template(client: &RpcRequestClient, net: &Network) -
                         .expect("response should be success output with a serialized `BlockProposalResponse`");
 
                     if let BlockProposalResponse::Rejected(reject_reason) = proposal_result {
+                        if reject_reason.contains("best-chain-tip") { continue; }
+
                         tracing::info!(
                             ?reject_reason,
                             ?template,


### PR DESCRIPTION
## Summary

The `rpc_get_block_template` CI integration test has been failing on main since ~May 22 with two distinct failure modes:

1. **Timeout (May 22 – Jun 8):** The sync stall bug (#5709) prevented the node from catching up from cached state to tip within the test timeout. This was resolved by #10679.

2. **Proposal race (Jun 8 onward):** With the stall fix in place, the node now reliably reaches tip — but the tip can advance between fetching a template and submitting it as a proposal, causing `"proposal is not based on the current best chain tip"`. The test treated this as a hard failure instead of retrying.

This PR fixes the second failure mode. When a proposal is rejected because the tip advanced, the test now `continue`s the existing retry loop to re-fetch a fresh template, matching the long-poll stale-template handling that already exists in the same function.

One line, no new dependencies.

## Test plan

- [ ] CI `rpc-get-block-template` integration test passes