### PR TITLE
release: Zebra v5.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [Zebra 5.1.2](https://github.com/ZcashFoundation/zebra/releases/tag/v5.1.2) - 2026-06-15
+
+This release increases Zebra's local rollback window as a defence-in-depth measure
+against sustained consensus splits.
+
 ### Changed
 
 - Increased Zebra's local rollback window (`MAX_BLOCK_REORG_HEIGHT`) from 99 to
-  1000 blocks as a defence-in-depth measure against sustained consensus splits.
+  1000 blocks as a defence-in-depth measure against sustained consensus splits
+  ([#10650](https://github.com/ZcashFoundation/zebra/pull/10650))
 
 ## [Zebra 5.1.1](https://github.com/ZcashFoundation/zebra/releases/tag/v5.1.1) - 2026-06-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7510,7 +7510,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-consensus"
-version = "9.0.0"
+version = "9.0.1"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7618,7 +7618,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "10.0.0"
+version = "10.0.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7701,7 +7701,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "9.0.0"
+version = "9.0.1"
 dependencies = [
  "bincode",
  "chrono",
@@ -7777,7 +7777,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-utils"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "color-eyre",
  "hex",
@@ -7799,7 +7799,7 @@ dependencies = [
 
 [[package]]
 name = "zebrad"
-version = "5.1.1"
+version = "5.1.2"
 dependencies = [
  "abscissa_core",
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ cargo install --locked zebrad
 Alternatively, you can install it from GitHub:
 
 ```sh
-cargo install --git https://github.com/ZcashFoundation/zebra --tag v5.1.1 zebrad
+cargo install --git https://github.com/ZcashFoundation/zebra --tag v5.1.2 zebrad
 ```
 
 You can start Zebra by running

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.0.1] - 2026-06-15
+
+### Changed
+
+- `zebra-state` dependency bumped to `9.0.1`
+
 ## [9.0.0] - 2026-06-10
 
 ### Changed

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-consensus"
-version = "9.0.0"
+version = "9.0.1"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks"
 license.workspace = true
@@ -71,7 +71,7 @@ tower-fallback = { path = "../tower-fallback/", version = "0.2.41" }
 tower-batch-control = { path = "../tower-batch-control/", version = "1.0.1" }
 
 zebra-script = { path = "../zebra-script", version = "9.0.0" }
-zebra-state = { path = "../zebra-state", version = "9.0.0" }
+zebra-state = { path = "../zebra-state", version = "9.0.1" }
 zebra-node-services = { path = "../zebra-node-services", version = "8.0.0" }
 zebra-chain = { path = "../zebra-chain", version = "10.0.0" }
 
@@ -97,7 +97,7 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zebra-state = { path = "../zebra-state", version = "9.0.0", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", version = "9.0.1", features = ["proptest-impl"] }
 zebra-chain = { path = "../zebra-chain", version = "10.0.0", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/", version = "3.0.0" }
 

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.0.1] - 2026-06-15
+
+### Changed
+
+- `zebra-state` dependency bumped to `9.0.1`, and `zebra-consensus` to `9.0.1`
+
 ## [10.0.0] - 2026-06-10
 
 ### Breaking Changes

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-rpc"
-version = "10.0.0"
+version = "10.0.1"
 authors.workspace = true
 description = "A Zebra JSON Remote Procedure Call (JSON-RPC) interface"
 license.workspace = true
@@ -112,13 +112,13 @@ proptest = { workspace = true, optional = true }
 zebra-chain = { path = "../zebra-chain", version = "10.0.0", features = [
     "json-conversion",
 ] }
-zebra-consensus = { path = "../zebra-consensus", version = "9.0.0" }
+zebra-consensus = { path = "../zebra-consensus", version = "9.0.1" }
 zebra-network = { path = "../zebra-network", version = "9.0.0" }
 zebra-node-services = { path = "../zebra-node-services", version = "8.0.0", features = [
     "rpc-client",
 ] }
 zebra-script = { path = "../zebra-script", version = "9.0.0" }
-zebra-state = { path = "../zebra-state", version = "9.0.0" }
+zebra-state = { path = "../zebra-state", version = "9.0.1" }
 
 [build-dependencies]
 openrpsee = { workspace = true }
@@ -139,13 +139,13 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 zebra-chain = { path = "../zebra-chain", version = "10.0.0", features = [
     "proptest-impl",
 ] }
-zebra-consensus = { path = "../zebra-consensus", version = "9.0.0", features = [
+zebra-consensus = { path = "../zebra-consensus", version = "9.0.1", features = [
     "proptest-impl",
 ] }
 zebra-network = { path = "../zebra-network", version = "9.0.0", features = [
     "proptest-impl",
 ] }
-zebra-state = { path = "../zebra-state", version = "9.0.0", features = [
+zebra-state = { path = "../zebra-state", version = "9.0.1", features = [
     "proptest-impl",
 ] }
 

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.0.1] - 2026-06-15
+
+### Changed
+
+- Increased the local rollback window (`MAX_BLOCK_REORG_HEIGHT`) from 99 to 1000
+  blocks as a defence-in-depth measure against sustained consensus splits
+  ([#10650](https://github.com/ZcashFoundation/zebra/pull/10650))
+
 ## [9.0.0] - 2026-06-10
 
 ### Breaking Changes

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-state"
-version = "9.0.0"
+version = "9.0.1"
 authors.workspace = true
 description = "State contextual verification and storage code for Zebra"
 license.workspace = true

--- a/zebra-utils/CHANGELOG.md
+++ b/zebra-utils/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.0.1] - 2026-06-15
+
+### Changed
+
+- `zebra-rpc` dependency bumped to `10.0.1`
+
 ## [8.0.0] - 2026-06-10
 
 ### Changed

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-utils"
-version = "8.0.0"
+version = "8.0.1"
 authors.workspace = true
 description = "Developer tools for Zebra maintenance and testing"
 license.workspace = true
@@ -64,7 +64,7 @@ zebra-node-services = { path = "../zebra-node-services", version = "8.0.0" }
 zebra-chain = { path = "../zebra-chain", version = "10.0.0" }
 
 # These crates are needed for the block-template-to-proposal binary
-zebra-rpc = { path = "../zebra-rpc", version = "10.0.0" }
+zebra-rpc = { path = "../zebra-rpc", version = "10.0.1" }
 
 # These crates are needed for the zebra-checkpoints binary
 itertools = { workspace = true, optional = true }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate metadata
 name = "zebrad"
-version = "5.1.1"
+version = "5.1.2"
 authors.workspace = true
 description = "The Zcash Foundation's independent, consensus-compatible implementation of a Zcash node"
 license.workspace = true
@@ -149,11 +149,11 @@ comparison-interpreter = ["zebra-script/comparison-interpreter"]
 
 [dependencies]
 zebra-chain = { path = "../zebra-chain", version = "10.0.0" }
-zebra-consensus = { path = "../zebra-consensus", version = "9.0.0" }
+zebra-consensus = { path = "../zebra-consensus", version = "9.0.1" }
 zebra-network = { path = "../zebra-network", version = "9.0.0" }
 zebra-node-services = { path = "../zebra-node-services", version = "8.0.0", features = ["rpc-client"] }
-zebra-rpc = { path = "../zebra-rpc", version = "10.0.0" }
-zebra-state = { path = "../zebra-state", version = "9.0.0" }
+zebra-rpc = { path = "../zebra-rpc", version = "10.0.1" }
+zebra-state = { path = "../zebra-state", version = "9.0.1" }
 # zebra-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
 # enabling it in the other imports of zcash-script.)
@@ -161,7 +161,7 @@ zebra-script = { path = "../zebra-script", version = "9.0.0" }
 zcash_script = { workspace = true }
 
 # Required for crates.io publishing, but it's only used in tests
-zebra-utils = { path = "../zebra-utils", version = "8.0.0", optional = true }
+zebra-utils = { path = "../zebra-utils", version = "8.0.1", optional = true }
 
 abscissa_core = { workspace = true }
 clap = { workspace = true, features = ["cargo"] }
@@ -294,9 +294,9 @@ proptest-derive = { workspace = true }
 color-eyre = { workspace = true }
 
 zebra-chain = { path = "../zebra-chain", version = "10.0.0", features = ["proptest-impl"] }
-zebra-consensus = { path = "../zebra-consensus", version = "9.0.0", features = ["proptest-impl"] }
+zebra-consensus = { path = "../zebra-consensus", version = "9.0.1", features = ["proptest-impl"] }
 zebra-network = { path = "../zebra-network", version = "9.0.0", features = ["proptest-impl"] }
-zebra-state = { path = "../zebra-state", version = "9.0.0", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", version = "9.0.1", features = ["proptest-impl"] }
 
 zebra-test = { path = "../zebra-test", version = "3.0.0" }
 
@@ -309,7 +309,7 @@ zebra-test = { path = "../zebra-test", version = "3.0.0" }
 # When `-Z bindeps` is stabilised, enable this binary dependency instead:
 # https://github.com/rust-lang/cargo/issues/9096
 # zebra-utils { path = "../zebra-utils", artifact = "bin:zebra-checkpoints" }
-zebra-utils = { path = "../zebra-utils", version = "8.0.0" }
+zebra-utils = { path = "../zebra-utils", version = "8.0.1" }
 
 [package.metadata.cargo-udeps.ignore]
 # These dependencies are false positives - they are actually used


### PR DESCRIPTION
## Motivation

Prepares the **Zebra v5.1.2** patch release. The increased local rollback
window (`MAX_BLOCK_REORG_HEIGHT` 99 → 1000) merged to `main` in #10650 and the
checkpoint settling fix in #10719 have not yet shipped; this patch ships them.

## Solution

- Bump `zebrad` 5.1.1 → 5.1.2
- Bump published crate versions: `zebra-state` 9.0.0 → 9.0.1,
  `zebra-consensus` 9.0.0 → 9.0.1, `zebra-rpc` 10.0.0 → 10.0.1,
  `zebra-utils` 8.0.0 → 8.0.1
- Update per-crate CHANGELOGs with release entries
- Update the install tag in `README.md`

No code changes are introduced here — #10650 and #10719 are already on `main`.
Checkpoint updates were intentionally skipped for this patch release.

## AI disclosure

The release branch (version bump + changelog/README edits) was prepared with
Claude Code. No consensus or runtime code was authored by AI in this PR.

---


# Prepare for the Release

- [ ] Make sure there has been [at least one successful full sync test in the main branch](https://github.com/ZcashFoundation/zebra/actions/workflows/zfnd-ci-integration-tests-gcp.yml?query=branch%3Amain) since the last state change, or start a manual full sync.

# Checkpoints

For performance and security, we want to update the Zebra checkpoints in every release.

- [ ] You can copy the latest checkpoints from CI by following [the zebra-checkpoints README](https://github.com/ZcashFoundation/zebra/blob/main/zebra-utils/README.md#zebra-checkpoints).

# Missed Dependency Updates

Sometimes `dependabot` misses some dependency updates, or we accidentally turned them off.

This step can be skipped if there is a large pending dependency upgrade. (For example, shared ECC crates.)

Here's how we make sure we got everything:

- [ ] Run `cargo update` on the latest `main` branch, and keep the output
- [ ] Until we bump the workspace MSRV to 1.88 or higher, `home` must be downgraded manually: `cargo update home@0.5.12 --precise 0.5.11`
- [ ] If needed, [add duplicate dependency exceptions to deny.toml](https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/continuous-integration.md#fixing-duplicate-dependencies-in-check-denytoml-bans)
- [ ] If needed, remove resolved duplicate dependencies from `deny.toml`
- [ ] Open a separate PR with the changes
- [ ] Add the output of `cargo update` to that PR as a comment

# Summarise Release Changes

These steps can be done a few days before the release, in the same PR:

## Change Log

**Important**: Any merge into `main` deletes any edits to the draft changelog.
Once you are ready to tag a release, copy the draft changelog into `CHANGELOG.md`.

We use [the Release Drafter workflow](https://github.com/marketplace/actions/release-drafter) to automatically create a [draft changelog](https://github.com/ZcashFoundation/zebra/releases). We follow the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.

To create the final change log:

- [ ] Copy the [**latest** draft
      changelog](https://github.com/ZcashFoundation/zebra/releases) into
      `CHANGELOG.md` (there can be multiple draft releases)
- [ ] Delete any trivial changes
  - [ ] Put the list of deleted changelog entries in a PR comment to make reviewing easier
- [ ] Combine duplicate changes
- [ ] Edit change descriptions so they will make sense to Zebra users
- [ ] Check the category for each change
  - Prefer the "Fix" category if you're not sure

## README

README updates can be skipped for urgent releases.

Update the README to:

- [ ] Remove any "Known Issues" that have been fixed since the last release.
- [ ] Update the "Build and Run Instructions" with any new dependencies.
      Check for changes in the `Dockerfile` since the last tag: `git diff <previous-release-tag> docker/Dockerfile`.
- [ ] If Zebra has started using newer Rust language features or standard library APIs, update the known working Rust version in the README, book, and `Cargo.toml`s

You can use a command like:

```sh
fastmod --fixed-strings '1.58' '1.65'
```

## Create the Release PR

- [ ] Push the updated changelog and README into a new branch
      for example: `bump-v1.0.0` - this needs to be different to the tag name
- [ ] Create a release PR by adding `&template=release-checklist.md` to the comparing url ([Example](https://github.com/ZcashFoundation/zebra/compare/bump-v1.0.0?expand=1&template=release-checklist.md)).
- [ ] Freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [ ] Mark all the release PRs as `Critical` priority, so they go in the `urgent` Mergify queue.
- [ ] Mark all non-release PRs with `do-not-merge`, because Mergify checks approved PRs against every commit, even when a queue is frozen.
- [ ] Add the `A-release` tag to the release pull request in order for the `check-no-git-dependencies` to run.

## Zebra git sources dependencies

- [ ] Ensure the `check-no-git-dependencies` check passes.

This check runs automatically on pull requests with the `A-release` label. It must pass for crates to be published to crates.io. If the check fails, you should either halt the release process or proceed with the understanding that the crates will not be published on crates.io.

# Update Versions and End of Support

## Update Zebra Version

Zebra follows [semantic versioning](https://semver.org). Semantic versions look like: MAJOR.MINOR.PATCH[-TAG.PRE-RELEASE]

Choose a release level for `zebrad`. Release levels are based on user-visible changes from the changelog:

- Mainnet Network Upgrades are `major` releases
- significant new features or behaviour changes; changes to RPCs, command-line, or configs; and deprecations or removals are `minor` releases
- otherwise, it is a `patch` release

## Update Crate Versions and Crate Change Logs

If you're publishing crates for the first time, [log in to crates.io](https://zebra.zfnd.org/dev/crate-owners.html#logging-in-to-cratesio),
and make sure you're a member of owners group.

Check that the release will work:

- [ ] Determine which crates require release. Run `git diff --stat <previous_tag>`
      and enumerate the crates that had changes.
- [ ] Update (or install) `semver-checks`: `cargo +stable install cargo-semver-checks --locked`
- [ ] Update (or install) `public-api`: `cargo +stable install cargo-public-api --locked`
- [ ] For each crate that requires a release:
  - [ ] Determine which type of release to make. Run `semver-checks` to list API
        changes: `cargo semver-checks -p <crate> --default-features`. If there are
        breaking API changes, do a major release, or try to revert the API change
        if it was accidental. Otherwise do a minor or patch release depending on
        whether a new API was added. Note that `semver-checks` won't work
        if the previous realase was yanked; you will have to determine the
        type of release manually.
  - [ ] Update the crate `CHANGELOG.md` listing the API changes or other
        relevant information for a crate consumer. Use `public-api` to list all
        API changes: `cargo public-api diff latest -p <crate> -sss`. You can use
        e.g. copilot to turn it into a human-readable list, e.g. (write the output
        to `api.txt` beforehand):
        ```
        copilot -p "Transform @api.txt which is a API diff into a human-readable description of the API changes. Be terse. Write output api-readable.txt. Use backtick quotes for identifiers. Use '### Breaking Changes' header for changes and removals, and '### Added' for additions. Make each item start with a verb e.g, Added, Changed" --allow-tool write
        ```
        It might also make sense to copy entries from the `zebrad` changelog.
  - [ ] Update crate versions:

```sh
cargo release version --verbose --execute --allow-branch '*' -p <crate> patch # [ major | minor ]
# zebrad only
cargo release replace --verbose --execute --allow-branch '*' -p zebrad
```

- [ ] Commit and push the above version changes to the release branch.

- [ ] **Major (network upgrade) releases only:** Check that `INITIAL_MIN_NETWORK_PROTOCOL_VERSION` in [`zebra-network/src/constants.rs`](https://github.com/ZcashFoundation/zebra/blob/main/zebra-network/src/constants.rs) uses the latest activated network upgrade.

## Update End of Support

The end of support height is calculated from the current blockchain height:

- [ ] Find where the Zcash blockchain tip is now by using a [Zcash Block Explorer](https://mainnet.zcashexplorer.app/) or other tool.
- [ ] Replace `ESTIMATED_RELEASE_HEIGHT` in [`end_of_support.rs`](https://github.com/ZcashFoundation/zebra/blob/main/zebrad/src/components/sync/end_of_support.rs) with the height you estimate the release will be tagged.

<details>

<summary>Optional: calculate the release tagging height</summary>

- Find where the Zcash blockchain tip is now by using a [Zcash Block Explorer](https://mainnet.zcashexplorer.app/) or other tool.
- Add `1152` blocks for each day until the release
- For example, if the release is in 3 days, add `1152 * 3` to the current Mainnet block height

</details>

## Update the Release PR

- [ ] Push the version increments and the release constants to the release branch.

# Publish the Zebra Release

## Create the GitHub Pre-Release

- [ ] Wait for all the release PRs to be merged
- [ ] Create a new release using the draft release as a base, by clicking the Edit icon in the [draft release](https://github.com/ZcashFoundation/zebra/releases)
- [ ] Set the tag name to the version tag,
      for example: `v1.0.0`
- [ ] Set the release to target the `main` branch
- [ ] Set the release title to `Zebra ` followed by the version tag,
      for example: `Zebra 1.0.0`
- [ ] Replace the prepopulated draft changelog in the release description with the final changelog you created;
      starting just _after_ the title `## [Zebra ...` of the current version being released,
      and ending just _before_ the title of the previous release.
- [ ] Mark the release as 'pre-release', until it has been built and tested
- [ ] Publish the pre-release to GitHub using "Publish Release"
- [ ] Delete all the [draft releases from the list of releases](https://github.com/ZcashFoundation/zebra/releases)

## Test the Pre-Release

- [ ] Wait until the Docker binaries have been built on `main`, and the quick tests have passed:
  - [ ] [zfnd-ci-integration-tests-gcp.yml](https://github.com/ZcashFoundation/zebra/actions/workflows/zfnd-ci-integration-tests-gcp.yml?query=branch%3Amain)
- [ ] Wait until the [pre-release deployment machines have successfully launched](https://github.com/ZcashFoundation/zebra/actions/workflows/zfnd-deploy-nodes-gcp.yml?query=event%3Arelease)

## Publish Release

- [ ] [Publish the release to GitHub](https://github.com/ZcashFoundation/zebra/releases) by disabling 'pre-release', then clicking "Set as the latest release"

## Publish Crates

- [ ] [Run `cargo login`](https://zebra.zfnd.org/dev/crate-owners.html#logging-in-to-cratesio)
- [ ] It is recommended that the following step be run from a fresh checkout of
      the repo, to avoid accidentally publishing files like e.g. logs that might
      be lingering around
- [ ] Publish the crates to crates.io; edit the list to only include the crates that
      have been changed, but keep their overall order:

```
for c in zebra-test tower-fallback zebra-chain tower-batch-control zebra-node-services zebra-script zebra-state zebra-consensus zebra-network zebra-rpc zebra-utils zebrad; do cargo release publish --verbose --execute -p $c; done
```

- [ ] Check that Zebra can be installed from `crates.io`:
      `cargo install --locked --force --version <version> zebrad && ~/.cargo/bin/zebrad`
      and put the output in a comment on the PR.

## Publish Docker Images

- [ ] Wait for the [the Docker images to be published successfully](https://github.com/ZcashFoundation/zebra/actions/workflows/release-binaries.yml?query=event%3Arelease).
- [ ] Wait for the new tag in the [dockerhub zebra space](https://hub.docker.com/r/zfnd/zebra/tags)
- [ ] Un-freeze the [`batched` queue](https://dashboard.mergify.com/github/ZcashFoundation/repo/zebra/queues) using Mergify.
- [ ] Remove `do-not-merge` from the PRs you added it to

## Release Failures

If building or running fails after tagging:

<details>

<summary>Tag a new release, following these instructions...</summary>

1. Fix the bug that caused the failure
2. Start a new `patch` release
3. Skip the **Release Preparation**, and start at the **Release Changes** step
4. Update `CHANGELOG.md` with details about the fix
5. Follow the release checklist for the new Zebra version

</details>