### PR TITLE
feat(ci): allow on-demand dispatch of integration tests for fork PRs

### DIFF
--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -55,6 +55,11 @@ jobs:
           SHA=$(echo "$DATA" | jq -r .headRefOid)
           BODY=$(echo "$DATA" | jq -r .body)
           TEST_SHA=$(echo "$BODY" | sed '/[^ ]ZIT-Revision/!d' | sed -E 's/.*ZIT-Revision: ([^\\]*)\\.*/\1/')
+          # PR body is contributor-controlled; only forward sha-like values.
+          if [[ -n "$TEST_SHA" ]] && ! [[ "$TEST_SHA" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+            echo "::warning::Ignoring invalid ZIT-Revision value"
+            TEST_SHA=""
+          fi
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "test_sha=$TEST_SHA" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -19,8 +19,15 @@ on:
       - .cargo/config.toml
       - .github/workflows/trigger-integration-tests.yml
 
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to run integration tests against (use for fork PRs)"
+        required: true
+        type: string
+
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || inputs.pr_number || github.run_id }}
   cancel-in-progress: true
 
 permissions: {}
@@ -28,12 +35,29 @@ permissions: {}
 jobs:
   trigger-integration:
     name: Trigger integration tests
-    # Fork PRs do not receive repository secrets, so `Z3_APP_ID` and
-    # `Z3_APP_PRIVATE_KEY` resolve to empty strings and the token step fails.
-    # Skip the job on fork PRs; keep it on same-repo PRs and main pushes.
-    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref_name == 'main') }}
+    # Fork PRs do not receive repository secrets on pull_request events.
+    # Skip the job on fork PRs; maintainers can still run it manually via
+    # workflow_dispatch with the PR number as input.
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
+    permissions:
+      # Needed to post a sticky comment on the PR when triggered manually.
+      pull-requests: write
     steps:
+      - name: Resolve target PR details (manual dispatch only)
+        id: pr
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ inputs.pr_number }}
+        run: |
+          DATA=$(gh pr view "$PR" --repo "$GITHUB_REPOSITORY" --json headRefOid,body)
+          SHA=$(echo "$DATA" | jq -r .headRefOid)
+          BODY=$(echo "$DATA" | jq -r .body)
+          TEST_SHA=$(echo "$BODY" | sed '/[^ ]ZIT-Revision/!d' | sed -E 's/.*ZIT-Revision: ([^\\]*)\\.*/\1/')
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "test_sha=$TEST_SHA" >> "$GITHUB_OUTPUT"
+
       - name: Generate app token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -56,10 +80,21 @@ jobs:
       - name: Trigger integration tests
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          TEST_SHA: ${{ steps.test-branch.outputs.test_sha }}
+          SHA: ${{ steps.pr.outputs.sha || github.event.pull_request.head.sha || github.sha }}
+          TEST_SHA: ${{ steps.pr.outputs.test_sha || steps.test-branch.outputs.test_sha }}
         run: >
           gh api repos/zcash/integration-tests/dispatches
           --field event_type="zebra-interop-request"
           --field client_payload[sha]="${SHA}"
           --field client_payload[test_sha]="${TEST_SHA}"
+
+      - name: Post sticky comment on PR (manual dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 #v3.0.4
+        with:
+          number: ${{ inputs.pr_number }}
+          header: integration-tests-dispatch
+          message: |
+            🚀 Integration tests dispatched manually against this PR's HEAD (`${{ steps.pr.outputs.sha }}`).
+
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## Motivation

`Trigger Integration Tests` cannot run automatically on PRs opened from forks because GitHub does not pass repository secrets (`Z3_APP_ID`, `Z3_APP_PRIVATE_KEY`) to `pull_request` workflows from forks. The previous change in #10712 made that situation graceful by skipping the job entirely on fork PRs.

That left no in-repo path for a maintainer to actually run the integration tests against a fork contribution. This PR adds an opt-in, maintainer-triggered dispatch path so external contributions can still get integration test coverage when warranted.

## Solution

- Add a `workflow_dispatch` trigger with a required `pr_number` input.
- When fired, the job resolves the PR's head SHA and body via the GitHub API (no checkout of fork code), dispatches to `zcash/integration-tests` with the same `client_payload[sha]` / `client_payload[test_sha]` shape as the automatic path, and posts a sticky comment on the PR linking to the Actions run.
- Extend the existing `if:` to also allow `workflow_dispatch` and add `pull-requests: write` to the job permissions so the sticky comment can be posted.

The fork's code is never checked out or executed in the upstream context. Only the commit SHA is forwarded to `zcash/integration-tests`, which is where the actual test code runs — exactly the same flow as same-repo PRs.

### How to use

1. Maintainer opens the **Actions → Trigger Integration Tests** page.
2. Click **Run workflow**, enter the PR number, and dispatch.
3. The workflow runs in upstream context (with secrets), looks up the PR's HEAD SHA, dispatches to `zcash/integration-tests`, and posts a sticky comment on the PR:

   > 🚀 Integration tests dispatched manually against this PR's HEAD (`<sha>`).
   >
   > Run: `<link to the Actions run>`

The sticky comment header (`integration-tests-dispatch`) means subsequent manual dispatches update the same comment instead of creating new ones.

### Tests

- `pull_request` and `push` paths are unchanged for non-fork PRs and main pushes (verified by diff).
- Step gating ensures only the manual-dispatch path touches the PR resolution + sticky comment.
- Concurrency group keys on `inputs.pr_number` when applicable so multiple manual dispatches against different PRs don't cancel each other.

### Specifications & References

- [GitHub Actions — workflows triggered by pull_request from forks](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)
- #10712 — the prior change that made fork PRs skip cleanly instead of perma-failing.

### Follow-up Work

A future iteration could add a GitHub Check Run tied to the PR's HEAD SHA, so the integration test status appears in the PR's Checks tab and merge box rather than only in a comment. That requires a callback from `zcash/integration-tests` when the downstream run completes, so it's out of scope here.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude (Anthropic) — drafted the workflow change and the PR body; reviewed before commit.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [ ] The documentation and changelogs are up to date.