### PR TITLE
chore(deps): Update to librustzcash 4b13be3c

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=703fe3e6608fab8be0dedbbcbf684f030a1ea451#703fe3e6608fab8be0dedbbcbf684f030a1ea451"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4b13be3c2ce6f91a4b386508aed0799358daadb1#4b13be3c2ce6f91a4b386508aed0799358daadb1"
 dependencies = [
  "blake2b_simd",
  "cc",
@@ -1599,7 +1599,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=703fe3e6608fab8be0dedbbcbf684f030a1ea451#703fe3e6608fab8be0dedbbcbf684f030a1ea451"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4b13be3c2ce6f91a4b386508aed0799358daadb1#4b13be3c2ce6f91a4b386508aed0799358daadb1"
 dependencies = [
  "blake2b_simd",
 ]
@@ -7110,7 +7110,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=703fe3e6608fab8be0dedbbcbf684f030a1ea451#703fe3e6608fab8be0dedbbcbf684f030a1ea451"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4b13be3c2ce6f91a4b386508aed0799358daadb1#4b13be3c2ce6f91a4b386508aed0799358daadb1"
 dependencies = [
  "bech32",
  "bs58",
@@ -7123,7 +7123,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=703fe3e6608fab8be0dedbbcbf684f030a1ea451#703fe3e6608fab8be0dedbbcbf684f030a1ea451"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4b13be3c2ce6f91a4b386508aed0799358daadb1#4b13be3c2ce6f91a4b386508aed0799358daadb1"
 dependencies = [
  "corez",
  "hex",
@@ -7133,7 +7133,7 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.5.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=703fe3e6608fab8be0dedbbcbf684f030a1ea451#703fe3e6608fab8be0dedbbcbf684f030a1ea451"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4b13be3c2ce6f91a4b386508aed0799358daadb1#4b13be3c2ce6f91a4b386508aed0799358daadb1"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -7143,7 +7143,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=703fe3e6608fab8be0dedbbcbf684f030a1ea451#703fe3e6608fab8be0dedbbcbf684f030a1ea451"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4b13be3c2ce6f91a4b386508aed0799358daadb1#4b13be3c2ce6f91a4b386508aed0799358daadb1"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -7183,7 +7183,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=703fe3e6608fab8be0dedbbcbf684f030a1ea451#703fe3e6608fab8be0dedbbcbf684f030a1ea451"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4b13be3c2ce6f91a4b386508aed0799358daadb1#4b13be3c2ce6f91a4b386508aed0799358daadb1"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7213,7 +7213,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=703fe3e6608fab8be0dedbbcbf684f030a1ea451#703fe3e6608fab8be0dedbbcbf684f030a1ea451"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4b13be3c2ce6f91a4b386508aed0799358daadb1#4b13be3c2ce6f91a4b386508aed0799358daadb1"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7235,7 +7235,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=703fe3e6608fab8be0dedbbcbf684f030a1ea451#703fe3e6608fab8be0dedbbcbf684f030a1ea451"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4b13be3c2ce6f91a4b386508aed0799358daadb1#4b13be3c2ce6f91a4b386508aed0799358daadb1"
 dependencies = [
  "corez",
  "document-features",
@@ -7273,7 +7273,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=703fe3e6608fab8be0dedbbcbf684f030a1ea451#703fe3e6608fab8be0dedbbcbf684f030a1ea451"
+source = "git+https://github.com/zcash/librustzcash.git?rev=4b13be3c2ce6f91a4b386508aed0799358daadb1#4b13be3c2ce6f91a4b386508aed0799358daadb1"
 dependencies = [
  "bip32",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -381,13 +381,13 @@ result_large_err = "allow"
 
 [patch.crates-io]
 # TEMPORARY: Pin librustzcash crates to https://github.com/zcash/librustzcash/pull/2509
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "703fe3e6608fab8be0dedbbcbf684f030a1ea451" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "703fe3e6608fab8be0dedbbcbf684f030a1ea451" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "703fe3e6608fab8be0dedbbcbf684f030a1ea451" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "703fe3e6608fab8be0dedbbcbf684f030a1ea451" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "703fe3e6608fab8be0dedbbcbf684f030a1ea451" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "703fe3e6608fab8be0dedbbcbf684f030a1ea451" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "703fe3e6608fab8be0dedbbcbf684f030a1ea451" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "703fe3e6608fab8be0dedbbcbf684f030a1ea451" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "703fe3e6608fab8be0dedbbcbf684f030a1ea451" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "703fe3e6608fab8be0dedbbcbf684f030a1ea451" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "4b13be3c2ce6f91a4b386508aed0799358daadb1" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "4b13be3c2ce6f91a4b386508aed0799358daadb1" }
+transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "4b13be3c2ce6f91a4b386508aed0799358daadb1" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "4b13be3c2ce6f91a4b386508aed0799358daadb1" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "4b13be3c2ce6f91a4b386508aed0799358daadb1" }
+zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "4b13be3c2ce6f91a4b386508aed0799358daadb1" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "4b13be3c2ce6f91a4b386508aed0799358daadb1" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "4b13be3c2ce6f91a4b386508aed0799358daadb1" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "4b13be3c2ce6f91a4b386508aed0799358daadb1" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "4b13be3c2ce6f91a4b386508aed0799358daadb1" }


### PR DESCRIPTION
Updates to librustzcash 4b13be3c2ce6f91a4b386508aed0799358daadb1 to fix an error in the flagging for Sprout support in NU6.3.

<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

<!--
- Describe the goals of the PR.
- If it closes any issues, enumerate them here.
-->

## Solution

<!-- Describe the changes in the PR. -->

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
-->

### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [ ] No AI tools were used in this PR
- [ ] AI tools were used: <!-- tool name and what it was used for, e.g., "Claude for test boilerplate" -->

### PR Checklist

- [ ] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [ ] The solution is tested.
- [ ] The documentation and changelogs are up to date.
