### PR TITLE
feat(rpc): resumable non-finalized streaming, finalized-gap bridging, and syncer hardening

### DIFF
--- a/zebra-rpc/proto/__generated__/zebra.indexer.rpc.rs
+++ b/zebra-rpc/proto/__generated__/zebra.indexer.rpc.rs
@@ -30,22 +30,12 @@ pub struct BlockAndHash {
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct BlockRequest {
     /// The block to fetch, identified by either its hash or its height.
-    #[prost(oneof = "block_request::HashOrHeight", tags = "1, 2")]
-    pub hash_or_height: ::core::option::Option<block_request::HashOrHeight>,
-}
-/// Nested message and enum types in `BlockRequest`.
-pub mod block_request {
-    /// The block to fetch, identified by either its hash or its height.
-    #[derive(serde::Deserialize, serde::Serialize)]
-    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
-    pub enum HashOrHeight {
-        /// The hash of the block in display order.
-        #[prost(bytes, tag = "1")]
-        Hash(::prost::alloc::vec::Vec<u8>),
-        /// The height of the block in the chain.
-        #[prost(uint32, tag = "2")]
-        Height(u32),
-    }
+    ///
+    /// A 32-byte value is interpreted as a block hash in display order; a 4-byte
+    /// value is interpreted as a big-endian block height. Any other length is
+    /// rejected.
+    #[prost(bytes = "vec", tag = "1")]
+    pub hash_or_height: ::prost::alloc::vec::Vec<u8>,
 }
 /// A request to subscribe to non-finalized state changes.
 #[derive(serde::Deserialize, serde::Serialize)]

--- a/zebra-rpc/proto/__generated__/zebra.indexer.rpc.rs
+++ b/zebra-rpc/proto/__generated__/zebra.indexer.rpc.rs
@@ -25,6 +25,28 @@ pub struct BlockAndHash {
     #[prost(bytes = "vec", tag = "2")]
     pub data: ::prost::alloc::vec::Vec<u8>,
 }
+/// A request for a single block by hash or height from the best chain.
+#[derive(serde::Deserialize, serde::Serialize)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct BlockRequest {
+    /// The block to fetch, identified by either its hash or its height.
+    #[prost(oneof = "block_request::HashOrHeight", tags = "1, 2")]
+    pub hash_or_height: ::core::option::Option<block_request::HashOrHeight>,
+}
+/// Nested message and enum types in `BlockRequest`.
+pub mod block_request {
+    /// The block to fetch, identified by either its hash or its height.
+    #[derive(serde::Deserialize, serde::Serialize)]
+    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
+    pub enum HashOrHeight {
+        /// The hash of the block in display order.
+        #[prost(bytes, tag = "1")]
+        Hash(::prost::alloc::vec::Vec<u8>),
+        /// The height of the block in the chain.
+        #[prost(uint32, tag = "2")]
+        Height(u32),
+    }
+}
 /// A request to subscribe to non-finalized state changes.
 #[derive(serde::Deserialize, serde::Serialize)]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
@@ -275,6 +297,31 @@ pub mod indexer_client {
                 .insert(GrpcMethod::new("zebra.indexer.rpc.Indexer", "MempoolChange"));
             self.inner.server_streaming(req, path, codec).await
         }
