### PR TITLE
fix(zebrad): reduce end of support for NU7 network upgrade

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -862,7 +862,55 @@ end = "2025-07-29"
 
 [[trusted.zebra-chain]]
 criteria = "safe-to-deploy"
+user-id = 159631
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-chain]]
+criteria = "safe-to-deploy"
+user-id = 199775
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-chain]]
+criteria = "safe-to-deploy"
+user-id = 215589
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-chain]]
+criteria = "safe-to-deploy"
 user-id = 228785 # Alfredo Garcia (oxarbitrage)
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-chain]]
+criteria = "safe-to-deploy"
+user-id = 235397
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-chain]]
+criteria = "safe-to-deploy"
+user-id = 405015
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-consensus]]
+criteria = "safe-to-deploy"
+user-id = 159631
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-consensus]]
+criteria = "safe-to-deploy"
+user-id = 199775
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-consensus]]
+criteria = "safe-to-deploy"
+user-id = 215589
 start = "2023-09-02"
 end = "2027-06-11"
 
@@ -872,9 +920,69 @@ user-id = 228785 # Alfredo Garcia (oxarbitrage)
 start = "2023-09-02"
 end = "2027-06-11"
 
+[[trusted.zebra-consensus]]
+criteria = "safe-to-deploy"
+user-id = 235397
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-consensus]]
+criteria = "safe-to-deploy"
+user-id = 405015
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-network]]
+criteria = "safe-to-deploy"
+user-id = 159631
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-network]]
+criteria = "safe-to-deploy"
+user-id = 199775
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-network]]
+criteria = "safe-to-deploy"
+user-id = 215589
+start = "2023-09-02"
+end = "2027-06-11"
+
 [[trusted.zebra-network]]
 criteria = "safe-to-deploy"
 user-id = 228785 # Alfredo Garcia (oxarbitrage)
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-network]]
+criteria = "safe-to-deploy"
+user-id = 235397
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-network]]
+criteria = "safe-to-deploy"
+user-id = 405015
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-node-services]]
+criteria = "safe-to-deploy"
+user-id = 159631
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-node-services]]
+criteria = "safe-to-deploy"
+user-id = 199775
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-node-services]]
+criteria = "safe-to-deploy"
+user-id = 215589
 start = "2023-09-02"
 end = "2027-06-11"
 
@@ -884,9 +992,69 @@ user-id = 228785 # Alfredo Garcia (oxarbitrage)
 start = "2023-09-02"
 end = "2027-06-11"
 
+[[trusted.zebra-node-services]]
+criteria = "safe-to-deploy"
+user-id = 235397
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-node-services]]
+criteria = "safe-to-deploy"
+user-id = 405015
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-rpc]]
+criteria = "safe-to-deploy"
+user-id = 159631
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-rpc]]
+criteria = "safe-to-deploy"
+user-id = 199775
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-rpc]]
+criteria = "safe-to-deploy"
+user-id = 215589
+start = "2023-09-02"
+end = "2027-06-11"
+
 [[trusted.zebra-rpc]]
 criteria = "safe-to-deploy"
 user-id = 228785 # Alfredo Garcia (oxarbitrage)
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-rpc]]
+criteria = "safe-to-deploy"
+user-id = 235397
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-rpc]]
+criteria = "safe-to-deploy"
+user-id = 405015
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-script]]
+criteria = "safe-to-deploy"
+user-id = 159631
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-script]]
+criteria = "safe-to-deploy"
+user-id = 199775
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-script]]
+criteria = "safe-to-deploy"
+user-id = 215589
 start = "2023-09-02"
 end = "2027-06-11"
 
@@ -896,9 +1064,69 @@ user-id = 228785 # Alfredo Garcia (oxarbitrage)
 start = "2023-09-02"
 end = "2027-06-11"
 
