### PR TITLE
fix(rpc): cache the getblocktemplate coinbase per block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- `getblocktemplate` now caches the built coinbase transaction per block, so repeated short-poll
+  requests within the same block no longer rebuild it. This prevents CPU saturation and multi-second
+  template latency when mining to a shielded (Sapling or Orchard) address
+  ([#10847](https://github.com/ZcashFoundation/zebra/pull/10847))
 - Released `zebrad` binaries report their source commit in `zebrad version`
   ([#10798](https://github.com/ZcashFoundation/zebra/pull/10798))
 - Handle `invalidateblock` and `reconsiderblock` edge cases (chain-root and

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `getblocktemplate` now caches the built coinbase transaction per `(height, fees)`, so repeated
+  short-poll requests within a block no longer rebuild it. This avoids re-running the
+  Sapling/Orchard proof on every request when mining to a shielded address, which otherwise pegged
+  the CPU and made each template take seconds.
 - `TrustedChainSync` no longer busy-loops and saturates logs when a block repeatedly
   fails to commit to the non-finalized state: it now backs off before re-subscribing
   and only logs the warning on transitions.

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -2464,6 +2464,7 @@ where
                     return Ok(BlockTemplateResponse::new_internal(
                         &self.network,
                         precomputed_coinbase,
+                        None,
                         miner_params,
                         &chain_info,
                         server_long_poll_id,
@@ -2530,6 +2531,7 @@ where
         Ok(BlockTemplateResponse::new_internal(
             &self.network,
             None,
+            Some(self.gbt.coinbase_cache()),
             miner_params,
             &chain_info,
             server_long_poll_id,

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -2508,6 +2508,7 @@ where
         let height = chain_info.tip_height.next().map_misc_error()?;
 
         // Randomly select some mempool transactions.
+        let coinbase_cache = self.gbt.coinbase_cache();
         let mempool_txs = select_mempool_transactions(
             &self.network,
             height,
@@ -2516,6 +2517,7 @@ where
             mempool_tx_deps,
             #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             None,
+            Some(&coinbase_cache),
         );
 
         tracing::debug!(

--- a/zebra-rpc/src/methods/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/types/get_block_template.rs
@@ -586,7 +586,10 @@ impl CoinbaseCache {
         height: block::Height,
         fee: Amount<NonNegative>,
     ) -> Option<TransactionTemplate<amount::NegativeOrZero>> {
-        let cache = self.0.lock().expect("coinbase cache mutex is not poisoned");
+        let cache = self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         match &*cache {
             Some((cached_height, cached_fee, coinbase))
                 if *cached_height == height && *cached_fee == fee =>
@@ -604,13 +607,18 @@ impl CoinbaseCache {
         fee: Amount<NonNegative>,
         coinbase: TransactionTemplate<amount::NegativeOrZero>,
     ) {
-        *self.0.lock().expect("coinbase cache mutex is not poisoned") =
-            Some((height, fee, coinbase));
+        *self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some((height, fee, coinbase));
     }
 
     /// Discards the cached coinbase, forcing the next request to rebuild it.
     fn clear(&self) {
-        *self.0.lock().expect("coinbase cache mutex is not poisoned") = None;
+        *self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
     }
 }
 

--- a/zebra-rpc/src/methods/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/types/get_block_template.rs
@@ -10,7 +10,7 @@ mod tests;
 
 use std::{
     fmt::{self},
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 use derive_getters::Getters;
@@ -275,6 +275,7 @@ impl BlockTemplateResponse {
     pub(crate) fn new_internal(
         net: &Network,
         precomputed_coinbase: Option<TransactionTemplate<amount::NegativeOrZero>>,
+        coinbase_cache: Option<CoinbaseCache>,
         miner_params: &MinerParams,
         chain_info: &GetBlockTemplateChainInfo,
         long_poll_id: LongPollId,
@@ -333,17 +334,32 @@ impl BlockTemplateResponse {
             .sum::<amount::Result<Amount<NonNegative>>>()
             .expect("mempool tx fees must be non-negative");
 
-        let coinbase_txn = precomputed_coinbase.unwrap_or_else(|| {
-            TransactionTemplate::new_coinbase(
-                net,
-                height,
-                miner_params,
-                txs_fee,
-                #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
-                zip233_amount,
-            )
-            .expect("valid coinbase tx")
-        });
+        // Prefer the long-poll precomputed coinbase, then the per-block cache, and only build (and
+        // re-prove, for a shielded address) as a last resort — caching the result so subsequent
+        // short-poll requests for the same height and fees reuse it.
+        let coinbase_txn = precomputed_coinbase
+            .or_else(|| {
+                coinbase_cache
+                    .as_ref()
+                    .and_then(|cache| cache.get(height, txs_fee))
+            })
+            .unwrap_or_else(|| {
+                let coinbase_txn = TransactionTemplate::new_coinbase(
+                    net,
+                    height,
+                    miner_params,
+                    txs_fee,
+                    #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+                    zip233_amount,
+                )
+                .expect("valid coinbase tx");
+
+                if let Some(cache) = &coinbase_cache {
+                    cache.store(height, txs_fee, coinbase_txn.clone());
+                }
+
+                coinbase_txn
+            });
 
         let default_roots = DefaultRoots::from_coinbase(
             net,
@@ -543,6 +559,61 @@ impl From<zcash_address::ConversionError<&'static str>> for MinerParamsError {
     }
 }
 
+/// Caches the most recently built coinbase transaction for the next block, keyed on its height and
+/// total transaction fees.
+///
+/// `getblocktemplate` clients commonly short-poll (re-request without long polling), and building
+/// the coinbase to a shielded address re-runs an expensive Sapling/Orchard proof. The coinbase only
+/// depends on `(height, fees)` for a given miner configuration, so repeated requests within the
+/// same block can reuse the cached transaction instead of re-proving it on every call.
+#[derive(Clone, Default)]
+pub(crate) struct CoinbaseCache(
+    Arc<
+        Mutex<
+            Option<(
+                block::Height,
+                Amount<NonNegative>,
+                TransactionTemplate<amount::NegativeOrZero>,
+            )>,
+        >,
+    >,
+);
+
+impl CoinbaseCache {
+    /// Returns the cached coinbase transaction if it was built for `height` and `fee`.
+    fn get(
+        &self,
+        height: block::Height,
+        fee: Amount<NonNegative>,
+    ) -> Option<TransactionTemplate<amount::NegativeOrZero>> {
+        let cache = self.0.lock().expect("coinbase cache mutex is not poisoned");
+        match &*cache {
+            Some((cached_height, cached_fee, coinbase))
+                if *cached_height == height && *cached_fee == fee =>
+            {
+                Some(coinbase.clone())
+            }
+            _ => None,
+        }
+    }
+
+    /// Stores `coinbase` as the cached transaction for `height` and `fee`.
+    fn store(
+        &self,
+        height: block::Height,
+        fee: Amount<NonNegative>,
+        coinbase: TransactionTemplate<amount::NegativeOrZero>,
+    ) {
+        *self.0.lock().expect("coinbase cache mutex is not poisoned") =
+            Some((height, fee, coinbase));
+    }
+
+    /// Discards the cached coinbase, forcing the next request to rebuild it.
+    fn clear(&self) {
+        *self.0.lock().expect("coinbase cache mutex is not poisoned") = None;
+    }
+}
+
 /// Handler for the `getblocktemplate` RPC.
 #[derive(Clone)]
 pub struct GetBlockTemplateHandler<BlockVerifierRouter, SyncStatus>
@@ -562,6 +633,10 @@ where
     /// A channel to send successful block submissions to the block gossip task,
     /// so they can be advertised to peers.
     mined_block_sender: mpsc::Sender<(block::Hash, block::Height)>,
+
+    /// Caches the most recently built coinbase transaction, so short-polling miners don't re-run
+    /// the shielded-coinbase proof on every request within a block.
+    coinbase_cache: CoinbaseCache,
 }
 
 impl<BlockVerifierRouter, SyncStatus> GetBlockTemplateHandler<BlockVerifierRouter, SyncStatus>
@@ -583,12 +658,18 @@ where
             sync_status,
             mined_block_sender: mined_block_sender
                 .unwrap_or(SubmitBlockChannel::default().sender()),
+            coinbase_cache: CoinbaseCache::default(),
         }
     }
 
     /// Returns the miner parameters, including the address, data, and memo.
     pub fn miner_params(&self) -> Option<&MinerParams> {
         self.miner_params.as_ref()
+    }
+
+    /// Returns a handle to the coinbase transaction cache.
+    pub(crate) fn coinbase_cache(&self) -> CoinbaseCache {
+        self.coinbase_cache.clone()
     }
 
     /// Returns the sync status.
@@ -615,6 +696,8 @@ where
         if let Some(miner_params) = &mut self.miner_params {
             miner_params.randomize_data();
             miner_params.randomize_memo();
+            // The cached coinbase was built with the previous data, so it's now stale.
+            self.coinbase_cache.clear();
         }
     }
 }

--- a/zebra-rpc/src/methods/types/get_block_template/tests.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/tests.rs
@@ -96,3 +96,63 @@ fn coinbase() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// Tests that the coinbase cache reuses a previously built coinbase for the same height and fees,
+/// so a short-polling miner doesn't re-run the shielded-coinbase proof on every request.
+#[test]
+fn coinbase_cache_reuses_built_coinbase() {
+    use super::CoinbaseCache;
+
+    let net = Network::Mainnet;
+    let height = NetworkUpgrade::Nu5
+        .activation_height(&net)
+        .expect("Nu5 is active on Mainnet");
+    let miner_params = MinerParams::from(
+        Address::decode(
+            &net,
+            default_miner_address(net.kind(), &MinerAddressType::Sapling),
+        )
+        .expect("hard-coded Sapling address is valid"),
+    );
+    let fee = Amount::zero();
+
+    let build = || {
+        TransactionTemplate::new_coinbase(
+            &net,
+            height,
+            &miner_params,
+            fee,
+            #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+            None,
+        )
+        .expect("valid coinbase tx")
+    };
+
+    // A shielded coinbase carries a randomized proof, so two fresh builds differ. Identical bytes
+    // therefore prove the cache returned a reused transaction rather than rebuilding it.
+    let coinbase = build();
+    assert_ne!(
+        build(),
+        coinbase,
+        "fresh shielded coinbases differ (randomized proof)"
+    );
+
+    let cache = CoinbaseCache::default();
+    assert!(cache.get(height, fee).is_none(), "an empty cache misses");
+
+    cache.store(height, fee, coinbase.clone());
+    assert_eq!(
+        cache.get(height, fee),
+        Some(coinbase.clone()),
+        "a cache hit reuses the stored coinbase",
+    );
+
+    // A different height key or a cleared cache misses, so the next request rebuilds.
+    let next_height = height.next().expect("height is below Height::MAX");
+    assert!(
+        cache.get(next_height, fee).is_none(),
+        "a different height misses"
+    );
+    cache.clear();
+    assert!(cache.get(height, fee).is_none(), "a cleared cache misses");
+}

--- a/zebra-rpc/src/methods/types/get_block_template/zip317.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/zip317.rs
@@ -22,6 +22,7 @@ use zebra_chain::{
 use zebra_consensus::MAX_BLOCK_SIGOPS;
 use zebra_node_services::mempool::TransactionDependencies;
 
+use super::CoinbaseCache;
 use crate::methods::types::transaction::TransactionTemplate;
 
 #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
@@ -66,18 +67,30 @@ pub fn select_mempool_transactions(
     #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))] zip233_amount: Option<
         Amount<NonNegative>,
     >,
+    coinbase_cache: Option<&CoinbaseCache>,
 ) -> Vec<SelectedMempoolTx> {
     // Use a fake coinbase transaction to break the dependency between transaction
     // selection, the miner fee, and the fee payment in the coinbase transaction.
-    let fake_coinbase_tx = TransactionTemplate::new_coinbase(
-        net,
-        height,
-        miner_params,
-        Amount::zero(),
-        #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
-        zip233_amount,
-    )
-    .expect("valid coinbase transaction template");
+    // The fake coinbase only depends on the height and miner parameters (its fee is always zero),
+    // so it's constant per block. Reuse the same per-block cache as the real coinbase to avoid
+    // re-proving a shielded coinbase on every `getblocktemplate` call just to read its size.
+    let fake_coinbase_tx = coinbase_cache
+        .and_then(|cache| cache.get(height, Amount::zero()))
+        .unwrap_or_else(|| {
+            let cb = TransactionTemplate::new_coinbase(
+                net,
+                height,
+                miner_params,
+                Amount::zero(),
+                #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+                zip233_amount,
+            )
+            .expect("valid coinbase transaction template");
+            if let Some(cache) = coinbase_cache {
+                cache.store(height, Amount::zero(), cb.clone());
+            }
+            cb
+        });
 
     let tx_dependencies = mempool_tx_deps.dependencies();
     let (independent_mempool_txs, mut dependent_mempool_txs): (HashMap<_, _>, HashMap<_, _>) =

--- a/zebra-rpc/src/methods/types/get_block_template/zip317/tests.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/zip317/tests.rs
@@ -36,6 +36,7 @@ fn excludes_tx_with_unselected_dependencies() {
             mempool_tx_deps,
             #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
             None,
+            None,
         ),
         vec![],
         "should not select any transactions when dependencies are unavailable"
@@ -76,6 +77,7 @@ fn includes_tx_with_selected_dependencies() {
         unmined_txs.clone(),
         mempool_tx_deps.clone(),
         #[cfg(all(zcash_unstable = "nu7", feature = "tx_v6"))]
+        None,
         None,
     );
 


### PR DESCRIPTION
## Motivation

Closes #10846.

## Solution

Cache the built coinbase per `(height, fees)` so short-poll `getblocktemplate` requests within a block reuse it instead of re-running the Sapling/Orchard proof. The ZIP-317 fee-calculation fake coinbase is routed through the same cache (it re-proved too). `randomize_coinbase_data` clears it (Regtest `generate` only).

## Tests

Unit tests assert a cache hit reuses identical bytes while two fresh shielded builds differ. Verified on a live testnet pool: shielded `getblocktemplate` dropped from ~6 core-sec/call to ~0 (cached) — only the first call per block proves.

## AI Disclosure

Claude Code was used for the ZIP-317-path fix and the end-to-end validation.
