### PR TITLE
fix(consensus): handle Elapsed timeout in AwaitUtxo to prevent near-tip sync stall

### DIFF
--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -746,19 +746,19 @@ where
 
                     utxo
                 } else {
-                    let query = state
+                    let response = state
                         .clone()
-                        .oneshot(zebra_state::Request::AwaitUtxo(*outpoint));
+                        .oneshot(zebra_state::Request::AwaitUtxo(*outpoint))
+                        .await
+                        .map_err(|boxed_error| match boxed_error.downcast::<Elapsed>() {
+                            Ok(_) => TransactionError::TransparentInputNotFound,
+                            Err(boxed_error) => TransactionError::from(boxed_error),
+                        })?;
 
-                    match query.await {
-                        Ok(zebra_state::Response::Utxo(utxo)) => utxo,
-                        Ok(_) => unreachable!("AwaitUtxo always responds with Utxo"),
-                        Err(err) => {
-                            return match err.downcast::<Elapsed>() {
-                                Ok(_) => Err(TransactionError::TransparentInputNotFound),
-                                Err(err) => Err(err.into()),
-                            };
-                        }
+                    if let zebra_state::Response::Utxo(utxo) = response {
+                        utxo
+                    } else {
+                        unreachable!("AwaitUtxo always responds with Utxo")
                     }
                 };
                 tracing::trace!(?utxo, "got UTXO");

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -749,10 +749,16 @@ where
                     let query = state
                         .clone()
                         .oneshot(zebra_state::Request::AwaitUtxo(*outpoint));
-                    if let zebra_state::Response::Utxo(utxo) = query.await? {
-                        utxo
-                    } else {
-                        unreachable!("AwaitUtxo always responds with Utxo")
+
+                    match query.await {
+                        Ok(zebra_state::Response::Utxo(utxo)) => utxo,
+                        Ok(_) => unreachable!("AwaitUtxo always responds with Utxo"),
+                        Err(err) => {
+                            return match err.downcast::<Elapsed>() {
+                                Ok(_) => Err(TransactionError::TransparentInputNotFound),
+                                Err(err) => Err(err.into()),
+                            };
+                        }
                     }
                 };
                 tracing::trace!(?utxo, "got UTXO");


### PR DESCRIPTION
## Summary

- Handle `tower::timeout::error::Elapsed` at the `AwaitUtxo` call site in the transaction verifier, matching the existing pattern already used by `AwaitOutput`
- Prevents `InternalDowncastError` → sync restart loop when UTXO lookups time out near the chain tip

## Problem

The state service is wrapped in `Timeout::new(state, UTXO_LOOKUP_TIMEOUT)` (6 minutes). When an `AwaitUtxo` request times out, Tower returns `Err(Elapsed)` as a `BoxError`. The `?` operator converts this via `From<BoxError> for TransactionError`, which doesn't handle `Elapsed`, so it falls through to:

```
TransactionError::InternalDowncastError(
  "downcast to known transaction error type failed, original error: Elapsed(())"
)
```

This error hits the catch-all in `should_restart_sync`, which restarts the syncer. The timeout fires again, creating an infinite restart loop — a sync stall.

The `AwaitOutput` call site in the same function already handles this correctly by explicitly downcasting `Elapsed` to `TransparentInputNotFound`. The `AwaitUtxo` call site was missed.

## Fix

Replace the `query.await?` with an explicit `match` that downcasts `Elapsed` to `TransparentInputNotFound`, identical to the `AwaitOutput` pattern.

## Evidence

Community user reported this exact error on v5.2.0 at height 3,387,584 (99.94% synced):
https://forum.zcashcommunity.com/t/zebrad-stalling/55819/63

Network crawl shows only 5 of 30 DNS seeder IPs are alive and at tip, making UTXO lookup timeouts more likely for nodes with few peers.

Closes #10629