### PR TITLE
fix(rpc): getblock verbosity 2 side-chain panic (GHSA-x6v8-c2xp-928m)

### DIFF
--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1328,25 +1328,24 @@ where
                 zebra_state::ReadResponse::BlockAndSize(block_and_size) => {
                     let (block, size) = block_and_size.ok_or_misc_error("Block not found")?;
                     let block_time = block.header.time;
-                    let transactions =
-                        block
-                            .transactions
-                            .iter()
-                            .map(|tx| {
-                                GetBlockTransaction::Object(Box::new(
-                                    TransactionObject::from_transaction(
-                                        tx.clone(),
-                                        Some(height),
-                                        Some(confirmations),
-                                        &network,
-                                        Some(block_time),
-                                        Some(hash),
-                                        Some(true),
-                                        tx.hash(),
-                                    ),
-                                ))
-                            })
-                            .collect();
+                    let transactions = block
+                        .transactions
+                        .iter()
+                        .map(|tx| {
+                            GetBlockTransaction::Object(Box::new(
+                                TransactionObject::from_transaction(
+                                    tx.clone(),
+                                    Some(height),
+                                    Some(confirmations),
+                                    &network,
+                                    Some(block_time),
+                                    Some(hash),
+                                    Some(true),
+                                    tx.hash(),
+                                ),
+                            ))
+                        })
+                        .collect();
                     (transactions, Some(size))
                 }
                 _ => unreachable!("unmatched response to a transaction_ids_for_block request"),

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1337,9 +1337,7 @@ where
                                     TransactionObject::from_transaction(
                                         tx.clone(),
                                         Some(height),
-                                        Some(confirmations.try_into().expect(
-                                            "should be less than max block height, i32::MAX",
-                                        )),
+                                        Some(confirmations),
                                         &network,
                                         Some(block_time),
                                         Some(hash),
@@ -1791,7 +1789,7 @@ where
                         AnyTx::Mined(mined) if in_best_chain => (
                             mined.tx.clone(),
                             Some(mined.height),
-                            Some(mined.confirmations),
+                            Some(mined.confirmations.into()),
                             Some(mined.block_time),
                         ),
                         _ => {
@@ -1834,7 +1832,7 @@ where
                                 TransactionObject::from_transaction(
                                     tx.tx.clone(),
                                     Some(tx.height),
-                                    Some(tx.confirmations),
+                                    Some(tx.confirmations.into()),
                                     &self.network,
                                     // TODO: Performance gain:
                                     // https://github.com/ZcashFoundation/zebra/pull/9458#discussion_r2059352752

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -853,12 +853,11 @@ async fn rpc_getblock_side_chain_verbosity2_does_not_panic() {
     let block_header = block.header.clone();
     let block_size = block.zcash_serialized_size();
 
-    let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
     let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
-    let mut read_state: MockService<_, _, _, BoxError> =
-        MockService::build()
-            .with_max_request_delay(std::time::Duration::from_secs(5))
-            .for_unit_tests();
+    let mut read_state: MockService<_, _, _, BoxError> = MockService::build()
+        .with_max_request_delay(std::time::Duration::from_secs(5))
+        .for_unit_tests();
 
     let (_tx, rx) = tokio::sync::watch::channel(None);
     let (rpc, _rpc_tx_queue) = RpcImpl::new(
@@ -880,8 +879,7 @@ async fn rpc_getblock_side_chain_verbosity2_does_not_panic() {
 
     let rpc_clone = rpc.clone();
     let hash_str = block_hash.to_string();
-    let block_future =
-        tokio::spawn(async move { rpc_clone.get_block(hash_str, Some(2u8)).await });
+    let block_future = tokio::spawn(async move { rpc_clone.get_block(hash_str, Some(2u8)).await });
 
     // get_block_header: BlockHeader, SaplingTree, Depth (None = side chain)
     read_state

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -831,7 +831,17 @@ async fn rpc_getblock_missing_error() {
     assert!(rpc_tx_queue_task_result.is_none());
 }
 
-/// Regression test for GHSA-x6v8-c2xp-928m.
+/// Regression test for GHSA-x6v8-c2xp-928m — panics (aborts) before the fix.
+///
+/// When `Depth` returns `None` (side-chain block), `get_block_header` sets
+/// `confirmations = -1`:
+/// https://github.com/ZcashFoundation/zebra/blob/v5.2.0/zebra-rpc/src/methods.rs#L1508
+/// The old code narrowed that to `u32` via `.try_into().expect()`, which panicked.
+///
+/// The fix changes `TransactionObject.confirmations` from `u32` to `i64`, matching
+/// zcashd's signed `int`:
+/// https://github.com/zcash/zcash/blob/v6.3.0/src/rpc/rawtransaction.cpp#L311
+/// https://github.com/zcash/zcash/blob/v6.3.0/src/rpc/blockchain.cpp#L404
 #[tokio::test(flavor = "multi_thread")]
 async fn rpc_getblock_side_chain_verbosity2_does_not_panic() {
     let _init_guard = zebra_test::init();
@@ -851,7 +861,7 @@ async fn rpc_getblock_side_chain_verbosity2_does_not_panic() {
             .for_unit_tests();
 
     let (_tx, rx) = tokio::sync::watch::channel(None);
-    let (rpc, rpc_tx_queue) = RpcImpl::new(
+    let (rpc, _rpc_tx_queue) = RpcImpl::new(
         Mainnet,
         Default::default(),
         Default::default(),
@@ -873,7 +883,7 @@ async fn rpc_getblock_side_chain_verbosity2_does_not_panic() {
     let block_future =
         tokio::spawn(async move { rpc_clone.get_block(hash_str, Some(2u8)).await });
 
-    // get_block_header sub-call: BlockHeader
+    // get_block_header: BlockHeader, SaplingTree, Depth (None = side chain)
     read_state
         .expect_request(ReadRequest::BlockHeader(block_hash.into()))
         .await
@@ -883,63 +893,37 @@ async fn rpc_getblock_side_chain_verbosity2_does_not_panic() {
             height: zebra_chain::block::Height(0),
             next_block_hash: None,
         });
-
-    // get_block_header sub-call: SaplingTree
     read_state
         .expect_request_that(|req| matches!(req, ReadRequest::SaplingTree(_)))
         .await
         .respond(ReadResponse::SaplingTree(Some(Default::default())));
-
-    // get_block_header sub-call: Depth — return None to simulate a side-chain block
     read_state
         .expect_request(ReadRequest::Depth(block_hash))
         .await
         .respond(ReadResponse::Depth(None));
 
-    // get_block: BlockAndSize
+    // get_block: BlockAndSize, OrchardTree, BlockInfo x2
     read_state
         .expect_request_that(|req| matches!(req, ReadRequest::BlockAndSize(_)))
         .await
         .respond(ReadResponse::BlockAndSize(Some((block, block_size))));
-
-    // get_block: OrchardTree
     read_state
         .expect_request_that(|req| matches!(req, ReadRequest::OrchardTree(_)))
         .await
         .respond(ReadResponse::OrchardTree(Some(Default::default())));
-
-    // get_block: BlockInfo (previous block)
     read_state
         .expect_request_that(|req| matches!(req, ReadRequest::BlockInfo(_)))
         .await
         .respond(ReadResponse::BlockInfo(None));
-
-    // get_block: BlockInfo (current block)
     read_state
         .expect_request_that(|req| matches!(req, ReadRequest::BlockInfo(_)))
         .await
         .respond(ReadResponse::BlockInfo(Some(BlockInfo::default())));
 
-    let result = block_future
+    block_future
         .await
         .expect("task should not panic")
         .expect("getblock should succeed for side-chain blocks");
-
-    if let GetBlockResponse::Object(obj) = &result {
-        let BlockObject { confirmations, .. } = &**obj;
-        assert_eq!(
-            *confirmations, -1,
-            "side-chain block should have -1 confirmations at the block level"
-        );
-    } else {
-        panic!("expected GetBlockResponse::Object for verbosity 2");
-    }
-
-    mempool.expect_no_requests().await;
-    read_state.expect_no_requests().await;
-
-    let rpc_tx_queue_task_result = rpc_tx_queue.now_or_never();
-    assert!(rpc_tx_queue_task_result.is_none());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1257,7 +1241,7 @@ async fn rpc_getrawtransaction() {
                 panic!("unexpected response to Depth request");
             };
 
-            let expected_confirmations = 1 + depth.expect("depth should be Some");
+            let expected_confirmations: i64 = (1 + depth.expect("depth should be Some")).into();
 
             (confirmations, expected_confirmations)
         }

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -831,6 +831,117 @@ async fn rpc_getblock_missing_error() {
     assert!(rpc_tx_queue_task_result.is_none());
 }
 
+/// Regression test for GHSA-x6v8-c2xp-928m.
+#[tokio::test(flavor = "multi_thread")]
+async fn rpc_getblock_side_chain_verbosity2_does_not_panic() {
+    let _init_guard = zebra_test::init();
+
+    let block: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
+        .zcash_deserialize_into()
+        .unwrap();
+    let block_hash = block.hash();
+    let block_header = block.header.clone();
+    let block_size = block.zcash_serialized_size();
+
+    let mut mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let mut read_state: MockService<_, _, _, BoxError> =
+        MockService::build()
+            .with_max_request_delay(std::time::Duration::from_secs(5))
+            .for_unit_tests();
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, rpc_tx_queue) = RpcImpl::new(
+        Mainnet,
+        Default::default(),
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool.clone(), 1),
+        Buffer::new(state.clone(), 1),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        MockSyncStatus::default(),
+        NoChainTip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    let rpc_clone = rpc.clone();
+    let hash_str = block_hash.to_string();
+    let block_future =
+        tokio::spawn(async move { rpc_clone.get_block(hash_str, Some(2u8)).await });
+
+    // get_block_header sub-call: BlockHeader
+    read_state
+        .expect_request(ReadRequest::BlockHeader(block_hash.into()))
+        .await
+        .respond(ReadResponse::BlockHeader {
+            header: block_header,
+            hash: block_hash,
+            height: zebra_chain::block::Height(0),
+            next_block_hash: None,
+        });
+
+    // get_block_header sub-call: SaplingTree
+    read_state
+        .expect_request_that(|req| matches!(req, ReadRequest::SaplingTree(_)))
+        .await
+        .respond(ReadResponse::SaplingTree(Some(Default::default())));
+
+    // get_block_header sub-call: Depth — return None to simulate a side-chain block
+    read_state
+        .expect_request(ReadRequest::Depth(block_hash))
+        .await
+        .respond(ReadResponse::Depth(None));
+
+    // get_block: BlockAndSize
+    read_state
+        .expect_request_that(|req| matches!(req, ReadRequest::BlockAndSize(_)))
+        .await
+        .respond(ReadResponse::BlockAndSize(Some((block, block_size))));
+
+    // get_block: OrchardTree
+    read_state
+        .expect_request_that(|req| matches!(req, ReadRequest::OrchardTree(_)))
+        .await
+        .respond(ReadResponse::OrchardTree(Some(Default::default())));
+
+    // get_block: BlockInfo (previous block)
+    read_state
+        .expect_request_that(|req| matches!(req, ReadRequest::BlockInfo(_)))
+        .await
+        .respond(ReadResponse::BlockInfo(None));
+
+    // get_block: BlockInfo (current block)
+    read_state
+        .expect_request_that(|req| matches!(req, ReadRequest::BlockInfo(_)))
+        .await
+        .respond(ReadResponse::BlockInfo(Some(BlockInfo::default())));
+
+    let result = block_future
+        .await
+        .expect("task should not panic")
+        .expect("getblock should succeed for side-chain blocks");
+
+    if let GetBlockResponse::Object(obj) = &result {
+        let BlockObject { confirmations, .. } = &**obj;
+        assert_eq!(
+            *confirmations, -1,
+            "side-chain block should have -1 confirmations at the block level"
+        );
+    } else {
+        panic!("expected GetBlockResponse::Object for verbosity 2");
+    }
+
+    mempool.expect_no_requests().await;
+    read_state.expect_no_requests().await;
+
+    let rpc_tx_queue_task_result = rpc_tx_queue.now_or_never();
+    assert!(rpc_tx_queue_task_result.is_none());
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn rpc_getblockheader() {
     let _init_guard = zebra_test::init();

--- a/zebra-rpc/src/methods/types/transaction.rs
+++ b/zebra-rpc/src/methods/types/transaction.rs
@@ -290,7 +290,7 @@ pub struct TransactionObject {
     /// mempool.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[getter(copy)]
-    pub(crate) confirmations: Option<u32>,
+    pub(crate) confirmations: Option<i64>,
 
     /// Transparent inputs of the transaction.
     #[serde(rename = "vin")]
@@ -794,7 +794,7 @@ impl TransactionObject {
     pub fn from_transaction(
         tx: Arc<Transaction>,
         height: Option<block::Height>,
-        confirmations: Option<u32>,
+        confirmations: Option<i64>,
         network: &Network,
         block_time: Option<DateTime<Utc>>,
         block_hash: Option<block::Hash>,


### PR DESCRIPTION
## Summary

`getblock <hash> 2` on a side-chain block panics because `-1` confirmations (`i64`) is narrowed to `u32`. This kills the node.

Fix: change `TransactionObject.confirmations` from `u32` to `i64`, matching zcashd and the rest of Zebra's codebase.

## Verified

- Regression test aborts on unfixed code, passes with fix
- `cargo test -p zebra-rpc --lib` — 75 passed
- `cargo test --workspace --lib` — 118 passed
- `cargo test --workspace --doc` — passed
