### PR TITLE
feat(release): build the GitHub Release body by wrapping the changelog

### DIFF
--- a/.github/prompts/release-notes.md
+++ b/.github/prompts/release-notes.md
@@ -1,0 +1,157 @@
+You are building the GitHub Release body for Zebra, a Zcash full-node
+(validator) implementation written in Rust. The audience is node operators
+who run `zebrad` in production, not Rust library consumers.
+
+## Input
+
+**Changelog section:** __SECTION_PATH__
+This file holds one release's curated changelog, sliced verbatim from the
+root `CHANGELOG.md`. It starts with a `## [Zebra __VERSION__]` heading,
+followed by a one-paragraph summary and Keep-a-Changelog subsections
+(`### Breaking Changes`, `### Added`, `### Changed`, `### Deprecated`,
+`### Removed`, `### Fixed`, `### Security`, `### Contributors`). Each entry
+is one line and may end with a PR link like `([#10650](url))`.
+
+Release metadata:
+- Version: `__VERSION__`
+- Tag: `__TAG__`
+- Previous tag: `__PREVIOUS_TAG__`
+- Repository: `__GITHUB_REPOSITORY__`
+
+## Your job
+
+Wrap the changelog section with operator-facing context. You add framing
+around the curated entries; you never rewrite the entries themselves. The
+changelog is the GitHub Release's core, not its whole: the Release adds
+what an operator needs to decide whether and how to upgrade.
+
+Produce a release body with these parts, in this exact order:
+
+1. **Update Priority** callout (one line, see scale below).
+2. **TL;DR**: two to four sentences in plain language summarizing what
+   this release does for an operator. No marketing tone.
+3. **The changelog sections**, copied verbatim (see strict rules).
+4. **How to Upgrade**: per platform (see template).
+5. **Compatibility**: OS, network protocol, and MSRV (see template).
+6. A closing **Full changelog** compare link.
+
+## Pick the template by reading the section
+
+- **Security release**: the section has a `### Security` entry describing a
+  vulnerability fix, or references a GHSA / CVE / advisory, or the summary
+  calls the change critical. Lead with a security advisory callout.
+- **Network Upgrade release**: the section mentions a network upgrade
+  (for example NU6, NU6.2, NU7) activating, a minimum network protocol
+  version bump, or an end-of-support window change tied to an upgrade.
+  Emphasize the activation height or date and the upgrade deadline.
+- **Standard release**: anything else.
+
+If more than one applies, prefer Security, then Network Upgrade, then
+Standard.
+
+## Update Priority scale
+
+Emit exactly one line at the top: `> **Update priority:** <Level>. <reason>`
+
+- **Critical**: security fix, consensus-affecting change, or an upgrade an
+  operator must apply before a network upgrade activates.
+- **High**: a fix for a stall, crash, sync failure, or data-handling bug
+  that operators are likely to hit.
+- **Medium**: meaningful correctness, RPC, or performance fixes with no
+  urgent operational risk.
+- **Low**: minor fixes, internal changes, or additions with no operational
+  pressure to upgrade.
+
+Choose the level from the changelog content only. Do not invent severity
+the entries do not support.
+
+## Section templates
+
+### Security release header (only for Security releases)
+
+Place this directly under the Update Priority line, before TL;DR:
+
+```
+> **Security advisory:** <one sentence naming the issue and its impact>.
+> Operators should upgrade as soon as possible. See <GHSA link if the
+> changelog provides one, otherwise omit this sentence>.
+```
+
+### How to Upgrade (all templates)
+
+Use this skeleton; keep only platforms Zebra actually ships. Confirm
+install methods from the repository before listing them (the changelog,
+`README.md`, and `book/`). If you cannot confirm a method, omit it rather
+than guess.
+
+```
+## How to upgrade
+
+**Docker**
+
+    docker pull zfnd/zebra:__VERSION__
+
+**Pre-built binary** (Linux `x86_64` and `aarch64`)
+
+Download the `zebrad` archive for your platform from the assets below,
+verify its checksum and signature, then replace your existing binary.
+
+**Cargo**
+
+    cargo install --locked --version __VERSION__ zebrad
+    # or, for a pre-built binary:
+    cargo binstall zebrad
+
+Stop the node, swap the binary or image, then restart. Zebra resumes from
+its existing state cache; no resync is required unless a section above says
+otherwise.
+```
+
+For a Network Upgrade release, add one line stating the upgrade and its
+activation height or date, and that operators must be on this version (or
+later) before activation.
+
+### Compatibility (all templates)
+
+```
+## Compatibility
+
+- **Operating systems:** Linux on `x86_64` and `aarch64` are tested and
+  supported.
+- **Network protocol:** <minimum peer protocol version, only if the
+  changelog or repo states it>.
+- **MSRV:** <Rust version, confirmed from `Cargo.toml` `rust-version`>.
+```
+
+Confirm the network protocol version and MSRV from the repository
+(`Cargo.toml` `rust-version`, and network constants). If a value cannot be
+confirmed, omit that bullet. Never state a version you did not verify.
+
+### Closing line (all templates)
+
+```
+**Full changelog:** [`__PREVIOUS_TAG__...__TAG__`](https://github.com/__GITHUB_REPOSITORY__/compare/__PREVIOUS_TAG__...__TAG__)
+```
+
+## Strict rules (do NOT violate)
+
+- Copy every changelog entry verbatim. Do not reword, shorten, expand,
+  merge, split, add, or remove any entry.
+- Do not change PR or issue links, or their numbers.
+- Do not reorder the `### ...` subsections or the entries inside them.
+- Keep the `### Contributors` block exactly as written, if present.
+- You may drop the top `## [Zebra __VERSION__]` heading line and its date,
+  since the Release title already carries the version. Keep the
+  one-paragraph summary that follows it as the basis for your TL;DR, but do
+  not delete information from it.
+- Do not invent entries, severities, heights, dates, versions, or links.
+  Everything factual must come from the changelog section or be verified in
+  the repository.
+- Do not use em dashes. Use colons, semicolons, parentheses, or commas.
+- No marketing language. Write for an operator deciding whether to upgrade.
+
+## Output
+
+Write the final release body to `__SECTION_PATH__.final`. Write nothing
+else to that file. If you cannot complete the wrap for any reason, do not
+create the file; the workflow falls back to the raw changelog section.

