### PR TITLE
feat(rpc): mine shielded coinbase to Ironwood pool on NU6.3+

### DIFF
--- a/zebra-rpc/src/methods/types/get_block_template/tests.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/tests.rs
@@ -147,3 +147,36 @@ fn coinbase_cache_reuses_built_coinbase() {
     cache.clear();
     assert!(cache.get(height, fee).is_none(), "a cleared cache misses");
 }
+
+/// From NU6.3 onward, a shielded coinbase paid to a Unified miner address with an Orchard
+/// receiver routes newly minted value into the Ironwood pool, not the Orchard pool.
+#[test]
+fn coinbase_at_nu6_3_routes_shielded_output_to_ironwood() {
+    let net = Network::new_default_testnet();
+    let height = NetworkUpgrade::Nu6_3
+        .activation_height(&net)
+        .expect("Nu6.3 is scheduled on Testnet");
+    let miner_params = MinerParams::from(
+        Address::decode(
+            &net,
+            default_miner_address(net.kind(), &MinerAddressType::Unified),
+        )
+        .expect("hard-coded Unified address is valid"),
+    );
+
+    let template = TransactionTemplate::new_coinbase(&net, height, &miner_params, Amount::zero())
+        .expect("valid coinbase tx");
+    let coinbase: Transaction = template.data.as_ref().zcash_deserialize_into().unwrap();
+
+    // The coinbase is a v6 transaction with Ironwood shielded data and no Orchard shielded data.
+    // ZIP-229: from NU6.3, coinbase MUST have an empty Orchard component.
+    assert_eq!(coinbase.version(), 6, "coinbase is v6 at NU6.3");
+    assert!(
+        coinbase.ironwood_shielded_data().is_some(),
+        "coinbase creates an Ironwood output"
+    );
+    assert!(
+        coinbase.orchard_shielded_data().is_none(),
+        "coinbase must not create Orchard components on NU6.3"
+    );
+}

--- a/zebra-rpc/src/methods/types/transaction.rs
+++ b/zebra-rpc/src/methods/types/transaction.rs
@@ -23,7 +23,7 @@ use zebra_chain::{
     orchard,
     parameters::{
         subsidy::{block_subsidy, funding_stream_values, miner_subsidy},
-        Network,
+        Network, NetworkUpgrade,
     },
     primitives::ed25519,
     sapling::ValueCommitment,
@@ -157,16 +157,26 @@ impl TransactionTemplate<NegativeOrZero> {
             };
         }
 
-        let add_orchard_reward = |builder: &mut Builder<_, _>, addr: &_| {
-            trace_err!(
-                builder.add_orchard_output::<String>(
-                    Some(::orchard::keys::OutgoingViewingKey::from([0u8; 32])),
-                    *addr,
-                    miner_reward,
-                    memo.clone(),
-                ),
-                "Orchard"
-            )
+        // On NU6.3 onward the coinbase MUST have an empty Orchard component, and newly shielded
+        // coinbase value is routed to the Ironwood pool instead (see the Ironwood pool spec and
+        // `coinbase_orchard_component_empty` in zebra-consensus). Ironwood outputs use the same
+        // Orchard-shaped `orchard::Address` as their recipient, so a unified miner address with an
+        // Orchard receiver just gets routed to the Ironwood output builder from NU6.3 onward.
+        let use_ironwood = NetworkUpgrade::current(net, height) >= NetworkUpgrade::Nu6_3;
+
+        let add_shielded_reward = |builder: &mut Builder<_, _>, addr: &_| {
+            let ovk = Some(::orchard::keys::OutgoingViewingKey::from([0u8; 32]));
+            if use_ironwood {
+                trace_err!(
+                    builder.add_ironwood_output::<String>(ovk, *addr, miner_reward, memo.clone()),
+                    "Ironwood"
+                )
+            } else {
+                trace_err!(
+                    builder.add_orchard_output::<String>(ovk, *addr, miner_reward, memo.clone()),
+                    "Orchard"
+                )
+            }
         };
 
         let add_sapling_reward = |builder: &mut Builder<_, _>, addr: &_| {
@@ -191,7 +201,7 @@ impl TransactionTemplate<NegativeOrZero> {
         match miner_params.addr() {
             Address::Unified(addr) => addr
                 .orchard()
-                .and_then(|addr| add_orchard_reward(&mut builder, addr))
+                .and_then(|addr| add_shielded_reward(&mut builder, addr))
                 .or_else(|| {
                     addr.sapling()
                         .and_then(|addr| add_sapling_reward(&mut builder, addr))


### PR DESCRIPTION
## Motivation

Closes #10879.

### AI Disclosure

- [x] AI tools were used: Claude for the routing edit, the new test at the NU6.3 activation height, and this PR body.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [ ] The documentation and changelogs are up to date. <!-- Covered by the parent #10762 "NU6.3 Ironwood" entry. -->