### PR TITLE
chore: address review comments on nuttycom/zebra#1

### DIFF
--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -1683,7 +1683,9 @@ impl DiskDb {
     // Used when opening a read-only secondary instance, which must never create the
     // primary's cache directory. Returns a [`StateInitError`] if the directory is missing
     // or unreadable.
-    fn check_cache_dir_readable(cache_dir: &std::path::Path) -> Result<(), StateInitError> {
+    pub(crate) fn check_cache_dir_readable(
+        cache_dir: &std::path::Path,
+    ) -> Result<(), StateInitError> {
         match fs::read_dir(cache_dir) {
             Ok(_) => Ok(()),
             Err(source) => Err(StateInitError::ReadOnlyCacheDirUnreadable {

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -101,17 +101,34 @@ impl ZebraDb {
         column_families_in_code: impl IntoIterator<Item = String>,
         read_only: bool,
     ) -> Result<ZebraDb, StateInitError> {
-        let disk_version = DiskDb::try_reusing_previous_db_after_major_upgrade(
-            &restorable_db_versions(),
-            format_version_in_code,
-            config,
-            &db_kind,
-            network,
-        )
-        .or_else(|| {
+        // A read-only secondary instance must never modify the primary's cache directory, so it
+        // skips the post-major-upgrade DB reuse (which can create directories and rename the
+        // on-disk database) and reads the on-disk format version directly. The cache directory is
+        // checked for readability first, so a missing or unreadable directory returns a typed
+        // `ReadOnlyCacheDirUnreadable` error here instead of panicking on the version-file read.
+        let disk_version = if read_only {
+            DiskDb::check_cache_dir_readable(&config.cache_dir)?;
+
             database_format_version_on_disk(config, &db_kind, format_version_in_code.major, network)
                 .expect("unable to read database format version file")
-        });
+        } else {
+            DiskDb::try_reusing_previous_db_after_major_upgrade(
+                &restorable_db_versions(),
+                format_version_in_code,
+                config,
+                &db_kind,
+                network,
+            )
+            .or_else(|| {
+                database_format_version_on_disk(
+                    config,
+                    &db_kind,
+                    format_version_in_code.major,
+                    network,
+                )
+                .expect("unable to read database format version file")
+            })
+        };
 
         // Log any format changes before opening the database, in case opening fails.
         let format_change = DbFormatChange::open_database(format_version_in_code, disk_version);

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -632,3 +632,29 @@ fn read_only_open_with_no_database_returns_error() {
         Ok(_) => panic!("expected an error when opening a read-only state with no database"),
     }
 }
+
+/// Opening a read-only state against a missing or unreadable cache directory must fail with a
+/// typed [`StateInitError::ReadOnlyCacheDirUnreadable`] rather than panicking while reading the
+/// on-disk format version.
+#[test]
+fn read_only_open_with_unreadable_cache_dir_returns_error() {
+    let network = Network::Mainnet;
+
+    // A cache directory that does not exist. `read_dir` fails for a missing directory the same way
+    // it does for an unreadable one, without depending on filesystem permissions (which `root`
+    // ignores, so a chmod-based unreadable directory would not be a reliable test under CI).
+    let parent = tempfile::tempdir().expect("creating a temporary directory should succeed");
+    let config = Config {
+        cache_dir: parent.path().join("missing"),
+        ephemeral: false,
+        ..Config::default()
+    };
+
+    match super::init_read_only(config, &network) {
+        Err(crate::StateInitError::ReadOnlyCacheDirUnreadable { .. }) => {}
+        Err(other) => panic!("expected ReadOnlyCacheDirUnreadable, got: {other:?}"),
+        Ok(_) => {
+            panic!("expected an error when opening a read-only state with an unreadable cache dir")
+        }
+    }
+}


### PR DESCRIPTION
I cannot push changes directly to the feat-nonfinalized-stream-from-tips branch, so I'm opening this PR to integrate changes.

The commits in this branch should be rebased on https://github.com/ZcashFoundation/zebra/tree/feat-nonfinalized-stream-from-tips (or, if nuttycom/zebra#1 merges, simply applied on top).