### PR TITLE
fix(release): adopt per-PR changelogs and disable release-plz semver-checks

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -12,8 +12,15 @@ release_always = false
 # release-triggered Docker and GCP workflows only run once, for the node binary.
 git_release_enable = false
 
-# These commits trigger version bumps. Other commits can still appear in
-# changelogs or dependency cascades, but do not trigger a release by themselves.
+# Changelogs are authored per PR in each crate's `[Unreleased]` section; release-plz
+# only versions, tags, and publishes.
+changelog_update = false
+
+# Breaking-change detection runs per PR via ziff, not in the release-pr job.
+semver_check = false
+
+# These commits trigger version bumps. Other commits can still cascade through
+# dependency bumps, but do not trigger a release by themselves.
 release_commits = "^(feat|fix|perf|refactor|build)"
 
 # Release PR metadata. Keep the generated long-lived PR out of the urgent queue
@@ -23,110 +30,38 @@ pr_labels = ["A-release"]
 pr_body = """
 ## Review the Release PR
 
-- [ ] Version bumps match user-visible changes for each changed crate (`major` for network upgrades or breaking API, `minor` for new API/behavior/RPC/config, `patch` otherwise)
-- [ ] `cargo-semver-checks` output has been reviewed for each published library crate
-- [ ] Public API diff has been reviewed for each published library crate (`cargo public-api diff latest -p <crate> -sss`)
-- [ ] Root `CHANGELOG.md` summary is clear and user-facing
-- [ ] Per-crate `CHANGELOG.md` entries describe crate-consumer impact
-- [ ] No git dependencies remain in crates that will publish to crates.io (`check-no-git-dependencies`)
-- [ ] Any required checkpoint, end-of-support height, README, or operational release-note changes already landed before this generated Release PR
-- [ ] `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` are both configured at repository or organization scope
-- [ ] Merge this Release PR only when crates should be published and the public `zebrad` GitHub Release should be created
+- [ ] Version bumps match user-visible changes for each crate (`major` for network upgrades or breaking API, `minor` for new API/behavior/RPC/config, `patch` otherwise)
+- [ ] Each changed crate's `[Unreleased]` entries follow the Changelog Guidelines (operator-focused in the root `CHANGELOG.md`, crate-consumer-focused per crate)
+- [ ] `[Unreleased]` has been renamed to the release heading (`## [Zebra <version>]` in the root, `## [<version>]` per crate)
+- [ ] No git dependencies remain in crates publishing to crates.io (`check-no-git-dependencies`)
+- [ ] Any required checkpoint, end-of-support height, README, or operational changes already landed
+- [ ] `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` are configured at repository or organization scope
+- [ ] Merge only when crates should publish and the public `zebrad` GitHub Release should be created
 
 ## Release Summary
 
 {% for release in releases %}
-- `{{ release.package }}`: {% if release.previous_version and release.previous_version != release.next_version %}{{ release.previous_version }} -> {% endif %}{{ release.next_version }}{% if release.semver_check == "incompatible" %} (API breaking changes){% elif release.semver_check == "compatible" %} (API compatible changes){% endif %}
+- `{{ release.package }}`: {% if release.previous_version and release.previous_version != release.next_version %}{{ release.previous_version }} -> {% endif %}{{ release.next_version }}
 {%- endfor %}
-{%- for release in releases %}{% if release.breaking_changes %}
-
-### `{{ release.package }}` Breaking Changes
-
-```text
-{{ release.breaking_changes }}
-```
-{% endif %}{% endfor %}
-{% for release in releases %}{% if release.changelog %}
-<details><summary><b>{{ release.package }} changelog</b></summary>
-
-{% if release.title %}### {{ release.title }}
-{% endif %}
-{{ release.changelog }}
-
-</details>
-{% endif %}{% endfor %}
 
 ---
 This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).
 """
 
-# Repository URL for changelog links
+# Repository URL.
 repo_url = "https://github.com/ZcashFoundation/zebra"
 
 # Timeout for waiting for each crate to appear on crates.io after publish
 publish_timeout = "30m"
 