--- a/.github/workflows/scripts/extract-changelog-section.sh
+++ b/.github/workflows/scripts/extract-changelog-section.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# Slice one release's section out of the root CHANGELOG.md.
+#
+# Given a Zebra version, prints every line from that version's
+# "## [Zebra <version>]" heading up to (but not including) the next
+# "## [" heading. This is the deterministic stage of the release-notes
+# builder: the AI stage only wraps this text with operational context and
+# must not add, reword, or reorder the curated entries.
+#
+# Usage:
+#   extract-changelog-section.sh <version> [changelog-file] [output-file]
+#
+# Environment overrides (used when CI passes values via env):
+#   VERSION, CHANGELOG_FILE, SECTION_FILE
+#
+# Step outputs (when GITHUB_OUTPUT is set):
+#   version, tag, previous_tag, section_path
+
+set -euo pipefail
+
+VERSION="${1:-${VERSION:-}}"
+CHANGELOG_FILE="${2:-${CHANGELOG_FILE:-CHANGELOG.md}}"
+SECTION_FILE="${3:-${SECTION_FILE:-}}"
+
+if [[ -z "${VERSION}" ]]; then
+    echo "Usage: extract-changelog-section.sh <version> [changelog-file] [output-file]" >&2
+    exit 1
+fi
+
+if [[ ! -f "${CHANGELOG_FILE}" ]]; then
+    echo "Changelog file not found: ${CHANGELOG_FILE}" >&2
+    exit 1
+fi
+
+if [[ -z "${SECTION_FILE}" ]]; then
+    SECTION_FILE="$(mktemp)"
+fi
+
+awk -v version="${VERSION}" '
+    BEGIN { heading = "## [Zebra " version "]" }
+    /^##[[:space:]]+\[/ {
+        if (found) { exit }
+        if (index($0, heading) == 1) { found = 1 }
+    }
+    found { print }
+' "${CHANGELOG_FILE}" > "${SECTION_FILE}"
+
+if [[ ! -s "${SECTION_FILE}" ]]; then
+    echo "No changelog section found for Zebra ${VERSION} in ${CHANGELOG_FILE}" >&2
+    exit 1
+fi
+
+# The first "## [Zebra X.Y.Z]" heading below the current section is the
+# previous release; use it for the compare link.
+PREVIOUS_VERSION="$(awk -v version="${VERSION}" '
+    /^## \[Zebra [0-9]+\.[0-9]+\.[0-9]+\]/ {
+        match($0, /[0-9]+\.[0-9]+\.[0-9]+/)
+        found_version = substr($0, RSTART, RLENGTH)
+        if (seen) { print found_version; exit }
+        if (found_version == version) { seen = 1 }
+    }
+' "${CHANGELOG_FILE}")"
+
+echo "Extracted Zebra ${VERSION} changelog section to ${SECTION_FILE}" >&2
+if [[ -n "${PREVIOUS_VERSION}" ]]; then
+    echo "Previous release: ${PREVIOUS_VERSION}" >&2
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+        echo "version=${VERSION}"
+        echo "tag=v${VERSION}"
+        echo "section_path=${SECTION_FILE}"
+        [[ -n "${PREVIOUS_VERSION}" ]] && echo "previous_tag=v${PREVIOUS_VERSION}"
+    } >> "${GITHUB_OUTPUT}"
+else
+    cat "${SECTION_FILE}"
+fi

