### PR TITLE
fix(ci): reduce flaky unit test failures

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -32,7 +32,7 @@ filter = "not test(=trusted_chain_sync_handles_forks_correctly) and not test(=de
 failure-output = "immediate"
 slow-timeout = { period = "5m", terminate-after = 4 }
 
-default-filter = "not test(check_no_git_dependencies) and not test(=fully_synced_rpc_z_getsubtreesbyindex_snapshot_test) and not test(=lwd_rpc_test) and not test(=lwd_rpc_send_tx) and not test(=lwd_grpc_wallet) and not test(=lwd_integration) and not test(=lwd_sync_full) and not test(=lwd_sync_update) and not test(=lightwalletd_test_suite) and not test(=rpc_get_block_template) and not test(=rpc_submit_block) and not test(=get_peer_info) and not test(~generate_checkpoints_) and not test(=sync_update_mainnet) and not test(=activate_mempool_mainnet)"
+default-filter = "not test(check_no_git_dependencies) and not test(=fully_synced_rpc_z_getsubtreesbyindex_snapshot_test) and not test(=lwd_rpc_test) and not test(=lwd_rpc_send_tx) and not test(=lwd_grpc_wallet) and not test(=lwd_integration) and not test(=lwd_sync_full) and not test(=lwd_sync_update) and not test(=lightwalletd_test_suite) and not test(=rpc_get_block_template) and not test(=rpc_submit_block) and not test(=get_peer_info) and not test(~generate_checkpoints_) and not test(=sync_update_mainnet) and not test(=activate_mempool_mainnet) and not test(=sync_large_checkpoints_mempool_mainnet)"
 
 # --- Individual Test Profiles ---
 

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -142,6 +142,7 @@ default-filter = 'package(zebrad) and test(=fully_synced_rpc_z_getsubtreesbyinde
 # 60s (= 30s × terminate-after 2) is 4000× their normal runtime.
 [[profile.all-tests.overrides]]
 filter = "test(~peer_set_ready) or test(=peer_set_rejects_connections_past_per_ip_limit) or test(=peer_set_route_inv_advertised_registry)"
+retries = 2
 slow-timeout = { period = "30s", terminate-after = 2 }
 
 # disconnects_from_misbehaving_peers: passes in 223-300s, but has no overall
@@ -149,4 +150,12 @@ slow-timeout = { period = "30s", terminate-after = 2 }
 # 10min (= 5m × terminate-after 2) gives 2-3× headroom.
 [[profile.all-tests.overrides]]
 filter = "test(=disconnects_from_misbehaving_peers)"
+retries = 2
+slow-timeout = { period = "5m", terminate-after = 2 }
+
+# trusted_chain_sync_handles_forks_correctly: passes in ~60s normally but
+# depends on peer connections and can fail with Elapsed/broken-pipe errors.
+[[profile.all-tests.overrides]]
+filter = "test(=trusted_chain_sync_handles_forks_correctly)"
+retries = 2
 slow-timeout = { period = "5m", terminate-after = 2 }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -32,7 +32,7 @@ filter = "not test(=trusted_chain_sync_handles_forks_correctly) and not test(=de
 failure-output = "immediate"
 slow-timeout = { period = "5m", terminate-after = 4 }
 
-default-filter = "not test(check_no_git_dependencies) and not test(=fully_synced_rpc_z_getsubtreesbyindex_snapshot_test) and not test(=lwd_rpc_test) and not test(=lwd_rpc_send_tx) and not test(=lwd_grpc_wallet) and not test(=lwd_integration) and not test(=lwd_sync_full) and not test(=lwd_sync_update) and not test(=lightwalletd_test_suite) and not test(=rpc_get_block_template) and not test(=rpc_submit_block) and not test(=get_peer_info) and not test(~generate_checkpoints_) and not test(=sync_update_mainnet) and not test(=activate_mempool_mainnet) and not test(=sync_large_checkpoints_mempool_mainnet)"
+default-filter = "not test(check_no_git_dependencies) and not test(=fully_synced_rpc_z_getsubtreesbyindex_snapshot_test) and not test(=lwd_rpc_test) and not test(=lwd_rpc_send_tx) and not test(=lwd_grpc_wallet) and not test(=lwd_integration) and not test(=lwd_sync_full) and not test(=lwd_sync_update) and not test(=lightwalletd_test_suite) and not test(=rpc_get_block_template) and not test(=rpc_submit_block) and not test(=get_peer_info) and not test(~generate_checkpoints_) and not test(=sync_update_mainnet) and not test(=activate_mempool_mainnet) and not test(=sync_large_checkpoints_mempool_mainnet) and not test(=sync_large_checkpoints_empty)"
 
 # --- Individual Test Profiles ---
 

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -30,6 +30,8 @@ filter = "not test(=trusted_chain_sync_handles_forks_correctly) and not test(=de
 # TODO: We need a better test architecture to run all non-stateful
 [profile.all-tests]
 failure-output = "immediate"
