### PR TITLE
chore(deps): pin librustzcash crates to NU6.3 testnet-supporting pre-release version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Added
 
-- Experimental, off-by-default support for the NU6.3 "Ironwood" shielded pool and
-  v6 transaction format, behind the `zcash_unstable="nu6.3"` cfg. This is incomplete
-  pending the deploy ZIP (no real activation height, version group ID, or consensus
-  branch ID yet) and is not built by default.
+- Experimental support for the NU6.3 "Ironwood" shielded pool and v6 transaction
+  format. This is incomplete pending the deploy ZIP (no real activation height,
+  version group ID, or consensus branch ID yet), so it cannot activate on any
+  network.
 - Added a Regtest configuration option, `should_allow_unshielded_coinbase_spends`,
   to forbid spending coinbase outputs into transparent outputs (the inverse of
   zcashd's `-regtestshieldcoinbase`). It defaults to allowing such spends, preserving

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1551,22 +1551,12 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
+source = "git+https://github.com/zcash/librustzcash.git?rev=703fe3e6608fab8be0dedbbcbf684f030a1ea451#703fe3e6608fab8be0dedbbcbf684f030a1ea451"
 dependencies = [
  "blake2b_simd",
  "cc",
  "corez",
  "document-features",
-]
-
-[[package]]
-name = "equihash"
-version = "0.3.0"
-source = "git+https://github.com/valargroup/librustzcash?branch=adam%2Fironwood-split-2-v6-txid#d098a6d7f5f62aa1d50c936f16d81428e17a2898"
-dependencies = [
- "blake2b_simd",
- "corez",
 ]
 
 [[package]]
@@ -1609,7 +1599,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/valargroup/librustzcash?branch=adam%2Fironwood-split-2-v6-txid#d098a6d7f5f62aa1d50c936f16d81428e17a2898"
+source = "git+https://github.com/zcash/librustzcash.git?rev=703fe3e6608fab8be0dedbbcbf684f030a1ea451#703fe3e6608fab8be0dedbbcbf684f030a1ea451"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3577,8 +3567,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.14.0"
-source = "git+https://github.com/valargroup/qr_orchard?rev=6f1a5eaddcf0e016101c0c62a477d48f31e7a83f#6f1a5eaddcf0e016101c0c62a477d48f31e7a83f"
+version = "0.15.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e277dd4b46f5d06deae3ffb8af1a951e8622368f028c2a4d6fe59339566403"
 dependencies = [
  "aes",
  "bitvec",
@@ -7118,8 +7109,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_address"
-version = "0.12.0"
-source = "git+https://github.com/valargroup/librustzcash?branch=adam%2Fironwood-split-2-v6-txid#d098a6d7f5f62aa1d50c936f16d81428e17a2898"
+version = "0.13.0-pre.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=703fe3e6608fab8be0dedbbcbf684f030a1ea451#703fe3e6608fab8be0dedbbcbf684f030a1ea451"
 dependencies = [
  "bech32",
  "bs58",
@@ -7132,7 +7123,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/valargroup/librustzcash?branch=adam%2Fironwood-split-2-v6-txid#d098a6d7f5f62aa1d50c936f16d81428e17a2898"
+source = "git+https://github.com/zcash/librustzcash.git?rev=703fe3e6608fab8be0dedbbcbf684f030a1ea451#703fe3e6608fab8be0dedbbcbf684f030a1ea451"
 dependencies = [
  "corez",
  "hex",
@@ -7141,8 +7132,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_history"
-version = "0.4.0"
-source = "git+https://github.com/valargroup/librustzcash?branch=adam%2Fironwood-split-2-v6-txid#d098a6d7f5f62aa1d50c936f16d81428e17a2898"
+version = "0.5.0-pre.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=703fe3e6608fab8be0dedbbcbf684f030a1ea451#703fe3e6608fab8be0dedbbcbf684f030a1ea451"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -7151,8 +7142,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.14.0"
-source = "git+https://github.com/valargroup/librustzcash?branch=adam%2Fironwood-split-2-v6-txid#d098a6d7f5f62aa1d50c936f16d81428e17a2898"
+version = "0.15.0-pre.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=703fe3e6608fab8be0dedbbcbf684f030a1ea451#703fe3e6608fab8be0dedbbcbf684f030a1ea451"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -7191,15 +7182,15 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.28.0"
-source = "git+https://github.com/valargroup/librustzcash?branch=adam%2Fironwood-split-2-v6-txid#d098a6d7f5f62aa1d50c936f16d81428e17a2898"
+version = "0.29.0-pre.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=703fe3e6608fab8be0dedbbcbf684f030a1ea451#703fe3e6608fab8be0dedbbcbf684f030a1ea451"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
  "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
- "equihash 0.3.0 (git+https://github.com/valargroup/librustzcash?branch=adam%2Fironwood-split-2-v6-txid)",
+ "equihash",
  "ff",
  "hex",
  "incrementalmerkletree",
@@ -7221,8 +7212,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.28.0"
-source = "git+https://github.com/valargroup/librustzcash?branch=adam%2Fironwood-split-2-v6-txid#d098a6d7f5f62aa1d50c936f16d81428e17a2898"
+version = "0.29.0-pre.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=703fe3e6608fab8be0dedbbcbf684f030a1ea451#703fe3e6608fab8be0dedbbcbf684f030a1ea451"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7243,8 +7234,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.9.0"
-source = "git+https://github.com/valargroup/librustzcash?branch=adam%2Fironwood-split-2-v6-txid#d098a6d7f5f62aa1d50c936f16d81428e17a2898"
+version = "0.10.0-pre.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=703fe3e6608fab8be0dedbbcbf684f030a1ea451#703fe3e6608fab8be0dedbbcbf684f030a1ea451"
 dependencies = [
  "corez",
  "document-features",
@@ -7281,8 +7272,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.8.0"
-source = "git+https://github.com/valargroup/librustzcash?branch=adam%2Fironwood-split-2-v6-txid#d098a6d7f5f62aa1d50c936f16d81428e17a2898"
+version = "0.9.0-pre.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=703fe3e6608fab8be0dedbbcbf684f030a1ea451#703fe3e6608fab8be0dedbbcbf684f030a1ea451"
 dependencies = [
  "bip32",
  "bs58",
@@ -7322,7 +7313,7 @@ dependencies = [
  "derive-getters",
  "dirs",
  "ed25519-zebra",
- "equihash 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "equihash",
  "futures",
  "group",
  "halo2_proofs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,16 +30,16 @@ edition = "2021"
 
 [workspace.dependencies]
 incrementalmerkletree = { version = "0.8.2", features = ["legacy-api"] }
-orchard = "0.14"
+orchard = "0.15.0-pre.1"
 sapling-crypto = "0.7"
-zcash_address = "0.12"
+zcash_address = "0.13.0-pre.0"
 zcash_encoding = "0.4"
-zcash_history = "0.4"
-zcash_keys = "0.14"
-zcash_primitives = "0.28"
-zcash_proofs = "0.28"
-zcash_transparent = "0.8"
-zcash_protocol = "0.9"
+zcash_history = "0.5.0-pre.0"
+zcash_keys = "0.15.0-pre.0"
+zcash_primitives = "0.29.0-pre.0"
+zcash_proofs = "0.29.0-pre.0"
+zcash_transparent = "0.9.0-pre.0"
+zcash_protocol = "0.10.0-pre.0"
 zip32 = "0.2"
 abscissa_core = "0.7"
 base64 = "0.22.1"
@@ -329,7 +329,7 @@ debug = false
 # The linter should ignore these expected config flags/values
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(tokio_unstable)', # Used by tokio-console
-    'cfg(zcash_unstable, values("zfuture", "nu6.1", "nu6.3", "nu7", "zip235"))' # Used in Zebra and librustzcash
+    'cfg(zcash_unstable, values("zfuture", "nu6.1", "nu7", "zip235"))' # Used in Zebra and librustzcash
 ] }
 
 # High-risk code
@@ -379,19 +379,15 @@ unwrap_in_result = "warn"
 # TODOs: fix this lint eventually
 result_large_err = "allow"
 
-# EXPERIMENTAL (NU6.3 / Ironwood spike): pin the librustzcash family to the
-# valargroup fork that adds v6 Ironwood txid/sighash support, and orchard to the
-# matching qr_orchard fork it depends on. Versions match our crates.io pins
-# (zcash_primitives 0.28, zcash_protocol 0.9, orchard 0.14), so this is a
-# source-only patch. Revert this block to return to the released crates.
-# Fork branch is force-pushed; pin to a rev before relying on this.
 [patch.crates-io]
-zcash_primitives = { git = "https://github.com/valargroup/librustzcash", branch = "adam/ironwood-split-2-v6-txid" }
-zcash_protocol = { git = "https://github.com/valargroup/librustzcash", branch = "adam/ironwood-split-2-v6-txid" }
-zcash_proofs = { git = "https://github.com/valargroup/librustzcash", branch = "adam/ironwood-split-2-v6-txid" }
-zcash_keys = { git = "https://github.com/valargroup/librustzcash", branch = "adam/ironwood-split-2-v6-txid" }
-zcash_address = { git = "https://github.com/valargroup/librustzcash", branch = "adam/ironwood-split-2-v6-txid" }
-zcash_encoding = { git = "https://github.com/valargroup/librustzcash", branch = "adam/ironwood-split-2-v6-txid" }
-zcash_transparent = { git = "https://github.com/valargroup/librustzcash", branch = "adam/ironwood-split-2-v6-txid" }
-zcash_history = { git = "https://github.com/valargroup/librustzcash", branch = "adam/ironwood-split-2-v6-txid" }
-orchard = { git = "https://github.com/valargroup/qr_orchard", rev = "6f1a5eaddcf0e016101c0c62a477d48f31e7a83f" }
+# TEMPORARY: Pin librustzcash crates to https://github.com/zcash/librustzcash/pull/2509
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "703fe3e6608fab8be0dedbbcbf684f030a1ea451" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "703fe3e6608fab8be0dedbbcbf684f030a1ea451" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "703fe3e6608fab8be0dedbbcbf684f030a1ea451" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "703fe3e6608fab8be0dedbbcbf684f030a1ea451" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "703fe3e6608fab8be0dedbbcbf684f030a1ea451" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "703fe3e6608fab8be0dedbbcbf684f030a1ea451" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "703fe3e6608fab8be0dedbbcbf684f030a1ea451" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "703fe3e6608fab8be0dedbbcbf684f030a1ea451" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "703fe3e6608fab8be0dedbbcbf684f030a1ea451" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "703fe3e6608fab8be0dedbbcbf684f030a1ea451" }

--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -608,7 +608,6 @@ where
                 sapling_shielded_data,
                 ..
             } => *sapling_shielded_data = None,
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 sapling_shielded_data,
                 ..

--- a/zebra-chain/src/ironwood.rs
+++ b/zebra-chain/src/ironwood.rs
@@ -7,10 +7,8 @@
 //! value pool — while reusing all of Orchard's wire-format and proof-verification machinery.
 //!
 //! The Ironwood *state* (nullifier set, note commitment tree, anchors, and chain value pool) is
-//! always compiled, so the on-disk database format is stable across build flags; it simply stays
-//! empty until NU6.3 transactions appear (which only happens in the experimental
-//! `zcash_unstable="nu6.3"` build). The Ironwood *transaction bundle*
-//! ([`ShieldedData`]) is only compiled for that experimental build.
+//! always present, so the on-disk database format is stable; it simply stays empty until NU6.3
+//! transactions appear on-chain.
 
 use crate::orchard;
 
@@ -39,11 +37,9 @@ impl From<orchard::Nullifier> for Nullifier {
 /// Orchard bundle; this newtype keeps the two type-distinct so they cannot be accidentally
 /// interchanged, and so the Ironwood bundle can commit into a separate note commitment tree and
 /// nullifier set.
-#[cfg(zcash_unstable = "nu6.3")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ShieldedData(orchard::ShieldedDataV6);
 
-#[cfg(zcash_unstable = "nu6.3")]
 impl ShieldedData {
     /// Wraps a v6 Orchard-protocol bundle as Ironwood shielded data.
     pub fn new(shielded_data: orchard::ShieldedDataV6) -> Self {

--- a/zebra-chain/src/orchard.rs
+++ b/zebra-chain/src/orchard.rs
@@ -24,5 +24,4 @@ pub use keys::Diversifier;
 pub use note::{EncryptedNote, Note, Nullifier, WrappedNoteKey};
 pub use shielded_data::{AuthorizedAction, Flags, ShieldedData};
 
-#[cfg(zcash_unstable = "nu6.3")]
 pub use shielded_data::{FlagsV6, ShieldedDataV6};

--- a/zebra-chain/src/orchard/shielded_data.rs
+++ b/zebra-chain/src/orchard/shielded_data.rs
@@ -63,11 +63,9 @@ pub struct ShieldedData {
 /// pre-NU6.3 serialization that the bare [`ShieldedData`] uses for v5 Orchard bundles. The two
 /// formats differ only in which flag bits are reserved; encoding the format in the type keeps the
 /// v5 and v6 (de)serialization paths from being confused.
-#[cfg(zcash_unstable = "nu6.3")]
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ShieldedDataV6(ShieldedData);
 
-#[cfg(zcash_unstable = "nu6.3")]
 impl ShieldedDataV6 {
     /// Wraps a v5-shaped Orchard [`ShieldedData`] as a v6 (NU6.3) Orchard bundle.
     pub fn new(shielded_data: ShieldedData) -> Self {
@@ -311,11 +309,9 @@ bitflags! {
 /// pre-NU6.3 (v5 Orchard) format, where bits 2..7 are all reserved. Encoding the format in the type
 /// keeps the v5 and v6 flag-parsing paths from being confused (parallels
 /// [`ShieldedDataV6`](super::ShieldedDataV6)).
-#[cfg(zcash_unstable = "nu6.3")]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct FlagsV6(Flags);
 
-#[cfg(zcash_unstable = "nu6.3")]
 impl From<FlagsV6> for Flags {
     fn from(flags: FlagsV6) -> Self {
         flags.0
@@ -327,7 +323,6 @@ impl Flags {
     const PRE_NU6_3_RESERVED: u8 = !(Self::ENABLE_SPENDS.bits() | Self::ENABLE_OUTPUTS.bits());
 
     /// The flag bits that are reserved (MUST be zero) in the NU6.3 format.
-    #[cfg(zcash_unstable = "nu6.3")]
     const NU6_3_RESERVED: u8 = !(Self::ENABLE_SPENDS.bits()
         | Self::ENABLE_OUTPUTS.bits()
         | Self::ENABLE_CROSS_ADDRESS.bits());
@@ -397,7 +392,6 @@ impl ZcashDeserialize for Flags {
     }
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 impl ZcashDeserialize for FlagsV6 {
     /// # Consensus
     ///

--- a/zebra-chain/src/orchard/tests/flags.rs
+++ b/zebra-chain/src/orchard/tests/flags.rs
@@ -2,7 +2,6 @@
 
 use crate::{orchard::Flags, serialization::ZcashDeserialize};
 
-#[cfg(zcash_unstable = "nu6.3")]
 use crate::orchard::FlagsV6;
 
 /// In the pre-NU6.3 format (the default `Flags` codec, v5 Orchard bundles), only bits 0..1 are
@@ -30,7 +29,6 @@ fn pre_nu6_3_format_rejects_reserved_bits() {
 
 /// In the NU6.3 format (the `FlagsV6` codec, v6 Orchard and Ironwood bundles), bit 2 is the valid
 /// `enableCrossAddress` flag; bits 3..7 stay reserved.
-#[cfg(zcash_unstable = "nu6.3")]
 #[test]
 fn nu6_3_format_accepts_cross_address_but_rejects_higher_bits() {
     // Bits 0..2 are all valid in the NU6.3 format.

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -538,7 +538,6 @@ impl From<zcash_protocol::consensus::NetworkUpgrade> for NetworkUpgrade {
             zcash_protocol::consensus::NetworkUpgrade::Nu6 => Self::Nu6,
             zcash_protocol::consensus::NetworkUpgrade::Nu6_1 => Self::Nu6_1,
             zcash_protocol::consensus::NetworkUpgrade::Nu6_2 => Self::Nu6_2,
-            #[cfg(zcash_unstable = "nu6.3")]
             zcash_protocol::consensus::NetworkUpgrade::Nu6_3 => Self::Nu6_3,
             #[cfg(zcash_unstable = "nu7")]
             zcash_protocol::consensus::NetworkUpgrade::Nu7 => Self::Nu7,

--- a/zebra-chain/src/primitives/zcash_primitives.rs
+++ b/zebra-chain/src/primitives/zcash_primitives.rs
@@ -290,7 +290,6 @@ impl PrecomputedTxData {
     ///
     /// The Ironwood bundle reuses the Orchard bundle type; it differs only by pool (separate tree,
     /// nullifier set, and value balance) and is verified under the NU6.3 Action circuit key.
-    #[cfg(zcash_unstable = "nu6.3")]
     pub fn ironwood_bundle(
         &self,
     ) -> Option<orchard::bundle::Bundle<orchard::bundle::Authorized, ZatBalance>> {

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -37,7 +37,6 @@ pub use unmined::{
 };
 use zcash_protocol::consensus;
 
-#[cfg(zcash_unstable = "nu6.3")]
 use crate::parameters::TX_V6_VERSION_GROUP_ID;
 use crate::{
     amount::{Amount, Error as AmountError, NegativeAllowed, NonNegative},
@@ -148,7 +147,6 @@ pub enum Transaction {
         orchard_shielded_data: Option<orchard::ShieldedData>,
     },
     /// A `version = 6` transaction, which is reserved for current development.
-    #[cfg(zcash_unstable = "nu6.3")]
     V6 {
         /// The Network Upgrade for this transaction.
         ///
@@ -289,7 +287,6 @@ impl Transaction {
             | Transaction::V3 { .. }
             | Transaction::V4 { .. } => None,
             Transaction::V5 { .. } => Some(AuthDigest::from(self)),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { .. } => Some(AuthDigest::from(self)),
         }
     }
@@ -403,7 +400,6 @@ impl Transaction {
         match self {
             Transaction::V1 { .. } | Transaction::V2 { .. } => false,
             Transaction::V3 { .. } | Transaction::V4 { .. } | Transaction::V5 { .. } => true,
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { .. } => true,
         }
     }
@@ -426,7 +422,6 @@ impl Transaction {
             Transaction::V3 { .. } => 3,
             Transaction::V4 { .. } => 4,
             Transaction::V5 { .. } => 5,
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { .. } => 6,
         }
     }
@@ -439,7 +434,6 @@ impl Transaction {
             | Transaction::V3 { lock_time, .. }
             | Transaction::V4 { lock_time, .. }
             | Transaction::V5 { lock_time, .. } => *lock_time,
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { lock_time, .. } => *lock_time,
         };
 
@@ -488,7 +482,6 @@ impl Transaction {
             | Transaction::V3 { lock_time, .. }
             | Transaction::V4 { lock_time, .. }
             | Transaction::V5 { lock_time, .. } => *lock_time,
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { lock_time, .. } => *lock_time,
         };
         let mut lock_time_bytes = Vec::new();
@@ -526,7 +519,6 @@ impl Transaction {
                 block::Height(0) => None,
                 block::Height(expiry_height) => Some(block::Height(*expiry_height)),
             },
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { expiry_height, .. } => match expiry_height {
                 // # Consensus
                 //
@@ -551,7 +543,6 @@ impl Transaction {
             Transaction::V5 {
                 network_upgrade, ..
             } => Some(*network_upgrade),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 network_upgrade, ..
             } => Some(*network_upgrade),
@@ -568,7 +559,6 @@ impl Transaction {
             Transaction::V3 { ref inputs, .. } => inputs,
             Transaction::V4 { ref inputs, .. } => inputs,
             Transaction::V5 { ref inputs, .. } => inputs,
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { ref inputs, .. } => inputs,
         }
     }
@@ -588,7 +578,6 @@ impl Transaction {
             Transaction::V3 { ref outputs, .. } => outputs,
             Transaction::V4 { ref outputs, .. } => outputs,
             Transaction::V5 { ref outputs, .. } => outputs,
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { ref outputs, .. } => outputs,
         }
     }
@@ -638,7 +627,6 @@ impl Transaction {
                 ..
             }
             | Transaction::V5 { .. } => Box::new(std::iter::empty()),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { .. } => Box::new(std::iter::empty()),
         }
     }
@@ -675,7 +663,6 @@ impl Transaction {
                 ..
             }
             | Transaction::V5 { .. } => Box::new(std::iter::empty()),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { .. } => Box::new(std::iter::empty()),
         }
     }
@@ -712,7 +699,6 @@ impl Transaction {
                 ..
             }
             | Transaction::V5 { .. } => 0,
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { .. } => 0,
         }
     }
@@ -753,7 +739,6 @@ impl Transaction {
                 ..
             }
             | Transaction::V5 { .. } => Box::new(std::iter::empty()),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { .. } => Box::new(std::iter::empty()),
         }
     }
@@ -791,7 +776,6 @@ impl Transaction {
                 ..
             }
             | Transaction::V5 { .. } => None,
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { .. } => None,
         }
     }
@@ -801,7 +785,6 @@ impl Transaction {
         match self {
             // No JoinSplits
             Transaction::V1 { .. } | Transaction::V5 { .. } => false,
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { .. } => false,
 
             // JoinSplits-on-BCTV14
@@ -850,7 +833,6 @@ impl Transaction {
             }
             | Transaction::V1 { .. }
             | Transaction::V5 { .. } => Box::new(std::iter::empty()),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { .. } => Box::new(std::iter::empty()),
         }
     }
@@ -873,7 +855,6 @@ impl Transaction {
                 ..
             } => Box::new(sapling_shielded_data.anchors()),
 
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
@@ -891,7 +872,6 @@ impl Transaction {
                 sapling_shielded_data: None,
                 ..
             } => Box::new(std::iter::empty()),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 sapling_shielded_data: None,
                 ..
@@ -921,7 +901,6 @@ impl Transaction {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
             } => Box::new(sapling_shielded_data.spends_per_anchor()),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
@@ -939,7 +918,6 @@ impl Transaction {
                 sapling_shielded_data: None,
                 ..
             } => Box::new(std::iter::empty()),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 sapling_shielded_data: None,
                 ..
@@ -959,7 +937,6 @@ impl Transaction {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
             } => Box::new(sapling_shielded_data.outputs()),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
@@ -977,7 +954,6 @@ impl Transaction {
                 sapling_shielded_data: None,
                 ..
             } => Box::new(std::iter::empty()),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 sapling_shielded_data: None,
                 ..
@@ -999,7 +975,6 @@ impl Transaction {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
             } => Box::new(sapling_shielded_data.nullifiers()),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
@@ -1017,7 +992,6 @@ impl Transaction {
                 sapling_shielded_data: None,
                 ..
             } => Box::new(std::iter::empty()),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 sapling_shielded_data: None,
                 ..
@@ -1041,7 +1015,6 @@ impl Transaction {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
             } => Box::new(sapling_shielded_data.note_commitments()),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
@@ -1059,7 +1032,6 @@ impl Transaction {
                 sapling_shielded_data: None,
                 ..
             } => Box::new(std::iter::empty()),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 sapling_shielded_data: None,
                 ..
@@ -1079,7 +1051,6 @@ impl Transaction {
                 sapling_shielded_data,
                 ..
             } => sapling_shielded_data.is_some(),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 sapling_shielded_data,
                 ..
@@ -1098,7 +1069,6 @@ impl Transaction {
                 orchard_shielded_data,
                 ..
             } => orchard_shielded_data.as_ref(),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 orchard_shielded_data,
                 ..
@@ -1158,7 +1128,6 @@ impl Transaction {
     /// separate note commitment tree and nullifier set. It only appears in v6 transactions.
     pub fn ironwood_shielded_data(&self) -> Option<&orchard::ShieldedData> {
         match self {
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 ironwood_shielded_data,
                 ..
@@ -1291,7 +1260,6 @@ impl Transaction {
                 ..
             }
             | Transaction::V5 { .. } => Box::new(std::iter::empty()),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { .. } => Box::new(std::iter::empty()),
         }
     }
@@ -1340,7 +1308,6 @@ impl Transaction {
                 ..
             }
             | Transaction::V5 { .. } => Box::new(std::iter::empty()),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { .. } => Box::new(std::iter::empty()),
         }
     }
@@ -1383,7 +1350,6 @@ impl Transaction {
                 ..
             }
             | Transaction::V5 { .. } => Box::new(iter::empty()),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { .. } => Box::new(iter::empty()),
         };
 
@@ -1426,7 +1392,6 @@ impl Transaction {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
             } => sapling_shielded_data.value_balance,
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
@@ -1443,7 +1408,6 @@ impl Transaction {
                 sapling_shielded_data: None,
                 ..
             } => Amount::zero(),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 sapling_shielded_data: None,
                 ..
@@ -1467,7 +1431,6 @@ impl Transaction {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
             } => Some(sapling_shielded_data.binding_sig),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
@@ -1646,7 +1609,6 @@ impl Transaction {
             Transaction::V3 { .. } => Some(OVERWINTER_VERSION_GROUP_ID),
             Transaction::V4 { .. } => Some(SAPLING_VERSION_GROUP_ID),
             Transaction::V5 { .. } => Some(TX_V5_VERSION_GROUP_ID),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { .. } => Some(TX_V6_VERSION_GROUP_ID),
         }
     }
@@ -1674,7 +1636,6 @@ impl Transaction {
                 *network_upgrade = nu;
                 Ok(())
             }
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 ref mut network_upgrade,
                 ..
@@ -1707,7 +1668,6 @@ impl Transaction {
                 ref mut expiry_height,
                 ..
             } => expiry_height,
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 ref mut expiry_height,
                 ..
@@ -1723,7 +1683,6 @@ impl Transaction {
             Transaction::V3 { ref mut inputs, .. } => inputs,
             Transaction::V4 { ref mut inputs, .. } => inputs,
             Transaction::V5 { ref mut inputs, .. } => inputs,
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { ref mut inputs, .. } => inputs,
         }
     }
@@ -1751,7 +1710,6 @@ impl Transaction {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
             } => Some(&mut sapling_shielded_data.value_balance),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 sapling_shielded_data: Some(sapling_shielded_data),
                 ..
@@ -1767,7 +1725,6 @@ impl Transaction {
                 sapling_shielded_data: None,
                 ..
             } => None,
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 sapling_shielded_data: None,
                 ..
@@ -1820,7 +1777,6 @@ impl Transaction {
                 ..
             }
             | Transaction::V5 { .. } => Box::new(std::iter::empty()),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { .. } => Box::new(std::iter::empty()),
         }
     }
@@ -1870,7 +1826,6 @@ impl Transaction {
                 ..
             }
             | Transaction::V5 { .. } => Box::new(std::iter::empty()),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { .. } => Box::new(std::iter::empty()),
         }
     }
