### PR TITLE
fix(network): avoid disconnecting peers that return empty find responses at the chain tip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+
+### Fixed
+
+- Don't disconnect from peers that return empty `FindBlocks` or `FindHeaders`
+  responses when the local node is at or near the chain tip
+  ([#10732](https://github.com/ZcashFoundation/zebra/pull/10732))
+
 ## [Zebra 6.0.0-rc.0](https://github.com/ZcashFoundation/zebra/releases/tag/v6.0.0-rc.0) - 2026-07-02
 
 ### Added

--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `AT_OR_NEAR_TIP_THRESHOLD` constant and `ChainTip::is_at_or_near_network_tip()`
+  method for determining whether the node is within 5 blocks of the estimated network tip
+  ([#10732](https://github.com/ZcashFoundation/zebra/pull/10732))
+
 ## [11.0.0] - 2026-07-02
 
 ### Added

--- a/zebra-chain/src/chain_tip.rs
+++ b/zebra-chain/src/chain_tip.rs
@@ -15,6 +15,13 @@ mod tests;
 
 pub use network_chain_tip_height_estimator::NetworkChainTipHeightEstimator;
 
+/// The maximum estimated distance to the network chain tip that is considered "at or near tip".
+///
+/// Allows for normal block-time variance and propagation delay. Considering the 75 second target
+/// for the time between blocks on mainnet, this equals approximately 6 minutes of time the node
+/// can stay without receiving a new block before being considered far from the tip.
+pub const AT_OR_NEAR_TIP_THRESHOLD: block::HeightDiff = 5;
+
 /// An interface for querying the chain tip.
 ///
 /// This trait helps avoid dependencies between:
@@ -117,6 +124,18 @@ pub trait ChainTip {
         let distance_to_tip = estimator.estimate_height_at(Utc::now()) - current_height;
 
         Some((distance_to_tip, current_height))
+    }
+
+    /// Returns `true` if the node is at or near the network chain tip.
+    ///
+    /// Returns `false` if the chain is empty or the node is more than
+    /// [`AT_OR_NEAR_TIP_THRESHOLD`] blocks behind the estimated network tip,
+    /// meaning stall detection should remain active.
+    fn is_at_or_near_network_tip(&self, network: &Network) -> bool {
+        match self.estimate_distance_to_network_chain_tip(network) {
+            None => false,
+            Some((distance, _height)) => distance <= AT_OR_NEAR_TIP_THRESHOLD,
+        }
     }
 }
 

--- a/zebra-network/CHANGELOG.md
+++ b/zebra-network/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Breaking Changes
+
+- `MinimumPeerVersion::chain_tip_height()` is replaced by `chain_tip()`, which returns a
+  reference to the underlying chain tip instead of a `Height`
+  ([#10732](https://github.com/ZcashFoundation/zebra/pull/10732))
+
 ## [10.0.0] - 2026-07-02
 
 ### Breaking Changes

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -28,6 +28,7 @@ use tracing::{span, Level, Span};
 use tracing_futures::Instrument;
 
 use zebra_chain::{
+    block,
     chain_tip::{ChainTip, NoChainTip},
     parameters::Network,
     serialization::{DateTime32, SerializationError},
@@ -674,6 +675,11 @@ where
         }
     };
 
+    let start_height = minimum_peer_version
+        .chain_tip()
+        .best_tip_height()
+        .unwrap_or(block::Height(0));
+
     let our_version = VersionMessage {
         version: constants::CURRENT_NETWORK_PROTOCOL_VERSION,
         services: our_services,
@@ -683,7 +689,7 @@ where
         address_from: AddrInVersion::new(our_listen_addr, our_services),
         nonce: local_nonce,
         user_agent: user_agent.clone(),
-        start_height: minimum_peer_version.chain_tip_height(),
+        start_height,
         relay,
     }
     .into();

--- a/zebra-network/src/peer/minimum_peer_version.rs
+++ b/zebra-network/src/peer/minimum_peer_version.rs
@@ -80,6 +80,11 @@ where
         }
     }
 
+    /// Returns a reference to the underlying chain tip.
+    pub fn chain_tip(&self) -> &C {
+        &self.chain_tip
+    }
+
     /// Return the current chain tip height.
     ///
     /// If it is not available return height zero.

--- a/zebra-network/src/peer/minimum_peer_version.rs
+++ b/zebra-network/src/peer/minimum_peer_version.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 
-use zebra_chain::{block::Height, chain_tip::ChainTip, parameters::Network};
+use zebra_chain::{chain_tip::ChainTip, parameters::Network};
 
 use crate::protocol::external::types::Version;
 
@@ -83,16 +83,6 @@ where
     /// Returns a reference to the underlying chain tip.
     pub fn chain_tip(&self) -> &C {
         &self.chain_tip
-    }
-
-    /// Return the current chain tip height.
-    ///
-    /// If it is not available return height zero.
-    pub fn chain_tip_height(&self) -> Height {
-        match self.chain_tip.best_tip_height() {
-            Some(height) => height,
-            None => Height(0),
-        }
     }
 }
 

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -943,10 +943,17 @@ where
                 .take_ready_service(&p2c_key)
                 .expect("selected peer must be ready");
 
-            let track_stalls = matches!(
+            let is_find_request = matches!(
                 &req,
                 Request::FindBlocks { .. } | Request::FindHeaders { .. }
             );
+            let is_syncing = || {
+                !self
+                    .minimum_peer_version
+                    .chain_tip()
+                    .is_at_or_near_network_tip(&self.network)
+            };
+            let track_stalls = is_find_request && is_syncing();
 
             let fut = svc.call(req);
             self.push_unready(p2c_key, svc);

--- a/zebra-network/src/peer_set/set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/set/tests/vectors.rs
@@ -874,3 +874,111 @@ fn find_blocks_stall_tracked_when_tip_unknown() {
         );
     });
 }
