### PR TITLE
fix(ci): skip Trigger Integration Tests on fork PRs

### DIFF
--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -28,6 +28,10 @@ permissions: {}
 jobs:
   trigger-integration:
     name: Trigger integration tests
+    # Fork PRs do not receive repository secrets, so `Z3_APP_ID` and
+    # `Z3_APP_PRIVATE_KEY` resolve to empty strings and the token step fails.
+    # Skip the job on fork PRs; keep it on same-repo PRs and main pushes.
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref_name == 'main') }}
     runs-on: ubuntu-latest
     steps:
       - name: Generate app token


### PR DESCRIPTION
## Motivation

The `Trigger Integration Tests` workflow uses `actions/create-github-app-token` to mint a GitHub App token from the `Z3_APP_ID` / `Z3_APP_PRIVATE_KEY` repository secrets. GitHub Actions deliberately does **not** pass repository secrets to workflows triggered by `pull_request` events from forks, so those secrets resolve to empty strings on every external contribution. The token step then errors with:

```
Error: The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string.
```

The job is a required check, so every fork PR ends up with a perma-failing status that has nothing to do with the contributor's change.

## Solution

Add a job-level `if:` gate that mirrors the fork-skip pattern already used in `zfnd-deploy-nodes-gcp.yml` and `zfnd-ci-integration-tests-gcp.yml`:

```yaml
if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref_name == 'main') }}
```

The workflow keeps running on:
- Same-repo PRs (where secrets are present)
- Pushes to `main`

Only fork PRs are skipped. Skipped jobs report a neutral status that does not block the queue.

### Tests

- Diff is 4 lines: a job-level `if:` and a three-line explanatory comment.
- Pattern verified against `zfnd-deploy-nodes-gcp.yml:256` and `zfnd-ci-integration-tests-gcp.yml:129`.
- On `push` events, `github.event.pull_request` is null, so `head.repo.fork` evaluates safely.

### Specifications & References

- [GitHub Actions — workflows triggered by pull_request from forks](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
- Same-shape gate at `.github/workflows/zfnd-deploy-nodes-gcp.yml:256`.

### Follow-up Work

None.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude (Anthropic) — drafted the diff and the PR body; reviewed before commit.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [ ] The documentation and changelogs are up to date.