### PR TITLE
fix(state): make read-only state DB open safe and back off the read-state syncer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- Opening a Zebra state read-only (for example, as a secondary instance over a
+  running node's database) now fails with a clear error instead of panicking when
+  the cache directory is missing or unreadable, or when no database exists at the
+  configured path. The read-write open path is unchanged.
+
 ## [Zebra 5.2.0](https://github.com/ZcashFoundation/zebra/releases/tag/v5.2.0) - 2026-06-18
 
 This release increases Zebra's local rollback window as a defence-in-depth measure

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `TrustedChainSync` no longer busy-loops and saturates logs when a block repeatedly
+  fails to commit to the non-finalized state: it now backs off before re-subscribing
+  and only logs the warning on transitions.
+  ([#10741](https://github.com/ZcashFoundation/zebra/pull/10741))
+
 ## [10.0.1] - 2026-06-18
 
 ### Changed

--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -328,8 +328,10 @@ pub fn init_read_state_with_syncer(
             return Err("standalone read state service cannot be used with ephemeral state".into());
         }
 
+        // The outer `?` propagates a `JoinError` if the blocking task panicked, and the
+        // inner `?` propagates a `StateInitError` (e.g. a missing read-only database).
         let (read_state, db, non_finalized_state_sender) =
-            spawn_init_read_only(config, &network).await?;
+            spawn_init_read_only(config, &network).await??;
         let (latest_chain_tip, chain_tip_change, sync_task) =
             TrustedChainSync::spawn(indexer_rpc_address, db, non_finalized_state_sender).await?;
         Ok((read_state, latest_chain_tip, chain_tip_change, sync_task))

--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -19,6 +19,13 @@ use crate::indexer::{indexer_client::IndexerClient, BlockAndHash, Empty};
 /// How long to wait between calls to `subscribe_to_non_finalized_state_change` when it returns an error.
 const POLL_DELAY: Duration = Duration::from_secs(5);
 
+/// How long to wait before re-subscribing after a block fails to commit to the non-finalized state.
+///
+/// A block can persistently fail to commit (e.g. [`ValidateContextError::NotReadyToBeCommitted`])
+/// when the secondary finalized state hasn't yet caught up with the primary. Without this delay,
+/// re-subscribing immediately turns that into a full-speed busy loop that saturates the logs.
+const COMMIT_RETRY_DELAY: Duration = Duration::from_secs(1);
+
 /// Syncs non-finalized blocks in the best chain from a trusted Zebra node's RPC methods.
 #[derive(Debug)]
 pub struct TrustedChainSync {
@@ -135,6 +142,9 @@ impl TrustedChainSync {
     #[tracing::instrument(skip_all)]
     async fn sync(&mut self) {
         let mut non_finalized_blocks_listener = None;
+        // The hash of the block that most recently failed to commit, used to avoid re-logging the
+        // same warning at full rate while a block persistently fails to commit.
+        let mut last_failed_commit_hash = None;
         self.try_catch_up_with_primary().await;
         if let Some(finalized_tip_block) = self.finalized_chain_tip_block().await {
             self.chain_tip_sender.set_finalized_tip(finalized_tip_block);
@@ -185,6 +195,8 @@ impl TrustedChainSync {
             let block = SemanticallyVerifiedBlock::with_hash(Arc::new(block), hash);
             match self.try_commit(block.clone()).await {
                 Ok(()) => {
+                    last_failed_commit_hash = None;
+
                     while self
                         .non_finalized_state
                         .root_height()
@@ -198,15 +210,25 @@ impl TrustedChainSync {
                     self.update_channels();
                 }
                 Err(error) => {
-                    tracing::warn!(
-                        ?error,
-                        ?hash,
-                        "failed to commit block to non-finalized state"
-                    );
+                    // Only log on transitions to avoid saturating the logs when the same block
+                    // persistently fails to commit (e.g. when the secondary finalized state hasn't
+                    // caught up with the primary yet).
+                    if last_failed_commit_hash != Some(hash) {
+                        tracing::warn!(
+                            ?error,
+                            ?hash,
+                            "failed to commit block to non-finalized state"
+                        );
+                        last_failed_commit_hash = Some(hash);
+                    }
 
                     // TODO: Investigate whether it would be correct to ignore some errors here instead of
                     //       trying every block in the non-finalized state again.
                     non_finalized_blocks_listener = None;
+
+                    // Back off before re-subscribing so a persistently failing block doesn't turn
+                    // re-subscription into a full-speed busy loop.
+                    tokio::time::sleep(COMMIT_RETRY_DELAY).await;
                 }
             };
         }

--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -328,8 +328,9 @@ pub fn init_read_state_with_syncer(
             return Err("standalone read state service cannot be used with ephemeral state".into());
         }
 
-        // The outer `?` propagates a `JoinError` if the blocking task panicked, and the
-        // inner `?` propagates a `StateInitError` (e.g. a missing read-only database).
+        // The outer `?` propagates a `JoinError` if the blocking task panicked or was
+        // cancelled, and the inner `?` propagates a `StateInitError` (e.g. a missing
+        // read-only database).
         let (read_state, db, non_finalized_state_sender) =
             spawn_init_read_only(config, &network).await??;
         let (latest_chain_tip, chain_tip_change, sync_task) =

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- The finalized-state open functions now return `Result<_, StateInitError>` instead
+  of panicking when a read-only state cannot be opened: `FinalizedState::new`,
+  `FinalizedState::new_with_debug`, `init_read_only`, `spawn_init_read_only`, and the
+  lower-level `ZebraDb::new` / `DiskDb::new`. A read-only open against a missing or
+  unreadable cache directory, or with no existing database on disk, now returns the
+  new public `StateInitError` rather than panicking. The read-write open path is
+  unchanged.
+  ([#10741](https://github.com/ZcashFoundation/zebra/pull/10741))
+
 ## [9.0.1] - 2026-06-18
 
 ### Changed

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -1,6 +1,6 @@
 //! Error types for Zebra's state.
 
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use chrono::{DateTime, Utc};
 use derive_new::new;
@@ -41,6 +41,48 @@ impl From<BoxError> for CloneError {
 
 /// A boxed [`std::error::Error`].
 pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// An error describing why opening the finalized state database failed.
+///
+/// These errors are recoverable open-time failures that the caller can report,
+/// as opposed to invariant violations that indicate a bug.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum StateInitError {
+    /// A read-only state was requested, but the configured cache directory is
+    /// missing or unreadable.
+    ///
+    /// A read-only secondary instance must never create the primary's cache
+    /// directory, so a missing or unreadable directory is a fatal configuration
+    /// error rather than something to be created.
+    #[error(
+        "cannot open read-only state: cache directory {path:?} is missing or unreadable. \
+         Hint: a read-only state requires an existing Zebra cache directory; check that the \
+         state cache_dir in the Zebra config points at a running Zebra node's cache directory"
+    )]
+    ReadOnlyCacheDirUnreadable {
+        /// The configured cache directory that could not be read.
+        path: PathBuf,
+        /// The underlying I/O error returned while reading the directory.
+        source: std::io::Error,
+    },
+
+    /// A read-only state was requested, but no database exists at the expected
+    /// path.
+    ///
+    /// A read-only secondary instance cannot create a database, so the absence
+    /// of an existing database is a fatal configuration error.
+    #[error(
+        "cannot open read-only state: no database found at {path:?}. \
+         Hint: a read-only state requires an existing finalized database created by a running \
+         Zebra node; check that the state cache_dir in the Zebra config points at that node's \
+         cache directory"
+    )]
+    ReadOnlyDatabaseNotFound {
+        /// The database path at which no database was found.
+        path: PathBuf,
+    },
+}
 
 /// An error describing why a block could not be queued to be committed to the state.
 #[derive(Debug, Error, Clone, PartialEq, Eq, new)]

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -42,7 +42,7 @@ pub use config::{
 pub use constants::{state_database_format_version_in_code, MAX_BLOCK_REORG_HEIGHT};
 pub use error::{
     BoxError, CloneError, CommitBlockError, CommitSemanticallyVerifiedError,
-    DuplicateNullifierError, ValidateContextError,
+    DuplicateNullifierError, StateInitError, ValidateContextError,
 };
 pub use request::{
     CheckpointVerifiedBlock, CommitSemanticallyVerifiedBlockRequest, HashOrHeight, MappedRequest,

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -57,7 +57,7 @@ use crate::{
         watch_receiver::WatchReceiver,
     },
     BoxError, CheckpointVerifiedBlock, CommitSemanticallyVerifiedError, Config, KnownBlock,
-    ReadRequest, ReadResponse, Request, Response, SemanticallyVerifiedBlock,
+    ReadRequest, ReadResponse, Request, Response, SemanticallyVerifiedBlock, StateInitError,
 };
 
 pub mod block_iter;
@@ -324,7 +324,8 @@ impl StateService {
                     &network,
                     #[cfg(feature = "elasticsearch")]
                     true,
-                );
+                )
+                .expect("opening a read-write finalized state database should not fail");
                 timer.finish_desc("opening finalized state database");
 
                 let timer = CodeTimer::start();
@@ -1833,11 +1834,14 @@ pub async fn init(
 pub fn init_read_only(
     config: Config,
     network: &Network,
-) -> (
-    ReadStateService,
-    ZebraDb,
-    tokio::sync::watch::Sender<NonFinalizedState>,
-) {
+) -> Result<
+    (
+        ReadStateService,
+        ZebraDb,
+        tokio::sync::watch::Sender<NonFinalizedState>,
+    ),
+    StateInitError,
+> {
     let finalized_state = FinalizedState::new_with_debug(
         &config,
         network,
@@ -1845,11 +1849,11 @@ pub fn init_read_only(
         #[cfg(feature = "elasticsearch")]
         false,
         true,
-    );
+    )?;
     let (non_finalized_state_sender, non_finalized_state_receiver) =
         tokio::sync::watch::channel(NonFinalizedState::new(network));
 
-    (
+    Ok((
         ReadStateService::new(
             &finalized_state,
             None,
@@ -1857,7 +1861,7 @@ pub fn init_read_only(
         ),
         finalized_state.db.clone(),
         non_finalized_state_sender,
-    )
+    ))
 }
 
 /// Calls [`init_read_only`] with the provided [`Config`] and [`Network`] from a blocking task.
@@ -1865,11 +1869,16 @@ pub fn init_read_only(
 pub fn spawn_init_read_only(
     config: Config,
     network: &Network,
-) -> tokio::task::JoinHandle<(
-    ReadStateService,
-    ZebraDb,
-    tokio::sync::watch::Sender<NonFinalizedState>,
-)> {
+) -> tokio::task::JoinHandle<
+    Result<
+        (
+            ReadStateService,
+            ZebraDb,
+            tokio::sync::watch::Sender<NonFinalizedState>,
+        ),
+        StateInitError,
+    >,
+> {
     let network = network.clone();
     tokio::task::spawn_blocking(move || init_read_only(config, &network))
 }

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -325,7 +325,11 @@ impl StateService {
                     #[cfg(feature = "elasticsearch")]
                     true,
                 )
-                .expect("opening a read-write finalized state database should not fail");
+                .expect(
+                    "opening the read-write finalized state database failed; check that the \
+                     state cache directory is writable and not locked by another Zebra instance, \
+                     and that there is free disk space",
+                );
                 timer.finish_desc("opening finalized state database");
 
                 let timer = CodeTimer::start();
@@ -1865,7 +1869,11 @@ pub fn init_read_only(
 }
 
 /// Calls [`init_read_only`] with the provided [`Config`] and [`Network`] from a blocking task.
-/// Returns a [`tokio::task::JoinHandle`] with a read state service and chain tip sender.
+///
+/// Returns a [`tokio::task::JoinHandle`] whose output is a [`Result`]: awaiting it yields a
+/// [`JoinError`](tokio::task::JoinError) if the blocking task panicked or was cancelled, and
+/// otherwise an `Err(`[`StateInitError`]`)` if the read-only state could not be opened (for
+/// example, a missing read-only database).
 pub fn spawn_init_read_only(
     config: Config,
     network: &Network,

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -166,6 +166,7 @@ impl FinalizedState {
     /// If there is no existing database, creates a new database on disk.
     ///
     /// This method is intended for use in tests.
+    #[allow(clippy::unwrap_in_result)]
     pub(crate) fn new_with_debug(
         config: &Config,
         network: &Network,

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -35,7 +35,7 @@ use crate::{
     error::CommitCheckpointVerifiedError,
     request::{FinalizableBlock, FinalizedBlock, Treestate},
     service::{check, QueuedCheckpointVerified},
-    CheckpointVerifiedBlock, Config, ValidateContextError,
+    CheckpointVerifiedBlock, Config, StateInitError, ValidateContextError,
 };
 
 pub mod column_family;
@@ -151,7 +151,7 @@ impl FinalizedState {
         config: &Config,
         network: &Network,
         #[cfg(feature = "elasticsearch")] enable_elastic_db: bool,
-    ) -> Self {
+    ) -> Result<Self, StateInitError> {
         Self::new_with_debug(
             config,
             network,
@@ -172,7 +172,7 @@ impl FinalizedState {
         debug_skip_format_upgrades: bool,
         #[cfg(feature = "elasticsearch")] enable_elastic_db: bool,
         read_only: bool,
-    ) -> Self {
+    ) -> Result<Self, StateInitError> {
         #[cfg(feature = "elasticsearch")]
         let elastic_db = if enable_elastic_db {
             use elasticsearch::{
@@ -211,7 +211,7 @@ impl FinalizedState {
                 .iter()
                 .map(ToString::to_string),
             read_only,
-        );
+        )?;
 
         #[cfg(feature = "elasticsearch")]
         let new_state = Self {
@@ -264,7 +264,7 @@ impl FinalizedState {
             }
         }
 
-        new_state
+        Ok(new_state)
     }
 
     /// Returns the configured network for this database.

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -32,7 +32,7 @@ use zebra_chain::{parameters::Network, primitives::byte_array::increment_big_end
 use crate::{
     database_format_version_on_disk,
     service::finalized_state::disk_format::{FromDisk, IntoDisk},
-    write_database_format_version_to_disk, Config,
+    write_database_format_version_to_disk, Config, StateInitError,
 };
 
 use super::zebra_db::transparent::{
@@ -965,9 +965,13 @@ impl DiskDb {
     /// with the supplied column families, preserving any existing column families,
     /// and returns a shared low-level database wrapper.
     ///
+    /// # Errors
+    ///
+    /// - In read-only mode, if the cache directory is missing or unreadable.
+    ///
     /// # Panics
     ///
-    /// - If the cache directory does not exist and can't be created.
+    /// - In read-write mode, if the cache directory does not exist and can't be created.
     /// - If the database cannot be opened for whatever reason.
     pub fn new(
         config: &Config,
@@ -976,14 +980,14 @@ impl DiskDb {
         network: &Network,
         column_families_in_code: impl IntoIterator<Item = String>,
         read_only: bool,
-    ) -> DiskDb {
+    ) -> Result<DiskDb, StateInitError> {
         // If the database is ephemeral, we don't need to check the cache directory.
         if !config.ephemeral {
             if read_only {
                 // A read-only secondary instance must never create the primary cache
                 // directory: the primary zebrad owns it. At most, verify it already
                 // exists and is readable, and fail with a clear error otherwise.
-                DiskDb::check_cache_dir_readable(&config.cache_dir);
+                DiskDb::check_cache_dir_readable(&config.cache_dir)?;
             } else {
                 DiskDb::validate_cache_dir(&config.cache_dir);
             }
@@ -1034,7 +1038,7 @@ impl DiskDb {
 
                 db.assert_default_cf_is_empty();
 
-                db
+                Ok(db)
             }
 
             Err(e) if matches!(e.kind(), ErrorKind::Busy | ErrorKind::IOError) => panic!(
@@ -1677,24 +1681,15 @@ impl DiskDb {
     // Checks that a cache directory already exists and is readable, without creating it.
     //
     // Used when opening a read-only secondary instance, which must never create the
-    // primary's cache directory. Panics with a specific error message if the directory
-    // is missing or unreadable.
-    fn check_cache_dir_readable(cache_dir: &std::path::PathBuf) {
+    // primary's cache directory. Returns a [`StateInitError`] if the directory is missing
+    // or unreadable.
+    fn check_cache_dir_readable(cache_dir: &std::path::Path) -> Result<(), StateInitError> {
         match fs::read_dir(cache_dir) {
-            Ok(_) => {}
-            Err(e) => match e.kind() {
-                std::io::ErrorKind::NotFound => panic!(
-                    "Cannot open read-only state: cache directory {cache_dir:?} does not exist. \
-                     Hint: a read-only state requires an existing Zebra cache directory; \
-                     check that the state cache_dir in the Zebra config points at a running \
-                     Zebra node's cache directory."
-                ),
-                std::io::ErrorKind::PermissionDenied => panic!(
-                    "Permission denied reading {cache_dir:?}. \
-                     Hint: check that the cache directory has read permissions."
-                ),
-                _ => panic!("Could not read cache dir {cache_dir:?}: {e}"),
-            },
+            Ok(_) => Ok(()),
+            Err(source) => Err(StateInitError::ReadOnlyCacheDirUnreadable {
+                path: cache_dir.to_path_buf(),
+                source,
+            }),
         }
     }
 

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -1683,7 +1683,9 @@ impl DiskDb {
     // Used when opening a read-only secondary instance, which must never create the
     // primary's cache directory. Returns a [`StateInitError`] if the directory is missing
     // or unreadable.
-    fn check_cache_dir_readable(cache_dir: &std::path::Path) -> Result<(), StateInitError> {
+    pub(crate) fn check_cache_dir_readable(
+        cache_dir: &std::path::Path,
+    ) -> Result<(), StateInitError> {
         match fs::read_dir(cache_dir) {
             Ok(_) => Ok(()),
             Err(source) => Err(StateInitError::ReadOnlyCacheDirUnreadable {

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -979,7 +979,14 @@ impl DiskDb {
     ) -> DiskDb {
         // If the database is ephemeral, we don't need to check the cache directory.
         if !config.ephemeral {
-            DiskDb::validate_cache_dir(&config.cache_dir);
+            if read_only {
+                // A read-only secondary instance must never create the primary cache
+                // directory: the primary zebrad owns it. At most, verify it already
+                // exists and is readable, and fail with a clear error otherwise.
+                DiskDb::check_cache_dir_readable(&config.cache_dir);
+            } else {
+                DiskDb::validate_cache_dir(&config.cache_dir);
+            }
         }
 
         let db_kind = db_kind.as_ref();
@@ -1664,6 +1671,30 @@ impl DiskDb {
                 self.zs_is_empty(&default_cf),
                 "Zebra should not store data in the 'default' column family"
             );
+        }
+    }
+
+    // Checks that a cache directory already exists and is readable, without creating it.
+    //
+    // Used when opening a read-only secondary instance, which must never create the
+    // primary's cache directory. Panics with a specific error message if the directory
+    // is missing or unreadable.
+    fn check_cache_dir_readable(cache_dir: &std::path::PathBuf) {
+        match fs::read_dir(cache_dir) {
+            Ok(_) => {}
+            Err(e) => match e.kind() {
+                std::io::ErrorKind::NotFound => panic!(
+                    "Cannot open read-only state: cache directory {cache_dir:?} does not exist. \
+                     Hint: a read-only state requires an existing Zebra cache directory; \
+                     check that the state cache_dir in the Zebra config points at a running \
+                     Zebra node's cache directory."
+                ),
+                std::io::ErrorKind::PermissionDenied => panic!(
+                    "Permission denied reading {cache_dir:?}. \
+                     Hint: check that the cache directory has read permissions."
+                ),
+                _ => panic!("Could not read cache dir {cache_dir:?}: {e}"),
+            },
         }
     }
 

--- a/zebra-state/src/service/finalized_state/disk_format/tests/snapshot.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/tests/snapshot.rs
@@ -63,7 +63,8 @@ fn test_raw_rocksdb_column_families_with_network(network: Network) {
         &network,
         #[cfg(feature = "elasticsearch")]
         false,
-    );
+    )
+    .expect("opening an ephemeral database should succeed");
 
     // Snapshot the column family names
     let mut cf_names = state.db.list_cf().expect("empty database is valid");

--- a/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/upgrade.rs
@@ -262,6 +262,12 @@ impl DbFormatChange {
         matches!(self, Upgrade { .. })
     }
 
+    /// Returns true if this format change indicates a newly created database
+    /// (no database was found on disk).
+    pub fn is_newly_created(&self) -> bool {
+        matches!(self, NewlyCreated { .. })
+    }
+
     /// Returns true if this format change/check happens at startup.
     #[allow(dead_code)]
     pub fn is_run_at_startup(&self) -> bool {

--- a/zebra-state/src/service/finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/finalized_state/tests/prop.rs
@@ -31,7 +31,7 @@ fn blocks_with_v5_transactions() -> Result<()> {
         .and_then(|v| v.parse().ok())
         .unwrap_or(DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES)),
         |((chain, count, network, _history_tree) in PreparedChain::default())| {
-            let mut state = FinalizedState::new(&Config::ephemeral(), &network, #[cfg(feature = "elasticsearch")] false);
+            let mut state = FinalizedState::new(&Config::ephemeral(), &network, #[cfg(feature = "elasticsearch")] false).expect("opening an ephemeral database should succeed");
             let mut height = Height(0);
             // use `count` to minimize test failures, so they are easier to diagnose
             for block in chain.iter().take(count) {
@@ -90,7 +90,7 @@ fn all_upgrades_and_wrong_commitments_with_fake_activation_heights() -> Result<(
         .unwrap_or(DEFAULT_PARTIAL_CHAIN_PROPTEST_CASES)),
         |((chain, _count, network, _history_tree) in PreparedChain::default().with_ledger_strategy(ledger_strategy).with_valid_commitments().no_shrink())| {
 
-            let mut state = FinalizedState::new(&Config::ephemeral(), &network, #[cfg(feature = "elasticsearch")] false);
+            let mut state = FinalizedState::new(&Config::ephemeral(), &network, #[cfg(feature = "elasticsearch")] false).expect("opening an ephemeral database should succeed");
             let mut height = Height(0);
             let heartwood_height = NetworkUpgrade::Heartwood.activation_height(&network).unwrap();
             let heartwood_height_plus1 = (heartwood_height + 1).unwrap();

--- a/zebra-state/src/service/finalized_state/tests/transparent.rs
+++ b/zebra-state/src/service/finalized_state/tests/transparent.rs
@@ -52,6 +52,7 @@ fn new_ephemeral_zebra_db(network: &Network) -> ZebraDb {
             .map(ToString::to_string),
         false,
     )
+    .expect("opening an ephemeral database should succeed")
 }
 
 /// Cross-version regression test for the credit-before-debit overflow panic.

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -101,17 +101,34 @@ impl ZebraDb {
         column_families_in_code: impl IntoIterator<Item = String>,
         read_only: bool,
     ) -> Result<ZebraDb, StateInitError> {
-        let disk_version = DiskDb::try_reusing_previous_db_after_major_upgrade(
-            &restorable_db_versions(),
-            format_version_in_code,
-            config,
-            &db_kind,
-            network,
-        )
-        .or_else(|| {
+        // A read-only secondary instance must never modify the primary's cache directory, so it
+        // skips the post-major-upgrade DB reuse (which can create directories and rename the
+        // on-disk database) and reads the on-disk format version directly. The cache directory is
+        // checked for readability first, so a missing or unreadable directory returns a typed
+        // `ReadOnlyCacheDirUnreadable` error here instead of panicking on the version-file read.
+        let disk_version = if read_only {
+            DiskDb::check_cache_dir_readable(&config.cache_dir)?;
+
             database_format_version_on_disk(config, &db_kind, format_version_in_code.major, network)
                 .expect("unable to read database format version file")
-        });
+        } else {
+            DiskDb::try_reusing_previous_db_after_major_upgrade(
+                &restorable_db_versions(),
+                format_version_in_code,
+                config,
+                &db_kind,
+                network,
+            )
+            .or_else(|| {
+                database_format_version_on_disk(
+                    config,
+                    &db_kind,
+                    format_version_in_code.major,
+                    network,
+                )
+                .expect("unable to read database format version file")
+            })
+        };
 
         // Log any format changes before opening the database, in case opening fails.
         let format_change = DbFormatChange::open_database(format_version_in_code, disk_version);

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -26,7 +26,7 @@ use crate::{
             upgrade::{DbFormatChange, DbFormatChangeThreadHandle},
         },
     },
-    write_database_format_version_to_disk, BoxError, Config,
+    write_database_format_version_to_disk, BoxError, Config, StateInitError,
 };
 
 use super::disk_format::upgrade::restorable_db_versions;
@@ -99,7 +99,7 @@ impl ZebraDb {
         debug_skip_format_upgrades: bool,
         column_families_in_code: impl IntoIterator<Item = String>,
         read_only: bool,
-    ) -> ZebraDb {
+    ) -> Result<ZebraDb, StateInitError> {
         let disk_version = DiskDb::try_reusing_previous_db_after_major_upgrade(
             &restorable_db_versions(),
             format_version_in_code,
@@ -121,12 +121,7 @@ impl ZebraDb {
         // The read-write path is unaffected: creating a new database is the correct behavior there.
         if read_only && format_change.is_newly_created() {
             let db_path = config.db_path(&db_kind, format_version_in_code.major, network);
-            panic!(
-                "cannot open read-only state: no database found at {db_path:?}. \
-                 Hint: a read-only state requires an existing finalized database created by a \
-                 running Zebra node; check that the state cache_dir in the Zebra config points at \
-                 that node's cache directory."
-            );
+            return Err(StateInitError::ReadOnlyDatabaseNotFound { path: db_path });
         }
 
         // Format upgrades try to write to the database, so we always skip them
@@ -135,23 +130,26 @@ impl ZebraDb {
         // We also allow skipping them when we are running tests.
         let debug_skip_format_upgrades = read_only || (cfg!(test) && debug_skip_format_upgrades);
 
-        // Open the database and do initial checks.
+        // Open the low-level database and do initial checks.
+        //
+        // After the database directory is created, a newly created database temporarily
+        // changes to the default database version. Then we set the correct version in the
+        // upgrade thread. We need to do the version change in this order, because the version
+        // file can only be changed while we hold the RocksDB database lock.
+        let disk_db = DiskDb::new(
+            config,
+            db_kind,
+            format_version_in_code,
+            network,
+            column_families_in_code,
+            read_only,
+        )?;
+
         let mut db = ZebraDb {
             config: Arc::new(config.clone()),
             debug_skip_format_upgrades,
             format_change_handle: None,
-            // After the database directory is created, a newly created database temporarily
-            // changes to the default database version. Then we set the correct version in the
-            // upgrade thread. We need to do the version change in this order, because the version
-            // file can only be changed while we hold the RocksDB database lock.
-            db: DiskDb::new(
-                config,
-                db_kind,
-                format_version_in_code,
-                network,
-                column_families_in_code,
-                read_only,
-            ),
+            db: disk_db,
         };
 
         let zero_location_utxos =
@@ -167,7 +165,7 @@ impl ZebraDb {
 
         db.spawn_format_change(format_change);
 
-        db
+        Ok(db)
     }
 
     /// Launch any required format changes or format checks, and store their thread handle.

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -115,6 +115,20 @@ impl ZebraDb {
         // Log any format changes before opening the database, in case opening fails.
         let format_change = DbFormatChange::open_database(format_version_in_code, disk_version);
 
+        // A read-only secondary instance cannot create a database. If there's no database on
+        // disk, fail with a clear, actionable error instead of silently "creating" one.
+        //
+        // The read-write path is unaffected: creating a new database is the correct behavior there.
+        if read_only && format_change.is_newly_created() {
+            let db_path = config.db_path(&db_kind, format_version_in_code.major, network);
+            panic!(
+                "cannot open read-only state: no database found at {db_path:?}. \
+                 Hint: a read-only state requires an existing finalized database created by a \
+                 running Zebra node; check that the state cache_dir in the Zebra config points at \
+                 that node's cache directory."
+            );
+        }
+
         // Format upgrades try to write to the database, so we always skip them
         // if `read_only` is `true`.
         //

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -91,6 +91,7 @@ impl ZebraDb {
     /// This argument is only used when running tests, it is ignored in production code.
     //
     // TODO: rename to StateDb and remove the db_kind and column_families_in_code arguments
+    #[allow(clippy::unwrap_in_result)]
     pub fn new(
         config: &Config,
         db_kind: impl AsRef<str>,

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/snapshot.rs
@@ -171,7 +171,8 @@ fn test_block_and_transaction_data_with_network(network: Network) {
         &network,
         #[cfg(feature = "elasticsearch")]
         false,
-    );
+    )
+    .expect("opening an ephemeral database should succeed");
 
     // Assert that empty databases are the same, regardless of the network.
     let mut settings = insta::Settings::clone_current();

--- a/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/block/tests/vectors.rs
@@ -92,7 +92,8 @@ fn test_block_db_round_trip_with(
             .iter()
             .map(ToString::to_string),
         false,
-    );
+    )
+    .expect("opening an ephemeral database should succeed");
 
     // Check that each block round-trips to the database
     for original_block in block_test_cases.into_iter() {

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -482,7 +482,7 @@ fn rejection_restores_internal_state_genesis() -> Result<()> {
       }
       ))| {
         let mut state = NonFinalizedState::new(&network);
-        let finalized_state = FinalizedState::new(&Config::ephemeral(), &network, #[cfg(feature = "elasticsearch")] false);
+        let finalized_state = FinalizedState::new(&Config::ephemeral(), &network, #[cfg(feature = "elasticsearch")] false).expect("opening an ephemeral database should succeed");
 
         let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
         finalized_state.set_finalized_value_pool(fake_value_pool);

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -163,7 +163,8 @@ fn best_chain_wins_for_network(network: Network) -> Result<()> {
         &network,
         #[cfg(feature = "elasticsearch")]
         false,
-    );
+    )
+    .expect("opening an ephemeral database should succeed");
 
     state.commit_new_chain(block2.prepare(), &finalized_state)?;
     state.commit_new_chain(child.prepare(), &finalized_state)?;
@@ -200,7 +201,8 @@ fn finalize_pops_from_best_chain_for_network(network: Network) -> Result<()> {
         &network,
         #[cfg(feature = "elasticsearch")]
         false,
-    );
+    )
+    .expect("opening an ephemeral database should succeed");
 
     let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
     finalized_state.set_finalized_value_pool(fake_value_pool);
@@ -245,7 +247,8 @@ fn invalidate_block_removes_block_and_descendants_from_chain_for_network(
         &network,
         #[cfg(feature = "elasticsearch")]
         false,
-    );
+    )
+    .expect("opening an ephemeral database should succeed");
 
     let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
     finalized_state.set_finalized_value_pool(fake_value_pool);
@@ -344,7 +347,8 @@ fn reconsider_block_inserts_block_and_descendants_into_chain_for_network(
         &network,
         #[cfg(feature = "elasticsearch")]
         false,
-    );
+    )
+    .expect("opening an ephemeral database should succeed");
 
     let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
     finalized_state.set_finalized_value_pool(fake_value_pool);
@@ -432,7 +436,8 @@ fn commit_block_extending_best_chain_doesnt_drop_worst_chains_for_network(
         &network,
         #[cfg(feature = "elasticsearch")]
         false,
-    );
+    )
+    .expect("opening an ephemeral database should succeed");
 
     let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
     finalized_state.set_finalized_value_pool(fake_value_pool);
@@ -476,7 +481,8 @@ fn shorter_chain_can_be_best_chain_for_network(network: Network) -> Result<()> {
         &network,
         #[cfg(feature = "elasticsearch")]
         false,
-    );
+    )
+    .expect("opening an ephemeral database should succeed");
 
     let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
     finalized_state.set_finalized_value_pool(fake_value_pool);
@@ -521,7 +527,8 @@ fn longer_chain_with_more_work_wins_for_network(network: Network) -> Result<()> 
         &network,
         #[cfg(feature = "elasticsearch")]
         false,
-    );
+    )
+    .expect("opening an ephemeral database should succeed");
 
     let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
     finalized_state.set_finalized_value_pool(fake_value_pool);
@@ -565,7 +572,8 @@ fn equal_length_goes_to_more_work_for_network(network: Network) -> Result<()> {
         &network,
         #[cfg(feature = "elasticsearch")]
         false,
-    );
+    )
+    .expect("opening an ephemeral database should succeed");
 
     let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
     finalized_state.set_finalized_value_pool(fake_value_pool);
@@ -613,7 +621,8 @@ fn history_tree_is_updated_for_network_upgrade(
         &network,
         #[cfg(feature = "elasticsearch")]
         false,
-    );
+    )
+    .expect("opening an ephemeral database should succeed");
 
     state
         .commit_new_chain(prev_block.clone().prepare(), &finalized_state)
@@ -712,7 +721,8 @@ fn commitment_is_validated_for_network_upgrade(network: Network, network_upgrade
         &network,
         #[cfg(feature = "elasticsearch")]
         false,
-    );
+    )
+    .expect("opening an ephemeral database should succeed");
 
     state
         .commit_new_chain(prev_block.clone().prepare(), &finalized_state)
@@ -777,7 +787,8 @@ async fn non_finalized_state_writes_blocks_to_and_restores_blocks_from_backup_ca
         &network,
         #[cfg(feature = "elasticsearch")]
         false,
-    );
+    )
+    .expect("opening an ephemeral database should succeed");
 
     let backup_dir_path = tempfile::Builder::new()
         .prefix("zebra-non-finalized-state-backup-cache")
@@ -951,7 +962,8 @@ fn commit_new_chain_sets_chain_value_pools_deferred_amount() -> Result<()> {
         &network,
         #[cfg(feature = "elasticsearch")]
         false,
-    );
+    )
+    .expect("opening an ephemeral database should succeed");
     finalized_state.set_finalized_value_pool(ValueBalance::<NonNegative>::fake_populated_pool());
 
     state.commit_new_chain(block.prepare(), &finalized_state.db)?;

--- a/zebra-state/src/service/read/tests/vectors.rs
+++ b/zebra-state/src/service/read/tests/vectors.rs
@@ -381,6 +381,7 @@ fn new_ephemeral_db() -> ZebraDb {
             .map(ToString::to_string),
         false,
     )
+    .expect("opening an ephemeral database should succeed")
 }
 
 /// Test that AnyChainBlock can find blocks by hash and height.
@@ -489,7 +490,8 @@ async fn any_chain_block_finds_side_chain_blocks() -> Result<()> {
         &network,
         #[cfg(feature = "elasticsearch")]
         false,
-    );
+    )
+    .expect("opening an ephemeral database should succeed");
 
     let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
     finalized_state.set_finalized_value_pool(fake_value_pool);

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -632,3 +632,29 @@ fn read_only_open_with_no_database_returns_error() {
         Ok(_) => panic!("expected an error when opening a read-only state with no database"),
     }
 }
+
+/// Opening a read-only state against a missing or unreadable cache directory must fail with a
+/// typed [`StateInitError::ReadOnlyCacheDirUnreadable`] rather than panicking while reading the
+/// on-disk format version.
+#[test]
+fn read_only_open_with_unreadable_cache_dir_returns_error() {
+    let network = Network::Mainnet;
+
+    // A cache directory that does not exist. `read_dir` fails for a missing directory the same way
+    // it does for an unreadable one, without depending on filesystem permissions (which `root`
+    // ignores, so a chmod-based unreadable directory would not be a reliable test under CI).
+    let parent = tempfile::tempdir().expect("creating a temporary directory should succeed");
+    let config = Config {
+        cache_dir: parent.path().join("missing"),
+        ephemeral: false,
+        ..Config::default()
+    };
+
+    match super::init_read_only(config, &network) {
+        Err(crate::StateInitError::ReadOnlyCacheDirUnreadable { .. }) => {}
+        Err(other) => panic!("expected ReadOnlyCacheDirUnreadable, got: {other:?}"),
+        Ok(_) => {
+            panic!("expected an error when opening a read-only state with an unreadable cache dir")
+        }
+    }
+}

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -609,3 +609,26 @@ fn continuous_empty_blocks_from_test_vectors() -> impl Strategy<
             )
         })
 }
+
+/// Opening a read-only state against an existing but empty cache directory (no database on
+/// disk) must fail with [`StateInitError::ReadOnlyDatabaseNotFound`] rather than silently
+/// creating a new, empty database.
+#[test]
+fn read_only_open_with_no_database_returns_error() {
+    let network = Network::Mainnet;
+
+    // An existing, readable, but empty cache directory: it contains no database.
+    let cache_dir =
+        tempfile::tempdir().expect("creating a temporary cache directory should succeed");
+    let config = Config {
+        cache_dir: cache_dir.path().to_path_buf(),
+        ephemeral: false,
+        ..Config::default()
+    };
+
+    match super::init_read_only(config, &network) {
+        Err(crate::StateInitError::ReadOnlyDatabaseNotFound { .. }) => {}
+        Err(other) => panic!("expected ReadOnlyDatabaseNotFound, got: {other:?}"),
+        Ok(_) => panic!("expected an error when opening a read-only state with no database"),
+    }
+}

--- a/zebra-state/src/tests/setup.rs
+++ b/zebra-state/src/tests/setup.rs
@@ -103,7 +103,8 @@ pub(crate) fn new_state_with_mainnet_genesis(
         #[cfg(feature = "elasticsearch")]
         false,
         false,
-    );
+    )
+    .expect("opening an ephemeral database should succeed");
     let non_finalized_state = NonFinalizedState::new(&network);
 
     assert_eq!(

--- a/zebrad/src/commands/copy_state.rs
+++ b/zebrad/src/commands/copy_state.rs
@@ -124,7 +124,7 @@ impl CopyStateCmd {
 
         // We're not verifying UTXOs here, so we don't need the maximum checkpoint height.
         let (mut source_read_only_state_service, _source_db, _source_latest_non_finalized_state) =
-            old_zs::spawn_init_read_only(source_config.clone(), network).await?;
+            old_zs::spawn_init_read_only(source_config.clone(), network).await??;
 
         let elapsed = source_start_time.elapsed();
         info!(?elapsed, "finished initializing source state service");

--- a/zebrad/src/commands/tip_height.rs
+++ b/zebrad/src/commands/tip_height.rs
@@ -46,20 +46,20 @@ impl Runnable for TipHeightCmd {
 impl TipHeightCmd {
     /// Load the chain tip height from the state cache directory.
     fn load_tip_height(&self) -> Result<block::Height> {
-        self.load_read_state()
+        self.load_read_state()?
             .best_tip()
             .map(|(height, _hash)| height)
             .ok_or_else(|| eyre!("State directory doesn't have a chain tip block"))
     }
 
     /// Starts a state service using the `cache_dir` and `network` from the provided arguments.
-    fn load_read_state(&self) -> ReadStateService {
+    fn load_read_state(&self) -> Result<ReadStateService> {
         let mut config = APPLICATION.config().state.clone();
 
         if let Some(cache_dir) = self.cache_dir.clone() {
             config.cache_dir = cache_dir;
         }
 
-        zebra_state::init_read_only(config, &self.network).0
+        Ok(zebra_state::init_read_only(config, &self.network)?.0)
     }
 }

--- a/zebrad/tests/common/cached_state.rs
+++ b/zebrad/tests/common/cached_state.rs
@@ -171,7 +171,8 @@ pub async fn load_finalized_tip_height_from_state_directory(
     let (_read_state, db, _sender) =
         tokio::task::spawn_blocking(move || zebra_state::init_read_only(config, &network))
             .await
-            .map_err(|e| eyre!("Blocking task failed while loading state: {e}"))?;
+            .map_err(|e| eyre!("Blocking task failed while loading state: {e}"))?
+            .map_err(|e| eyre!("Failed to open read-only state: {e}"))?;
 
     let finalized_tip_height = db
         .finalized_tip_height()


### PR DESCRIPTION
## Motivation

These fixes address rough edges hit when opening a running node's Zebra finalized state **read-only** — as a secondary RocksDB instance over the node's existing on-disk state — and following its non-finalized tip via `zebra_rpc::sync::init_read_state_with_syncer` (e.g. a service that reads chain state from a co-located `zebrad` instead of maintaining its own copy):

- Opening the finalized state read-only still tried to **create** the primary cache directory (a write), even though a read-only secondary should never create or modify the primary's data.
- When there was **no database** at the configured cache directory, a read-only open silently fell through to "creating new database", yielding an empty finalized state instead of failing — easy to misdiagnose (e.g. a mistyped `cache_dir`).
- These read-only open failures were surfaced as **panics**, deep in an infallible open chain, rather than as errors callers could handle.
- `TrustedChainSync`, on a failed commit to the non-finalized state (e.g. `NotReadyToBeCommitted` while the secondary's finalized tip lags the streamed chain), reset its subscription and retried with **no backoff**, producing a full-speed busy loop that saturated the logs with identical warnings.

## Solution

- **`zebra-state`** — opening the finalized state **read-only** no longer creates the primary cache directory, and no longer silently creates a new (empty) database when none exists at the configured path. These read-only open failures (missing/unreadable cache directory, or no database present) now return a typed **`StateInitError`** instead of panicking: the finalized-state open chain (`DiskDb::new` → `ZebraDb::new` → `FinalizedState::new`/`new_with_debug` → `init_read_only`/`spawn_init_read_only`) now returns `Result`. The read-write open path is unchanged (it still creates the cache directory and a new database on first run).
- **`zebra-rpc`** — in `TrustedChainSync::sync`, back off before re-subscribing after a commit failure, and only log the warning on transitions (tracking the last failed block hash), so a persistently-uncommittable block no longer produces a log-saturating busy loop.

### Tests

- `cargo check --workspace --all-targets` passes (run in the project's `nix develop` shell, due to a pre-existing rocksdb/GCC toolchain workaround the flake provides — not from this change).
- The read-only behaviors were validated manually against a running node's state opened read-only as a secondary: the previous create-the-cache-dir / create-an-empty-DB behaviors and the full-speed retry-loop log saturation were each reproduced before the change and resolved after.
- No new automated tests were added for the read-only error paths: they require a populated on-disk state database opened read-only as a secondary alongside a running primary, which the current test harness does not set up. (Existing tests were updated for the now-`Result`-returning open functions.)

### Specifications & References

- Read-only / secondary open path: `zebra_state::{init_read_only, spawn_init_read_only}`, the new `zebra_state::StateInitError`, and `DiskDb::open_cf_descriptors_as_secondary`.
- Syncer: `zebra_rpc::sync::{init_read_state_with_syncer, TrustedChainSync}`.

### Follow-up Work

- The `NotReadyToBeCommitted` retry (rate-limited here) is a symptom of the secondary's finalized tip lagging the start of the streamed non-finalized chain; making the secondary reliably catch up to (or fetch) that gap is separate follow-up.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude Code (Opus) — implemented the fixes and helped diagnose the read-only open and syncer-retry behavior.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [ ] The solution is tested.
- [x] The documentation and changelogs are up to date.
