### PR TITLE
release: Zebra v5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
-## [Zebra 5.1.2](https://github.com/ZcashFoundation/zebra/releases/tag/v5.1.2) - 2026-06-15
+## [Zebra 5.2.0](https://github.com/ZcashFoundation/zebra/releases/tag/v5.2.0) - 2026-06-17
 
 This release increases Zebra's local rollback window as a defence-in-depth measure
 against sustained consensus splits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [Zebra 5.1.2](https://github.com/ZcashFoundation/zebra/releases/tag/v5.1.2) - 2026-06-15
+
+This release increases Zebra's local rollback window as a defence-in-depth measure
+against sustained consensus splits.
+
 ### Changed
 
 - Increased Zebra's local rollback window (`MAX_BLOCK_REORG_HEIGHT`) from 99 to
-  1000 blocks as a defence-in-depth measure against sustained consensus splits.
+  1000 blocks as a defence-in-depth measure against sustained consensus splits
+  ([#10650](https://github.com/ZcashFoundation/zebra/pull/10650))
 
 ## [Zebra 5.1.1](https://github.com/ZcashFoundation/zebra/releases/tag/v5.1.1) - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
-## [Zebra 5.2.0](https://github.com/ZcashFoundation/zebra/releases/tag/v5.2.0) - 2026-06-17
+## [Zebra 5.2.0](https://github.com/ZcashFoundation/zebra/releases/tag/v5.2.0) - 2026-06-18
 
 This release increases Zebra's local rollback window as a defence-in-depth measure
 against sustained consensus splits.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7440,7 +7440,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "10.0.0"
+version = "10.1.0"
 dependencies = [
  "bech32",
  "bitflags 2.11.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7799,7 +7799,7 @@ dependencies = [
 
 [[package]]
 name = "zebrad"
-version = "5.1.2"
+version = "5.2.0"
 dependencies = [
  "abscissa_core",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7510,7 +7510,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-consensus"
-version = "9.0.0"
+version = "9.0.1"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7618,7 +7618,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "10.0.0"
+version = "10.0.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7701,7 +7701,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "9.0.0"
+version = "9.0.1"
 dependencies = [
  "bincode",
  "chrono",
@@ -7777,7 +7777,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-utils"
-version = "8.0.0"
+version = "8.0.1"
 dependencies = [
  "color-eyre",
  "hex",
@@ -7799,7 +7799,7 @@ dependencies = [
 
 [[package]]
 name = "zebrad"
-version = "5.1.1"
+version = "5.1.2"
 dependencies = [
  "abscissa_core",
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ cargo install --locked zebrad
 Alternatively, you can install it from GitHub:
 
 ```sh
-cargo install --git https://github.com/ZcashFoundation/zebra --tag v5.1.2 zebrad
+cargo install --git https://github.com/ZcashFoundation/zebra --tag v5.2.0 zebrad
 ```
 
 You can start Zebra by running

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ cargo install --locked zebrad
 Alternatively, you can install it from GitHub:
 
 ```sh
-cargo install --git https://github.com/ZcashFoundation/zebra --tag v5.1.1 zebrad
+cargo install --git https://github.com/ZcashFoundation/zebra --tag v5.1.2 zebrad
 ```
 
 You can start Zebra by running

--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.1.0] - 2026-06-18
+
 ### Added
 
 - `parameters::constants::MAX_BLOCK_REORG_HEIGHT`: the maximum chain reorganisation height (1000).

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-chain"
-version = "10.0.0"
+version = "10.1.0"
 authors.workspace = true
 description = "Core Zcash data structures"
 license.workspace = true

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [9.0.1] - 2026-06-17
+## [9.0.1] - 2026-06-18
 
 ### Changed
 

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [9.0.1] - 2026-06-17
 
 ### Changed

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [9.0.1] - 2026-06-15
+## [9.0.1] - 2026-06-17
 
 ### Changed
 

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.0.1] - 2026-06-15
+
+### Changed
+
+- `zebra-state` dependency bumped to `9.0.1`
+
 ## [9.0.0] - 2026-06-10
 
 ### Changed

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -73,7 +73,7 @@ tower-batch-control = { path = "../tower-batch-control/", version = "1.0.1" }
 zebra-script = { path = "../zebra-script", version = "9.0.0" }
 zebra-state = { path = "../zebra-state", version = "9.0.1" }
 zebra-node-services = { path = "../zebra-node-services", version = "8.0.0" }
-zebra-chain = { path = "../zebra-chain", version = "10.0.0" }
+zebra-chain = { path = "../zebra-chain", version = "10.1.0" }
 
 zcash_protocol.workspace = true
 
@@ -98,7 +98,7 @@ tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 zebra-state = { path = "../zebra-state", version = "9.0.1", features = ["proptest-impl"] }
-zebra-chain = { path = "../zebra-chain", version = "10.0.0", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "10.1.0", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/", version = "3.0.0" }
 
 criterion = { workspace = true, features = ["html_reports"] }

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-consensus"
-version = "9.0.0"
+version = "9.0.1"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks"
 license.workspace = true
@@ -71,7 +71,7 @@ tower-fallback = { path = "../tower-fallback/", version = "0.2.41" }
 tower-batch-control = { path = "../tower-batch-control/", version = "1.0.1" }
 
 zebra-script = { path = "../zebra-script", version = "9.0.0" }
-zebra-state = { path = "../zebra-state", version = "9.0.0" }
+zebra-state = { path = "../zebra-state", version = "9.0.1" }
 zebra-node-services = { path = "../zebra-node-services", version = "8.0.0" }
 zebra-chain = { path = "../zebra-chain", version = "10.0.0" }
 
@@ -97,7 +97,7 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zebra-state = { path = "../zebra-state", version = "9.0.0", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", version = "9.0.1", features = ["proptest-impl"] }
 zebra-chain = { path = "../zebra-chain", version = "10.0.0", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/", version = "3.0.0" }
 

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -85,7 +85,7 @@ howudoin = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "10.0.0", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "10.1.0", features = ["async-error"] }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/zebra-node-services/Cargo.toml
+++ b/zebra-node-services/Cargo.toml
@@ -31,7 +31,7 @@ rpc-client = [
 ]
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain" , version = "10.0.0" }
+zebra-chain = { path = "../zebra-chain" , version = "10.1.0" }
 tower = { workspace = true }
 
 # Optional dependencies

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [10.0.1] - 2026-06-17
 
 ### Changed

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [10.0.1] - 2026-06-15
+## [10.0.1] - 2026-06-17
 
 ### Changed
 

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.0.1] - 2026-06-15
+
+### Changed
+
+- `zebra-state` dependency bumped to `9.0.1`, and `zebra-consensus` to `9.0.1`
+
 ## [10.0.0] - 2026-06-10
 
 ### Breaking Changes

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [10.0.1] - 2026-06-17
+## [10.0.1] - 2026-06-18
 
 ### Changed
 

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -109,7 +109,7 @@ zcash_transparent = { workspace = true }
 # Test-only feature proptest-impl
 proptest = { workspace = true, optional = true }
 
-zebra-chain = { path = "../zebra-chain", version = "10.0.0", features = [
+zebra-chain = { path = "../zebra-chain", version = "10.1.0", features = [
     "json-conversion",
 ] }
 zebra-consensus = { path = "../zebra-consensus", version = "9.0.1" }
@@ -136,7 +136,7 @@ proptest = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zebra-chain = { path = "../zebra-chain", version = "10.0.0", features = [
+zebra-chain = { path = "../zebra-chain", version = "10.1.0", features = [
     "proptest-impl",
 ] }
 zebra-consensus = { path = "../zebra-consensus", version = "9.0.1", features = [

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-rpc"
-version = "10.0.0"
+version = "10.0.1"
 authors.workspace = true
 description = "A Zebra JSON Remote Procedure Call (JSON-RPC) interface"
 license.workspace = true
@@ -112,13 +112,13 @@ proptest = { workspace = true, optional = true }
 zebra-chain = { path = "../zebra-chain", version = "10.0.0", features = [
     "json-conversion",
 ] }
-zebra-consensus = { path = "../zebra-consensus", version = "9.0.0" }
+zebra-consensus = { path = "../zebra-consensus", version = "9.0.1" }
 zebra-network = { path = "../zebra-network", version = "9.0.0" }
 zebra-node-services = { path = "../zebra-node-services", version = "8.0.0", features = [
     "rpc-client",
 ] }
 zebra-script = { path = "../zebra-script", version = "9.0.0" }
-zebra-state = { path = "../zebra-state", version = "9.0.0" }
+zebra-state = { path = "../zebra-state", version = "9.0.1" }
 
 [build-dependencies]
 openrpsee = { workspace = true }
@@ -139,13 +139,13 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 zebra-chain = { path = "../zebra-chain", version = "10.0.0", features = [
     "proptest-impl",
 ] }
-zebra-consensus = { path = "../zebra-consensus", version = "9.0.0", features = [
+zebra-consensus = { path = "../zebra-consensus", version = "9.0.1", features = [
     "proptest-impl",
 ] }
 zebra-network = { path = "../zebra-network", version = "9.0.0", features = [
     "proptest-impl",
 ] }
-zebra-state = { path = "../zebra-state", version = "9.0.0", features = [
+zebra-state = { path = "../zebra-state", version = "9.0.1", features = [
     "proptest-impl",
 ] }
 

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -26,7 +26,7 @@ comparison-interpreter = []
 libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
-zebra-chain = { path = "../zebra-chain", version = "10.0.0" }
+zebra-chain = { path = "../zebra-chain", version = "10.1.0" }
 
 rand = { workspace = true }
 thiserror = { workspace = true }

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [9.0.1] - 2026-06-17
+## [9.0.1] - 2026-06-18
 
 ### Changed
 

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [9.0.1] - 2026-06-17
 
 ### Changed

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [9.0.1] - 2026-06-15
+## [9.0.1] - 2026-06-17
 
 ### Changed
 

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.0.1] - 2026-06-15
+
+### Changed
+
+- Increased the local rollback window (`MAX_BLOCK_REORG_HEIGHT`) from 99 to 1000
+  blocks as a defence-in-depth measure against sustained consensus splits
+  ([#10650](https://github.com/ZcashFoundation/zebra/pull/10650))
+
 ## [9.0.0] - 2026-06-10
 
 ### Breaking Changes

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -79,7 +79,7 @@ elasticsearch = { workspace = true, features = ["rustls-tls"], optional = true }
 serde_json = { workspace = true, optional = true }
 
 zebra-node-services = { path = "../zebra-node-services", version = "8.0.0" }
-zebra-chain = { path = "../zebra-chain", version = "10.0.0", features = ["async-error"] }
+zebra-chain = { path = "../zebra-chain", version = "10.1.0", features = ["async-error"] }
 
 # prod feature progress-bar
 howudoin = { workspace = true, optional = true }
@@ -109,7 +109,7 @@ jubjub = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zebra-chain = { path = "../zebra-chain", version = "10.0.0", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "10.1.0", features = ["proptest-impl"] }
 zebra-test = { path = "../zebra-test/", version = "3.0.0" }
 
 [lints]

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-state"
-version = "9.0.0"
+version = "9.0.1"
 authors.workspace = true
 description = "State contextual verification and storage code for Zebra"
 license.workspace = true

--- a/zebra-utils/CHANGELOG.md
+++ b/zebra-utils/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [8.0.1] - 2026-06-15
+## [8.0.1] - 2026-06-17
 
 ### Changed
 

--- a/zebra-utils/CHANGELOG.md
+++ b/zebra-utils/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [8.0.1] - 2026-06-17
 
 ### Changed

--- a/zebra-utils/CHANGELOG.md
+++ b/zebra-utils/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [8.0.1] - 2026-06-17
+## [8.0.1] - 2026-06-18
 
 ### Changed
 

--- a/zebra-utils/CHANGELOG.md
+++ b/zebra-utils/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.0.1] - 2026-06-15
+
+### Changed
+
+- `zebra-rpc` dependency bumped to `10.0.1`
+
 ## [8.0.0] - 2026-06-10
 
 ### Changed

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -61,7 +61,7 @@ tracing-subscriber = { workspace = true }
 thiserror = { workspace = true }
 
 zebra-node-services = { path = "../zebra-node-services", version = "8.0.0" }
-zebra-chain = { path = "../zebra-chain", version = "10.0.0" }
+zebra-chain = { path = "../zebra-chain", version = "10.1.0" }
 
 # These crates are needed for the block-template-to-proposal binary
 zebra-rpc = { path = "../zebra-rpc", version = "10.0.1" }

--- a/zebra-utils/Cargo.toml
+++ b/zebra-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-utils"
-version = "8.0.0"
+version = "8.0.1"
 authors.workspace = true
 description = "Developer tools for Zebra maintenance and testing"
 license.workspace = true
@@ -64,7 +64,7 @@ zebra-node-services = { path = "../zebra-node-services", version = "8.0.0" }
 zebra-chain = { path = "../zebra-chain", version = "10.0.0" }
 
 # These crates are needed for the block-template-to-proposal binary
-zebra-rpc = { path = "../zebra-rpc", version = "10.0.0" }
+zebra-rpc = { path = "../zebra-rpc", version = "10.0.1" }
 
 # These crates are needed for the zebra-checkpoints binary
 itertools = { workspace = true, optional = true }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate metadata
 name = "zebrad"
-version = "5.1.2"
+version = "5.2.0"
 authors.workspace = true
 description = "The Zcash Foundation's independent, consensus-compatible implementation of a Zcash node"
 license.workspace = true

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -148,7 +148,7 @@ tx_v6 = ["zebra-chain/tx_v6", "zebra-state/tx_v6", "zebra-consensus/tx_v6", "zeb
 comparison-interpreter = ["zebra-script/comparison-interpreter"]
 
 [dependencies]
-zebra-chain = { path = "../zebra-chain", version = "10.0.0" }
+zebra-chain = { path = "../zebra-chain", version = "10.1.0" }
 zebra-consensus = { path = "../zebra-consensus", version = "9.0.1" }
 zebra-network = { path = "../zebra-network", version = "9.0.0" }
 zebra-node-services = { path = "../zebra-node-services", version = "8.0.0", features = ["rpc-client"] }
@@ -293,7 +293,7 @@ proptest-derive = { workspace = true }
 # enable span traces and track caller in tests
 color-eyre = { workspace = true }
 
-zebra-chain = { path = "../zebra-chain", version = "10.0.0", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", version = "10.1.0", features = ["proptest-impl"] }
 zebra-consensus = { path = "../zebra-consensus", version = "9.0.1", features = ["proptest-impl"] }
 zebra-network = { path = "../zebra-network", version = "9.0.0", features = ["proptest-impl"] }
 zebra-state = { path = "../zebra-state", version = "9.0.1", features = ["proptest-impl"] }

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate metadata
 name = "zebrad"
-version = "5.1.1"
+version = "5.1.2"
 authors.workspace = true
 description = "The Zcash Foundation's independent, consensus-compatible implementation of a Zcash node"
 license.workspace = true
@@ -149,11 +149,11 @@ comparison-interpreter = ["zebra-script/comparison-interpreter"]
 
 [dependencies]
 zebra-chain = { path = "../zebra-chain", version = "10.0.0" }
-zebra-consensus = { path = "../zebra-consensus", version = "9.0.0" }
+zebra-consensus = { path = "../zebra-consensus", version = "9.0.1" }
 zebra-network = { path = "../zebra-network", version = "9.0.0" }
 zebra-node-services = { path = "../zebra-node-services", version = "8.0.0", features = ["rpc-client"] }
-zebra-rpc = { path = "../zebra-rpc", version = "10.0.0" }
-zebra-state = { path = "../zebra-state", version = "9.0.0" }
+zebra-rpc = { path = "../zebra-rpc", version = "10.0.1" }
+zebra-state = { path = "../zebra-state", version = "9.0.1" }
 # zebra-script is not used directly, but we list it here to enable the
 # "comparison-interpreter" feature. (Feature unification will take care of
 # enabling it in the other imports of zcash-script.)
@@ -161,7 +161,7 @@ zebra-script = { path = "../zebra-script", version = "9.0.0" }
 zcash_script = { workspace = true }
 
 # Required for crates.io publishing, but it's only used in tests
-zebra-utils = { path = "../zebra-utils", version = "8.0.0", optional = true }
+zebra-utils = { path = "../zebra-utils", version = "8.0.1", optional = true }
 
 abscissa_core = { workspace = true }
 clap = { workspace = true, features = ["cargo"] }
@@ -294,9 +294,9 @@ proptest-derive = { workspace = true }
 color-eyre = { workspace = true }
 
 zebra-chain = { path = "../zebra-chain", version = "10.0.0", features = ["proptest-impl"] }
-zebra-consensus = { path = "../zebra-consensus", version = "9.0.0", features = ["proptest-impl"] }
+zebra-consensus = { path = "../zebra-consensus", version = "9.0.1", features = ["proptest-impl"] }
 zebra-network = { path = "../zebra-network", version = "9.0.0", features = ["proptest-impl"] }
-zebra-state = { path = "../zebra-state", version = "9.0.0", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", version = "9.0.1", features = ["proptest-impl"] }
 
 zebra-test = { path = "../zebra-test", version = "3.0.0" }
 
@@ -309,7 +309,7 @@ zebra-test = { path = "../zebra-test", version = "3.0.0" }
 # When `-Z bindeps` is stabilised, enable this binary dependency instead:
 # https://github.com/rust-lang/cargo/issues/9096
 # zebra-utils { path = "../zebra-utils", artifact = "bin:zebra-checkpoints" }
-zebra-utils = { path = "../zebra-utils", version = "8.0.0" }
+zebra-utils = { path = "../zebra-utils", version = "8.0.1" }
 
 [package.metadata.cargo-udeps.ignore]
 # These dependencies are false positives - they are actually used

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_374_490;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_382_189;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.
@@ -22,8 +22,8 @@ pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_374_490;
 ///
 /// - Zebra will exit with a panic if the current tip height is bigger than the
 ///   `ESTIMATED_RELEASE_HEIGHT` plus this number of days.
-/// - Reduced to 44 days for the NU7 network upgrade expected at end of July 2026.
-pub const EOS_PANIC_AFTER: u32 = 44;
+/// - Reduced to 37 days for the NU7 network upgrade expected at end of July 2026.
+pub const EOS_PANIC_AFTER: u32 = 37;
 
 /// The number of days before the end of support where Zebra will display warnings.
 pub const EOS_WARN_AFTER: u32 = EOS_PANIC_AFTER - 14;

--- a/zebrad/tests/common/checkpoints.rs
+++ b/zebrad/tests/common/checkpoints.rs
@@ -15,8 +15,8 @@ use tempfile::TempDir;
 
 use zebra_chain::{
     block::{Height, HeightDiff, TryIntoHeight},
-    parameters::Network,
     parameters::constants::MAX_BLOCK_REORG_HEIGHT,
+    parameters::Network,
 };
 use zebra_consensus::MAX_CHECKPOINT_HEIGHT_GAP;
 use zebra_node_services::rpc_client::RpcRequestClient;

--- a/zebrad/tests/common/checkpoints.rs
+++ b/zebrad/tests/common/checkpoints.rs
@@ -16,7 +16,7 @@ use tempfile::TempDir;
 use zebra_chain::{
     block::{Height, HeightDiff, TryIntoHeight},
     parameters::Network,
-    transparent::MIN_TRANSPARENT_COINBASE_MATURITY,
+    parameters::constants::MAX_BLOCK_REORG_HEIGHT,
 };
 use zebra_consensus::MAX_CHECKPOINT_HEIGHT_GAP;
 use zebra_node_services::rpc_client::RpcRequestClient;
@@ -400,7 +400,7 @@ pub fn wait_for_zebra_checkpoints_generation<
     test_type: TestType,
     show_zebrad_logs: bool,
 ) -> Result<(TestChild<TempDir>, TestChild<P>)> {
-    let last_checkpoint_gap = HeightDiff::from(MIN_TRANSPARENT_COINBASE_MATURITY)
+    let last_checkpoint_gap = HeightDiff::from(MAX_BLOCK_REORG_HEIGHT)
         + HeightDiff::try_from(MAX_CHECKPOINT_HEIGHT_GAP).expect("constant fits in HeightDiff");
     let expected_final_checkpoint_height =
         (zebra_tip_height - last_checkpoint_gap).expect("network tip is high enough");


### PR DESCRIPTION
Supersedes #10723 (rebranched from `bump-v5.1.2` to `bump-v5.2.0` — minor bump is more appropriate for the behavioural change).

## Motivation

Prepares the **Zebra v5.2.0** minor release. The increased local rollback
window (`MAX_BLOCK_REORG_HEIGHT` 99 → 1000) merged to `main` in #10650 and the
checkpoint settling fix in #10719 have not yet shipped; this release ships them.

Minor bump because `MAX_BLOCK_REORG_HEIGHT` is a public constant whose value
changed 10x, affecting memory usage and downstream consumers who import it.

## Solution

- Bump `zebrad` 5.1.1 → 5.2.0
- Bump published crate versions: `zebra-state` 9.0.0 → 9.0.1,
  `zebra-consensus` 9.0.0 → 9.0.1, `zebra-rpc` 10.0.0 → 10.0.1,
  `zebra-utils` 8.0.0 → 8.0.1
- Update per-crate CHANGELOGs with release entries
- Update the install tag in `README.md`
- Update end of support: `ESTIMATED_RELEASE_HEIGHT` → 3,382,189, `EOS_PANIC_AFTER` → 37 days

No code changes are introduced here — #10650 and #10719 are already on `main`.
Checkpoint updates were intentionally skipped for this release.

## End of Support

| | v5.1.1 | v5.2.0 |
|---|---|---|
| Release height | 3,374,490 | 3,382,189 |
| Panic after | 44 days | 37 days |
| Warn starts | ~July 3 | ~July 11 |
| Panic date | ~July 25 | ~July 25 |

## AI disclosure

The release branch (version bump + changelog/README edits) was prepared with
Claude Code. No consensus or runtime code was authored by AI in this PR.