### PR TITLE
fix(ci): restate queue gates on the Mergify urgent queue

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -44,7 +44,19 @@ queue_rules:
     batch_size: 5
     # Wait a short time to embark hotfixes together in a merge train
     batch_max_wait_time: "2 minutes"
+    # A queue_rule's `queue_conditions` REPLACES the value from
+    # `defaults.queue_rule.queue_conditions` rather than extending it. Restate
+    # the same gates here so a P-Critical label cannot bypass the approval,
+    # changes-requested, base-branch, and required-check checks.
     queue_conditions:
+      - base=main
+      - -draft
+      - label!=do-not-merge
+      - "#approved-reviews-by >= 1"
+      - "#changes-requested-reviews-by = 0"
+      - check-success=lint
+      - check-success=unit-tests
+      - check-success=test-crates
       # is labeled with Critical priority
       - 'label~=^P-Critical'
 


### PR DESCRIPTION
## Motivation

A Mergify `queue_rule`'s `queue_conditions` field **replaces** `defaults.queue_rule.queue_conditions` rather than extending it. The `urgent` queue on this repo overrides `queue_conditions` with a single condition:

```yaml
queue_rules:
  - name: urgent
    queue_conditions:
      - 'label~=^P-Critical'
```

So a PR with the `P-Critical` label is accepted into the urgent queue without satisfying any of the gates the default queue requires: approval count, no changes-requested, `base=main`, or required-check success. Anyone who can add `P-Critical` can bypass every merge protection.

This is the path used to merge PR #10799 into the `reproducible-builds` feature branch without any approving review. The blast radius this time was a feature branch rather than `main`, but the same path would have worked against `main`.

## Solution

Restate the same gates inside the urgent queue's `queue_conditions`, plus the `P-Critical` label requirement. The label keeps its role of raising the queue's priority (smaller batch, shorter wait) without removing any of the protections.

```yaml
queue_conditions:
  - base=main
  - -draft
  - label!=do-not-merge
  - "#approved-reviews-by >= 1"
  - "#changes-requested-reviews-by = 0"
  - check-success=lint
  - check-success=unit-tests
  - check-success=test-crates
  - 'label~=^P-Critical'
```

This complements the gates added to `defaults.queue_rule.queue_conditions` in #10701.

### Tests

- Diff is mechanical (12 lines added) and parsed by Mergify's config validator.
- After this change, a PR labeled `P-Critical` still cannot enter the urgent queue without satisfying approval, base-branch, changes-requested, and the three aggregator check-runs — matching the default queue's behavior.

### Specifications & References

- [Mergify — queue rules and defaults](https://docs.mergify.com/configuration/queue-rules/)
- Prior gate hardening: #10701.
- The PR that surfaced the gap by merging through it: #10799.

### Follow-up Work

A future cleanup could collapse `urgent` and `batched` into a single queue and use `priority_rules` alone to differentiate, removing this duplication. Out of scope here — this change is the minimal hot-fix.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude (Anthropic) — drafted the change and this description; reviewed before commit.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [ ] The documentation and changelogs are up to date.