+[[trusted.zebra-script]]
+criteria = "safe-to-deploy"
+user-id = 235397
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-script]]
+criteria = "safe-to-deploy"
+user-id = 405015
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-state]]
+criteria = "safe-to-deploy"
+user-id = 159631
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-state]]
+criteria = "safe-to-deploy"
+user-id = 199775
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-state]]
+criteria = "safe-to-deploy"
+user-id = 215589
+start = "2023-09-02"
+end = "2027-06-11"
+
 [[trusted.zebra-state]]
 criteria = "safe-to-deploy"
 user-id = 228785 # Alfredo Garcia (oxarbitrage)
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-state]]
+criteria = "safe-to-deploy"
+user-id = 235397
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-state]]
+criteria = "safe-to-deploy"
+user-id = 405015
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-utils]]
+criteria = "safe-to-deploy"
+user-id = 159631
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-utils]]
+criteria = "safe-to-deploy"
+user-id = 199775
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-utils]]
+criteria = "safe-to-deploy"
+user-id = 215589
 start = "2023-09-02"
 end = "2027-06-11"
 
@@ -908,8 +1136,50 @@ user-id = 228785 # Alfredo Garcia (oxarbitrage)
 start = "2023-09-02"
 end = "2027-06-11"
 
+[[trusted.zebra-utils]]
+criteria = "safe-to-deploy"
+user-id = 235397
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-utils]]
+criteria = "safe-to-deploy"
+user-id = 405015
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebrad]]
+criteria = "safe-to-deploy"
+user-id = 159631
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebrad]]
+criteria = "safe-to-deploy"
+user-id = 199775
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebrad]]
+criteria = "safe-to-deploy"
+user-id = 215589
+start = "2023-09-02"
+end = "2027-06-11"
+
 [[trusted.zebrad]]
 criteria = "safe-to-deploy"
 user-id = 228785 # Alfredo Garcia (oxarbitrage)
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebrad]]
+criteria = "safe-to-deploy"
+user-id = 235397
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebrad]]
+criteria = "safe-to-deploy"
+user-id = 405015
 start = "2023-09-02"
 end = "2027-06-11"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -859,3 +859,57 @@ criteria = "safe-to-deploy"
 user-id = 6741
 start = "2020-12-25"
 end = "2025-07-29"
+
+[[trusted.zebra-chain]]
+criteria = "safe-to-deploy"
+user-id = 228785 # Alfredo Garcia (oxarbitrage)
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-consensus]]
+criteria = "safe-to-deploy"
+user-id = 228785 # Alfredo Garcia (oxarbitrage)
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-network]]
+criteria = "safe-to-deploy"
+user-id = 228785 # Alfredo Garcia (oxarbitrage)
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-node-services]]
+criteria = "safe-to-deploy"
+user-id = 228785 # Alfredo Garcia (oxarbitrage)
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-rpc]]
+criteria = "safe-to-deploy"
+user-id = 228785 # Alfredo Garcia (oxarbitrage)
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-script]]
+criteria = "safe-to-deploy"
+user-id = 228785 # Alfredo Garcia (oxarbitrage)
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-state]]
+criteria = "safe-to-deploy"
+user-id = 228785 # Alfredo Garcia (oxarbitrage)
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebra-utils]]
+criteria = "safe-to-deploy"
+user-id = 228785 # Alfredo Garcia (oxarbitrage)
+start = "2023-09-02"
+end = "2027-06-11"
+
+[[trusted.zebrad]]
+criteria = "safe-to-deploy"
+user-id = 228785 # Alfredo Garcia (oxarbitrage)
+start = "2023-09-02"
+end = "2027-06-11"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -2151,44 +2151,8 @@ criteria = "safe-to-deploy"
 version = "0.8.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.zebra-chain]]
-version = "9.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-consensus]]
-version = "8.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-network]]
-version = "8.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-node-services]]
-version = "7.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-rpc]]
-version = "9.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-script]]
-version = "8.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-state]]
-version = "8.0.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.zebra-test]]
 version = "3.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-utils]]
-version = "7.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebrad]]
-version = "5.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -129,6 +129,69 @@ version = "0.244.0"
 when = "2026-01-06"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