-[changelog]
-header = ""
-body = """
-{% if package == "zebrad" -%}
-## [Zebra {{ version }}](https://github.com/ZcashFoundation/zebra/releases/tag/v{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
-{% else -%}
-## [{{ version }}]{%- if release_link -%}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
-{% endif %}
-{% for group, commits in commits | group_by(attribute="group") %}
-### {{ group | upper_first }}
-{% for commit in commits %}
-- {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | split(pat="\n") | first | trim | upper_first }}\
-{% if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}](https://github.com/ZcashFoundation/zebra/pull/{{ commit.remote.pr_number }})){% endif %}
-{%- endfor %}
-{% endfor %}
-"""
-trim = true
-postprocessors = [
-    { pattern = "(?m)^- (\\[\\*\\*breaking\\*\\*\\] )?[[:alpha:]]+(\\([^)]*\\))?!?:[[:space:]]*", replace = "- ${1}" },
-]
-protect_breaking_commits = true
-sort_commits = "oldest"
-# Changelog display only; release triggering is `release_commits` above. Skipped
-# types still publish (they just print no changelog line), and
-# `protect_breaking_commits = true` keeps breaking commits visible even when
-# their type is skipped, so breaking changes never silently vanish.
-commit_parsers = [
-    { message = "^feat", group = "Added" },
-    { message = "^fix", group = "Fixed" },
-    { message = "^perf", group = "Changed" },
-    { message = "^refactor", skip = true },
-    { message = "^docs", skip = true },
-    { message = "^build", skip = true },
-    { message = "^test", skip = true },
-    { message = "^ci", skip = true },
-    { message = "^chore", skip = true },
-    { message = "^style", skip = true },
-]
-
-# ── zebrad: the node binary ─────────────────────────────────────
-# Aggregates changelogs from all zebra-* crates for a complete release view.
-# Uses the legacy v-prefixed tag format (v4.3.1) for compatibility with
-# GCP deployment, which parses the tag to extract the semver.
+# zebrad uses the legacy v-prefixed tag format (v4.3.1); GCP deployment parses
+# the tag to extract the semver.
 [[package]]
 name = "zebrad"
-changelog_include = [
-    "zebra-chain",
-    "zebra-consensus",
-    "zebra-network",
-    "zebra-state",
-    "zebra-rpc",
-    "zebra-script",
-    "zebra-node-services",
-    "zebra-utils",
-]
 git_tag_name = "v{{ version }}"
-changelog_path = "./CHANGELOG.md"
 
 # ── Library crates ──────────────────────────────────────────────
-# No special config needed for most crates. release-plz defaults:
+# No special config needed. release-plz defaults:
 # - Tag format: <crate>-v<version> (e.g., zebra-chain-v6.0.2)
 # - Change detection: file-path-based (only files in crate directory)
 # - Version bump: from conventional commits touching the crate's files
-# - Changelog: per-crate CHANGELOG.md in the crate directory


### PR DESCRIPTION
The auto-generated Release PR duplicated changelog entries and could exceed the 1-hour token limit. release-plz regenerated `CHANGELOG.md` from commit subjects on top of hand-curated `[Unreleased]` entries, and ran `cargo-semver-checks`, whose per-crate rustdoc builds outlived the GitHub App token in the `release-pr` job.

Zebra now authors changelogs per PR. release-plz only versions, tags, publishes, and opens the Release PR:

- `changelog_update = false`: entries live in each crate's `[Unreleased]` section, written when the PR is made.
- `semver_check = false`: breaking-change detection moves to a per-PR check (ziff), outside the token-bound job.
- The dead git-cliff `[changelog]` config and `changelog_include` are removed.

At release, the `[Unreleased]` heading is renamed to the version heading; this is a checklist item in the Release PR body. A ziff CI gate for breaking changes and a `/changelog` drafting command are follow-ups.

AI disclosure: Claude (Claude Code) analyzed release-plz and ziff and produced this change.