### PR TITLE
fix(ci): ignore quick-xml RUSTSEC-2026-0194 and RUSTSEC-2026-0195 until inferno updates

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -9,12 +9,17 @@
 [advisories]
 version = 2
 yanked = "deny"
-# Unmaintained-crate advisories. Each entry is a transitive dep we can't upgrade
-# yet, or a direct dep. Remove each entry as its dependency chain is upgraded.
+# Ignored advisories. Each entry is a transitive dep we can't upgrade yet, or a
+# direct dep. Remove each entry as its dependency chain is upgraded.
 ignore = [
     "RUSTSEC-2026-0173", # proc-macro-error2 (unmaintained): via librustzcash orchard -> getset
     "RUSTSEC-2025-0119", # number_prefix: transitive via indicatif
     "RUSTSEC-2025-0141", # bincode: direct dependency
+    # quick-xml DoS advisories: via inferno (zebrad's `flamegraph` feature), which has no release
+    # allowing the fixed quick-xml 0.41 yet: https://github.com/jonhoo/inferno/pull/369.
+    # Zebra only feeds inferno locally generated profiling data, never untrusted XML.
+    "RUSTSEC-2026-0194", # quick-xml: quadratic duplicate-attribute check
+    "RUSTSEC-2026-0195", # quick-xml: unbounded namespace-declaration allocation
 ]
 
 # This section is considered when running `cargo deny check licenses`.


### PR DESCRIPTION
### Motivation

Closes #10898.

### Solution

Ignore RUSTSEC-2026-0194 and RUSTSEC-2026-0195 in `deny.toml`: the only path to `quick-xml` is via `inferno` (zebrad's `flamegraph` feature), which has no release allowing the fixed `quick-xml 0.41` yet (jonhoo/inferno#369). Zebra only feeds `inferno` locally generated profiling data, never untrusted XML. Remove the ignores once `inferno` updates.

### Tests

`cargo deny check advisories` passes locally in all three CI feature variants (default, `--features default-release-binaries`, `--all-features`); `bans`, `sources`, and `licenses` stay green.

### AI Disclosure

Used Claude Code to diagnose the failing job and draft the `deny.toml` change and this PR.