+        /// Returns the block with the given hash or height from the best chain.
+        ///
+        /// Used by a syncer to fetch finalized blocks that bridge the gap between its
+        /// local finalized tip and the start of the streamed non-finalized chain.
+        pub async fn get_block(
+            &mut self,
+            request: impl tonic::IntoRequest<super::BlockRequest>,
+        ) -> std::result::Result<tonic::Response<super::BlockAndHash>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic_prost::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/zebra.indexer.rpc.Indexer/GetBlock",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("zebra.indexer.rpc.Indexer", "GetBlock"));
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -336,6 +383,14 @@ pub mod indexer_server {
             tonic::Response<Self::MempoolChangeStream>,
             tonic::Status,
         >;
+        /// Returns the block with the given hash or height from the best chain.
+        ///
+        /// Used by a syncer to fetch finalized blocks that bridge the gap between its
+        /// local finalized tip and the start of the streamed non-finalized chain.
+        async fn get_block(
+            &self,
+            request: tonic::Request<super::BlockRequest>,
+        ) -> std::result::Result<tonic::Response<super::BlockAndHash>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct IndexerServer<T> {
@@ -547,6 +602,49 @@ pub mod indexer_server {
                                 max_encoding_message_size,
                             );
                         let res = grpc.server_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/zebra.indexer.rpc.Indexer/GetBlock" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetBlockSvc<T: Indexer>(pub Arc<T>);
+                    impl<T: Indexer> tonic::server::UnaryService<super::BlockRequest>
+                    for GetBlockSvc<T> {
+                        type Response = super::BlockAndHash;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::BlockRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as Indexer>::get_block(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = GetBlockSvc(inner);
+                        let codec = tonic_prost::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)

--- a/zebra-rpc/proto/__generated__/zebra.indexer.rpc.rs
+++ b/zebra-rpc/proto/__generated__/zebra.indexer.rpc.rs
@@ -25,6 +25,19 @@ pub struct BlockAndHash {
     #[prost(bytes = "vec", tag = "2")]
     pub data: ::prost::alloc::vec::Vec<u8>,
 }
+/// A request to subscribe to non-finalized state changes.
+#[derive(serde::Deserialize, serde::Serialize)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct NonFinalizedStateChangeRequest {
+    /// The hashes of the chain tips the caller already has, in display order.
+    ///
+    /// The server streams only the non-finalized blocks that come after these
+    /// tips, skipping any block at or below a provided tip on the same chain.
+    /// If empty, every block currently in the non-finalized state is sent, so an
+    /// empty request is equivalent to the previous no-argument behavior.
+    #[prost(bytes = "vec", repeated, tag = "1")]
+    pub chain_tip_hashes: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+}
 /// Represents a change in the mempool.
 #[derive(serde::Deserialize, serde::Serialize)]
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
@@ -204,9 +217,13 @@ pub mod indexer_client {
             self.inner.server_streaming(req, path, codec).await
         }
         /// Notifies listeners of new blocks in the non-finalized state.
+        ///
+        /// Callers may provide the hashes of the chain tips they already have so the
+        /// server only streams blocks after those tips. An empty request streams every
+        /// block currently in the non-finalized state.
         pub async fn non_finalized_state_change(
             &mut self,
-            request: impl tonic::IntoRequest<super::Empty>,
+            request: impl tonic::IntoRequest<super::NonFinalizedStateChangeRequest>,
         ) -> std::result::Result<
             tonic::Response<tonic::codec::Streaming<super::BlockAndHash>>,
             tonic::Status,
@@ -294,9 +311,13 @@ pub mod indexer_server {
             + std::marker::Send
             + 'static;
         /// Notifies listeners of new blocks in the non-finalized state.
+        ///
+        /// Callers may provide the hashes of the chain tips they already have so the
+        /// server only streams blocks after those tips. An empty request streams every
+        /// block currently in the non-finalized state.
         async fn non_finalized_state_change(
             &self,
-            request: tonic::Request<super::Empty>,
+            request: tonic::Request<super::NonFinalizedStateChangeRequest>,
         ) -> std::result::Result<
             tonic::Response<Self::NonFinalizedStateChangeStream>,
             tonic::Status,
@@ -439,8 +460,11 @@ pub mod indexer_server {
                 "/zebra.indexer.rpc.Indexer/NonFinalizedStateChange" => {
                     #[allow(non_camel_case_types)]
                     struct NonFinalizedStateChangeSvc<T: Indexer>(pub Arc<T>);
-                    impl<T: Indexer> tonic::server::ServerStreamingService<super::Empty>
-                    for NonFinalizedStateChangeSvc<T> {
+                    impl<
+                        T: Indexer,
+                    > tonic::server::ServerStreamingService<
+                        super::NonFinalizedStateChangeRequest,
+                    > for NonFinalizedStateChangeSvc<T> {
                         type Response = super::BlockAndHash;
                         type ResponseStream = T::NonFinalizedStateChangeStream;
                         type Future = BoxFuture<
@@ -449,7 +473,9 @@ pub mod indexer_server {
                         >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::Empty>,
+                            request: tonic::Request<
+                                super::NonFinalizedStateChangeRequest,
+                            >,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {

--- a/zebra-rpc/proto/indexer.proto
+++ b/zebra-rpc/proto/indexer.proto
@@ -22,6 +22,18 @@ message BlockAndHash {
   bytes data = 2;
 };
 
+// A request for a single block by hash or height from the best chain.
+message BlockRequest {
+  // The block to fetch, identified by either its hash or its height.
+  oneof hash_or_height {
+    // The hash of the block in display order.
+    bytes hash = 1;
+
+    // The height of the block in the chain.
+    uint32 height = 2;
+  }
+};
+
 // A request to subscribe to non-finalized state changes.
 message NonFinalizedStateChangeRequest {
   // The hashes of the chain tips the caller already has, in display order.
@@ -69,4 +81,10 @@ service Indexer {
 
   // Notifies listeners of mempool changes
   rpc MempoolChange(Empty) returns (stream MempoolChangeMessage);
+
+  // Returns the block with the given hash or height from the best chain.
+  //
+  // Used by a syncer to fetch finalized blocks that bridge the gap between its
+  // local finalized tip and the start of the streamed non-finalized chain.
+  rpc GetBlock(BlockRequest) returns (BlockAndHash);
 }

--- a/zebra-rpc/proto/indexer.proto
+++ b/zebra-rpc/proto/indexer.proto
@@ -22,6 +22,17 @@ message BlockAndHash {
   bytes data = 2;
 };
 
+// A request to subscribe to non-finalized state changes.
+message NonFinalizedStateChangeRequest {
+  // The hashes of the chain tips the caller already has, in display order.
+  //
+  // The server streams only the non-finalized blocks that come after these
+  // tips, skipping any block at or below a provided tip on the same chain.
+  // If empty, every block currently in the non-finalized state is sent, so an
+  // empty request is equivalent to the previous no-argument behavior.
+  repeated bytes chain_tip_hashes = 1;
+};
+
 // Represents a change in the mempool.
 message MempoolChangeMessage {
   // The type of change that occurred.
@@ -50,7 +61,11 @@ service Indexer {
   rpc ChainTipChange(Empty) returns (stream BlockHashAndHeight);
 
   // Notifies listeners of new blocks in the non-finalized state.
-  rpc NonFinalizedStateChange(Empty) returns (stream BlockAndHash);
+  //
+  // Callers may provide the hashes of the chain tips they already have so the
+  // server only streams blocks after those tips. An empty request streams every
+  // block currently in the non-finalized state.
+  rpc NonFinalizedStateChange(NonFinalizedStateChangeRequest) returns (stream BlockAndHash);
 
   // Notifies listeners of mempool changes
   rpc MempoolChange(Empty) returns (stream MempoolChangeMessage);

--- a/zebra-rpc/proto/indexer.proto
+++ b/zebra-rpc/proto/indexer.proto
@@ -25,13 +25,11 @@ message BlockAndHash {
 // A request for a single block by hash or height from the best chain.
 message BlockRequest {
   // The block to fetch, identified by either its hash or its height.
-  oneof hash_or_height {
-    // The hash of the block in display order.
-    bytes hash = 1;
-
-    // The height of the block in the chain.
-    uint32 height = 2;
-  }
+  //
+  // A 32-byte value is interpreted as a block hash in display order; a 4-byte
+  // value is interpreted as a big-endian block height. Any other length is
+  // rejected.
+  bytes hash_or_height = 1;
 };
 
 // A request to subscribe to non-finalized state changes.

--- a/zebra-rpc/src/indexer/methods.rs
+++ b/zebra-rpc/src/indexer/methods.rs
@@ -13,8 +13,8 @@ use zebra_node_services::mempool::MempoolChangeKind;
 use zebra_state::{ReadRequest, ReadResponse, ReadState, MAX_NON_FINALIZED_CHAIN_FORKS};
 
 use super::{
-    indexer_server::Indexer, server::IndexerRPC, BlockAndHash, BlockHashAndHeight, Empty,
-    MempoolChangeMessage, NonFinalizedStateChangeRequest,
+    block_request, indexer_server::Indexer, server::IndexerRPC, BlockAndHash, BlockHashAndHeight,
+    BlockRequest, Empty, MempoolChangeMessage, NonFinalizedStateChangeRequest,
 };
 
 /// The maximum number of messages that can be queued to be streamed to a client.
@@ -212,6 +212,47 @@ where
         });
 
         Ok(Response::new(Box::pin(response_stream)))
+    }
+
+    async fn get_block(
+        &self,
+        request: tonic::Request<BlockRequest>,
+    ) -> Result<Response<BlockAndHash>, Status> {
+        let hash_or_height = match request.into_inner().hash_or_height {
+            Some(block_request::HashOrHeight::Hash(hash)) => {
+                let bytes: [u8; 32] = hash.try_into().map_err(|hash: Vec<u8>| {
+                    Status::invalid_argument(format!(
+                        "invalid block hash length: expected 32 bytes, got {}",
+                        hash.len()
+                    ))
+                })?;
+                zebra_state::HashOrHeight::Hash(block::Hash::from_bytes_in_display_order(&bytes))
+            }
+            Some(block_request::HashOrHeight::Height(height)) => {
+                zebra_state::HashOrHeight::Height(block::Height(height))
+            }
+            None => {
+                return Err(Status::invalid_argument(
+                    "block request must specify a hash or height",
+                ));
+            }
+        };
+
+        match self
+            .read_state
+            .clone()
+            .oneshot(ReadRequest::Block(hash_or_height))
+            .await
+        {
+            Ok(ReadResponse::Block(Some(block))) => {
+                Ok(Response::new(BlockAndHash::new(block.hash(), block)))
+            }
+            Ok(ReadResponse::Block(None)) => Err(Status::not_found("block not found")),
+            Ok(_) => unreachable!("unexpected response type from ReadStateService"),
+            Err(error) => Err(Status::unavailable(format!(
+                "failed to read block: {error}"
+            ))),
+        }
     }
 }
 

--- a/zebra-rpc/src/indexer/methods.rs
+++ b/zebra-rpc/src/indexer/methods.rs
@@ -10,7 +10,7 @@ use tower::util::ServiceExt;
 use tracing::Span;
 use zebra_chain::{block, chain_tip::ChainTip, serialization::BytesInDisplayOrder};
 use zebra_node_services::mempool::MempoolChangeKind;
-use zebra_state::{ReadRequest, ReadResponse, ReadState};
+use zebra_state::{ReadRequest, ReadResponse, ReadState, MAX_NON_FINALIZED_CHAIN_FORKS};
 
 use super::{
     indexer_server::Indexer, server::IndexerRPC, BlockAndHash, BlockHashAndHeight, Empty,
@@ -223,9 +223,20 @@ where
 ///
 /// # Errors
 ///
-/// Returns an [`invalid_argument`](Status::invalid_argument) status if any hash is not exactly
-/// 32 bytes long.
+/// Returns an [`invalid_argument`](Status::invalid_argument) status if there are more hashes than
+/// the non-finalized state can hold chains ([`MAX_NON_FINALIZED_CHAIN_FORKS`]), or if any hash is
+/// not exactly 32 bytes long.
 fn decode_known_chain_tips(chain_tip_hashes: Vec<Vec<u8>>) -> Result<HashSet<block::Hash>, Status> {
+    // The non-finalized state holds at most `MAX_NON_FINALIZED_CHAIN_FORKS` chains, so a caller can
+    // never legitimately have more chain tips than that. Bound the untrusted input up front rather
+    // than allocating a set sized by the request.
+    if chain_tip_hashes.len() > MAX_NON_FINALIZED_CHAIN_FORKS {
+        return Err(Status::invalid_argument(format!(
+            "too many chain tip hashes: got {}, expected at most {MAX_NON_FINALIZED_CHAIN_FORKS}",
+            chain_tip_hashes.len(),
+        )));
+    }
+
     chain_tip_hashes
         .into_iter()
         .map(|hash| {
@@ -238,4 +249,66 @@ fn decode_known_chain_tips(chain_tip_hashes: Vec<Vec<u8>>) -> Result<HashSet<blo
             Ok(block::Hash::from_bytes_in_display_order(&bytes))
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tonic::Code;
+
+    fn hash(byte: u8) -> block::Hash {
+        block::Hash::from_bytes_in_display_order(&[byte; 32])
+    }
+
+    #[test]
+    fn decode_known_chain_tips_round_trips_display_order() {
+        let hashes = [hash(1), hash(2), hash(3)];
+        let encoded = hashes
+            .iter()
+            .map(|h| h.bytes_in_display_order().to_vec())
+            .collect();
+
+        let decoded = decode_known_chain_tips(encoded).expect("valid hashes should decode");
+
+        assert_eq!(decoded, hashes.into_iter().collect());
+    }
+
+    #[test]
+    fn decode_known_chain_tips_accepts_empty() {
+        assert!(decode_known_chain_tips(Vec::new())
+            .expect("empty input should decode")
+            .is_empty());
+    }
+
+    #[test]
+    fn decode_known_chain_tips_dedups() {
+        let encoded = vec![
+            hash(7).bytes_in_display_order().to_vec(),
+            hash(7).bytes_in_display_order().to_vec(),
+        ];
+
+        let decoded = decode_known_chain_tips(encoded).expect("duplicate hashes should decode");
+
+        assert_eq!(decoded, std::iter::once(hash(7)).collect());
+    }
+
+    #[test]
+    fn decode_known_chain_tips_rejects_wrong_length() {
+        let status = decode_known_chain_tips(vec![vec![0; 31]])
+            .expect_err("a 31-byte hash should be rejected");
+
+        assert_eq!(status.code(), Code::InvalidArgument);
+    }
+
+    #[test]
+    fn decode_known_chain_tips_rejects_too_many() {
+        let encoded = (0..=MAX_NON_FINALIZED_CHAIN_FORKS as u8)
+            .map(|b| hash(b).bytes_in_display_order().to_vec())
+            .collect();
+
+        let status = decode_known_chain_tips(encoded)
+            .expect_err("more than MAX_NON_FINALIZED_CHAIN_FORKS hashes should be rejected");
+
+        assert_eq!(status.code(), Code::InvalidArgument);
+    }
 }

--- a/zebra-rpc/src/indexer/methods.rs
+++ b/zebra-rpc/src/indexer/methods.rs
@@ -1,6 +1,6 @@
 //! Implements `Indexer` methods on the `IndexerRPC` type
 
-use std::pin::Pin;
+use std::{collections::HashSet, pin::Pin};
 
 use futures::Stream;
 use tokio_stream::wrappers::ReceiverStream;
@@ -8,13 +8,13 @@ use tonic::{Response, Status};
 use tower::util::ServiceExt;
 
 use tracing::Span;
-use zebra_chain::{chain_tip::ChainTip, serialization::BytesInDisplayOrder};
+use zebra_chain::{block, chain_tip::ChainTip, serialization::BytesInDisplayOrder};
 use zebra_node_services::mempool::MempoolChangeKind;
 use zebra_state::{ReadRequest, ReadResponse, ReadState};
 
 use super::{
     indexer_server::Indexer, server::IndexerRPC, BlockAndHash, BlockHashAndHeight, Empty,
-    MempoolChangeMessage,
+    MempoolChangeMessage, NonFinalizedStateChangeRequest,
 };
 
 /// The maximum number of messages that can be queued to be streamed to a client.
@@ -83,16 +83,20 @@ where
 
     async fn non_finalized_state_change(
         &self,
-        _: tonic::Request<Empty>,
+        request: tonic::Request<NonFinalizedStateChangeRequest>,
     ) -> Result<Response<Self::NonFinalizedStateChangeStream>, Status> {
         let span = Span::current();
         let read_state = self.read_state.clone();
         let (response_sender, response_receiver) = tokio::sync::mpsc::channel(RESPONSE_BUFFER_SIZE);
         let response_stream = ReceiverStream::new(response_receiver);
 
+        // The caller may provide the hashes of the chain tips it already has so the server only
+        // streams blocks after those tips. Malformed hashes (wrong length) are rejected up front.
+        let known_chain_tips = decode_known_chain_tips(request.into_inner().chain_tip_hashes)?;
+
         tokio::spawn(async move {
             let mut non_finalized_state_change = match read_state
-                .oneshot(ReadRequest::NonFinalizedBlocksListener)
+                .oneshot(ReadRequest::NonFinalizedBlocksListener { known_chain_tips })
                 .await
             {
                 Ok(ReadResponse::NonFinalizedBlocksListener(listener)) => listener.unwrap(),
@@ -212,4 +216,29 @@ where
 
         Ok(Response::new(Box::pin(response_stream)))
     }
+}
+
+/// Decodes the chain tip hashes from a [`NonFinalizedStateChangeRequest`] into a set of
+/// [`block::Hash`]es.
+///
+/// Each hash is expected to be 32 bytes in display order, matching the encoding used when the
+/// server streams [`BlockAndHash`] messages back to the caller.
+///
+/// # Errors
+///
+/// Returns an [`invalid_argument`](Status::invalid_argument) status if any hash is not exactly
+/// 32 bytes long.
+fn decode_known_chain_tips(chain_tip_hashes: Vec<Vec<u8>>) -> Result<HashSet<block::Hash>, Status> {
+    chain_tip_hashes
+        .into_iter()
+        .map(|hash| {
+            let bytes: [u8; 32] = hash.try_into().map_err(|hash: Vec<u8>| {
+                Status::invalid_argument(format!(
+                    "invalid chain tip hash length: expected 32 bytes, got {}",
+                    hash.len()
+                ))
+            })?;
+            Ok(block::Hash::from_bytes_in_display_order(&bytes))
+        })
+        .collect()
 }

--- a/zebra-rpc/src/indexer/methods.rs
+++ b/zebra-rpc/src/indexer/methods.rs
@@ -13,8 +13,8 @@ use zebra_node_services::mempool::MempoolChangeKind;
 use zebra_state::{ReadRequest, ReadResponse, ReadState, MAX_NON_FINALIZED_CHAIN_FORKS};
 
 use super::{
-    block_request, indexer_server::Indexer, server::IndexerRPC, BlockAndHash, BlockHashAndHeight,
-    BlockRequest, Empty, MempoolChangeMessage, NonFinalizedStateChangeRequest,
+    indexer_server::Indexer, server::IndexerRPC, BlockAndHash, BlockHashAndHeight, BlockRequest,
+    Empty, MempoolChangeMessage, NonFinalizedStateChangeRequest,
 };
 
 /// The maximum number of messages that can be queued to be streamed to a client.
@@ -237,20 +237,26 @@ where
         &self,
         request: tonic::Request<BlockRequest>,
     ) -> Result<Response<BlockAndHash>, Status> {
-        let hash_or_height = match request.into_inner().hash_or_height {
-            Some(block_request::HashOrHeight::Hash(hash)) => {
-                zebra_state::HashOrHeight::Hash(hash_from_display_bytes(hash)?)
-            }
-            Some(block_request::HashOrHeight::Height(height)) => {
+        // The request carries a single `hash_or_height` byte string: a 32-byte block hash in
+        // display order, or a 4-byte big-endian block height. The length tells the two apart.
+        let hash_or_height = request.into_inner().hash_or_height;
+        let hash_or_height = match hash_or_height.len() {
+            32 => zebra_state::HashOrHeight::Hash(hash_from_display_bytes(hash_or_height)?),
+            4 => {
+                let height = u32::from_be_bytes(
+                    hash_or_height
+                        .try_into()
+                        .expect("a 4-byte vec always converts to a [u8; 4]"),
+                );
                 let height = block::Height::try_from(height).map_err(|_| {
                     Status::invalid_argument(format!("block height out of range: {height}"))
                 })?;
                 zebra_state::HashOrHeight::Height(height)
             }
-            None => {
-                return Err(Status::invalid_argument(
-                    "block request must specify a hash or height",
-                ));
+            len => {
+                return Err(Status::invalid_argument(format!(
+                    "block request must be a 32-byte hash or a 4-byte height, got {len} bytes"
+                )));
             }
         };
 

--- a/zebra-rpc/src/indexer/methods.rs
+++ b/zebra-rpc/src/indexer/methods.rs
@@ -118,26 +118,23 @@ where
                 }
             };
 
-            // Notify the client of chain tip changes until the channel is closed
+            // Notify the client of new blocks until the channel is closed.
+            //
+            // Unlike the other streams, this uses `send().await` to apply backpressure to the
+            // non-finalized state listener rather than dropping blocks for a slow consumer. The
+            // only error is the receiver being closed, which means the client has disconnected.
             while let Some((hash, block)) = non_finalized_state_change.recv().await {
-                match response_sender.try_send(Ok(BlockAndHash::new(hash, block))) {
-                    Ok(()) => {}
-                    Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                        span.in_scope(|| {
-                            tracing::info!(
-                                "client disconnected, dropping non_finalized_state_change task"
-                            );
-                        });
-                        return;
-                    }
-                    Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                        span.in_scope(|| {
-                            tracing::warn!(
-                                "slow consumer, dropping non_finalized_state_change stream"
-                            );
-                        });
-                        return;
-                    }
+                if response_sender
+                    .send(Ok(BlockAndHash::new(hash, block)))
+                    .await
+                    .is_err()
+                {
+                    span.in_scope(|| {
+                        tracing::info!(
+                            "client disconnected, dropping non_finalized_state_change task"
+                        );
+                    });
+                    return;
                 }
             }
 

--- a/zebra-rpc/src/indexer/methods.rs
+++ b/zebra-rpc/src/indexer/methods.rs
@@ -242,7 +242,10 @@ where
                 zebra_state::HashOrHeight::Hash(hash_from_display_bytes(hash)?)
             }
             Some(block_request::HashOrHeight::Height(height)) => {
-                zebra_state::HashOrHeight::Height(block::Height(height))
+                let height = block::Height::try_from(height).map_err(|_| {
+                    Status::invalid_argument(format!("block height out of range: {height}"))
+                })?;
+                zebra_state::HashOrHeight::Height(height)
             }
             None => {
                 return Err(Status::invalid_argument(

--- a/zebra-rpc/src/indexer/methods.rs
+++ b/zebra-rpc/src/indexer/methods.rs
@@ -1,6 +1,6 @@
 //! Implements `Indexer` methods on the `IndexerRPC` type
 
-use std::{collections::HashSet, pin::Pin};
+use std::{collections::HashSet, pin::Pin, time::Duration};
 
 use futures::Stream;
 use tokio_stream::wrappers::ReceiverStream;
@@ -19,6 +19,14 @@ use super::{
 
 /// The maximum number of messages that can be queued to be streamed to a client.
 const RESPONSE_BUFFER_SIZE: usize = 64;
+
+/// How long to wait for a backpressured send to the non-finalized stream before treating the
+/// consumer as hung and dropping the subscription.
+///
+/// The non-finalized stream applies backpressure (rather than dropping blocks) so a slow consumer
+/// doesn't miss blocks, but without a bound a consumer whose connection is half-open (dead TCP not
+/// yet detected) would block the listener task indefinitely.
+const NON_FINALIZED_SEND_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[tonic::async_trait]
 impl<ReadStateService, Tip> Indexer for IndexerRPC<ReadStateService, Tip>
@@ -121,20 +129,31 @@ where
             // Notify the client of new blocks until the channel is closed.
             //
             // Unlike the other streams, this uses `send().await` to apply backpressure to the
-            // non-finalized state listener rather than dropping blocks for a slow consumer. The
-            // only error is the receiver being closed, which means the client has disconnected.
+            // non-finalized state listener rather than dropping blocks for a slow consumer. A send
+            // error means the client disconnected; a send that doesn't complete within
+            // `NON_FINALIZED_SEND_TIMEOUT` means the consumer is hung. In both cases the task ends
+            // rather than blocking forever.
             while let Some((hash, block)) = non_finalized_state_change.recv().await {
-                if response_sender
-                    .send(Ok(BlockAndHash::new(hash, block)))
-                    .await
-                    .is_err()
-                {
-                    span.in_scope(|| {
-                        tracing::info!(
-                            "client disconnected, dropping non_finalized_state_change task"
-                        );
-                    });
-                    return;
+                let send = response_sender.send(Ok(BlockAndHash::new(hash, block)));
+                match tokio::time::timeout(NON_FINALIZED_SEND_TIMEOUT, send).await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(_)) => {
+                        span.in_scope(|| {
+                            tracing::info!(
+                                "client disconnected, dropping non_finalized_state_change task"
+                            );
+                        });
+                        return;
+                    }
+                    Err(_) => {
+                        span.in_scope(|| {
+                            tracing::warn!(
+                                "slow consumer, dropping non_finalized_state_change stream after \
+                                 send timed out"
+                            );
+                        });
+                        return;
+                    }
                 }
             }
 

--- a/zebra-rpc/src/indexer/methods.rs
+++ b/zebra-rpc/src/indexer/methods.rs
@@ -239,13 +239,7 @@ where
     ) -> Result<Response<BlockAndHash>, Status> {
         let hash_or_height = match request.into_inner().hash_or_height {
             Some(block_request::HashOrHeight::Hash(hash)) => {
-                let bytes: [u8; 32] = hash.try_into().map_err(|hash: Vec<u8>| {
-                    Status::invalid_argument(format!(
-                        "invalid block hash length: expected 32 bytes, got {}",
-                        hash.len()
-                    ))
-                })?;
-                zebra_state::HashOrHeight::Hash(block::Hash::from_bytes_in_display_order(&bytes))
+                zebra_state::HashOrHeight::Hash(hash_from_display_bytes(hash)?)
             }
             Some(block_request::HashOrHeight::Height(height)) => {
                 zebra_state::HashOrHeight::Height(block::Height(height))
@@ -299,16 +293,20 @@ fn decode_known_chain_tips(chain_tip_hashes: Vec<Vec<u8>>) -> Result<HashSet<blo
 
     chain_tip_hashes
         .into_iter()
-        .map(|hash| {
-            let bytes: [u8; 32] = hash.try_into().map_err(|hash: Vec<u8>| {
-                Status::invalid_argument(format!(
-                    "invalid chain tip hash length: expected 32 bytes, got {}",
-                    hash.len()
-                ))
-            })?;
-            Ok(block::Hash::from_bytes_in_display_order(&bytes))
-        })
+        .map(hash_from_display_bytes)
         .collect()
+}
+
+/// Decodes a 32-byte block hash in display order, rejecting wrong-length input.
+fn hash_from_display_bytes(hash: Vec<u8>) -> Result<block::Hash, Status> {
+    let bytes: [u8; 32] = hash.try_into().map_err(|hash: Vec<u8>| {
+        Status::invalid_argument(format!(
+            "invalid block hash length: expected 32 bytes, got {}",
+            hash.len()
+        ))
+    })?;
+
+    Ok(block::Hash::from_bytes_in_display_order(&bytes))
 }
 
 #[cfg(test)]

--- a/zebra-rpc/src/indexer/tests/vectors.rs
+++ b/zebra-rpc/src/indexer/tests/vectors.rs
@@ -53,6 +53,15 @@ async fn test_get_block(
         .expect_err("a block request without a hash or height should be rejected");
     assert_eq!(status.code(), tonic::Code::InvalidArgument);
 
+    // A height above the maximum valid block height is rejected without touching the state.
+    let status = client
+        .get_block(tonic::Request::new(BlockRequest {
+            hash_or_height: Some(block_request::HashOrHeight::Height(u32::MAX)),
+        }))
+        .await
+        .expect_err("an out-of-range block height should be rejected");
+    assert_eq!(status.code(), tonic::Code::InvalidArgument);
+
     // A block requested by height is returned along with its hash.
     let block: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
     let expected_hash = block.hash();

--- a/zebra-rpc/src/indexer/tests/vectors.rs
+++ b/zebra-rpc/src/indexer/tests/vectors.rs
@@ -1,32 +1,86 @@
 //! Fixed test vectors for indexer RPCs
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use futures::StreamExt;
 use tokio::{sync::broadcast, task::JoinHandle};
 use tower::BoxError;
 use zebra_chain::{
-    block::Height,
+    block::{Block, Height},
     chain_tip::mock::{MockChainTip, MockChainTipSender},
+    serialization::ZcashDeserializeInto,
     transaction::{self, UnminedTxId},
 };
 use zebra_node_services::mempool::{MempoolChange, MempoolTxSubscriber};
+use zebra_state::{HashOrHeight, ReadRequest, ReadResponse};
 use zebra_test::{
-    mock_service::MockService,
+    mock_service::{MockService, PanicAssertion},
     prelude::color_eyre::{eyre::eyre, Result},
 };
 
-use crate::indexer::{self, indexer_client::IndexerClient, Empty};
+use crate::indexer::{self, block_request, indexer_client::IndexerClient, BlockRequest, Empty};
 
 #[tokio::test]
 async fn rpc_server_spawn() -> Result<()> {
     let _init_guard = zebra_test::init();
 
-    let (_server_task, client, mock_chain_tip_sender, mempool_transaction_sender) =
-        start_server_and_get_client().await?;
+    let (
+        _server_task,
+        client,
+        mock_read_service,
+        mock_chain_tip_sender,
+        mempool_transaction_sender,
+    ) = start_server_and_get_client().await?;
 
     test_chain_tip_change(client.clone(), mock_chain_tip_sender).await?;
     test_mempool_change(client.clone(), mempool_transaction_sender).await?;
+    test_get_block(client.clone(), mock_read_service).await?;
+
+    Ok(())
+}
+
+/// Tests that the `GetBlock` method returns the requested block and rejects an empty request.
+async fn test_get_block(
+    mut client: IndexerClient<tonic::transport::Channel>,
+    mut mock_read_service: MockService<ReadRequest, ReadResponse, PanicAssertion, BoxError>,
+) -> Result<()> {
+    // A request that specifies neither a hash nor a height is rejected without touching the state.
+    let status = client
+        .get_block(tonic::Request::new(BlockRequest {
+            hash_or_height: None,
+        }))
+        .await
+        .expect_err("a block request without a hash or height should be rejected");
+    assert_eq!(status.code(), tonic::Code::InvalidArgument);
+
+    // A block requested by height is returned along with its hash.
+    let block: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
+    let expected_hash = block.hash();
+    let height = block
+        .coinbase_height()
+        .expect("test block has a coinbase height");
+
+    let mut request_client = client.clone();
+    let request_task = tokio::spawn(async move {
+        request_client
+            .get_block(tonic::Request::new(BlockRequest {
+                hash_or_height: Some(block_request::HashOrHeight::Height(height.0)),
+            }))
+            .await
+    });
+
+    mock_read_service
+        .expect_request(ReadRequest::Block(HashOrHeight::Height(height)))
+        .await
+        .respond(ReadResponse::Block(Some(block.clone())));
+
+    let response = request_task
+        .await?
+        .expect("get_block should succeed")
+        .into_inner();
+    let (decoded_block, decoded_hash) = response.decode().expect("response should decode");
+    assert_eq!(decoded_hash, expected_hash);
+    assert_eq!(decoded_block.hash(), expected_hash);
 
     Ok(())
 }
@@ -79,6 +133,7 @@ async fn test_mempool_change(
 async fn start_server_and_get_client() -> Result<(
     JoinHandle<Result<(), BoxError>>,
     IndexerClient<tonic::transport::Channel>,
+    MockService<ReadRequest, ReadResponse, PanicAssertion, BoxError>,
     MockChainTipSender,
     broadcast::Sender<MempoolChange>,
 )> {
@@ -95,7 +150,7 @@ async fn start_server_and_get_client() -> Result<(
     let mempool_tx_subscriber = MempoolTxSubscriber::new(mempool_transaction_sender.clone());
     let (server_task, listen_addr) = indexer::server::init(
         listen_addr,
-        mock_read_service,
+        mock_read_service.clone(),
         mock_chain_tip_change,
         mempool_tx_subscriber.clone(),
     )
@@ -117,6 +172,7 @@ async fn start_server_and_get_client() -> Result<(
     Ok((
         server_task,
         client,
+        mock_read_service,
         mock_chain_tip_change_sender,
         mempool_transaction_sender,
     ))

--- a/zebra-rpc/src/indexer/tests/vectors.rs
+++ b/zebra-rpc/src/indexer/tests/vectors.rs
@@ -18,7 +18,7 @@ use zebra_test::{
     prelude::color_eyre::{eyre::eyre, Result},
 };
 
-use crate::indexer::{self, block_request, indexer_client::IndexerClient, BlockRequest, Empty};
+use crate::indexer::{self, indexer_client::IndexerClient, BlockRequest, Empty};
 
 #[tokio::test]
 async fn rpc_server_spawn() -> Result<()> {
@@ -44,19 +44,20 @@ async fn test_get_block(
     mut client: IndexerClient<tonic::transport::Channel>,
     mut mock_read_service: MockService<ReadRequest, ReadResponse, PanicAssertion, BoxError>,
 ) -> Result<()> {
-    // A request that specifies neither a hash nor a height is rejected without touching the state.
+    // A request whose bytes are neither a 32-byte hash nor a 4-byte height is rejected without
+    // touching the state.
     let status = client
         .get_block(tonic::Request::new(BlockRequest {
-            hash_or_height: None,
+            hash_or_height: Vec::new(),
         }))
         .await
-        .expect_err("a block request without a hash or height should be rejected");
+        .expect_err("a block request without a valid hash or height should be rejected");
     assert_eq!(status.code(), tonic::Code::InvalidArgument);
 
     // A height above the maximum valid block height is rejected without touching the state.
     let status = client
         .get_block(tonic::Request::new(BlockRequest {
-            hash_or_height: Some(block_request::HashOrHeight::Height(u32::MAX)),
+            hash_or_height: u32::MAX.to_be_bytes().to_vec(),
         }))
         .await
         .expect_err("an out-of-range block height should be rejected");
@@ -73,7 +74,7 @@ async fn test_get_block(
     let request_task = tokio::spawn(async move {
         request_client
             .get_block(tonic::Request::new(BlockRequest {
-                hash_or_height: Some(block_request::HashOrHeight::Height(height.0)),
+                hash_or_height: height.0.to_be_bytes().to_vec(),
             }))
             .await
     });

--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -26,6 +26,22 @@ use crate::indexer::{
 /// How long to wait between calls to `subscribe_to_non_finalized_state_change` when it returns an error.
 const POLL_DELAY: Duration = Duration::from_secs(5);
 
+/// How long to wait for a message on a gRPC subscription stream before assuming the stream is dead
+/// and re-subscribing.
+///
+/// Generous, because legitimate gaps between blocks/tip changes can be several minutes; this is a
+/// backstop against a wedged connection that the keep-alive ping below doesn't catch. Re-subscribing
+/// is cheap and resumes from the syncer's current chain tips, so an occasional false trigger during
+/// a quiet period is harmless.
+const STREAM_MESSAGE_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+
+/// HTTP/2 keep-alive ping interval for the indexer gRPC connection, so a half-open connection is
+/// detected promptly instead of hanging a stream read indefinitely.
+const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(60);
+
+/// How long to wait for a keep-alive ping response before treating the connection as dead.
+const KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(20);
+
 /// How long to wait before re-subscribing after a block fails to commit to the non-finalized state.
 ///
 /// A block can persistently fail to commit (e.g. [`ValidateContextError::NotReadyToBeCommitted`])
@@ -73,19 +89,25 @@ async fn update_finalized_chain_tip(
             continue;
         };
 
-        let message = match chain_tip_change.message().await {
-            Ok(Some(block_hash_and_height)) => block_hash_and_height,
-            Ok(None) => {
-                tracing::warn!("chain_tip_change stream ended unexpectedly");
-                chain_tip_change_stream = None;
-                continue;
-            }
-            Err(err) => {
-                tracing::warn!(?err, "error receiving chain tip change");
-                chain_tip_change_stream = None;
-                continue;
-            }
-        };
+        let message =
+            match tokio::time::timeout(STREAM_MESSAGE_TIMEOUT, chain_tip_change.message()).await {
+                Ok(Ok(Some(block_hash_and_height))) => block_hash_and_height,
+                Ok(Ok(None)) => {
+                    tracing::warn!("chain_tip_change stream ended unexpectedly");
+                    chain_tip_change_stream = None;
+                    continue;
+                }
+                Ok(Err(err)) => {
+                    tracing::warn!(?err, "error receiving chain tip change");
+                    chain_tip_change_stream = None;
+                    continue;
+                }
+                Err(_) => {
+                    tracing::debug!("chain tip change stream timed out, re-subscribing");
+                    chain_tip_change_stream = None;
+                    continue;
+                }
+            };
 
         let Some((hash, _height)) = message.try_into_hash_and_height() else {
             tracing::warn!("failed to convert message into a block hash and height");
@@ -93,7 +115,11 @@ async fn update_finalized_chain_tip(
         };
 
         // Skip the chain tip change if catching up to the primary db instance fails.
-        if db.spawn_try_catch_up_with_primary().await.is_err() {
+        if let Err(error) = db.spawn_try_catch_up_with_primary().await {
+            tracing::debug!(
+                ?error,
+                "failed to catch up to the primary database while updating the finalized tip"
+            );
             continue;
         }
 
@@ -122,8 +148,14 @@ impl TrustedChainSync {
         let non_finalized_state = NonFinalizedState::new(&db.network());
         let (chain_tip_sender, latest_chain_tip, chain_tip_change) =
             ChainTipSender::new(None, &db.network());
-        let indexer_rpc_client =
-            IndexerClient::connect(format!("http://{indexer_rpc_address}")).await?;
+        let channel =
+            tonic::transport::Endpoint::from_shared(format!("http://{indexer_rpc_address}"))?
+                .keep_alive_while_idle(true)
+                .http2_keep_alive_interval(KEEPALIVE_INTERVAL)
+                .keep_alive_timeout(KEEPALIVE_TIMEOUT)
+                .connect()
+                .await?;
+        let indexer_rpc_client = IndexerClient::new(channel);
         let finalized_chain_tip_sender = chain_tip_sender.finalized_sender();
 
         let mut syncer = Self {
@@ -179,15 +211,25 @@ impl TrustedChainSync {
                 continue;
             };
 
-            let message = match non_finalized_state_change.message().await {
-                Ok(Some(block_and_hash)) => block_and_hash,
-                Ok(None) => {
+            let message = match tokio::time::timeout(
+                STREAM_MESSAGE_TIMEOUT,
+                non_finalized_state_change.message(),
+            )
+            .await
+            {
+                Ok(Ok(Some(block_and_hash))) => block_and_hash,
+                Ok(Ok(None)) => {
                     tracing::warn!("non-finalized state change stream ended unexpectedly");
                     non_finalized_blocks_listener = None;
                     continue;
                 }
-                Err(err) => {
+                Ok(Err(err)) => {
                     tracing::warn!(?err, "error receiving non-finalized state change");
+                    non_finalized_blocks_listener = None;
+                    continue;
+                }
+                Err(_) => {
+                    tracing::debug!("non-finalized state change stream timed out, re-subscribing");
                     non_finalized_blocks_listener = None;
                     continue;
                 }
@@ -386,8 +428,16 @@ impl TrustedChainSync {
     }
 
     /// Tries to catch up to the primary db instance for an up-to-date view of finalized blocks.
+    ///
+    /// Logs a warning on failure: a secondary that repeatedly can't catch up will serve an
+    /// increasingly stale finalized state, so the failure should be visible rather than silent.
     async fn try_catch_up_with_primary(&self) {
-        let _ = self.db.spawn_try_catch_up_with_primary().await;
+        if let Err(error) = self.db.spawn_try_catch_up_with_primary().await {
+            tracing::warn!(
+                ?error,
+                "failed to catch up to the primary database; the finalized state may be stale"
+            );
+        }
     }
 
     /// Reads the finalized tip block from the secondary db instance and converts it to a [`ChainTipBlock`].

--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -19,7 +19,7 @@ use zebra_state::{
 use zebra_chain::diagnostic::task::WaitForPanics;
 
 use crate::indexer::{
-    block_request, indexer_client::IndexerClient, BlockAndHash, BlockRequest, Empty,
+    indexer_client::IndexerClient, BlockAndHash, BlockRequest, Empty,
     NonFinalizedStateChangeRequest,
 };
 
@@ -434,16 +434,13 @@ impl TrustedChainSync {
         &self,
         hash_or_height: HashOrHeight,
     ) -> Result<(Block, block::Hash), Status> {
-        let request = match hash_or_height {
-            HashOrHeight::Hash(hash) => BlockRequest {
-                hash_or_height: Some(block_request::HashOrHeight::Hash(
-                    hash.bytes_in_display_order().to_vec(),
-                )),
-            },
-            HashOrHeight::Height(height) => BlockRequest {
-                hash_or_height: Some(block_request::HashOrHeight::Height(height.0)),
-            },
+        // Encode the request as a single `hash_or_height` byte string: a 32-byte hash in display
+        // order, or a 4-byte big-endian height. The server tells them apart by length.
+        let hash_or_height = match hash_or_height {
+            HashOrHeight::Hash(hash) => hash.bytes_in_display_order().to_vec(),
+            HashOrHeight::Height(height) => height.0.to_be_bytes().to_vec(),
         };
+        let request = BlockRequest { hash_or_height };
 
         let response = tokio::time::timeout(
             GET_BLOCK_TIMEOUT,

--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -77,6 +77,7 @@ async fn update_finalized_chain_tip(
     db: ZebraDb,
     mut indexer_rpc_client: IndexerClient<tonic::transport::Channel>,
     mut finalized_chain_tip_sender: ChainTipSender,
+    non_finalized_state_receiver: tokio::sync::watch::Receiver<NonFinalizedState>,
 ) {
     let mut chain_tip_change_stream = None;
 
@@ -127,16 +128,26 @@ async fn update_finalized_chain_tip(
 
         // Catch the secondary's finalized state up to the primary, then publish its finalized tip.
         //
-        // This keeps the finalized tip current while the secondary is still catching up. Once
-        // `TrustedChainSync::sync()` commits its first non-finalized block, the chain tip sender
-        // switches to the non-finalized tip and these finalized updates become no-ops, so this task
-        // doesn't need to stop itself once the syncer has taken over.
+        // This keeps the finalized tip current while the secondary is still catching up, before
+        // `TrustedChainSync::sync()` has any non-finalized blocks of its own to publish.
         if let Err(error) = db.spawn_try_catch_up_with_primary().await {
             tracing::debug!(
                 ?error,
                 "failed to catch up to the primary database while updating the finalized tip"
             );
             continue;
+        }
+
+        // Stop once the syncer has committed its first non-finalized block. From then on `sync()`
+        // owns the published chain tip via the (higher) non-finalized tip, and publishing our
+        // lagging finalized tip here would drag the reported tip backwards.
+        //
+        // `sync()`'s `ChainTipSender` latches onto the non-finalized tip, but this task holds a
+        // separate `finalized_sender()` handle that doesn't, so `set_finalized_tip` would keep
+        // overwriting the non-finalized tip rather than becoming a no-op. The task therefore stops
+        // itself. The non-finalized state only grows once populated, so this handover is permanent.
+        if non_finalized_state_receiver.borrow().best_chain().is_some() {
+            return;
         }
 
         if let Some(tip_block) = finalized_chain_tip_block(&db).await {
@@ -182,6 +193,10 @@ impl TrustedChainSync {
         let indexer_rpc_client = IndexerClient::new(channel);
         let finalized_chain_tip_sender = chain_tip_sender.finalized_sender();
 
+        // Subscribe to the non-finalized state before moving the sender into the syncer, so the
+        // finalized-tip task can tell when `sync()` has taken over the chain tip.
+        let non_finalized_state_receiver = non_finalized_state_sender.subscribe();
+
         let mut syncer = Self {
             indexer_rpc_client: indexer_rpc_client.clone(),
             db: db.clone(),
@@ -192,7 +207,13 @@ impl TrustedChainSync {
 
         // Spawn a task to send finalized chain tip changes to the chain tip change and latest chain tip channels.
         tokio::spawn(async move {
-            update_finalized_chain_tip(db, indexer_rpc_client, finalized_chain_tip_sender).await
+            update_finalized_chain_tip(
+                db,
+                indexer_rpc_client,
+                finalized_chain_tip_sender,
+                non_finalized_state_receiver,
+            )
+            .await
         });
 
         let sync_task = tokio::spawn(async move {

--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -49,6 +49,11 @@ const KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(20);
 /// re-subscribing immediately turns that into a full-speed busy loop that saturates the logs.
 const COMMIT_RETRY_DELAY: Duration = Duration::from_secs(1);
 
+/// How long to wait for a single `get_block` fetch while bridging the finalized gap before giving
+/// up. A single block fetch from a co-located node should return promptly, so this bounds a wedged
+/// connection without false-triggering; the bridge retries on the next subscription.
+const GET_BLOCK_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Syncs non-finalized blocks in the best chain from a trusted Zebra node's RPC methods.
 #[derive(Debug)]
 pub struct TrustedChainSync {
@@ -395,10 +400,14 @@ impl TrustedChainSync {
             },
         };
 
-        self.indexer_rpc_client
-            .clone()
-            .get_block(request)
-            .await?
+        let response = tokio::time::timeout(
+            GET_BLOCK_TIMEOUT,
+            self.indexer_rpc_client.clone().get_block(request),
+        )
+        .await
+        .map_err(|_| Status::deadline_exceeded("get_block request timed out"))??;
+
+        response
             .into_inner()
             .decode()
             .ok_or_else(|| Status::internal("failed to decode block from get_block response"))

--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -59,7 +59,7 @@ async fn update_finalized_chain_tip(
             {
                 Ok(listener) => Some(listener),
                 Err(err) => {
-                    tracing::warn!(?err, "failed to subscribe to non-finalized state changes");
+                    tracing::warn!(?err, "failed to subscribe to chain tip changes");
                     tokio::time::sleep(POLL_DELAY).await;
                     None
                 }
@@ -233,12 +233,13 @@ impl TrustedChainSync {
         block: SemanticallyVerifiedBlock,
     ) -> Result<(), ValidateContextError> {
         self.try_catch_up_with_primary().await;
-        self.prune_finalized();
 
         if self.db.finalized_tip_hash() == block.block.header.previous_block_hash {
+            self.prune_finalized();
             self.non_finalized_state.commit_new_chain(block, &self.db)
         } else {
             self.non_finalized_state.commit_block(block, &self.db)?;
+            self.prune_finalized();
             Ok(())
         }
     }

--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -41,6 +41,67 @@ pub struct TrustedChainSync {
     non_finalized_state_sender: tokio::sync::watch::Sender<NonFinalizedState>,
 }
 
+async fn update_finalized_chain_tip(
+    db: ZebraDb,
+    mut indexer_rpc_client: IndexerClient<tonic::transport::Channel>,
+    mut finalized_chain_tip_sender: ChainTipSender,
+) {
+    let mut chain_tip_change_stream = None;
+
+    loop {
+        let Some(ref mut chain_tip_change) = chain_tip_change_stream else {
+            chain_tip_change_stream = match indexer_rpc_client
+                .chain_tip_change(Empty {})
+                .await
+                .map(|a| a.into_inner())
+            {
+                Ok(listener) => Some(listener),
+                Err(err) => {
+                    tracing::warn!(?err, "failed to subscribe to non-finalized state changes");
+                    tokio::time::sleep(POLL_DELAY).await;
+                    None
+                }
+            };
+
+            continue;
+        };
+
+        let message = match chain_tip_change.message().await {
+            Ok(Some(block_hash_and_height)) => block_hash_and_height,
+            Ok(None) => {
+                tracing::warn!("chain_tip_change stream ended unexpectedly");
+                chain_tip_change_stream = None;
+                continue;
+            }
+            Err(err) => {
+                tracing::warn!(?err, "error receiving chain tip change");
+                chain_tip_change_stream = None;
+                continue;
+            }
+        };
+
+        let Some((hash, _height)) = message.try_into_hash_and_height() else {
+            tracing::warn!("failed to convert message into a block hash and height");
+            continue;
+        };
+
+        // Skip the chain tip change if catching up to the primary db instance fails.
+        if db.spawn_try_catch_up_with_primary().await.is_err() {
+            continue;
+        }
+
+        // End the task and let the `TrustedChainSync::sync()` method send non-finalized chain tip updates if
+        // the latest chain tip hash is not present in the db.
+        let Some(tip_block) = db.block(hash.into()) else {
+            return;
+        };
+
+        finalized_chain_tip_sender.set_finalized_tip(Some(
+            SemanticallyVerifiedBlock::with_hash(tip_block, hash).into(),
+        ));
+    }
+}
+
 impl TrustedChainSync {
     /// Creates a new [`TrustedChainSync`] with a [`ChainTipSender`], then spawns a task to sync blocks
     /// from the node's non-finalized best chain.
@@ -54,9 +115,9 @@ impl TrustedChainSync {
         let non_finalized_state = NonFinalizedState::new(&db.network());
         let (chain_tip_sender, latest_chain_tip, chain_tip_change) =
             ChainTipSender::new(None, &db.network());
-        let mut indexer_rpc_client =
+        let indexer_rpc_client =
             IndexerClient::connect(format!("http://{indexer_rpc_address}")).await?;
-        let mut finalized_chain_tip_sender = chain_tip_sender.finalized_sender();
+        let finalized_chain_tip_sender = chain_tip_sender.finalized_sender();
 
         let mut syncer = Self {
             indexer_rpc_client: indexer_rpc_client.clone(),
@@ -68,63 +129,7 @@ impl TrustedChainSync {
 
         // Spawn a task to send finalized chain tip changes to the chain tip change and latest chain tip channels.
         tokio::spawn(async move {
-            let mut chain_tip_change_stream = None;
-
-            loop {
-                let Some(ref mut chain_tip_change) = chain_tip_change_stream else {
-                    chain_tip_change_stream = match indexer_rpc_client
-                        .chain_tip_change(Empty {})
-                        .await
-                        .map(|a| a.into_inner())
-                    {
-                        Ok(listener) => Some(listener),
-                        Err(err) => {
-                            tracing::warn!(
-                                ?err,
-                                "failed to subscribe to non-finalized state changes"
-                            );
-                            tokio::time::sleep(POLL_DELAY).await;
-                            None
-                        }
-                    };
-
-                    continue;
-                };
-
-                let message = match chain_tip_change.message().await {
-                    Ok(Some(block_hash_and_height)) => block_hash_and_height,
-                    Ok(None) => {
-                        tracing::warn!("chain_tip_change stream ended unexpectedly");
-                        chain_tip_change_stream = None;
-                        continue;
-                    }
-                    Err(err) => {
-                        tracing::warn!(?err, "error receiving chain tip change");
-                        chain_tip_change_stream = None;
-                        continue;
-                    }
-                };
-
-                let Some((hash, _height)) = message.try_into_hash_and_height() else {
-                    tracing::warn!("failed to convert message into a block hash and height");
-                    continue;
-                };
-
-                // Skip the chain tip change if catching up to the primary db instance fails.
-                if db.spawn_try_catch_up_with_primary().await.is_err() {
-                    continue;
-                }
-
-                // End the task and let the `TrustedChainSync::sync()` method send non-finalized chain tip updates if
-                // the latest chain tip hash is not present in the db.
-                let Some(tip_block) = db.block(hash.into()) else {
-                    return;
-                };
-
-                finalized_chain_tip_sender.set_finalized_tip(Some(
-                    SemanticallyVerifiedBlock::with_hash(tip_block, hash).into(),
-                ));
-            }
+            update_finalized_chain_tip(db, indexer_rpc_client, finalized_chain_tip_sender).await
         });
 
         let sync_task = tokio::spawn(async move {

--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -138,19 +138,24 @@ async fn update_finalized_chain_tip(
             continue;
         }
 
-        // Stop once the syncer has committed its first non-finalized block. From then on `sync()`
-        // owns the published chain tip via the (higher) non-finalized tip, and publishing our
-        // lagging finalized tip here would drag the reported tip backwards.
-        //
-        // `sync()`'s `ChainTipSender` latches onto the non-finalized tip, but this task holds a
-        // separate `finalized_sender()` handle that doesn't, so `set_finalized_tip` would keep
-        // overwriting the non-finalized tip rather than becoming a no-op. The task therefore stops
-        // itself. The non-finalized state only grows once populated, so this handover is permanent.
-        if non_finalized_state_receiver.borrow().best_chain().is_some() {
-            return;
-        }
-
         if let Some(tip_block) = finalized_chain_tip_block(&db).await {
+            // Stop once the syncer has committed its first non-finalized block. From then on
+            // `sync()` owns the published chain tip via the (higher) non-finalized tip, and
+            // publishing our lagging finalized tip here would drag the reported tip backwards.
+            //
+            // `sync()`'s `ChainTipSender` latches onto the non-finalized tip, but this task holds a
+            // separate `finalized_sender()` handle that doesn't, so `set_finalized_tip` would keep
+            // overwriting the non-finalized tip rather than becoming a no-op. The task therefore
+            // stops itself. The non-finalized state only grows once populated, so this handover is
+            // permanent.
+            //
+            // Check this immediately before publishing, after the awaits above: the syncer can take
+            // over while we wait on `spawn_try_catch_up_with_primary` or `finalized_chain_tip_block`,
+            // so checking any earlier would leave a window where we still publish the stale tip.
+            if non_finalized_state_receiver.borrow().best_chain().is_some() {
+                return;
+            }
+
             finalized_chain_tip_sender.set_finalized_tip(tip_block);
         }
     }

--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -428,16 +428,8 @@ impl TrustedChainSync {
     }
 
     /// Tries to catch up to the primary db instance for an up-to-date view of finalized blocks.
-    ///
-    /// Logs a warning on failure: a secondary that repeatedly can't catch up will serve an
-    /// increasingly stale finalized state, so the failure should be visible rather than silent.
     async fn try_catch_up_with_primary(&self) {
-        if let Err(error) = self.db.spawn_try_catch_up_with_primary().await {
-            tracing::warn!(
-                ?error,
-                "failed to catch up to the primary database; the finalized state may be stale"
-            );
-        }
+        let _ = self.db.spawn_try_catch_up_with_primary().await;
     }
 
     /// Reads the finalized tip block from the secondary db instance and converts it to a [`ChainTipBlock`].

--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -54,6 +54,10 @@ const COMMIT_RETRY_DELAY: Duration = Duration::from_secs(1);
 /// connection without false-triggering; the bridge retries on the next subscription.
 const GET_BLOCK_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// How long to wait to establish a gRPC subscription stream before assuming the request is wedged
+/// and retrying. The subscription handshake should complete promptly.
+const SUBSCRIBE_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Syncs non-finalized blocks in the best chain from a trusted Zebra node's RPC methods.
 #[derive(Debug)]
 pub struct TrustedChainSync {
@@ -78,14 +82,20 @@ async fn update_finalized_chain_tip(
 
     loop {
         let Some(ref mut chain_tip_change) = chain_tip_change_stream else {
-            chain_tip_change_stream = match indexer_rpc_client
-                .chain_tip_change(Empty {})
-                .await
-                .map(|a| a.into_inner())
+            chain_tip_change_stream = match tokio::time::timeout(
+                SUBSCRIBE_TIMEOUT,
+                indexer_rpc_client.chain_tip_change(Empty {}),
+            )
+            .await
             {
-                Ok(listener) => Some(listener),
-                Err(err) => {
+                Ok(Ok(response)) => Some(response.into_inner()),
+                Ok(Err(err)) => {
                     tracing::warn!(?err, "failed to subscribe to chain tip changes");
+                    tokio::time::sleep(POLL_DELAY).await;
+                    None
+                }
+                Err(_) => {
+                    tracing::warn!("timed out subscribing to chain tip changes");
                     tokio::time::sleep(POLL_DELAY).await;
                     None
                 }
@@ -94,32 +104,33 @@ async fn update_finalized_chain_tip(
             continue;
         };
 
-        let message =
-            match tokio::time::timeout(STREAM_MESSAGE_TIMEOUT, chain_tip_change.message()).await {
-                Ok(Ok(Some(block_hash_and_height))) => block_hash_and_height,
-                Ok(Ok(None)) => {
-                    tracing::warn!("chain_tip_change stream ended unexpectedly");
-                    chain_tip_change_stream = None;
-                    continue;
-                }
-                Ok(Err(err)) => {
-                    tracing::warn!(?err, "error receiving chain tip change");
-                    chain_tip_change_stream = None;
-                    continue;
-                }
-                Err(_) => {
-                    tracing::debug!("chain tip change stream timed out, re-subscribing");
-                    chain_tip_change_stream = None;
-                    continue;
-                }
-            };
+        // The message is only a signal that the primary's best chain advanced. We publish our own
+        // finalized tip below, not the primary's (non-finalized) best tip, so the hash is unused.
+        match tokio::time::timeout(STREAM_MESSAGE_TIMEOUT, chain_tip_change.message()).await {
+            Ok(Ok(Some(_block_hash_and_height))) => {}
+            Ok(Ok(None)) => {
+                tracing::warn!("chain_tip_change stream ended unexpectedly");
+                chain_tip_change_stream = None;
+                continue;
+            }
+            Ok(Err(err)) => {
+                tracing::warn!(?err, "error receiving chain tip change");
+                chain_tip_change_stream = None;
+                continue;
+            }
+            Err(_) => {
+                tracing::debug!("chain tip change stream timed out, re-subscribing");
+                chain_tip_change_stream = None;
+                continue;
+            }
+        }
 
-        let Some((hash, _height)) = message.try_into_hash_and_height() else {
-            tracing::warn!("failed to convert message into a block hash and height");
-            continue;
-        };
-
-        // Skip the chain tip change if catching up to the primary db instance fails.
+        // Catch the secondary's finalized state up to the primary, then publish its finalized tip.
+        //
+        // This keeps the finalized tip current while the secondary is still catching up. Once
+        // `TrustedChainSync::sync()` commits its first non-finalized block, the chain tip sender
+        // switches to the non-finalized tip and these finalized updates become no-ops, so this task
+        // doesn't need to stop itself once the syncer has taken over.
         if let Err(error) = db.spawn_try_catch_up_with_primary().await {
             tracing::debug!(
                 ?error,
@@ -128,16 +139,24 @@ async fn update_finalized_chain_tip(
             continue;
         }
 
-        // End the task and let the `TrustedChainSync::sync()` method send non-finalized chain tip updates if
-        // the latest chain tip hash is not present in the db.
-        let Some(tip_block) = db.block(hash.into()) else {
-            return;
-        };
-
-        finalized_chain_tip_sender.set_finalized_tip(Some(
-            SemanticallyVerifiedBlock::with_hash(tip_block, hash).into(),
-        ));
+        if let Some(tip_block) = finalized_chain_tip_block(&db).await {
+            finalized_chain_tip_sender.set_finalized_tip(tip_block);
+        }
     }
+}
+
+/// Reads the finalized tip block from the secondary db instance and converts it to a
+/// [`ChainTipBlock`].
+async fn finalized_chain_tip_block(db: &ZebraDb) -> Option<ChainTipBlock> {
+    let db = db.clone();
+    tokio::task::spawn_blocking(move || {
+        let (height, hash) = db.tip()?;
+        db.block(height.into())
+            .map(|block| CheckpointVerifiedBlock::with_hash(block, hash))
+            .map(ChainTipBlock::from)
+    })
+    .wait_for_panics()
+    .await
 }
 
 impl TrustedChainSync {
@@ -195,7 +214,7 @@ impl TrustedChainSync {
         // same warning at full rate while a block persistently fails to commit.
         let mut last_failed_commit_hash = None;
         self.try_catch_up_with_primary().await;
-        if let Some(finalized_tip_block) = self.finalized_chain_tip_block().await {
+        if let Some(finalized_tip_block) = finalized_chain_tip_block(&self.db).await {
             self.chain_tip_sender.set_finalized_tip(finalized_tip_block);
         }
 
@@ -423,35 +442,30 @@ impl TrustedChainSync {
     async fn subscribe_to_non_finalized_state_change(
         &mut self,
     ) -> Result<Streaming<BlockAndHash>, Status> {
-        self.indexer_rpc_client
-            .clone()
-            .non_finalized_state_change(NonFinalizedStateChangeRequest {
-                chain_tip_hashes: self
-                    .non_finalized_state
-                    .chain_iter()
-                    .map(|c| c.non_finalized_tip_hash().bytes_in_display_order().to_vec())
-                    .collect(),
-            })
-            .await
-            .map(|a| a.into_inner())
+        let request = NonFinalizedStateChangeRequest {
+            chain_tip_hashes: self
+                .non_finalized_state
+                .chain_iter()
+                .map(|c| c.non_finalized_tip_hash().bytes_in_display_order().to_vec())
+                .collect(),
+        };
+
+        tokio::time::timeout(
+            SUBSCRIBE_TIMEOUT,
+            self.indexer_rpc_client
+                .clone()
+                .non_finalized_state_change(request),
+        )
+        .await
+        .map_err(|_| {
+            Status::deadline_exceeded("non_finalized_state_change subscription timed out")
+        })?
+        .map(|a| a.into_inner())
     }
 
     /// Tries to catch up to the primary db instance for an up-to-date view of finalized blocks.
     async fn try_catch_up_with_primary(&self) {
         let _ = self.db.spawn_try_catch_up_with_primary().await;
-    }
-
-    /// Reads the finalized tip block from the secondary db instance and converts it to a [`ChainTipBlock`].
-    async fn finalized_chain_tip_block(&self) -> Option<ChainTipBlock> {
-        let db = self.db.clone();
-        tokio::task::spawn_blocking(move || {
-            let (height, hash) = db.tip()?;
-            db.block(height.into())
-                .map(|block| CheckpointVerifiedBlock::with_hash(block, hash))
-                .map(ChainTipBlock::from)
-        })
-        .wait_for_panics()
-        .await
     }
 
     /// Finalizes any non-finalized blocks that are at or below the finalized tip height.

--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -5,7 +5,7 @@ use std::{net::SocketAddr, sync::Arc, time::Duration};
 use tokio::task::JoinHandle;
 use tonic::{Status, Streaming};
 use tower::BoxError;
-use zebra_chain::{block::Height, parameters::Network};
+use zebra_chain::{block::Height, parameters::Network, serialization::BytesInDisplayOrder};
 use zebra_state::{
     spawn_init_read_only, ChainTipBlock, ChainTipChange, ChainTipSender, CheckpointVerifiedBlock,
     LatestChainTip, NonFinalizedState, ReadStateService, SemanticallyVerifiedBlock,
@@ -14,7 +14,9 @@ use zebra_state::{
 
 use zebra_chain::diagnostic::task::WaitForPanics;
 
-use crate::indexer::{indexer_client::IndexerClient, BlockAndHash, Empty};
+use crate::indexer::{
+    indexer_client::IndexerClient, BlockAndHash, Empty, NonFinalizedStateChangeRequest,
+};
 
 /// How long to wait between calls to `subscribe_to_non_finalized_state_change` when it returns an error.
 const POLL_DELAY: Duration = Duration::from_secs(5);
@@ -193,7 +195,7 @@ impl TrustedChainSync {
             };
 
             if self.non_finalized_state.any_chain_contains(&hash) {
-                tracing::info!(?hash, "non-finalized state already contains block");
+                tracing::warn!(?hash, "non-finalized state already contains block");
                 continue;
             }
 
@@ -201,17 +203,6 @@ impl TrustedChainSync {
             match self.try_commit(block.clone()).await {
                 Ok(()) => {
                     last_failed_commit_hash = None;
-
-                    while self
-                        .non_finalized_state
-                        .root_height()
-                        .expect("just successfully inserted a non-finalized block above")
-                        <= self.db.finalized_tip_height().unwrap_or(Height::MIN)
-                    {
-                        tracing::trace!("finalizing block past the reorg limit");
-                        self.non_finalized_state.finalize();
-                    }
-
                     self.update_channels();
                 }
                 Err(error) => {
@@ -227,8 +218,6 @@ impl TrustedChainSync {
                         last_failed_commit_hash = Some(hash);
                     }
 
-                    // TODO: Investigate whether it would be correct to ignore some errors here instead of
-                    //       trying every block in the non-finalized state again.
                     non_finalized_blocks_listener = None;
 
                     // Back off before re-subscribing so a persistently failing block doesn't turn
@@ -244,22 +233,35 @@ impl TrustedChainSync {
         block: SemanticallyVerifiedBlock,
     ) -> Result<(), ValidateContextError> {
         self.try_catch_up_with_primary().await;
+        self.prune_finalized();
 
         if self.db.finalized_tip_hash() == block.block.header.previous_block_hash {
             self.non_finalized_state.commit_new_chain(block, &self.db)
         } else {
-            self.non_finalized_state.commit_block(block, &self.db)
+            self.non_finalized_state.commit_block(block, &self.db)?;
+            Ok(())
         }
     }
 
-    /// Calls `non_finalized_state_change()` method on the indexer gRPC client to subscribe
+    /// Calls the `non_finalized_state_change()` method on the indexer gRPC client to subscribe
     /// to non-finalized state changes, and returns the response stream.
+    ///
+    /// Passes the tip hashes of every chain currently in this syncer's non-finalized state so the
+    /// server only streams blocks after the tips we already have, instead of re-sending the whole
+    /// non-finalized state on every (re)subscription. When the non-finalized state is empty, the
+    /// request carries no tips and the server streams every non-finalized block.
     async fn subscribe_to_non_finalized_state_change(
         &mut self,
     ) -> Result<Streaming<BlockAndHash>, Status> {
         self.indexer_rpc_client
             .clone()
-            .non_finalized_state_change(Empty {})
+            .non_finalized_state_change(NonFinalizedStateChangeRequest {
+                chain_tip_hashes: self
+                    .non_finalized_state
+                    .chain_iter()
+                    .map(|c| c.non_finalized_tip_hash().bytes_in_display_order().to_vec())
+                    .collect(),
+            })
             .await
             .map(|a| a.into_inner())
     }
@@ -280,6 +282,24 @@ impl TrustedChainSync {
         })
         .wait_for_panics()
         .await
+    }
+
+    /// Finalizes any non-finalized blocks that are at or below the finalized tip height.
+    ///
+    /// The secondary's finalized state follows the primary, so after catching up it may have
+    /// advanced past the root of the non-finalized state. This drops those now-finalized blocks so
+    /// the non-finalized state only tracks blocks above the finalized tip. Does nothing when the
+    /// non-finalized state is empty.
+    fn prune_finalized(&mut self) {
+        let finalized_tip_height = self.db.finalized_tip_height().unwrap_or(Height::MIN);
+        while self
+            .non_finalized_state
+            .root_height()
+            .is_some_and(|root_height| root_height <= finalized_tip_height)
+        {
+            tracing::trace!("finalizing block past the reorg limit");
+            self.non_finalized_state.finalize();
+        }
     }
 
     /// Sends the new chain tip and non-finalized state to the latest chain channels.

--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -5,17 +5,22 @@ use std::{net::SocketAddr, sync::Arc, time::Duration};
 use tokio::task::JoinHandle;
 use tonic::{Status, Streaming};
 use tower::BoxError;
-use zebra_chain::{block::Height, parameters::Network, serialization::BytesInDisplayOrder};
+use zebra_chain::{
+    block::{self, Block, Height},
+    parameters::Network,
+    serialization::BytesInDisplayOrder,
+};
 use zebra_state::{
     spawn_init_read_only, ChainTipBlock, ChainTipChange, ChainTipSender, CheckpointVerifiedBlock,
-    LatestChainTip, NonFinalizedState, ReadStateService, SemanticallyVerifiedBlock,
+    HashOrHeight, LatestChainTip, NonFinalizedState, ReadStateService, SemanticallyVerifiedBlock,
     ValidateContextError, ZebraDb,
 };
 
 use zebra_chain::diagnostic::task::WaitForPanics;
 
 use crate::indexer::{
-    indexer_client::IndexerClient, BlockAndHash, Empty, NonFinalizedStateChangeRequest,
+    block_request, indexer_client::IndexerClient, BlockAndHash, BlockRequest, Empty,
+    NonFinalizedStateChangeRequest,
 };
 
 /// How long to wait between calls to `subscribe_to_non_finalized_state_change` when it returns an error.
@@ -203,7 +208,6 @@ impl TrustedChainSync {
             match self.try_commit(block.clone()).await {
                 Ok(()) => {
                     last_failed_commit_hash = None;
-                    self.update_channels();
                 }
                 Err(error) => {
                     // Only log on transitions to avoid saturating the logs when the same block
@@ -234,14 +238,128 @@ impl TrustedChainSync {
     ) -> Result<(), ValidateContextError> {
         self.try_catch_up_with_primary().await;
 
+        // When the non-finalized state is empty and the incoming block doesn't build directly on
+        // the secondary's finalized tip, the secondary's finalized state is lagging the primary's.
+        // The streamed non-finalized blocks start at the primary's finalized tip, which can be
+        // several blocks above ours, so the incoming block has no parent to attach to. Bridge that
+        // gap by fetching the missing (already-finalized) blocks from the primary, so the incoming
+        // block has a contiguous chain to commit onto.
+        if self.non_finalized_state.best_chain().is_none()
+            && self.db.finalized_tip_hash() != block.block.header.previous_block_hash
+        {
+            self.fill_finalized_gap(block.height).await;
+        }
+
+        self.commit(block)
+    }
+
+    /// Commits `block` to the non-finalized state, starting a new chain if it builds on the
+    /// finalized tip or extending an existing chain otherwise, prunes newly-finalized blocks, and
+    /// publishes the updated chain tip and non-finalized state.
+    ///
+    /// Updating the channels here (rather than only after `try_commit` returns) means the bridge
+    /// blocks committed by [`Self::fill_finalized_gap`] also advance the published chain tip.
+    fn commit(&mut self, block: SemanticallyVerifiedBlock) -> Result<(), ValidateContextError> {
         if self.db.finalized_tip_hash() == block.block.header.previous_block_hash {
             self.prune_finalized();
-            self.non_finalized_state.commit_new_chain(block, &self.db)
+            self.non_finalized_state.commit_new_chain(block, &self.db)?;
         } else {
             self.non_finalized_state.commit_block(block, &self.db)?;
             self.prune_finalized();
-            Ok(())
         }
+
+        self.update_channels();
+
+        Ok(())
+    }
+
+    /// Fetches the blocks between the secondary's finalized tip and `target_height` (exclusive)
+    /// from the primary and commits them to the non-finalized state.
+    ///
+    /// These blocks are finalized on the primary but not yet on the lagging secondary. Committing
+    /// them as non-finalized bridge blocks gives the block at `target_height` a contiguous chain to
+    /// attach to; they are dropped again by [`Self::prune_finalized`] as the secondary catches up.
+    ///
+    /// This is best-effort: if a block can't be fetched or committed, it returns early and lets the
+    /// caller's commit fail so the block is retried on the next subscription.
+    async fn fill_finalized_gap(&mut self, target_height: Height) {
+        loop {
+            // Try to advance the secondary's finalized state first: if it catches up to the gap on
+            // its own, we can stop fetching blocks. This also drops any bridge blocks the secondary
+            // has since finalized, so the next height is recomputed from where we actually are.
+            self.try_catch_up_with_primary().await;
+            self.prune_finalized();
+
+            // The next height to bridge is just above the highest block we already have: the
+            // non-finalized tip if we've committed bridge blocks, otherwise the finalized tip.
+            let Some(highest) = self
+                .non_finalized_state
+                .best_tip()
+                .map(|(height, _hash)| height)
+                .or_else(|| self.db.finalized_tip_height())
+            else {
+                return;
+            };
+
+            let Ok(next_height) = highest.next() else {
+                return;
+            };
+
+            // Stop once the chain reaches the streamed block's parent, whether by the finalized
+            // state catching up or by the bridge blocks we fetched.
+            if next_height >= target_height {
+                return;
+            }
+
+            let (block, hash) = match self.get_block(next_height.into()).await {
+                Ok(block_and_hash) => block_and_hash,
+                Err(error) => {
+                    tracing::warn!(
+                        ?error,
+                        ?next_height,
+                        "failed to fetch a block while bridging the finalized gap; \
+                         will retry on the next subscription"
+                    );
+                    return;
+                }
+            };
+
+            let block = SemanticallyVerifiedBlock::with_hash(Arc::new(block), hash);
+            if let Err(error) = self.commit(block) {
+                tracing::warn!(
+                    ?error,
+                    ?next_height,
+                    "failed to commit a block while bridging the finalized gap; \
+                     will retry on the next subscription"
+                );
+                return;
+            }
+        }
+    }
+
+    /// Fetches a single block from the primary by hash or height via the indexer gRPC.
+    async fn get_block(
+        &self,
+        hash_or_height: HashOrHeight,
+    ) -> Result<(Block, block::Hash), Status> {
+        let request = match hash_or_height {
+            HashOrHeight::Hash(hash) => BlockRequest {
+                hash_or_height: Some(block_request::HashOrHeight::Hash(
+                    hash.bytes_in_display_order().to_vec(),
+                )),
+            },
+            HashOrHeight::Height(height) => BlockRequest {
+                hash_or_height: Some(block_request::HashOrHeight::Height(height.0)),
+            },
+        };
+
+        self.indexer_rpc_client
+            .clone()
+            .get_block(request)
+            .await?
+            .into_inner()
+            .decode()
+            .ok_or_else(|| Status::internal("failed to decode block from get_block response"))
     }
 
     /// Calls the `non_finalized_state_change()` method on the indexer gRPC client to subscribe

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -39,7 +39,9 @@ pub use config::{
     check_and_delete_old_databases, check_and_delete_old_state_databases,
     database_format_version_on_disk, state_database_format_version_on_disk, Config,
 };
-pub use constants::{state_database_format_version_in_code, MAX_BLOCK_REORG_HEIGHT};
+pub use constants::{
+    state_database_format_version_in_code, MAX_BLOCK_REORG_HEIGHT, MAX_NON_FINALIZED_CHAIN_FORKS,
+};
 pub use error::{
     BoxError, CloneError, CommitBlockError, CommitSemanticallyVerifiedError,
     DuplicateNullifierError, StateInitError, ValidateContextError,

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -1403,7 +1403,15 @@ pub enum ReadRequest {
 
     /// Returns [`ReadResponse::NonFinalizedBlocksListener`] with a channel receiver
     /// allowing the caller to listen for new blocks in the non-finalized state.
-    NonFinalizedBlocksListener,
+    NonFinalizedBlocksListener {
+        /// The hashes of the chain tips the caller already has.
+        ///
+        /// Only blocks that come after these tips are streamed: walking each
+        /// non-finalized chain from its tip downwards, blocks are sent until a
+        /// hash in this set is reached. If empty, every block currently in the
+        /// non-finalized state is sent.
+        known_chain_tips: HashSet<block::Hash>,
+    },
 
     /// Returns `true` if the transparent output is spent in the best chain,
     /// or `false` if it is unspent.
@@ -1450,7 +1458,7 @@ impl ReadRequest {
             ReadRequest::SolutionRate { .. } => "solution_rate",
             ReadRequest::CheckBlockProposalValidity(_) => "check_block_proposal_validity",
             ReadRequest::TipBlockSize => "tip_block_size",
-            ReadRequest::NonFinalizedBlocksListener => "non_finalized_blocks_listener",
+            ReadRequest::NonFinalizedBlocksListener { .. } => "non_finalized_blocks_listener",
             ReadRequest::IsTransparentOutputSpent(_) => "is_transparent_output_spent",
         }
     }

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -207,6 +207,8 @@ impl MinedTx {
 ///
 /// It's okay to occasionally miss updates when the buffer is full, as the new blocks in the missed change will be
 /// sent to the listener on the next change to the non-finalized state.
+// `MAX_BLOCK_REORG_HEIGHT` is a small `u32` constant (the reorg limit), so widening it to `usize`
+// and doubling it cannot overflow on any supported platform.
 const NON_FINALIZED_STATE_CHANGE_BUFFER_SIZE: usize = 2 * MAX_BLOCK_REORG_HEIGHT as usize;
 
 /// A listener for changes in the non-finalized state.
@@ -251,10 +253,12 @@ impl NonFinalizedBlocksListener {
     /// Spawns a task to listen for changes in the non-finalized state and sends any blocks in the non-finalized state
     /// to the caller that have not already been sent.
     ///
-    /// `known_chain_tips` holds the hashes of chain tips the caller already has. Walking each
-    /// non-finalized chain from its tip downwards, blocks are sent until a hash in this set is
-    /// reached, so any block at or below a known tip on the same chain is skipped. If it is empty,
-    /// every block currently in the non-finalized state is sent.
+    /// `known_chain_tips` holds the hashes of chain tips the caller already has. On the first send
+    /// only, each non-finalized chain is walked from its tip downwards and blocks are sent until a
+    /// hash in this set is reached, so any block at or below a known tip on the same chain is
+    /// skipped. If it is empty, every block currently in the non-finalized state is sent. After the
+    /// first send, those blocks are already tracked as sent, so later sends only forward blocks that
+    /// weren't in the previously seen non-finalized state.
     ///
     /// Returns a new instance of [`NonFinalizedBlocksListener`] for the caller to listen for new blocks in the non-finalized state.
     pub fn spawn(

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -1,6 +1,9 @@
 //! State [`tower::Service`] response types.
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+};
 
 use chrono::{DateTime, Utc};
 
@@ -215,16 +218,23 @@ impl NonFinalizedBlocksListener {
     /// Spawns a task to listen for changes in the non-finalized state and sends any blocks in the non-finalized state
     /// to the caller that have not already been sent.
     ///
+    /// `known_chain_tips` holds the hashes of chain tips the caller already has. Walking each
+    /// non-finalized chain from its tip downwards, blocks are sent until a hash in this set is
+    /// reached, so any block at or below a known tip on the same chain is skipped. If it is empty,
+    /// every block currently in the non-finalized state is sent.
+    ///
     /// Returns a new instance of [`NonFinalizedBlocksListener`] for the caller to listen for new blocks in the non-finalized state.
     pub fn spawn(
         network: Network,
         mut non_finalized_state_receiver: WatchReceiver<NonFinalizedState>,
+        known_chain_tips: HashSet<block::Hash>,
     ) -> Self {
         let (sender, receiver) = tokio::sync::mpsc::channel(NON_FINALIZED_STATE_CHANGE_BUFFER_SIZE);
 
         tokio::spawn(async move {
-            // Start with an empty non-finalized state with the expectation that the caller doesn't yet have
-            // any blocks from the non-finalized state.
+            // Start with an empty non-finalized state. Any blocks the caller already has are
+            // identified by the `known_chain_tips` hashes below, so by default we assume the
+            // caller doesn't yet have any blocks from the non-finalized state.
             let mut prev_non_finalized_state = NonFinalizedState::new(&network);
 
             loop {
@@ -249,6 +259,7 @@ impl NonFinalizedBlocksListener {
                             .rev()
                             .take_while(|cv_block| {
                                 !prev_non_finalized_state.any_chain_contains(&cv_block.hash)
+                                    && !known_chain_tips.contains(&cv_block.hash)
                             })
                             .collect();
                         new_blocks.reverse();

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -31,6 +31,9 @@ use crate::{
     WatchReceiver, MAX_BLOCK_REORG_HEIGHT,
 };
 
+#[cfg(test)]
+mod tests;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// A response to a [`StateService`](crate::service::StateService) [`Request`].
 pub enum Response {

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -11,9 +11,7 @@ use zebra_chain::{
     amount::{Amount, NonNegative},
     block::{self, Block, ChainHistoryMmrRootHash},
     block_info::BlockInfo,
-    orchard,
-    parameters::Network,
-    sapling,
+    orchard, sapling,
     serialization::DateTime32,
     subtree::{NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex},
     transaction::{self, Transaction},
@@ -28,7 +26,10 @@ use zebra_chain::work::difficulty::CompactDifficulty;
 #[allow(unused_imports)]
 use crate::{ReadRequest, Request};
 
-use crate::{service::read::AddressUtxos, NonFinalizedState, TransactionLocation, WatchReceiver};
+use crate::{
+    service::read::AddressUtxos, ContextuallyVerifiedBlock, NonFinalizedState, TransactionLocation,
+    WatchReceiver, MAX_BLOCK_REORG_HEIGHT,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// A response to a [`StateService`](crate::service::StateService) [`Request`].
@@ -206,7 +207,7 @@ impl MinedTx {
 ///
 /// It's okay to occasionally miss updates when the buffer is full, as the new blocks in the missed change will be
 /// sent to the listener on the next change to the non-finalized state.
-const NON_FINALIZED_STATE_CHANGE_BUFFER_SIZE: usize = 1_000;
+const NON_FINALIZED_STATE_CHANGE_BUFFER_SIZE: usize = 2 * MAX_BLOCK_REORG_HEIGHT as usize;
 
 /// A listener for changes in the non-finalized state.
 #[derive(Clone, Debug)]
@@ -215,6 +216,38 @@ pub struct NonFinalizedBlocksListener(
 );
 
 impl NonFinalizedBlocksListener {
+    /// Sends the blocks in `non_finalized_state` that satisfy `take_cond` to `sender`, in
+    /// ascending height order.
+    ///
+    /// Walks each chain from its tip downwards, taking blocks while `take_cond` holds and stopping
+    /// at the first block that fails it, so it sends the blocks a listener hasn't been sent yet by
+    /// stopping at the first block it already has.
+    ///
+    /// Returns an error if the receiver has been dropped.
+    async fn take_and_send_blocks<'a>(
+        sender: &tokio::sync::mpsc::Sender<(block::Hash, Arc<Block>)>,
+        non_finalized_state: &'a NonFinalizedState,
+        take_cond: impl Fn(&&ContextuallyVerifiedBlock) -> bool + Copy + 'a,
+    ) -> Result<(), tokio::sync::mpsc::error::SendError<(block::Hash, Arc<Block>)>> {
+        let new_blocks = non_finalized_state
+            .chain_iter()
+            .flat_map(move |chain| {
+                // Take blocks from the chain in reverse height order until we reach a block the
+                // listener already has, then restore ascending height order.
+                let mut blocks: Vec<_> =
+                    chain.blocks.values().rev().take_while(take_cond).collect();
+                blocks.reverse();
+                blocks
+            })
+            .map(|cv_block| (cv_block.hash, cv_block.block.clone()));
+
+        for new_block_with_hash in new_blocks {
+            sender.send(new_block_with_hash).await?;
+        }
+
+        Ok(())
+    }
+
     /// Spawns a task to listen for changes in the non-finalized state and sends any blocks in the non-finalized state
     /// to the caller that have not already been sent.
     ///
@@ -225,58 +258,55 @@ impl NonFinalizedBlocksListener {
     ///
     /// Returns a new instance of [`NonFinalizedBlocksListener`] for the caller to listen for new blocks in the non-finalized state.
     pub fn spawn(
-        network: Network,
         mut non_finalized_state_receiver: WatchReceiver<NonFinalizedState>,
         known_chain_tips: HashSet<block::Hash>,
     ) -> Self {
         let (sender, receiver) = tokio::sync::mpsc::channel(NON_FINALIZED_STATE_CHANGE_BUFFER_SIZE);
 
         tokio::spawn(async move {
-            // Start with an empty non-finalized state. Any blocks the caller already has are
-            // identified by the `known_chain_tips` hashes below, so by default we assume the
-            // caller doesn't yet have any blocks from the non-finalized state.
-            let mut prev_non_finalized_state = NonFinalizedState::new(&network);
+            // `prev_non_finalized_state` starts as the current non-finalized state. The first send
+            // below skips blocks at or below the caller's known chain tips; afterwards those blocks
+            // are already in `prev_non_finalized_state`, so later sends only need to check it.
+            let mut prev_non_finalized_state = non_finalized_state_receiver.cloned_watch_data();
 
+            // Send the blocks the caller is missing relative to its known chain tips. This checks
+            // `known_chain_tips` once; from here on those blocks are covered by the state check.
+            if Self::take_and_send_blocks(&sender, &prev_non_finalized_state, |b| {
+                !known_chain_tips.contains(&b.hash)
+            })
+            .await
+            .is_err()
+            {
+                tracing::debug!("non-finalized blocks receiver closed, ending task");
+                return;
+            }
+
+            // # Correctness
+            //
+            // This loop should check that the non-finalized state receiver has changed sooner
+            // than the non-finalized state could possibly have changed to avoid missing updates, so
+            // the logic here should be quicker than the contextual verification logic that precedes
+            // commits to the non-finalized state.
+            //
+            // See the `NON_FINALIZED_STATE_CHANGE_BUFFER_SIZE` documentation for more details.
             loop {
-                // # Correctness
-                //
-                // This loop should check that the non-finalized state receiver has changed sooner
-                // than the non-finalized state could possibly have changed to avoid missing updates, so
-                // the logic here should be quicker than the contextual verification logic that precedes
-                // commits to the non-finalized state.
-                //
-                // See the `NON_FINALIZED_STATE_CHANGE_BUFFER_SIZE` documentation for more details.
-                let latest_non_finalized_state = non_finalized_state_receiver.cloned_watch_data();
+                let non_finalized_state = non_finalized_state_receiver.cloned_watch_data();
 
-                let new_blocks = latest_non_finalized_state
-                    .chain_iter()
-                    .flat_map(|chain| {
-                        // Take blocks from the chain in reverse height order until we reach a block that was
-                        // present in the last seen copy of the non-finalized state.
-                        let mut new_blocks: Vec<_> = chain
-                            .blocks
-                            .values()
-                            .rev()
-                            .take_while(|cv_block| {
-                                !prev_non_finalized_state.any_chain_contains(&cv_block.hash)
-                                    && !known_chain_tips.contains(&cv_block.hash)
-                            })
-                            .collect();
-                        new_blocks.reverse();
-                        new_blocks
-                    })
-                    .map(|cv_block| (cv_block.hash, cv_block.block.clone()));
-
-                for new_block_with_hash in new_blocks {
-                    if sender.send(new_block_with_hash).await.is_err() {
-                        tracing::debug!("non-finalized blocks receiver closed, ending task");
-                        return;
-                    }
+                // Send blocks that weren't in the last seen copy of the non-finalized state. The
+                // caller's known tips are already covered by `prev_non_finalized_state`.
+                if Self::take_and_send_blocks(&sender, &non_finalized_state, |b| {
+                    !prev_non_finalized_state.any_chain_contains(&b.hash)
+                })
+                .await
+                .is_err()
+                {
+                    tracing::debug!("non-finalized blocks receiver closed, ending task");
+                    return;
                 }
 
-                prev_non_finalized_state = latest_non_finalized_state;
+                prev_non_finalized_state = non_finalized_state;
 
-                // Wait for the next update to the non-finalized state
+                // Wait for the next update to the non-finalized state.
                 if let Err(error) = non_finalized_state_receiver.changed().await {
                     warn!(
                         ?error,

--- a/zebra-state/src/response/tests.rs
+++ b/zebra-state/src/response/tests.rs
@@ -11,8 +11,8 @@ use zebra_chain::{
 };
 
 use crate::{
-    arbitrary::Prepare, service::finalized_state::FinalizedState, tests::FakeChainHelper, Config,
-    NonFinalizedState, WatchReceiver,
+    arbitrary::Prepare, service::finalized_state::FinalizedState, Config, NonFinalizedState,
+    WatchReceiver,
 };
 
 use super::NonFinalizedBlocksListener;

--- a/zebra-state/src/response/tests.rs
+++ b/zebra-state/src/response/tests.rs
@@ -11,8 +11,8 @@ use zebra_chain::{
 };
 
 use crate::{
-    arbitrary::Prepare, service::finalized_state::FinalizedState, Config, NonFinalizedState,
-    WatchReceiver,
+    arbitrary::Prepare, service::finalized_state::FinalizedState, tests::FakeChainHelper, Config,
+    NonFinalizedState, WatchReceiver,
 };
 
 use super::NonFinalizedBlocksListener;

--- a/zebra-state/src/response/tests.rs
+++ b/zebra-state/src/response/tests.rs
@@ -1,0 +1,154 @@
+//! Tests for [`NonFinalizedBlocksListener`].
+
+use std::{collections::HashSet, sync::Arc, time::Duration};
+
+use tokio::sync::{mpsc, watch};
+use zebra_chain::{
+    amount::NonNegative,
+    block::{self, Block},
+    parameters::Network,
+    value_balance::ValueBalance,
+};
+
+use crate::{
+    arbitrary::Prepare, service::finalized_state::FinalizedState, tests::FakeChainHelper, Config,
+    NonFinalizedState, WatchReceiver,
+};
+
+use super::NonFinalizedBlocksListener;
+
+/// Builds `len` fake blocks forming a single chain, in ascending height order.
+///
+/// The first block is a pre-Heartwood block so committing the fake children doesn't trigger
+/// history tree updates in the non-finalized state.
+fn fake_chain(network: &Network, len: usize) -> Vec<Arc<Block>> {
+    let mut blocks = vec![Arc::new(network.test_block(653599, 583999).unwrap())];
+    while blocks.len() < len {
+        let child = blocks.last().unwrap().make_fake_child().set_work(10);
+        blocks.push(child);
+    }
+    blocks
+}
+
+/// Commits `blocks` (a single chain in ascending height order) into a fresh non-finalized state.
+fn state_from_chain(network: &Network, blocks: &[Arc<Block>]) -> NonFinalizedState {
+    let finalized_state = FinalizedState::new(
+        &Config::ephemeral(),
+        network,
+        #[cfg(feature = "elasticsearch")]
+        false,
+    )
+    .expect("opening an ephemeral database should succeed");
+    finalized_state.set_finalized_value_pool(ValueBalance::<NonNegative>::fake_populated_pool());
+
+    let mut state = NonFinalizedState::new(network);
+    let (root, rest) = blocks.split_first().expect("chain must not be empty");
+    state
+        .commit_new_chain(root.clone().prepare(), &finalized_state)
+        .expect("committing the root block should succeed");
+    for block in rest {
+        state
+            .commit_block(block.clone().prepare(), &finalized_state)
+            .expect("committing a child block should succeed");
+    }
+
+    state
+}
+
+/// Receives the next block hash from the listener, failing if none arrives promptly.
+async fn recv_hash(rx: &mut mpsc::Receiver<(block::Hash, Arc<Block>)>) -> block::Hash {
+    tokio::time::timeout(Duration::from_secs(10), rx.recv())
+        .await
+        .expect("listener should send a block before timing out")
+        .expect("listener channel should stay open")
+        .0
+}
+
+/// Asserts the listener doesn't send any more blocks within a short window.
+async fn assert_idle(rx: &mut mpsc::Receiver<(block::Hash, Arc<Block>)>) {
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), rx.recv())
+            .await
+            .is_err(),
+        "listener should not send any more blocks",
+    );
+}
+
+/// With no known chain tips, every block currently in the non-finalized state is sent, in
+/// ascending height order.
+#[tokio::test]
+async fn sends_all_blocks_when_no_known_tips() {
+    let network = Network::Mainnet;
+    let blocks = fake_chain(&network, 3);
+    let hashes: Vec<_> = blocks.iter().map(|b| b.hash()).collect();
+
+    let (_tx, rx) = watch::channel(state_from_chain(&network, &blocks));
+    let listener = NonFinalizedBlocksListener::spawn(WatchReceiver::new(rx), HashSet::new());
+    let mut received = listener.unwrap();
+
+    assert_eq!(recv_hash(&mut received).await, hashes[0]);
+    assert_eq!(recv_hash(&mut received).await, hashes[1]);
+    assert_eq!(recv_hash(&mut received).await, hashes[2]);
+    assert_idle(&mut received).await;
+}
+
+/// When the caller provides a chain tip it already has, only the blocks above that tip are sent;
+/// the tip and its ancestors are skipped.
+#[tokio::test]
+async fn skips_blocks_at_or_below_known_tip() {
+    let network = Network::Mainnet;
+    let blocks = fake_chain(&network, 3);
+    let hashes: Vec<_> = blocks.iter().map(|b| b.hash()).collect();
+
+    // The caller already has block2 (and therefore its ancestor block1), so only block3 is new.
+    let known_tips = std::iter::once(hashes[1]).collect();
+
+    let (_tx, rx) = watch::channel(state_from_chain(&network, &blocks));
+    let listener = NonFinalizedBlocksListener::spawn(WatchReceiver::new(rx), known_tips);
+    let mut received = listener.unwrap();
+
+    assert_eq!(recv_hash(&mut received).await, hashes[2]);
+    assert_idle(&mut received).await;
+}
+
+/// When the caller already has the whole chain (its tip is the current best tip), nothing is sent
+/// until the state changes.
+#[tokio::test]
+async fn sends_nothing_when_caller_has_the_tip() {
+    let network = Network::Mainnet;
+    let blocks = fake_chain(&network, 3);
+    let tip = blocks.last().unwrap().hash();
+
+    let (_tx, rx) = watch::channel(state_from_chain(&network, &blocks));
+    let listener =
+        NonFinalizedBlocksListener::spawn(WatchReceiver::new(rx), std::iter::once(tip).collect());
+    let mut received = listener.unwrap();
+
+    assert_idle(&mut received).await;
+}
+
+/// After the initial send, only blocks added since the previously seen state are forwarded, and
+/// the one-time `known_chain_tips` check doesn't re-filter later updates.
+#[tokio::test]
+async fn sends_only_new_blocks_on_update() {
+    let network = Network::Mainnet;
+    let blocks = fake_chain(&network, 4);
+    let hashes: Vec<_> = blocks.iter().map(|b| b.hash()).collect();
+
+    let initial = state_from_chain(&network, &blocks[..3]);
+    let extended = state_from_chain(&network, &blocks);
+
+    let (tx, rx) = watch::channel(initial);
+    let listener = NonFinalizedBlocksListener::spawn(WatchReceiver::new(rx), HashSet::new());
+    let mut received = listener.unwrap();
+
+    // Drain the initial three blocks.
+    for expected in &hashes[..3] {
+        assert_eq!(recv_hash(&mut received).await, *expected);
+    }
+
+    // Publishing the extended state forwards only the newly added block.
+    tx.send(extended).expect("listener should still be running");
+    assert_eq!(recv_hash(&mut received).await, hashes[3]);
+    assert_idle(&mut received).await;
+}

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1371,12 +1371,13 @@ impl Service<ReadRequest> for ReadStateService {
         let timed_span = TimedSpan::new(timer, span);
         let state = self.clone();
 
-        if req == ReadRequest::NonFinalizedBlocksListener {
+        if let ReadRequest::NonFinalizedBlocksListener { known_chain_tips } = req {
             // The non-finalized blocks listener is used to notify the state service
             // about new blocks that have been added to the non-finalized state.
             let non_finalized_blocks_listener = NonFinalizedBlocksListener::spawn(
                 self.network.clone(),
                 self.non_finalized_state_receiver.clone(),
+                known_chain_tips,
             );
 
             return async move {
@@ -1771,7 +1772,7 @@ impl Service<ReadRequest> for ReadStateService {
                 ))
             }
 
-            ReadRequest::NonFinalizedBlocksListener => {
+            ReadRequest::NonFinalizedBlocksListener { .. } => {
                 unreachable!("should return early");
             }
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1375,7 +1375,6 @@ impl Service<ReadRequest> for ReadStateService {
             // The non-finalized blocks listener is used to notify the state service
             // about new blocks that have been added to the non-finalized state.
             let non_finalized_blocks_listener = NonFinalizedBlocksListener::spawn(
-                self.network.clone(),
                 self.non_finalized_state_receiver.clone(),
                 known_chain_tips,
             );

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -1683,7 +1683,9 @@ impl DiskDb {
     // Used when opening a read-only secondary instance, which must never create the
     // primary's cache directory. Returns a [`StateInitError`] if the directory is missing
     // or unreadable.
-    fn check_cache_dir_readable(cache_dir: &std::path::Path) -> Result<(), StateInitError> {
+    pub(crate) fn check_cache_dir_readable(
+        cache_dir: &std::path::Path,
+    ) -> Result<(), StateInitError> {
         match fs::read_dir(cache_dir) {
             Ok(_) => Ok(()),
             Err(source) => Err(StateInitError::ReadOnlyCacheDirUnreadable {

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -101,17 +101,34 @@ impl ZebraDb {
         column_families_in_code: impl IntoIterator<Item = String>,
         read_only: bool,
     ) -> Result<ZebraDb, StateInitError> {
-        let disk_version = DiskDb::try_reusing_previous_db_after_major_upgrade(
-            &restorable_db_versions(),
-            format_version_in_code,
-            config,
-            &db_kind,
-            network,
-        )
-        .or_else(|| {
+        // A read-only secondary instance must never modify the primary's cache directory, so it
+        // skips the post-major-upgrade DB reuse (which can create directories and rename the
+        // on-disk database) and reads the on-disk format version directly. The cache directory is
+        // checked for readability first, so a missing or unreadable directory returns a typed
+        // `ReadOnlyCacheDirUnreadable` error here instead of panicking on the version-file read.
+        let disk_version = if read_only {
+            DiskDb::check_cache_dir_readable(&config.cache_dir)?;
+
             database_format_version_on_disk(config, &db_kind, format_version_in_code.major, network)
                 .expect("unable to read database format version file")
-        });
+        } else {
+            DiskDb::try_reusing_previous_db_after_major_upgrade(
+                &restorable_db_versions(),
+                format_version_in_code,
+                config,
+                &db_kind,
+                network,
+            )
+            .or_else(|| {
+                database_format_version_on_disk(
+                    config,
+                    &db_kind,
+                    format_version_in_code.major,
+                    network,
+                )
+                .expect("unable to read database format version file")
+            })
+        };
 
         // Log any format changes before opening the database, in case opening fails.
         let format_change = DbFormatChange::open_database(format_version_in_code, disk_version);

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -632,3 +632,29 @@ fn read_only_open_with_no_database_returns_error() {
         Ok(_) => panic!("expected an error when opening a read-only state with no database"),
     }
 }
+
+/// Opening a read-only state against a missing or unreadable cache directory must fail with a
+/// typed [`StateInitError::ReadOnlyCacheDirUnreadable`] rather than panicking while reading the
+/// on-disk format version.
+#[test]
+fn read_only_open_with_unreadable_cache_dir_returns_error() {
+    let network = Network::Mainnet;
+
+    // A cache directory that does not exist. `read_dir` fails for a missing directory the same way
+    // it does for an unreadable one, without depending on filesystem permissions (which `root`
+    // ignores, so a chmod-based unreadable directory would not be a reliable test under CI).
+    let parent = tempfile::tempdir().expect("creating a temporary directory should succeed");
+    let config = Config {
+        cache_dir: parent.path().join("missing"),
+        ephemeral: false,
+        ..Config::default()
+    };
+
+    match super::init_read_only(config, &network) {
+        Err(crate::StateInitError::ReadOnlyCacheDirUnreadable { .. }) => {}
+        Err(other) => panic!("expected ReadOnlyCacheDirUnreadable, got: {other:?}"),
+        Ok(_) => {
+            panic!("expected an error when opening a read-only state with an unreadable cache dir")
+        }
+    }
+}


### PR DESCRIPTION
> **Stacked PR.** This targets `fix/read-state-replica-warts` (a replica of #10741's branch on this remote), so the diff is only this work, not #10741's. It mirrors nuttycom/zebra#1, opened here for ZcashFoundation/zebra CI and review.
>
> Depends on / stacks on #10741. Re-target to `main` once #10741 merges.

## Motivation

Builds on #10741 (opening a running node's finalized state read-only as a secondary and following its non-finalized tip via `init_read_state_with_syncer`). Three rough edges hurt a long-running co-located consumer (e.g. Zaino serving Zallet):

- On every (re)subscribe the server re-streamed the **entire** non-finalized state, with no way to resume from what the caller already has — and a near-tip subscriber could livelock bursting the whole state into a small buffer.
- When the secondary's finalized state **lagged** the primary's, the first streamed non-finalized block had no parent to attach to and failed to commit (`NotReadyToBeCommitted`), stalling the syncer's tip until the secondary caught up.
- The syncer/indexer streams could **hang indefinitely** on a half-open connection, **silently** fall behind when secondary catch-up failed, or **block the listener task** on a hung consumer.

## Solution

- **Resumable non-finalized streaming** — `NonFinalizedStateChange` gains an optional `chain_tip_hashes` request field; the server streams only the blocks after the caller's tips (known tips checked once, then diff against the previously seen state). The input is bounded against untrusted callers, and `send().await` backpressure replaces drop-on-full so a slow consumer doesn't miss blocks.
- **Finalized-tip gap bridging** — a new unary `GetBlock(BlockRequest)` indexer method (by hash or height). `TrustedChainSync` uses it to fetch the already-finalized blocks between the secondary's lagging finalized tip and the streamed non-finalized root, committing them so the streamed block has a contiguous chain. Between fetches it keeps trying to catch the secondary's finalized state up to the primary, and stops fetching once the finalized state closes the gap on its own; each bridge block advances the published chain tip / non-finalized state channels.
- **Hardening** — stream-read timeouts plus HTTP/2 keep-alive on the indexer connection (a half-open connection re-subscribes instead of hanging); secondary catch-up failures are logged instead of swallowed; and a send timeout drops a hung consumer's subscription instead of blocking the listener task forever.

### Tests

- New unit tests: `decode_known_chain_tips` (round-trip, empty, dedup, wrong-length, over-cap); `NonFinalizedBlocksListener` (all blocks with no known tips, skip at/below a known tip, nothing when the caller has the tip, only-new-on-update); `GetBlock` indexer method (happy path by height + invalid-argument).
- `cargo test -p zebra-rpc -p zebra-state --lib` → 74 + 136 passing; `cargo clippy --workspace --all-targets` and `cargo fmt --all -- --check` clean.
- Not added: end-to-end integration of the gap-bridge and stream timeouts (needs a live indexer server + a deliberately lagging secondary) — see follow-up.

### Specifications & References

- Mirror of nuttycom/zebra#1; stacks on #10741.
- Motivated by the Zebra → Zaino → Zallet read-state path; e.g. the non-atomic chain-tip / reorg race in zingolabs/zaino#249.

### Follow-up Work

- Integration test for the gap-bridge and stream timeouts.
- Optional batching / a cap for very large finalized gaps (currently fetched one block at a time).
- Changelog entries (held pending where this lands relative to #10741).

### AI Disclosure

- [x] AI tools were used: Claude Code (Claude Opus) — implemented the streaming, gap-bridge, and hardening changes and their tests, and drafted this description. The contributor reviewed and directed the work.

### PR Checklist

- [x] The PR title follows conventional commits format
- [x] This change extends the in-flight PR #10741 and is targeted at its (replicated) branch
- [x] The solution is tested (unit tests; integration is follow-up)
- [ ] The documentation and changelogs are up to date (changelog follow-up)
