### PR TITLE
fix(rpc): stop read-state syncer re-subscribing ~1/sec under finalized lag

### DIFF
--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -29,6 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fails to commit to the non-finalized state: it now backs off before re-subscribing
   and only logs the warning on transitions.
   ([#10741](https://github.com/ZcashFoundation/zebra/pull/10741))
+- `TrustedChainSync` no longer tears down and re-subscribes its non-finalized block
+  subscription roughly once per second while its finalized state catches up to the
+  primary. It now retries committing the streamed block in place, keeping the
+  subscription open, and only re-subscribes as a bounded backstop. The server-side
+  stream-teardown messages (`client disconnected, dropping … task`) are logged at
+  `debug` instead of `info`, so a normal consumer disconnect no longer floods the
+  node's logs. ([#10803](https://github.com/ZcashFoundation/zebra/issues/10803))
 
 ## [10.0.1] - 2026-06-18
 

--- a/zebra-rpc/src/indexer/methods.rs
+++ b/zebra-rpc/src/indexer/methods.rs
@@ -62,7 +62,7 @@ where
                     Ok(()) => {}
                     Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
                         span.in_scope(|| {
-                            tracing::info!("client disconnected, dropping chain_tip_change task");
+                            tracing::debug!("client disconnected, dropping chain_tip_change task");
                         });
                         return;
                     }
@@ -139,7 +139,7 @@ where
                     Ok(Ok(())) => {}
                     Ok(Err(_)) => {
                         span.in_scope(|| {
-                            tracing::info!(
+                            tracing::debug!(
                                 "client disconnected, dropping non_finalized_state_change task"
                             );
                         });
@@ -205,7 +205,9 @@ where
                         Ok(()) => {}
                         Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
                             span.in_scope(|| {
-                                tracing::info!("client disconnected, dropping mempool_change task");
+                                tracing::debug!(
+                                    "client disconnected, dropping mempool_change task"
+                                );
                             });
                             return;
                         }

--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -42,12 +42,33 @@ const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(60);
 /// How long to wait for a keep-alive ping response before treating the connection as dead.
 const KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(20);
 
-/// How long to wait before re-subscribing after a block fails to commit to the non-finalized state.
+/// How long to wait between attempts to commit the same streamed block while it can't yet attach to
+/// the non-finalized chain.
 ///
 /// A block can persistently fail to commit (e.g. [`ValidateContextError::NotReadyToBeCommitted`])
-/// when the secondary finalized state hasn't yet caught up with the primary. Without this delay,
-/// re-subscribing immediately turns that into a full-speed busy loop that saturates the logs.
+/// when the secondary finalized state hasn't yet caught up with the primary. The syncer retries the
+/// same block in place (see [`MAX_IN_PLACE_COMMIT_RETRIES`]); this delay keeps that retry from
+/// becoming a full-speed busy loop while the finalized state catches up.
 const COMMIT_RETRY_DELAY: Duration = Duration::from_secs(1);
+
+/// How many times to retry committing the same streamed block in place — keeping the existing
+/// subscription open — before giving up and re-subscribing.
+///
+/// A commit failure is almost always transient: the secondary's finalized state hasn't caught up
+/// enough for the streamed block to attach yet, and [`TrustedChainSync::try_commit`] advances that
+/// catch-up on every attempt, so the block becomes committable as the gap closes. Retrying in place
+/// rather than tearing the subscription down avoids churning the connection — and flooding the
+/// server with `client disconnected` logs — because re-subscribing would only replay the same
+/// backlog from our unchanged chain tips.
+///
+/// This bound is only a wedge backstop, not the reorg path: a healthy syncer following the tip
+/// receives reorg blocks on its open subscription and commits them like any other block, so this
+/// retry loop isn't entered at all. It runs only while a block is actively failing to commit, and
+/// after `MAX_IN_PLACE_COMMIT_RETRIES * COMMIT_RETRY_DELAY` of that, the syncer re-subscribes to
+/// recover a possibly-wedged stream and refresh the blocks the server sends from its current tips.
+/// The bound is kept below the server's non-finalized send timeout so the syncer re-subscribes
+/// before the server drops it as a slow consumer.
+const MAX_IN_PLACE_COMMIT_RETRIES: usize = 30;
 
 /// How long to wait for a single `get_block` fetch while bridging the finalized gap before giving
 /// up. A single block fetch from a co-located node should return promptly, so this bounds a wedged
@@ -303,30 +324,50 @@ impl TrustedChainSync {
             }
 
             let block = SemanticallyVerifiedBlock::with_hash(Arc::new(block), hash);
-            match self.try_commit(block.clone()).await {
-                Ok(()) => {
-                    last_failed_commit_hash = None;
-                }
-                Err(error) => {
-                    // Only log on transitions to avoid saturating the logs when the same block
-                    // persistently fails to commit (e.g. when the secondary finalized state hasn't
-                    // caught up with the primary yet).
-                    if last_failed_commit_hash != Some(hash) {
-                        tracing::warn!(
-                            ?error,
-                            ?hash,
-                            "failed to commit block to non-finalized state"
-                        );
-                        last_failed_commit_hash = Some(hash);
+
+            // Commit the block, retrying it in place while it can't yet attach because our finalized
+            // state is still catching up to the primary. Keep the existing subscription open across
+            // retries rather than tearing it down: re-subscribing would replay the same backlog from
+            // our unchanged chain tips and churn the connection (flooding the server with
+            // `client disconnected` logs), while `try_commit` advances the secondary's finalized
+            // state on each attempt so the block becomes committable as the gap closes.
+            let mut committed = false;
+            for _ in 0..MAX_IN_PLACE_COMMIT_RETRIES {
+                match self.try_commit(block.clone()).await {
+                    Ok(()) => {
+                        committed = true;
+                        break;
                     }
+                    Err(error) => {
+                        // Only log on transitions to avoid saturating the logs while the same block
+                        // fails repeatedly (e.g. while the secondary finalized state hasn't caught
+                        // up with the primary yet).
+                        if last_failed_commit_hash != Some(hash) {
+                            tracing::warn!(
+                                ?error,
+                                ?hash,
+                                "block not yet committable; finalized state is catching up, retrying"
+                            );
+                            last_failed_commit_hash = Some(hash);
+                        }
 
-                    non_finalized_blocks_listener = None;
-
-                    // Back off before re-subscribing so a persistently failing block doesn't turn
-                    // re-subscription into a full-speed busy loop.
-                    tokio::time::sleep(COMMIT_RETRY_DELAY).await;
+                        // Back off between attempts so a persistently failing block doesn't turn the
+                        // retry into a full-speed busy loop.
+                        tokio::time::sleep(COMMIT_RETRY_DELAY).await;
+                    }
                 }
-            };
+            }
+
+            if committed {
+                last_failed_commit_hash = None;
+            } else {
+                // The block stayed uncommittable for the whole in-place retry budget. Drop the
+                // subscription so the next iteration re-subscribes, recovering a possibly-wedged
+                // stream and refreshing which blocks the server sends from our current tips. This is
+                // not the reorg path: a healthy syncer commits reorg blocks as they arrive on the
+                // open subscription, so it never reaches here.
+                non_finalized_blocks_listener = None;
+            }
         }
     }
 

--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -23,6 +23,9 @@ use crate::indexer::{
     NonFinalizedStateChangeRequest,
 };
 
+#[cfg(test)]
+mod tests;
+
 /// How long to wait between calls to `subscribe_to_non_finalized_state_change` when it returns an error.
 const POLL_DELAY: Duration = Duration::from_secs(5);
 
@@ -457,7 +460,7 @@ impl TrustedChainSync {
                         ?error,
                         ?next_height,
                         "failed to fetch a block while bridging the finalized gap; \
-                         will retry on the next subscription"
+                         will retry"
                     );
                     return;
                 }
@@ -469,7 +472,7 @@ impl TrustedChainSync {
                     ?error,
                     ?next_height,
                     "failed to commit a block while bridging the finalized gap; \
-                     will retry on the next subscription"
+                     will retry"
                 );
                 return;
             }