+
+/// Check that stall counts accumulated while syncing are preserved across a tip transition,
+/// so a peer cannot avoid detection by temporarily becoming useful as the node reaches the tip.
+///
+/// This verifies that returning an empty response at tip does not reset a peer's accumulated
+/// stall count. When the node falls back behind tip, one more empty response reaches the
+/// threshold and the peer is disconnected.
+#[test]
+fn find_blocks_stall_count_preserved_across_tip_transition() {
+    let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6_2);
+    let peer_versions = PeerVersions {
+        peer_versions: vec![peer_version],
+    };
+
+    let (runtime, _init_guard) = zebra_test::init_async();
+    let _guard = runtime.enter();
+
+    let (discovered_peers, handles) = peer_versions.mock_peer_discovery();
+    let (minimum_peer_version, best_tip) =
+        MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
+
+    // Start syncing: FIND_RESPONSE_STALL_THRESHOLD - 1 stalls away from disconnect.
+    best_tip.send_best_tip_height(Some(block::Height(2_490_000)));
+    best_tip.send_estimated_distance_to_network_chain_tip(Some(10_000));
+
+    let mut handle = handles.into_iter().next().expect("there is one peer");
+
+    runtime.block_on(async move {
+        let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
+            .with_discover(discovered_peers)
+            .with_minimum_peer_version(minimum_peer_version)
+            .build();
+
+        // Accumulate THRESHOLD - 1 stalls while syncing.
+        for _ in 0..FIND_RESPONSE_STALL_THRESHOLD - 1 {
+            let peer_ready = peer_set.ready().await.expect("peer set is ready");
+
+            let response_fut = peer_ready.call(Request::FindBlocks {
+                known_blocks: vec![],
+                stop: None,
+            });
+
+            let client_request = handle
+                .try_to_receive_outbound_client_request()
+                .request()
+                .expect("peer received the request");
+
+            let _ = client_request.tx.send(Ok(Response::BlockHashes(vec![])));
+
+            response_fut.await.expect("response received");
+        }
+
+        // Transition to at-tip: stall count is now THRESHOLD - 1 (one below disconnect).
+        best_tip.send_best_tip_height(Some(block::Height(2_500_000)));
+        best_tip.send_estimated_distance_to_network_chain_tip(Some(0));
+
+        // Send one empty response at tip. Since track_stalls is false, no stall event is
+        // emitted and the peer's accumulated count is unchanged.
+        {
+            let peer_ready = peer_set.ready().await.expect("peer set is ready");
+
+            let response_fut = peer_ready.call(Request::FindBlocks {
+                known_blocks: vec![],
+                stop: None,
+            });
+
+            let client_request = handle
+                .try_to_receive_outbound_client_request()
+                .request()
+                .expect("peer received the request");
+
+            let _ = client_request.tx.send(Ok(Response::BlockHashes(vec![])));
+
+            response_fut.await.expect("response received");
+        }
+
+        // Transition back to syncing: count is still THRESHOLD - 1.
+        best_tip.send_estimated_distance_to_network_chain_tip(Some(10_000));
+
+        // One more syncing response reaches the threshold.
+        {
+            let peer_ready = peer_set.ready().await.expect("peer set is ready");
+
+            let response_fut = peer_ready.call(Request::FindBlocks {
+                known_blocks: vec![],
+                stop: None,
+            });
+
+            let client_request = handle
+                .try_to_receive_outbound_client_request()
+                .request()
+                .expect("peer received the request");
+
+            let _ = client_request.tx.send(Ok(Response::BlockHashes(vec![])));
+
+            response_fut.await.expect("response received");
+        }
+
+        // One final poll_ready to drain the last stall event and process the disconnect.
+        let _ = peer_set.ready().now_or_never();
+
+        // The peer must be disconnected: the accumulated stall count was not reset at tip.
+        assert!(
+            !handle.wants_connection_heartbeats(),
+            "peer should be disconnected: stall count accumulated during sync was preserved"
+        );
+    });
+}

