### PR TITLE
fix(ci): verify release binaries against the running repo path

### DIFF
--- a/.github/workflows/zfnd-release-binaries.yml
+++ b/.github/workflows/zfnd-release-binaries.yml
@@ -173,12 +173,12 @@ jobs:
           set -euo pipefail
           cosign verify-blob SHA256SUMS \
             --bundle SHA256SUMS.sigstore.json \
-            --certificate-identity-regexp='^https://github\.com/ZcashFoundation/zebra/\.github/workflows/zfnd-release-binaries\.yml@' \
+            --certificate-identity-regexp="^https://github\\.com/${REPOSITORY}/\\.github/workflows/zfnd-release-binaries\\.yml@" \
             --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
           for archive in *.tar.gz; do
             gh attestation verify "${archive}" \
               --repo "${REPOSITORY}" \
-              --signer-workflow ZcashFoundation/zebra/.github/workflows/zfnd-release-binaries.yml
+              --signer-workflow "${REPOSITORY}/.github/workflows/zfnd-release-binaries.yml"
           done
 
       - name: Upload binaries to the release


### PR DESCRIPTION
## Motivation

`zfnd-release-binaries.yml`'s verify step signs with the workflow's OIDC identity — which always reflects the repository running it — but checks the resulting cert and attestation against a hardcoded `ZcashFoundation/zebra` subject. A release cut from any fork, mirror, or test repo signs with its own identity (correctly), fails the hardcoded verify, and never reaches `gh release upload`. The published binaries never land.

The end-user verification instructions in `install.md` continue to point at the canonical public path, so users still know to verify against `ZcashFoundation/zebra` — that behavior is unchanged.

## Solution

Use `${REPOSITORY}` (= `github.repository`) in `--certificate-identity-regexp` and `--signer-workflow`. The variable is already exported in the step's `env:` block; this just consumes it consistently with the rest of the script.

Two-line change, no other side effects.

### Tests

Validated end-to-end on a private mirror: with the hardcoded subject, verify fails and the publish job stops before upload. With the dynamic subject, the same workflow signs and verifies under the running repo's identity and proceeds to `gh release upload`. Tarballs land on the release, with cosign + attestation bundles attached.

### AI Disclosure

- [x] AI tools were used: Claude (Anthropic) drafted the patch and PR body.

### PR Checklist

- [x] Conventional commits title
- [x] Discussed with the team beforehand
- [x] Solution is tested