### PR TITLE
feat: read-state bootstrap for co-located ephemeral/Regtest followers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   consumer's known chain tips instead of re-streaming the whole non-finalized state,
   and a new `GetBlock` indexer method lets the consumer fetch blocks it is missing
   while its finalized state catches up.
+- New `zebra-state` read request `ReadRequest::FindForkPoint` (with response
+  `ReadResponse::ForkPoint`) that returns the most recent block in a caller-supplied
+  locator that is on the best chain — the fork point — for clients tracking chain
+  reorganizations through a read-only state service.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 - Opening a Zebra state read-only (for example, as a secondary instance over a
   running node's database) now fails with a clear error instead of panicking when
-  the cache directory is missing or unreadable, or when no database exists at the
-  configured path. The read-write open path is unchanged.
+  the cache directory is missing or unreadable, when no database exists at the
+  configured path, or when an ephemeral database is also configured (a read-only
+  secondary must not delete the primary's files). The read-write open path is
+  unchanged.
 
 ## [Zebra 5.2.0](https://github.com/ZcashFoundation/zebra/releases/tag/v5.2.0) - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   `ReadResponse::ForkPoint`) that returns the most recent block in a caller-supplied
   locator that is on the best chain — the fork point — for clients tracking chain
   reorganizations through a read-only state service.
+- New `getreadstateinfo` JSON-RPC method that reports a node's live state database
+  path, indexer gRPC address, database format version, and network (including Regtest
+  activation heights), so a co-located read-state follower can bootstrap a read-only
+  secondary — including against an ephemeral or Regtest node — instead of
+  hand-configuring those values.
 
 ### Changed
 

--- a/zebra-rpc/src/lib.rs
+++ b/zebra-rpc/src/lib.rs
@@ -17,5 +17,6 @@ mod tests;
 
 pub use methods::types::{
     get_block_template::{fetch_chain_info, proposal::proposal_block_from_template, MinerParams},
+    get_read_state_info::{GetReadStateInfo, ReadStateNetworkInfo},
     submit_block::SubmitBlockChannel,
 };

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -763,6 +763,13 @@ pub trait Rpc {
         n: u32,
         include_mempool: Option<bool>,
     ) -> Result<GetTxOutResponse>;
+
+    /// Returns the information a co-located read-state follower needs to open a read-only
+    /// secondary of this node's state and follow its non-finalized chain.
+    ///
+    /// zebra-only; not a zcashd-compatible method.
+    #[method(name = "getreadstateinfo")]
+    async fn get_read_state_info(&self) -> Result<types::get_read_state_info::GetReadStateInfo>;
 }
 
 /// RPC method implementations.
@@ -787,6 +794,10 @@ where
 
     /// The configured network for this RPC service.
     network: Network,
+
+    /// The node's indexer gRPC listen address, reported to read-state followers. `None`
+    /// when the indexer is not configured.
+    indexer_grpc_addr: Option<std::net::SocketAddr>,
 
     /// Test-only option that makes Zebra say it is at the chain tip,
     /// no matter what the estimated height or local clock is.
@@ -878,6 +889,7 @@ where
         address_book: AddressBook,
         last_warn_error_log_rx: LoggedLastEvent,
         mined_block_sender: Option<mpsc::Sender<(block::Hash, block::Height)>>,
+        indexer_grpc_addr: Option<std::net::SocketAddr>,
     ) -> (Self, JoinHandle<()>)
     where
         VersionString: ToString + Clone + Send + 'static,
@@ -905,6 +917,7 @@ where
             build_version,
             user_agent,
             network: network.clone(),
+            indexer_grpc_addr,
             debug_force_finished_sync,
             mempool: mempool.clone(),
             state: state.clone(),
@@ -3170,6 +3183,34 @@ where
             zebra_state::ReadResponse::Transaction(None) => Ok(GetTxOutResponse(None)),
             _ => unreachable!("unmatched response to a `Transaction` request"),
         }
+    }
+
+    async fn get_read_state_info(&self) -> Result<types::get_read_state_info::GetReadStateInfo> {
+        use types::get_read_state_info::{network_info, GetReadStateInfo};
+
+        let response = self
+            .read_state
+            .clone()
+            .oneshot(zebra_state::ReadRequest::StateDbInfo)
+            .await
+            .map_misc_error()?;
+
+        let zebra_state::ReadResponse::StateDbInfo {
+            path,
+            format_version,
+            db_kind,
+        } = response
+        else {
+            unreachable!("unexpected response to StateDbInfo request: {response:?}")
+        };
+
+        Ok(GetReadStateInfo::new(
+            self.indexer_grpc_addr.map(|addr| addr.to_string()),
+            path.display().to_string(),
+            format_version.to_string(),
+            db_kind,
+            network_info(&self.network),
+        ))
     }
 }
 

--- a/zebra-rpc/src/methods/tests/prop.rs
+++ b/zebra-rpc/src/methods/tests/prop.rs
@@ -1004,6 +1004,7 @@ where
         MockAddressBookPeers::default(),
         rx,
         None,
+        None,
     );
 
     (mempool, read_state, rpc, mempool_tx_queue)

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -157,6 +157,7 @@ async fn test_z_get_treestate() {
         MockAddressBookPeers::default(),
         rx,
         None,
+        None,
     );
 
     // Request the treestate by a hash.
@@ -261,6 +262,7 @@ async fn test_rpc_response_data_for_network(network: &Network) {
         tip,
         MockAddressBookPeers::default(),
         rx,
+        None,
         None,
     );
 
@@ -636,6 +638,7 @@ async fn test_mocked_rpc_response_data_for_network(network: &Network) {
         latest_chain_tip,
         MockAddressBookPeers::default(),
         rx,
+        None,
         None,
     );
 
