### PR TITLE
feat: attach downloadable signed zebrad binaries to releases

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -44,6 +44,18 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
+  # Build and attach downloadable zebrad binaries to the GitHub release.
+  binaries:
+    name: Attach release binaries
+    if: github.repository_owner == 'ZcashFoundation'
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/zfnd-release-binaries.yml
+    with:
+      release_tag: ${{ github.event.release.tag_name }}
+
   dockerhub-description:
     if: github.repository_owner == 'ZcashFoundation'
     runs-on: ubuntu-latest
@@ -71,6 +83,7 @@ jobs:
       }}
     needs:
       - build
+      - binaries
       - dockerhub-description
     timeout-minutes: 1
     steps:
@@ -82,7 +95,7 @@ jobs:
   failure-issue:
     name: Open or update issues for release binaries failures
     # When a new job is added to this workflow, add it to this list.
-    needs: [ build, dockerhub-description ]
+    needs: [ build, binaries, dockerhub-description ]
     # Open tickets for any failed build in this workflow.
     if: failure() || cancelled()
     runs-on: ubuntu-latest

--- a/.github/workflows/test-release-binaries.yml
+++ b/.github/workflows/test-release-binaries.yml
@@ -1,0 +1,31 @@
+# Validation harness for the release-binaries build and signing path.
+# Builds from the current ref with the same reusable workflow the release uses,
+# and uploads the result as a CI artifact instead of to a release.
+#
+# Runs a full release build, so it is scoped to this branch. Temporary: remove
+# once the release path has run on a real release.
+name: Test release binaries
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version label for the test archives"
+        required: false
+        type: string
+        default: "0.0.0-test"
+  push:
+    branches:
+      - build/release-binary-downloads
+
+permissions: {}
+
+jobs:
+  test:
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/zfnd-release-binaries.yml
+    with:
+      version: ${{ inputs.version || '0.0.0-test' }}