--- a/zebra-network/src/peer_set/set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/set/tests/vectors.rs
@@ -819,3 +819,58 @@ fn find_blocks_stall_tracked_when_syncing() {
         );
     });
 }
+
+/// Check that stall tracking is active when the chain tip state is unknown (empty node state),
+/// so that stalling peers are still disconnected even before the first block is synced.
+#[test]
+fn find_blocks_stall_tracked_when_tip_unknown() {
+    let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6_2);
+    let peer_versions = PeerVersions {
+        peer_versions: vec![peer_version],
+    };
+
+    let (runtime, _init_guard) = zebra_test::init_async();
+    let _guard = runtime.enter();
+
+    let (discovered_peers, handles) = peer_versions.mock_peer_discovery();
+    let (minimum_peer_version, _best_tip) =
+        MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
+
+    // Leave the chain tip in its default state (None height, None distance).
+    // is_at_or_near_network_tip returns false when the tip is unknown, so stall
+    // tracking is active.
+
+    let mut handle = handles.into_iter().next().expect("there is one peer");
+
+    runtime.block_on(async move {
+        let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
+            .with_discover(discovered_peers)
+            .with_minimum_peer_version(minimum_peer_version)
+            .build();
+
+        for _ in 0..FIND_RESPONSE_STALL_THRESHOLD {
+            let peer_ready = peer_set.ready().await.expect("peer set is ready");
+
+            let response_fut = peer_ready.call(Request::FindBlocks {
+                known_blocks: vec![],
+                stop: None,
+            });
+
+            let client_request = handle
+                .try_to_receive_outbound_client_request()
+                .request()
+                .expect("peer received the request");
+
+            let _ = client_request.tx.send(Ok(Response::BlockHashes(vec![])));
+
+            response_fut.await.expect("response received");
+        }
+
+        let _ = peer_set.ready().now_or_never();
+
+        assert!(
+            !handle.wants_connection_heartbeats(),
+            "peer should be disconnected when tip is unknown and stall threshold is reached"
+        );
+    });
+}

--- a/zebra-network/src/peer_set/set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/set/tests/vectors.rs
@@ -2,6 +2,7 @@
 
 use std::{cmp::max, collections::HashSet, iter, net::SocketAddr, sync::Arc, time::Duration};
 
+use futures::FutureExt as _;
 use tokio::time::timeout;
 use tower::{Service, ServiceExt};
 