@@ -1890,7 +1845,6 @@ impl Transaction {
                 orchard_shielded_data: Some(orchard_shielded_data),
                 ..
             } => Some(orchard_shielded_data),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 orchard_shielded_data: Some(orchard_shielded_data),
                 ..
@@ -1904,7 +1858,6 @@ impl Transaction {
                 orchard_shielded_data: None,
                 ..
             } => None,
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 orchard_shielded_data: None,
                 ..
@@ -1930,7 +1883,6 @@ impl Transaction {
             Transaction::V5 {
                 ref mut outputs, ..
             } => outputs,
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 ref mut outputs, ..
             } => outputs,

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -958,7 +958,6 @@ pub fn transaction_to_fake_v5(
             orchard_shielded_data: None,
         },
         v5 @ V5 { .. } => v5.clone(),
-        #[cfg(zcash_unstable = "nu6.3")]
         v6 @ V6 { .. } => v6.clone(),
     }
 }
@@ -1044,7 +1043,6 @@ pub fn v5_transactions<'b>(
         | Transaction::V3 { .. }
         | Transaction::V4 { .. } => None,
         ref tx @ Transaction::V5 { .. } => Some(tx.clone()),
-        #[cfg(zcash_unstable = "nu6.3")]
         ref tx @ Transaction::V6 { .. } => Some(tx.clone()),
     })
 }