--- a/.github/workflows/zfnd-release-binaries.yml
+++ b/.github/workflows/zfnd-release-binaries.yml
@@ -1,0 +1,173 @@
+# Builds the zebrad binary for Linux and packages it into signed, checksummed
+# `.tar.gz` archives. Reused by the release path and by the validation harness.
+#
+# Binaries are built on Ubuntu 22.04 for a low glibc floor, with RocksDB and the
+# zcash FFI linked statically, so they run on most current distributions.
+#
+# With `release_tag`, the archives are uploaded to that GitHub release; without
+# it, they are uploaded as a CI artifact for inspection.
+name: Release binaries (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: "Release tag to upload assets to; empty uploads a CI artifact instead"
+        required: false
+        type: string
+        default: ""
+      version:
+        description: "Version used in asset filenames; defaults to release_tag without its `v`"
+        required: false
+        type: string
+        default: ""
+      features:
+        description: "Cargo features to build zebrad with"
+        required: false
+        type: string
+        default: "default-release-binaries"
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build zebrad (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-22.04
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-22.04-arm
+    permissions:
+      contents: read
+    env:
+      TARGET: ${{ matrix.target }}
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      VERSION_INPUT: ${{ inputs.version }}
+      FEATURES: ${{ inputs.features }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get -qq install -y --no-install-recommends \
+            clang libclang-dev cmake protobuf-compiler
+
+      # Toolchain version comes from rust-toolchain.toml.
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 #v1.16.1
+        with:
+          cache-on-failure: true
+
+      - name: Build and package zebrad
+        run: |
+          set -euo pipefail
+          version="${VERSION_INPUT}"
+          if [ -z "${version}" ]; then version="${RELEASE_TAG#v}"; fi
+          if [ -z "${version}" ]; then echo "::error::no version or release_tag provided"; exit 1; fi
+
+          SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)"
+          export SOURCE_DATE_EPOCH
+          # Keep build-host paths out of the binary.
+          export RUSTFLAGS="--remap-path-prefix=${GITHUB_WORKSPACE}=/zebra --remap-path-prefix=${HOME}/.cargo=/cargo"
+          export CARGO_PROFILE_RELEASE_STRIP=symbols
+          # ROCKSDB_LIB_DIR is left unset so librocksdb-sys builds and links RocksDB
+          # statically; the binary then depends only on glibc and libstdc++.
+          cargo build --locked --release --features "${FEATURES}" --package zebrad --bin zebrad
+
+          echo "glibc floor: $(objdump -T target/release/zebrad | grep -oE 'GLIBC_[0-9.]+' | sed 's/GLIBC_//' | sort -V | tail -1)"
+
+          stage="zebrad-${version}-${TARGET}"
+          mkdir -p "dist/${stage}"
+          cp target/release/zebrad "dist/${stage}/zebrad"
+          cp LICENSE-APACHE LICENSE-MIT README.md "dist/${stage}/"
+          tar --sort=name --owner=0 --group=0 --numeric-owner \
+            --mtime="@${SOURCE_DATE_EPOCH}" \
+            -cf - -C "dist/${stage}" zebrad LICENSE-APACHE LICENSE-MIT README.md \
+            | gzip -n > "dist/${stage}.tar.gz"
+          rm -rf "dist/${stage}"
+          ( cd dist && sha256sum "${stage}.tar.gz" > "${stage}.tar.gz.sha256" )
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
+        with:
+          name: binary-${{ matrix.target }}
+          path: dist/
+          retention-days: 1
+
+  publish:
+    name: Sign and publish binaries
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      REPOSITORY: ${{ github.repository }}
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
+        with:
+          path: staging
+          pattern: binary-*
+          merge-multiple: true
+
+      - name: Collect archives and generate the checksum manifest
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          mv staging/*.tar.gz staging/*.tar.gz.sha256 dist/
+          ( cd dist && sha256sum -- *.tar.gz > SHA256SUMS )
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: dist/*.tar.gz
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign the checksum manifest
+        working-directory: dist
+        run: cosign sign-blob --yes --bundle SHA256SUMS.sigstore.json SHA256SUMS
+
+      - name: Verify signatures
+        working-directory: dist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          cosign verify-blob SHA256SUMS \
+            --bundle SHA256SUMS.sigstore.json \
+            --certificate-identity-regexp='^https://github\.com/ZcashFoundation/zebra/\.github/workflows/zfnd-release-binaries\.yml@' \
+            --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
+          for archive in *.tar.gz; do
+            gh attestation verify "${archive}" \
+              --repo "${REPOSITORY}" \
+              --signer-workflow ZcashFoundation/zebra/.github/workflows/zfnd-release-binaries.yml
+          done
+
+      - name: Upload binaries to the release
+        if: inputs.release_tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${RELEASE_TAG}" \
+            dist/*.tar.gz dist/*.sha256 dist/SHA256SUMS dist/SHA256SUMS.sigstore.json \
+            --repo "${REPOSITORY}" --clobber
+
+      - name: Upload binaries as a CI artifact
+        if: inputs.release_tag == ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
+        with:
+          name: release-binaries
+          path: dist/
+          retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Added
 
+- Pre-built `zebrad` binaries are attached to each GitHub release for Linux on
+  `x86_64` and `aarch64`, so operators can run a node without Docker or a source
+  build, also installable with `cargo binstall zebrad`. Each `.tar.gz` carries a
+  SHA-256 checksum, a Sigstore build-provenance attestation, and a Cosign signature
+  over the checksum manifest ([#10799](https://github.com/ZcashFoundation/zebra/pull/10799))
 - Added a Regtest configuration option, `should_allow_unshielded_coinbase_spends`,
   to forbid spending coinbase outputs into transparent outputs (the inverse of
   zcashd's `-regtestshieldcoinbase`). It defaults to allowing such spends, preserving

--- a/book/src/user/install.md
+++ b/book/src/user/install.md
@@ -3,6 +3,35 @@
 The easiest way to install and run Zebra is to follow the [Getting
 Started](https://zebra.zfnd.org/index.html#getting-started) section.
 
+## Pre-built binaries
+
+Every [GitHub release](https://github.com/ZcashFoundation/zebra/releases) ships
+pre-built `zebrad` binaries for Linux on `x86_64` and `aarch64`, as
+`zebrad-<version>-<target>.tar.gz` archives. They are built on Ubuntu 22.04 and
+need glibc 2.35 or newer (Ubuntu 22.04+, Debian 12+); on older or other platforms
+use the [Docker image](https://hub.docker.com/r/zfnd/zebra) or build from source.
+
+Install the latest release with
+[`cargo binstall`](https://github.com/cargo-bins/cargo-binstall):
+
+```bash
+cargo binstall zebrad
+```
+
+Or download an archive, verify it, and extract `zebrad`:
+
+```bash
+gh attestation verify zebrad-<version>-x86_64-unknown-linux-gnu.tar.gz \
+  --repo ZcashFoundation/zebra \
+  --signer-workflow ZcashFoundation/zebra/.github/workflows/zfnd-release-binaries.yml
+cosign verify-blob SHA256SUMS \
+  --bundle SHA256SUMS.sigstore.json \
+  --certificate-identity-regexp='^https://github\.com/ZcashFoundation/zebra/\.github/workflows/zfnd-release-binaries\.yml@' \
+  --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
+sha256sum --ignore-missing -c SHA256SUMS
+tar xzf zebrad-<version>-x86_64-unknown-linux-gnu.tar.gz
+```
+
 ## Building Zebra
 
 If you want to build Zebra, install the build dependencies as described in the

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -33,6 +33,12 @@ pre-release-replacements = [
   {file="../README.md", search="--tag [a-z0-9\\.-]+", replace="--tag v{{version}}"},
 ]
 
+# `cargo binstall zebrad` fetches the release archives built by release-binaries.yml.
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ version }-{ target }{ archive-suffix }"
+pkg-fmt = "tgz"
+bin-dir = "{ bin }{ binary-ext }"
+
 [package.metadata.docs.rs]
 
 # Publish Zebra's supported production and developer features on docs.rs.


### PR DESCRIPTION
## Motivation

Releases ship only Docker images and a crates.io source build, so an operator who wants a ready-to-run `zebrad` without Docker or a Rust toolchain has to compile it. This adds pre-built Linux binaries to each GitHub release.

## Solution

`zebrad` is built for `x86_64` and `aarch64` Linux on native `ubuntu-22.04` runners, with RocksDB and the zcash script FFI linked statically. The build links against glibc 2.34, so the binaries run on the common server distributions (Ubuntu 22.04+, Debian 12+, RHEL 9+, Amazon Linux 2023); the binary then needs only glibc and `libstdc++`.

Each target is packaged as a `.tar.gz` with a SHA-256 checksum. A Sigstore build-provenance attestation is produced per archive and the checksum manifest is Cosign-signed, both pinned to the signing workflow and verified before publish. Building and signing live in a reusable workflow (`zfnd-release-binaries.yml`) the release path calls.

`cargo binstall zebrad` resolves the archives via `[package.metadata.binstall]`.

macOS and Windows are out of scope. The binaries are signed and attested but not bit-for-bit reproducible; reproducibility stays a property of the release image.

`test-release-binaries.yml` is temporary scaffolding: it builds and signs from the current ref and uploads a CI artifact, so the path can be validated on demand without a release.

### Tests

- `test-release-binaries.yml` builds, attests, Cosign-signs, and verifies the archives in CI on demand; the build logs the measured glibc floor.
- Confirmed locally that a statically linked `zebrad` (RocksDB and the zcash FFI built from source) needs only glibc and `libstdc++`, which the native build reproduces by leaving `ROCKSDB_LIB_DIR` unset.

### Follow-up Work

- Additional targets (macOS, musl) if there is demand.
- A lower glibc floor (RHEL 9 / Amazon Linux 2023 at 2.34) would need a build on an older base.

### AI Disclosure

- [x] AI tools were used: Claude Code, for the workflow YAML, documentation, and this description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