+[[publisher.zebra-chain]]
+version = "10.0.0"
+when = "2026-06-11"
+user-id = 228785
+user-login = "oxarbitrage"
+user-name = "Alfredo Garcia"
+
+[[publisher.zebra-consensus]]
+version = "9.0.0"
+when = "2026-06-11"
+user-id = 228785
+user-login = "oxarbitrage"
+user-name = "Alfredo Garcia"
+
+[[publisher.zebra-network]]
+version = "9.0.0"
+when = "2026-06-11"
+user-id = 228785
+user-login = "oxarbitrage"
+user-name = "Alfredo Garcia"
+
+[[publisher.zebra-node-services]]
+version = "8.0.0"
+when = "2026-06-11"
+user-id = 228785
+user-login = "oxarbitrage"
+user-name = "Alfredo Garcia"
+
+[[publisher.zebra-rpc]]
+version = "10.0.0"
+when = "2026-06-11"
+user-id = 228785
+user-login = "oxarbitrage"
+user-name = "Alfredo Garcia"
+
+[[publisher.zebra-script]]
+version = "9.0.0"
+when = "2026-06-11"
+user-id = 228785
+user-login = "oxarbitrage"
+user-name = "Alfredo Garcia"
+
+[[publisher.zebra-state]]
+version = "9.0.0"
+when = "2026-06-11"
+user-id = 228785
+user-login = "oxarbitrage"
+user-name = "Alfredo Garcia"
+
+[[publisher.zebra-utils]]
+version = "8.0.0"
+when = "2026-06-11"
+user-id = 228785
+user-login = "oxarbitrage"
+user-name = "Alfredo Garcia"
+
+[[publisher.zebrad]]
+version = "5.1.0"
+when = "2026-06-11"
+user-id = 228785
+user-login = "oxarbitrage"
+user-name = "Alfredo Garcia"
+
 [[audits.bytecode-alliance.wildcard-audits.bumpalo]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_375_400;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_374_490;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.
@@ -22,8 +22,8 @@ pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_375_400;
 ///
 /// - Zebra will exit with a panic if the current tip height is bigger than the
 ///   `ESTIMATED_RELEASE_HEIGHT` plus this number of days.
-/// - Currently set to 15 weeks.
-pub const EOS_PANIC_AFTER: u32 = 105;
+/// - Reduced to 44 days for the NU7 network upgrade expected at end of July 2026.
+pub const EOS_PANIC_AFTER: u32 = 44;
 
 /// The number of days before the end of support where Zebra will display warnings.
 pub const EOS_WARN_AFTER: u32 = EOS_PANIC_AFTER - 14;


### PR DESCRIPTION
## Motivation

v5.1.0 shipped with the default 105-day EOS (panic ~Sep 24), which extends well past the NU7 network upgrade expected at the end of July. Nodes on v5.1.0 will break at the NU7 activation height but the EOS mechanism won't warn operators until weeks after the fork.

Additionally, the v5.1.0 crate publish introduced new versions that cargo-vet didn't have audits for, failing CI on every PR on main.

## Changes

### End of Support reduction
- `ESTIMATED_RELEASE_HEIGHT`: 3,375,400 → 3,374,490
- `EOS_PANIC_AFTER`: 105 → 44 days

| Event | Date | Height |
|-------|------|--------|
| ⚠️ Warning starts | ~July 11 | ~3,409,050 |
| 🛑 Stops running | ~July 25 | ~3,425,178 |
| 🔄 NU7 activation | End of July | TBD |

This gives operators 14 days of warning before force-stop, and ~a week buffer before the expected NU7 fork.

### cargo-vet trust entries
- Adds `cargo vet trust` for all 9 zebra crates published by oxarbitrage, replacing version-pinned exemptions. Fixes CI after the v5.1.0 crate publish.
- Adds trust entries for all team members who may publish future releases: gustavovalverde, conradoplg, upbqdn (Marek), arya2, natalieesk. This prevents cargo-vet failures when someone other than oxarbitrage does a release.

Part of #10709