### PR TITLE
ci: cap `zebrad-runtime` artifact retention at 7 days

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           name: zebrad-runtime
           path: ${{ runner.temp }}/zebrad-runtime.tar
+          retention-days: 7
 
   test-configurations:
     name: Test ${{ matrix.name }}


### PR DESCRIPTION
## Motivation

The `zebrad-runtime` artifact (formerly `zebrad-test`, renamed in #10821) is a handoff inside the same workflow run: the `build-docker-image` job exports the Docker image as a tar and uploads it; the `test-configurations` matrix downloads it for ten configuration tests. Nothing references it after that — `grep` confirms two hits in `test-docker.yml` and no other.

`actions/upload-artifact` defaults to 90-day retention. Even though the runtime image is much smaller than the old tests image, there is no reason to keep these tars for 90 days.

## Solution

Set `retention-days: 7` on the upload step. Seven days is well past every matrix runtime and gives margin for any maintainer who wants to re-download the tar to debug a failed run.

### AI Disclosure

- [x] AI tools were used: Claude (Anthropic) drafted the change and PR body.

### PR Checklist

- [x] Conventional commits title
- [x] Discussed with the team beforehand
- [x] Solution is tested (workflow-config only)