--- a/zebra-rpc/src/sync/tests.rs
+++ b/zebra-rpc/src/sync/tests.rs
@@ -1,0 +1,291 @@
+//! Tests for [`TrustedChainSync`].
+
+use std::{
+    net::SocketAddr,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use futures::{Stream, StreamExt};
+use tonic::{transport::server::TcpIncoming, Request, Response, Status};
+
+use zebra_chain::{
+    block::{self, Block, Height},
+    chain_tip::ChainTip,
+    parameters::Network,
+    serialization::ZcashDeserializeInto,
+    transaction::{LockTime, Transaction},
+};
+use zebra_state::{CheckpointVerifiedBlock, Config, FinalizedState, NonFinalizedState};
+
+use crate::indexer::{
+    indexer_server::{Indexer, IndexerServer},
+    BlockAndHash, BlockHashAndHeight, BlockRequest, Empty, MempoolChangeMessage,
+    NonFinalizedStateChangeRequest,
+};
+
+use super::TrustedChainSync;
+
+/// How many times `get_block` for the gap block fails before it starts succeeding.
+const GET_BLOCK_FAILURES: usize = 2;
+
+/// A fully-custom mock implementation of the indexer gRPC server.
+///
+/// Unlike the production server it does not wrap a [`ReadStateService`]; instead each method is
+/// driven directly to reproduce the "follower's finalized state is behind the primary" scenario:
+/// the non-finalized stream yields a single block (the streamed block) whose parent (the gap block)
+/// is not yet in the follower's finalized state, and `get_block` for that parent fails
+/// [`GET_BLOCK_FAILURES`] times before succeeding, forcing the syncer to retry the streamed block
+/// in place.
+struct MockIndexer {
+    /// Incremented at the start of every `non_finalized_state_change` call.
+    subscribe_count: Arc<AtomicUsize>,
+    /// Incremented on every `get_block` call for the gap block's height.
+    get_block_attempts: Arc<AtomicUsize>,
+    /// The block streamed on the non-finalized subscription (the gap block's child).
+    streamed_block: Arc<Block>,
+    /// The gap block fetched via `get_block` (the streamed block's parent).
+    gap_block: Arc<Block>,
+    /// The height of the gap block, the only height `get_block` is expected to be called with.
+    gap_height: u32,
+    /// How many times `get_block` for the gap block fails before succeeding.
+    get_block_failures: usize,
+}
+
+#[tonic::async_trait]
+impl Indexer for MockIndexer {
+    type ChainTipChangeStream =
+        Pin<Box<dyn Stream<Item = Result<BlockHashAndHeight, Status>> + Send>>;
+    type NonFinalizedStateChangeStream =
+        Pin<Box<dyn Stream<Item = Result<BlockAndHash, Status>> + Send>>;
+    type MempoolChangeStream =
+        Pin<Box<dyn Stream<Item = Result<MempoolChangeMessage, Status>> + Send>>;
+
+    async fn chain_tip_change(
+        &self,
+        _: Request<Empty>,
+    ) -> Result<Response<Self::ChainTipChangeStream>, Status> {
+        // The syncer's finalized-tip task subscribes here; never yield, so it just parks.
+        Ok(Response::new(Box::pin(futures::stream::pending())))
+    }
+
+    async fn non_finalized_state_change(
+        &self,
+        _request: Request<NonFinalizedStateChangeRequest>,
+    ) -> Result<Response<Self::NonFinalizedStateChangeStream>, Status> {
+        self.subscribe_count.fetch_add(1, Ordering::SeqCst);
+
+        // Yield exactly one block (the streamed block) then stay pending forever, so the syncer
+        // parks after committing it rather than re-subscribing.
+        let item = Ok(BlockAndHash::new(
+            self.streamed_block.hash(),
+            self.streamed_block.clone(),
+        ));
+        let stream = futures::stream::once(async move { item }).chain(futures::stream::pending());
+
+        Ok(Response::new(Box::pin(stream)))
+    }
+
+    async fn mempool_change(
+        &self,
+        _: Request<Empty>,
+    ) -> Result<Response<Self::MempoolChangeStream>, Status> {
+        Ok(Response::new(Box::pin(futures::stream::pending())))
+    }
+
+    async fn get_block(
+        &self,
+        request: Request<BlockRequest>,
+    ) -> Result<Response<BlockAndHash>, Status> {
+        // Decode the request the same way the production server does: a 4-byte big-endian height or
+        // a 32-byte hash.
+        let hash_or_height = request.into_inner().hash_or_height;
+        let height = match hash_or_height.len() {
+            4 => u32::from_be_bytes(
+                hash_or_height
+                    .try_into()
+                    .expect("a 4-byte vec always converts to a [u8; 4]"),
+            ),
+            _ => return Err(Status::not_found("unexpected get_block")),
+        };
+
+        if height == self.gap_height {
+            let n = self.get_block_attempts.fetch_add(1, Ordering::SeqCst);
+            if n < self.get_block_failures {
+                Err(Status::unavailable("gap not ready"))
+            } else {
+                Ok(Response::new(BlockAndHash::new(
+                    self.gap_block.hash(),
+                    self.gap_block.clone(),
+                )))
+            }
+        } else {
+            Err(Status::not_found("unexpected get_block"))
+        }
+    }
+}
+
+/// Binds a mock indexer gRPC server on an ephemeral port and spawns it, returning its address.
+async fn spawn_mock_indexer(mock: MockIndexer) -> SocketAddr {
+    let tcp_listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("binding an ephemeral port should succeed");
+    let local_addr = tcp_listener
+        .local_addr()
+        .expect("a bound listener has a local address");
+
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(IndexerServer::new(mock))
+            .serve_with_incoming(TcpIncoming::from(tcp_listener))
+            .await
+            .expect("mock indexer server should run");
+    });
+
+    // Give the listener a moment to start accepting before the syncer connects.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    local_addr
+}
+
+/// Reads a continuous mainnet block from the test vectors by height.
+fn mainnet_block(height: u32) -> Block {
+    zebra_test::vectors::CONTINUOUS_MAINNET_BLOCKS
+        .get(&height)
+        .unwrap_or_else(|| panic!("test vectors should contain mainnet block {height}"))
+        .zcash_deserialize_into()
+        .unwrap_or_else(|_| panic!("mainnet block {height} should deserialize"))
+}
+
+/// Returns a `Transaction::V4` carrying the coinbase data from `coinbase`.
+///
+/// The non-finalized state rejects the V1–V3 transactions in the early mainnet blocks (they only
+/// ever exist in finalized blocks). Re-emitting the coinbase as V4 makes the block committable to
+/// the non-finalized state without changing its (empty) spend/anchor footprint.
+fn coinbase_as_v4(coinbase: &Transaction) -> Transaction {
+    assert!(
+        !coinbase.has_sapling_shielded_data(),
+        "early-block coinbase transactions have no sapling shielded data"
+    );
+
+    Transaction::V4 {
+        inputs: coinbase.inputs().to_vec(),
+        outputs: coinbase.outputs().to_vec(),
+        lock_time: coinbase.lock_time().unwrap_or_else(LockTime::unlocked),
+        expiry_height: coinbase.expiry_height().unwrap_or(Height(0)),
+        joinsplit_data: None,
+        sapling_shielded_data: None,
+    }
+}
+
+/// Rewrites `block` to hold only its coinbase transaction (re-emitted as V4) and to build on
+/// `parent_hash`.
+///
+/// This yields a coinbase-only block that the non-finalized state accepts: there are no transparent
+/// spends or shielded anchors to validate, and the explicit re-linking keeps the chain contiguous
+/// even though re-encoding the coinbase changes each block's hash.
+fn v4_coinbase_block(mut block: Block, parent_hash: Option<block::Hash>) -> Arc<Block> {
+    let coinbase = coinbase_as_v4(&block.transactions[0]);
+    block.transactions = vec![Arc::new(coinbase)];
+    if let Some(parent_hash) = parent_hash {
+        Arc::make_mut(&mut block.header).previous_block_hash = parent_hash;
+    }
+
+    Arc::new(block)
+}
+
+/// While a streamed block repeatedly fails to commit because the follower's finalized state is
+/// behind and the gap block must be fetched via `get_block`, the syncer retries the same block in
+/// place (keeping the subscription open) rather than re-subscribing, and commits it once the gap
+/// becomes fillable.
+#[tokio::test(flavor = "multi_thread")]
+async fn syncer_retries_in_place_without_resubscribing() {
+    let _init_guard = zebra_test::init();
+
+    let network = Network::Mainnet;
+
+    // A short, contiguous chain of coinbase-only blocks (genesis, gap, streamed), each re-emitted
+    // with a V4 coinbase so the gap and streamed blocks are committable to the non-finalized state,
+    // and re-linked so the chain stays contiguous after the re-encoding changes their hashes.
+    let genesis_block = v4_coinbase_block(mainnet_block(0), None);
+    let gap_block = v4_coinbase_block(mainnet_block(1), Some(genesis_block.hash()));
+    let streamed_block = v4_coinbase_block(mainnet_block(2), Some(gap_block.hash()));
+
+    // Build a writable, genesis-only finalized state and take its db. The gap block (height 1) and
+    // streamed block (height 2) sit above this finalized tip.
+    let mut finalized = FinalizedState::new(&Config::ephemeral(), &network)
+        .expect("creating an ephemeral finalized state should succeed");
+
+    finalized
+        .commit_finalized_direct(
+            CheckpointVerifiedBlock::from(genesis_block.clone()).into(),
+            None,
+            "test",
+        )
+        .expect("committing genesis to the finalized state should succeed");
+
+    let db = finalized.db.clone();
+
+    // Set up the mock indexer's shared counters.
+    let subscribe_count = Arc::new(AtomicUsize::new(0));
+    let get_block_attempts = Arc::new(AtomicUsize::new(0));
+
+    let mock = MockIndexer {
+        subscribe_count: subscribe_count.clone(),
+        get_block_attempts: get_block_attempts.clone(),
+        streamed_block: streamed_block.clone(),
+        gap_block: gap_block.clone(),
+        gap_height: 1,
+        get_block_failures: GET_BLOCK_FAILURES,
+    };
+
+    let mock_addr = spawn_mock_indexer(mock).await;
+
+    // Spawn the syncer against the mock indexer and the follower db.
+    let (sender, _receiver) = tokio::sync::watch::channel(NonFinalizedState::new(&network));
+    let (latest_chain_tip, _chain_tip_change, _sync_task) =
+        TrustedChainSync::spawn(mock_addr, db, sender)
+            .await
+            .expect("spawning the syncer should succeed");
+
+    let streamed_height = Height(2);
+
+    // Poll until the syncer commits the streamed block (or time out).
+    tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            if latest_chain_tip.best_tip_height() == Some(streamed_height) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("syncer should commit the streamed block within the timeout");
+
+    // The block was committed: in-place retry recovered once the gap became fillable.
+    assert_eq!(
+        latest_chain_tip.best_tip_height(),
+        Some(streamed_height),
+        "the streamed block should have been committed"
+    );
+
+    // THE key assertion: the syncer retried in place and never re-subscribed.
+    assert_eq!(
+        subscribe_count.load(Ordering::SeqCst),
+        1,
+        "the syncer should have subscribed exactly once, retrying in place instead of re-subscribing"
+    );
+
+    // It actively retried `get_block` while the gap was unfillable: more than the failing
+    // attempts, i.e. it kept trying until the gap became fillable and the fetch finally succeeded.
+    assert!(
+        get_block_attempts.load(Ordering::SeqCst) > GET_BLOCK_FAILURES,
+        "get_block should have been attempted more than {} times, got {}",
+        GET_BLOCK_FAILURES,
+        get_block_attempts.load(Ordering::SeqCst),
+    );
+}