@@ -752,6 +753,69 @@ fn find_blocks_stall_not_tracked_when_at_tip() {
         assert!(
             handle.wants_connection_heartbeats(),
             "peer should not be disconnected when at tip"
+        );
+    });
+}
+
+/// Check that empty `FindBlocks` responses DO trigger stall tracking when the node is syncing,
+/// and that the peer is disconnected after exceeding the stall threshold.
+///
+/// This verifies the security property from GHSA-h9hm-m2xj-4rq9 is preserved: peers that
+/// return only empty responses during initial sync are still detected and disconnected.
+#[test]
+fn find_blocks_stall_tracked_when_syncing() {
+    let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6_2);
+    let peer_versions = PeerVersions {
+        peer_versions: vec![peer_version],
+    };
+
+    let (runtime, _init_guard) = zebra_test::init_async();
+    let _guard = runtime.enter();
+
+    let (discovered_peers, handles) = peer_versions.mock_peer_discovery();
+    let (minimum_peer_version, best_tip) =
+        MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
+
+    // Simulate being far behind the chain tip, as during initial sync.
+    best_tip.send_best_tip_height(Some(block::Height(2_490_000)));
+    best_tip.send_estimated_distance_to_network_chain_tip(Some(10_000));
+
+    let mut handle = handles.into_iter().next().expect("there is one peer");
+
+    runtime.block_on(async move {
+        let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
+            .with_discover(discovered_peers)
+            .with_minimum_peer_version(minimum_peer_version)
+            .build();
+
+        // Send exactly FIND_RESPONSE_STALL_THRESHOLD empty FindBlocks responses.
+        // Each response emits a stall event; the third one triggers disconnect.
+        for _ in 0..FIND_RESPONSE_STALL_THRESHOLD {
+            let peer_ready = peer_set.ready().await.expect("peer set is ready");
+
+            let response_fut = peer_ready.call(Request::FindBlocks {
+                known_blocks: vec![],
+                stop: None,
+            });
+
+            let client_request = handle
+                .try_to_receive_outbound_client_request()
+                .request()
+                .expect("peer received the request");
+
+            let _ = client_request.tx.send(Ok(Response::BlockHashes(vec![])));
+
+            response_fut.await.expect("response received");
+        }
+
+        // One extra poll_ready to drain the final stall event and process the disconnect.
+        // Since there are no remaining ready peers, the future does not resolve.
+        let _ = peer_set.ready().now_or_never();
+
+        // The peer must be disconnected: stall threshold was reached while syncing.
+        assert!(
+            !handle.wants_connection_heartbeats(),
+            "peer should be disconnected after stall threshold is reached while syncing"
         );
     });
 }

--- a/zebra-network/src/peer_set/set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/set/tests/vectors.rs
@@ -13,9 +13,9 @@ use zebra_chain::{
 use crate::{
     constants::DEFAULT_MAX_CONNS_PER_IP,
     peer::{ClientRequest, MinimumPeerVersion},
-    peer_set::inventory_registry::InventoryStatus,
+    peer_set::{inventory_registry::InventoryStatus, stall_tracker::FIND_RESPONSE_STALL_THRESHOLD},
     protocol::external::{types::Version, InventoryHash},
-    PeerSocketAddr, Request, SharedPeerError,
+    PeerSocketAddr, Request, Response, SharedPeerError,
 };
 use indexmap::IndexMap;
 use tokio::sync::watch;
@@ -692,6 +692,66 @@ fn peer_set_route_inv_all_missing_fail() {
                 .expect("peer set should return a boxed SharedPeerError")
                 .inner_debug(),
             "NotFoundRegistry([Block(block::Hash(\"0000000000000000000000000000000000000000000000000000000000000000\"))])"
+        );
+    });
+}
+
+/// Check that empty `FindBlocks` responses do not trigger stall tracking when the node is at the
+/// chain tip, so peers that correctly return no hashes are not disconnected.
+#[test]
+fn find_blocks_stall_not_tracked_when_at_tip() {
+    let peer_version = Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6_2);
+    let peer_versions = PeerVersions {
+        peer_versions: vec![peer_version],
+    };
+
+    let (runtime, _init_guard) = zebra_test::init_async();
+    let _guard = runtime.enter();
+
+    let (discovered_peers, handles) = peer_versions.mock_peer_discovery();
+    let (minimum_peer_version, best_tip) =
+        MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
+
+    // Simulate being at the chain tip.
+    best_tip.send_best_tip_height(Some(block::Height(2_500_000)));
+    best_tip.send_estimated_distance_to_network_chain_tip(Some(0));
+
+    let mut handle = handles.into_iter().next().expect("there is one peer");
+
+    runtime.block_on(async move {
+        let (mut peer_set, _peer_set_guard) = PeerSetBuilder::new()
+            .with_discover(discovered_peers)
+            .with_minimum_peer_version(minimum_peer_version)
+            .build();
+
+        // Send more FindBlocks requests than FIND_RESPONSE_STALL_THRESHOLD, each
+        // returning an empty response. If stall events were tracked, the peer would be
+        // disconnected after the third response.
+        let request_count = FIND_RESPONSE_STALL_THRESHOLD + 1;
+
+        for _ in 0..request_count {
+            let peer_ready = peer_set.ready().await.expect("peer set is ready");
+
+            let response_fut = peer_ready.call(Request::FindBlocks {
+                known_blocks: vec![],
+                stop: None,
+            });
+
+            let client_request = handle
+                .try_to_receive_outbound_client_request()
+                .request()
+                .expect("peer received the request");
+
+            // Reply with an empty BlockHashes response — protocol-correct at tip.
+            let _ = client_request.tx.send(Ok(Response::BlockHashes(vec![])));
+
+            response_fut.await.expect("response received");
+        }
+
+        // The peer must still be connected: no stall events were emitted.
+        assert!(
+            handle.wants_connection_heartbeats(),
+            "peer should not be disconnected when at tip"
         );
     });
 }

