### PR TITLE
fix!: address more Ironwood review findings across chain, consensus, and state

### DIFF
--- a/zebra-chain/src/history_tree.rs
+++ b/zebra-chain/src/history_tree.rs
@@ -399,7 +399,16 @@ impl NonEmptyHistoryTree {
         // Remove all non-peak entries
         self.peaks.retain(|k, _| peak_pos_set.contains(k));
         // Rebuild tree
-        self.inner = match self.inner {
+        self.inner = self.rebuilt_inner()?;
+        Ok(())
+    }
+
+    /// Rebuilds the inner tree from the cached `network`, `network_upgrade`, `size`, and `peaks`.
+    ///
+    /// Shared by [`Self::prune`] and the [`Clone`] impl, which reconstruct the inner tree
+    /// identically and differ only in how they handle the (practically impossible) rebuild error.
+    fn rebuilt_inner(&self) -> Result<InnerHistoryTree, io::Error> {
+        Ok(match &self.inner {
             InnerHistoryTree::PreOrchard(_) => {
                 InnerHistoryTree::PreOrchard(Tree::<PreOrchard>::new_from_cache(
                     &self.network,
@@ -427,8 +436,7 @@ impl NonEmptyHistoryTree {
                     &Default::default(),
                 )?)
             }
-        };
-        Ok(())
+        })
     }
 
     /// Return the hash of the tree root.
@@ -463,38 +471,9 @@ impl NonEmptyHistoryTree {
 
 impl Clone for NonEmptyHistoryTree {
     fn clone(&self) -> Self {
-        let tree = match self.inner {
-            InnerHistoryTree::PreOrchard(_) => InnerHistoryTree::PreOrchard(
-                Tree::<PreOrchard>::new_from_cache(
-                    &self.network,
-                    self.network_upgrade,
-                    self.size,
-                    &self.peaks,
-                    &Default::default(),
-                )
-                .expect("rebuilding an existing tree should always work"),
-            ),
-            InnerHistoryTree::OrchardOnward(_) => InnerHistoryTree::OrchardOnward(
-                Tree::<OrchardOnward>::new_from_cache(
-                    &self.network,
-                    self.network_upgrade,
-                    self.size,
-                    &self.peaks,
-                    &Default::default(),
-                )
-                .expect("rebuilding an existing tree should always work"),
-            ),
-            InnerHistoryTree::IronwoodOnward(_) => InnerHistoryTree::IronwoodOnward(
-                Tree::<IronwoodOnward>::new_from_cache(
-                    &self.network,
-                    self.network_upgrade,
-                    self.size,
-                    &self.peaks,
-                    &Default::default(),
-                )
-                .expect("rebuilding an existing tree should always work"),
-            ),
-        };
+        let tree = self
+            .rebuilt_inner()
+            .expect("rebuilding an existing tree should always work");
         NonEmptyHistoryTree {
             network: self.network.clone(),
             network_upgrade: self.network_upgrade,

--- a/zebra-chain/src/ironwood.rs
+++ b/zebra-chain/src/ironwood.rs
@@ -38,11 +38,11 @@ impl From<orchard::Nullifier> for Nullifier {
 
 /// Ironwood shielded data: a v6 Orchard-protocol bundle committed to the Ironwood pool.
 ///
-/// Wraps [`orchard::ShieldedDataV6`] (which itself carries the NU6.3 flag-byte format that permits
-/// the `enableCrossAddress` flag). The Ironwood bundle shares the exact wire format of the v6
-/// Orchard bundle; this newtype keeps the two type-distinct so they cannot be accidentally
-/// interchanged, and so the Ironwood bundle can commit into a separate note commitment tree and
-/// nullifier set.
+/// Wraps [`orchard::ShieldedDataV6`] (the v6 Orchard bundle shape). The Ironwood bundle shares the
+/// exact wire format of the v6 Orchard bundle, but is the only pool that permits the
+/// `enableCrossAddress` flag (bit 2), which the Orchard pool reserves regardless of tx version. This
+/// newtype keeps the two type-distinct so they cannot be accidentally interchanged, and so the
+/// Ironwood bundle can commit into a separate note commitment tree and nullifier set.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ShieldedData(orchard::ShieldedDataV6);
 

--- a/zebra-chain/src/orchard/shielded_data.rs
+++ b/zebra-chain/src/orchard/shielded_data.rs
@@ -296,19 +296,19 @@ bitflags! {
         /// `enableCrossAddress` (NU6.3, bit 2): allow output notes to use a different
         /// protocol-level address than the spending key.
         ///
-        /// Reserved (MUST be 0) before NU6.3. Valid only in the NU6.3 flag-byte format (v6
-        /// Orchard and Ironwood bundles); parsed via the `FlagsV6` newtype.
+        /// Reserved (MUST be 0) for the Orchard pool in every tx version. Valid only for the
+        /// Ironwood pool (v6), parsed via the `FlagsV6` newtype.
         const ENABLE_CROSS_ADDRESS = 0b00000100;
     }
 }
 
-/// The Orchard flags of a v6 (NU6.3) Orchard or Ironwood bundle.
+/// The Orchard flags of an Ironwood (v6) bundle.
 ///
-/// Newtype over [`Flags`] whose [`ZcashDeserialize`] impl uses the NU6.3 flag-byte format: bit 2
-/// (`enableCrossAddress`) is valid and only bits 3..7 are reserved. The bare [`Flags`] codec is the
-/// pre-NU6.3 (v5 Orchard) format, where bits 2..7 are all reserved. Encoding the format in the type
-/// keeps the v5 and v6 flag-parsing paths from being confused (parallels
-/// [`ShieldedDataV6`]).
+/// Newtype over [`Flags`] whose [`ZcashDeserialize`] impl uses the NU6.3 Ironwood flag-byte format:
+/// bit 2 (`enableCrossAddress`) is valid and only bits 3..7 are reserved. The bare [`Flags`] codec
+/// is the format for every Orchard-pool bundle (v5 *and* v6), where bits 2..7 are all reserved —
+/// `enableCrossAddress` is permitted only for the Ironwood pool. Encoding the format in the type
+/// keeps the two flag-parsing paths from being confused (parallels [`ShieldedDataV6`]).
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct FlagsV6(Flags);
 
@@ -380,14 +380,14 @@ impl ZcashDeserialize for Flags {
     /// > [NU5 onward] In a version 5 transaction, the reserved bits 2..7 of the flagsOrchard
     /// > field MUST be zero.
     ///
-    /// From NU6.3, the v6 Orchard and Ironwood flag bytes use bit 2 as `enableCrossAddress`, so
-    /// only bits 3..7 are reserved (see [`FlagsV6`]).
+    /// From NU6.3, the Ironwood flag byte uses bit 2 as `enableCrossAddress`, so only bits 3..7 are
+    /// reserved (see [`FlagsV6`]); the Orchard pool keeps bit 2 reserved in every tx version.
     ///
     /// <https://zips.z.cash/protocol/protocol.pdf#txnconsensus>
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
-        // The default codec is the pre-NU6.3 format, used by v5 Orchard bundles, where bits 2..7
-        // (including `enableCrossAddress`) are reserved and MUST be zero. v6 Orchard and Ironwood
-        // bundles deserialize via the `FlagsV6` newtype, which permits bit 2.
+        // The default codec is the pre-NU6.3 format, used by v5 *and* v6 Orchard bundles, where
+        // bits 2..7 (including `enableCrossAddress`) are reserved and MUST be zero. Only the Ironwood
+        // bundle deserializes via the `FlagsV6` newtype, which permits bit 2.
         Flags::from_byte(reader.read_u8()?, Flags::PRE_NU6_3_RESERVED)
     }
 }
@@ -395,13 +395,14 @@ impl ZcashDeserialize for Flags {
 impl ZcashDeserialize for FlagsV6 {
     /// # Consensus
     ///
-    /// From NU6.3, the v6 Orchard and Ironwood flag bytes use bit 2 as `enableCrossAddress`, so
-    /// only bits 3..7 are reserved and MUST be zero (cf. the v5 rule on [`Flags`]).
+    /// From NU6.3, the Ironwood flag byte uses bit 2 as `enableCrossAddress`, so only bits 3..7 are
+    /// reserved and MUST be zero (cf. the Orchard-pool rule on [`Flags`], which keeps bit 2
+    /// reserved).
     ///
     /// <https://zips.z.cash/protocol/protocol.pdf#txnconsensus>
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
-        // The NU6.3 format, used by v6 Orchard and Ironwood bundles: bit 2 (`enableCrossAddress`)
-        // is valid and only bits 3..7 are reserved.
+        // The NU6.3 Ironwood format: bit 2 (`enableCrossAddress`) is valid and only bits 3..7 are
+        // reserved.
         Ok(FlagsV6(Flags::from_byte(
             reader.read_u8()?,
             Flags::NU6_3_RESERVED,

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -324,7 +324,7 @@ impl Transaction {
                     .orchard_flags()
                     .unwrap_or_else(orchard::Flags::empty)
                     .contains(orchard::Flags::ENABLE_SPENDS))
-            || (self.ironwood_actions().count() > 0
+            || (self.has_ironwood_shielded_data()
                 && self
                     .ironwood_flags()
                     .unwrap_or_else(orchard::Flags::empty)
@@ -342,7 +342,7 @@ impl Transaction {
                     .orchard_flags()
                     .unwrap_or_else(orchard::Flags::empty)
                     .contains(orchard::Flags::ENABLE_OUTPUTS))
-            || (self.ironwood_actions().count() > 0
+            || (self.has_ironwood_shielded_data()
                 && self
                     .ironwood_flags()
                     .unwrap_or_else(orchard::Flags::empty)
@@ -369,7 +369,7 @@ impl Transaction {
     ///
     /// Mirrors [`Self::has_enough_orchard_flags`] for the Ironwood pool.
     pub fn has_enough_ironwood_flags(&self) -> bool {
-        if self.ironwood_actions().count() == 0 {
+        if !self.has_ironwood_shielded_data() {
             return true;
         }
         self.ironwood_flags()

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -8,7 +8,6 @@ use reddsa::{orchard::Binding, Signature};
 
 use crate::{
     amount::{self, Amount, NegativeAllowed, NonNegative},
-    at_least_one,
     block::{self, arbitrary::MAX_PARTIAL_CHAIN_BLOCKS},
     orchard,
     parameters::{Network, NetworkUpgrade},
@@ -1078,28 +1077,12 @@ pub fn transactions_from_blocks<'a>(
 pub fn insert_fake_orchard_shielded_data(
     transaction: &mut Transaction,
 ) -> &mut orchard::ShieldedData {
-    // Create a dummy action
-    let mut runner = TestRunner::default();
-    let dummy_action = orchard::Action::arbitrary()
-        .new_tree(&mut runner)
-        .unwrap()
-        .current();
-
-    // Pair the dummy action with a fake signature
-    let dummy_authorized_action = orchard::AuthorizedAction {
-        action: dummy_action,
-        spend_auth_sig: Signature::from([0u8; 64]),
-    };
-
-    // Place the dummy action inside the Orchard shielded data
-    let dummy_shielded_data = orchard::ShieldedData {
-        flags: orchard::Flags::empty(),
-        value_balance: Amount::try_from(0).expect("invalid transaction amount"),
-        shared_anchor: orchard::tree::Root::default(),
-        proof: Halo2Proof(vec![]),
-        actions: at_least_one![dummy_authorized_action],
-        binding_sig: Signature::from([0u8; 64]),
-    };
+    // A single-action dummy bundle with no flags and a zero value balance.
+    let dummy_shielded_data = fake_v6_orchard_shielded_data(
+        orchard::Flags::empty(),
+        Amount::try_from(0).expect("invalid transaction amount"),
+        1,
+    );
 
     // Replace the shielded data in the transaction
     match transaction {

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -419,19 +419,45 @@ impl ZcashSerialize for orchard::ShieldedData {
     }
 }
 
-// A v6 (NU6.3) Orchard or Ironwood bundle encodes identically on the wire to a v5 Orchard bundle
-// (the flag byte is written as-is), so the (de)serializers below delegate to the v5 Orchard bundle
-// codec, only wrapping/unwrapping their newtypes (`orchard::ShieldedDataV6` and
-// `ironwood::ShieldedData`). They differ only in the reserved-bit rule applied to `flagsOrchard` on
-// *deserialization*: the `enableCrossAddress` bit (bit 2) is permitted only for the Ironwood pool,
-// and is reserved (MUST be 0) for the Orchard pool regardless of tx version — matching
-// `orchard::bundle::Flags::from_byte`, which rejects bit 2 for `ValuePool::Orchard`. So the v6
-// Orchard bundle parses with the pre-NU6.3 `orchard::Flags` codec (exactly like v5); only the
-// Ironwood bundle uses the `orchard::FlagsV6` codec.
+/// The `flagsOrchard` codec a v6 Orchard-protocol bundle newtype uses on deserialization.
+///
+/// A v6 Orchard or Ironwood bundle encodes identically on the wire to a v5 Orchard bundle (the flag
+/// byte is written as-is); the pools differ only in the reserved-bit rule applied to `flagsOrchard`.
+/// The `enableCrossAddress` bit (bit 2) is permitted only for the Ironwood pool, and is reserved
+/// (MUST be 0) for the Orchard pool regardless of tx version — matching
+/// `orchard::bundle::Flags::from_byte`, which rejects bit 2 for `ValuePool::Orchard`. Tying the
+/// codec to the bundle type lets the (de)serializers below imply it instead of naming it explicitly.
+trait V6FlagCodec {
+    /// The flag codec: `orchard::Flags` reserves bit 2, `orchard::FlagsV6` permits it.
+    type Codec: ZcashDeserialize + Into<orchard::Flags>;
+}
+
+impl V6FlagCodec for orchard::ShieldedDataV6 {
+    // The v6 Orchard bundle parses with the pre-NU6.3 codec, exactly like v5.
+    type Codec = orchard::Flags;
+}
+
+impl V6FlagCodec for ironwood::ShieldedData {
+    // Only the Ironwood bundle permits `enableCrossAddress`.
+    type Codec = orchard::FlagsV6;
+}
+
+/// Deserializes the shared Orchard-protocol bundle body of a v6 bundle newtype `T`, using the flag
+/// codec [implied by `T`](V6FlagCodec) rather than one named at the call site.
+fn deserialize_v6_orchard_shielded_data<R, T>(
+    reader: R,
+) -> Result<Option<orchard::ShieldedData>, SerializationError>
+where
+    R: io::Read,
+    T: V6FlagCodec,
+{
+    deserialize_orchard_shielded_data::<R, T::Codec>(reader)
+}
+
 impl ZcashDeserialize for Option<orchard::ShieldedDataV6> {
     fn zcash_deserialize<R: io::Read>(reader: R) -> Result<Self, SerializationError> {
         Ok(
-            deserialize_orchard_shielded_data::<R, orchard::Flags>(reader)?
+            deserialize_v6_orchard_shielded_data::<R, orchard::ShieldedDataV6>(reader)?
                 .map(orchard::ShieldedDataV6::new),
         )
     }
@@ -445,10 +471,8 @@ impl ZcashSerialize for Option<orchard::ShieldedDataV6> {
 
 impl ZcashDeserialize for Option<ironwood::ShieldedData> {
     fn zcash_deserialize<R: io::Read>(reader: R) -> Result<Self, SerializationError> {
-        // Unlike the v6 Orchard bundle above, the Ironwood bundle permits `enableCrossAddress`
-        // (bit 2), so it parses with the `orchard::FlagsV6` codec.
         Ok(
-            deserialize_orchard_shielded_data::<R, orchard::FlagsV6>(reader)?
+            deserialize_v6_orchard_shielded_data::<R, ironwood::ShieldedData>(reader)?
                 .map(orchard::ShieldedDataV6::new)
                 .map(ironwood::ShieldedData::new),
         )

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -419,15 +419,19 @@ impl ZcashSerialize for orchard::ShieldedData {
     }
 }
 
-// A v6 (NU6.3) Orchard or Ironwood bundle differs from a v5 Orchard bundle only in its flag-byte
-// format on *deserialization* (the NU6.3 format permits `enableCrossAddress`). It encodes
-// identically on the wire (the flag byte is written as-is), so the v6 Orchard and Ironwood
-// (de)serializers below delegate to the v5 Orchard bundle codec, only wrapping/unwrapping their
-// newtypes (`orchard::ShieldedDataV6` and `ironwood::ShieldedData`).
+// A v6 (NU6.3) Orchard or Ironwood bundle encodes identically on the wire to a v5 Orchard bundle
+// (the flag byte is written as-is), so the (de)serializers below delegate to the v5 Orchard bundle
+// codec, only wrapping/unwrapping their newtypes (`orchard::ShieldedDataV6` and
+// `ironwood::ShieldedData`). They differ only in the reserved-bit rule applied to `flagsOrchard` on
+// *deserialization*: the `enableCrossAddress` bit (bit 2) is permitted only for the Ironwood pool,
+// and is reserved (MUST be 0) for the Orchard pool regardless of tx version — matching
+// `orchard::bundle::Flags::from_byte`, which rejects bit 2 for `ValuePool::Orchard`. So the v6
+// Orchard bundle parses with the pre-NU6.3 `orchard::Flags` codec (exactly like v5); only the
+// Ironwood bundle uses the `orchard::FlagsV6` codec.
 impl ZcashDeserialize for Option<orchard::ShieldedDataV6> {
     fn zcash_deserialize<R: io::Read>(reader: R) -> Result<Self, SerializationError> {
         Ok(
-            deserialize_orchard_shielded_data::<R, orchard::FlagsV6>(reader)?
+            deserialize_orchard_shielded_data::<R, orchard::Flags>(reader)?
                 .map(orchard::ShieldedDataV6::new),
         )
     }
@@ -441,8 +445,11 @@ impl ZcashSerialize for Option<orchard::ShieldedDataV6> {
 
 impl ZcashDeserialize for Option<ironwood::ShieldedData> {
     fn zcash_deserialize<R: io::Read>(reader: R) -> Result<Self, SerializationError> {
+        // Unlike the v6 Orchard bundle above, the Ironwood bundle permits `enableCrossAddress`
+        // (bit 2), so it parses with the `orchard::FlagsV6` codec.
         Ok(
-            Option::<orchard::ShieldedDataV6>::zcash_deserialize(reader)?
+            deserialize_orchard_shielded_data::<R, orchard::FlagsV6>(reader)?
+                .map(orchard::ShieldedDataV6::new)
                 .map(ironwood::ShieldedData::new),
         )
     }
@@ -1166,6 +1173,12 @@ impl ZcashDeserialize for Transaction {
                 let ironwood_shielded_data = (&mut limited_reader)
                     .zcash_deserialize_into::<Option<ironwood::ShieldedData>>()?;
 
+                // Unlike the v5 arm, the v6 arm does not round-trip through `to_librustzcash` here:
+                // that would drive librustzcash's proof parser (which rejects the structurally-fake
+                // proofs the test helpers produce), coupling wire deserialization to proof parsing.
+                // The `enableCrossAddress` divergence that would otherwise reach the txid-path
+                // `expect(...)` is already rejected above, inside `orchard::Flags::from_byte`, before
+                // this transaction is constructed.
                 Ok(Transaction::V6 {
                     network_upgrade,
                     lock_time,

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -1162,9 +1162,9 @@ impl ZcashDeserialize for Transaction {
 
                 // A bundle of fields denoted in the spec as `nActionsOrchard`, `vActionsOrchard`,
                 // `flagsOrchard`,`valueBalanceOrchard`, `anchorOrchard`, `sizeProofsOrchard`,
-                // `proofsOrchard`, `vSpendAuthSigsOrchard`, and `bindingSigOrchard`. The
-                // `ShieldedDataV6` codec uses the NU6.3 flag-byte format (`enableCrossAddress`
-                // permitted).
+                // `proofsOrchard`, `vSpendAuthSigsOrchard`, and `bindingSigOrchard`. The v6 Orchard
+                // bundle reserves the `enableCrossAddress` bit (like v5); only the Ironwood bundle
+                // below permits it.
                 let orchard_shielded_data = (&mut limited_reader)
                     .zcash_deserialize_into::<Option<orchard::ShieldedDataV6>>()?;
 

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -1122,6 +1122,56 @@ fn v6_transaction_with_bundles_round_trips() {
     assert_eq!(tx, tx2);
 }
 
+/// The `enableCrossAddress` flag (bit 2) is permitted only for the Ironwood pool: a v6 Orchard
+/// bundle carrying it MUST be rejected at deserialization (matching `orchard::Flags::from_byte`,
+/// which reserves bit 2 for `ValuePool::Orchard` in every tx version), while the same flag on the
+/// Ironwood bundle round-trips.
+///
+/// The Orchard case is the wire-layer guard: without it, a crafted bundle deserializes and then
+/// aborts the node in the txid-path `expect(...)` when `to_librustzcash` rejects the flag.
+#[test]
+fn v6_orchard_bundle_rejects_cross_address_flag_on_the_wire() {
+    use crate::ironwood;
+    use crate::orchard::{Flags, ShieldedDataV6};
+
+    let _init_guard = zebra_test::init();
+    let zero = Amount::try_from(0).expect("zero is a valid amount");
+
+    // A v6 Orchard bundle with `enableCrossAddress` serializes (the flag byte is written as-is) but
+    // MUST NOT deserialize.
+    let orchard = ShieldedDataV6::new(arbitrary::fake_v6_orchard_shielded_data(
+        Flags::ENABLE_SPENDS | Flags::ENABLE_CROSS_ADDRESS,
+        zero,
+        1,
+    ));
+    let tx = arbitrary::fake_v6_transaction(NetworkUpgrade::Nu6_3, Some(orchard), None);
+    let bytes = tx
+        .zcash_serialize_to_vec()
+        .expect("v6 transaction serializes");
+    let result: Result<Transaction, _> = bytes.zcash_deserialize_into();
+    assert!(
+        result.is_err(),
+        "a v6 Orchard bundle with enableCrossAddress must be rejected on the wire",
+    );
+
+    // The same flag on the Ironwood bundle is valid and round-trips.
+    let ironwood = ironwood::ShieldedData::new(ShieldedDataV6::new(
+        arbitrary::fake_v6_orchard_shielded_data(
+            Flags::ENABLE_SPENDS | Flags::ENABLE_CROSS_ADDRESS,
+            zero,
+            1,
+        ),
+    ));
+    let tx = arbitrary::fake_v6_transaction(NetworkUpgrade::Nu6_3, None, Some(ironwood));
+    let bytes = tx
+        .zcash_serialize_to_vec()
+        .expect("v6 transaction serializes");
+    let tx2: Transaction = bytes
+        .zcash_deserialize_into()
+        .expect("a v6 Ironwood bundle with enableCrossAddress round-trips");
+    assert_eq!(tx, tx2);
+}
+
 #[test]
 fn test_coinbase_script() -> Result<()> {
     let _init_guard = zebra_test::init();

--- a/zebra-consensus/src/primitives/halo2.rs
+++ b/zebra-consensus/src/primitives/halo2.rs
@@ -5,6 +5,7 @@ use std::{
     future::Future,
     mem,
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
 };
 
@@ -114,7 +115,10 @@ lazy_static::lazy_static! {
 /// against exactly one key and eras are never mixed within a batch.
 #[derive(Clone, Debug)]
 pub struct Item {
-    bundle: orchard::bundle::Bundle<orchard::bundle::Authorized, ZatBalance>,
+    // `Arc`-wrapped so cloning an `Item` — which `tower-fallback` does eagerly for every request —
+    // shares the bundle instead of deep-copying its actions and multi-KB proof. `add_bundle` only
+    // needs `&Bundle`.
+    bundle: Arc<orchard::bundle::Bundle<orchard::bundle::Authorized, ZatBalance>>,
     sighash: SigHash,
 }
 
@@ -130,7 +134,10 @@ impl Item {
         bundle: orchard::bundle::Bundle<orchard::bundle::Authorized, ZatBalance>,
         sighash: SigHash,
     ) -> Self {
-        Self { bundle, sighash }
+        Self {
+            bundle: Arc::new(bundle),
+            sighash,
+        }
     }
 
     /// Perform non-batched verification of this [`Item`] against `vk`.
@@ -155,7 +162,7 @@ trait QueueBatchVerify {
 
 impl QueueBatchVerify for BatchValidator<'_> {
     fn queue(&mut self, Item { bundle, sighash }: Item) -> Result<(), orchard::bundle::BatchError> {
-        self.add_bundle(&bundle, sighash.0)
+        self.add_bundle(bundle.as_ref(), sighash.0)
     }
 }
 

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -570,6 +570,11 @@ where
         height: block::Height,
         network: &Network,
     ) -> Result<(), TransactionError> {
+        // The network upgrade active at this height is used by several of the checks below;
+        // `NetworkUpgrade::current` rebuilds the activation-height map on each call, so compute it
+        // once and share it rather than recomputing it per check.
+        let network_upgrade = NetworkUpgrade::current(network, height);
+
         check::has_inputs_and_outputs(tx)?;
         check::has_enough_orchard_flags(tx)?;
         // NU6.3 / Ironwood flag rules (no-ops for pre-v6 transactions).
@@ -577,10 +582,10 @@ where
         check::orchard_cross_address_disabled(tx)?;
         // [NU6.3 onward] valueBalanceOrchard must be non-negative (Orchard pool frozen against new
         // inflows; see `orchard_value_balance_non_negative`).
-        check::orchard_value_balance_non_negative(tx, height, network)?;
+        check::orchard_value_balance_non_negative(tx, network_upgrade)?;
         // [NU6.3 onward] Coinbase transactions must have an empty Orchard component (new shielded
         // coinbase value is routed to the Ironwood pool instead).
-        check::coinbase_orchard_component_empty(tx, height, network)?;
+        check::coinbase_orchard_component_empty(tx, network_upgrade)?;
         check::consensus_branch_id(tx, height, network)?;
 
         // Soft fork: temporarily require transactions to not contain Orchard actions.

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -172,8 +172,9 @@ pub fn has_enough_ironwood_flags(tx: &Transaction) -> Result<(), TransactionErro
 ///
 /// <https://zips.z.cash/protocol/protocol.pdf#txnconsensus>
 ///
-/// A v5 Orchard bundle can never set this flag (it is rejected at deserialization), so this only
-/// constrains v6 Orchard bundles.
+/// An Orchard bundle can never carry this flag off the wire: bit 2 is rejected at deserialization
+/// for the Orchard pool in every tx version (only the Ironwood pool permits it). So this is a
+/// defense-in-depth check that also covers an in-memory-constructed bundle.
 pub fn orchard_cross_address_disabled(tx: &Transaction) -> Result<(), TransactionError> {
     if let Some(orchard_shielded_data) = tx.orchard_shielded_data() {
         if orchard_shielded_data
@@ -205,10 +206,9 @@ pub fn orchard_cross_address_disabled(tx: &Transaction) -> Result<(), Transactio
 /// (No-op for transactions without an Orchard bundle, and before NU6.3.)
 pub fn orchard_value_balance_non_negative(
     tx: &Transaction,
-    height: Height,
-    network: &Network,
+    network_upgrade: NetworkUpgrade,
 ) -> Result<(), TransactionError> {
-    if NetworkUpgrade::current(network, height) >= NetworkUpgrade::Nu6_3 {
+    if network_upgrade >= NetworkUpgrade::Nu6_3 {
         if let Some(orchard_shielded_data) = tx.orchard_shielded_data() {
             if orchard_shielded_data.value_balance() < Amount::<NegativeAllowed>::zero() {
                 return Err(TransactionError::NegativeOrchardValueBalance);
@@ -236,10 +236,9 @@ pub fn orchard_value_balance_non_negative(
 /// NU6.3.)
 pub fn coinbase_orchard_component_empty(
     tx: &Transaction,
-    height: Height,
-    network: &Network,
+    network_upgrade: NetworkUpgrade,
 ) -> Result<(), TransactionError> {
-    if NetworkUpgrade::current(network, height) >= NetworkUpgrade::Nu6_3
+    if network_upgrade >= NetworkUpgrade::Nu6_3
         && tx.is_coinbase()
         && tx.orchard_shielded_data().is_some()
     {

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -207,21 +207,36 @@ fn orchard_value_balance_frozen_at_nu6_3() {
 
     // Rejected from NU6.3 onward,
     assert_eq!(
-        check::orchard_value_balance_non_negative(&tx, nu6_3_height, &network),
+        check::orchard_value_balance_non_negative(
+            &tx,
+            NetworkUpgrade::current(&network, nu6_3_height)
+        ),
         Err(TransactionError::NegativeOrchardValueBalance),
     );
     // but allowed before NU6.3, where the Orchard pool is not yet frozen.
-    assert!(check::orchard_value_balance_non_negative(&tx, pre_nu6_3_height, &network).is_ok());
+    assert!(check::orchard_value_balance_non_negative(
+        &tx,
+        NetworkUpgrade::current(&network, pre_nu6_3_height)
+    )
+    .is_ok());
 
     // A zero balance (Orchard-to-Orchard note management) is allowed at NU6.3.
     tx.orchard_shielded_data_mut().unwrap().value_balance =
         Amount::try_from(0).expect("0 is a valid amount");
-    assert!(check::orchard_value_balance_non_negative(&tx, nu6_3_height, &network).is_ok());
+    assert!(check::orchard_value_balance_non_negative(
+        &tx,
+        NetworkUpgrade::current(&network, nu6_3_height)
+    )
+    .is_ok());
 
     // A positive balance (Orchard-to-transparent unshielding) is allowed at NU6.3.
     tx.orchard_shielded_data_mut().unwrap().value_balance =
         Amount::try_from(1).expect("1 is a valid amount");
-    assert!(check::orchard_value_balance_non_negative(&tx, nu6_3_height, &network).is_ok());
+    assert!(check::orchard_value_balance_non_negative(
+        &tx,
+        NetworkUpgrade::current(&network, nu6_3_height)
+    )
+    .is_ok());
 
     // A transaction with no Orchard bundle is unaffected at NU6.3.
     let no_orchard_tx = Transaction::V5 {
@@ -233,9 +248,11 @@ fn orchard_value_balance_frozen_at_nu6_3() {
         orchard_shielded_data: None,
         network_upgrade: NetworkUpgrade::Nu5,
     };
-    assert!(
-        check::orchard_value_balance_non_negative(&no_orchard_tx, nu6_3_height, &network).is_ok()
-    );
+    assert!(check::orchard_value_balance_non_negative(
+        &no_orchard_tx,
+        NetworkUpgrade::current(&network, nu6_3_height)
+    )
+    .is_ok());
 }
 
 /// Tests the `[NU6.3 onward] if there are Ironwood actions, at least one of enableSpendsIronwood
@@ -335,7 +352,11 @@ fn coinbase_orchard_component_empty_at_nu6_3() {
         .expect("a V5 coinbase transaction");
 
     // A coinbase with no Orchard component is always accepted.
-    assert!(check::coinbase_orchard_component_empty(&tx, nu6_3_height, &network).is_ok());
+    assert!(check::coinbase_orchard_component_empty(
+        &tx,
+        NetworkUpgrade::current(&network, nu6_3_height)
+    )
+    .is_ok());
 
     // Give the coinbase a (non-empty) Orchard component.
     insert_fake_orchard_shielded_data(&mut tx);
@@ -343,11 +364,18 @@ fn coinbase_orchard_component_empty_at_nu6_3() {
 
     // Rejected from NU6.3 onward,
     assert_eq!(
-        check::coinbase_orchard_component_empty(&tx, nu6_3_height, &network),
+        check::coinbase_orchard_component_empty(
+            &tx,
+            NetworkUpgrade::current(&network, nu6_3_height)
+        ),
         Err(TransactionError::CoinbaseHasOrchardActions),
     );
     // but allowed before NU6.3, where coinbase Orchard outputs are still permitted.
-    assert!(check::coinbase_orchard_component_empty(&tx, pre_nu6_3_height, &network).is_ok());
+    assert!(check::coinbase_orchard_component_empty(
+        &tx,
+        NetworkUpgrade::current(&network, pre_nu6_3_height)
+    )
+    .is_ok());
 
     // The rule only constrains coinbase transactions: a non-coinbase tx with an Orchard component
     // is unaffected at NU6.3.
@@ -355,7 +383,11 @@ fn coinbase_orchard_component_empty_at_nu6_3() {
         .find(|transaction| !transaction.is_coinbase())
         .expect("a non-coinbase V5 transaction");
     insert_fake_orchard_shielded_data(&mut non_coinbase);
-    assert!(check::coinbase_orchard_component_empty(&non_coinbase, nu6_3_height, &network).is_ok());
+    assert!(check::coinbase_orchard_component_empty(
+        &non_coinbase,
+        NetworkUpgrade::current(&network, nu6_3_height)
+    )
+    .is_ok());
 }
 
 /// Tests that a transaction revealing the same Ironwood nullifier twice is rejected as a

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -33,10 +33,10 @@ use crate::{
     CommitSemanticallyVerifiedError,
 };
 
-/// The Ironwood-pool nullifier type, used by [`Spend::Ironwood`] (imported here rather than in the
-/// shared import block because it is only referenced by the indexer-only `Spend` enum).
+/// The per-pool nullifier types used by the indexer-only [`Spend`] enum, imported here rather than
+/// in the shared import block because they are only referenced under the `indexer` feature.
 #[cfg(feature = "indexer")]
-use zebra_chain::ironwood;
+use zebra_chain::{ironwood, orchard, sapling, sprout};
 
 /// Identify a spend by a transparent outpoint or revealed nullifier.
 ///

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -13,12 +13,9 @@ use zebra_chain::{
     block::{self, Block, HeightDiff},
     diagnostic::{task::WaitForPanics, CodeTimer},
     history_tree::HistoryTree,
-    orchard,
     parallel::tree::NoteCommitmentTrees,
-    sapling,
     serialization::SerializationError,
-    sprout,
-    subtree::{NoteCommitmentSubtree, NoteCommitmentSubtreeIndex},
+    subtree::NoteCommitmentSubtreeIndex,
     transaction::{self, UnminedTx},
     transparent::{self, utxos_from_ordered_utxos},
     value_balance::{ValueBalance, ValueBalanceError},
@@ -347,27 +344,12 @@ pub struct Treestate {
 
 impl Treestate {
     #[allow(missing_docs)]
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        sprout: Arc<sprout::tree::NoteCommitmentTree>,
-        sapling: Arc<sapling::tree::NoteCommitmentTree>,
-        orchard: Arc<orchard::tree::NoteCommitmentTree>,
-        ironwood: Arc<orchard::tree::NoteCommitmentTree>,
-        sapling_subtree: Option<NoteCommitmentSubtree<sapling_crypto::Node>>,
-        orchard_subtree: Option<NoteCommitmentSubtree<orchard::tree::Node>>,
-        ironwood_subtree: Option<NoteCommitmentSubtree<orchard::tree::Node>>,
+        note_commitment_trees: NoteCommitmentTrees,
         history_tree: Arc<HistoryTree>,
     ) -> Self {
         Self {
-            note_commitment_trees: NoteCommitmentTrees {
-                sprout,
-                sapling,
-                sapling_subtree,
-                orchard,
-                orchard_subtree,
-                ironwood,
-                ironwood_subtree,
-            },
+            note_commitment_trees,
             history_tree,
         }
     }

--- a/zebra-state/src/service/finalized_state/disk_format/chain.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/chain.rs
@@ -143,21 +143,19 @@ impl FromDisk for HistoryTreeParts {
         // fall back to the legacy width and zero-pad each entry up to the current width. New data
         // always parses at the current width, so it never reaches the fallback.
         //
-        // The fallback is gated on `UnexpectedEof`, which is the specific error a legacy-width
-        // record produces (we run out of bytes reading a wider-format entry). Any other error
-        // indicates real corruption of a current-format record and must not be silently
-        // reinterpreted as legacy data.
+        // The fallback must run on *any* current-width parse error, not just `UnexpectedEof`.
+        // Entries are fixed-size arrays with no length prefix, so parsing a multi-peak legacy record
+        // at the wider width reads later `BTreeMap` keys from the middle of an entry's bytes; bincode
+        // then fails with a varint/integer-range error (not `UnexpectedEof`) whenever a misread key
+        // byte is out of range. Gating on `UnexpectedEof` alone panicked on those records. A genuine
+        // current-format record only reaches the fallback if it is corrupt, in which case the legacy
+        // parse fails too and the error still surfaces.
         options
             .deserialize::<HistoryTreeParts>(bytes)
-            .or_else(|err| match err.as_ref() {
-                bincode::ErrorKind::Io(io_err)
-                    if io_err.kind() == std::io::ErrorKind::UnexpectedEof =>
-                {
-                    options
-                        .deserialize::<LegacyHistoryTreeParts>(bytes)
-                        .map(HistoryTreeParts::from)
-                }
-                _ => Err(err),
+            .or_else(|_| {
+                options
+                    .deserialize::<LegacyHistoryTreeParts>(bytes)
+                    .map(HistoryTreeParts::from)
             })
             .expect("deserialization format should match the serialization format used by IntoDisk")
     }

--- a/zebra-state/src/service/finalized_state/disk_format/chain/tests.rs
+++ b/zebra-state/src/service/finalized_state/disk_format/chain/tests.rs
@@ -46,6 +46,62 @@ fn history_tree_parts_reads_legacy_entry_width() {
     assert!(parts.as_bytes().len() > legacy_bytes.len());
 }
 
+/// A multi-peak legacy history tree whose bytes make the current-width parse fail with a *non-EOF*
+/// bincode error must still fall back to the legacy width.
+///
+/// The `0xFF` fill is deliberate: entries are fixed-size arrays with no length prefix, so parsing
+/// the first 253-byte entry at the current (wider) width overruns into the next map key, which
+/// bincode decodes from `0xFF` bytes and rejects as an invalid varint — not `UnexpectedEof`. The
+/// previous fallback gated on `UnexpectedEof` only, so it panicked on records like this.
+#[test]
+fn history_tree_parts_reads_legacy_entry_width_with_non_eof_misparse() {
+    let legacy = LegacyHistoryTreeParts {
+        network_kind: NetworkKind::Mainnet,
+        size: 7,
+        peaks: BTreeMap::from([
+            (
+                0,
+                LegacyEntry {
+                    inner: [0xFF; LEGACY_MAX_ENTRY_SIZE],
+                },
+            ),
+            (
+                1,
+                LegacyEntry {
+                    inner: [0xFF; LEGACY_MAX_ENTRY_SIZE],
+                },
+            ),
+        ]),
+        current_height: Height(500),
+    };
+
+    let legacy_bytes = bincode::DefaultOptions::new()
+        .serialize(&legacy)
+        .expect("legacy serialization succeeds");
+
+    // Sanity check: the current-width parse of this record fails with a non-`UnexpectedEof` error —
+    // the exact case the old fallback did not cover.
+    let current_err = bincode::DefaultOptions::new()
+        .deserialize::<HistoryTreeParts>(&legacy_bytes)
+        .err()
+        .expect("current-width parse of a legacy record fails");
+    assert!(
+        !matches!(
+            current_err.as_ref(),
+            bincode::ErrorKind::Io(io_err) if io_err.kind() == std::io::ErrorKind::UnexpectedEof,
+        ),
+        "expected a non-EOF misparse error, got: {current_err:?}",
+    );
+
+    // The fallback reads it anyway, instead of panicking.
+    let parts = HistoryTreeParts::from_bytes(&legacy_bytes);
+    assert_eq!(parts.network_kind, NetworkKind::Mainnet);
+    assert_eq!(parts.size, 7);
+    assert_eq!(parts.current_height, Height(500));
+    assert_eq!(parts.peaks.len(), 2);
+    assert_eq!(parts.as_bytes(), HistoryTreeParts::from(legacy).as_bytes());
+}
+
 /// Data written at the current entry width round-trips without hitting the legacy fallback.
 #[test]
 fn history_tree_parts_round_trips_current_width() {

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -465,10 +465,7 @@ impl NonFinalizedState {
                 finalized_state
                     .finalized_tip_height()
                     .ok_or(ReconsiderError::ParentChainNotFound(block_hash))?,
-                finalized_state.sprout_tree_for_tip(),
-                finalized_state.sapling_tree_for_tip(),
-                finalized_state.orchard_tree_for_tip(),
-                finalized_state.ironwood_tree_for_tip(),
+                finalized_state.note_commitment_trees_for_tip(),
                 finalized_state.history_tree(),
                 finalized_state.finalized_value_pool(),
             );
@@ -530,10 +527,7 @@ impl NonFinalizedState {
         let chain = Chain::new(
             &self.network,
             finalized_tip_height,
-            finalized_state.sprout_tree_for_tip(),
-            finalized_state.sapling_tree_for_tip(),
-            finalized_state.orchard_tree_for_tip(),
-            finalized_state.ironwood_tree_for_tip(),
+            finalized_state.note_commitment_trees_for_tip(),
             finalized_state.history_tree(),
             finalized_state.finalized_value_pool(),
         );

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -256,17 +256,27 @@ pub struct ChainInner {
 
 impl Chain {
     /// Create a new Chain with the given finalized tip trees and network.
-    #[allow(clippy::too_many_arguments)]
+    ///
+    /// The subtree fields of `note_commitment_trees` are unused: a forked chain starts tracking
+    /// subtrees from empty and fills them from its own block commits.
     pub(crate) fn new(
         network: &Network,
         finalized_tip_height: Height,
-        sprout_note_commitment_tree: Arc<sprout::tree::NoteCommitmentTree>,
-        sapling_note_commitment_tree: Arc<sapling::tree::NoteCommitmentTree>,
-        orchard_note_commitment_tree: Arc<orchard::tree::NoteCommitmentTree>,
-        ironwood_note_commitment_tree: Arc<orchard::tree::NoteCommitmentTree>,
+        note_commitment_trees: NoteCommitmentTrees,
         history_tree: Arc<HistoryTree>,
         finalized_tip_chain_value_pools: ValueBalance<NonNegative>,
     ) -> Self {
+        // Passing the trees in a named struct (rather than four adjacent positional arguments, two
+        // of them the same `Arc<orchard::tree::NoteCommitmentTree>` type) makes an orchard/ironwood
+        // swap a compile error instead of silent tree corruption.
+        let NoteCommitmentTrees {
+            sprout: sprout_note_commitment_tree,
+            sapling: sapling_note_commitment_tree,
+            orchard: orchard_note_commitment_tree,
+            ironwood: ironwood_note_commitment_tree,
+            ..
+        } = note_commitment_trees;
+
         let inner = ChainInner {
             blocks: Default::default(),
             height_by_hash: Default::default(),
@@ -1370,13 +1380,15 @@ impl Chain {
         let ironwood_subtree = self.ironwood_subtree(hash_or_height);
 
         Some(Treestate::new(
-            sprout_tree,
-            sapling_tree,
-            orchard_tree,
-            ironwood_tree,
-            sapling_subtree,
-            orchard_subtree,
-            ironwood_subtree,
+            NoteCommitmentTrees {
+                sprout: sprout_tree,
+                sapling: sapling_tree,
+                sapling_subtree,
+                orchard: orchard_tree,
+                orchard_subtree,
+                ironwood: ironwood_tree,
+                ironwood_subtree,
+            },
             history_tree,
         ))
     }
@@ -1783,6 +1795,7 @@ impl Chain {
                 sapling_shielded_data_per_spend_anchor,
                 sapling_shielded_data_shared_anchor,
                 orchard_shielded_data,
+                ironwood_shielded_data,
             ) = match transaction.deref() {
                 V4 {
                     inputs,
@@ -1790,7 +1803,15 @@ impl Chain {
                     joinsplit_data,
                     sapling_shielded_data,
                     ..
-                } => (inputs, outputs, joinsplit_data, sapling_shielded_data, &None, None),
+                } => (
+                    inputs,
+                    outputs,
+                    joinsplit_data,
+                    sapling_shielded_data,
+                    &None,
+                    None,
+                    None,
+                ),
                 V5 {
                     inputs,
                     outputs,
@@ -1804,12 +1825,14 @@ impl Chain {
                     &None,
                     sapling_shielded_data,
                     orchard_shielded_data.as_ref(),
+                    None,
                 ),
                 V6 {
                     inputs,
                     outputs,
                     sapling_shielded_data,
                     orchard_shielded_data,
+                    ironwood_shielded_data,
                     ..
                 } => (
                     inputs,
@@ -1818,6 +1841,7 @@ impl Chain {
                     &None,
                     sapling_shielded_data,
                     orchard_shielded_data.as_ref().map(|data| data.data()),
+                    ironwood_shielded_data.as_ref(),
                 ),
 
                 V1 { .. } | V2 { .. } | V3 { .. } => unreachable!(
@@ -1849,17 +1873,9 @@ impl Chain {
 
                 // The Ironwood pool reuses orchard::ShieldedData, so its nullifiers are applied
                 // through a distinct UpdateWith impl keyed on the ironwood::ShieldedData newtype
-                // (which doesn't collide with the Orchard impl).
-                if let V6 {
-                    ironwood_shielded_data,
-                    ..
-                } = transaction.deref()
-                {
-                    self.update_chain_tip_with(&(
-                        ironwood_shielded_data.as_ref(),
-                        &transaction_hash,
-                    ))?;
-                }
+                // (which doesn't collide with the Orchard impl). It flows through the version match
+                // above so a new tx version cannot silently skip it.
+                self.update_chain_tip_with(&(ironwood_shielded_data, &transaction_hash))?;
             }
 
             // add key `transaction.hash` and value `(height, tx_index)` to `tx_loc_by_hash`
@@ -1991,6 +2007,7 @@ impl UpdateWith<ContextuallyVerifiedBlock> for Chain {
                 sapling_shielded_data_per_spend_anchor,
                 sapling_shielded_data_shared_anchor,
                 orchard_shielded_data,
+                ironwood_shielded_data,
             ) = match transaction.deref() {
                 V4 {
                     inputs,
@@ -1998,7 +2015,15 @@ impl UpdateWith<ContextuallyVerifiedBlock> for Chain {
                     joinsplit_data,
                     sapling_shielded_data,
                     ..
-                } => (inputs, outputs, joinsplit_data, sapling_shielded_data, &None, None),
+                } => (
+                    inputs,
+                    outputs,
+                    joinsplit_data,
+                    sapling_shielded_data,
+                    &None,
+                    None,
+                    None,
+                ),
                 V5 {
                     inputs,
                     outputs,
@@ -2012,12 +2037,14 @@ impl UpdateWith<ContextuallyVerifiedBlock> for Chain {
                     &None,
                     sapling_shielded_data,
                     orchard_shielded_data.as_ref(),
+                    None,
                 ),
                 V6 {
                     inputs,
                     outputs,
                     sapling_shielded_data,
                     orchard_shielded_data,
+                    ironwood_shielded_data,
                     ..
                 } => (
                     inputs,
@@ -2026,6 +2053,7 @@ impl UpdateWith<ContextuallyVerifiedBlock> for Chain {
                     &None,
                     sapling_shielded_data,
                     orchard_shielded_data.as_ref().map(|data| data.data()),
+                    ironwood_shielded_data.as_ref(),
                 ),
 
                 V1 { .. } | V2 { .. } | V3 { .. } => unreachable!(
@@ -2062,17 +2090,9 @@ impl UpdateWith<ContextuallyVerifiedBlock> for Chain {
             self.revert_chain_with(&(orchard_shielded_data, transaction_hash), position);
 
             // Revert the Ironwood nullifiers through the matching UpdateWith impl (see
-            // `update_chain_tip_with_block_except_trees`).
-            if let V6 {
-                ironwood_shielded_data,
-                ..
-            } = transaction.deref()
-            {
-                self.revert_chain_with(
-                    &(ironwood_shielded_data.as_ref(), transaction_hash),
-                    position,
-                );
-            }
+            // `update_chain_tip_with_block_except_trees`). It flows through the version match above
+            // so the revert stays in lockstep with the update for every tx version.
+            self.revert_chain_with(&(ironwood_shielded_data, transaction_hash), position);
         }
 
         // TODO: move these to the shielded UpdateWith.revert...()?

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -8,6 +8,7 @@ use zebra_chain::{
     amount::{DeferredPoolBalanceChange, NonNegative},
     block::{self, arbitrary::allow_all_transparent_coinbase_spends, Block, Height},
     history_tree::{HistoryTree, NonEmptyHistoryTree},
+    parallel::tree::NoteCommitmentTrees,
     parameters::NetworkUpgrade::*,
     parameters::*,
     value_balance::ValueBalance,
@@ -41,7 +42,7 @@ fn push_genesis_chain() -> Result<()> {
     |((chain, count, network, empty_tree) in PreparedChain::default())| {
         prop_assert!(empty_tree.is_none());
 
-        let mut only_chain = Chain::new(&network, Height(0), Default::default(), Default::default(), Default::default(), Default::default(), empty_tree, ValueBalance::zero());
+        let mut only_chain = Chain::new(&network, Height(0), NoteCommitmentTrees::default(), empty_tree, ValueBalance::zero());
         // contains the block value pool changes and chain value pool balances for each height
         let mut chain_values = BTreeMap::new();
 
@@ -94,7 +95,7 @@ fn push_history_tree_chain() -> Result<()> {
         let count = std::cmp::min(count, chain.len() - 1);
         let chain = &chain[1..];
 
-        let mut only_chain = Chain::new(&network, Height(0), Default::default(), Default::default(), Default::default(), Default::default(), finalized_tree, ValueBalance::zero());
+        let mut only_chain = Chain::new(&network, Height(0), NoteCommitmentTrees::default(), finalized_tree, ValueBalance::zero());
 
         for block in chain
             .iter()
@@ -139,10 +140,7 @@ fn forked_equals_pushed_genesis() -> Result<()> {
         let mut partial_chain = Chain::new(
             &network,
             Height(0),
-            Default::default(),
-            Default::default(),
-            Default::default(),
-            Default::default(),
+            NoteCommitmentTrees::default(),
             empty_tree.clone(),
             ValueBalance::zero(),
         );
@@ -161,10 +159,7 @@ fn forked_equals_pushed_genesis() -> Result<()> {
         let mut full_chain = Chain::new(
             &network,
             Height(0),
-            Default::default(),
-            Default::default(),
-            Default::default(),
-            Default::default(),
+            NoteCommitmentTrees::default(),
             empty_tree,
             ValueBalance::zero(),
         );
@@ -248,8 +243,8 @@ fn forked_equals_pushed_history_tree() -> Result<()> {
         // use `fork_at_count` as the fork tip
         let fork_tip_hash = chain[fork_at_count - 1].hash;
 
-        let mut full_chain = Chain::new(&network, Height(0), Default::default(), Default::default(), Default::default(), Default::default(), finalized_tree.clone(), ValueBalance::zero());
-        let mut partial_chain = Chain::new(&network, Height(0), Default::default(), Default::default(), Default::default(), Default::default(), finalized_tree, ValueBalance::zero());
+        let mut full_chain = Chain::new(&network, Height(0), NoteCommitmentTrees::default(), finalized_tree.clone(), ValueBalance::zero());
+        let mut partial_chain = Chain::new(&network, Height(0), NoteCommitmentTrees::default(), finalized_tree, ValueBalance::zero());
 
         for block in chain
             .iter()
@@ -316,7 +311,7 @@ fn finalized_equals_pushed_genesis() -> Result<()> {
 
         let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
 
-        let mut full_chain = Chain::new(&network, Height(0), Default::default(), Default::default(), Default::default(), Default::default(), empty_tree, fake_value_pool);
+        let mut full_chain = Chain::new(&network, Height(0), NoteCommitmentTrees::default(), empty_tree, fake_value_pool);
         for block in chain
             .clone()
             .take(finalized_count) {
@@ -326,10 +321,13 @@ fn finalized_equals_pushed_genesis() -> Result<()> {
         let mut partial_chain = Chain::new(
             &network,
             full_chain.non_finalized_tip_height(),
-            full_chain.sprout_note_commitment_tree_for_tip(),
-            full_chain.sapling_note_commitment_tree_for_tip(),
-            full_chain.orchard_note_commitment_tree_for_tip(),
-            full_chain.ironwood_note_commitment_tree_for_tip(),
+            NoteCommitmentTrees {
+                sprout: full_chain.sprout_note_commitment_tree_for_tip(),
+                sapling: full_chain.sapling_note_commitment_tree_for_tip(),
+                orchard: full_chain.orchard_note_commitment_tree_for_tip(),
+                ironwood: full_chain.ironwood_note_commitment_tree_for_tip(),
+                ..Default::default()
+            },
             full_chain.history_block_commitment_tree(),
             full_chain.chain_value_pools,
         );
@@ -394,7 +392,7 @@ fn finalized_equals_pushed_history_tree() -> Result<()> {
 
         let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
 
-        let mut full_chain = Chain::new(&network, Height(0), Default::default(), Default::default(), Default::default(), Default::default(), finalized_tree, fake_value_pool);
+        let mut full_chain = Chain::new(&network, Height(0), NoteCommitmentTrees::default(), finalized_tree, fake_value_pool);
         for block in chain
             .iter()
             .take(finalized_count)
@@ -405,10 +403,13 @@ fn finalized_equals_pushed_history_tree() -> Result<()> {
         let mut partial_chain = Chain::new(
             &network,
             Height(finalized_count.try_into().unwrap()),
-            full_chain.sprout_note_commitment_tree_for_tip(),
-            full_chain.sapling_note_commitment_tree_for_tip(),
-            full_chain.orchard_note_commitment_tree_for_tip(),
-            full_chain.ironwood_note_commitment_tree_for_tip(),
+            NoteCommitmentTrees {
+                sprout: full_chain.sprout_note_commitment_tree_for_tip(),
+                sapling: full_chain.sapling_note_commitment_tree_for_tip(),
+                orchard: full_chain.orchard_note_commitment_tree_for_tip(),
+                ironwood: full_chain.ironwood_note_commitment_tree_for_tip(),
+                ..Default::default()
+            },
             full_chain.history_block_commitment_tree(),
             full_chain.chain_value_pools,
         );
@@ -590,8 +591,8 @@ fn different_blocks_different_chains() -> Result<()> {
             Default::default()
         };
 
-        let chain1 = Chain::new(&Network::Mainnet, Height(0), Default::default(), Default::default(), Default::default(), Default::default(), finalized_tree1, ValueBalance::fake_populated_pool());
-        let chain2 = Chain::new(&Network::Mainnet, Height(0), Default::default(), Default::default(), Default::default(), Default::default(), finalized_tree2, ValueBalance::fake_populated_pool());
+        let chain1 = Chain::new(&Network::Mainnet, Height(0), NoteCommitmentTrees::default(), finalized_tree1, ValueBalance::fake_populated_pool());
+        let chain2 = Chain::new(&Network::Mainnet, Height(0), NoteCommitmentTrees::default(), finalized_tree2, ValueBalance::fake_populated_pool());
 
         let block1 = vec1[1].clone().prepare().test_with_zero_spent_utxos();
         let block2 = vec2[1].clone().prepare().test_with_zero_spent_utxos();

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -7,6 +7,7 @@ use zebra_chain::{
     block::{self, Block, Height},
     history_tree::NonEmptyHistoryTree,
     orchard,
+    parallel::tree::NoteCommitmentTrees,
     parameters::{Network, NetworkUpgrade},
     serialization::ZcashDeserializeInto,
     subtree::NoteCommitmentSubtree,
@@ -34,10 +35,7 @@ fn construct_empty() {
     let _chain = Chain::new(
         &Network::Mainnet,
         Height(0),
-        Default::default(),
-        Default::default(),
-        Default::default(),
-        Default::default(),
+        NoteCommitmentTrees::default(),
         Default::default(),
         ValueBalance::zero(),
     );
@@ -52,10 +50,7 @@ fn construct_single() -> Result<()> {
     let mut chain = Chain::new(
         &Network::Mainnet,
         Height(0),
-        Default::default(),
-        Default::default(),
-        Default::default(),
-        Default::default(),
+        NoteCommitmentTrees::default(),
         Default::default(),
         ValueBalance::fake_populated_pool(),
     );
@@ -87,10 +82,7 @@ fn construct_many() -> Result<()> {
     let mut chain = Chain::new(
         &Network::Mainnet,
         (initial_height - 1).expect("Initial height should be at least 1."),
-        Default::default(),
-        Default::default(),
-        Default::default(),
-        Default::default(),
+        NoteCommitmentTrees::default(),
         Default::default(),
         ValueBalance::fake_populated_pool(),
     );
@@ -115,10 +107,7 @@ fn ord_matches_work() -> Result<()> {
     let mut lesser_chain = Chain::new(
         &Network::Mainnet,
         Height(0),
-        Default::default(),
-        Default::default(),
-        Default::default(),
-        Default::default(),
+        NoteCommitmentTrees::default(),
         Default::default(),
         ValueBalance::fake_populated_pool(),
     );
@@ -127,10 +116,7 @@ fn ord_matches_work() -> Result<()> {
     let mut bigger_chain = Chain::new(
         &Network::Mainnet,
         Height(0),
-        Default::default(),
-        Default::default(),
-        Default::default(),
-        Default::default(),
+        NoteCommitmentTrees::default(),
         Default::default(),
         ValueBalance::zero(),
     );
@@ -1074,10 +1060,7 @@ fn fork_drops_subtrees_above_fork_point() -> Result<()> {
     let mut chain = Chain::new(
         &network,
         (block1.coinbase_height().unwrap() - 1).unwrap(),
-        Default::default(),
-        Default::default(),
-        Default::default(),
-        Default::default(),
+        NoteCommitmentTrees::default(),
         Default::default(),
         ValueBalance::fake_populated_pool(),
     );


### PR DESCRIPTION
## Motivation

A second multi-agent review round of the Ironwood work (#10762, and the first review-fixes round #10884) surfaced two node-crash bugs plus a set of fragility, efficiency, and duplication findings. This stacks on #10884 and fixes them.

## Solution

Correctness:

- **chain:** reject the `enableCrossAddress` flag (bit 2) on the v6 **Orchard** bundle at deserialization. `orchard::Flags::from_byte` reserves bit 2 for the Orchard pool in every tx version and permits it only for Ironwood, so a crafted v6 tx with the bit set on the Orchard bundle parsed in Zebra but then aborted the node in the txid-path `expect()` when `to_librustzcash` rejected it. Only the Ironwood bundle now uses the `FlagsV6` codec.
- **state:** fall back to the legacy history-tree entry width on *any* current-width parse error, not just `UnexpectedEof`. A multi-peak pre-NU6.3 record misaligns at the widened entry width and bincode fails with a varint error, which the EOF-only gate turned into a deterministic crash-loop for a fraction of nodes on the v27→v28 upgrade.
- **state:** serve the empty Ironwood tree only *before* NU6.3 activation (the genuine pre-backfill window); from activation onward a missing tree is a real invariant violation, so fail loudly like the Orchard accessor instead of masking corruption with a wrong (empty) tree.

Type safety / fragility:

- **state:** yield `ironwood_shielded_data` from the per-transaction version `match` in both `update_chain_tip_with_block` and `revert_chain_with`, replacing two hand-synced `if let V6` blocks so a future tx version can't silently skip Ironwood nullifier tracking in one direction only.
- **state:** pass the note commitment trees to `Chain::new`/`Treestate::new` in a `NoteCommitmentTrees` struct instead of adjacent positional `Arc<orchard::tree::NoteCommitmentTree>` args (orchard and ironwood share the type), so an orchard/ironwood swap is a compile error rather than silent tree corruption.

Efficiency:

- **consensus:** compute `NetworkUpgrade::current` once per transaction and thread it into the two NU6.3 Orchard checks, instead of each rebuilding the activation-height map.
- **consensus:** store the halo2 `Item` bundle in an `Arc` so the eager clone `tower-fallback` makes per request shares it instead of deep-copying the actions and proof.

Cleanup (no behavior change):

- share the `InnerHistoryTree` rebuild between `prune()` and `Clone` via `rebuilt_inner()`; test Ironwood-bundle presence with `has_ironwood_shielded_data()` instead of counting `AtLeastOne` actions; delegate `insert_fake_orchard_shielded_data` to `fake_v6_orchard_shielded_data`.

### Tests

Local gate green on `d.lan`: `fmt --check`, `clippy --workspace --all-targets -D warnings`, `cargo doc`, and `nextest` for the touched crates (zebra-chain/consensus/state) plus a workspace sweep. New regression tests: a wire v6 Orchard bundle with `enableCrossAddress` is rejected while the Ironwood one round-trips; a multi-peak legacy history-tree record whose current-width parse fails with a non-EOF error still falls back. No changelog entries — every fix here is for a bug that only exists on the unmerged Ironwood branch.

### Specifications & References

- Second review of #10762 / #10884.

### Follow-up Work

Deferred, low-risk dedup that is better as a focused follow-up (the `find_duplicate_nullifier` precedent applies): the Orchard/Ironwood anchor check in `check::anchors`, the non-finalized Ironwood read accessors, and the v5/v6 `verify_*_transaction_network_upgrade` matches. The Ironwood tree/subtree read path (`z_gettreestate`, `z_getsubtreesbyindex`, verbose `getblock` trees) is a separate PR.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude ran the multi-agent review, implemented the fixes, and drafted this description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
