### PR TITLE
fix(network): update peer set test mocks to Nu6_2 protocol version

### DIFF
--- a/zebra-network/src/peer_set/set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/set/tests/vectors.rs
@@ -28,7 +28,7 @@ fn peer_set_ready_single_connection() {
     let peer_versions = PeerVersions {
         peer_versions: vec![Version::min_specified_for_upgrade(
             &Network::Mainnet,
-            NetworkUpgrade::Nu6,
+            NetworkUpgrade::Nu6_2,
         )],
     };
 
@@ -120,7 +120,7 @@ fn peer_set_ready_single_connection() {
 #[test]
 fn peer_set_ready_multiple_connections() {
     // Use three peers with the same version
-    let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6);
+    let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6_2);
     let peer_versions = PeerVersions {
         peer_versions: vec![peer_version, peer_version, peer_version],
     };
@@ -184,7 +184,7 @@ fn peer_set_rejects_connections_past_per_ip_limit() {
     const NUM_PEER_VERSIONS: usize = crate::constants::DEFAULT_MAX_CONNS_PER_IP + 1;
 
     // Use three peers with the same version
-    let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6);
+    let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6_2);
     let peer_versions = PeerVersions {
         peer_versions: [peer_version; NUM_PEER_VERSIONS].into_iter().collect(),
     };
@@ -234,7 +234,7 @@ fn peer_set_route_inv_empty_registry() {
     let test_hash = block::Hash([0; 32]);
 
     // Use two peers with the same version
-    let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6);
+    let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6_2);
     let peer_versions = PeerVersions {
         peer_versions: vec![peer_version, peer_version],
     };
@@ -298,7 +298,7 @@ fn broadcast_all_queued_removes_banned_peers() {
     let peer_versions = PeerVersions {
         peer_versions: vec![Version::min_specified_for_upgrade(
             &Network::Mainnet,
-            NetworkUpgrade::Nu6,
+            NetworkUpgrade::Nu6_2,
         )],
     };
 
@@ -345,7 +345,7 @@ fn remove_unready_peer_clears_cancel_handle_and_updates_counts() {
     let peer_versions = PeerVersions {
         peer_versions: vec![Version::min_specified_for_upgrade(
             &Network::Mainnet,
-            NetworkUpgrade::Nu6,
+            NetworkUpgrade::Nu6_2,
         )],
     };
 
@@ -412,7 +412,7 @@ fn peer_set_route_inv_advertised_registry_order(advertised_first: bool) {
     let test_change = InventoryStatus::new_available(test_inv, test_peer);
 
     // Use two peers with the same version
-    let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6);
+    let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6_2);
     let peer_versions = PeerVersions {
         peer_versions: vec![peer_version, peer_version],
     };
@@ -520,7 +520,7 @@ fn peer_set_route_inv_missing_registry_order(missing_first: bool) {
     let test_change = InventoryStatus::new_missing(test_inv, test_peer);
 
     // Use two peers with the same version
-    let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6);
+    let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6_2);
     let peer_versions = PeerVersions {
         peer_versions: vec![peer_version, peer_version],
     };
@@ -622,7 +622,7 @@ fn peer_set_route_inv_all_missing_fail() {
     let test_change = InventoryStatus::new_missing(test_inv, test_peer);
 
     // Use one peer
-    let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6);
+    let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6_2);
     let peer_versions = PeerVersions {
         peer_versions: vec![peer_version],
     };


### PR DESCRIPTION
## Summary

- The `INITIAL_MIN_NETWORK_PROTOCOL_VERSION` bump to Nu6_2 (170150) in #10692 left all 9 peer set test mocks creating peers at the old Nu6 version (170120), below the new minimum
- Mock peers are silently dropped by `push_ready`, causing `.ready().await` to hang forever and timing out the entire Unit Tests workflow (120 min) on every branch including `main`
- Updates all 9 mock peer version constructions in `peer_set/set/tests/vectors.rs` from `NetworkUpgrade::Nu6` to `NetworkUpgrade::Nu6_2`

## Test plan

- [ ] Unit Tests CI passes (all 4 runners: ubuntu stable/beta, macos, windows)
- [ ] `cargo check -p zebra-network --tests` compiles cleanly (verified locally)