+slow-timeout = { period = "5m", terminate-after = 4 }
+
 default-filter = "not test(check_no_git_dependencies) and not test(=fully_synced_rpc_z_getsubtreesbyindex_snapshot_test) and not test(=lwd_rpc_test) and not test(=lwd_rpc_send_tx) and not test(=lwd_grpc_wallet) and not test(=lwd_integration) and not test(=lwd_sync_full) and not test(=lwd_sync_update) and not test(=lightwalletd_test_suite) and not test(=rpc_get_block_template) and not test(=rpc_submit_block) and not test(=get_peer_info) and not test(~generate_checkpoints_) and not test(=sync_update_mainnet) and not test(=activate_mempool_mainnet)"
 
 # --- Individual Test Profiles ---
@@ -130,3 +132,21 @@ default-filter = 'package(zebrad) and test(=lightwalletd_test_suite)'
 [profile.rpc-z-getsubtreesbyindex-snapshot]
 slow-timeout = { period = "30m", terminate-after = 2 }
 default-filter = 'package(zebrad) and test(=fully_synced_rpc_z_getsubtreesbyindex_snapshot_test)'
+
+# --- Flaky test overrides for the all-tests profile ---
+# These tests occasionally hang on CI due to async deadlocks or network
+# issues.  The timeouts are based on measured passing durations (see PR).
+
+# peer_set vector tests: pass in 9-16ms, but occasionally deadlock forever
+# due to tokio::time::pause() + timer auto-advance interactions.
+# 60s (= 30s × terminate-after 2) is 4000× their normal runtime.
+[[profile.all-tests.overrides]]
+filter = "test(~peer_set_ready) or test(=peer_set_rejects_connections_past_per_ip_limit) or test(=peer_set_route_inv_advertised_registry)"
+slow-timeout = { period = "30s", terminate-after = 2 }
+
+# disconnects_from_misbehaving_peers: passes in 223-300s, but has no overall
+# timeout and can hang indefinitely if an RPC call blocks.
+# 10min (= 5m × terminate-after 2) gives 2-3× headroom.
+[[profile.all-tests.overrides]]
+filter = "test(=disconnects_from_misbehaving_peers)"
+slow-timeout = { period = "5m", terminate-after = 2 }

--- a/zebra-network/src/peer/client/tests.rs
+++ b/zebra-network/src/peer/client/tests.rs
@@ -7,7 +7,6 @@
 use std::{
     net::{Ipv4Addr, SocketAddrV4},
     sync::Arc,
-    time::Duration,
 };
 
 use chrono::Utc;