### PR DESCRIPTION
## Motivation

A co-located read-state follower (`zebra_rpc::sync::TrustedChainSync`, used by Zaino's `ReadStateService` backend and other `init_read_state_with_syncer` consumers) re-subscribes to the `non_finalized_state_change` indexer stream roughly **once per second** for the entire time its finalized (secondary) state lags the primary. Each teardown makes the node log one `INFO` line:

```
INFO zebra_rpc::indexer::methods: client disconnected, dropping non_finalized_state_change task
```

so a multi-minute catch-up window produces thousands of them.

The cadence is the consumer's commit-retry backoff, not many clients: `sync()` subscribes → receives one block → `try_commit` fails (the secondary's finalized state hasn't caught up, so the streamed block has no parent — `ValidateContextError::NotReadyToBeCommitted`) → drops the subscription and sleeps `COMMIT_RETRY_DELAY` (1s) → re-subscribes. Re-subscribing buys nothing: it replays the same backlog from the consumer's unchanged chain tips.

Closes #10803.

## Solution

- `zebra-rpc/src/sync.rs`: on a commit failure, retry the same block **in place** (keeping the subscription open) up to `MAX_IN_PLACE_COMMIT_RETRIES` (30) × `COMMIT_RETRY_DELAY` (1s). `try_commit` drives `try_catch_up_with_primary` + `fill_finalized_gap` on every attempt, so the block becomes committable as the finalized gap closes — without churning the connection. Re-subscribe only as a bounded backstop, kept under the server's 60s non-finalized send timeout so the syncer resets before the server would drop it as a slow consumer. This is **not** the reorg path: a healthy syncer commits reorg blocks as they arrive on the open subscription, so the retry loop isn't entered.
- `zebra-rpc/src/indexer/methods.rs`: demote the three indexer stream-teardown logs (`client disconnected, dropping … task` in `chain_tip_change`, `non_finalized_state_change`, `mempool_change`) from `info!` to `debug!` — a consumer disconnect is a normal lifecycle event.

Net effect: during a finalized-state catch-up window, re-subscriptions drop from ~1/sec to at most ~1/30s (and only when a block is genuinely stuck), and the residual teardown lines no longer appear at default `INFO`.

### Tests

- `cargo fmt -p zebra-rpc -- --check` — clean.
- `cargo clippy -p zebra-rpc --lib -- -D warnings` — clean.
- `cargo test -p zebra-rpc --lib indexer` — passes (indexer decode tests + server spawn).
- The happy path is unchanged (first `try_commit` `Ok` → `break` immediately), so the existing `zebrad/tests/e2e/trusted_chain.rs` tip-change assertions are unaffected.

The failure/retry path is not yet covered by an automated test — there's no mock-indexer harness for `TrustedChainSync`, and the existing e2e test only exercises the happy path. See Follow-up Work.

### Specifications & References

- Root-cause issue: #10803
- Prior frequency-reduction work: #10741 (1s backoff), #10776 (resume-from-tips + backpressure)
- Related but distinct: #10728 (`slow consumer` buffer-overflow livelock)

### Follow-up Work

- A focused integration test for the retry-in-place + backstop path (a mock read-state that fails N commits then succeeds) would be valuable but needs a new harness.

### AI Disclosure

- [x] AI tools were used: Claude Code (Opus 4.8) for investigation, implementation, and drafting this description. The contributor reviewed and is responsible for all changes.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand. <!-- Issue #10803 filed; opening this draft to inform maintainers and gather feedback before review. -->
- [ ] The solution is tested. <!-- Build/lint/unit + happy path; failure-path integration test is follow-up. -->
- [x] The documentation and changelogs are up to date.
