### PR TITLE
fix: enforce per-peer admission cap on directly pushed transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,13 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   attestation, and a signed SBOM, so anyone can confirm an image came from Zebra's CI
   with `cosign verify` or `gh attestation verify`
   ([#10798](https://github.com/ZcashFoundation/zebra/pull/10798))
+- Route directly pushed transactions (`tx` messages) through the same per-peer
+  mempool admission accounting as advertised transaction IDs, so a single inbound
+  peer cannot bypass the per-peer download cap by pushing full transactions
+  instead of advertising them
+  ([GHSA-m9xx-8rcj-vmgp](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-m9xx-8rcj-vmgp)).
+  This is the direct-push counterpart of the advertisement-path fix in
+  GHSA-4fc2-h7jh-287c. Thanks to @SuplabsYi for reporting the issue.
 
 ## [Zebra 5.2.0](https://github.com/ZcashFoundation/zebra/releases/tag/v5.2.0) - 2026-06-18
 

--- a/zebra-network/CHANGELOG.md
+++ b/zebra-network/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- `Request::PushTransaction` now carries the sending peer's address as a second field
+  (`Option<PeerSocketAddr>`), so directly pushed transactions are attributed to the
+  sending peer and subject to the same per-peer mempool admission cap as advertised
+  transaction IDs
+  ([GHSA-m9xx-8rcj-vmgp](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-m9xx-8rcj-vmgp)).
+
 ### Added
 
 - Added the Regtest-only network config option `should_allow_unshielded_coinbase_spends`,

--- a/zebra-network/src/peer/client/tests.rs
+++ b/zebra-network/src/peer/client/tests.rs
@@ -205,6 +205,10 @@ impl ClientTestHarness {
 /// The result of an attempt to receive a [`ClientRequest`] sent by the [`Client`] instance.
 ///
 /// The remote peer that would receive the request is mocked for testing.
+// The size disparity between the empty `Closed`/`Empty` variants and the
+// request-carrying variant is intrinsic to this test helper, which is only
+// constructed once per receive attempt.
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum ReceiveRequestAttempt {
     /// The [`Client`] instance has closed the sender endpoint of the channel.
     Closed,

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -1114,7 +1114,7 @@ where
                     )
             }
 
-            (AwaitingRequest, PushTransaction(transaction)) => {
+            (AwaitingRequest, PushTransaction(transaction, _)) => {
                 self
                     .peer_tx
                     .send(Message::Tx(transaction))
@@ -1275,7 +1275,14 @@ where
 
                 Consumed
             }
-            Message::Tx(ref transaction) => Request::PushTransaction(transaction.clone()).into(),
+            Message::Tx(ref transaction) => Request::PushTransaction(
+                transaction.clone(),
+                // Tag the directly pushed transaction with the sending peer so the
+                // mempool downloader can enforce a per-peer queue cap, just like
+                // advertised transaction IDs. See `GHSA-m9xx-8rcj-vmgp`.
+                self.connection_info.connected_addr.get_transient_addr(),
+            )
+            .into(),
             Message::Inv(ref items) => match &items[..] {
                 // We don't expect to be advertised multiple blocks at a time,
                 // so we ignore any advertisements of multiple blocks.

--- a/zebra-network/src/protocol/internal/request.rs
+++ b/zebra-network/src/protocol/internal/request.rs
@@ -142,10 +142,16 @@ pub enum Request {
     ///
     /// This is implemented by sending an unsolicited `tx` message.
     ///
+    /// The second field is the address of the peer that pushed this `tx` to us:
+    /// `Some(addr)` when a remote peer sent us the full transaction directly,
+    /// and `None` when Zebra originates the push itself. Used by the mempool
+    /// downloader to enforce a per-peer queue cap, mirroring
+    /// [`Request::AdvertiseTransactionIds`]. See `GHSA-m9xx-8rcj-vmgp`.
+    ///
     /// # Returns
     ///
     /// Returns [`Response::Nil`](super::Response::Nil).
-    PushTransaction(UnminedTx),
+    PushTransaction(UnminedTx, Option<PeerSocketAddr>),
 
     /// Advertise a set of unmined transactions to all peers.
     ///
@@ -235,7 +241,7 @@ impl fmt::Display for Request {
                 if stop.is_some() { "Some" } else { "None" },
             ),
 
-            Request::PushTransaction(_) => "PushTransaction".to_string(),
+            Request::PushTransaction(..) => "PushTransaction".to_string(),
             Request::AdvertiseTransactionIds(ids, _) => {
                 format!("AdvertiseTransactionIds({})", ids.len())
             }
@@ -260,7 +266,7 @@ impl Request {
             Request::FindBlocks { .. } => "FindBlocks",
             Request::FindHeaders { .. } => "FindHeaders",
 
-            Request::PushTransaction(_) => "PushTransaction",
+            Request::PushTransaction(..) => "PushTransaction",
             Request::AdvertiseTransactionIds(_, _) => "AdvertiseTransactionIds",
 
             Request::AdvertiseBlock(_, _) | Request::AdvertiseBlockToAll(_) => "AdvertiseBlock",

--- a/zebra-node-services/CHANGELOG.md
+++ b/zebra-node-services/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Breaking Changes
+
+- `mempool::Request::QueueFromPeer` now carries `candidates: Vec<Gossip>` instead of
+  `txids: HashSet<UnminedTxId>`, so directly pushed transactions (`Tx` messages) are
+  attributed to the sending peer and routed through the same per-peer admission
+  accounting as advertised transaction IDs
+  ([GHSA-m9xx-8rcj-vmgp](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-m9xx-8rcj-vmgp)).
+
 ## [8.0.0] - 2026-06-10
 
 ### Changed

--- a/zebra-node-services/src/mempool.rs
+++ b/zebra-node-services/src/mempool.rs
@@ -85,13 +85,17 @@ pub enum Request {
     /// The transaction downloader checks for duplicates across IDs and transactions.
     Queue(Vec<Gossip>),
 
-    /// Queue transaction IDs advertised by a specific peer via an `Inv`
-    /// message, tagging each one with the announcing peer so the downloader
-    /// can enforce a per-peer queue cap. See `GHSA-4fc2-h7jh-287c`.
+    /// Queue candidate transactions received from a specific peer — either
+    /// transaction IDs advertised via an `Inv` message, or a full transaction
+    /// pushed via a `Tx` message — tagging each one with the sending peer so the
+    /// downloader can enforce a per-peer queue cap. This routes every
+    /// peer-originated candidate through the same per-peer admission accounting,
+    /// so a single peer cannot crowd out honest peers' transaction relay.
+    /// See `GHSA-4fc2-h7jh-287c` and `GHSA-m9xx-8rcj-vmgp`.
     QueueFromPeer {
-        /// The transaction IDs advertised by the peer.
-        txids: HashSet<UnminedTxId>,
-        /// The address of the peer that advertised them.
+        /// The candidate transactions received from the peer.
+        candidates: Vec<Gossip>,
+        /// The address of the peer that sent them.
         source: SocketAddr,
     },
 

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -524,10 +524,20 @@ impl Service<zn::Request> for Inbound {
                 })
                     .boxed()
             }
-            zn::Request::PushTransaction(transaction) => {
+            zn::Request::PushTransaction(transaction, sender) => {
+                // Tag a directly pushed transaction with the sending peer so the
+                // mempool downloader can enforce a per-peer queue cap, mirroring
+                // the advertisement path below. See `GHSA-m9xx-8rcj-vmgp`.
+                let request = match sender {
+                    Some(peer_addr) => mempool::Request::QueueFromPeer {
+                        candidates: vec![transaction.into()],
+                        source: *peer_addr,
+                    },
+                    None => mempool::Request::Queue(vec![transaction.into()]),
+                };
                 mempool
                     .clone()
-                    .oneshot(mempool::Request::Queue(vec![transaction.into()]))
+                    .oneshot(request)
                     // The response just indicates if processing was queued or not; ignore it
                     .map_ok(|_resp| zn::Response::Nil)
                     .boxed()
@@ -538,7 +548,7 @@ impl Service<zn::Request> for Inbound {
                 // See `GHSA-4fc2-h7jh-287c`.
                 let request = match advertiser {
                     Some(peer_addr) => mempool::Request::QueueFromPeer {
-                        txids: transactions,
+                        candidates: transactions.into_iter().map(Into::into).collect(),
                         source: *peer_addr,
                     },
                     None => mempool::Request::Queue(

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -226,6 +226,118 @@ async fn mempool_push_transaction() -> Result<(), crate::BoxError> {
     Ok(())
 }
 
+/// The inbound service must route a directly pushed transaction that carries a
+/// sending peer through the per-peer-capped mempool path
+/// ([`mempool::Request::QueueFromPeer`]), and only fall back to the uncapped
+/// [`mempool::Request::Queue`] path for a source-less local/internal push.
+///
+/// Routing a peer push through `Queue` was the actual bypass: it dropped the
+/// peer address, so the downloader's per-peer cap never applied. The downloader
+/// already enforced the cap for source-tagged candidates before this fix, so the
+/// regression lives in this routing decision, not in the downloader.
+///
+/// Regression test for `GHSA-m9xx-8rcj-vmgp`.
+#[tokio::test(flavor = "multi_thread")]
+async fn push_transaction_routing_enforces_per_peer_source() -> Result<(), crate::BoxError> {
+    let _init_guard = zebra_test::init();
+
+    let network = Mainnet;
+    let consensus_config = ConsensusConfig::default();
+    let state_config = StateConfig::ephemeral();
+
+    let address_book = AddressBook::new(
+        SocketAddr::from_str("0.0.0.0:0").unwrap(),
+        &Mainnet,
+        DEFAULT_MAX_CONNS_PER_IP,
+        Span::none(),
+    );
+    let address_book = Arc::new(std::sync::Mutex::new(address_book));
+
+    // The push path only touches the mempool; the state and block verifier are
+    // wired up because `Inbound` requires them, but are never driven here.
+    let (state, _read_only_state_service, latest_chain_tip, _chain_tip_change) =
+        zebra_state::init(state_config, &network, Height::MAX, 0).await;
+    let state_service = ServiceBuilder::new().buffer(1).service(state);
+
+    let (block_verifier, _transaction_verifier, _groth16_download_handle, _max_checkpoint_height) =
+        zebra_consensus::router::init_test(consensus_config, &network, state_service.clone()).await;
+
+    let peer_set = MockService::build()
+        .with_max_request_delay(MAX_PEER_SET_REQUEST_DELAY)
+        .for_unit_tests();
+    let buffered_peer_set = Buffer::new(BoxService::new(peer_set), 10);
+
+    // Keep a handle to the mock mempool so we can assert on the request the
+    // inbound service routes to it.
+    let mut mempool_service: MockService<mempool::Request, mempool::Response, PanicAssertion> =
+        MockService::build()
+            .with_max_request_delay(MAX_PEER_SET_REQUEST_DELAY)
+            .for_unit_tests();
+    let buffered_mempool = Buffer::new(BoxService::new(mempool_service.clone()), 10);
+
+    let (setup_tx, setup_rx) = oneshot::channel();
+    let inbound_service = ServiceBuilder::new()
+        .load_shed()
+        .service(Inbound::new(MAX_INBOUND_CONCURRENCY, setup_rx));
+    let inbound_service = BoxService::new(inbound_service);
+    let inbound_service = ServiceBuilder::new().buffer(1).service(inbound_service);
+
+    let (misbehavior_sender, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
+    let setup_data = InboundSetupData {
+        address_book,
+        block_download_peer_set: buffered_peer_set,
+        block_verifier,
+        mempool: buffered_mempool,
+        state: state_service,
+        latest_chain_tip,
+        misbehavior_sender,
+    };
+    let r = setup_tx.send(setup_data);
+    // We can't expect or unwrap because the returned Result does not implement Debug.
+    assert!(r.is_ok(), "unexpected setup channel send failure");
+
+    // A non-coinbase transaction to push.
+    let block: Arc<Block> =
+        zebra_test::vectors::BLOCK_MAINNET_982681_BYTES.zcash_deserialize_into()?;
+    let unmined_tx: UnminedTx = block.transactions[1].clone().into();
+
+    // A push tagged with a sending peer is routed through the per-peer-capped path.
+    let peer = PeerSocketAddr::from(([192, 168, 180, 9], 10_000));
+    let request = inbound_service
+        .clone()
+        .oneshot(Request::PushTransaction(unmined_tx.clone(), Some(peer)));
+    let expected = mempool_service
+        .expect_request(mempool::Request::QueueFromPeer {
+            candidates: vec![mempool::Gossip::Tx(unmined_tx.clone())],
+            source: *peer,
+        })
+        .map(|responder| responder.respond(mempool::Response::Queued(vec![])));
+    let (push_response, _) = futures::join!(request, expected);
+    assert_eq!(
+        push_response.expect("unexpected error response from inbound service"),
+        Response::Nil,
+        "a peer-sourced push must be accepted and routed to `QueueFromPeer`",
+    );
+
+    // A source-less push (local/internal) stays on the uncapped `Queue` path.
+    let request = inbound_service
+        .clone()
+        .oneshot(Request::PushTransaction(unmined_tx.clone(), None));
+    let expected = mempool_service
+        .expect_request(mempool::Request::Queue(vec![mempool::Gossip::Tx(
+            unmined_tx,
+        )]))
+        .map(|responder| responder.respond(mempool::Response::Queued(vec![])));
+    let (push_response, _) = futures::join!(request, expected);
+    assert_eq!(
+        push_response.expect("unexpected error response from inbound service"),
+        Response::Nil,
+        "a source-less push must be accepted and routed to `Queue`",
+    );
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn mempool_advertise_transaction_ids() -> Result<(), crate::BoxError> {
     // get a block that has at least one non coinbase transaction

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -23,7 +23,7 @@ use zebra_network::{
         ADDR_RESPONSE_LIMIT_DENOMINATOR, DEFAULT_MAX_CONNS_PER_IP, MAX_ADDRS_IN_ADDRESS_BOOK,
     },
     types::{MetaAddr, PeerServices},
-    AddressBook, InventoryResponse, Request, Response,
+    AddressBook, InventoryResponse, PeerSocketAddr, Request, Response,
 };
 use zebra_node_services::mempool;
 use zebra_rpc::SubmitBlockChannel;
@@ -154,9 +154,10 @@ async fn mempool_push_transaction() -> Result<(), crate::BoxError> {
     ) = setup(false).await;
 
     // Test `Request::PushTransaction`
-    let request = inbound_service
-        .clone()
-        .oneshot(Request::PushTransaction(tx.clone().into()));
+    let request = inbound_service.clone().oneshot(Request::PushTransaction(
+        tx.clone().into(),
+        Some(PeerSocketAddr::from(([192, 168, 180, 9], 10_000))),
+    ));
     // Simulate a successful transaction verification
     let verification = tx_verifier.expect_request_that(|_| true).map(|responder| {
         let transaction = responder
@@ -367,9 +368,10 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
     ) = setup(false).await;
 
     // Push test transaction
-    let request = inbound_service
-        .clone()
-        .oneshot(Request::PushTransaction(tx1.clone().into()));
+    let request = inbound_service.clone().oneshot(Request::PushTransaction(
+        tx1.clone().into(),
+        Some(PeerSocketAddr::from(([192, 168, 180, 9], 10_000))),
+    ));
     // Simulate a successful transaction verification
     let verification = tx_verifier.expect_request_that(|_| true).map(|responder| {
         tx1_id = responder.request().tx_id();
@@ -508,9 +510,10 @@ async fn mempool_transaction_expiration() -> Result<(), crate::BoxError> {
         .respond(Response::Nil);
 
     // Push a second transaction to trigger `remove_expired_transactions()`
-    let request = inbound_service
-        .clone()
-        .oneshot(Request::PushTransaction(tx2.clone().into()));
+    let request = inbound_service.clone().oneshot(Request::PushTransaction(
+        tx2.clone().into(),
+        Some(PeerSocketAddr::from(([192, 168, 180, 9], 10_000))),
+    ));
     // Simulate a successful transaction verification
     let verification = tx_verifier.expect_request_that(|_| true).map(|responder| {
         tx2_id = responder.request().tx_id();

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -893,17 +893,18 @@ impl Service<Request> for Mempool {
                     async move { Ok(Response::Queued(rsp)) }.boxed()
                 }
 
-                // Queue inv-advertised candidates from a specific peer.
-                // Per-peer accounting is enforced inside the downloader.
-                Request::QueueFromPeer { txids, source } => {
-                    trace!(req_count = ?txids.len(), ?source, "got mempool QueueFromPeer request");
+                // Queue candidates received from a specific peer (advertised IDs
+                // or a directly pushed transaction). Per-peer accounting is
+                // enforced inside the downloader.
+                Request::QueueFromPeer { candidates, source } => {
+                    trace!(req_count = ?candidates.len(), ?source, "got mempool QueueFromPeer request");
 
-                    for txid in txids {
-                        if storage.should_download_or_verify(txid).is_err() {
+                    for candidate in candidates {
+                        if storage.should_download_or_verify(candidate.id()).is_err() {
                             continue;
                         }
                         let _ = tx_downloads.download_if_needed_and_verify(
-                            Gossip::Id(txid),
+                            candidate,
                             Some(source),
                             None,
                         );

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -645,3 +645,6 @@ where
         metrics::gauge!("mempool.currently.queued.transactions").set(0 as f64);
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/zebrad/src/components/mempool/downloads/tests.rs
+++ b/zebrad/src/components/mempool/downloads/tests.rs
@@ -1,0 +1,65 @@
+//! Fixed test vectors for the mempool transaction downloader.
+
+use zebra_chain::parameters::Network;
+use zebra_test::mock_service::{MockService, PanicAssertion};
+
+use super::*;
+
+/// A directly pushed full transaction must consume the sending peer's
+/// per-peer admission budget, exactly like an advertised transaction ID, so
+/// a single peer cannot bypass [`MAX_INBOUND_CONCURRENCY_PER_PEER`] by
+/// sending `tx` messages instead of `inv` advertisements.
+///
+/// Regression test for `GHSA-m9xx-8rcj-vmgp`.
+#[tokio::test]
+async fn per_peer_cap_applies_to_pushed_transactions() {
+    let _init_guard = zebra_test::init();
+
+    let network = Network::Mainnet;
+    let source: SocketAddr = "192.168.0.1:8233".parse().expect("valid socket address");
+
+    // Distinct full transactions, as if pushed directly by a single peer.
+    let pushed: Vec<Gossip> = network
+        .unmined_transactions_in_blocks(1..=10)
+        .take(MAX_INBOUND_CONCURRENCY_PER_PEER + 1)
+        .map(|tx| Gossip::Tx(tx.transaction))
+        .collect();
+    assert_eq!(
+        pushed.len(),
+        MAX_INBOUND_CONCURRENCY_PER_PEER + 1,
+        "test needs enough distinct transactions to exceed the per-peer cap",
+    );
+
+    // The cap is enforced before any download/verify work, so the services
+    // are never actually driven in this test.
+    let peer_set: MockService<zn::Request, zn::Response, PanicAssertion> =
+        MockService::build().for_unit_tests();
+    let verifier: MockService<tx::Request, tx::Response, PanicAssertion> =
+        MockService::build().for_unit_tests();
+    let state: MockService<zs::Request, zs::Response, PanicAssertion> =
+        MockService::build().for_unit_tests();
+
+    let mut downloads = Downloads::new(peer_set, verifier, state);
+
+    // The first `MAX_INBOUND_CONCURRENCY_PER_PEER` pushes from this peer are admitted.
+    for gossip in pushed.iter().take(MAX_INBOUND_CONCURRENCY_PER_PEER) {
+        downloads
+            .download_if_needed_and_verify(gossip.clone(), Some(source), None)
+            .expect("pushes below the per-peer cap are admitted");
+    }
+
+    // The next push from the same peer exceeds the per-peer cap and is
+    // rejected, even though the global queue still has spare capacity.
+    let result = downloads.download_if_needed_and_verify(
+        pushed[MAX_INBOUND_CONCURRENCY_PER_PEER].clone(),
+        Some(source),
+        None,
+    );
+    assert!(
+        matches!(result, Err(MempoolError::FullQueue)),
+        "a push exceeding the per-peer cap must be rejected with `FullQueue`, got {result:?}",
+    );
+
+    // Don't leave spawned download tasks behind when the runtime shuts down.
+    downloads.cancel_all();
+}


### PR DESCRIPTION
## Motivation

Fixes **GHSA-m9xx-8rcj-vmgp** — direct P2P `tx` messages bypass the per-peer mempool admission cap.

Zebra caps concurrent inbound mempool admissions per peer (`MAX_INBOUND_CONCURRENCY_PER_PEER = 5`) alongside a global cap. The advertisement path (`inv` / `AdvertiseTransactionIds`) carries the announcing peer and is capped (GHSA-4fc2-h7jh-287c). The direct-push path (`Message::Tx`) converted the full transaction to an internal push request that **dropped the peer address**, queuing it with `source = None`, so the per-peer cap never applied. A single inbound peer could hold more than its five slots by pushing full transactions instead of advertising txids, crowding out honest peers' relay. The global cap still bounds total in-flight work, so this is a per-peer fairness bypass, not resource exhaustion.

## Solution

Thread the sending peer through the push path and route every peer-originated candidate through the same per-peer admission accounting, which now converges at the downloader:

- `Request::PushTransaction` carries the sender's `Option<PeerSocketAddr>`, mirroring `AdvertiseTransactionIds`. The `Message::Tx` handler tags it with the peer's transient address.
- `QueueFromPeer` is generalized from `{ txids: HashSet<UnminedTxId>, source }` to `{ candidates: Vec<Gossip>, source }`, so it handles advertised IDs and directly pushed full transactions alike.
- The inbound service routes pushes through `QueueFromPeer` when a peer source is present, falling back to the uncapped `Queue` only for genuinely local/internal pushes (`source = None`).

Direct-push counterpart of the advertisement-path fix in GHSA-4fc2-h7jh-287c.

## Test evidence

- New regression test `per_peer_cap_applies_to_pushed_transactions` (`zebrad/src/components/mempool/downloads/tests.rs`): pushing `MAX_INBOUND_CONCURRENCY_PER_PEER + 1` full transactions from one peer admits 5 and rejects the 6th with `FullQueue` while the global queue still has capacity. Passes.
- Existing inbound push/advertise tests updated to exercise the peer-sourced path; all 75 zebrad mempool/inbound lib tests and 187 zebra-network lib tests pass.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo check --workspace --all-targets` are clean.

## Changelog

`### Security` entry in the workspace `CHANGELOG.md`; breaking-change entries in the `zebra-network` and `zebra-node-services` crate changelogs (both public enums changed).

## AI disclosure

Implemented with Claude Code (Opus 4.8): the code change, the regression test, the changelog entries, and this description. Reviewed by the author, who is the responsible contributor.

https://claude.ai/code/session_01V6cmTG3abFnvSCJrZLCaAX

