### PR TITLE
fix: settle checkpoints past the 1000-block rollback window

### DIFF
--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `parameters::constants::MAX_BLOCK_REORG_HEIGHT`: the maximum chain reorganisation height (1000).
+
 ## [10.0.0] - 2026-06-10
 
 ### Breaking Changes

--- a/zebra-chain/src/parameters/constants.rs
+++ b/zebra-chain/src/parameters/constants.rs
@@ -1,6 +1,7 @@
 //! Definitions of Zebra chain constants, including:
 //! - slow start interval,
-//! - slow start shift
+//! - slow start shift,
+//! - maximum reorg height
 
 use crate::block::Height;
 
@@ -15,6 +16,18 @@ pub const SLOW_START_INTERVAL: Height = Height(20_000);
 ///
 /// This calculation is exact, because `SLOW_START_INTERVAL` is divisible by 2.
 pub const SLOW_START_SHIFT: Height = Height(SLOW_START_INTERVAL.0 / 2);
+
+/// The maximum chain reorganisation height.
+///
+/// This threshold determines the maximum length of the best non-finalized
+/// chain. Once the chain grows past this height, Zebra finalizes its oldest
+/// blocks; deeper reorganisations are outside Zebra's rollback window.
+///
+/// This is a local-only node policy; it is not part of consensus. The window is
+/// sized as a defence-in-depth measure against sustained consensus splits.
+//
+// TODO: change to HeightDiff
+pub const MAX_BLOCK_REORG_HEIGHT: u32 = 1000;
 
 /// Magic numbers used to identify different Zcash networks.
 pub mod magics {

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `MAX_BLOCK_REORG_HEIGHT` increased from 99 to 1000.
+
 ## [9.0.0] - 2026-06-10
 
 ### Breaking Changes

--- a/zebra-state/src/constants.rs
+++ b/zebra-state/src/constants.rs
@@ -13,17 +13,10 @@ use crate::{
 
 pub use zebra_chain::transparent::MIN_TRANSPARENT_COINBASE_MATURITY;
 
-/// The maximum chain reorganisation height.
-///
-/// This threshold determines the maximum length of the best non-finalized
-/// chain. Once the chain grows past this height, Zebra finalizes its oldest
-/// blocks; deeper reorganisations are outside Zebra's rollback window.
-///
-/// This is a local-only node policy; it is not part of consensus. The window is
-/// sized as a defence-in-depth measure against sustained consensus splits.
-//
-// TODO: change to HeightDiff
-pub const MAX_BLOCK_REORG_HEIGHT: u32 = 1000;
+/// The maximum chain reorganisation height; it bounds the length of the best
+/// non-finalized chain. The value lives in `zebra-chain` so tooling (e.g.
+/// `zebra-checkpoints`) can use it without depending on `zebra-state`.
+pub const MAX_BLOCK_REORG_HEIGHT: u32 = zebra_chain::parameters::constants::MAX_BLOCK_REORG_HEIGHT;
 
 /// The directory name used to distinguish the state database from Zebra's other databases or flat files.
 pub const STATE_DATABASE_KIND: &str = "state";

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -821,6 +821,10 @@ pub enum Request {
     ///
     /// <https://zips.z.cash/protocol/protocol.pdf#blockchain>
     ///
+    /// Note: Zebra's local rollback window
+    /// ([`MAX_BLOCK_REORG_HEIGHT`](crate::MAX_BLOCK_REORG_HEIGHT)) is now 1000 blocks, larger
+    /// than the 100 quoted from the protocol specification above.
+    ///
     /// # Correctness
     ///
     /// Block commit requests should be wrapped in a timeout, so that

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -90,7 +90,8 @@ pub use self::traits::{ReadState, State};
 /// A read-write service for Zebra's cached blockchain state.
 ///
 /// This service modifies and provides access to:
-/// - the non-finalized state: the ~100 most recent blocks.
+/// - the non-finalized state: the most recent blocks, up to
+///   [`MAX_BLOCK_REORG_HEIGHT`](crate::MAX_BLOCK_REORG_HEIGHT) of them.
 ///   Zebra allows chain forks in the non-finalized state,
 ///   stores it in memory, and re-downloads it when restarted.
 /// - the finalized state: older blocks that have many confirmations.
@@ -192,7 +193,8 @@ pub(crate) struct StateService {
 /// A read-only service for accessing Zebra's cached blockchain state.
 ///
 /// This service provides read-only access to:
-/// - the non-finalized state: the ~100 most recent blocks.
+/// - the non-finalized state: the most recent blocks, up to
+///   [`MAX_BLOCK_REORG_HEIGHT`](crate::MAX_BLOCK_REORG_HEIGHT) of them.
 /// - the finalized state: older blocks that have many confirmations.
 ///
 /// Requests to this service are processed in parallel,

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -676,7 +676,8 @@ impl NonFinalizedState {
     /// or `None` if the best chain has no blocks.
     pub fn best_chain_len(&self) -> Option<u32> {
         // This `as` can't overflow because the number of blocks in the chain is limited to i32::MAX,
-        // and the non-finalized chain is further limited by the fork length (slightly over 100 blocks).
+        // and the non-finalized chain is further limited by the rollback window
+        // (`MAX_BLOCK_REORG_HEIGHT`, currently 1000 blocks).
         Some(self.best_chain()?.blocks.len() as u32)
     }
 

--- a/zebra-utils/CHANGELOG.md
+++ b/zebra-utils/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `zebra-checkpoints` now backs off `MAX_BLOCK_REORG_HEIGHT` (1000) instead of the coinbase
+  maturity (100) when choosing the highest checkpoint.
+
 ## [8.0.0] - 2026-06-10
 
 ### Changed

--- a/zebra-utils/src/bin/zebra-checkpoints/main.rs
+++ b/zebra-utils/src/bin/zebra-checkpoints/main.rs
@@ -23,6 +23,7 @@ use structopt::StructOpt;
 
 use zebra_chain::{
     block::{self, Block, Height, HeightDiff, TryIntoHeight},
+    parameters::constants::MAX_BLOCK_REORG_HEIGHT,
     serialization::ZcashDeserializeInto,
     transparent::MIN_TRANSPARENT_COINBASE_MATURITY,
 };
@@ -31,6 +32,14 @@ use zebra_node_services::{
     rpc_client::RpcRequestClient,
 };
 use zebra_utils::init_tracing;
+
+// Checkpoints are generated past Zebra's rollback window (`MAX_BLOCK_REORG_HEIGHT`),
+// which must be at least the coinbase maturity so that checkpointed coinbase outputs
+// are already settled.
+const _: () = assert!(
+    MAX_BLOCK_REORG_HEIGHT >= MIN_TRANSPARENT_COINBASE_MATURITY,
+    "checkpoint settlement margin must be at least the coinbase maturity",
+);
 
 pub mod args;
 
@@ -162,14 +171,15 @@ async fn main() -> Result<()> {
         .try_into_height()
         .expect("height: unexpected invalid value, missing field, or field type");
 
-    // Checkpoints must be on the main chain, so we skip blocks that are within the
-    // Zcash reorg limit.
-    let height_limit = height_limit - HeightDiff::from(MIN_TRANSPARENT_COINBASE_MATURITY);
+    // Checkpoints must be on a settled part of the best chain, so we skip blocks
+    // within Zebra's rollback window (`MAX_BLOCK_REORG_HEIGHT`). A smaller margin
+    // could let a reorg that Zebra would still follow orphan a shipped checkpoint.
+    let height_limit = height_limit - HeightDiff::from(MAX_BLOCK_REORG_HEIGHT);
     let height_limit = height_limit
         .ok_or_else(|| {
             eyre!(
                 "checkpoint generation needs at least {:?} blocks",
-                MIN_TRANSPARENT_COINBASE_MATURITY
+                MAX_BLOCK_REORG_HEIGHT
             )
         })
         .with_suggestion(|| "Hint: wait for the node to sync more blocks")?;

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -3038,7 +3038,7 @@ async fn getrawtransaction_confirmations_include_non_finalized_blocks() -> Resul
     let client = RpcRequestClient::new(rpc_address);
 
     // Mine enough blocks to push the first few blocks into the finalized state.
-    // Block at height 2 is finalized once tip > 2 + MAX_BLOCK_REORG_HEIGHT = 101.
+    // Block at height 2 is finalized once tip > 2 + MAX_BLOCK_REORG_HEIGHT (= 1002).
     let blocks_to_mine = MAX_BLOCK_REORG_HEIGHT + 10;
     client.generate(blocks_to_mine).await?;
 
@@ -3958,8 +3958,8 @@ async fn has_spending_transaction_ids() -> Result<()> {
 
     tracing::info!("checking indexes of spending transaction ids");
 
-    // Read the last 500 blocks - should be greater than the MAX_BLOCK_REORG_HEIGHT so that
-    // both the finalized and non-finalized state are checked.
+    // Read the last 500 blocks. This exceeds the 100 blocks committed to the non-finalized
+    // state above, so the loop reads into the finalized state too, checking both.
     let num_blocks_to_check = 500;
     let mut is_failure = false;
     for i in 0..num_blocks_to_check {


### PR DESCRIPTION
## Motivation

Closes #10718.

## Solution

- Move `MAX_BLOCK_REORG_HEIGHT` into `zebra-chain` (`parameters::constants`);
  `zebra-state` re-exports it, so existing paths are unchanged and
  `zebra-checkpoints` can use it without depending on `zebra-state`.
- `zebra-checkpoints` skips blocks within the rollback window instead of the
  coinbase maturity, with a compile-time
  `assert!(MAX_BLOCK_REORG_HEIGHT >= MIN_TRANSPARENT_COINBASE_MATURITY)`.
- Refresh stale "~100 blocks" doc/comments in `zebra-state` and the reorg
  acceptance tests to reference `MAX_BLOCK_REORG_HEIGHT`.

### PR Checklist

- [x] Conventional-commits title.
- [x] Follows the contribution guidelines.
- [x] Tested.
- [x] Docs and changelogs updated.
