### PR TITLE
chore: Set the NU6.3 consensus constants to match librustzcash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Added
 
-- Experimental support for the NU6.3 "Ironwood" shielded pool and v6 transaction
-  format. This is incomplete pending the deploy ZIP (no real activation height,
-  version group ID, or consensus branch ID yet), so it cannot activate on any
-  network.
+- Support for the NU6.3 "Ironwood" shielded pool and v6 transaction format,
+  activating on Testnet at height 4,134,000. The consensus parameters (v6 version
+  group ID, consensus branch ID, and Testnet activation height) match
+  `zcash_protocol`. No Mainnet activation height is set yet.
 - Added a Regtest configuration option, `should_allow_unshielded_coinbase_spends`,
   to forbid spending coinbase outputs into transparent outputs (the inverse of
   zcashd's `-regtestshieldcoinbase`). It defaults to allowing such spends, preserving

--- a/zebra-chain/src/parameters/constants.rs
+++ b/zebra-chain/src/parameters/constants.rs
@@ -67,6 +67,8 @@ pub mod activation_heights {
         pub const NU6_1: Height = Height(3_536_500);
         /// The block height at which `NU6.2` activates on Testnet.
         pub const NU6_2: Height = Height(4_052_000);
+        /// The block height at which `NU6.3` activates on Testnet.
+        pub const NU6_3: Height = Height(4_134_000);
     }
 
     /// Network upgrade activation heights for Mainnet.

--- a/zebra-chain/src/parameters/network_upgrade.rs
+++ b/zebra-chain/src/parameters/network_upgrade.rs
@@ -141,6 +141,7 @@ pub(super) const TESTNET_ACTIVATION_HEIGHTS: &[(block::Height, NetworkUpgrade)] 
         (NU6, Nu6),
         (NU6_1, Nu6_1),
         (NU6_2, Nu6_2),
+        (NU6_3, Nu6_3),
     ]
 };
 
@@ -235,16 +236,13 @@ pub(crate) const CONSENSUS_BRANCH_IDS: &[(NetworkUpgrade, ConsensusBranchId)] = 
     (Nu6, ConsensusBranchId(0xc8e71055)),
     (Nu6_1, ConsensusBranchId(0x4dec4df0)),
     (Nu6_2, ConsensusBranchId(0x5437f330)),
-    // TODO: set the real NU6.3 (Ironwood) branch id once it is published. This placeholder matches
-    // the placeholder `BranchId::Nu6_3 = 0xffff_ffff` in the librustzcash Ironwood fork, so that
-    // `Transaction::to_librustzcash` resolves v6 transactions to the fork's NU6.3 branch id.
-    #[cfg(any(test, feature = "zebra-test"))]
-    (Nu6_3, ConsensusBranchId(0xffffffff)),
+    // The NU6.3 (Ironwood) consensus branch id, matching zcash_protocol's `BranchId::Nu6_3`.
+    (Nu6_3, ConsensusBranchId(0x37a5165b)),
     // TODO: set below to (Nu7, ConsensusBranchId(0x77190ad8)), once the same value is set in librustzcash
     #[cfg(any(test, feature = "zebra-test"))]
     (Nu7, ConsensusBranchId(0xfffffffe)),
-    // Distinct test placeholder so it never collides with the `Nu6_3`/`Nu7` placeholders above
-    // (which are gated on `test`/`zebra-test`, independent of `zfuture`); a collision would break
+    // Distinct test placeholder so it never collides with the `Nu7` placeholder above
+    // (which is gated on `test`/`zebra-test`, independent of `zfuture`); a collision would break
     // the `branch_id_bijective` test under `--cfg zcash_unstable="zfuture"`.
     #[cfg(zcash_unstable = "zfuture")]
     (ZFuture, ConsensusBranchId(0xfffffffd)),

--- a/zebra-chain/src/parameters/transaction.rs
+++ b/zebra-chain/src/parameters/transaction.rs
@@ -13,5 +13,4 @@ pub const SAPLING_VERSION_GROUP_ID: u32 = 0x892F_2085;
 pub const TX_V5_VERSION_GROUP_ID: u32 = 0x26A7_270A;
 
 /// The version group ID for version 6 transactions.
-/// TODO: update this after it's chosen
-pub const TX_V6_VERSION_GROUP_ID: u32 = 0xFFFF_FFFF;
+pub const TX_V6_VERSION_GROUP_ID: u32 = 0xD884_B698;


### PR DESCRIPTION
Match zcash_protocol (librustzcash rev 703fe3e):

- TX_V6_VERSION_GROUP_ID = 0xD884_B698 (was the 0xFFFF_FFFF placeholder)
- NU6.3 consensus branch id = 0x37a5165b (was a test-only 0xffffffff placeholder)
- Testnet NU6.3 activation height = 4_134_000

Mainnet gets no NU6.3 activation height (zcash_protocol MainNetwork returns None), so only the Testnet table gains an entry.

<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

<!--
- Describe the goals of the PR.
- If it closes any issues, enumerate them here.
-->

## Solution

<!-- Describe the changes in the PR. -->

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
-->

### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [ ] No AI tools were used in this PR
- [ ] AI tools were used: <!-- tool name and what it was used for, e.g., "Claude for test boilerplate" -->

### PR Checklist

- [ ] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [ ] The solution is tested.
- [ ] The documentation and changelogs are up to date.
