### PR TITLE
fix(ci): pass `github_token` to claude-code-action so it skips OIDC

### DIFF
--- a/.github/workflows/changelog-command.yml
+++ b/.github/workflows/changelog-command.yml
@@ -66,6 +66,8 @@ jobs:
         uses: anthropics/claude-code-action@11ba60486e4aec9ddfeafcf4bb3f00b028ac2c16 # v1.0.142
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Provide a token so the action skips its OIDC exchange, which needs id-token: write.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Draft Keep-a-Changelog entries for this Zebra pull request, for a maintainer to
             paste into the [Unreleased] sections of the repo's CHANGELOG.md files.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,6 +228,8 @@ jobs:
         uses: anthropics/claude-code-action@11ba60486e4aec9ddfeafcf4bb3f00b028ac2c16 # v1.0.142
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Provide a token so the action skips its OIDC exchange, which needs id-token: write.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Rewrite the changelog section below into operator-facing GitHub Release
             notes for Zebra ${{ steps.zebrad-release.outputs.tag }}.


### PR DESCRIPTION
## Motivation

The `/changelog` command and the release-notes enhancement never produced a Claude draft. The `claude-code-action` step failed at startup with "Could not fetch an OIDC token. Did you remember to add `id-token: write`". Because the step is `continue-on-error`, the job stayed green and posted the deterministic fallback, so the failure was silent (for example, a `/changelog` comment replied "Could not draft changelog entries automatically").

## Solution

The action uses an OIDC exchange to mint a GitHub token only when no token is provided (`OVERRIDE_GITHUB_TOKEN` in its `token.ts`). Passing `github_token: ${{ secrets.GITHUB_TOKEN }}` makes it use that token and skip OIDC, so no `id-token: write` permission is needed and the workflows stay least-privilege.

## AI Disclosure

AI tools were used: Claude diagnosed the failure and wrote the fix.