### PR TITLE
fix(ci): raise Claude changelog step max-turns to 5

### DIFF
--- a/.github/workflows/changelog-command.yml
+++ b/.github/workflows/changelog-command.yml
@@ -103,7 +103,7 @@ jobs:
             Return the changelog markdown in the structured output.
           claude_args: |
             --json-schema '{"type":"object","properties":{"changelog":{"type":"string"}},"required":["changelog"],"additionalProperties":false}'
-            --max-turns 1
+            --max-turns 5
 
       - name: Post the changelog suggestion
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,7 +246,7 @@ jobs:
             ${{ steps.notes.outputs.section }}
           claude_args: |
             --json-schema '{"type":"object","properties":{"notes":{"type":"string"}},"required":["notes"],"additionalProperties":false}'
-            --max-turns 1
+            --max-turns 5
 
       - name: Select release notes
         if: steps.zebrad-release.outputs.released == 'true'


### PR DESCRIPTION
## Motivation

The `/changelog` command and the release-notes enhancement posted the deterministic fallback instead of a Claude draft. With `--max-turns 1`, the model spends its single turn on a reasoning preamble and reaches the turn limit before emitting the forced structured output. The action returns `error_max_turns` (exit 1), and because the steps are `continue-on-error` the failure surfaced silently as the fallback.

## Solution

Allow enough turns for the model to reason and then return the structured result. The action's own documentation uses `--max-turns 3` as its example; 5 leaves margin for a large diff without unbounded cost.

## AI Disclosure

AI tools were used: Claude diagnosed and wrote the fix.