### PR TITLE
fix(rpc): improve non_finalized_state_change buffer sizing and add regression test

### DIFF
--- a/zebra-rpc/src/indexer/methods.rs
+++ b/zebra-rpc/src/indexer/methods.rs
@@ -20,18 +20,18 @@ use super::{
     MempoolChangeMessage,
 };
 
-/// The maximum number of messages that can be queued to be streamed to a client.
+/// Buffer size for `chain_tip_change` and `mempool_change` streams, which emit incrementally.
+const RESPONSE_BUFFER_SIZE: usize = 64;
+
+/// Buffer size for the `non_finalized_state_change` stream.
 ///
-/// Sized to hold the entire non-finalized state, because `non_finalized_state_change`
-/// bursts every non-finalized block to each new subscriber on subscribe: up to
-/// 2 chains of up to `MAX_BLOCK_REORG_HEIGHT` blocks each
-/// (forks re-emit their shared prefix). If this buffer is smaller than that burst, a
-/// subscriber near the tip can never assemble the full non-finalized state within one
-/// subscription, which livelocks consumers like `TrustedChainSync`. Derived from the
-/// state constants so it can't silently go stale if the reorg limit changes.
-const RESPONSE_BUFFER_SIZE: usize =
-    // `MAX_BLOCK_REORG_HEIGHT` is a small compile-time constant that always fits `usize`.
-    2 * MAX_BLOCK_REORG_HEIGHT as usize;
+/// On subscribe, `NonFinalizedBlocksListener` bursts every block from every non-finalized
+/// chain (`chain_iter()` can return up to `MAX_NON_FINALIZED_CHAIN_FORKS` chains of
+/// `MAX_BLOCK_REORG_HEIGHT` blocks, with forks re-emitting their shared prefix).
+/// Backpressure (`send().await`) handles transient overflow, but sizing the buffer to
+/// fit the burst avoids blocking the listener task.
+const NON_FINALIZED_STATE_CHANGE_BUFFER_SIZE: usize =
+    MAX_NON_FINALIZED_CHAIN_FORKS * MAX_BLOCK_REORG_HEIGHT as usize;
 
 #[tonic::async_trait]
 impl<ReadStateService, Tip> Indexer for IndexerRPC<ReadStateService, Tip>
@@ -100,7 +100,8 @@ where
     ) -> Result<Response<Self::NonFinalizedStateChangeStream>, Status> {
         let span = Span::current();
         let read_state = self.read_state.clone();
-        let (response_sender, response_receiver) = tokio::sync::mpsc::channel(RESPONSE_BUFFER_SIZE);
+        let (response_sender, response_receiver) =
+            tokio::sync::mpsc::channel(NON_FINALIZED_STATE_CHANGE_BUFFER_SIZE);
         let response_stream = ReceiverStream::new(response_receiver);
 
         tokio::spawn(async move {

--- a/zebra-rpc/src/indexer/tests/vectors.rs
+++ b/zebra-rpc/src/indexer/tests/vectors.rs
@@ -1,16 +1,18 @@
 //! Fixed test vectors for indexer RPCs
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use futures::StreamExt;
 use tokio::{sync::broadcast, task::JoinHandle};
 use tower::BoxError;
 use zebra_chain::{
-    block::Height,
+    block::{self, Block, Height},
     chain_tip::mock::{MockChainTip, MockChainTipSender},
+    serialization::ZcashDeserializeInto,
     transaction::{self, UnminedTxId},
 };
 use zebra_node_services::mempool::{MempoolChange, MempoolTxSubscriber};
+use zebra_state::{NonFinalizedBlocksListener, ReadRequest, ReadResponse};
 use zebra_test::{
     mock_service::MockService,
     prelude::color_eyre::{eyre::eyre, Result},
@@ -73,6 +75,83 @@ async fn test_mempool_change(
         .expect("response stream should not be empty")
         .expect("chain tip change response should not be an error message");
 
+    Ok(())
+}
+
+/// Verify that `non_finalized_state_change` can deliver more than 64 blocks without
+/// dropping the stream (regression test for #10728).
+#[tokio::test]
+async fn non_finalized_state_change_delivers_burst() -> Result<()> {
+    let _init_guard = zebra_test::init();
+
+    const BLOCK_COUNT: usize = 100;
+
+    let listen_addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let mut mock_read_service = MockService::build()
+        .with_max_request_delay(Duration::from_secs(2))
+        .for_unit_tests();
+    let (mock_chain_tip, _mock_chain_tip_sender) = MockChainTip::new();
+    let (mempool_tx_sender, _) = tokio::sync::broadcast::channel(1);
+    let mempool_tx_subscriber = MempoolTxSubscriber::new(mempool_tx_sender);
+
+    let (server_task, listen_addr) = indexer::server::init(
+        listen_addr,
+        mock_read_service.clone(),
+        mock_chain_tip,
+        mempool_tx_subscriber,
+    )
+    .await
+    .map_err(|err| eyre!(err))?;
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let endpoint = tonic::transport::channel::Endpoint::new(format!("http://{listen_addr}"))
+        .unwrap()
+        .timeout(Duration::from_secs(10));
+    let mut client = IndexerClient::connect(endpoint).await.unwrap();
+
+    // Pre-load a channel with BLOCK_COUNT fake blocks.
+    let (sender, receiver) = tokio::sync::mpsc::channel(BLOCK_COUNT);
+    let block: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
+        .zcash_deserialize_into()
+        .unwrap();
+
+    for i in 0..BLOCK_COUNT {
+        let hash = block::Hash([i as u8; 32]);
+        sender.send((hash, block.clone())).await.unwrap();
+    }
+    drop(sender);
+
+    let listener = NonFinalizedBlocksListener(Arc::new(receiver));
+
+    // Spawn request so MockService can respond.
+    let stream_handle = tokio::spawn(async move {
+        let request = tonic::Request::new(Empty {});
+        client.non_finalized_state_change(request).await
+    });
+
+    // Respond with our pre-loaded listener.
+    mock_read_service
+        .expect_request(ReadRequest::NonFinalizedBlocksListener)
+        .await
+        .respond(ReadResponse::NonFinalizedBlocksListener(listener));
+
+    let response = stream_handle.await.unwrap().unwrap();
+    let mut stream = response.into_inner();
+    let mut received = 0;
+    while let Some(Ok(_)) = tokio::time::timeout(Duration::from_secs(5), stream.next())
+        .await
+        .unwrap_or(None)
+    {
+        received += 1;
+    }
+
+    assert_eq!(
+        received, BLOCK_COUNT,
+        "stream should deliver all {BLOCK_COUNT} blocks without dropping"
+    );
+
+    drop(server_task);
     Ok(())
 }
 


### PR DESCRIPTION
Follow-up to #10743.

- Split `RESPONSE_BUFFER_SIZE` into two constants: keep 64 for `chain_tip_change` and `mempool_change` (incremental streams), use `MAX_NON_FINALIZED_CHAIN_FORKS * MAX_BLOCK_REORG_HEIGHT` for `non_finalized_state_change` (burst stream).
- Add `non_finalized_state_change_delivers_burst` test that pumps 100 blocks through the stream and verifies all arrive (regression test for #10728).