--- a/zebrad/tests/integration/network.rs
+++ b/zebrad/tests/integration/network.rs
@@ -367,6 +367,141 @@ async fn disconnects_from_misbehaving_peers_impl() -> Result<()> {
     Ok(())
 }
 
+/// Regression test for #10715: a node that has synced to the shared chain tip must not
+/// disconnect its upstream peer due to empty `FindBlocks` responses.
+///
+/// Before the fix, the stall tracker ran unconditionally and disconnected peers after 3
+/// consecutive empty-response `FindBlocks` cycles, even when both nodes were already at
+/// the same tip. The fix gates stall tracking on `is_at_or_near_network_tip`, so the
+/// peer is only tracked during genuine catch-up, not once the node is fully synced.
+///
+/// Sets up two regtest nodes:
+/// - Node A (upstream): mines a small chain and listens for P2P connections
+/// - Node B (internal): connects exclusively to Node A and syncs to its tip
+///
+/// After both nodes share the same tip, the test polls `getpeerinfo` on Node B for
+/// 30 seconds and asserts that Node A is always connected. If the stall tracker fires
+/// incorrectly, Node A is dropped within ~6 seconds (3 cycles × 2-second regtest restart
+/// delay) and the assertion fails.
+#[tokio::test]
+async fn synced_node_keeps_upstream_peer_connected() -> Result<()> {
+    tokio::time::timeout(
+        Duration::from_secs(5 * 60),
+        synced_node_keeps_upstream_peer_connected_impl(),
+    )
+    .await
+    .wrap_err("synced_node_keeps_upstream_peer_connected timed out")?
+}
+
+async fn synced_node_keeps_upstream_peer_connected_impl() -> Result<()> {
+    use zebra_chain::parameters::Network;
+    use zebra_rpc::{client::PeerInfo, server::OPENED_RPC_ENDPOINT_MSG};
+
+    use crate::common::{
+        config::{os_assigned_rpc_port_config, read_listen_addr_from_logs},
+        launch::LAUNCH_DELAY,
+        regtest::MiningRpcMethods,
+    };
+
+    let _init_guard = zebra_test::init();
+
+    let net = Network::new_regtest(
+        ConfiguredActivationHeights {
+            nu5: Some(1),
+            ..Default::default()
+        }
+        .into(),
+    );
+
+    // Use a preselected port for Node A's P2P listener so Node B's config can
+    // reference it without having to parse Node A's logs.
+    let upstream_p2p_addr = format!("127.0.0.1:{}", random_known_port());
+
+    let mut upstream_config = os_assigned_rpc_port_config(false, &net)?;
+    upstream_config.network.listen_addr = upstream_p2p_addr.parse()?;
+    upstream_config.network.initial_testnet_peers = [].into();
+    upstream_config.mempool.debug_enable_at_height = Some(0);
+
+    let mut upstream = testdir()?
+        .with_config(&mut upstream_config)?
+        .spawn_child(args!["start"])?;
+
+    let upstream_rpc_addr = read_listen_addr_from_logs(&mut upstream, OPENED_RPC_ENDPOINT_MSG)?;
+
+    tokio::time::sleep(LAUNCH_DELAY).await;
+
+    let upstream_client = RpcRequestClient::new(upstream_rpc_addr);
+
+    const BLOCKS_TO_MINE: u32 = 100;
+    for _ in 0..BLOCKS_TO_MINE {
+        let (block, _height) = upstream_client.block_from_template(&net).await?;
+        upstream_client.submit_block(block).await?;
+    }
+
+    // Node B connects only to Node A; limit target size to 1 to avoid crawling.
+    let mut internal_config = os_assigned_rpc_port_config(false, &net)?;
+    internal_config.network.initial_testnet_peers = [upstream_p2p_addr].into();
+    internal_config.network.peerset_initial_target_size = 1;
+
+    let mut internal = testdir()?
+        .with_config(&mut internal_config)?
+        .spawn_child(args!["start"])?;
+
+    let internal_rpc_addr = read_listen_addr_from_logs(&mut internal, OPENED_RPC_ENDPOINT_MSG)?;
+
+    let internal_client = RpcRequestClient::new(internal_rpc_addr);
+
+    // Wait for Node B to connect to Node A.
+    wait_for_outbound_peer(&internal_client).await?;
+
+    // Wait for Node B to sync to Node A's tip.
+    tokio::time::timeout(Duration::from_secs(120), async {
+        loop {
+            let info = internal_client.blockchain_info().await?;
+            if info.blocks() >= Height(BLOCKS_TO_MINE) {
+                return Ok::<_, color_eyre::eyre::Report>(());
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    })
+    .await
+    .wrap_err("timed out waiting for Node B to sync to Node A's tip")??;
+
+    tracing::info!("Node B has synced to Node A's tip; verifying Node A stays connected");
+
+    // The regtest sync loop restarts every 2 seconds. With the bug, 3 consecutive
+    // empty-response cycles (~6 seconds) would disconnect Node A. Poll for 30 seconds
+    // to give the stall tracker ample time to fire if the fix is not in effect.
+    for i in 0..30_u32 {
+        let peer_info: Vec<PeerInfo> = internal_client
+            .json_result_from_call("getpeerinfo", "[]")
+            .await
+            .map_err(|err| eyre!(err))?;
+
+        assert!(
+            !peer_info.is_empty(),
+            "upstream peer was disconnected {i} seconds after reaching the shared tip; \
+             the stall tracker must not fire when the node is at or near the network tip"
+        );
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+
+    upstream.kill(false)?;
+    internal.kill(false)?;
+
+    upstream
+        .wait_with_output()?
+        .assert_was_killed()
+        .wrap_err("Possible port conflict. Are there other acceptance tests running?")?;
+    internal
+        .wait_with_output()?
+        .assert_was_killed()
+        .wrap_err("Possible port conflict. Are there other acceptance tests running?")?;
+
+    Ok(())
+}
+
 async fn wait_for_outbound_peer(rpc_client: &RpcRequestClient) -> Result<Vec<PeerInfo>> {
     tokio::time::timeout(Duration::from_secs(2 * 60), async {
         loop {


### PR DESCRIPTION
## Motivation

Closes #10715.

At the shared chain tip, `FindBlocks`/`FindHeaders` correctly return empty responses — there
are no new blocks to report. The stall tracker was treating these as misbehaviour,
disconnecting peers that were behaving correctly. This was introduced as a side effect of
the fix for GHSA-h9hm-m2xj-4rq9, which must remain active during catch-up.

## Solution

Gate stall tracking on chain-tip state in `PeerSet::route_p2c`. When the node is at or
near the network tip, `track_stalls` is set to `false` and no stall event is emitted —
the peer's counter is neither incremented nor cleared. During catch-up the node is
meaningfully behind, so stall detection fires exactly as before.

Changes:
- `zebra-chain`: add `AT_OR_NEAR_TIP_THRESHOLD` constant and `is_at_or_near_network_tip`
  provided method to the `ChainTip` trait.
- `zebra-network`: add `chain_tip()` getter to `MinimumPeerVersion`, replacing the
  removed `chain_tip_height()` method; gate `track_stalls` on `is_syncing` in
  `route_p2c`.
  
### Tests

Four unit tests were added:
- `find_blocks_stall_not_tracked_when_at_tip`: Verifies that a peer sending empty `FindBlocks` responses is not disconnected when the node is at the chain tip, confirming the stall tracker is suppressed by the fix.
- `find_blocks_stall_tracked_when_syncing`: Verifies that a peer sending only empty `FindBlocks` responses is still disconnected after exceeding the stall threshold during initial sync, confirming the security property from GHSA-h9hm-m2xj-4rq9 is preserved.
- `find_blocks_stall_tracked_when_tip_unknown`: Verifies that stall tracking remains active when the chain tip is unknown (empty state), so the node is protected even before it has synced its first block.
- `find_blocks_stall_count_preserved_across_tip_transition`: Verifies that stall counts accumulated during sync are not reset when the node transitions to at-tip and back, so a peer cannot avoid detection by sending one useful response when the node nears the tip.

A regression test was added that spawns a regtest network with only two nodes. One mines 100 blocks, then the other syncs. When the tip is reached, the test ensures that the nodes are still connected.

### Specifications & References

- Issue: #10715
- Security advisory preserved: GHSA-h9hm-m2xj-4rq9 (CVE-2026-44499)

### Follow-up Work

We might want a 

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude Sonnet for discussing the solution and coding it

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.