### PR TITLE
fix(state): serve the empty Ironwood tree before NU6.3 activation

### DIFF
--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -21,6 +21,7 @@ use zebra_chain::{
     block::Height,
     ironwood, orchard,
     parallel::tree::NoteCommitmentTrees,
+    parameters::NetworkUpgrade,
     sapling, sprout,
     subtree::{NoteCommitmentSubtreeData, NoteCommitmentSubtreeIndex},
     transaction::Transaction,
@@ -527,18 +528,29 @@ impl ZebraDb {
 
         let ironwood_trees = self.db.cf_handle("ironwood_note_commitment_tree").unwrap();
 
+        // The genesis Ironwood tree is seeded with the empty tree by the `add_ironwood_tree` format
+        // upgrade and then written per-height by block commits, so once the upgrade has run there is
+        // always a tree at or below any height up to the tip. The upgrade runs on a background
+        // thread (`spawn_format_change`), so there is a brief window right after a v27->v28 upgrade
+        // where the column family is still empty while block commits proceed. Any read during that
+        // window is at a pre-NU6.3 height — an upgrading node's chain is entirely pre-NU6.3, and no
+        // NU6.3 block can be committed before the tree is seeded — where the empty tree is the
+        // correct answer. So before activation, fall back to the empty tree rather than panicking.
+        // (This also covers networks where NU6.3 is not scheduled, whose whole chain is
+        // pre-Ironwood.) From NU6.3 activation onward a missing tree is a real invariant violation
+        // (corruption or an interrupted backfill), so fail loudly instead of masking it.
+        let nu6_3_activated = NetworkUpgrade::Nu6_3
+            .activation_height(&self.network())
+            .is_some_and(|activation| *height >= activation);
+
         // Search backwards for the tree.
-        //
-        // The Ironwood column family is seeded with the genesis (empty) tree by the
-        // `add_ironwood_tree` format upgrade and then written per-height by block commits, so once
-        // the upgrade has run there is always a tree at or below any height up to the tip. The
-        // upgrade runs on a background thread, so there is a brief window right after a v27->v28
-        // upgrade where the column family is still empty. That window only occurs before NU6.3
-        // activation, when the Ironwood tree at every height is in fact the empty tree, so fall
-        // back to the empty tree instead of panicking.
         match self.db.zs_prev_key_value_back_from(&ironwood_trees, height) {
             Some((_first_duplicate_height, tree)) => Some(Arc::new(tree)),
-            None => Some(Default::default()),
+            None if !nu6_3_activated => Some(Default::default()),
+            None => panic!(
+                "Ironwood note commitment tree must exist for all heights at or below the finalized \
+                 tip from NU6.3 activation onward"
+            ),
         }
     }
 


### PR DESCRIPTION
## Motivation

`ZebraDb::ironwood_tree_by_height` falls back to the empty tree when the `ironwood_note_commitment_tree` column family has no entry at or below the queried height. That fallback exists to cover the brief window right after a v27→v28 upgrade, before the `add_ironwood_tree` backfill (which runs on a background thread, `spawn_format_change`) seeds the genesis tree.

But the fallback is **unbounded**: it also returns the empty tree for a missing entry *after* NU6.3 activation, where every committed block writes its Ironwood tree and a missing one is a real invariant violation (corruption or an interrupted backfill). Silently returning the empty tree there masks the fault and hands callers the wrong tree/anchor. The accessor's own comment already notes the window "only occurs before NU6.3 activation" — so the unbounded code is broader than its stated justification.

## Solution

Bound the fallback to pre-NU6.3 heights (matching that reasoning): before activation, and on networks where NU6.3 is unscheduled, return the empty tree; from activation onward, panic loudly instead of masking a missing tree.

### Tests

`clippy -p zebra-state --all-targets --all-features -D warnings` and the `zebra-state` `--all-features` suite pass (the one unrelated failure, `transparent::intra_block_self_spend_chain_in_finalized_state`, also fails on `main`).

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude found the issue and implemented the fix and description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
