### PR TITLE
feat(zebrad): run a command on chain tip changes (block notify)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   `ReadResponse::ForkPoint`) that returns the most recent block in a caller-supplied
   locator that is on the best chain — the fork point — for clients tracking chain
   reorganizations through a read-only state service.
+- Added a `[notify] block_notify_command` option that runs a command on each best-chain-tip
+  change, with `%s` replaced by the new block hash — Zebra's equivalent of `zcashd`'s
+  `-blocknotify`.
 
 ### Changed
 

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -186,7 +186,7 @@ toml = { workspace = true }
 
 futures = { workspace = true }
 rayon = { workspace = true }
-tokio = { workspace = true, features = ["time", "rt-multi-thread", "macros", "tracing", "signal"] }
+tokio = { workspace = true, features = ["time", "rt-multi-thread", "macros", "tracing", "signal", "process"] }
 tokio-stream = { workspace = true, features = ["time"] }
 tower = { workspace = true, features = ["hedge", "limit"] }
 pin-project = { workspace = true }

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -42,6 +42,9 @@
 //!  * Block Gossip Task
 //!    * runs in the background and continuously queries the state for
 //!      newly committed blocks to be gossiped to peers
+//!  * Block Notify Task
+//!    * if the user has configured a `notify.block_notify_command`, runs that command
+//!      whenever the best chain tip changes (Zebra's equivalent of zcashd's `-blocknotify`)
 //!  * Progress Task
 //!    * logs progress towards the chain tip
 //!
