### PR TITLE
fix(state): surface RocksDB error messages in the block-write panic

### DIFF
--- a/zebra-state/src/service/finalized_state/zebra_db/block.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block.rs
@@ -569,9 +569,9 @@ impl ZebraDb {
 
         // Track batch commit latency for observability
         let batch_start = std::time::Instant::now();
-        self.db
-            .write(batch)
-            .expect("unexpected rocksdb error while writing block");
+        if let Err(error) = self.db.write(batch) {
+            panic!("unexpected rocksdb error while writing block: {error}");
+        }
         metrics::histogram!("zebra.state.rocksdb.batch_commit.duration_seconds")
             .record(batch_start.elapsed().as_secs_f64());
 


### PR DESCRIPTION
## Motivation

If Zebra's data disk fills up, operators currently see "unexpected rocksdb error while writing block". This could be more verbose to help operators pinpoint the issue quickly.

## Solution

This patch surfaces the exact RocksDB error message. Operators now see error messages like "unexpected rocksdb error while writing block: IO error: No space left on device".

### AI Disclosure

- [x] No AI tools were used in this PR

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand. (a ZF team member encouraged this PR on Discord)
- [x] The solution is tested.
- [ ] The documentation and changelogs are up to date.
