### PR TITLE
fix(rpc): skip blocks already finalized on secondary in non-finalized syncer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   responses when the local node is at or near the chain tip
   ([#10732](https://github.com/ZcashFoundation/zebra/pull/10732))
 - Fix syncer restarts due to incorrect error downcasting.
+- Fix a read-state syncer startup hang: a co-located consumer whose finalized state
+  had caught up past the node's non-finalized root would re-subscribe endlessly
+  instead of syncing, advancing only one block per newly mined block
+  ([#10841](https://github.com/ZcashFoundation/zebra/pull/10841))
 
 ## [Zebra 6.0.0-rc.0](https://github.com/ZcashFoundation/zebra/releases/tag/v6.0.0-rc.0) - 2026-07-02
 

--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -344,6 +344,22 @@ impl TrustedChainSync {
                 continue;
             }
 
+            // Skip blocks that are already finalized on the secondary. The server streams its
+            // entire non-finalized chain on initial subscription, which can start below our
+            // secondary's finalized tip when the secondary has caught up past the server's
+            // non-finalized root. Trying to commit those blocks fails with NotReadyToBeCommitted
+            // and triggers an endless re-subscribe loop.
+            if let Some(height) = block.coinbase_height() {
+                if self
+                    .db
+                    .finalized_tip_height()
+                    .is_some_and(|tip| height <= tip)
+                {
+                    tracing::debug!(?height, "skipping block already finalized on secondary");
+                    continue;
+                }
+            }
+
             let block = SemanticallyVerifiedBlock::with_hash(Arc::new(block), hash);
             match self.try_commit(block.clone()).await {
                 Ok(()) => {
@@ -482,8 +498,6 @@ impl TrustedChainSync {
         &self,
         hash_or_height: HashOrHeight,
     ) -> Result<(Block, block::Hash), Status> {
-        // Encode the request as a single `hash_or_height` byte string: a 32-byte hash in display
-        // order, or a 4-byte big-endian height. The server tells them apart by length.
         let hash_or_height = match hash_or_height {
             HashOrHeight::Hash(hash) => hash.bytes_in_display_order().to_vec(),
             HashOrHeight::Height(height) => height.0.to_be_bytes().to_vec(),

--- a/zebra-rpc/src/sync.rs
+++ b/zebra-rpc/src/sync.rs
@@ -498,6 +498,8 @@ impl TrustedChainSync {
         &self,
         hash_or_height: HashOrHeight,
     ) -> Result<(Block, block::Hash), Status> {
+        // Encode the request as a single `hash_or_height` byte string: a 32-byte hash in display
+        // order, or a 4-byte big-endian height. The server tells them apart by length.
         let hash_or_height = match hash_or_height {
             HashOrHeight::Hash(hash) => hash.bytes_in_display_order().to_vec(),
             HashOrHeight::Height(height) => height.0.to_be_bytes().to_vec(),


### PR DESCRIPTION
Closes zcash/zallet#559

## Motivation

When `TrustedChainSync` starts with an empty non-finalized state, the server streams its entire non-finalized chain from its root. On mainnet the non-finalized chain is ~100 blocks deep so this is fine. On testnet, the non-finalized chain can be several hundred blocks deep because checkpoint coverage is sparse — and the server's non-finalized root can sit **below** the secondary's current finalized tip.

When that happens, every block in the stream fails with `NotReadyToBeCommitted` (no parent in finalized or non-finalized state), the syncer re-subscribes after a 1-second delay, and the whole thing repeats indefinitely. The secondary only advances one block per new block mined (~75 s on testnet), making startup effectively broken for hundreds of blocks.

**In plain terms:** if the syncer disconnects and reconnects while zebra keeps running, on reconnect it re-offers blocks the syncer already has, thinks it's still at the very start, and only crawls forward 1 block per real block interval instead of catching up. It never actually stops — it just never gets faster than "one block per ~75s."

**Terminology:** "primary" and "secondary" refer to the two ends of `TrustedChainSync`, not two Zebra instances. Zebra is the **primary** — it streams its non-finalized chain over RPC. The **secondary** is the downstream client consuming that stream into its own local state (e.g. a Zallet wallet, or another `zebrad` acting as a light client).

## Solution

Skip any streamed block whose height is at or below the secondary's current finalized tip. Those blocks are already in the secondary's RocksDB state; trying to commit them as non-finalized is both unnecessary and impossible. The first block above the finalized tip attaches cleanly via `commit_new_chain` and the non-finalized chain grows normally from there.

The change is 16 lines in `sync()`, immediately after the existing `any_chain_contains` skip.

### Tests

Tested manually on testnet against a secondary whose finalized state lagged the server's non-finalized root by ~900 blocks:

- **Before:** syncer spun with `NotReadyToBeCommitted` on every subscription, wallet tip advanced 1 block per ~75 s
- **After:** syncer skips the already-finalized blocks, commits the first non-finalized block, and the wallet reaches chain tip within seconds

No automated test added — reproducing the condition requires a testnet node with a lagging secondary, which isn't straightforward to set up in CI.

### Follow-up Work

A parallel `get_block` fetch in `fill_finalized_gap` could further reduce startup latency when the gap is large, but that's a separate improvement and not needed once this fix lands.

### Update (reopened)

This PR was previously closed without merging. Since then we independently re-derived and re-verified the exact same root cause and fix while debugging the equivalent symptom from a Zallet-side wallet (`zcash/zallet#559`):

- Confirmed via a completely fresh testnet wallet + fresh `zebrad` restart (not a corrupted/stale local setup) that a cold-started `TrustedChainSync` permanently settles ~1000 blocks behind the real tip, advancing only ~1 block per real block interval, matching the numbers in this PR's original description almost exactly.
- Confirmed directly against `zebrad`'s own live RPC that the "conflicting" blocks being re-streamed are **not** a fork/reorg — both the secondary's finalized block and its parent match `zebrad`'s own canonical chain exactly. The server is simply re-offering a block the secondary already has finalized.
- Confirmed this gap is **not** covered by the since-merged #10776 or #10818: `NonFinalizedBlocksListener::spawn`'s resumable-streaming logic only filters against `known_chain_tips` sent by the *caller* — and on a cold start (empty non-finalized state), `known_chain_tips` is empty, so per that function's own doc comment ("If it is empty, every block currently in the non-finalized state is sent"), the server streams unconditionally from its root exactly as before. Pulled `zebra-rpc/src/sync.rs` directly from `main` today and confirmed the gap this PR fixes is still present, unchanged.
- Applied this exact patch locally (via a `[patch]` path override in a downstream consumer) and confirmed it resolves the issue end-to-end: `node_tip` and `wallet_tip` match exactly and stay in sync going forward, with no regression.

Reopening with this additional verification. Happy to add a regression test or adjust the approach if there's a preferred direction — let me know.

### AI Disclosure

- [x] AI tools were used: Claude assisted with root-cause analysis and drafting the fix; the author reviewed and verified the solution end-to-end on testnet, both originally and again during the re-verification above.

### PR Checklist

- [x] The PR title follows conventional commits format
- [ ] This change was discussed in an issue or with the team beforehand
- [x] The solution is tested (manually on testnet, twice, independently)

