### PR TITLE
fix(chain): round-trip v6 transactions through librustzcash on deserialize

### DIFF
--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -1129,7 +1129,15 @@ pub fn fake_v6_orchard_shielded_data(
         flags,
         value_balance,
         shared_anchor: orchard::tree::Root::default(),
-        proof: Halo2Proof(vec![]),
+        // A canonically-sized (zero-filled) proof, so librustzcash's parser — which enforces the
+        // canonical proof size — accepts the bundle when the wire deserializer round-trips through
+        // it. The proof is not cryptographically valid.
+        proof: Halo2Proof(vec![
+            0u8;
+            orchard::shielded_data::expected_proof_size(
+                action_count.max(1)
+            )
+        ]),
         actions: actions.try_into().expect("action_count is at least one"),
         binding_sig: Signature::from([0u8; 64]),
     }

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -1197,13 +1197,7 @@ impl ZcashDeserialize for Transaction {
                 let ironwood_shielded_data = (&mut limited_reader)
                     .zcash_deserialize_into::<Option<ironwood::ShieldedData>>()?;
 
-                // Unlike the v5 arm, the v6 arm does not round-trip through `to_librustzcash` here:
-                // that would drive librustzcash's proof parser (which rejects the structurally-fake
-                // proofs the test helpers produce), coupling wire deserialization to proof parsing.
-                // The `enableCrossAddress` divergence that would otherwise reach the txid-path
-                // `expect(...)` is already rejected above, inside `orchard::Flags::from_byte`, before
-                // this transaction is constructed.
-                Ok(Transaction::V6 {
+                let tx = Transaction::V6 {
                     network_upgrade,
                     lock_time,
                     expiry_height,
@@ -1212,7 +1206,16 @@ impl ZcashDeserialize for Transaction {
                     sapling_shielded_data,
                     orchard_shielded_data,
                     ironwood_shielded_data,
-                })
+                };
+
+                // Validate that the whole transaction round-trips to the librustzcash format, as the
+                // v5 arm above does. Zebra's and librustzcash's parsers are not identical, so this
+                // fails closed at the wire layer for any divergence, ensuring an incompatibility can
+                // never reach the `expect(...)` in the txid/auth-digest path (`Hash::from`), which
+                // would otherwise abort the node on attacker-supplied input.
+                tx.to_librustzcash(network_upgrade)?;
+
+                Ok(tx)
             }
             (_, _) => Err(SerializationError::Parse("bad tx header")),
         }


### PR DESCRIPTION
## Motivation

Follow-up to the review of #10886 ([conradoplg's comment](https://github.com/ZcashFoundation/zebra/pull/10886#discussion_r3515374947)): the v6 deserialize arm should keep the `to_librustzcash` round-trip that the v5 arm has, because Zebra's and librustzcash's parsers are not identical and any divergence not caught at the wire layer resurfaces as a panic in the txid/auth-digest `expect(...)`.

## Solution

Restore the `tx.to_librustzcash(network_upgrade)?` guard on the v6 arm (matching v5), so a Zebra/librustzcash parser divergence fails closed at parse time instead of reaching `Hash::from`'s `expect(...)` and aborting the node.

librustzcash's parser enforces the canonical Orchard proof size, so the v6 test helpers (`fake_v6_orchard_shielded_data`) now emit a canonically-sized (still cryptographically invalid) proof instead of an empty one, so the round-trip accepts the fixtures. The `enableCrossAddress` divergence #10886 targets is still rejected earlier in `orchard::Flags::from_byte`; this guard is the general backstop for any other divergence.

### Tests

Local gate green on `d.lan` under `--all-features`: `fmt --check`, `clippy --workspace --all-targets --all-features -D warnings`, and `nextest -p zebra-chain -p zebra-consensus --all-features` (377/377), including `v6_transaction_with_bundles_round_trips`, `v6_ironwood_txid_and_roundtrip`, and `v6_orchard_bundle_rejects_cross_address_flag_on_the_wire`.

### Specifications & References

- Follow-up to #10886 (now merged); based on `main`.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude implemented the fix and drafted this description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.