### PR TITLE
feat(state): add FindForkPoint read request for locating chain reorg fork points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   consumer's known chain tips instead of re-streaming the whole non-finalized state,
   and a new `GetBlock` indexer method lets the consumer fetch blocks it is missing
   while its finalized state catches up.
+- New `zebra-state` read request `ReadRequest::FindForkPoint` (with response
+  `ReadResponse::ForkPoint`) that returns the most recent block in a caller-supplied
+  locator that is on the best chain — the fork point — for clients tracking chain
+  reorganizations through a read-only state service.
 
 ### Changed
 

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   caller's `known_chain_tips`, so the non-finalized blocks listener streams only the
   blocks above the chain tips the caller already has. `MAX_NON_FINALIZED_CHAIN_FORKS`
   is now re-exported from the crate root.
+- Added `ReadRequest::FindForkPoint { known_blocks }` request and the corresponding
+  `ReadResponse::ForkPoint(Option<(block::Height, block::Hash)>)` response. The
+  server returns the most recent block in the caller-supplied locator that is
+  on the best chain (the fork point) to assist in reorg handling for clients
+  that track only a single chain tip at a time.
+  ([#10764](https://github.com/ZcashFoundation/zebra/pull/10764)).
 
 ## [9.0.1] - 2026-06-18
 

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -1269,6 +1269,33 @@ pub enum ReadRequest {
         stop: Option<block::Hash>,
     },
 
+    /// Finds the fork point between the locator `known_blocks` and the best chain.
+    ///
+    /// `known_blocks` is a block locator. Returns the most recent locator entry that is
+    /// on the best chain (the fork point), or `None` if no entry is on the best chain.
+    /// Returns `None` if the state is empty.
+    ///
+    /// This is intentionally a narrow, best-chain-only query: it reports a single
+    /// locator intersection against the best chain. It does not enumerate side-chain
+    /// tips, branch lengths, or per-tip statuses, so it is not a general
+    /// fork-monitoring API in the style of `getchaintips`. Callers that need to
+    /// observe side chains should use a dedicated request rather than building on this
+    /// one.
+    ///
+    /// The read state service rejects this request with an error if `known_blocks`
+    /// is longer than [`MAX_BLOCK_LOCATOR_LENGTH`](zebra_chain::block::MAX_BLOCK_LOCATOR_LENGTH),
+    /// so an untrusted caller cannot force an unbounded number of lookups. A locator
+    /// built the usual way (one hash per standard block-locator height) is always
+    /// within that bound.
+    ///
+    /// Returns
+    ///
+    /// [`ReadResponse::ForkPoint(Option<(block::Height, block::Hash)>)`](ReadResponse::ForkPoint).
+    FindForkPoint {
+        /// Hashes of known blocks, ordered from highest height to lowest height.
+        known_blocks: Vec<block::Hash>,
+    },
+
     /// Looks up a Sapling note commitment tree either by a hash or height.
     ///
     /// Returns
@@ -1440,6 +1467,7 @@ impl ReadRequest {
             ReadRequest::BlockLocator => "block_locator",
             ReadRequest::FindBlockHashes { .. } => "find_block_hashes",
             ReadRequest::FindBlockHeaders { .. } => "find_block_headers",
+            ReadRequest::FindForkPoint { .. } => "find_fork_point",
             ReadRequest::SaplingTree { .. } => "sapling_tree",
             ReadRequest::OrchardTree { .. } => "orchard_tree",
             ReadRequest::SaplingSubtrees { .. } => "sapling_subtrees",

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -426,6 +426,11 @@ pub enum ReadResponse {
     /// The response to a `FindBlockHeaders` request.
     BlockHeaders(Vec<block::CountedHeader>),
 
+    /// The response to a `FindForkPoint` request.
+    /// Returns the height and hash of the fork point, or `None` if no locator entry is
+    /// on the best chain.
+    ForkPoint(Option<(block::Height, block::Hash)>),
+
     /// The response to a `UnspentBestChainUtxo` request, from verified blocks in the
     /// _best_ non-finalized chain, or the finalized chain.
     UnspentBestChainUtxo(Option<transparent::Utxo>),
@@ -596,7 +601,8 @@ impl TryFrom<ReadResponse> for Response {
             | ReadResponse::AddressUtxos(_)
             | ReadResponse::ChainInfo(_)
             | ReadResponse::NonFinalizedBlocksListener(_)
-            | ReadResponse::IsTransparentOutputSpent(_) => {
+            | ReadResponse::IsTransparentOutputSpent(_)
+            | ReadResponse::ForkPoint(_) => {
                 Err("there is no corresponding Response for this ReadResponse")
             }
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1556,6 +1556,28 @@ impl Service<ReadRequest> for ReadStateService {
                 .collect(),
             )),
 
+            ReadRequest::FindForkPoint { known_blocks } => {
+                // Reject over-long locators before doing any work, so an untrusted
+                // caller can't force unbounded lookups.
+                let locator_len: u64 = known_blocks
+                    .len()
+                    .try_into()
+                    .expect("usize always fits in u64 on supported (<=64-bit) platforms");
+                if locator_len > block::MAX_BLOCK_LOCATOR_LENGTH {
+                    return Err(BoxError::from(format!(
+                        "FindForkPoint locator length {locator_len} exceeds \
+                         MAX_BLOCK_LOCATOR_LENGTH ({})",
+                        block::MAX_BLOCK_LOCATOR_LENGTH,
+                    )));
+                }
+
+                Ok(ReadResponse::ForkPoint(read::find_fork_point(
+                    state.latest_best_chain(),
+                    &state.db,
+                    known_blocks,
+                )))
+            }
+
             ReadRequest::SaplingTree(hash_or_height) => Ok(ReadResponse::SaplingTree(
                 read::sapling_tree(state.latest_best_chain(), &state.db, hash_or_height),
             )),

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -39,12 +39,9 @@ pub use block::spending_transaction_hash;
 
 pub use find::{
     best_tip, block_locator, depth, finalized_state_contains_block_hash, find_chain_hashes,
-    find_chain_headers, hash_by_height, height_by_hash, next_median_time_past,
+    find_chain_headers, find_fork_point, hash_by_height, height_by_hash, next_median_time_past,
     non_finalized_state_contains_block_hash, tip, tip_height, tip_with_value_balance,
 };
-// Re-exported for use in the ReadRequest handler (added in a later task).
-#[allow(unused_imports)]
-pub use find::find_fork_point;
 pub use tree::{orchard_subtrees, orchard_tree, sapling_subtrees, sapling_tree};
 
 #[cfg(any(test, feature = "proptest-impl"))]

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -42,6 +42,9 @@ pub use find::{
     find_chain_headers, hash_by_height, height_by_hash, next_median_time_past,
     non_finalized_state_contains_block_hash, tip, tip_height, tip_with_value_balance,
 };
+// Re-exported for use in the ReadRequest handler (added in a later task).
+#[allow(unused_imports)]
+pub use find::find_fork_point;
 pub use tree::{orchard_subtrees, orchard_tree, sapling_subtrees, sapling_tree};
 
 #[cfg(any(test, feature = "proptest-impl"))]

--- a/zebra-state/src/service/read/find.rs
+++ b/zebra-state/src/service/read/find.rs
@@ -584,6 +584,35 @@ where
     collect_chain_hashes(chain, db, intersection, stop, max_len)
 }
 
+/// Finds the fork point between the locator `known_blocks` and the best chain.
+///
+/// `known_blocks` is a block locator: hashes ordered from highest height to lowest
+/// height. Returns the height and hash of the highest locator entry that is on the best
+/// chain (in `chain` or the finalized `db`) — the most recent common ancestor — or
+/// `None` if no locator entry is on the best chain.
+///
+/// Returns `None` if the state is empty.
+#[allow(dead_code)]
+pub fn find_fork_point<C>(
+    chain: Option<C>,
+    db: &ZebraDb,
+    known_blocks: Vec<block::Hash>,
+) -> Option<(Height, block::Hash)>
+where
+    C: AsRef<Chain>,
+{
+    // # Correctness
+    //
+    // See the note in `block_locator()`.
+
+    let chain = chain.as_ref();
+
+    let fork_hash = find_chain_intersection(chain, db, known_blocks)?;
+    let fork_height = height_by_hash(chain, db, fork_hash)?;
+
+    Some((fork_height, fork_hash))
+}
+
 /// Finds the first hash that's in the peer's `known_blocks` and the chain.
 /// Returns a list of headers that follow that intersection, from the chain.
 ///

--- a/zebra-state/src/service/read/find.rs
+++ b/zebra-state/src/service/read/find.rs
@@ -592,7 +592,6 @@ where
 /// `None` if no locator entry is on the best chain.
 ///
 /// Returns `None` if the state is empty.
-#[allow(dead_code)]
 pub fn find_fork_point<C>(
     chain: Option<C>,
     db: &ZebraDb,

--- a/zebra-state/src/service/read/find/tests/vectors.rs
+++ b/zebra-state/src/service/read/find/tests/vectors.rs
@@ -20,6 +20,96 @@ static BLOCK_LOCATOR_CASES: &[(u32, u32)] = &[
     (10000, 9000),
 ];
 
+/// Tests that `find_fork_point` returns the most recent locator entry on the best chain.
+#[test]
+fn find_fork_point_locates_the_fork() {
+    use std::sync::Arc;
+
+    use zebra_chain::{
+        amount::NonNegative, block::Block, parameters::Network::Mainnet,
+        value_balance::ValueBalance,
+    };
+
+    use crate::{
+        arbitrary::Prepare,
+        service::{
+            finalized_state::FinalizedState, non_finalized_state::NonFinalizedState,
+            read::find_fork_point,
+        },
+        tests::FakeChainHelper,
+        Config,
+    };
+
+    let _init_guard = zebra_test::init();
+    let network = Mainnet;
+
+    // Pre-Heartwood block as a base, to avoid history-tree complications (matches the
+    // `any_chain_block_finds_side_chain_blocks` fixture in read/tests/vectors.rs).
+    let base: Arc<Block> = Arc::new(network.test_block(653599, 583999).unwrap());
+
+    // Two competing children of `base`: different work -> different hashes -> a fork.
+    let best_block = base.make_fake_child().set_work(100);
+    let side_block = base.make_fake_child().set_work(50);
+
+    let base_hash = base.hash();
+    let base_height = base.coinbase_height().unwrap();
+    let best_hash = best_block.hash();
+    let best_height = best_block.coinbase_height().unwrap();
+    let side_hash = side_block.hash();
+
+    assert_ne!(
+        best_hash, side_hash,
+        "could not create distinct block hashes for fork-point test",
+    );
+
+    let mut non_finalized_state = NonFinalizedState::new(&network);
+    let finalized_state = FinalizedState::new(
+        &Config::ephemeral(),
+        &network,
+        #[cfg(feature = "elasticsearch")]
+        false,
+    )
+    .expect("opening an ephemeral database should succeed");
+    finalized_state.set_finalized_value_pool(ValueBalance::<NonNegative>::fake_populated_pool());
+
+    non_finalized_state
+        .commit_new_chain(base.prepare(), &finalized_state)
+        .unwrap();
+    non_finalized_state
+        .commit_block(best_block.clone().prepare(), &finalized_state)
+        .unwrap();
+    non_finalized_state
+        .commit_block(side_block.clone().prepare(), &finalized_state)
+        .unwrap();
+    assert_eq!(
+        non_finalized_state.chain_count(),
+        2,
+        "should have two competing chains"
+    );
+
+    let best_chain = non_finalized_state.best_chain();
+    let db = &finalized_state.db;
+
+    // No reorg: the locator's top is on the best chain -> it is its own fork point.
+    assert_eq!(
+        find_fork_point(best_chain, db, vec![best_hash]),
+        Some((best_height, best_hash)),
+    );
+
+    // Reorg: a locator over the orphaned tip plus its shared ancestor -> the shared
+    // ancestor (`base`) is the fork point.
+    assert_eq!(
+        find_fork_point(best_chain, db, vec![side_hash, base_hash]),
+        Some((base_height, base_hash)),
+    );
+
+    // A locator containing only the orphaned tip has no entry on the best chain.
+    assert_eq!(find_fork_point(best_chain, db, vec![side_hash]), None);
+
+    // An empty locator has no fork point.
+    assert_eq!(find_fork_point(best_chain, db, vec![]), None);
+}
+
 /// Check that the block locator heights are sensible.
 #[test]
 fn test_block_locator_heights() {

--- a/zebra-state/src/service/read/tests/vectors.rs
+++ b/zebra-state/src/service/read/tests/vectors.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use tower::ServiceExt;
 use zebra_chain::{
-    block::{Block, Height},
+    block::{Block, Hash, Height, MAX_BLOCK_LOCATOR_LENGTH},
     orchard,
     parameters::Network::*,
     serialization::ZcashDeserializeInto,
@@ -45,6 +45,32 @@ async fn empty_read_state_still_responds_to_requests() -> Result<()> {
     Ok(())
 }
 
+/// Test that the ReadStateService rejects a `FindForkPoint` locator longer than
+/// `MAX_BLOCK_LOCATOR_LENGTH`, rather than performing an unbounded number of lookups.
+#[tokio::test]
+async fn find_fork_point_rejects_over_long_locator() -> Result<()> {
+    let _init_guard = zebra_test::init();
+
+    let network = Mainnet;
+    let (_state, read_state, _latest_chain_tip, _chain_tip_change) =
+        init_test_services(&network).await;
+
+    // One hash over the cap. The contents are irrelevant: the length is checked
+    // before any block is looked up.
+    let over_long = vec![Hash([0; 32]); MAX_BLOCK_LOCATOR_LENGTH as usize + 1];
+
+    let transcript = Transcript::from(vec![(
+        ReadRequest::FindForkPoint {
+            known_blocks: over_long,
+        },
+        Err(ExpectedTranscriptError::Any),
+    )]);
+
+    transcript.check(read_state).await?;
+
+    Ok(())
+}
+
 /// Test that ReadStateService responds correctly when the state contains blocks.
 #[tokio::test(flavor = "multi_thread")]
 async fn populated_read_state_responds_correctly() -> Result<()> {
@@ -78,6 +104,18 @@ async fn populated_read_state_responds_correctly() -> Result<()> {
 
         let block_cases = Transcript::from(block_cases);
         block_cases.check(read_state.clone()).await?;
+
+        let fork_point_cases = vec![(
+            ReadRequest::FindForkPoint {
+                known_blocks: vec![block.hash()],
+            },
+            Ok(ReadResponse::ForkPoint(Some((
+                block.coinbase_height().unwrap(),
+                block.hash(),
+            )))),
+        )];
+        let fork_point_cases = Transcript::from(fork_point_cases);
+        fork_point_cases.check(read_state.clone()).await?;
 
         // Spec: transactions in the genesis block are ignored.
         if block.coinbase_height().unwrap().0 == 0 {
@@ -352,6 +390,12 @@ fn empty_state_test_cases() -> Vec<(ReadRequest, Result<ReadResponse, ExpectedTr
         (
             ReadRequest::Block(block.coinbase_height().unwrap().into()),
             Ok(ReadResponse::Block(None)),
+        ),
+        (
+            ReadRequest::FindForkPoint {
+                known_blocks: vec![block.hash()],
+            },
+            Ok(ReadResponse::ForkPoint(None)),
         ),
     ]
 }


### PR DESCRIPTION
Stacked atop  https://github.com/ZcashFoundation/zebra/pull/10784

## Motivation

Read-only consumers of the state service — for example, a wallet reading a secondary copy of the state database — need to determine where their view of the chain diverges from the node's best chain after a reorg. The existing `FindBlockHashes` computes the locator/best-chain intersection internally but returns the hashes *following* it, not the fork point itself.

## Summary

Adds `ReadRequest::FindForkPoint { known_blocks }` → `ReadResponse::ForkPoint(Option<(Height, Hash)>)`, which returns the most recent block in a caller-supplied locator that is on the best chain (finalized or best non-finalized) — the fork point — or `None` if no locator entry is on the best chain.

- A new `read::find_fork_point` helper reuses the existing private `find_chain_intersection` and `height_by_hash`.
- Dispatched against the best chain in the `ReadStateService`, mirroring the `FindBlockHashes` / `FindBlockHeaders` family.
- Locator-based by design, for consistency with the existing intersection requests and for robustness: it works even when the caller's orphaned side chain is no longer retained, because the locator carries the shared ancestors.
- `ReadRequest`-only; no write-path `Request` variant; no feature gate.

## Test plan

- [x] `cargo test -p zebra-state` — 137 passed, 0 failed (new unit coverage for a non-finalized best-vs-side-chain fork, plus integration coverage for empty state and populated/finalized fork points)
- [x] `cargo build -p zebra-state --all-features`
- [x] `cargo build -p zebra-rpc` — the downstream consumer compiles with the new variants
- [x] `cargo doc -p zebra-state --no-deps` — no intra-doc-link warnings

---

This PR was prepared with the assistance of Claude Code.
