### PR TITLE
test(zebrad): load cached-state submit/send tests at the finalized tip

### DIFF
--- a/zebrad/tests/common/get_block_template_rpcs/submit_block.rs
+++ b/zebrad/tests/common/get_block_template_rpcs/submit_block.rs
@@ -15,7 +15,7 @@ use zebra_node_services::rpc_client::RpcRequestClient;
 
 use crate::common::{
     cached_state::raw_future_blocks,
-    launch::{can_spawn_zebrad_for_test_type, spawn_zebrad_for_rpc},
+    launch::{can_spawn_zebrad_for_test_type, spawn_zebrad_for_rpc_with_opts},
     test_type::TestType,
 };
 
@@ -48,9 +48,18 @@ pub(crate) async fn run() -> Result<()> {
 
     // Start zebrad with no peers, we run the rest of the submitblock test without syncing.
     let should_sync = false;
-    let (mut zebrad, zebra_rpc_address) =
-        spawn_zebrad_for_rpc(network, test_name, test_type, should_sync)?
-            .expect("Already checked zebra state path with can_spawn_zebrad_for_test_type");
+    // Disable the non-finalized state backup so the node loads at the finalized tip: the blocks
+    // fetched above it are then genuinely new and `submitblock` accepts them instead of reporting
+    // duplicates.
+    let use_non_finalized_backup = false;
+    let (mut zebrad, zebra_rpc_address) = spawn_zebrad_for_rpc_with_opts(
+        network,
+        test_name,
+        test_type,
+        should_sync,
+        use_non_finalized_backup,
+    )?
+    .expect("Already checked zebra state path with can_spawn_zebrad_for_test_type");
 
     let rpc_address = zebra_rpc_address.expect("submitblock test must have RPC port");
 

--- a/zebrad/tests/common/lightwalletd/send_transaction_test.rs
+++ b/zebrad/tests/common/lightwalletd/send_transaction_test.rs
@@ -33,7 +33,7 @@ use zebrad::components::mempool::downloads::MAX_INBOUND_CONCURRENCY;
 
 use crate::common::{
     cached_state::future_blocks,
-    launch::{can_spawn_zebrad_for_test_type, spawn_zebrad_for_rpc},
+    launch::{can_spawn_zebrad_for_test_type, spawn_zebrad_for_rpc_with_opts},
     lightwalletd::{
         can_spawn_lightwalletd_for_rpc, spawn_lightwalletd_for_rpc,
         sync::wait_for_zebrad_and_lightwalletd_sync,
@@ -112,12 +112,18 @@ pub async fn run() -> Result<()> {
 
     // Start zebrad with no peers, we want to send transactions without blocks coming in. If `wallet_grpc_test`
     // runs before this test (as it does in `lightwalletd_test_suite`), then we are the most up to date with tip we can.
-    let (mut zebrad, zebra_rpc_address) = if let Some(zebrad_and_address) = spawn_zebrad_for_rpc(
-        network.clone(),
-        test_name,
-        test_type,
-        use_internet_connection,
-    )? {
+    //
+    // Disable the non-finalized state backup so the node loads at the finalized tip: the
+    // transactions taken from blocks above it are not already in the chain when we send them.
+    let use_non_finalized_backup = false;
+    let (mut zebrad, zebra_rpc_address) = if let Some(zebrad_and_address) =
+        spawn_zebrad_for_rpc_with_opts(
+            network.clone(),
+            test_name,
+            test_type,
+            use_internet_connection,
+            use_non_finalized_backup,
+        )? {
         zebrad_and_address
     } else {
         // Skip the test, we don't have the required cached state


### PR DESCRIPTION
## Motivation

Two cached-state integration tests, `rpc_submit_block` and `lwd_rpc_send_tx`, fail in CI. Each spawns an isolated node from a cached state and replays blocks and transactions taken from heights just above the finalized tip, expecting them to be new. The node restores its non-finalized state from a backup left on the reused cached disk, so it loads roughly 1000 blocks ahead of where the test expects. Every replayed block or transaction is then already committed: `submitblock` returns `"duplicate"` and lightwalletd returns error `-25 "transaction is already in state"`.

This regressed when the non-finalized state backup feature merged (#9809): the test's block generator was switched to spawn with the backup disabled, but the node under test kept the backup-enabled default.

## Solution

Spawn both isolated nodes with the non-finalized state backup disabled, so they load at the finalized tip where the replayed blocks and transactions are genuinely new. The strict success assertions are unchanged, so a real `submitblock` or `sendrawtransaction` regression still fails the test.

### Specifications & References

Regressed in #9809. Same cached-state-near-tip test family as #10636.

### Follow-up Work

CI cached disk images carry a stale `non_finalized_state` backup directory with no cleanup path: `delete_old_databases` only prunes the finalized `state/` tree. This is benign for production restarts and harmless here once the backup is disabled, but a future cached-state test that assumes an empty non-finalized state on a reused disk could hit the same surprise. Pruning that directory in the disk-prep step, or extending the cleanup, would remove the footgun.

### AI Disclosure

- [x] AI tools were used: Claude for diagnosis, implementation, and this description.

### PR Checklist

- [x] The PR title follows conventional commits format.
- [x] The PR follows the contribution guidelines.
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
