### PR TITLE
ci: mint GitHub App tokens with client-id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,10 @@ jobs:
     steps:
       - name: Generate release app token
         id: app-token
-        if: vars.RELEASE_APP_ID != ''
+        if: vars.RELEASE_APP_CLIENT_ID != ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 #v3.2.0
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
@@ -86,10 +86,10 @@ jobs:
     steps:
       - name: Generate release app token
         id: app-token
-        if: vars.RELEASE_APP_ID != ''
+        if: vars.RELEASE_APP_CLIENT_ID != ''
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 #v3.2.0
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: read
@@ -119,7 +119,7 @@ jobs:
       - name: Validate release app token
         if: steps.release-pr.outputs.merged == 'true' && steps.app-token.outputs.token == ''
         run: |
-          echo "::error::Configure RELEASE_APP_ID and RELEASE_APP_PRIVATE_KEY before merging a Release PR. The app token is required before crates publish so the zebrad GitHub Release can trigger Docker and GCP workflows."
+          echo "::error::Configure RELEASE_APP_CLIENT_ID and RELEASE_APP_PRIVATE_KEY before merging a Release PR. The app token is required before crates publish so the zebrad GitHub Release can trigger Docker and GCP workflows."
           exit 1
       - name: Publish crates and create tags
         id: release-plz
@@ -184,7 +184,7 @@ jobs:
           set -euo pipefail
 
           if [ -z "${GH_TOKEN}" ]; then
-            echo "::error::Configure RELEASE_APP_ID and RELEASE_APP_PRIVATE_KEY before publishing a zebrad GitHub Release. Releases created with GITHUB_TOKEN do not trigger release-binaries.yml or zfnd-deploy-nodes-gcp.yml."
+            echo "::error::Configure RELEASE_APP_CLIENT_ID and RELEASE_APP_PRIVATE_KEY before publishing a zebrad GitHub Release. Releases created with GITHUB_TOKEN do not trigger release-binaries.yml or zfnd-deploy-nodes-gcp.yml."
             exit 1
           fi
 

--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -67,7 +67,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.Z3_APP_ID }}
+          client-id: ${{ secrets.Z3_APP_CLIENT_ID }}
           private-key: ${{ secrets.Z3_APP_PRIVATE_KEY }}
           owner: zcash
           repositories: integration-tests

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -30,7 +30,7 @@ pr_body = """
 - [ ] Per-crate `CHANGELOG.md` entries describe crate-consumer impact
 - [ ] No git dependencies remain in crates that will publish to crates.io (`check-no-git-dependencies`)
 - [ ] Any required checkpoint, end-of-support height, README, or operational release-note changes already landed before this generated Release PR
-- [ ] `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` are both configured at repository or organization scope
+- [ ] `RELEASE_APP_CLIENT_ID` and `RELEASE_APP_PRIVATE_KEY` are both configured at repository or organization scope
 - [ ] Merge this Release PR only when crates should be published and the public `zebrad` GitHub Release should be created
 
 ## Release Summary


### PR DESCRIPTION
The release and integration-test workflows emit a deprecation warning on every run, because `actions/create-github-app-token` deprecated the `app-id` input. They now pass the GitHub App `client-id`.

The `RELEASE_APP_CLIENT_ID` variable and `Z3_APP_CLIENT_ID` secret are already configured. The old `RELEASE_APP_ID` / `Z3_APP_ID` remain until this merges, then get removed.

AI disclosure: Claude (Claude Code) performed the input migration and set the new credentials.