### PR TITLE
fix(ci): check out the repo for the `/changelog` Claude step

### DIFF
--- a/.github/workflows/changelog-command.yml
+++ b/.github/workflows/changelog-command.yml
@@ -28,6 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - name: Acknowledge the command

--- a/.github/workflows/changelog-command.yml
+++ b/.github/workflows/changelog-command.yml
@@ -39,6 +39,12 @@ jobs:
           set -euo pipefail
           gh api --method POST "repos/${REPOSITORY}/issues/comments/${COMMENT_ID}/reactions" -f content=+1 >/dev/null || true
 
+      # issue_comment checks out the default branch (never PR head), giving the Claude action
+      # a git repo to operate in. The PR content is supplied as the diff below, not from here.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Collect the PR diff
         id: diff
         env:


### PR DESCRIPTION
## Motivation

After the OIDC fix (#10864), the `/changelog` Claude step still failed: `claude-code-action` runs git operations (configure user, `git fetch origin main`) that assume a checked-out repo. `changelog-command.yml` had no checkout, so the step failed with git exit 128 and, being `continue-on-error`, silently posted the fallback comment ("Could not draft… add by hand") instead of a draft.

## Solution

Add a checkout of the default branch before the Claude step, matching what the release job already does. `persist-credentials` is off and PR head is never checked out; the PR content is still supplied only as the diff passed in the prompt, so no PR or fork code is executed.

## AI Disclosure

AI tools were used: Claude diagnosed and wrote the fix.