### PR TITLE
ci: drop Windows and macOS runners

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -12,12 +12,6 @@ fail-fast = true
 status-level = "pass"
 default-filter = 'not test(/^stateful::/) and not test(/^e2e::/) and not test(=unit::end_of_support::check_no_git_dependencies)'
 
-# --- Platform overrides ---
-
-[[profile.default.overrides]]
-platform = 'cfg(target_os = "windows")'
-filter = "not test(=integration::database::delete_old_databases)"
-
 # --- CI Profile (PRs) ---
 
 [profile.ci]
@@ -25,10 +19,6 @@ fail-fast = false
 failure-output = "immediate"
 slow-timeout = { period = "5m", terminate-after = 4 }
 default-filter = 'not test(/^stateful::/) and not test(/^e2e::/) and not test(=unit::end_of_support::check_no_git_dependencies)'
-
-[[profile.ci.overrides]]
-platform = 'cfg(target_os = "windows")'
-filter = "not test(=integration::database::delete_old_databases)"
 
 [[profile.ci.overrides]]
 filter = 'test(=integration::network::disconnects_from_misbehaving_peers)'

--- a/.github/actions/setup-zebra-build/action.yml
+++ b/.github/actions/setup-zebra-build/action.yml
@@ -4,6 +4,7 @@ runs:
   using: 'composite'
   steps:
     - name: Install protoc and librocksdb-dev on Ubuntu
+      if: runner.os == 'Linux'
       shell: bash
       run: |
         sudo apt-get -qq update

--- a/.github/actions/setup-zebra-build/action.yml
+++ b/.github/actions/setup-zebra-build/action.yml
@@ -4,27 +4,8 @@ runs:
   using: 'composite'
   steps:
     - name: Install protoc and librocksdb-dev on Ubuntu
-      if: runner.os == 'Linux'
       shell: bash
       run: |
         sudo apt-get -qq update
         sudo apt-get -qq install -y --no-install-recommends protobuf-compiler librocksdb-dev
         echo "ROCKSDB_LIB_DIR=/usr/lib/" >> $GITHUB_ENV
-
-    - name: Install protoc and RocksDB on macOS
-      if: runner.os == 'macOS'
-      shell: bash
-      run: |
-        brew install protobuf rocksdb
-        # Set ROCKSDB_LIB_DIR for both Intel and Apple Silicon Macs
-        if [ -d "/opt/homebrew/lib" ]; then
-          echo "ROCKSDB_LIB_DIR=/opt/homebrew/lib" >> $GITHUB_ENV
-        else
-          echo "ROCKSDB_LIB_DIR=/usr/local/lib" >> $GITHUB_ENV
-        fi
-
-    - name: Install protoc on Windows
-      if: runner.os == 'Windows'
-      shell: bash
-      run: |
-        choco install protoc -y

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -43,28 +43,20 @@ jobs:
           filters: .github/path-filters.yml
 
   run-unit-tests:
-    name: ${{ matrix.rust-version }} on ${{ matrix.os }}
+    name: ${{ matrix.rust-version }}
     needs: changes
     if: needs.changes.outputs.unit_tests == 'true'
     permissions:
       contents: read
       id-token: write
       statuses: write
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
         rust-version: [stable, beta]
         features: [default-release-binaries]
-        exclude:
-          # Exclude macOS beta due to limited runner capacity and slower performance
-          # Exclude Windows beta to reduce the amount of minutes cost per workflow run
-          - os: macos-latest
-            rust-version: beta
-          - os: windows-latest
-            rust-version: beta
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
@@ -73,30 +65,12 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 #v1.16.1
         with:
           toolchain: ${{ matrix.rust-version }}
-          cache-key: unit-tests-${{ matrix.os }}-${{ matrix.rust-version }}-${{ matrix.features }}
+          cache-key: unit-tests-${{ matrix.rust-version }}-${{ matrix.features }}
           cache-on-failure: true
       - uses: taiki-e/install-action@65851e10cd6c377f11a60e600abc07cb08643468 #v2.79.3
         with:
           tool: cargo-nextest
       - uses: ./.github/actions/setup-zebra-build
