### PR TITLE
fix(state): don't flush read-only secondary databases on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 - Opening a Zebra state read-only (for example, as a secondary instance over a
   running node's database) now fails with a clear error instead of panicking when
-  the cache directory is missing or unreadable, or when no database exists at the
-  configured path. The read-write open path is unchanged.
+  the cache directory is missing or unreadable, when no database exists at the
+  configured path, or when an ephemeral database is also configured (a read-only
+  secondary must not delete the primary's files). The read-write open path is
+  unchanged.
 
 ## [Zebra 5.2.0](https://github.com/ZcashFoundation/zebra/releases/tag/v5.2.0) - 2026-06-18
 

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -13,9 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of panicking when a read-only state cannot be opened: `FinalizedState::new`,
   `FinalizedState::new_with_debug`, `init_read_only`, `spawn_init_read_only`, and the
   lower-level `ZebraDb::new` / `DiskDb::new`. A read-only open against a missing or
-  unreadable cache directory, or with no existing database on disk, now returns the
-  new public `StateInitError` rather than panicking. The read-write open path is
-  unchanged.
+  unreadable cache directory, with no existing database on disk, or with an ephemeral
+  database also configured (a read-only secondary must not delete the primary's
+  files), now returns the new public `StateInitError` rather than panicking. The
+  read-write open path is unchanged.
   ([#10741](https://github.com/ZcashFoundation/zebra/pull/10741))
 - `ReadRequest::NonFinalizedBlocksListener` is now a struct variant carrying the
   caller's `known_chain_tips`, so the non-finalized blocks listener streams only the

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -82,6 +82,18 @@ pub enum StateInitError {
         /// The database path at which no database was found.
         path: PathBuf,
     },
+
+    /// A read-only state was requested together with an ephemeral database.
+    ///
+    /// A read-only secondary follows another process's primary database and must
+    /// never delete it, whereas an ephemeral database deletes its files on drop. The
+    /// two are mutually exclusive, so requesting both is a fatal configuration error.
+    #[error(
+        "cannot open read-only state: an ephemeral database was also requested. \
+         Hint: a read-only state follows an existing Zebra node's database and must not \
+         delete it; set `ephemeral = false`, or do not request a read-only state"
+    )]
+    ReadOnlyEphemeralConflict,
 }
 
 /// An error describing why a block could not be queued to be committed to the state.

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -88,10 +88,9 @@ pub struct DiskDb {
     /// The configured network for this database.
     network: Network,
 
-    /// The configured temporary database setting.
-    ///
-    /// If true, the database files are deleted on drop.
-    ephemeral: bool,
+    /// How this database was opened: a read-write primary (persistent or ephemeral)
+    /// or a read-only secondary. See [`DbMode`].
+    mode: DbMode,
 
     /// A boolean flag indicating whether the db format change task has finished
     /// applying any format changes that may have been required.
@@ -380,6 +379,38 @@ pub trait ReadDisk {
         R: RangeBounds<K>;
 }
 
+/// How a [`DiskDb`] instance is opened.
+///
+/// These modes are mutually exclusive — an ephemeral database is a read-write primary
+/// this process owns and deletes on drop, a persistent database is a read-write primary
+/// whose files are kept, and a read-only secondary follows another process's primary and
+/// never writes, flushes, or deletes it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DbMode {
+    /// A read-write primary backed by persistent on-disk files that are kept on drop.
+    Persistent,
+
+    /// A read-write primary backed by temporary files that are deleted on drop.
+    Ephemeral,
+
+    /// A read-only secondary that follows an existing primary's on-disk state. It owns
+    /// no files and never writes, flushes, or deletes them.
+    ReadOnlySecondary,
+}
+
+impl DbMode {
+    /// Returns true if dropping the database should delete its files.
+    fn deletes_files_on_drop(self) -> bool {
+        matches!(self, DbMode::Ephemeral)
+    }
+
+    /// Returns true if this is a read-only secondary instance, which RocksDB does not
+    /// allow writes or flushes on.
+    fn is_read_only(self) -> bool {
+        matches!(self, DbMode::ReadOnlySecondary)
+    }
+}
+
 impl PartialEq for DiskDb {
     fn eq(&self, other: &Self) -> bool {
         if self.db.path() == other.db.path() {
@@ -388,7 +419,8 @@ impl PartialEq for DiskDb {
                 "database with same path but different network configs",
             );
             assert_eq!(
-                self.ephemeral, other.ephemeral,
+                self.mode.deletes_files_on_drop(),
+                other.mode.deletes_files_on_drop(),
                 "database with same path but different ephemeral configs",
             );
 
@@ -981,6 +1013,19 @@ impl DiskDb {
         column_families_in_code: impl IntoIterator<Item = String>,
         read_only: bool,
     ) -> Result<DiskDb, StateInitError> {
+        // `ephemeral` and `read_only` describe mutually-exclusive modes: an ephemeral
+        // database is a read-write primary this process owns and deletes on drop, while
+        // a read-only secondary follows another process's primary and must never delete
+        // it. Combining them is a configuration error — it would delete the primary's
+        // files on drop — so reject it here rather than silently coercing it (a check
+        // that must hold in release builds, not just debug).
+        let mode = match (read_only, config.ephemeral) {
+            (true, true) => return Err(StateInitError::ReadOnlyEphemeralConflict),
+            (true, false) => DbMode::ReadOnlySecondary,
+            (false, true) => DbMode::Ephemeral,
+            (false, false) => DbMode::Persistent,
+        };
+
         // If the database is ephemeral, we don't need to check the cache directory.
         if !config.ephemeral {
             if read_only {
@@ -1031,7 +1076,7 @@ impl DiskDb {
                     db_kind: db_kind.to_string(),
                     format_version_in_code: format_version_in_code.clone(),
                     network: network.clone(),
-                    ephemeral: config.ephemeral,
+                    mode,
                     db: Arc::new(db),
                     finished_format_upgrades: Arc::new(AtomicBool::new(false)),
                 };
@@ -1450,7 +1495,7 @@ impl DiskDb {
             let mut ephemeral_note = "";
 
             if force {
-                if self.ephemeral {
+                if self.mode.deletes_files_on_drop() {
                     ephemeral_note = " and removing ephemeral files";
                 }
 
@@ -1468,7 +1513,7 @@ impl DiskDb {
                     ephemeral_note,
                 );
             } else {
-                if self.ephemeral {
+                if self.mode.deletes_files_on_drop() {
                     ephemeral_note = " and files";
                 }
 
@@ -1493,39 +1538,42 @@ impl DiskDb {
         let path = self.path();
         debug!(?path, "flushing database to disk");
 
-        // These flushes can fail during forced shutdown or during Drop after a shutdown,
-        // particularly in tests. If they fail, there's nothing we can do about it anyway.
-        if let Err(error) = self.db.flush() {
-            let error = format!("{error:?}");
-            if error.to_ascii_lowercase().contains("shutdown in progress") {
-                debug!(
-                    ?error,
-                    ?path,
-                    "expected shutdown error flushing database SST files to disk"
-                );
-            } else {
-                info!(
-                    ?error,
-                    ?path,
-                    "unexpected error flushing database SST files to disk during shutdown"
-                );
+        // A read-only secondary instance has nothing to flush, and RocksDB rejects
+        // `flush()`/`flush_wal()` on secondaries with "Not supported operation in
+        // secondary mode". Only a read-write primary needs flushing on shutdown.
+        if !self.mode.is_read_only() {
+            // These flushes can fail during forced shutdown or during Drop after a shutdown,
+            // particularly in tests. If they fail, there's nothing we can do about it anyway.
+            if let Err(error) = self.db.flush() {
+                if matches!(error.kind(), ErrorKind::ShutdownInProgress) {
+                    debug!(
+                        ?error,
+                        ?path,
+                        "expected shutdown error flushing database SST files to disk"
+                    );
+                } else {
+                    info!(
+                        ?error,
+                        ?path,
+                        "unexpected error flushing database SST files to disk during shutdown"
+                    );
+                }
             }
-        }
 
-        if let Err(error) = self.db.flush_wal(true) {
-            let error = format!("{error:?}");
-            if error.to_ascii_lowercase().contains("shutdown in progress") {
-                debug!(
-                    ?error,
-                    ?path,
-                    "expected shutdown error flushing database WAL buffer to disk"
-                );
-            } else {
-                info!(
-                    ?error,
-                    ?path,
-                    "unexpected error flushing database WAL buffer to disk during shutdown"
-                );
+            if let Err(error) = self.db.flush_wal(true) {
+                if matches!(error.kind(), ErrorKind::ShutdownInProgress) {
+                    debug!(
+                        ?error,
+                        ?path,
+                        "expected shutdown error flushing database WAL buffer to disk"
+                    );
+                } else {
+                    info!(
+                        ?error,
+                        ?path,
+                        "unexpected error flushing database WAL buffer to disk during shutdown"
+                    );
+                }
             }
         }
 
@@ -1610,7 +1658,7 @@ impl DiskDb {
         // This function and all functions that it calls should avoid cloning the shared database
         // instance. See `shutdown()` for details.
 
-        if !self.ephemeral {
+        if !self.mode.deletes_files_on_drop() {
             return;
         }
 

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -658,3 +658,25 @@ fn read_only_open_with_unreadable_cache_dir_returns_error() {
         }
     }
 }
+
+/// Opening a read-only state with an ephemeral database configured must fail with
+/// [`StateInitError::ReadOnlyEphemeralConflict`]: a read-only secondary follows another
+/// process's primary database and must never delete it, so it cannot also be ephemeral
+/// (which would delete the primary's files on drop).
+#[test]
+fn read_only_open_with_ephemeral_config_returns_error() {
+    let network = Network::Mainnet;
+
+    let config = Config {
+        ephemeral: true,
+        ..Config::default()
+    };
+
+    match super::init_read_only(config, &network) {
+        Err(crate::StateInitError::ReadOnlyEphemeralConflict) => {}
+        Err(other) => panic!("expected ReadOnlyEphemeralConflict, got: {other:?}"),
+        Ok(_) => {
+            panic!("expected an error when opening a read-only state with an ephemeral config")
+        }
+    }
+}


### PR DESCRIPTION
## Motivation
A read-only secondary RocksDB instance has nothing to flush, and RocksDB rejects `flush()`/`flush_wal()` on secondaries with "Not supported operation in secondary mode". `DiskDb::shutdown` logged those benign failures at INFO as "unexpected error flushing database ... during shutdown".

## Solution
Model the database open mode as a `DbMode` enum (`Persistent`, `Ephemeral`, `ReadOnlySecondary`) instead of separate `ephemeral`/`read_only` flags, making the nonsensical "ephemeral read-only secondary" state -- which would delete the primary's files on drop -- unrepresentable internally. `DiskDb::new` rejects that flag combination with a `StateInitError::ReadOnlyEphemeralConflict` (a real error, enforced in release builds, not a debug assertion), and shutdown skips flushing a secondary. The existing file-deletion behaviour is preserved for every valid mode.

While here, match the expected RocksDB shutdown error by `ErrorKind::ShutdownInProgress` rather than by substring, consistent with the existing `e.kind()` check at the database open site.


<!-- Describe the changes in the PR. -->

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
-->

### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [ ] No AI tools were used in this PR
- [x] AI tools were used: <!-- tool name and what it was used for, e.g., "Claude for test boilerplate" -->

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