@@ -1076,6 +1079,7 @@ pub async fn test_mining_rpcs<State, ReadState>(
         mock_address_book,
         rx.clone(),
         None,
+        None,
     );
 
     if network.is_a_test_network() && !network.is_default_testnet() {
@@ -1222,6 +1226,7 @@ pub async fn test_mining_rpcs<State, ReadState>(
         MockAddressBookPeers::default(),
         rx.clone(),
         None,
+        None,
     );
 
     // Basic variant (default mode and no extra features)
@@ -1338,6 +1343,7 @@ pub async fn test_mining_rpcs<State, ReadState>(
         mock_tip,
         MockAddressBookPeers::default(),
         rx,
+        None,
         None,
     );
 

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -75,6 +75,7 @@ async fn rpc_getinfo() {
         MockAddressBookPeers::default(),
         rx,
         None,
+        None,
     );
 
     let getinfo_future = tokio::spawn(async move { rpc.get_info().await });
@@ -222,6 +223,7 @@ async fn rpc_getblock() {
         tip,
         MockAddressBookPeers::default(),
         rx,
+        None,
         None,
     );
 
@@ -744,6 +746,7 @@ async fn rpc_getblock_parse_error() {
         MockAddressBookPeers::default(),
         rx,
         None,
+        None,
     );
 
     // Make sure we get an error if Zebra can't parse the block height.
@@ -793,6 +796,7 @@ async fn rpc_getblock_missing_error() {
         NoChainTip,
         MockAddressBookPeers::default(),
         rx,
+        None,
         None,
     );
 
@@ -860,6 +864,7 @@ async fn rpc_getblockheader() {
         tip,
         MockAddressBookPeers::default(),
         rx,
+        None,
         None,
     );
 
@@ -994,6 +999,7 @@ async fn rpc_getbestblockhash() {
         MockAddressBookPeers::default(),
         rx,
         None,
+        None,
     );
 
     // Get the tip hash using RPC method `get_best_block_hash`
@@ -1044,6 +1050,7 @@ async fn rpc_getrawtransaction() {
         tip,
         MockAddressBookPeers::default(),
         rx,
+        None,
         None,
     );
 
@@ -1231,6 +1238,7 @@ async fn rpc_getaddresstxids_invalid_arguments() {
         tip,
         MockAddressBookPeers::default(),
         rx,
+        None,
         None,
     );
 
@@ -1422,6 +1430,7 @@ async fn rpc_getaddresstxids_response_with(
         MockAddressBookPeers::default(),
         rx,
         None,
+        None,
     );
 
     // call the method with valid arguments
@@ -1497,6 +1506,7 @@ async fn getaddresstxids_single_equals_object_full_range() {
         MockAddressBookPeers::default(),
         rx,
         None,
+        None,
     );
 
     let addr_str = address.to_string();
@@ -1549,6 +1559,7 @@ async fn rpc_getaddressutxos_invalid_arguments() {
         NoChainTip,
         MockAddressBookPeers::default(),
         rx,
+        None,
         None,
     );
 
@@ -1608,6 +1619,7 @@ async fn rpc_getaddressutxos_response() {
         tip,
         MockAddressBookPeers::default(),
         rx,
+        None,
         None,
     );
 
@@ -1702,6 +1714,7 @@ async fn rpc_getblockcount() {
         MockAddressBookPeers::default(),
         rx,
         None,
+        None,
     );
 
     // Get the tip height using RPC method `get_block_count`
@@ -1745,6 +1758,7 @@ async fn rpc_getblockcount_empty_state() {
         tip.clone(),
         MockAddressBookPeers::default(),
         rx,
+        None,
         None,
     );
 
@@ -1848,6 +1862,7 @@ async fn rpc_getpeerinfo() {
         mock_address_book,
         rx,
         None,
+        None,
     );
 
     // Call `get_peer_info`
@@ -1916,6 +1931,7 @@ async fn rpc_getblockhash() {
         MockAddressBookPeers::default(),
         rx,
         None,
+        None,
     );
 
     // Query the hashes using positive indexes
@@ -1974,6 +1990,7 @@ async fn rpc_getmininginfo() {
         MockAddressBookPeers::default(),
         rx,
         None,
+        None,
     );
 
     rpc.get_mining_info()
@@ -2010,6 +2027,7 @@ async fn rpc_getnetworksolps() {
         tip.clone(),
         MockAddressBookPeers::default(),
         rx,
+        None,
         None,
     );
 
@@ -2117,6 +2135,7 @@ async fn gbt_with(net: Network, addr: ZcashAddress) {
         mock_tip,
         MockAddressBookPeers::default(),
         rx,
+        None,
         None,
     );
 
@@ -2406,6 +2425,7 @@ async fn rpc_submitblock_errors() {
         MockAddressBookPeers::default(),
         rx,
         None,
+        None,
     );
 
     // Try to submit pre-populated blocks and assert that it responds with duplicate.
@@ -2454,6 +2474,7 @@ async fn rpc_validateaddress() {
         NoChainTip,
         MockAddressBookPeers::default(),
         rx,
+        None,
         None,
     );
 
@@ -2541,6 +2562,7 @@ async fn rpc_validateaddress_regtest() {
         MockAddressBookPeers::default(),
         rx,
         None,
+        None,
     );
 
     // t1 address: invalid
@@ -2599,6 +2621,7 @@ async fn rpc_z_validateaddress() {
         NoChainTip,
         MockAddressBookPeers::default(),
         rx,
+        None,
         None,
     );
 
@@ -2709,6 +2732,7 @@ async fn rpc_z_validateaddress_regtest() {
         MockAddressBookPeers::default(),
         rx,
         None,
+        None,
     );
 
     // tm address (P2PKH): valid
@@ -2809,6 +2833,7 @@ async fn rpc_getdifficulty() {
         mock_tip,
         MockAddressBookPeers::default(),
         rx,
+        None,
         None,
     );
 
@@ -2930,6 +2955,7 @@ async fn rpc_z_listunifiedreceivers() {
         MockAddressBookPeers::default(),
         rx,
         None,
+        None,
     );
 
     // invalid address
@@ -3023,6 +3049,7 @@ async fn rpc_z_listunifiedreceivers_rejects_bad_sapling_receiver() {
         MockAddressBookPeers::default(),
         rx,
         None,
+        None,
     );
 
     let result = rpc.z_list_unified_receivers(encoded).await;
@@ -3071,6 +3098,7 @@ async fn rpc_addnode() {
         tip.clone(),
         mock_address_book,
         rx,
+        None,
         None,
     );
 
@@ -3140,6 +3168,7 @@ async fn rpc_gettxout() {
         MockAddressBookPeers::default(),
         rx,
         None,
+        None,
     );
 
     // TODO: Create a mempool test
@@ -3189,4 +3218,47 @@ async fn rpc_gettxout() {
     // The queue task should continue without errors or panics
     let rpc_tx_queue_task_result = rpc_tx_queue.now_or_never();
     assert!(rpc_tx_queue_task_result.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_read_state_info_reports_state_and_network() {
+    let _init_guard = zebra_test::init();
+
+    let network = Network::new_regtest(Default::default());
+    let (state, read_state, tip, _) = zebra_state::init_test_services(&network).await;
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, _queue) = RpcImpl::new(
+        network,
+        Default::default(),
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(MockService::build().for_unit_tests::<_, _, BoxError>(), 1),
+        Buffer::new(state, 1),
+        Buffer::new(read_state, 1),
+        MockService::build().for_unit_tests(),
+        MockSyncStatus::default(),
+        tip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+        None,
+    );
+
+    let info = rpc
+        .get_read_state_info()
+        .await
+        .expect("getreadstateinfo should succeed");
+
+    assert_eq!(info.network().kind(), "Regtest");
+    assert!(
+        info.network().regtest_activation_heights().is_some(),
+        "Regtest should always have activation heights"
+    );
+    assert_eq!(info.db_kind(), "state");
+    assert!(
+        !info.state_db_path().is_empty(),
+        "state_db_path should not be empty"
+    );
 }

--- a/zebra-rpc/src/methods/types.rs
+++ b/zebra-rpc/src/methods/types.rs
@@ -6,6 +6,7 @@ pub mod get_blockchain_info;
 pub mod get_mempool_info;
 pub mod get_mining_info;
 pub mod get_raw_mempool;
+pub mod get_read_state_info;
 pub mod long_poll;
 pub mod network_info;
 pub mod peer_info;

--- a/zebra-rpc/src/methods/types/get_read_state_info.rs
+++ b/zebra-rpc/src/methods/types/get_read_state_info.rs
@@ -16,8 +16,12 @@ pub struct ReadStateNetworkInfo {
     /// The network's genesis block hash, in display order.
     genesis_hash: String,
     /// Configured network-upgrade activation heights. Present only for Regtest, where the
-    /// follower must reconstruct them; absent for Mainnet/Testnet, whose heights are fixed
-    /// by the network kind.
+    /// follower must reconstruct them; absent for Mainnet and the default Testnet, whose
+    /// heights are fixed by the network kind.
+    ///
+    /// Note: a *custom* (non-default) Testnet is not supported here — its heights are not
+    /// reported, so a follower would reconstruct the default public Testnet instead. Only
+    /// Mainnet, the default Testnet, and Regtest are supported for bootstrap.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     regtest_activation_heights: Option<ConfiguredActivationHeights>,
 }
@@ -28,6 +32,9 @@ pub struct ReadStateNetworkInfo {
 #[serde(rename_all = "camelCase")]
 pub struct GetReadStateInfo {
     /// The node's indexer gRPC listen address, or `None` if the indexer is not enabled.
+    ///
+    /// This reflects the operator's configured `indexer_listen_addr` and may be a public
+    /// bind address; treat it as you would the indexer port itself.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     indexer_grpc_addr: Option<String>,
     /// The live on-disk path of the node's finalized-state database.
@@ -51,6 +58,10 @@ pub fn network_info(network: &Network) -> ReadStateNetworkInfo {
     .to_string();
 
     let regtest_activation_heights = network.is_regtest().then(|| {
+        // The *effective* activation height of each upgrade: an unconfigured upgrade
+        // reports its successor's height (`activation_height` falls through), so the
+        // heights are monotonic. Feeding them back through `Network::new_regtest`
+        // reproduces the same `activation_list`, so this extraction is lossless.
         let h = |nu: NetworkUpgrade| nu.activation_height(network).map(|height| height.0);
         // `..Default::default()` covers the cfg-gated `zfuture` field without a cfg here.
         #[allow(clippy::needless_update)]

--- a/zebra-rpc/src/methods/types/get_read_state_info.rs
+++ b/zebra-rpc/src/methods/types/get_read_state_info.rs
@@ -1,0 +1,78 @@
+//! Types used in the `getreadstateinfo` RPC method.
+
+use derive_getters::Getters;
+use derive_new::new;
+
+use zebra_chain::parameters::{
+    testnet::ConfiguredActivationHeights, Network, NetworkKind, NetworkUpgrade,
+};
+
+/// Network identity reported to a co-located read-state follower.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, Getters, new)]
+#[serde(rename_all = "camelCase")]
+pub struct ReadStateNetworkInfo {
+    /// `"Mainnet"`, `"Testnet"`, or `"Regtest"`.
+    kind: String,
+    /// The network's genesis block hash, in display order.
+    genesis_hash: String,
+    /// Configured network-upgrade activation heights. Present only for Regtest, where the
+    /// follower must reconstruct them; absent for Mainnet/Testnet, whose heights are fixed
+    /// by the network kind.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    regtest_activation_heights: Option<ConfiguredActivationHeights>,
+}
+
+/// The response to a `getreadstateinfo` request: everything a co-located follower needs to
+/// open a read-only secondary of this node's state and follow its non-finalized chain.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, Getters, new)]
+#[serde(rename_all = "camelCase")]
+pub struct GetReadStateInfo {
+    /// The node's indexer gRPC listen address, or `None` if the indexer is not enabled.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    indexer_grpc_addr: Option<String>,
+    /// The live on-disk path of the node's finalized-state database.
+    state_db_path: String,
+    /// The database format version of the running node.
+    db_format_version: String,
+    /// The database kind (e.g. `"state"`).
+    db_kind: String,
+    /// The node's network identity.
+    network: ReadStateNetworkInfo,
+}
+
+/// Builds the reported network identity from a [`Network`], including Regtest activation
+/// heights when applicable.
+pub fn network_info(network: &Network) -> ReadStateNetworkInfo {
+    let kind = match network.kind() {
+        NetworkKind::Mainnet => "Mainnet",
+        NetworkKind::Testnet => "Testnet",
+        NetworkKind::Regtest => "Regtest",
+    }
+    .to_string();
+
+    let regtest_activation_heights = network.is_regtest().then(|| {
+        let h = |nu: NetworkUpgrade| nu.activation_height(network).map(|height| height.0);
+        // `..Default::default()` covers the cfg-gated `zfuture` field without a cfg here.
+        #[allow(clippy::needless_update)]
+        ConfiguredActivationHeights {
+            before_overwinter: h(NetworkUpgrade::BeforeOverwinter),
+            overwinter: h(NetworkUpgrade::Overwinter),
+            sapling: h(NetworkUpgrade::Sapling),
+            blossom: h(NetworkUpgrade::Blossom),
+            heartwood: h(NetworkUpgrade::Heartwood),
+            canopy: h(NetworkUpgrade::Canopy),
+            nu5: h(NetworkUpgrade::Nu5),
+            nu6: h(NetworkUpgrade::Nu6),
+            nu6_1: h(NetworkUpgrade::Nu6_1),
+            nu6_2: h(NetworkUpgrade::Nu6_2),
+            nu7: h(NetworkUpgrade::Nu7),
+            ..Default::default()
+        }
+    });
+
+    ReadStateNetworkInfo::new(
+        kind,
+        network.genesis_hash().to_string(),
+        regtest_activation_heights,
+    )
+}

--- a/zebra-rpc/src/server/tests/vectors.rs
+++ b/zebra-rpc/src/server/tests/vectors.rs
@@ -64,6 +64,7 @@ async fn rpc_server_spawn() {
         MockAddressBookPeers::default(),
         rx,
         None,
+        None,
     );
 
     RpcServer::start(rpc_impl, conf)
@@ -133,6 +134,7 @@ async fn rpc_spawn_unallocated_port(do_shutdown: bool) {
         MockAddressBookPeers::default(),
         rx,
         None,
+        None,
     );
 
     let rpc = RpcServer::start(rpc_impl, conf)
@@ -189,6 +191,7 @@ async fn rpc_server_spawn_port_conflict() {
         NoChainTip,
         MockAddressBookPeers::default(),
         rx.clone(),
+        None,
         None,
     );
 

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `ReadRequest::StateDbInfo` (response `ReadResponse::StateDbInfo`) reporting the
+  live finalized-state database path, running format version, and kind — usable to
+  bootstrap a read-only secondary against a database whose path cannot be derived from
+  config (for example, an ephemeral primary).
+- A read-only state can now be opened at an explicit on-disk path via the new
+  `Config::read_only_db_path`, overriding the `cache_dir`-derived path so a follower can
+  tail an ephemeral primary's randomly-located database.
+
 ### Breaking Changes
 
 - The finalized-state open functions now return `Result<_, StateInitError>` instead

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -13,9 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of panicking when a read-only state cannot be opened: `FinalizedState::new`,
   `FinalizedState::new_with_debug`, `init_read_only`, `spawn_init_read_only`, and the
   lower-level `ZebraDb::new` / `DiskDb::new`. A read-only open against a missing or
-  unreadable cache directory, or with no existing database on disk, now returns the
-  new public `StateInitError` rather than panicking. The read-write open path is
-  unchanged.
+  unreadable cache directory, with no existing database on disk, or with an ephemeral
+  database also configured (a read-only secondary must not delete the primary's
+  files), now returns the new public `StateInitError` rather than panicking. The
+  read-write open path is unchanged.
   ([#10741](https://github.com/ZcashFoundation/zebra/pull/10741))
 - `ReadRequest::NonFinalizedBlocksListener` is now a struct variant carrying the
   caller's `known_chain_tips`, so the non-finalized blocks listener streams only the

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -138,6 +138,16 @@ pub struct Config {
     #[cfg(feature = "elasticsearch")]
     /// The elasticsearch database password.
     pub elasticsearch_password: String,
+
+    /// An explicit on-disk path for a read-only secondary to follow, overriding the
+    /// `cache_dir`-derived path.
+    ///
+    /// Runtime-only (never (de)serialized): set programmatically when following another
+    /// process's database whose path cannot be derived from this config — e.g. an
+    /// ephemeral primary at a random temporary directory. Ignored unless the state is
+    /// opened read-only.
+    #[serde(skip)]
+    pub read_only_db_path: Option<PathBuf>,
 }
 
 fn gen_temp_path(prefix: &str) -> PathBuf {
@@ -225,6 +235,7 @@ impl Default for Config {
             elasticsearch_username: "elastic".to_string(),
             #[cfg(feature = "elasticsearch")]
             elasticsearch_password: "".to_string(),
+            read_only_db_path: None,
         }
     }
 }

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -82,6 +82,18 @@ pub enum StateInitError {
         /// The database path at which no database was found.
         path: PathBuf,
     },
+
+    /// A read-only state was requested together with an ephemeral database.
+    ///
+    /// A read-only secondary follows another process's primary database and must
+    /// never delete it, whereas an ephemeral database deletes its files on drop. The
+    /// two are mutually exclusive, so requesting both is a fatal configuration error.
+    #[error(
+        "cannot open read-only state: an ephemeral database was also requested. \
+         Hint: a read-only state follows an existing Zebra node's database and must not \
+         delete it; set `ephemeral = false`, or do not request a read-only state"
+    )]
+    ReadOnlyEphemeralConflict,
 }
 
 /// An error describing why a block could not be queued to be committed to the state.

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -1269,6 +1269,20 @@ pub enum ReadRequest {
         stop: Option<block::Hash>,
     },
 
+    /// Finds the fork point between the locator `known_blocks` and the best chain.
+    ///
+    /// `known_blocks` is a block locator. Returns the most recent locator entry that is
+    /// on the best chain (the fork point), or `None` if no entry is on the best chain.
+    /// Returns `None` if the state is empty.
+    ///
+    /// Returns
+    ///
+    /// [`ReadResponse::ForkPoint(Option<(block::Height, block::Hash)>)`](ReadResponse::ForkPoint).
+    FindForkPoint {
+        /// Hashes of known blocks, ordered from highest height to lowest height.
+        known_blocks: Vec<block::Hash>,
+    },
+
     /// Looks up a Sapling note commitment tree either by a hash or height.
     ///
     /// Returns
@@ -1440,6 +1454,7 @@ impl ReadRequest {
             ReadRequest::BlockLocator => "block_locator",
             ReadRequest::FindBlockHashes { .. } => "find_block_hashes",
             ReadRequest::FindBlockHeaders { .. } => "find_block_headers",
+            ReadRequest::FindForkPoint { .. } => "find_fork_point",
             ReadRequest::SaplingTree { .. } => "sapling_tree",
             ReadRequest::OrchardTree { .. } => "orchard_tree",
             ReadRequest::SaplingSubtrees { .. } => "sapling_subtrees",

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -1283,6 +1283,16 @@ pub enum ReadRequest {
         known_blocks: Vec<block::Hash>,
     },
 
+    /// Returns the live finalized-state database location and identity.
+    ///
+    /// Returns
+    ///
+    /// [`ReadResponse::StateDbInfo`](ReadResponse::StateDbInfo) with the on-disk path,
+    /// the running format version, and the database kind. Used by a co-located follower
+    /// to bootstrap a read-only secondary, including against an ephemeral database whose
+    /// path cannot be recomputed from config.
+    StateDbInfo,
+
     /// Looks up a Sapling note commitment tree either by a hash or height.
     ///
     /// Returns
@@ -1455,6 +1465,7 @@ impl ReadRequest {
             ReadRequest::FindBlockHashes { .. } => "find_block_hashes",
             ReadRequest::FindBlockHeaders { .. } => "find_block_headers",
             ReadRequest::FindForkPoint { .. } => "find_fork_point",
+            ReadRequest::StateDbInfo => "state_db_info",
             ReadRequest::SaplingTree { .. } => "sapling_tree",
             ReadRequest::OrchardTree { .. } => "orchard_tree",
             ReadRequest::SaplingSubtrees { .. } => "sapling_subtrees",

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -431,6 +431,17 @@ pub enum ReadResponse {
     /// on the best chain.
     ForkPoint(Option<(block::Height, block::Hash)>),
 
+    /// The response to a `StateDbInfo` request: the live finalized-state database
+    /// location, running format version, and kind.
+    StateDbInfo {
+        /// The on-disk path of the finalized-state database.
+        path: std::path::PathBuf,
+        /// The database format version of the running code.
+        format_version: semver::Version,
+        /// The database kind (e.g. `"state"`).
+        db_kind: String,
+    },
+
     /// The response to a `UnspentBestChainUtxo` request, from verified blocks in the
     /// _best_ non-finalized chain, or the finalized chain.
     UnspentBestChainUtxo(Option<transparent::Utxo>),
@@ -602,7 +613,8 @@ impl TryFrom<ReadResponse> for Response {
             | ReadResponse::ChainInfo(_)
             | ReadResponse::NonFinalizedBlocksListener(_)
             | ReadResponse::IsTransparentOutputSpent(_)
-            | ReadResponse::ForkPoint(_) => {
+            | ReadResponse::ForkPoint(_)
+            | ReadResponse::StateDbInfo { .. } => {
                 Err("there is no corresponding Response for this ReadResponse")
             }
 

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -426,6 +426,11 @@ pub enum ReadResponse {
     /// The response to a `FindBlockHeaders` request.
     BlockHeaders(Vec<block::CountedHeader>),
 
+    /// The response to a `FindForkPoint` request.
+    /// Returns the height and hash of the fork point, or `None` if no locator entry is
+    /// on the best chain.
+    ForkPoint(Option<(block::Height, block::Hash)>),
+
     /// The response to a `UnspentBestChainUtxo` request, from verified blocks in the
     /// _best_ non-finalized chain, or the finalized chain.
     UnspentBestChainUtxo(Option<transparent::Utxo>),
@@ -596,7 +601,8 @@ impl TryFrom<ReadResponse> for Response {
             | ReadResponse::AddressUtxos(_)
             | ReadResponse::ChainInfo(_)
             | ReadResponse::NonFinalizedBlocksListener(_)
-            | ReadResponse::IsTransparentOutputSpent(_) => {
+            | ReadResponse::IsTransparentOutputSpent(_)
+            | ReadResponse::ForkPoint(_) => {
                 Err("there is no corresponding Response for this ReadResponse")
             }
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1560,6 +1560,12 @@ impl Service<ReadRequest> for ReadStateService {
                 read::find_fork_point(state.latest_best_chain(), &state.db, known_blocks),
             )),
 
+            ReadRequest::StateDbInfo => Ok(ReadResponse::StateDbInfo {
+                path: state.db.path().to_path_buf(),
+                format_version: state.db.format_version_in_code(),
+                db_kind: state.db.db_kind(),
+            }),
+
             ReadRequest::SaplingTree(hash_or_height) => Ok(ReadResponse::SaplingTree(
                 read::sapling_tree(state.latest_best_chain(), &state.db, hash_or_height),
             )),

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1556,6 +1556,10 @@ impl Service<ReadRequest> for ReadStateService {
                 .collect(),
             )),
 
+            ReadRequest::FindForkPoint { known_blocks } => Ok(ReadResponse::ForkPoint(
+                read::find_fork_point(state.latest_best_chain(), &state.db, known_blocks),
+            )),
+
             ReadRequest::SaplingTree(hash_or_height) => Ok(ReadResponse::SaplingTree(
                 read::sapling_tree(state.latest_best_chain(), &state.db, hash_or_height),
             )),

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -1032,14 +1032,21 @@ impl DiskDb {
                 // A read-only secondary instance must never create the primary cache
                 // directory: the primary zebrad owns it. At most, verify it already
                 // exists and is readable, and fail with a clear error otherwise.
-                DiskDb::check_cache_dir_readable(&config.cache_dir)?;
+                let dir_to_check = config
+                    .read_only_db_path
+                    .as_deref()
+                    .unwrap_or(&config.cache_dir);
+                DiskDb::check_cache_dir_readable(dir_to_check)?;
             } else {
                 DiskDb::validate_cache_dir(&config.cache_dir);
             }
         }
 
         let db_kind = db_kind.as_ref();
-        let path = config.db_path(db_kind, format_version_in_code.major, network);
+        let path = match (read_only, config.read_only_db_path.as_ref()) {
+            (true, Some(explicit)) => explicit.clone(),
+            _ => config.db_path(db_kind, format_version_in_code.major, network),
+        };
 
         let db_options = DiskDb::options();
 

--- a/zebra-state/src/service/finalized_state/disk_db.rs
+++ b/zebra-state/src/service/finalized_state/disk_db.rs
@@ -88,10 +88,9 @@ pub struct DiskDb {
     /// The configured network for this database.
     network: Network,
 
-    /// The configured temporary database setting.
-    ///
-    /// If true, the database files are deleted on drop.
-    ephemeral: bool,
+    /// How this database was opened: a read-write primary (persistent or ephemeral)
+    /// or a read-only secondary. See [`DbMode`].
+    mode: DbMode,
 
     /// A boolean flag indicating whether the db format change task has finished
     /// applying any format changes that may have been required.
@@ -380,6 +379,38 @@ pub trait ReadDisk {
         R: RangeBounds<K>;
 }
 
+/// How a [`DiskDb`] instance is opened.
+///
+/// These modes are mutually exclusive — an ephemeral database is a read-write primary
+/// this process owns and deletes on drop, a persistent database is a read-write primary
+/// whose files are kept, and a read-only secondary follows another process's primary and
+/// never writes, flushes, or deletes it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DbMode {
+    /// A read-write primary backed by persistent on-disk files that are kept on drop.
+    Persistent,
+
+    /// A read-write primary backed by temporary files that are deleted on drop.
+    Ephemeral,
+
+    /// A read-only secondary that follows an existing primary's on-disk state. It owns
+    /// no files and never writes, flushes, or deletes them.
+    ReadOnlySecondary,
+}
+
+impl DbMode {
+    /// Returns true if dropping the database should delete its files.
+    fn deletes_files_on_drop(self) -> bool {
+        matches!(self, DbMode::Ephemeral)
+    }
+
+    /// Returns true if this is a read-only secondary instance, which RocksDB does not
+    /// allow writes or flushes on.
+    fn is_read_only(self) -> bool {
+        matches!(self, DbMode::ReadOnlySecondary)
+    }
+}
+
 impl PartialEq for DiskDb {
     fn eq(&self, other: &Self) -> bool {
         if self.db.path() == other.db.path() {
@@ -388,7 +419,8 @@ impl PartialEq for DiskDb {
                 "database with same path but different network configs",
             );
             assert_eq!(
-                self.ephemeral, other.ephemeral,
+                self.mode.deletes_files_on_drop(),
+                other.mode.deletes_files_on_drop(),
                 "database with same path but different ephemeral configs",
             );
 
@@ -981,6 +1013,19 @@ impl DiskDb {
         column_families_in_code: impl IntoIterator<Item = String>,
         read_only: bool,
     ) -> Result<DiskDb, StateInitError> {
+        // `ephemeral` and `read_only` describe mutually-exclusive modes: an ephemeral
+        // database is a read-write primary this process owns and deletes on drop, while
+        // a read-only secondary follows another process's primary and must never delete
+        // it. Combining them is a configuration error — it would delete the primary's
+        // files on drop — so reject it here rather than silently coercing it (a check
+        // that must hold in release builds, not just debug).
+        let mode = match (read_only, config.ephemeral) {
+            (true, true) => return Err(StateInitError::ReadOnlyEphemeralConflict),
+            (true, false) => DbMode::ReadOnlySecondary,
+            (false, true) => DbMode::Ephemeral,
+            (false, false) => DbMode::Persistent,
+        };
+
         // If the database is ephemeral, we don't need to check the cache directory.
         if !config.ephemeral {
             if read_only {
@@ -1031,7 +1076,7 @@ impl DiskDb {
                     db_kind: db_kind.to_string(),
                     format_version_in_code: format_version_in_code.clone(),
                     network: network.clone(),
-                    ephemeral: config.ephemeral,
+                    mode,
                     db: Arc::new(db),
                     finished_format_upgrades: Arc::new(AtomicBool::new(false)),
                 };
@@ -1450,7 +1495,7 @@ impl DiskDb {
             let mut ephemeral_note = "";
 
             if force {
-                if self.ephemeral {
+                if self.mode.deletes_files_on_drop() {
                     ephemeral_note = " and removing ephemeral files";
                 }
 
@@ -1468,7 +1513,7 @@ impl DiskDb {
                     ephemeral_note,
                 );
             } else {
-                if self.ephemeral {
+                if self.mode.deletes_files_on_drop() {
                     ephemeral_note = " and files";
                 }
 
@@ -1493,39 +1538,42 @@ impl DiskDb {
         let path = self.path();
         debug!(?path, "flushing database to disk");
 
-        // These flushes can fail during forced shutdown or during Drop after a shutdown,
-        // particularly in tests. If they fail, there's nothing we can do about it anyway.
-        if let Err(error) = self.db.flush() {
-            let error = format!("{error:?}");
-            if error.to_ascii_lowercase().contains("shutdown in progress") {
-                debug!(
-                    ?error,
-                    ?path,
-                    "expected shutdown error flushing database SST files to disk"
-                );
-            } else {
-                info!(
-                    ?error,
-                    ?path,
-                    "unexpected error flushing database SST files to disk during shutdown"
-                );
+        // A read-only secondary instance has nothing to flush, and RocksDB rejects
+        // `flush()`/`flush_wal()` on secondaries with "Not supported operation in
+        // secondary mode". Only a read-write primary needs flushing on shutdown.
+        if !self.mode.is_read_only() {
+            // These flushes can fail during forced shutdown or during Drop after a shutdown,
+            // particularly in tests. If they fail, there's nothing we can do about it anyway.
+            if let Err(error) = self.db.flush() {
+                if matches!(error.kind(), ErrorKind::ShutdownInProgress) {
+                    debug!(
+                        ?error,
+                        ?path,
+                        "expected shutdown error flushing database SST files to disk"
+                    );
+                } else {
+                    info!(
+                        ?error,
+                        ?path,
+                        "unexpected error flushing database SST files to disk during shutdown"
+                    );
+                }
             }
-        }
 
-        if let Err(error) = self.db.flush_wal(true) {
-            let error = format!("{error:?}");
-            if error.to_ascii_lowercase().contains("shutdown in progress") {
-                debug!(
-                    ?error,
-                    ?path,
-                    "expected shutdown error flushing database WAL buffer to disk"
-                );
-            } else {
-                info!(
-                    ?error,
-                    ?path,
-                    "unexpected error flushing database WAL buffer to disk during shutdown"
-                );
+            if let Err(error) = self.db.flush_wal(true) {
+                if matches!(error.kind(), ErrorKind::ShutdownInProgress) {
+                    debug!(
+                        ?error,
+                        ?path,
+                        "expected shutdown error flushing database WAL buffer to disk"
+                    );
+                } else {
+                    info!(
+                        ?error,
+                        ?path,
+                        "unexpected error flushing database WAL buffer to disk during shutdown"
+                    );
+                }
             }
         }
 
@@ -1610,7 +1658,7 @@ impl DiskDb {
         // This function and all functions that it calls should avoid cloning the shared database
         // instance. See `shutdown()` for details.
 
-        if !self.ephemeral {
+        if !self.mode.deletes_files_on_drop() {
             return;
         }
 

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -17,7 +17,7 @@ use semver::Version;
 use zebra_chain::{block::Height, diagnostic::task::WaitForPanics, parameters::Network};
 
 use crate::{
-    config::database_format_version_on_disk,
+    config::{database_format_version_at_path, database_format_version_on_disk},
     service::finalized_state::{
         disk_db::DiskDb,
         disk_format::{
@@ -107,10 +107,34 @@ impl ZebraDb {
         // checked for readability first, so a missing or unreadable directory returns a typed
         // `ReadOnlyCacheDirUnreadable` error here instead of panicking on the version-file read.
         let disk_version = if read_only {
-            DiskDb::check_cache_dir_readable(&config.cache_dir)?;
+            // When an explicit DB path is provided, check that path for readability rather than
+            // the cache_dir; otherwise fall back to the standard cache_dir check.
+            let dir_to_check = config
+                .read_only_db_path
+                .as_deref()
+                .unwrap_or(&config.cache_dir);
+            DiskDb::check_cache_dir_readable(dir_to_check)?;
 
-            database_format_version_on_disk(config, &db_kind, format_version_in_code.major, network)
+            // When an explicit DB path is provided, read the format version from that path rather
+            // than the one derived from cache_dir.
+            if let Some(explicit_path) = config.read_only_db_path.as_ref() {
+                let version_path =
+                    explicit_path.join(crate::constants::DATABASE_FORMAT_VERSION_FILE_NAME);
+                database_format_version_at_path(
+                    &version_path,
+                    explicit_path,
+                    format_version_in_code.major,
+                )
                 .expect("unable to read database format version file")
+            } else {
+                database_format_version_on_disk(
+                    config,
+                    &db_kind,
+                    format_version_in_code.major,
+                    network,
+                )
+                .expect("unable to read database format version file")
+            }
         } else {
             DiskDb::try_reusing_previous_db_after_major_upgrade(
                 &restorable_db_versions(),
@@ -138,7 +162,10 @@ impl ZebraDb {
         //
         // The read-write path is unaffected: creating a new database is the correct behavior there.
         if read_only && format_change.is_newly_created() {
-            let db_path = config.db_path(&db_kind, format_version_in_code.major, network);
+            let db_path = config
+                .read_only_db_path
+                .clone()
+                .unwrap_or_else(|| config.db_path(&db_kind, format_version_in_code.major, network));
             return Err(StateInitError::ReadOnlyDatabaseNotFound { path: db_path });
         }
 

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -39,12 +39,9 @@ pub use block::spending_transaction_hash;
 
 pub use find::{
     best_tip, block_locator, depth, finalized_state_contains_block_hash, find_chain_hashes,
-    find_chain_headers, hash_by_height, height_by_hash, next_median_time_past,
+    find_chain_headers, find_fork_point, hash_by_height, height_by_hash, next_median_time_past,
     non_finalized_state_contains_block_hash, tip, tip_height, tip_with_value_balance,
 };
-// Re-exported for use in the ReadRequest handler (added in a later task).
-#[allow(unused_imports)]
-pub use find::find_fork_point;
 pub use tree::{orchard_subtrees, orchard_tree, sapling_subtrees, sapling_tree};
 
 #[cfg(any(test, feature = "proptest-impl"))]

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -42,6 +42,9 @@ pub use find::{
     find_chain_headers, hash_by_height, height_by_hash, next_median_time_past,
     non_finalized_state_contains_block_hash, tip, tip_height, tip_with_value_balance,
 };
+// Re-exported for use in the ReadRequest handler (added in a later task).
+#[allow(unused_imports)]
+pub use find::find_fork_point;
 pub use tree::{orchard_subtrees, orchard_tree, sapling_subtrees, sapling_tree};
 
 #[cfg(any(test, feature = "proptest-impl"))]

--- a/zebra-state/src/service/read/find.rs
+++ b/zebra-state/src/service/read/find.rs
@@ -584,6 +584,35 @@ where
     collect_chain_hashes(chain, db, intersection, stop, max_len)
 }
 
+/// Finds the fork point between the locator `known_blocks` and the best chain.
+///
+/// `known_blocks` is a block locator: hashes ordered from highest height to lowest
+/// height. Returns the height and hash of the highest locator entry that is on the best
+/// chain (in `chain` or the finalized `db`) — the most recent common ancestor — or
+/// `None` if no locator entry is on the best chain.
+///
+/// Returns `None` if the state is empty.
+#[allow(dead_code)]
+pub fn find_fork_point<C>(
+    chain: Option<C>,
+    db: &ZebraDb,
+    known_blocks: Vec<block::Hash>,
+) -> Option<(Height, block::Hash)>
+where
+    C: AsRef<Chain>,
+{
+    // # Correctness
+    //
+    // See the note in `block_locator()`.
+
+    let chain = chain.as_ref();
+
+    let fork_hash = find_chain_intersection(chain, db, known_blocks)?;
+    let fork_height = height_by_hash(chain, db, fork_hash)?;
+
+    Some((fork_height, fork_hash))
+}
+
 /// Finds the first hash that's in the peer's `known_blocks` and the chain.
 /// Returns a list of headers that follow that intersection, from the chain.
 ///

--- a/zebra-state/src/service/read/find.rs
+++ b/zebra-state/src/service/read/find.rs
@@ -592,7 +592,6 @@ where
 /// `None` if no locator entry is on the best chain.
 ///
 /// Returns `None` if the state is empty.
-#[allow(dead_code)]
 pub fn find_fork_point<C>(
     chain: Option<C>,
     db: &ZebraDb,

--- a/zebra-state/src/service/read/find/tests/vectors.rs
+++ b/zebra-state/src/service/read/find/tests/vectors.rs
@@ -20,6 +20,96 @@ static BLOCK_LOCATOR_CASES: &[(u32, u32)] = &[
     (10000, 9000),
 ];
 
+/// Tests that `find_fork_point` returns the most recent locator entry on the best chain.
+#[test]
+fn find_fork_point_locates_the_fork() {
+    use std::sync::Arc;
+
+    use zebra_chain::{
+        amount::NonNegative, block::Block, parameters::Network::Mainnet,
+        value_balance::ValueBalance,
+    };
+
+    use crate::{
+        arbitrary::Prepare,
+        service::{
+            finalized_state::FinalizedState, non_finalized_state::NonFinalizedState,
+            read::find_fork_point,
+        },
+        tests::FakeChainHelper,
+        Config,
+    };
+
+    let _init_guard = zebra_test::init();
+    let network = Mainnet;
+
+    // Pre-Heartwood block as a base, to avoid history-tree complications (matches the
+    // `any_chain_block_finds_side_chain_blocks` fixture in read/tests/vectors.rs).
+    let base: Arc<Block> = Arc::new(network.test_block(653599, 583999).unwrap());
+
+    // Two competing children of `base`: different work -> different hashes -> a fork.
+    let best_block = base.make_fake_child().set_work(100);
+    let side_block = base.make_fake_child().set_work(50);
+
+    let base_hash = base.hash();
+    let base_height = base.coinbase_height().unwrap();
+    let best_hash = best_block.hash();
+    let best_height = best_block.coinbase_height().unwrap();
+    let side_hash = side_block.hash();
+
+    if best_hash == side_hash {
+        tracing::warn!("could not create distinct block hashes, skipping");
+        return;
+    }
+
+    let mut non_finalized_state = NonFinalizedState::new(&network);
+    let finalized_state = FinalizedState::new(
+        &Config::ephemeral(),
+        &network,
+        #[cfg(feature = "elasticsearch")]
+        false,
+    )
+    .expect("opening an ephemeral database should succeed");
+    finalized_state.set_finalized_value_pool(ValueBalance::<NonNegative>::fake_populated_pool());
+
+    non_finalized_state
+        .commit_new_chain(base.prepare(), &finalized_state)
+        .unwrap();
+    non_finalized_state
+        .commit_block(best_block.clone().prepare(), &finalized_state)
+        .unwrap();
+    non_finalized_state
+        .commit_block(side_block.clone().prepare(), &finalized_state)
+        .unwrap();
+    assert_eq!(
+        non_finalized_state.chain_count(),
+        2,
+        "should have two competing chains"
+    );
+
+    let best_chain = non_finalized_state.best_chain();
+    let db = &finalized_state.db;
+
+    // No reorg: the locator's top is on the best chain -> it is its own fork point.
+    assert_eq!(
+        find_fork_point(best_chain, db, vec![best_hash]),
+        Some((best_height, best_hash)),
+    );
+
+    // Reorg: a locator over the orphaned tip plus its shared ancestor -> the shared
+    // ancestor (`base`) is the fork point.
+    assert_eq!(
+        find_fork_point(best_chain, db, vec![side_hash, base_hash]),
+        Some((base_height, base_hash)),
+    );
+
+    // A locator containing only the orphaned tip has no entry on the best chain.
+    assert_eq!(find_fork_point(best_chain, db, vec![side_hash]), None);
+
+    // An empty locator has no fork point.
+    assert_eq!(find_fork_point(best_chain, db, vec![]), None);
+}
+
 /// Check that the block locator heights are sensible.
 #[test]
 fn test_block_locator_heights() {

--- a/zebra-state/src/service/read/tests/vectors.rs
+++ b/zebra-state/src/service/read/tests/vectors.rs
@@ -79,6 +79,18 @@ async fn populated_read_state_responds_correctly() -> Result<()> {
         let block_cases = Transcript::from(block_cases);
         block_cases.check(read_state.clone()).await?;
 
+        let fork_point_cases = vec![(
+            ReadRequest::FindForkPoint {
+                known_blocks: vec![block.hash()],
+            },
+            Ok(ReadResponse::ForkPoint(Some((
+                block.coinbase_height().unwrap(),
+                block.hash(),
+            )))),
+        )];
+        let fork_point_cases = Transcript::from(fork_point_cases);
+        fork_point_cases.check(read_state.clone()).await?;
+
         // Spec: transactions in the genesis block are ignored.
         if block.coinbase_height().unwrap().0 == 0 {
             continue;
@@ -352,6 +364,12 @@ fn empty_state_test_cases() -> Vec<(ReadRequest, Result<ReadResponse, ExpectedTr
         (
             ReadRequest::Block(block.coinbase_height().unwrap().into()),
             Ok(ReadResponse::Block(None)),
+        ),
+        (
+            ReadRequest::FindForkPoint {
+                known_blocks: vec![block.hash()],
+            },
+            Ok(ReadResponse::ForkPoint(None)),
         ),
     ]
 }

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -658,3 +658,25 @@ fn read_only_open_with_unreadable_cache_dir_returns_error() {
         }
     }
 }
+
+/// Opening a read-only state with an ephemeral database configured must fail with
+/// [`StateInitError::ReadOnlyEphemeralConflict`]: a read-only secondary follows another
+/// process's primary database and must never delete it, so it cannot also be ephemeral
+/// (which would delete the primary's files on drop).
+#[test]
+fn read_only_open_with_ephemeral_config_returns_error() {
+    let network = Network::Mainnet;
+
+    let config = Config {
+        ephemeral: true,
+        ..Config::default()
+    };
+
+    match super::init_read_only(config, &network) {
+        Err(crate::StateInitError::ReadOnlyEphemeralConflict) => {}
+        Err(other) => panic!("expected ReadOnlyEphemeralConflict, got: {other:?}"),
+        Ok(_) => {
+            panic!("expected an error when opening a read-only state with an ephemeral config")
+        }
+    }
+}

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -697,6 +697,45 @@ async fn read_request_state_db_info_reports_live_db() {
     );
 }
 
+/// A read-only secondary can be opened at an explicit DB path that differs from the
+/// path `Config::db_path` would derive (the ephemeral/secondary case).
+#[test]
+fn read_only_open_honors_explicit_db_path() {
+    let network = Network::Mainnet;
+
+    // Create a persistent primary so there is a real on-disk DB to follow.
+    let primary_dir = tempfile::tempdir().expect("temp dir");
+    let primary_config = Config {
+        cache_dir: primary_dir.path().to_path_buf(),
+        ephemeral: false,
+        ..Config::default()
+    };
+    let primary = crate::FinalizedState::new(
+        &primary_config,
+        &network,
+        #[cfg(feature = "elasticsearch")]
+        false,
+    )
+    .expect("opening the primary should succeed");
+    let primary_db_path = primary.db.path().to_path_buf();
+
+    // Open a read-only secondary pointed explicitly at the primary's DB path, using a
+    // DIFFERENT cache_dir so success can only come from the explicit override.
+    let follower_dir = tempfile::tempdir().expect("temp dir");
+    let follower_config = Config {
+        cache_dir: follower_dir.path().to_path_buf(),
+        ephemeral: false,
+        read_only_db_path: Some(primary_db_path.clone()),
+        ..Config::default()
+    };
+
+    let (read_state, db, _sender) =
+        super::init_read_only(follower_config, &network).expect("read-only open should succeed");
+
+    assert_eq!(db.path(), primary_db_path.as_path());
+    drop(read_state);
+}
+
 /// Opening a read-only state with an ephemeral database configured must fail with
 /// [`StateInitError::ReadOnlyEphemeralConflict`]: a read-only secondary follows another
 /// process's primary database and must never delete it, so it cannot also be ephemeral

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -659,6 +659,44 @@ fn read_only_open_with_unreadable_cache_dir_returns_error() {
     }
 }
 
+/// `ReadRequest::StateDbInfo` reports the live database location, kind, and format version.
+#[tokio::test(flavor = "multi_thread")]
+async fn read_request_state_db_info_reports_live_db() {
+    use tower::ServiceExt;
+
+    use crate::{ReadRequest, ReadResponse};
+
+    let _init_guard = zebra_test::init();
+
+    let network = Network::Mainnet;
+    let (_state, read_state, _latest_chain_tip, _chain_tip_change) =
+        super::init_test_services(&network).await;
+
+    let response = read_state
+        .oneshot(ReadRequest::StateDbInfo)
+        .await
+        .expect("StateDbInfo request should succeed");
+
+    let ReadResponse::StateDbInfo {
+        path,
+        format_version,
+        db_kind,
+    } = response
+    else {
+        panic!("expected ReadResponse::StateDbInfo, got {response:?}");
+    };
+
+    assert_eq!(db_kind, "state");
+    assert!(
+        path.exists(),
+        "reported db path should exist on disk: {path:?}"
+    );
+    assert_eq!(
+        format_version.major,
+        crate::constants::state_database_format_version_in_code().major,
+    );
+}
+
 /// Opening a read-only state with an ephemeral database configured must fail with
 /// [`StateInitError::ReadOnlyEphemeralConflict`]: a read-only secondary follows another
 /// process's primary database and must never delete it, so it cannot also be ephemeral

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -301,6 +301,7 @@ impl StartCmd {
             address_book.clone(),
             LAST_WARN_ERROR_LOG_SENDER.subscribe(),
             Some(submit_block_channel.sender()),
+            config.rpc.indexer_listen_addr,
         );
 
         let rpc_task_handle = if config.rpc.listen_addr.is_some() {

--- a/zebrad/tests/integration/regtest.rs
+++ b/zebrad/tests/integration/regtest.rs
@@ -253,6 +253,7 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
         MockAddressBookPeers::default(),
         rx,
         Some(submitblock_channel.sender()),
+        None,
     );
 
     let make_mock_mempool_request_handler = || async move {
@@ -617,6 +618,7 @@ async fn nu7_nsm_transactions() -> Result<()> {
         MockAddressBookPeers::default(),
         rx,
         Some(submitblock_channel.sender()),
+        None,
     );
 
     let make_mock_mempool_request_handler = || async move {


### PR DESCRIPTION
> **Draft for discussion**, not a merge request. Posted so the team can see the concrete
> Zebra-side changes while evaluating the approach in #10786.

Builds atop #10764 

## Motivation

A co-located read-state follower (e.g. Zallet's `zebra-state` backend) opens a node's
state DB as a read-only RocksDB secondary and follows its non-finalized best chain over the
indexer gRPC stream. It cannot follow an **ephemeral** or **Regtest** node today: an
ephemeral DB lives at a random temp path the follower can't discover, and a follower has no
way to learn a Regtest node's configured activation heights.

## Solution

- **`getreadstateinfo`** JSON-RPC method (zebra-only): reports the node's live state DB
  path, indexer gRPC address, DB format version/kind, and network identity (kind + genesis
  hash +, for Regtest, activation heights).
- **`ReadRequest::StateDbInfo`** → `ReadResponse::StateDbInfo`: surfaces the live
  finalized-state DB path/version/kind from the read-state service (correct for ephemeral
  DBs, whose path can't be recomputed from config).
- **Explicit-path read-only open** (`Config::read_only_db_path`): open a read-only secondary
  at an explicit on-disk path so a follower can tail an ephemeral primary's randomly-located
  DB.
- (Foundational, already on the branch) `FindForkPoint` read request/helper for reorg
  tracking; don't flush read-only secondary DBs on shutdown.

## Testing

- New unit tests: `ReadRequest::StateDbInfo` reports the live DB; read-only open honors an
  explicit path; `getreadstateinfo` reports state + Regtest network info.
- `cargo fmt --all -- --check`, `cargo clippy -p zebra-state -p zebra-rpc -p zebrad
  --all-targets -- -D warnings`, and `cargo test -p zebra-state -p zebra-rpc` pass locally
  (141 + 2 tests).

## Notes for reviewers / known limitations

- **Custom (non-default) Testnets are not supported for bootstrap.** Only Mainnet, the
  default Testnet, and Regtest report enough to reconstruct the network; a custom Testnet
  would be mis-reconstructed as the default public Testnet. Intentional for this scope.
- **Exposure:** `getreadstateinfo` returns a local filesystem path and the indexer address.
  It is gated by the same JSON-RPC cookie auth as every method, is read-only, and only
  reflects config the operator already set. The reported `indexer_grpc_addr` may be a public
  bind address.

## AI disclosure

Implemented with Claude Code assistance (design, code, and tests). The contributor is the
sole responsible author.

Closes #10786.