--- a/docs/proposals/release-notes-builder.md
+++ b/docs/proposals/release-notes-builder.md
@@ -1,0 +1,183 @@
+---
+status: proposal
+date: 2026-06-26
+story: Build the GitHub Release body by wrapping the released version's changelog with operational context.
+---
+
+# Release-notes builder
+
+## Context and problem
+
+Zebra creates its own GitHub Release in `.github/workflows/release.yml`
+(release-plz runs with `git_release_enable = false`). Today the release job
+slices the released version's section out of `CHANGELOG.md` with an inline
+`awk` and uses it as the Release body unchanged.
+
+The changelog guidelines draw a line between two artifacts. `CHANGELOG.md`
+is the curated record for node operators. The GitHub Release is not that
+record: it wraps the record with operational context an operator needs to
+decide whether and how to upgrade. A Release body should add Update
+Priority, a TL;DR, the changelog sections, How to Upgrade (per platform),
+and Compatibility (OS, network protocol, MSRV). Posting the raw changelog
+section gives operators the entries but none of that framing.
+
+The wrapping is judgement work (severity, upgrade urgency, platform steps),
+which is why it is a good fit for an AI stage. The risk with an AI stage is
+that it invents or reorders entries. The design contains that risk by
+splitting the work in two: a deterministic stage owns the entries, and the
+AI stage may only wrap them.
+
+## Two-stage flow
+
+### Stage 1: deterministic extraction
+
+`.github/workflows/scripts/extract-changelog-section.sh <version>` slices
+one release's section out of `CHANGELOG.md`, from its
+`## [Zebra <version>]` heading up to the next `## [` heading. It writes the
+section to a file and, under GitHub Actions, sets step outputs `version`,
+`tag`, `previous_tag`, and `section_path`. The previous tag comes from the
+next `## [Zebra X.Y.Z]` heading below the current one, which is the compare
+base for the closing changelog link.
+
+This stage has no model in the loop. Its output is the source of truth for
+which entries belong to the release, and it is the raw fallback body.
+
+### Stage 2: AI wrap
+
+`.github/prompts/release-notes.md` instructs Claude to wrap the extracted
+section with operational context. The workflow substitutes the section
+path, version, tags, and repository into the prompt placeholders, then runs
+the Claude action with read and limited shell tools so it can confirm
+facts (MSRV, install methods) from the repository.
+
+The prompt selects one of three templates by reading the section:
+
+- **Standard**: Update Priority, TL;DR, the changelog sections, How to
+  Upgrade, Compatibility.
+- **Network Upgrade**: same shape, with the activation height or date and
+  the upgrade deadline made prominent; flagged by a network-upgrade
+  mention, a minimum protocol-version bump, or an end-of-support change.
+- **Security**: same shape, led by a security advisory callout and a
+  Critical update priority; flagged by a `### Security` vulnerability entry
+  or a GHSA / CVE reference.
+
+The prompt's strict rules forbid adding, rewording, removing, or reordering
+entries and forbid altering PR links. The AI may only add the wrapper
+sections around the verbatim changelog. It writes the wrapped body to
+`<section_path>.final`.
+
+## Fallback chain
+
+The Release body is chosen in this order, so a model failure can never
+block or corrupt a release:
+
+1. `<section_path>.final` if the AI step produced it and validation passed.
+2. `<section_path>` (the raw extracted changelog section) otherwise.
+3. A minimal `Zebra <tag>` body if extraction itself found nothing.
+
+Validation before accepting the `.final` body: every PR link present in the
+raw section must still be present, and no `### ...` subsection heading may
+be missing. If either check fails the workflow deletes `.final` and falls
+back to the raw section. The extractor, prompt build, and Claude steps all
+run with `continue-on-error`, so the existing `gh release create` path runs
+regardless.
+
+## Where it hooks into release.yml
+
+The integration replaces the body-building part of the existing
+`Create zebrad GitHub Release` step in the `release` job. It is additive
+and gated, so it is safe to land without a Claude token configured: with no
+token the AI step is skipped and the raw section is used, which is the
+current behavior. This snippet is illustrative and is not yet applied to
+`release.yml`.
+
+```yaml
+      - name: Extract changelog section
+        id: changelog
+        if: steps.zebrad-release.outputs.released == 'true'
+        env:
+          VERSION: ${{ steps.zebrad-release.outputs.version }}
+        run: .github/workflows/scripts/extract-changelog-section.sh "${VERSION}"
+
+      - name: Build release-notes prompt
+        id: notes-prompt
+        if: steps.changelog.outputs.section_path != '' && vars.RELEASE_NOTES_AI == 'true'
+        continue-on-error: true
+        env:
+          SECTION_PATH: ${{ steps.changelog.outputs.section_path }}
+          VERSION: ${{ steps.zebrad-release.outputs.version }}
+          TAG: ${{ steps.changelog.outputs.tag }}
+          PREVIOUS_TAG: ${{ steps.changelog.outputs.previous_tag }}
+        run: |
+          PROMPT="$(sed \
+            -e "s|__SECTION_PATH__|${SECTION_PATH}|g" \
+            -e "s|__VERSION__|${VERSION}|g" \
+            -e "s|__TAG__|${TAG}|g" \
+            -e "s|__PREVIOUS_TAG__|${PREVIOUS_TAG}|g" \
+            -e "s|__GITHUB_REPOSITORY__|${GITHUB_REPOSITORY}|g" \
+            .github/prompts/release-notes.md)"
+          EOF_DELIM="PROMPT_EOF_$(openssl rand -hex 8)"
+          {
+            echo "prompt<<${EOF_DELIM}"
+            echo "${PROMPT}"
+            echo "${EOF_DELIM}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Wrap release notes with AI
+        id: notes-ai
+        if: steps.notes-prompt.outcome == 'success'
+        continue-on-error: true
+        uses: anthropics/claude-code-action/base-action@<pinned-sha> # vX.Y.Z
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.notes-prompt.outputs.prompt }}
+          claude_args: >-
+            --max-turns 40
+            --allowedTools "Read Write Bash(gh release view*) Bash(grep*)"
+
+      - name: Select and validate release body
+        id: notes-body
+        if: steps.changelog.outputs.section_path != ''
+        env:
+          SECTION_PATH: ${{ steps.changelog.outputs.section_path }}
+        run: |
+          set -euo pipefail
+          FINAL="${SECTION_PATH}.final"
+          BODY="${SECTION_PATH}"
+          if [ -f "${FINAL}" ]; then
+            RAW_PRS="$(grep -coE '\[#[0-9]+\]' "${SECTION_PATH}" || true)"
+            FINAL_PRS="$(grep -coE '\[#[0-9]+\]' "${FINAL}" || true)"
+            if [ "${FINAL_PRS:-0}" -ge "${RAW_PRS:-0}" ]; then
+              BODY="${FINAL}"
+            else
+              echo "::warning::AI body dropped PR links; using raw changelog section."
+            fi
+          fi
+          echo "path=${BODY}" >> "${GITHUB_OUTPUT}"
+```
+
+The existing `gh release create` / `gh release edit` step then points
+`--notes-file` at `steps.notes-body.outputs.path` instead of the inline
+`awk` output. The rest of that step (title, target SHA, `--latest`) is
+unchanged.
+
+## Assumptions and open questions
+
+- **Claude action and auth.** The snippet assumes
+  `anthropics/claude-code-action/base-action` (pinned by SHA) with a
+  `CLAUDE_CODE_OAUTH_TOKEN` secret, matching the proven pattern. Whether to
+  adopt that action, an API-key variant, or a different runner is open.
+- **How the body reaches the release.** The snippet keeps Zebra's existing
+  `gh release create`/`edit` path and only swaps the `--notes-file` source.
+  No change to how the release is created.
+- **MSRV and compatibility source of truth.** The prompt instructs the
+  model to confirm MSRV from `Cargo.toml` `rust-version` and to omit any
+  value it cannot verify, rather than hardcode. The canonical source for
+  supported OS targets and the minimum peer protocol version still needs to
+  be pinned (`README.md`, `book/`, or network constants) so the model has
+  one place to read.
+- **Gating.** The AI step is gated on a `RELEASE_NOTES_AI` repository
+  variable so it can be enabled per environment; with it unset, releases
+  keep their current raw-changelog body.


