### PR TITLE
release: Zebra v5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [Zebra 5.1.1](https://github.com/ZcashFoundation/zebra/releases/tag/v5.1.1) - 2026-06-11
+
+This release reduces Zebra's end-of-support window ahead of the NU7 network upgrade
+expected at the end of July 2026, so that nodes running outdated versions stop before
+the upgrade activates.
+
+### Changed
+
+- Reduced the end-of-support period from 105 to 44 days, and updated the estimated
+  release height, ahead of the NU7 network upgrade
+  ([#10710](https://github.com/ZcashFoundation/zebra/pull/10710))
+
 ## [Zebra 5.1.0](https://github.com/ZcashFoundation/zebra/releases/tag/v5.1.0) - 2026-06-10
 
 This release fixes a genesis-to-tip sync stall that could cause new nodes to hang

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7799,7 +7799,7 @@ dependencies = [
 
 [[package]]
 name = "zebrad"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "abscissa_core",
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ cargo install --locked zebrad
 Alternatively, you can install it from GitHub:
 
 ```sh
-cargo install --git https://github.com/ZcashFoundation/zebra --tag v5.1.0 zebrad
+cargo install --git https://github.com/ZcashFoundation/zebra --tag v5.1.1 zebrad
 ```
 
 You can start Zebra by running

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate metadata
 name = "zebrad"
-version = "5.1.0"
+version = "5.1.1"
 authors.workspace = true
 description = "The Zcash Foundation's independent, consensus-compatible implementation of a Zcash node"
 license.workspace = true


### PR DESCRIPTION
# Release Zebra v5.1.1

## Motivation

Patch release to ship the reduced end-of-support timeline ahead of the NU7 network
upgrade expected at the end of July 2026 (merged to `main` in #10710). Nodes running
outdated versions will warn from ~July 11 and halt from ~July 25, before NU7 activates.

## Solution

- Bump `zebrad` `5.1.0` → `5.1.1` (only crate changed since `v5.1.0`)
- Add `## [Zebra 5.1.1]` to `CHANGELOG.md`
- Update the install tag in `README.md`
- Refresh `Cargo.lock`

## Release type

`patch` — only `zebrad` source changed since `v5.1.0` (commit #10710, a `fix`).
`git diff --stat v5.1.0..main` touches only `supply-chain/*` and
`zebrad/src/components/sync/end_of_support.rs`, so no library crate needs a release
and no `semver-checks`/`public-api` analysis is required.

## AI disclosure

This release branch (version bump, changelog, README, lockfile) and the worked
checklist below were prepared with Claude Code. The contributor is the responsible author.

---

# Release Checklist

## Prepare for the Release

- [ ] At least one successful full sync test on `main` since the last state change.
      **Maintainer/CI action** — no state change in this release (EOS constant + version
      metadata only), so a fresh full sync is not strictly required; confirm the latest
      scheduled run is green before tagging.

## Checkpoints

- [ ] Update checkpoints.
      **Skipped (urgent EOS patch).** Per the release issue template, checkpoint updates
      "can be skipped for urgent releases." This release contains no consensus/state
      change. Generate from CI if you'd prefer to include them.

## Missed Dependency Updates

- [ ] `cargo update` on `main` (+ `home@0.5.12 -> 0.5.11`, `deny.toml` fixups).
      **Out of scope for this PR** — the checklist routes this to a *separate* PR. Not
      bundled here to keep the release diff minimal.

## Summarise Release Changes

### Change Log

- [x] `## [Zebra 5.1.1]` section added to `CHANGELOG.md`, describing the EOS reduction (#10710).
- [x] Trivial/duplicate entries: none (single user-visible change).

### README

- [x] Install tag updated `v5.1.0` → `v5.1.1`.
- [x] No "Known Issues" to remove; no `Dockerfile` dependency changes; MSRV unchanged
      — no other README edits needed.

### Create the Release PR

- [x] Pushed to branch `bump-v5.1.1` (distinct from the `v5.1.1` tag).
- [x] Release PR opened against `main` with this template.
- [ ] Freeze the `batched` Mergify queue. **Maintainer action** — not performed (no publish requested).
- [x] Marked `Critical` priority via `P-Critical` label (urgent queue).
- [ ] Mark non-release PRs `do-not-merge`. **Maintainer action** — not performed.
- [x] `A-release` label added (enables `check-no-git-dependencies`).

### Zebra git sources dependencies

- [ ] `check-no-git-dependencies` passes. **Runs in CI** on this PR via the `A-release` label.

## Update Versions and End of Support

### Update Zebra Version

- [x] Release level: `patch`.

### Update Crate Versions and Crate Change Logs

- [x] Crates requiring release: `zebrad` only (`git diff --stat v5.1.0..main`).
- [x] `zebrad` `5.1.0` → `5.1.1` (`cargo release version ... -p zebrad patch`), `Cargo.lock` refreshed.
- [x] `semver-checks` / `public-api`: N/A — `zebrad` is the binary crate, no published library API changed.
- [x] **Major-release-only** `INITIAL_MIN_NETWORK_PROTOCOL_VERSION` check: N/A (patch release).

### Update End of Support

- [x] `ESTIMATED_RELEASE_HEIGHT = 3_374_490` and `EOS_PANIC_AFTER = 44` are already set on
      `main` by #10710. Verified against the live mainnet tip (~3,374,838 on 2026-06-11):
      warning height ~3,409,050 (~July 11), panic height ~3,425,178 (~July 25). Correct for a
      release tagged now — no change needed.

---

## Publish steps — NOT performed in this PR (deliberate)

Per the request, this PR stops at "release PR up". The following are **not** done and are
left for a maintainer after review/merge:

- [ ] Create & test the GitHub pre-release / tag `v5.1.1`
- [ ] Publish the GitHub release
- [ ] Publish crates to crates.io (`zebrad` only)
- [ ] Publish Docker images
- [ ] Un-freeze the Mergify queue / remove `do-not-merge`

PR opened as a **draft** so it cannot auto-merge until a maintainer marks it ready.
