### PR TITLE
fix(ci): pin unused-deps to nightly-2026-06-29 to dodge a rustc ICE

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -183,7 +183,9 @@ jobs:
           persist-credentials: false
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 #v1.16.1
         with:
-          toolchain: nightly
+          # Pinned to dodge a nightly rustc ICE in `cargo udeps`; see #10870.
+          # Restore `nightly` once the upstream ICE is fixed.
+          toolchain: nightly-2026-06-29
           cache-on-failure: true
       - uses: taiki-e/install-action@65851e10cd6c377f11a60e600abc07cb08643468 #v2.79.3
         with:


### PR DESCRIPTION
## Motivation

Works around #10870 — the `unused-deps` job ICEs on `nightly-2026-06-30` (`DynCompatible(...Future...) should have been handled by fulfillment already`), so `lint` has been red on `main` since 2026-06-30.

## Solution

Pin the job to `nightly-2026-06-29` (last green). Verified `cargo udeps --workspace --all-targets --all-features --locked` passes on it. #10870 stays open to track restoring `nightly` once the upstream ICE is fixed.

## AI Disclosure

Claude Code: located the nightly boundary, applied the pin, and verified udeps.