@@ -1126,7 +1124,6 @@ pub fn insert_fake_orchard_shielded_data(
 /// dummy action — so all actions share one nullifier, which is convenient for duplicate-nullifier
 /// tests. The proof is empty (not canonically sized) and the signatures are not valid, so this MUST
 /// NOT be used where proof verification or a canonical proof size is required.
-#[cfg(zcash_unstable = "nu6.3")]
 pub fn fake_v6_orchard_shielded_data(
     flags: orchard::Flags,
     value_balance: Amount<NegativeAllowed>,
@@ -1160,7 +1157,6 @@ pub fn fake_v6_orchard_shielded_data(
 ///
 /// The transaction is non-coinbase (no inputs) and otherwise empty. The bundles are not
 /// cryptographically valid (see [`fake_v6_orchard_shielded_data`]).
-#[cfg(zcash_unstable = "nu6.3")]
 pub fn fake_v6_transaction(
     network_upgrade: NetworkUpgrade,
     orchard_shielded_data: Option<orchard::ShieldedDataV6>,

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -21,7 +21,6 @@ use crate::{
     },
 };
 
-#[cfg(zcash_unstable = "nu6.3")]
 use crate::parameters::TX_V6_VERSION_GROUP_ID;
 
 use super::*;
@@ -425,7 +424,6 @@ impl ZcashSerialize for orchard::ShieldedData {
 // identically on the wire (the flag byte is written as-is), so the v6 Orchard and Ironwood
 // (de)serializers below delegate to the v5 Orchard bundle codec, only wrapping/unwrapping their
 // newtypes (`orchard::ShieldedDataV6` and `ironwood::ShieldedData`).
-#[cfg(zcash_unstable = "nu6.3")]
 impl ZcashDeserialize for Option<orchard::ShieldedDataV6> {
     fn zcash_deserialize<R: io::Read>(reader: R) -> Result<Self, SerializationError> {
         Ok(
@@ -435,14 +433,12 @@ impl ZcashDeserialize for Option<orchard::ShieldedDataV6> {
     }
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 impl ZcashSerialize for Option<orchard::ShieldedDataV6> {
     fn zcash_serialize<W: io::Write>(&self, writer: W) -> Result<(), io::Error> {
         zcash_serialize_optional_orchard_bundle(self.as_ref().map(|data| data.data()), writer)
     }
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 impl ZcashDeserialize for Option<ironwood::ShieldedData> {
     fn zcash_deserialize<R: io::Read>(reader: R) -> Result<Self, SerializationError> {
         Ok(
@@ -452,7 +448,6 @@ impl ZcashDeserialize for Option<ironwood::ShieldedData> {
     }
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 impl ZcashSerialize for Option<ironwood::ShieldedData> {
     fn zcash_serialize<W: io::Write>(&self, writer: W) -> Result<(), io::Error> {
         zcash_serialize_optional_orchard_bundle(self.as_ref().map(|data| data.data()), writer)
@@ -770,7 +765,6 @@ impl ZcashSerialize for Transaction {
                 orchard_shielded_data.zcash_serialize(&mut writer)?;
             }
 
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 {
                 network_upgrade,
                 lock_time,
@@ -1114,7 +1108,6 @@ impl ZcashDeserialize for Transaction {
 
                 Ok(tx)
             }
-            #[cfg(zcash_unstable = "nu6.3")]
             (6, true) => {
                 // Denoted as `nVersionGroupId` in the spec.
                 let id = limited_reader.read_u32::<LittleEndian>()?;

--- a/zebra-chain/src/transaction/sighash.rs
+++ b/zebra-chain/src/transaction/sighash.rs
@@ -150,7 +150,6 @@ impl SigHasher {
     }
 
     /// Returns the Ironwood bundle in the precomputed transaction data (NU6.3 onward).
-    #[cfg(zcash_unstable = "nu6.3")]
     pub fn ironwood_bundle(
         &self,
     ) -> Option<::orchard::bundle::Bundle<::orchard::bundle::Authorized, ZatBalance>> {

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -1011,7 +1011,6 @@ fn binding_signatures() {
                             at_least_one_v5_checked = true;
                         }
                     }
-                    #[cfg(zcash_unstable = "nu6.3")]
                     Transaction::V6 {
                         sapling_shielded_data,
                         ..
@@ -1059,7 +1058,6 @@ fn binding_signatures() {
 /// v6 (ZIP-244) digest path, which is the runtime path that does not work against released
 /// librustzcash. The branch id resolves to the fork's `BranchId::Nu6_3`.
 #[test]
-#[cfg(zcash_unstable = "nu6.3")]
 fn v6_ironwood_txid_and_roundtrip() {
     let _init_guard = zebra_test::init();
 
@@ -1097,7 +1095,6 @@ fn v6_ironwood_txid_and_roundtrip() {
 /// helpers produce. This exercises Zebra's self-contained v6 wire codec for *non-empty* bundles
 /// (the empty-bundle path is already covered above).
 #[test]
-#[cfg(zcash_unstable = "nu6.3")]
 fn v6_transaction_with_bundles_round_trips() {
     use crate::ironwood;
     use crate::orchard::{Flags, ShieldedDataV6};

--- a/zebra-chain/src/transaction/txid.rs
+++ b/zebra-chain/src/transaction/txid.rs
@@ -28,7 +28,6 @@ impl<'a> TxIdBuilder<'a> {
             | Transaction::V3 { .. }
             | Transaction::V4 { .. } => self.txid_v1_to_v4(),
             Transaction::V5 { .. } => self.txid_v5(),
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { .. } => self.txid_v6(),
         }
     }
@@ -52,7 +51,6 @@ impl<'a> TxIdBuilder<'a> {
     }
 
     /// Passthrough to txid_v5 for V6 transactions.
-    #[cfg(zcash_unstable = "nu6.3")]
     fn txid_v6(self) -> Option<Hash> {
         self.txid_v5()
     }

--- a/zebra-chain/src/transaction/unmined.rs
+++ b/zebra-chain/src/transaction/unmined.rs
@@ -143,7 +143,6 @@ impl From<&Transaction> for UnminedTxId {
         match transaction {
             V1 { .. } | V2 { .. } | V3 { .. } | V4 { .. } => Legacy(transaction.into()),
             V5 { .. } => Witnessed(transaction.into()),
-            #[cfg(zcash_unstable = "nu6.3")]
             V6 { .. } => Witnessed(transaction.into()),
         }
     }

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -877,7 +877,6 @@ where
             Transaction::V5 { .. } => {
                 Self::verify_v5_transaction(req, network, script_verifier, cached_ffi_transaction)
             }
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { .. } => {
                 Self::verify_v6_transaction(req, network, script_verifier, cached_ffi_transaction)
             }
@@ -1069,7 +1068,6 @@ where
     /// Differs from [`Self::verify_v5_transaction`] in the Orchard verifier: a v6 Orchard bundle
     /// commits to the NU6.3 cross-address circuit, so it (and the Ironwood bundle) verify under the
     /// NU6.3 key, not the v5 fixed key.
-    #[cfg(zcash_unstable = "nu6.3")]
     fn verify_v6_transaction(
         request: &Request,
         network: &Network,
@@ -1104,7 +1102,6 @@ where
     /// Verifies that a V6 `transaction` is supported by `network_upgrade`.
     ///
     /// V6 transactions are only valid from NU6.3 onward.
-    #[cfg(zcash_unstable = "nu6.3")]
     fn verify_v6_transaction_network_upgrade(
         transaction: &Transaction,
         network_upgrade: NetworkUpgrade,
@@ -1341,7 +1338,6 @@ where
     /// A v6 Orchard bundle commits to the NU6.3 cross-address circuit, so it always verifies under
     /// the NU6.3 key ([`primitives::halo2::orchard_v6_verifier`]), independent of the block's
     /// network upgrade (v6 transactions only exist from NU6.3 onward).
-    #[cfg(zcash_unstable = "nu6.3")]
     fn verify_orchard_v6_bundle(
         bundle: Option<::orchard::bundle::Bundle<::orchard::bundle::Authorized, ZatBalance>>,
         sighash: &SigHash,

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -241,7 +241,6 @@ fn orchard_value_balance_frozen_at_nu6_3() {
 /// Tests the `[NU6.3 onward] if there are Ironwood actions, at least one of enableSpendsIronwood
 /// and enableOutputsIronwood MUST be 1` rule.
 #[test]
-#[cfg(zcash_unstable = "nu6.3")]
 fn v6_transaction_with_ironwood_actions_must_have_flags() {
     use zebra_chain::ironwood;
     use zebra_chain::orchard::ShieldedDataV6;
@@ -278,7 +277,6 @@ fn v6_transaction_with_ironwood_actions_must_have_flags() {
 /// Tests the `[NU6.3 onward] the enableCrossAddress flag of flagsOrchard MUST be 0` rule, which only
 /// a v6 Orchard bundle can violate (a v5 Orchard bundle rejects the flag bit at deserialization).
 #[test]
-#[cfg(zcash_unstable = "nu6.3")]
 fn v6_orchard_bundle_must_not_enable_cross_address() {
     use zebra_chain::orchard::ShieldedDataV6;
     use zebra_chain::transaction::arbitrary::{fake_v6_orchard_shielded_data, fake_v6_transaction};
@@ -363,7 +361,6 @@ fn coinbase_orchard_component_empty_at_nu6_3() {
 /// Tests that a transaction revealing the same Ironwood nullifier twice is rejected as a
 /// double-spend, and that the Ironwood and Orchard nullifier sets are checked separately.
 #[test]
-#[cfg(zcash_unstable = "nu6.3")]
 fn v6_transaction_with_duplicate_ironwood_nullifier_is_rejected() {
     use zebra_chain::ironwood;
     use zebra_chain::orchard::ShieldedDataV6;

--- a/zebra-consensus/src/transaction/tests/prop.rs
+++ b/zebra-consensus/src/transaction/tests/prop.rs
@@ -321,7 +321,6 @@ fn mock_transparent_transaction(
             orchard_shielded_data: None,
             network_upgrade,
         },
-        #[cfg(zcash_unstable = "nu6.3")]
         6 => Transaction::V6 {
             inputs,
             outputs,

--- a/zebra-rpc/src/methods/types/transaction.rs
+++ b/zebra-rpc/src/methods/types/transaction.rs
@@ -157,7 +157,7 @@ impl TransactionTemplate<NegativeOrZero> {
             };
         }
 
-        let add_orchard_reward = |builder: &mut Builder<'_, _, _>, addr: &_| {
+        let add_orchard_reward = |builder: &mut Builder<_, _>, addr: &_| {
             trace_err!(
                 builder.add_orchard_output::<String>(
                     Some(::orchard::keys::OutgoingViewingKey::from([0u8; 32])),
@@ -169,7 +169,7 @@ impl TransactionTemplate<NegativeOrZero> {
             )
         };
 
-        let add_sapling_reward = |builder: &mut Builder<'_, _, _>, addr: &_| {
+        let add_sapling_reward = |builder: &mut Builder<_, _>, addr: &_| {
             trace_err!(
                 builder.add_sapling_output::<String>(
                     Some(sapling_crypto::keys::OutgoingViewingKey([0u8; 32])),
@@ -181,7 +181,7 @@ impl TransactionTemplate<NegativeOrZero> {
             )
         };
 
-        let add_transparent_reward = |builder: &mut Builder<'_, _, _>, addr| {
+        let add_transparent_reward = |builder: &mut Builder<_, _>, addr| {
             trace_err!(
                 builder.add_transparent_output(addr, miner_reward),
                 "transparent"

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -1805,7 +1805,6 @@ impl Chain {
                     sapling_shielded_data,
                     orchard_shielded_data.as_ref(),
                 ),
-                #[cfg(zcash_unstable = "nu6.3")]
                 V6 {
                     inputs,
                     outputs,
@@ -1851,7 +1850,6 @@ impl Chain {
                 // The Ironwood pool reuses orchard::ShieldedData, so its nullifiers are applied
                 // through a distinct UpdateWith impl keyed on the ironwood::ShieldedData newtype
                 // (which doesn't collide with the Orchard impl).
-                #[cfg(zcash_unstable = "nu6.3")]
                 if let V6 {
                     ironwood_shielded_data,
                     ..
@@ -2015,7 +2013,6 @@ impl UpdateWith<ContextuallyVerifiedBlock> for Chain {
                     sapling_shielded_data,
                     orchard_shielded_data.as_ref(),
                 ),
-                #[cfg(zcash_unstable = "nu6.3")]
                 V6 {
                     inputs,
                     outputs,
@@ -2066,7 +2063,6 @@ impl UpdateWith<ContextuallyVerifiedBlock> for Chain {
 
             // Revert the Ironwood nullifiers through the matching UpdateWith impl (see
             // `update_chain_tip_with_block_except_trees`).
-            #[cfg(zcash_unstable = "nu6.3")]
             if let V6 {
                 ironwood_shielded_data,
                 ..
@@ -2471,7 +2467,6 @@ impl UpdateWith<(Option<&orchard::ShieldedData>, &SpendingTransactionId)> for Ch
     }
 }
 
-#[cfg(zcash_unstable = "nu6.3")]
 impl UpdateWith<(Option<&ironwood::ShieldedData>, &SpendingTransactionId)> for Chain {
     #[instrument(skip(self, ironwood_shielded_data))]
     fn update_chain_tip_with(

--- a/zebra-state/src/tests.rs
+++ b/zebra-state/src/tests.rs
@@ -36,7 +36,6 @@ impl FakeChainHelper for Arc<Block> {
             Transaction::V3 { inputs, .. } => &mut inputs[0],
             Transaction::V4 { inputs, .. } => &mut inputs[0],
             Transaction::V5 { inputs, .. } => &mut inputs[0],
-            #[cfg(zcash_unstable = "nu6.3")]
             Transaction::V6 { inputs, .. } => &mut inputs[0],
         };
 

--- a/zebrad/src/components/mempool/storage/tests/prop.rs
+++ b/zebrad/src/components/mempool/storage/tests/prop.rs
@@ -589,7 +589,6 @@ impl SpendConflictTestInput {
 
                 // No JoinSplits
                 Transaction::V1 { .. } | Transaction::V5 { .. } => {}
-                #[cfg(zcash_unstable = "nu6.3")]
                 Transaction::V6 { .. } => {}
             }
         }
@@ -661,7 +660,6 @@ impl SpendConflictTestInput {
                     Self::remove_sapling_transfers_with_conflicts(sapling_shielded_data, &conflicts)
                 }
 
-                #[cfg(zcash_unstable = "nu6.3")]
                 Transaction::V6 {
                     sapling_shielded_data,
                     ..
@@ -740,7 +738,6 @@ impl SpendConflictTestInput {
                     ..
                 } => Self::remove_orchard_actions_with_conflicts(orchard_shielded_data, &conflicts),
 
-                #[cfg(zcash_unstable = "nu6.3")]
                 Transaction::V6 {
                     orchard_shielded_data,
                     ..

--- a/zebrad/tests/integration/regtest.rs
+++ b/zebrad/tests/integration/regtest.rs
@@ -504,9 +504,8 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
 /// Test successful block template submission as a block proposal.
 ///
 /// This test can be run locally with:
-/// `RUSTFLAGS='--cfg zcash_unstable="nu6.3"' cargo test --package zebrad --test zebrad-tests -- nu6_3_block_template_proposal --exact --show-output`
+/// `cargo test --package zebrad --test zebrad-tests -- nu6_3_block_template_proposal --exact --show-output`
 #[tokio::test(flavor = "multi_thread")]
-#[cfg(zcash_unstable = "nu6.3")]
 async fn nu6_3_block_template_proposal() -> Result<()> {
     use zebra_chain::{
         chain_sync_status::MockSyncStatus,


### PR DESCRIPTION
## Motivation

Track upstream `librustzcash` development by pinning Zebra's `zcash_*` dependencies to `librustzcash` `release/nu6.3_testnet_support` branch, ahead of the next round of crate releases. 

> The `[patch.crates-io]` entries are **temporary** — they point at a `librustzcash` git revision and must be
> replaced with published crate versions before the target branch is released. 
## Solution

- Add `[patch.crates-io]` directives pinning `equihash`, `f4jumble`,
  `transparent` (`zcash_transparent`), `zcash_address`, `zcash_encoding`,
  `zcash_history`, `zcash_keys`, `zcash_primitives`, `zcash_proofs`, and
  `zcash_protocol` to the `librustzcash` `release/nu6.3_testnet_support` branch
  (rev `703fe3e6608fab8be0dedbbcbf684f030a1ea451`).
- Update the miner-reward transaction builders in
  `zebra-rpc/src/methods/types/transaction.rs` for the removed lifetime
  parameter on `zcash_primitives`' transaction `Builder` — it is now
  `Builder<P, U>` instead of `Builder<'a, P, U>`, so the closure type
  annotations change from `Builder<'_, _, _>` to `Builder<_, _>`.
- Remove the `zcash_unstable=nu6.3` config gate.

### Tests

- `CXXFLAGS="-include cstdint" cargo check --workspace --all-targets` passes
  cleanly (0 errors).
- Full `cargo clippy -D warnings` and `cargo test` / nextest CI have **not**
  yet been run — see Follow-up Work.

### Specifications & References

- `librustzcash` `release/nu6.3_testnet_support`: https://github.com/zcash/librustzcash
  (rev `703fe3e6608fab8be0dedbbcbf684f030a1ea451`)

### Follow-up Work

- Replace the temporary `[patch.crates-io]` git pins with published crate
  releases before taking this out of draft.
- Run the full `cargo clippy -D warnings` and `cargo test` / nextest CI
  suites and add a `CHANGELOG.md` entry if the final version is user-visible.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude Code — fixed the compilation error caused by
  the `Builder` lifetime change and drafted this PR description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand. _(Opened as a draft; coordinating directly with maintainers, no tracking issue yet.)_
- [ ] The solution is tested. _(`cargo check` only so far — see Tests / Follow-up.)_
- [ ] The documentation and changelogs are up to date. _(Deferred until the dependencies are on published versions — see Follow-up.)_
