### PR TITLE
fix(ci): avoid nightly rustc ICE by returning concrete service types

### DIFF
--- a/zebra-consensus/src/router/tests.rs
+++ b/zebra-consensus/src/router/tests.rs
@@ -47,22 +47,8 @@ pub fn block_no_transactions() -> Block {
 async fn verifiers_from_network(
     network: Network,
 ) -> (
-    impl Service<
-            Request,
-            Response = block::Hash,
-            Error = BoxError,
-            Future = impl Future<Output = Result<block::Hash, BoxError>>,
-        > + Send
-        + Clone
-        + 'static,
-    impl Service<
-            zs::Request,
-            Response = zs::Response,
-            Error = BoxError,
-            Future = impl Future<Output = Result<zs::Response, BoxError>>,
-        > + Send
-        + Clone
-        + 'static,
+    Buffer<BoxService<Request, block::Hash, RouterError>, Request>,
+    Buffer<BoxService<zs::Request, zs::Response, BoxError>, zs::Request>,
 ) {
     let state_service = zs::init_test(&network).await;
     let (

--- a/zebrad/tests/common/cached_state.rs
+++ b/zebrad/tests/common/cached_state.rs
@@ -13,7 +13,7 @@ use std::{
 
 use color_eyre::eyre::{eyre, Result};
 use semver::Version;
-use tower::{util::BoxService, Service};
+use tower::util::BoxService;
 
 use zebra_chain::{
     block::{self, Block, Height},
@@ -132,11 +132,7 @@ pub async fn start_state_service_with_cache_dir(
     cache_dir: impl Into<PathBuf>,
 ) -> Result<(
     BoxStateService,
-    impl Service<
-        zebra_state::ReadRequest,
-        Response = zebra_state::ReadResponse,
-        Error = zebra_state::BoxError,
-    >,
+    zebra_state::ReadStateService,
     LatestChainTip,
     ChainTipChange,
 )> {


### PR DESCRIPTION
## Motivation

Nightly rustc from 2026-06-30 hits an internal compiler error while type-checking two `impl Service<…>` test helpers, so the required Lint check has failed on `main` and every Rust-touching PR since then. The `unused-deps` job is the only one that compiles test targets on nightly (`cargo udeps --all-targets`), which is why it alone breaks.

The ICE traces to [rust-lang/rust#158477](https://github.com/rust-lang/rust/pull/158477): a `DynCompatible` obligation now reaches a `bug!()` on the `evaluate_obligation` query path whenever an opaque return type's associated types resolve to a `dyn` trait (`Error = Box<dyn Error>`, or a boxed `dyn Future`). The code is valid Rust; the compiler regressed.

## Solution

`verifiers_from_network` and `start_state_service_with_cache_dir` are the only return-position `impl Service` functions in the workspace. Both already build concrete services, so they now return those concrete types (`Buffer<BoxService<…>>` from `init_test`, `ReadStateService` from `zebra_state::init`) instead of an opaque `impl Service`. That removes the opaque-type obligation the compiler chokes on, matches how the rest of the codebase returns these services, and compiles on stable and the broken nightly alike, so there is no toolchain pin to unwind once rustc is fixed upstream.

### Tests

`cargo check -p zebra-consensus -p zebrad --all-targets --all-features` passes (the targets the `unused-deps` job compiles). A minimal reproducer confirmed the concrete-return form compiles on the exact failing nightly (`f46ec5218`, 2026-06-30) where the opaque form ICEs.

### AI Disclosure

- [x] AI tools were used: Claude for the root-cause investigation (reproducing the ICE, bisecting the nightly, confirming the two trigger sites) and for drafting this description.
