### PR TITLE
build: force-include <cstdint> via CXXFLAGS for GCC 15+

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -11,6 +11,8 @@ rustdocflags = [
 
 [env]
 RUST_BACKTRACE="1"
+# Workaround for GCC 15+: librocksdb-sys / libzcash_script vendored C++ relies on transitive <cstdint>.
+CXXFLAGS = { value = "-include cstdint", force = false, relative = false }
 
 [profile.profiling]
 inherits = "release"


### PR DESCRIPTION
Cherry-picked from https://github.com/zodl-inc/zebra/pull/5

## Motivation

librocksdb-sys and libzcash_script's vendored C++ rely on transitive <cstdint>, which GCC 15+ libstdc++ no longer provides. 

## Solution

Adding the CXXFLAGS="-include cstdint" directive to .cargo/config.toml saves users from having to (a) know to use this workaround, and (b) do this manually every time we go to build.

### Tests

Tested locally; this works fine.

### Follow-up Work

This can removed once both upstream libraries' builds add the include.

### AI Disclosure

- [x] No AI tools were used in this PR
- [ ] AI tools were used: <!-- tool name and what it was used for, e.g., "Claude for test boilerplate" -->

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [ ] The documentation and changelogs are up to date.
