### PR TITLE
chore: Update to published librustzcash NU6.3 crates.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1551,7 +1551,8 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=4b13be3c2ce6f91a4b386508aed0799358daadb1#4b13be3c2ce6f91a4b386508aed0799358daadb1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
 dependencies = [
  "blake2b_simd",
  "cc",
@@ -1599,7 +1600,8 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=4b13be3c2ce6f91a4b386508aed0799358daadb1#4b13be3c2ce6f91a4b386508aed0799358daadb1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
 dependencies = [
  "blake2b_simd",
 ]
@@ -7110,7 +7112,8 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=4b13be3c2ce6f91a4b386508aed0799358daadb1#4b13be3c2ce6f91a4b386508aed0799358daadb1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2918e73eff76388cda87695a6e7398f96a2e3383a0de7b77729a204ec00a0"
 dependencies = [
  "bech32",
  "bs58",
@@ -7123,7 +7126,8 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=4b13be3c2ce6f91a4b386508aed0799358daadb1#4b13be3c2ce6f91a4b386508aed0799358daadb1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
 dependencies = [
  "corez",
  "hex",
@@ -7133,7 +7137,8 @@ dependencies = [
 [[package]]
 name = "zcash_history"
 version = "0.5.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=4b13be3c2ce6f91a4b386508aed0799358daadb1#4b13be3c2ce6f91a4b386508aed0799358daadb1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e8634d011026cb181cb67b2a412e601dc344a2827b9c576fe3a727fdebf441"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -7143,7 +7148,8 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=4b13be3c2ce6f91a4b386508aed0799358daadb1#4b13be3c2ce6f91a4b386508aed0799358daadb1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a0bac3a9e5b0d954684ba1f07386d55b5ae4588b3ba2d93cad05ee09f3e0947"
 dependencies = [
  "bech32",
  "blake2b_simd",
@@ -7183,7 +7189,8 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=4b13be3c2ce6f91a4b386508aed0799358daadb1#4b13be3c2ce6f91a4b386508aed0799358daadb1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba7bfe66975658f44dba87d535f9ebb9fb4c9c0c4fecca3f5c40cbe1583dece6"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7213,7 +7220,8 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=4b13be3c2ce6f91a4b386508aed0799358daadb1#4b13be3c2ce6f91a4b386508aed0799358daadb1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39b90964ffe6bdc314368c7b849aaa6dcc2b495249a3bf1b9bfbdc92ba4e4f6"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7235,7 +7243,8 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=4b13be3c2ce6f91a4b386508aed0799358daadb1#4b13be3c2ce6f91a4b386508aed0799358daadb1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97f339a9801c7f70295732a5cf822346f194202cea6425fc2fc14a5af679b004"
 dependencies = [
  "corez",
  "document-features",
@@ -7273,7 +7282,8 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0-pre.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=4b13be3c2ce6f91a4b386508aed0799358daadb1#4b13be3c2ce6f91a4b386508aed0799358daadb1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e941230f67056aad41c8fa9b926f9cc4d9d1a321f32e95c39c0b0e38e85f79b"
 dependencies = [
  "bip32",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -378,16 +378,3 @@ unwrap_in_result = "warn"
 
 # TODOs: fix this lint eventually
 result_large_err = "allow"
-
-[patch.crates-io]
-# TEMPORARY: Pin librustzcash crates to https://github.com/zcash/librustzcash/pull/2509
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "4b13be3c2ce6f91a4b386508aed0799358daadb1" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "4b13be3c2ce6f91a4b386508aed0799358daadb1" }
-transparent = { package = "zcash_transparent", git = "https://github.com/zcash/librustzcash.git", rev = "4b13be3c2ce6f91a4b386508aed0799358daadb1" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "4b13be3c2ce6f91a4b386508aed0799358daadb1" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "4b13be3c2ce6f91a4b386508aed0799358daadb1" }
-zcash_history = { git = "https://github.com/zcash/librustzcash.git", rev = "4b13be3c2ce6f91a4b386508aed0799358daadb1" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "4b13be3c2ce6f91a4b386508aed0799358daadb1" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "4b13be3c2ce6f91a4b386508aed0799358daadb1" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "4b13be3c2ce6f91a4b386508aed0799358daadb1" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "4b13be3c2ce6f91a4b386508aed0799358daadb1" }


### PR DESCRIPTION
This removes the `[patch.crates-io]` directive to allow Zebrad to use the published versions of the NU6.3-supporting librustzcash crates.

<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

<!--
- Describe the goals of the PR.
- If it closes any issues, enumerate them here.
-->

## Solution

<!-- Describe the changes in the PR. -->

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
-->

### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [ ] No AI tools were used in this PR
- [ ] AI tools were used: <!-- tool name and what it was used for, e.g., "Claude for test boilerplate" -->

### PR Checklist

- [ ] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [ ] The solution is tested.
- [ ] The documentation and changelogs are up to date.