@@ -38,9 +37,6 @@ use crate::{
 
 #[cfg(test)]
 mod vectors;
-
-/// The maximum time a mocked peer connection should be alive during a test.
-const MAX_PEER_CONNECTION_TIME: Duration = Duration::from_secs(10);
 
 /// A harness with mocked channels for testing a [`Client`] instance.
 pub struct ClientTestHarness {
@@ -355,14 +351,14 @@ where
     /// Spawn a mock background abortable task `task_future` if provided, or a fallback task
     /// otherwise.
     ///
-    /// The fallback task lives as long as [`MAX_PEER_CONNECTION_TIME`].
+    /// The fallback task stays alive until explicitly aborted.
     fn spawn_background_task_or_fallback<T>(task_future: Option<T>) -> (JoinHandle<()>, AbortHandle)
     where
         T: Future<Output = ()> + Send + 'static,
     {
         match task_future {
             Some(future) => Self::spawn_background_task(future),
-            None => Self::spawn_background_task(tokio::time::sleep(MAX_PEER_CONNECTION_TIME)),
+            None => Self::spawn_background_task(future::pending()),
         }
     }
 
@@ -391,9 +387,7 @@ where
     {
         match task_future {
             Some(future) => Self::spawn_background_task_with_result(future),
-            None => Self::spawn_background_task_with_result(tokio::time::sleep(
-                MAX_PEER_CONNECTION_TIME,
-            )),
+            None => Self::spawn_background_task_with_result(future::pending()),
         }
     }
 

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1203,9 +1203,11 @@ fn sync_large_checkpoints_empty() -> Result<()> {
     Ok(())
 }
 
-// TODO: We had `sync_large_checkpoints_empty` and `sync_large_checkpoints_mempool_testnet`,
-// but they were removed because the testnet is unreliable (#1222).
-// We should re-add them after we have more testnet instances (#1791).
+// TODO: This test and its removed variants (`sync_large_checkpoints_empty`,
+// `sync_large_checkpoints_mempool_testnet`) depend on real network peers and
+// fail ~15-20% of CI runs (#1222, #1791). This test is excluded from the
+// `all-tests` nextest profile; `activate_mempool_mainnet` covers mempool +
+// checkpoint sync with 1 block. Replace with regtest-based variants (#9941).
 
 /// Test if `zebrad` can run side by side with the mempool.
 /// This is done by running the mempool and syncing some checkpoints.

--- a/zebrad/tests/acceptance.rs
+++ b/zebrad/tests/acceptance.rs
@@ -1165,6 +1165,11 @@ fn activate_mempool_mainnet() -> Result<()> {
 /// This test might fail or timeout on slow or unreliable networks,
 /// so we don't run it by default. It also takes a lot longer than
 /// our 10 second target time for default tests.
+///
+// TODO: This test depends on real network peers and takes 58s–23min depending
+// on peer availability, causing flaky CI failures. Excluded from the
+// `all-tests` nextest profile; use the dedicated `sync-large-checkpoints-empty`
+// profile instead. Replace with regtest-based variants (#9941).
 #[test]
 #[ignore]
 fn sync_large_checkpoints_empty() -> Result<()> {


### PR DESCRIPTION
## Summary

Unit tests fail ~19% of CI runs due to flaky tests, requiring re-runs across all platforms. This PR addresses the main causes:

- **Nextest slow-timeouts**: Add a 20min global safety net and targeted overrides for known offenders, so hanging tests get killed in minutes instead of burning the full 2h job timeout.
- **Nextest retries**: Add `retries = 2` for known flaky tests so CI auto-retries before failing. With ~20% failure rate, 2 retries reduce flake probability to 0.8%.
- **peer_set deadlock fix**: Replace `sleep(10s)` with `future::pending()` in mock peer connections. The sleep interacts badly with `tokio::time::pause()` auto-advance, causing 4 peer_set tests (9-16ms normally) to deadlock forever.
- **Exclude network-dependent tests from `all-tests`**: `sync_large_checkpoints_mempool_mainnet` and `sync_large_checkpoints_empty` connect to real mainnet peers and fail whenever CI runners can't reach enough peers. Both have dedicated nextest profiles for when they need to run. `activate_mempool_mainnet` still covers mempool + checkpoint sync. Regtest replacement tracked in #9941.
- **trusted_chain_sync_handles_forks_correctly**: Added timeout + retry override after observing CI failures from Elapsed/broken-pipe errors.

## Test plan

- [x] All 4 peer_set tests pass locally (13-24ms)
- [x] `disconnects_from_misbehaving_peers` passes locally (242s)
- [x] `sync_large_checkpoints_mempool_mainnet` confirmed failing locally due to peer unavailability
- [x] CI passes on this branch — all 4 unit test jobs passed first try (no retries needed)