@@ -92,6 +95,7 @@ use crate::{
         health,
         inbound::{self, InboundSetupData, MAX_INBOUND_RESPONSE_TIME},
         mempool::{self, Mempool},
+        notify::{self, BlockNotifyError},
         sync::{self, show_block_chain_progress, VERIFICATION_PIPELINE_SCALING_MULTIPLIER},
         tokio::{RuntimeRun, TokioComponent},
         ChainSync, Inbound,
@@ -344,6 +348,21 @@ impl StartCmd {
             .in_current_span(),
         );
 
+        info!("spawning block notify task");
+        let block_notify_task_handle: tokio::task::JoinHandle<Result<(), BlockNotifyError>> =
+            if let Some(command) = config.notify.block_notify_command.clone() {
+                tokio::spawn(
+                    notify::run_block_notify(
+                        command,
+                        sync_status.clone(),
+                        chain_tip_change.clone(),
+                    )
+                    .in_current_span(),
+                )
+            } else {
+                tokio::spawn(std::future::pending().in_current_span())
+            };
+
         info!("spawning mempool queue checker task");
         let mempool_queue_checker_task_handle = mempool::QueueChecker::spawn(mempool.clone());
 
@@ -458,6 +477,7 @@ impl StartCmd {
         pin!(indexer_rpc_task_handle);
         pin!(syncer_task_handle);
         pin!(block_gossip_task_handle);
+        pin!(block_notify_task_handle);
         pin!(mempool_crawler_task_handle);
         pin!(mempool_queue_checker_task_handle);
         pin!(tx_gossip_task_handle);
@@ -509,6 +529,11 @@ impl StartCmd {
                 block_gossip_result = &mut block_gossip_task_handle => block_gossip_result
                     .expect("unexpected panic in the chain tip block gossip task")
                     .map(|_| info!("chain tip block gossip task exited"))
+                    .map_err(|e| eyre!(e)),
+
+                block_notify_result = &mut block_notify_task_handle => block_notify_result
+                    .expect("unexpected panic in the block notify task")
+                    .map(|_| info!("block notify task exited"))
                     .map_err(|e| eyre!(e)),
 
                 mempool_crawl_result = &mut mempool_crawler_task_handle => mempool_crawl_result
@@ -582,6 +607,7 @@ impl StartCmd {
         health_task_handle.abort();
         syncer_task_handle.abort();
         block_gossip_task_handle.abort();
+        block_notify_task_handle.abort();
         mempool_crawler_task_handle.abort();
         mempool_queue_checker_task_handle.abort();
         tx_gossip_task_handle.abort();

--- a/zebrad/src/components.rs
+++ b/zebrad/src/components.rs
@@ -10,6 +10,7 @@ pub mod inbound;
 #[allow(missing_docs)]
 pub mod mempool;
 pub mod metrics;
+pub mod notify;
 #[allow(missing_docs)]
 pub mod sync;
 #[allow(missing_docs)]

--- a/zebrad/src/components/notify.rs
+++ b/zebrad/src/components/notify.rs
@@ -80,22 +80,25 @@ pub async fn run_block_notify(
     info!("initializing block notify task");
 
     loop {
-        // Wait for at least one tip change first. This blocks while in initial block download, so
-        // we don't busy-loop on `wait_until_close_to_tip()` before any blocks have arrived.
+        // Block until the tip changes. This always waits for a real change, so it paces the loop.
+        // The gate below can't pace the loop: it returns immediately when synced. It doesn't skip
+        // the initial sync (the tip changes throughout it); that's the gate's job.
         let tip_action = chain_tip_change
             .wait_for_tip_change()
             .await
             .map_err(BlockNotifyError::TipChange)?;
 
-        // Suppress notifications until we're close to the tip, like zcashd suppresses the callback
-        // during initial block download.
+        // Gate: hold until we're close to the tip (done catching up), suppressing notifications
+        // during sync. Must sit right before the spawn so close-to-tip still holds when we fire;
+        // gating earlier could fire on an intermediate block if we fall behind again first.
         sync_status
             .wait_until_close_to_tip()
             .await
             .map_err(BlockNotifyError::SyncStatus)?;
 
-        // Re-read the tip after the IBD gate: reaching the tip can take time, so `tip_action` may
-        // be stale by now. Fall back to it if no newer change is pending.
+        // Grab the freshest tip: catching up can take a while, during which newer blocks may have
+        // landed and made `tip_action` stale. This peek doesn't block; fall back to `tip_action`
+        // when nothing newer is pending.
         let (hash, height) = chain_tip_change
             .last_tip_change()
             .unwrap_or(tip_action)
@@ -139,20 +142,16 @@ fn spawn_notify_command(command: &str, hash: block::Hash, height: block::Height)
     let span = info_span!("block_notify_command", %hash, ?height);
 
     match cmd.spawn() {
-        Ok(child) => {
+        Ok(mut child) => {
             // Reap the child asynchronously to avoid zombies, and log non-zero exits like zcashd's
             // `runCommand`. The main loop never awaits this, so it returns immediately to await the
-            // next tip change.
+            // next tip change. stdout/stderr go to `/dev/null`, so we only need the exit status.
             tokio::spawn(async move {
                 let _enter = span.enter();
 
-                match child.wait_with_output().await {
-                    Ok(output) if !output.status.success() => {
-                        warn!(
-                            ?rendered,
-                            status = ?output.status,
-                            "block notify command exited non-zero"
-                        );
+                match child.wait().await {
+                    Ok(status) if !status.success() => {
+                        warn!(?rendered, ?status, "block notify command exited non-zero");
                     }
                     Ok(_) => {}
                     Err(error) => {

--- a/zebrad/src/components/notify.rs
+++ b/zebrad/src/components/notify.rs
@@ -9,6 +9,7 @@ use std::process::Stdio;
 
 use thiserror::Error;
 use tokio::sync::watch;
+use tracing::Instrument;
 
 use zebra_chain::block;
 use zebra_state::ChainTipChange;
@@ -146,19 +147,20 @@ fn spawn_notify_command(command: &str, hash: block::Hash, height: block::Height)
             // Reap the child asynchronously to avoid zombies, and log non-zero exits like zcashd's
             // `runCommand`. The main loop never awaits this, so it returns immediately to await the
             // next tip change. stdout/stderr go to `/dev/null`, so we only need the exit status.
-            tokio::spawn(async move {
-                let _enter = span.enter();
-
-                match child.wait().await {
-                    Ok(status) if !status.success() => {
-                        warn!(?rendered, ?status, "block notify command exited non-zero");
-                    }
-                    Ok(_) => {}
-                    Err(error) => {
-                        warn!(?rendered, ?error, "failed to wait on block notify command");
+            tokio::spawn(
+                async move {
+                    match child.wait().await {
+                        Ok(status) if !status.success() => {
+                            warn!(?rendered, ?status, "block notify command exited non-zero");
+                        }
+                        Ok(_) => {}
+                        Err(error) => {
+                            warn!(?rendered, ?error, "failed to wait on block notify command");
+                        }
                     }
                 }
-            });
+                .instrument(span),
+            );
         }
         Err(error) => warn!(?rendered, ?error, "failed to spawn block notify command"),
     }

--- a/zebrad/src/components/notify.rs
+++ b/zebrad/src/components/notify.rs
@@ -1,0 +1,175 @@
+//! A task that runs an external command whenever the best chain tip changes.
+//!
+//! This is Zebra's port of zcashd's `-blocknotify`. Whenever the node's best chain tip changes,
+//! and the node is close to the network tip (Zebra's analogue of "not in initial block download"),
+//! the configured command is run via the system shell with every `%s` replaced by the new tip's
+//! block hash. The command is run detached and never blocks block validation.
+
+use std::process::Stdio;
+
+use thiserror::Error;
+use tokio::sync::watch;
+
+use zebra_chain::block;
+use zebra_state::ChainTipChange;
+
+use crate::components::sync::SyncStatus;
+
+#[cfg(test)]
+mod tests;
+
+/// Block notify configuration section.
+///
+/// Mirrors zcashd's `-blocknotify` option.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct Config {
+    /// Command run whenever the best chain tip changes, mirroring zcashd's `-blocknotify`.
+    ///
+    /// Every `%s` in the command is replaced with the new tip's block hash in `getbestblockhash`
+    /// hex format. The command is run via the system shell (`/bin/sh -c` on Unix, `cmd /C` on
+    /// Windows), detached, and never blocks block validation. It is not run during initial block
+    /// download (gated on [`SyncStatus::wait_until_close_to_tip`]).
+    ///
+    /// Best-effort per tip change: during fast sync or reorgs, intermediate tip hashes may be
+    /// coalesced and skipped — only the current best tip hash fires. Disabled when `None`.
+    pub block_notify_command: Option<String>,
+}
+
+// we like our default configs to be explicit
+#[allow(unknown_lints)]
+#[allow(clippy::derivable_impls)]
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            block_notify_command: None,
+        }
+    }
+}
+
+/// Errors that can occur in the block notify task.
+#[derive(Error, Debug)]
+pub enum BlockNotifyError {
+    /// The chain tip sender was dropped, so we can't observe further tip changes.
+    #[error("chain tip sender was dropped")]
+    TipChange(watch::error::RecvError),
+
+    /// The sync status sender was dropped, so we can't tell when we're close to the tip.
+    #[error("sync status sender was dropped")]
+    SyncStatus(watch::error::RecvError),
+}
+
+/// Run continuously, executing `command` whenever the best chain tip changes.
+///
+/// Mirrors zcashd's `-blocknotify`: each `%s` in `command` is replaced with the new tip's block
+/// hash in `getbestblockhash` hex format, and the command is run detached via the system shell.
+///
+/// The command is only run once the node is close to the network tip, which is Zebra's analogue
+/// of zcashd suppressing the callback during initial block download. If a lot of blocks are
+/// committed at once, intermediate tip hashes are coalesced into a single [`Reset`] by
+/// [`ChainTipChange`], so only the current best tip hash fires.
+///
+/// Returns an error if communication with the state or the syncer is lost.
+///
+/// [`Reset`]: zebra_state::TipAction::Reset
+pub async fn run_block_notify(
+    command: String,
+    mut sync_status: SyncStatus,
+    mut chain_tip_change: ChainTipChange,
+) -> Result<(), BlockNotifyError> {
+    info!("initializing block notify task");
+
+    loop {
+        // Wait for at least one tip change first. This blocks while in initial block download, so
+        // we don't busy-loop on `wait_until_close_to_tip()` before any blocks have arrived.
+        let tip_action = chain_tip_change
+            .wait_for_tip_change()
+            .await
+            .map_err(BlockNotifyError::TipChange)?;
+
+        // Suppress notifications until we're close to the tip, like zcashd suppresses the callback
+        // during initial block download.
+        sync_status
+            .wait_until_close_to_tip()
+            .await
+            .map_err(BlockNotifyError::SyncStatus)?;
+
+        // Re-read the tip after the IBD gate: reaching the tip can take time, so `tip_action` may
+        // be stale by now. Fall back to it if no newer change is pending.
+        let (hash, height) = chain_tip_change
+            .last_tip_change()
+            .unwrap_or(tip_action)
+            .best_tip_hash_and_height();
+
+        spawn_notify_command(&command, hash, height);
+    }
+}
+
+/// Renders `command` for `hash` and spawns it detached via the system shell.
+///
+/// The command never blocks the caller: it is spawned and reaped in a separate task, so a hung
+/// command cannot stall block validation.
+fn spawn_notify_command(command: &str, hash: block::Hash, height: block::Height) {
+    let rendered = render_command(command, hash);
+
+    // Run the command via the system shell, like zcashd's `system()`: `/bin/sh -c` on Unix, and
+    // `cmd /C` on Windows.
+    #[cfg(not(target_os = "windows"))]
+    let mut cmd = {
+        let mut cmd = tokio::process::Command::new("/bin/sh");
+        cmd.arg("-c").arg(&rendered);
+        cmd
+    };
+    #[cfg(target_os = "windows")]
+    let mut cmd = {
+        let mut cmd = tokio::process::Command::new("cmd");
+        cmd.arg("/C").arg(&rendered);
+        cmd
+    };
+
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    // Put the command in its own process group on Unix, so signals sent to zebrad's process group
+    // (such as Ctrl-C) don't also hit the notify command.
+    #[cfg(unix)]
+    cmd.process_group(0);
+
+    let span = info_span!("block_notify_command", %hash, ?height);
+
+    match cmd.spawn() {
+        Ok(child) => {
+            // Reap the child asynchronously to avoid zombies, and log non-zero exits like zcashd's
+            // `runCommand`. The main loop never awaits this, so it returns immediately to await the
+            // next tip change.
+            tokio::spawn(async move {
+                let _enter = span.enter();
+
+                match child.wait_with_output().await {
+                    Ok(output) if !output.status.success() => {
+                        warn!(
+                            ?rendered,
+                            status = ?output.status,
+                            "block notify command exited non-zero"
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(error) => {
+                        warn!(?rendered, ?error, "failed to wait on block notify command");
+                    }
+                }
+            });
+        }
+        Err(error) => warn!(?rendered, ?error, "failed to spawn block notify command"),
+    }
+}
+
+/// Replaces every `%s` in `command` with `hash` in `getbestblockhash` hex format.
+///
+/// [`block::Hash`]'s [`Display`](std::fmt::Display) impl already yields the `getbestblockhash`
+/// format (display-order hex), so the substituted value is a fixed 64-char `[0-9a-f]` string with
+/// no shell metacharacters.
+fn render_command(command: &str, hash: block::Hash) -> String {
+    command.replace("%s", &hash.to_string())
+}

--- a/zebrad/src/components/notify/tests.rs
+++ b/zebrad/src/components/notify/tests.rs
@@ -1,0 +1,130 @@
+//! Unit tests for the block notify task.
+
+use std::time::Duration;
+
+use hex::FromHex;
+
+use zebra_chain::block;
+
+use super::{render_command, spawn_notify_command, Config};
+
+/// A fixed, deterministic block hash in `getbestblockhash` (display-order) hex format.
+const TIP_HASH_HEX: &str = "00000000019960941bd62fbf6504c5be23a061665a9c0e2e36180a263ab6cb50";
+
+/// Returns a deterministic [`block::Hash`] for tests.
+fn test_hash() -> block::Hash {
+    block::Hash::from_hex(TIP_HASH_HEX).expect("test hash is valid display-order hex")
+}
+
+#[test]
+fn render_command_substitutes_every_placeholder() {
+    let hash = test_hash();
+
+    // A single `%s` is replaced with the display-order hex.
+    assert_eq!(
+        render_command("echo %s", hash),
+        format!("echo {TIP_HASH_HEX}"),
+    );
+
+    // Multiple `%s` are all replaced.
+    assert_eq!(
+        render_command("a %s b %s c", hash),
+        format!("a {TIP_HASH_HEX} b {TIP_HASH_HEX} c"),
+    );
+
+    // A command without `%s` is left unchanged.
+    assert_eq!(render_command("echo hello", hash), "echo hello");
+}
+
+#[test]
+fn render_command_matches_getbestblockhash_display_format() {
+    let hash = test_hash();
+
+    // The substituted value is exactly `block::Hash`'s `Display`, which is the `getbestblockhash`
+    // format, and is a 64-char lowercase `[0-9a-f]` string.
+    let rendered = render_command("%s", hash);
+
+    assert_eq!(rendered, hash.to_string());
+    assert_eq!(rendered, TIP_HASH_HEX);
+    assert_eq!(rendered.len(), 64);
+    assert!(rendered
+        .chars()
+        .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()));
+}
+
+#[test]
+fn config_default_disables_block_notify() {
+    assert_eq!(Config::default().block_notify_command, None);
+}
+
+#[test]
+fn config_round_trips_through_toml() {
+    // An empty `[notify]` section deserializes to the default (disabled).
+    let default: Config = toml::from_str("").expect("empty config is valid");
+    assert_eq!(default, Config::default());
+
+    // A configured command round-trips.
+    let configured = Config {
+        block_notify_command: Some("touch /tmp/zebra-%s".to_string()),
+    };
+    let toml = toml::to_string(&configured).expect("config serializes");
+    let parsed: Config = toml::from_str(&toml).expect("config deserializes");
+    assert_eq!(parsed, configured);
+}
+
+#[test]
+fn config_rejects_unknown_fields() {
+    // `deny_unknown_fields` guards against typos in the config file.
+    let result: Result<Config, _> = toml::from_str("block_notify_comand = \"echo\"\n");
+    assert!(result.is_err(), "unknown field should be rejected");
+}
+
+/// Spawning a notify command runs the shell with `%s` substituted, detached from the caller, and
+/// reaps the child without blocking.
+#[tokio::test]
+async fn spawn_notify_command_runs_shell_with_substituted_hash() {
+    let _init_guard = zebra_test::init();
+
+    let hash = test_hash();
+    let height = block::Height(1_234_567);
+
+    let dir = tempfile::tempdir().expect("can create temp dir");
+    // The command writes the substituted hash to a file, so we can confirm both that the shell ran
+    // and that `%s` was substituted correctly.
+    let out_path = dir.path().join("notified");
+    let command = format!("printf '%s' > {}", out_path.display());
+
+    spawn_notify_command(&command, hash, height);
+
+    // The command runs detached, so poll for its side effect rather than awaiting it.
+    let mut contents = None;
+    for _ in 0..100 {
+        if let Ok(read) = tokio::fs::read_to_string(&out_path).await {
+            contents = Some(read);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    assert_eq!(
+        contents.as_deref(),
+        Some(TIP_HASH_HEX),
+        "notify command should write the substituted tip hash",
+    );
+}
+
+/// A failing notify command does not panic or block the caller; it is reaped in the background.
+#[tokio::test]
+async fn spawn_notify_command_tolerates_non_zero_exit() {
+    let _init_guard = zebra_test::init();
+
+    let hash = test_hash();
+    let height = block::Height(0);
+
+    // `false` exits non-zero; this must not panic or block the caller. The non-zero exit is logged
+    // by the reaper task.
+    spawn_notify_command("false", hash, height);
+
+    // Give the reaper task a chance to run, then confirm we're still here.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+}

--- a/zebrad/src/components/notify/tests.rs
+++ b/zebrad/src/components/notify/tests.rs
@@ -81,6 +81,10 @@ fn config_rejects_unknown_fields() {
 
 /// Spawning a notify command runs the shell with `%s` substituted, detached from the caller, and
 /// reaps the child without blocking.
+///
+/// The test command uses `/bin/sh` syntax, so it only runs on Unix; the Windows `cmd /C` branch
+/// of `spawn_notify_command` is covered by `render_command` and the non-zero-exit test.
+#[cfg(not(target_os = "windows"))]
 #[tokio::test]
 async fn spawn_notify_command_runs_shell_with_substituted_hash() {
     let _init_guard = zebra_test::init();

--- a/zebrad/src/config.rs
+++ b/zebrad/src/config.rs
@@ -75,6 +75,9 @@ pub struct ZebradConfig {
     /// Mempool configuration
     pub mempool: crate::components::mempool::Config,
 
+    /// Block notify configuration
+    pub notify: crate::components::notify::Config,
+
     /// RPC configuration
     pub rpc: zebra_rpc::config::rpc::Config,
 

--- a/zebrad/tests/common/configs/v5.2.0.toml
+++ b/zebrad/tests/common/configs/v5.2.0.toml
@@ -1,0 +1,107 @@
+# Default configuration for zebrad.
+#
+# This file can be used as a skeleton for custom configs.
+#
+# Unspecified fields use default values. Optional fields are Some(field) if the
+# field is present and None if it is absent.
+#
+# This file is generated as an example using zebrad's current defaults.
+# You should set only the config options you want to keep, and delete the rest.
+# Only a subset of fields are present in the skeleton, since optional values
+# whose default is None are omitted.
+#
+# The config format (including a complete list of sections and fields) is
+# documented here:
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
+#
+# CONFIGURATION SOURCES (in order of precedence, highest to lowest):
+#
+# 1. Environment variables with ZEBRA_ prefix (highest precedence)
+#    - Format: ZEBRA_SECTION__KEY (double underscore for nested keys)
+#    - Examples:
+#      - ZEBRA_NETWORK__NETWORK=Testnet
+#      - ZEBRA_RPC__LISTEN_ADDR=127.0.0.1:8232
+#      - ZEBRA_STATE__CACHE_DIR=/path/to/cache
+#      - ZEBRA_TRACING__FILTER=debug
+#      - ZEBRA_METRICS__ENDPOINT_ADDR=0.0.0.0:9999
+#
+# 2. Configuration file (TOML format)
+#    - At the path specified via -c flag, e.g. `zebrad -c myconfig.toml start`, or
+#    - At the default path in the user's preference directory (platform-dependent, see below)
+#
+# 3. Hard-coded defaults (lowest precedence)
+#
+# The user's preference directory and the default path to the `zebrad` config are platform dependent,
+# based on `dirs::preference_dir`, see https://docs.rs/dirs/latest/dirs/fn.preference_dir.html :
+#
+# | Platform | Value                                 | Example                                        |
+# | -------- | ------------------------------------- | ---------------------------------------------- |
+# | Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/zebrad.toml`              |
+# | macOS    | `$HOME/Library/Preferences`           | `/Users/Alice/Library/Preferences/zebrad.toml` |
+# | Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Local\zebrad.toml`     |
+
+[consensus]
+checkpoint_sync = true
+
+[health]
+enforce_on_test_networks = false
+min_connected_peers = 1
+ready_max_blocks_behind = 2
+ready_max_tip_age = "5m"
+
+[mempool]
+eviction_memory_time = "1h"
+max_datacarrier_bytes = 83
+tx_cost_limit = 80000000
+
+[metrics]
+
+[mining]
+internal_miner = false
+
+[network]
+cache_dir = true
+crawl_new_peer_interval = "1m 1s"
+initial_mainnet_peers = [
+    "dnsseed.str4d.xyz:8233",
+    "dnsseed.z.cash:8233",
+    "mainnet.seeder.shieldedinfra.net:8233",
+    "mainnet.seeder.zfnd.org:8233",
+]
+initial_testnet_peers = [
+    "dnsseed.testnet.z.cash:18233",
+    "testnet.seeder.zfnd.org:18233",
+]
+listen_addr = "[::]:8233"
+max_connections_per_ip = 1
+network = "Mainnet"
+peerset_initial_target_size = 25
+
+[notify]
+
+[rpc]
+cookie_dir = "cache_dir"
+debug_force_finished_sync = false
+enable_cookie_auth = true
+max_response_body_size = 52428800
+parallel_cpu_threads = 0
+
+[state]
+cache_dir = "cache_dir"
+debug_skip_non_finalized_state_backup_task = false
+delete_old_database = true
+ephemeral = false
+should_backup_non_finalized_state = true
+
+[sync]
+checkpoint_verify_concurrency_limit = 1000
+download_concurrency_limit = 50
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+
+[tracing]
+buffer_limit = 128000
+force_use_color = false
+use_color = true
+use_journald = false
+


### PR DESCRIPTION
## Motivation

Closes #10727

## Solution

Adds a `[notify]` config section with a single `block_notify_command` option. A
background task (modeled on the existing block gossip task) waits for tip changes,
gates on `SyncStatus::wait_until_close_to_tip` (Zebra's analogue of zcashd
suppressing the callback during initial block download), substitutes every `%s`
with the new tip's block hash (`getbestblockhash` hex format), and runs the command
via the system shell (`/bin/sh -c` on Unix, `cmd /C` on Windows). The command is
detached and reaped in a separate task, so a hung command never blocks block
validation; non-zero exits are logged like zcashd's `runCommand`. Disabled (no-op
task) when unset.

Matches zcashd's surface deliberately: no timeout, rate-limiting, or dedup. Note
that `ChainTipChange` coalesces bursts of commits, so under fast sync intermediate
tip hashes may be skipped — only the current best tip fires (harmless for the
canonical use cases).

### Tests

- Unit tests for `%s` substitution (single/multiple/none) and an assertion that the
  substituted value is exactly the 64-char lowercase-hex `getbestblockhash` format
  (pins the command-injection-safety invariant).
- `Config` tests: default-disabled, TOML round-trip, `deny_unknown_fields`.
- Two `#[tokio::test]`s drive the real spawn path: one proves the shell ran with the
  substituted hash (tempfile side-effect), one proves a non-zero exit (`false`)
  neither panics nor blocks the caller.
- New stored config snapshot `zebrad/tests/common/configs/v5.2.0.toml`; `config_tests`
  passes. `clippy --all-targets -D warnings` and `fmt --check` clean.

### Specifications & References

- zcashd `-blocknotify`: `BlockNotifyCallback` (`src/init.cpp`), fired from
  `NotifyBlockTip` after `ActivateBestChain` (`src/main.cpp`).

### AI Disclosure

- [x] AI tools were used: Claude Code (Anthropic). Used to write the component,
  tests, and wiring, and a multi-agent workflow to design/adversarially-review the
  implementation. The contributor is the responsible author.

### PR Checklist

- [x] The PR title follows conventional commits format.
- [x] The PR follows the contribution guidelines.
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
