### PR TITLE
fix(ci): grant `attestations:write` to the docker-image build callers

### DIFF
--- a/.github/workflows/zfnd-ci-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-ci-integration-tests-gcp.yml
@@ -132,6 +132,7 @@ jobs:
       id-token: write
       pull-requests: write
       statuses: write
+      attestations: write # required by the called build workflow's merge job
     uses: ./.github/workflows/zfnd-build-docker-image.yml
     with:
       dockerfile_path: ./docker/Dockerfile

--- a/.github/workflows/zfnd-deploy-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-nodes-gcp.yml
@@ -251,6 +251,7 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
+      attestations: write # required by the called build workflow's merge job
     uses: ./.github/workflows/zfnd-build-docker-image.yml
     # Build for:
     # - Pull requests


### PR DESCRIPTION
## Motivation

Every "Integration Tests on GCP" and "Deploy Nodes to GCP" run has failed at startup since the reproducible-builds change (#10798) merged on 2026-06-25, so no integration test or node deploy has run since.

## Solution

#10798 added a `merge` job to the reusable `zfnd-build-docker-image.yml` that declares `attestations: write`. A reusable workflow can't use a permission the caller hasn't granted, and GitHub validates that when it builds the run graph, so a caller missing the grant fails the whole workflow before any job starts. The integration-test and node-deploy callers never granted `attestations` (only the release caller did). Grant it on both.

### Tests

`actionlint` and `zizmor` pass with no new findings. With the grant in place the suite reaches the run graph instead of `startup_failure`; this PR's own labeled integration run confirms it starts.

### AI Disclosure

- [x] AI tools were used: Claude for diagnosis, implementation, and this description.

### PR Checklist

- [x] The PR title follows conventional commits format.
- [x] The PR follows the contribution guidelines.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