-
-      # Windows-specific setup
-      - name: Install LLVM on Windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          choco install llvm -y
-          echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          echo "LIBCLANG_PATH=C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      - name: Minimise proptest cases on macOS and Windows
-        # We set cases to 1, because some tests already run 1 case by default.
-        # We keep maximum shrink iterations at the default value, because it only happens on failure.
-        #
-        # Windows compilation and tests are slower than other platforms.
-        if: matrix.os == 'windows-latest'
-        run: |
-          echo "PROPTEST_CASES=1" >> $GITHUB_ENV
-          echo "PROPTEST_MAX_SHRINK_ITERS=1024" >> $GITHUB_ENV
 
       - name: Run unit tests
         run: cargo nextest run --profile ci --locked --release --features "${{ matrix.features }}" --run-ignored=all

--- a/book/src/user/supported-platforms.md
+++ b/book/src/user/supported-platforms.md
@@ -43,8 +43,6 @@ For the full requirements, see [Tier 2 platform policy](target-tier-policies.md#
 | -------------------------- | ----------------------------------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------ | --------- |
 | `x86_64-unknown-linux-gnu` | [GitHub ubuntu-latest](https://github.com/actions/virtual-environments#available-environments)  | 64-bit      | [latest stable release](https://github.com/rust-lang/rust/releases)            | N/A       |
 | `x86_64-unknown-linux-gnu` | [GitHub ubuntu-latest](https://github.com/actions/virtual-environments#available-environments)  | 64-bit beta | [latest beta release](https://github.com/rust-lang/rust/blob/beta/src/version) | N/A       |
-| `x86_64-apple-darwin`      | [GitHub macos-latest](https://github.com/actions/virtual-environments#available-environments)   | 64-bit      | [latest stable release](https://github.com/rust-lang/rust/releases)            | N/A       |
-| `x86_64-pc-windows-msvc`   | [GitHub windows-latest](https://github.com/actions/virtual-environments#available-environments) | 64-bit      | [latest stable release](https://github.com/rust-lang/rust/releases)            | N/A       |
 
 > **Note:** Linux is tested on both stable and beta Rust to catch potential regressions early.
 
@@ -56,6 +54,8 @@ work. Official builds are not available.
 
 For the full requirements, see [Tier 3 platform policy](target-tier-policies.md#tier-3-platform-policy) in the Platform Tier Policy.
 
-| platform               | os           | notes                  | rust                                                                | artifacts |
-| ---------------------- | ------------ | ---------------------- | ------------------------------------------------------------------- | --------- |
-| `aarch64-apple-darwin` | latest macOS | 64-bit, Apple M1 or M2 | [latest stable release](https://github.com/rust-lang/rust/releases) | N/A       |
+| platform                 | os             | notes                  | rust                                                                | artifacts |
+| ------------------------ | -------------- | ---------------------- | ------------------------------------------------------------------- | --------- |
+| `x86_64-apple-darwin`    | latest macOS   | 64-bit                 | [latest stable release](https://github.com/rust-lang/rust/releases) | N/A       |
+| `aarch64-apple-darwin`   | latest macOS   | 64-bit, Apple M1 or M2 | [latest stable release](https://github.com/rust-lang/rust/releases) | N/A       |
+| `x86_64-pc-windows-msvc` | latest Windows | 64-bit                 | [latest stable release](https://github.com/rust-lang/rust/releases) | N/A       |

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -27,7 +27,6 @@ use tower::{service_fn, Layer, Service, ServiceExt};
 
 use zebra_chain::{chain_tip::NoChainTip, parameters::Network, serialization::DateTime32};
 
-#[cfg(not(target_os = "windows"))]
 use zebra_test::net::random_known_port;
 
 use crate::{
@@ -147,7 +146,6 @@ async fn local_listener_unspecified_port_localhost_addr_v6() {
 
 /// Test that zebra-network propagates fixed localhost listener ports to the `AddressBook`.
 #[tokio::test]
-#[cfg(not(target_os = "windows"))]
 async fn local_listener_fixed_port_localhost_addr_v4() {
     let _init_guard = zebra_test::init();
 
@@ -164,7 +162,6 @@ async fn local_listener_fixed_port_localhost_addr_v4() {
 
 /// Test that zebra-network propagates fixed localhost listener ports to the `AddressBook`.
 #[tokio::test]
-#[cfg(not(target_os = "windows"))]
 async fn local_listener_fixed_port_localhost_addr_v6() {
     let _init_guard = zebra_test::init();
 
@@ -946,10 +943,6 @@ async fn listener_peer_limit_default_handshake_error() {
 
 /// Test the listener with the default inbound peer limit,
 /// and a handshaker that returns success then disconnects the peer.
-///
-/// TODO: tweak the crawler timeouts and rate-limits so we get over the actual limit on macOS
-///       (currently, getting over the limit can take 30 seconds or more)
-#[cfg(not(target_os = "macos"))]
 #[tokio::test]
 async fn listener_peer_limit_default_handshake_ok_then_drop() {
     let _init_guard = zebra_test::init();

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -447,7 +447,6 @@ fn finalized_equals_pushed_history_tree() -> Result<()> {
 /// Check that rejected blocks do not change the internal state of a genesis chain
 /// in a non-finalized state.
 #[test]
-#[cfg(not(target_os = "windows"))]
 fn rejection_restores_internal_state_genesis() -> Result<()> {
     use zebra_chain::fmt::DisplayToDebug;
 

--- a/zebrad/src/components/health/tests.rs
+++ b/zebrad/src/components/health/tests.rs
@@ -175,7 +175,6 @@ async fn not_ready_when_tip_is_too_old() {
 }
 
 #[tokio::test]
-#[cfg(not(target_os = "windows"))]
 async fn rate_limiting_drops_bursts() {
     // With a sleep shorter than the configured interval we should only be able
     // to observe one successful request before the limiter responds with 429.

--- a/zebrad/tests/e2e/lightwalletd.rs
+++ b/zebrad/tests/e2e/lightwalletd.rs
@@ -8,12 +8,8 @@ use crate::common::{lightwalletd::lwd_integration_test, test_type::TestType::Ful
 /// - `TEST_LIGHTWALLETD` is set,
 /// - a persistent cached state is configured (e.g., via `ZEBRA_STATE__CACHE_DIR`), and
 /// - Zebra is compiled with `--features=lightwalletd-grpc-tests`.
-///
-///
-/// This test doesn't work on Windows, so it is always skipped on that platform.
 #[test]
 #[ignore]
-#[cfg(not(target_os = "windows"))]
 fn lwd_sync_full() -> Result<()> {
     lwd_integration_test(FullSyncFromGenesis {
         allow_lightwalletd_cached_state: false,

--- a/zebrad/tests/integration/database.rs
+++ b/zebrad/tests/integration/database.rs
@@ -174,7 +174,6 @@ where
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
 fn delete_old_databases() -> Result<()> {
     use std::fs::{canonicalize, create_dir};
 

--- a/zebrad/tests/integration/mod.rs
+++ b/zebrad/tests/integration/mod.rs
@@ -1,5 +1,4 @@
 pub mod database;
-#[cfg(not(target_os = "windows"))]
 pub mod network;
 pub mod regtest;
 pub mod rpc;

--- a/zebrad/tests/integration/network.rs
+++ b/zebrad/tests/integration/network.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-#[cfg(not(target_os = "windows"))]
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -16,11 +15,9 @@ use zebra_chain::{
     },
 };
 use zebra_node_services::rpc_client::RpcRequestClient;
-#[cfg(not(target_os = "windows"))]
 use zebra_rpc::client::PeerInfo;
 use zebra_test::{args, net::random_known_port, prelude::*};
 
-#[cfg(not(target_os = "windows"))]
 use zebra_network::constants::PORT_IN_USE_ERROR;
 
 use crate::common::{
@@ -35,7 +32,6 @@ use crate::integration::database::check_config_conflict;
 /// It is expected that the first node spawned will get exclusive use of the port.
 /// The second node will panic with the Zcash listener conflict hint added in #1535.
 #[test]
-#[cfg(not(target_os = "windows"))]
 fn zebra_zcash_listener_conflict() -> Result<()> {
     let _init_guard = zebra_test::init();
 
@@ -64,7 +60,7 @@ fn zebra_zcash_listener_conflict() -> Result<()> {
 /// exclusive use of the port. The second node will panic with the Zcash metrics
 /// conflict hint added in #1535.
 #[test]
-#[cfg(all(feature = "prometheus", not(target_os = "windows")))]
+#[cfg(feature = "prometheus")]
 fn zebra_metrics_conflict() -> Result<()> {
     let _init_guard = zebra_test::init();
 
@@ -93,7 +89,7 @@ fn zebra_metrics_conflict() -> Result<()> {
 /// exclusive use of the port. The second node will panic with the Zcash tracing
 /// conflict hint added in #1535.
 #[test]
-#[cfg(all(feature = "filter-reload", not(target_os = "windows")))]
+#[cfg(feature = "filter-reload")]
 fn zebra_tracing_conflict() -> Result<()> {
     let _init_guard = zebra_test::init();
 
@@ -120,11 +116,7 @@ fn zebra_tracing_conflict() -> Result<()> {
 /// Start 2 zebrad nodes using the same RPC listener port, but different
 /// state directories and Zcash listener ports. The first node should get
 /// exclusive use of the port. The second node will panic.
-///
-/// This test is sometimes unreliable on Windows, and hangs on macOS.
-/// We believe this is a CI infrastructure issue, not a platform-specific issue.
 #[test]
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
 fn zebra_rpc_conflict() -> Result<()> {
     use crate::common::config::random_known_rpc_port_config;
 
@@ -164,7 +156,6 @@ fn zebra_rpc_conflict() -> Result<()> {
 /// The second zebrad instance will connect to the first one, and when the first one mines
 /// blocks with invalid PoW the second one should disconnect from it.
 #[tokio::test]
-#[cfg(not(target_os = "windows"))]
 async fn disconnects_from_misbehaving_peers() -> Result<()> {
     tokio::time::timeout(
         Duration::from_secs(10 * 60),
@@ -174,7 +165,6 @@ async fn disconnects_from_misbehaving_peers() -> Result<()> {
     .wrap_err("disconnects_from_misbehaving_peers timed out")?
 }
 
-#[cfg(not(target_os = "windows"))]
 async fn disconnects_from_misbehaving_peers_impl() -> Result<()> {
     use crate::common::regtest::MiningRpcMethods;
     use zebra_rpc::client::PeerInfo;
@@ -377,7 +367,6 @@ async fn disconnects_from_misbehaving_peers_impl() -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(target_os = "windows"))]
 async fn wait_for_outbound_peer(rpc_client: &RpcRequestClient) -> Result<Vec<PeerInfo>> {
     tokio::time::timeout(Duration::from_secs(2 * 60), async {
         loop {
@@ -403,17 +392,14 @@ async fn wait_for_outbound_peer(rpc_client: &RpcRequestClient) -> Result<Vec<Pee
     .wrap_err("timed out waiting for outbound peer")?
 }
 
-#[cfg(not(target_os = "windows"))]
 struct FinishOnDrop(Arc<AtomicBool>);
 
-#[cfg(not(target_os = "windows"))]
 impl FinishOnDrop {
     fn new(is_finished: Arc<AtomicBool>) -> Self {
         Self(is_finished)
     }
 }
 
-#[cfg(not(target_os = "windows"))]
 impl Drop for FinishOnDrop {
     fn drop(&mut self) {
         self.0.store(true, Ordering::SeqCst);

--- a/zebrad/tests/integration/rpc.rs
+++ b/zebrad/tests/integration/rpc.rs
@@ -12,16 +12,10 @@ use crate::common::{
     launch::{ZebradTestDirExt, LAUNCH_DELAY},
 };
 
-// Used by metrics_endpoint and tracing_endpoint (feature + platform gated).
-#[cfg(all(
-    any(feature = "prometheus", feature = "filter-reload"),
-    not(target_os = "windows")
-))]
+// Used by metrics_endpoint and tracing_endpoint (feature gated).
+#[cfg(any(feature = "prometheus", feature = "filter-reload"))]
 use crate::common::config::default_test_config;
-#[cfg(all(
-    any(feature = "prometheus", feature = "filter-reload"),
-    not(target_os = "windows")
-))]
+#[cfg(any(feature = "prometheus", feature = "filter-reload"))]
 use zebra_test::net::random_known_port;
 
 #[tokio::test]

--- a/zebrad/tests/integration/rpc.rs
+++ b/zebrad/tests/integration/rpc.rs
@@ -25,7 +25,7 @@ use crate::common::config::default_test_config;
 use zebra_test::net::random_known_port;
 
 #[tokio::test]
-#[cfg(all(feature = "prometheus", not(target_os = "windows")))]
+#[cfg(feature = "prometheus")]
 async fn metrics_endpoint() -> Result<()> {
     use bytes::Bytes;
     use http_body_util::BodyExt;
@@ -92,7 +92,7 @@ async fn metrics_endpoint() -> Result<()> {
     Ok(())
 }
 
-#[cfg(all(feature = "filter-reload", not(target_os = "windows")))]
+#[cfg(feature = "filter-reload")]
 #[tokio::test]
 async fn tracing_endpoint() -> Result<()> {
     use bytes::Bytes;

--- a/zebrad/tests/stateful/lightwalletd.rs
+++ b/zebrad/tests/stateful/lightwalletd.rs
@@ -1,20 +1,14 @@
-#[cfg(not(target_os = "windows"))]
 use color_eyre::eyre::Result;
 
-#[cfg(not(target_os = "windows"))]
 use crate::common::test_type::TestType::*;
 
-#[cfg(not(target_os = "windows"))]
 use crate::common::lightwalletd::lwd_integration_test;
 
 /// Make sure `lightwalletd` works with Zebra, when both their states are empty.
 ///
 /// This test only runs when the `TEST_LIGHTWALLETD` env var is set.
-///
-/// This test doesn't work on Windows, so it is always skipped on that platform.
 #[test]
 #[ignore]
-#[cfg(not(target_os = "windows"))]
 fn lwd_integration() -> Result<()> {
     lwd_integration_test(LaunchWithEmptyState {
         launches_lightwalletd: true,
@@ -27,11 +21,8 @@ fn lwd_integration() -> Result<()> {
 /// - `TEST_LIGHTWALLETD` is set,
 /// - a persistent cached state directory path is configured (e.g., via `ZEBRA_STATE__CACHE_DIR`), and
 /// - Zebra is compiled with `--features=lightwalletd-grpc-tests`.
-///
-/// This test doesn't work on Windows, so it is always skipped on that platform.
 #[test]
 #[ignore]
-#[cfg(not(target_os = "windows"))]
 #[cfg(feature = "lightwalletd-grpc-tests")]
 fn lwd_sync_update() -> Result<()> {
     lwd_integration_test(UpdateCachedState)
@@ -49,11 +40,8 @@ fn lwd_sync_update() -> Result<()> {
 ///   - run read-only gRPC tests.
 ///
 /// The lightwalletd full, update, and gRPC tests only run with `--features=lightwalletd-grpc-tests`.
-///
-/// These tests don't work on Windows, so they are always skipped on that platform.
 #[tokio::test]
 #[ignore]
-#[cfg(not(target_os = "windows"))]
 #[cfg(feature = "lightwalletd-grpc-tests")]
 async fn lightwalletd_test_suite() -> Result<()> {
     lwd_integration_test(LaunchWithEmptyState {
@@ -88,11 +76,8 @@ async fn lightwalletd_test_suite() -> Result<()> {
 /// Test sending transactions using a lightwalletd instance connected to a zebrad instance.
 ///
 /// See [`crate::common::lightwalletd::send_transaction_test`] for more information.
-///
-/// This test doesn't work on Windows, so it is always skipped on that platform.
 #[tokio::test]
 #[ignore]
-#[cfg(not(target_os = "windows"))]
 #[cfg(feature = "lightwalletd-grpc-tests")]
 async fn lwd_rpc_send_tx() -> Result<()> {
     crate::common::lightwalletd::send_transaction_test::run().await
@@ -101,11 +86,8 @@ async fn lwd_rpc_send_tx() -> Result<()> {
 /// Test all the rpc methods a wallet connected to lightwalletd can call.
 ///
 /// See [`crate::common::lightwalletd::wallet_grpc_test`] for more information.
-///
-/// This test doesn't work on Windows, so it is always skipped on that platform.
 #[tokio::test]
 #[ignore]
-#[cfg(not(target_os = "windows"))]
 #[cfg(feature = "lightwalletd-grpc-tests")]
 async fn lwd_grpc_wallet() -> Result<()> {
     crate::common::lightwalletd::wallet_grpc_test::run().await

--- a/zebrad/tests/unit/config.rs
+++ b/zebrad/tests/unit/config.rs
@@ -6,7 +6,6 @@ use color_eyre::eyre::{eyre, Result, WrapErr};
 use tempfile::{Builder, TempDir};
 
 use zebra_chain::parameters::Network::*;
-#[cfg(not(target_os = "windows"))]
 use zebra_state;
 use zebra_test::{args, command::to_regex::CollectRegexSet, prelude::*};
 use zebrad::config::ZebradConfig;
@@ -19,15 +18,11 @@ use crate::common::{
     launch::{ZebradTestDirExt, EXTENDED_LAUNCH_DELAY, LAUNCH_DELAY},
 };
 
-// Used by `non_blocking_logger` test, which is disabled on macOS.
-#[cfg(not(target_os = "macos"))]
 use crate::common::{
     config::{os_assigned_rpc_port_config, read_listen_addr_from_logs},
     sync::TINY_CHECKPOINT_TIMEOUT,
 };
-#[cfg(not(target_os = "macos"))]
 use zebra_node_services::rpc_client::RpcRequestClient;
-#[cfg(not(target_os = "macos"))]
 use zebra_rpc::server::OPENED_RPC_ENDPOINT_MSG;
 
 /// Check that the block state and peer list caches are written to disk.
@@ -212,7 +207,6 @@ fn config_tests() -> Result<()> {
     invalid_generated_config()?;
 
     // Check that we have a current version of the config stored
-    #[cfg(not(target_os = "windows"))]
     last_config_is_stored()?;
 
     // Check that Zebra's previous configurations still work
@@ -311,7 +305,6 @@ fn valid_generated_config(command: &str, expect_stdout_line_contains: &str) -> R
 }
 
 /// Check if the config produced by current zebrad is stored.
-#[cfg(not(target_os = "windows"))]
 #[tracing::instrument]
 #[allow(clippy::print_stdout)]
 fn last_config_is_stored() -> Result<()> {
@@ -626,10 +619,7 @@ fn stored_configs_work() -> Result<()> {
 
 /// Test that Zebra's non-blocking logger works, by creating lots of debug output, but not reading the logs.
 /// Then make sure Zebra drops excess log lines. (Previously, it would block waiting for logs to be read.)
-///
-/// This test is unreliable and sometimes hangs on macOS.
 #[test]
-#[cfg(not(target_os = "macos"))]
 fn non_blocking_logger() -> Result<()> {
     use futures::FutureExt;
     use std::{sync::mpsc, time::Duration};

--- a/zebrad/tests/unit/config.rs
+++ b/zebrad/tests/unit/config.rs
@@ -13,13 +13,10 @@ use zebrad::config::ZebradConfig;
 use crate::common::{
     check::{EphemeralCheck, EphemeralConfig},
     config::{
-        config_file_full_path, configs_dir, default_test_config, persistent_test_config, testdir,
+        config_file_full_path, configs_dir, default_test_config, os_assigned_rpc_port_config,
+        persistent_test_config, read_listen_addr_from_logs, testdir,
     },
     launch::{ZebradTestDirExt, EXTENDED_LAUNCH_DELAY, LAUNCH_DELAY},
-};
-
-use crate::common::{
-    config::{os_assigned_rpc_port_config, read_listen_addr_from_logs},
     sync::TINY_CHECKPOINT_TIMEOUT,
 };
 use zebra_node_services::rpc_client::RpcRequestClient;


### PR DESCRIPTION
## Motivation

Closes #10844

Windows and macOS unit-test runners are unnecessary CI overhead. No relevant node operators run those OSes; other enthusiasts should use Docker.

## Solution

Drop the Windows/macOS unit-test matrix and the brew/choco install branches from `setup-zebra-build`. Linux only.

Demote macOS and Windows from tier 2 to tier 3 in the platform-support docs, since CI no longer builds or tests them.

### AI Disclosure

- [x] AI tools were used: Claude for the CI edits, docs, and PR text.