### PR TITLE
fix(ci): stop the broad nextest override from shadowing per-test timeouts

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -53,14 +53,18 @@ fail-fast = false
 failure-output = "immediate"
 success-output = "immediate"
 default-filter = 'test(/^stateful::/)'
+# Default hard timeout for stateful tests; longer-running tests override it below.
+slow-timeout = { period = "30m", terminate-after = 2 }
 
 [test-groups]
 serial-state = { max-threads = 1 }
 
+# Stateful tests share on-disk state, so run them serially. This override sets
+# only the test-group: adding slow-timeout here would shadow every per-test
+# timeout below, since nextest applies the first matching override per setting.
 [[profile.ci-stateful.overrides]]
 filter = 'test(/^stateful::/)'
 test-group = 'serial-state'
-slow-timeout = { period = "30m", terminate-after = 2 }
 
 [[profile.ci-stateful.overrides]]
 filter = 'test(=stateful::sync::sync_to_mandatory_checkpoint_mainnet) or test(=stateful::sync::sync_to_mandatory_checkpoint_testnet)'
@@ -69,10 +73,6 @@ slow-timeout = { period = "1500m", terminate-after = 1 }
 [[profile.ci-stateful.overrides]]
 filter = 'test(=stateful::sync::sync_past_mandatory_checkpoint_mainnet) or test(=stateful::sync::sync_past_mandatory_checkpoint_testnet) or test(=stateful::rpc::rpc_get_block_from_cached_state) or test(=stateful::lightwalletd::lightwalletd_test_suite) or test(=stateful::lightwalletd::lwd_grpc_wallet)'
 slow-timeout = { period = "60m", terminate-after = 2 }
-
-[[profile.ci-stateful.overrides]]
-filter = 'test(=stateful::rpc::rpc_get_block_template) or test(=stateful::rpc::rpc_submit_block) or test(=stateful::rpc::fully_synced_rpc_z_getsubtreesbyindex_snapshot_test) or test(=stateful::indexer::has_spending_transaction_ids) or test(=stateful::sync::sync_update_mainnet) or test(=stateful::lightwalletd::lwd_sync_update) or test(=stateful::lightwalletd::lwd_rpc_send_tx)'
-slow-timeout = { period = "30m", terminate-after = 2 }
 
 # --- CI E2E Profile (GCP VMs) ---
 # CI selects specific tests via --filter-expr / NEXTEST_FILTER. The scoped
@@ -83,11 +83,15 @@ fail-fast = false
 failure-output = "immediate"
 success-output = "immediate"
 default-filter = 'test(/^e2e::/)'
+# Default hard timeout for e2e tests; longer-running tests override it below.
+slow-timeout = { period = "60m", terminate-after = 2 }
 
+# E2e tests share on-disk state, so run them serially. This override sets only
+# the test-group: adding slow-timeout here would shadow every per-test timeout
+# below, since nextest applies the first matching override per setting.
 [[profile.ci-e2e.overrides]]
 filter = 'test(/^e2e::/)'
 test-group = 'serial-state'
-slow-timeout = { period = "60m", terminate-after = 2 }
 
 [[profile.ci-e2e.overrides]]
 filter = 'test(=e2e::sync::sync_full_mainnet) or test(=e2e::lightwalletd::lwd_sync_full)'
@@ -100,10 +104,6 @@ slow-timeout = { period = "1500m", terminate-after = 1 }
 [[profile.ci-e2e.overrides]]
 filter = 'test(=e2e::checkpoints::generate_checkpoints_mainnet) or test(=e2e::checkpoints::generate_checkpoints_testnet)'
 slow-timeout = { period = "90m", terminate-after = 1 }
-
-[[profile.ci-e2e.overrides]]
-filter = 'test(=e2e::sync::sync_large_checkpoints_empty) or test(=e2e::sync::sync_large_checkpoints_mempool_mainnet)'
-slow-timeout = { period = "60m", terminate-after = 2 }
 
 # --- Special Profile ---
 


### PR DESCRIPTION
## Motivation

The `ci-stateful` and `ci-e2e` nextest profiles each open with a broad override that matches every test in the tier and assigns the `serial-state` group. That override also sets `slow-timeout`. nextest resolves each setting from the first override that matches a test, so this broad timeout shadows every per-test `slow-timeout` that follows it.

The result is one tier-wide hard timeout where specific tests were meant to run longer. `sync_past_mandatory_checkpoint` was killed at 60 minutes instead of 120 and timed out mid-sync. `sync_to_mandatory_checkpoint` (1500m) and the full-sync e2e tests (`sync_full_mainnet`, `sync_full_testnet`) lost their long budgets the same way. A recent scheduled run of `sync_past_mandatory_checkpoint` needed about 72 minutes and passed only because the budget was still 120; under the shadowed 60-minute kill it would have failed.

## Solution

Move the tier-wide timeout to a profile-level default and leave the broad override carrying only `test-group`. The per-test overrides become the first match for `slow-timeout` and apply as written; tests without a specific override fall back to the default. The two overrides whose values equalled the new default are removed.

### Tests

Confirmed nextest parses the updated profiles and accepts them (`cargo nextest list --profile ci-stateful`). The affected tests run on GCP, so the restored budgets are exercised by the scheduled integration pipeline.

### Follow-up Work

Restoring the budgets does not change why some runs take far longer than others. `sync_past_mandatory_checkpoint` ranges from about 20 minutes to over an hour; the slow tail comes from sync degradation near the mandatory checkpoint and is out of scope here.

### AI Disclosure

- [x] AI tools were used: Claude Code diagnosed the override shadowing and made the config change.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date (CI-only change; no changelog needed).
