### PR TITLE
feat(tower-batch-control): impl RequestWeight for tonic::Request<T> behind tonic feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5939,6 +5939,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tokio-util",
+ "tonic",
  "tower 0.4.13",
  "tower-fallback",
  "tower-test",

--- a/tower-batch-control/CHANGELOG.md
+++ b/tower-batch-control/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added a `tonic` feature that implements `RequestWeight` for `tonic::Request<T>`,
+  so gRPC requests can be used as the batch request type without consumer-side
+  newtype wrappers ([#10667](https://github.com/ZcashFoundation/zebra/issues/10667))
+
 ## [0.2.42] - 2025-10-15
 
 ### Added

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -22,6 +22,11 @@ keywords = ["tower", "batch"]
 # Must be one of <https://crates.io/category_slugs>
 categories = ["algorithms", "asynchronous"]
 
+[features]
+# Implement `RequestWeight` for `tonic::Request<T>`, so gRPC requests can be
+# used as the batch request type without consumer-side newtype wrappers.
+tonic = ["dep:tonic"]
+
 [dependencies]
 futures = { workspace = true }
 futures-core = { workspace = true }
@@ -30,6 +35,7 @@ rayon = { workspace = true }
 tokio = { workspace = true, features = ["time", "sync", "tracing", "macros"] }
 tokio-util = { workspace = true }
 tower = { workspace = true, features = ["util", "buffer"] }
+tonic = { workspace = true, optional = true }
 tracing = { workspace = true }
 tracing-futures = { workspace = true }
 

--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -34,8 +34,8 @@ pin-project = { workspace = true }
 rayon = { workspace = true }
 tokio = { workspace = true, features = ["time", "sync", "tracing", "macros"] }
 tokio-util = { workspace = true }
-tower = { workspace = true, features = ["util", "buffer"] }
 tonic = { workspace = true, optional = true }
+tower = { workspace = true, features = ["util", "buffer"] }
 tracing = { workspace = true }
 tracing-futures = { workspace = true }
 

--- a/tower-batch-control/src/lib.rs
+++ b/tower-batch-control/src/lib.rs
@@ -133,3 +133,11 @@ pub trait RequestWeight {
 // `RequestWeight` impls for test `Item` types
 impl RequestWeight for () {}
 impl RequestWeight for &'static str {}
+
+// `tonic::Request<T>` is a foreign type, so consumers cannot implement the
+// foreign `RequestWeight` trait for it due to the orphan rule. Provide the impl
+// here, behind the `tonic` feature, so gRPC requests can be used as the batch
+// request type directly. Uses the default weight of `1`, which is correct for
+// gRPC services where each request has equal weight.
+#[cfg(feature = "tonic")]
+impl<T> RequestWeight for tonic::Request<T> {}


### PR DESCRIPTION
## Motivation

Closes #10667.

When using `tower-batch-control` with `tonic::Request<T>` as the batch request type, downstream crates cannot satisfy the `RequestWeight` bound due to Rust's orphan rule: both `RequestWeight` (defined in `tower-batch-control`) and `tonic::Request<T>` (defined in `tonic`) are foreign types from the perspective of any consuming crate. This forces consumers into newtype wrappers with adapter layers, or to avoid using `tonic::Request<T>` entirely (losing tonic's metadata/extensions mechanism).

## Solution

Add a blanket `impl<T> RequestWeight for tonic::Request<T>` in `tower-batch-control`, gated behind a new optional `tonic` compilation feature. It uses the trait's default `request_weight() -> 1`, which is correct for gRPC services where each request has equal weight.

- New `tonic` feature: `tonic = ["dep:tonic"]`
- New optional dependency `tonic` (inherited from the workspace `0.14`)
- The impl is `#[cfg(feature = "tonic")]`, so default builds are unaffected

### Note on `default-features`

The issue suggested `default-features = false`. With workspace dependency inheritance, cargo ignores per-crate `default-features` (and warns it may become a hard error), and `tonic` is already pulled in with full features elsewhere in the workspace, so the flag would only add a warning. The optional dependency is therefore inherited from the workspace as-is.

## Testing

- `cargo build -p tower-batch-control` (default, feature off) — builds
- `cargo build -p tower-batch-control --features tonic` — builds
- `cargo clippy -p tower-batch-control --features tonic --all-targets -- -D warnings` — clean

## AI disclosure

Used Claude Code to implement the change, changelog entry, and this PR description.