### PR TITLE
ci: grant `attestations:read` to the release-binaries publish job

### DIFF
--- a/.github/workflows/zfnd-release-binaries.yml
+++ b/.github/workflows/zfnd-release-binaries.yml
@@ -137,6 +137,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      attestations: read
     env:
       RELEASE_TAG: ${{ inputs.release_tag }}
       REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
## Motivation

The release publish job verifies each binary's build provenance with `gh attestation verify`, which reads attestations through the GitHub API. The job declares an explicit `permissions:` block, so any permission it does not list defaults to `none`, and `attestations: read` was missing.

On a public repository the read still succeeds because attestations are world-readable, so releases here are unaffected. Where the attestations API is not publicly readable, the same step fails with `HTTP 403: Resource not accessible by integration`. This grants the permission the step actually needs.

## Solution

Add `attestations: read` to the `publish` job's `permissions`.

### Tests

Ran the full release-binaries pipeline end to end on a private fork running this workflow (build → checksum → `cosign sign-blob` → `cosign verify-blob` + `gh attestation verify` → upload). Without the permission, the verify step returned `HTTP 403: Resource not accessible by integration`; with it, the step passes and the release completes. Re-validated the published artifacts afterward: checksums, Cosign signature, and SLSA provenance all verify.

### AI Disclosure

- [x] AI tools were used: Claude (Claude Code) to diagnose the failure, make the one-line change, and draft this description.

### PR Checklist

- [x] The PR title follows conventional commits format.
- [x] The solution is tested.
- [x] Documentation and changelogs are up to date (CI-only change, no user-visible behavior).