### PR DESCRIPTION
## Motivation

Zebra creates its own `zebrad` GitHub Release, and the release body should give operators the context a raw changelog dump cannot: an update priority, a short summary, per-platform upgrade steps, and compatibility (OS, protocol, MSRV). The changelog itself stays the curated source of truth; the release wraps it.

## Solution

A two-stage builder, matching the proven pattern in other projects:

1. A deterministic extractor (`extract-changelog-section.sh`) slices one release's section out of the root `CHANGELOG.md`, from its `## [Zebra <version>]` heading to the next heading, and reports `version`, `tag`, `previous_tag`, and `section_path` as step outputs.
2. A Claude prompt (`.github/prompts/release-notes.md`) wraps that verbatim section with the operational context above, selecting a Standard, Network Upgrade, or Security template, under strict no-add and no-reorder rules with a raw-section fallback.

`docs/proposals/release-notes-builder.md` documents the flow and the fallback chain. The extractor passes shellcheck and was verified against the current `CHANGELOG.md` (extracts the 5.2.0 section, resolves the previous tag to v5.1.1).

Wiring this into `release.yml` is described in the proposal and intentionally left as the follow-up step, so `release.yml` is unchanged and current behavior is unaffected until the team adopts it.

### AI Disclosure

AI tools were used: Claude designed the builder and wrote the script, prompt, and proposal.
