### PR TITLE
fix(chain): generate v6 transactions in NU6.3+ arbitrary strategies

### DIFF
--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AT_OR_NEAR_TIP_THRESHOLD` constant and `ChainTip::is_at_or_near_network_tip()`
   method for determining whether the node is within 5 blocks of the estimated network tip
   ([#10732](https://github.com/ZcashFoundation/zebra/pull/10732))
+- `ironwood::ShieldedData::data_mut`
+- With the `proptest-impl` feature:
+  - `transaction::Transaction::v6_strategy`
+  - `impl Arbitrary for orchard::ShieldedDataV6` and `ironwood::ShieldedData`
+  - `parameters::NetworkUpgrade::nu6_3_branch_id_strategy`
+  - `transaction::Transaction::ironwood_value_balance_mut`
+
+### Fixed
+
+- With the `proptest-impl` feature, the arbitrary `Transaction` strategy now generates v6
+  transactions (with v6 Orchard and Ironwood bundles) for NU6.3 and later network upgrades,
+  and accepts a transaction version override of 6. Previously it only generated v4/v5
+  transactions for those upgrades, so property tests built on it could never observe
+  v6/Ironwood data.
 
 ## [11.0.0] - 2026-07-02
 

--- a/zebra-chain/src/block/arbitrary.rs
+++ b/zebra-chain/src/block/arbitrary.rs
@@ -430,9 +430,10 @@ impl Block {
             let mut chain_value_pools = ValueBalance::zero();
             let mut sapling_tree = sapling::tree::NoteCommitmentTree::default();
             let mut orchard_tree = orchard::tree::NoteCommitmentTree::default();
-            // Ironwood reuses the Orchard note commitment tree type. Generated blocks have no
-            // Ironwood data, so this stays empty, but it must be threaded through the V3 history
-            // node (NU6.3+) using its real empty-tree root so commitments match validation.
+            // Ironwood reuses the Orchard note commitment tree type. Generated v6 transactions
+            // (NU6.3+) can carry Ironwood bundles, whose note commitments are appended below and
+            // threaded through the V3 history node so commitments match validation. For pre-NU6.3
+            // chains this stays empty, and its real empty-tree root is used the same way.
             let mut ironwood_tree = orchard::tree::NoteCommitmentTree::default();
             // The history tree usually takes care of "creating itself". But this
             // only works when blocks are pushed into it starting from genesis

--- a/zebra-chain/src/ironwood.rs
+++ b/zebra-chain/src/ironwood.rs
@@ -57,4 +57,10 @@ impl ShieldedData {
     pub fn data(&self) -> &orchard::ShieldedData {
         self.0.data()
     }
+
+    /// Returns the inner Orchard [`ShieldedData`](orchard::ShieldedData) backing this Ironwood
+    /// bundle, mutably.
+    pub fn data_mut(&mut self) -> &mut orchard::ShieldedData {
+        self.0.data_mut()
+    }
 }

--- a/zebra-chain/src/ironwood/arbitrary.rs
+++ b/zebra-chain/src/ironwood/arbitrary.rs
@@ -2,13 +2,35 @@
 
 use proptest::prelude::*;
 
-use crate::{ironwood::Nullifier, orchard};
+use crate::{
+    ironwood::{Nullifier, ShieldedData},
+    orchard,
+};
 
 impl Arbitrary for Nullifier {
     type Parameters = ();
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
         any::<orchard::Nullifier>().prop_map(Nullifier).boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
+impl Arbitrary for ShieldedData {
+    type Parameters = ();
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        (any::<orchard::ShieldedData>(), any::<u8>())
+            .prop_map(|(mut shielded_data, flag_bits)| {
+                // The base Orchard strategy only generates the pre-NU6.3 flag bits, because
+                // Orchard-pool bundles (v5 and v6) reserve `enableCrossAddress`. The Ironwood
+                // bundle is the only place that flag is valid, so re-generate the flags over
+                // all three defined bits to exercise the `FlagsV6` codec path.
+                shielded_data.flags = orchard::Flags::from_bits_truncate(flag_bits);
+                Self::new(orchard::ShieldedDataV6::new(shielded_data))
+            })
+            .boxed()
     }
 
     type Strategy = BoxedStrategy<Self>;

--- a/zebra-chain/src/orchard/arbitrary.rs
+++ b/zebra-chain/src/orchard/arbitrary.rs
@@ -119,10 +119,10 @@ impl Arbitrary for Flags {
     type Parameters = ();
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        // Only generate flags valid in the pre-NU6.3 (v5 Orchard) format: bit 2
-        // (`ENABLE_CROSS_ADDRESS`) is reserved before NU6.3, so generating it would produce v5
-        // Orchard bundles that do not round-trip. The arbitrary transaction strategies generate
-        // v4/v5 transactions, whose Orchard bundles use this format.
+        // Only generate flags valid for Orchard-pool bundles: bit 2 (`ENABLE_CROSS_ADDRESS`) is
+        // reserved for the Orchard pool in every transaction version (v5 and v6), so generating
+        // it would produce Orchard bundles that do not round-trip. Only the Ironwood bundle
+        // permits that flag; its strategy re-generates the flags (see `ironwood::ShieldedData`).
         let pre_nu6_3 = Self::ENABLE_SPENDS.bits() | Self::ENABLE_OUTPUTS.bits();
         (any::<u8>())
             .prop_map(move |bits| Self::from_bits_truncate(bits & pre_nu6_3))

--- a/zebra-chain/src/parameters/arbitrary.rs
+++ b/zebra-chain/src/parameters/arbitrary.rs
@@ -28,6 +28,19 @@ impl NetworkUpgrade {
         .boxed()
     }
 
+    /// Generates network upgrades that are valid for V6 transactions (NU6.3 onward).
+    ///
+    /// Does not generate `Nu7`: its consensus branch ID is still a placeholder that
+    /// librustzcash does not recognise, so transactions carrying it cannot round-trip
+    /// through `to_librustzcash` (which computes txids and auth digests).
+    pub fn nu6_3_branch_id_strategy() -> BoxedStrategy<NetworkUpgrade> {
+        prop_oneof![
+            Just(NetworkUpgrade::Nu6_3),
+            // TODO: add Nu7 once its consensus branch ID is set in librustzcash
+        ]
+        .boxed()
+    }
+
     /// Generates network upgrades from a reduced set
     pub fn reduced_branch_id_strategy() -> BoxedStrategy<NetworkUpgrade> {
         // We use this strategy to test legacy chain

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -1696,6 +1696,29 @@ impl Transaction {
             .map(|shielded_data| &mut shielded_data.value_balance)
     }
 
+    /// Modify the `value_balance` field from the `ironwood::ShieldedData` in this transaction,
+    /// regardless of version.
+    ///
+    /// See `ironwood_value_balance` for details.
+    pub fn ironwood_value_balance_mut(&mut self) -> Option<&mut Amount<NegativeAllowed>> {
+        match self {
+            Transaction::V6 {
+                ironwood_shielded_data: Some(ironwood_shielded_data),
+                ..
+            } => Some(&mut ironwood_shielded_data.data_mut().value_balance),
+
+            Transaction::V1 { .. }
+            | Transaction::V2 { .. }
+            | Transaction::V3 { .. }
+            | Transaction::V4 { .. }
+            | Transaction::V5 { .. }
+            | Transaction::V6 {
+                ironwood_shielded_data: None,
+                ..
+            } => None,
+        }
+    }
+
     /// Modify the `value_balance` field from the `sapling::ShieldedData` in this transaction,
     /// regardless of version.
     ///

--- a/zebra-chain/src/transaction/arbitrary.rs
+++ b/zebra-chain/src/transaction/arbitrary.rs
@@ -9,7 +9,7 @@ use reddsa::{orchard::Binding, Signature};
 use crate::{
     amount::{self, Amount, NegativeAllowed, NonNegative},
     block::{self, arbitrary::MAX_PARTIAL_CHAIN_BLOCKS},
-    orchard,
+    ironwood, orchard,
     parameters::{Network, NetworkUpgrade},
     primitives::{Bctv14Proof, Groth16Proof, Halo2Proof, ZkSnarkProof},
     sapling::{self, AnchorVariant, PerSpendAnchor, SharedAnchor},
@@ -180,6 +180,63 @@ impl Transaction {
             .boxed()
     }
 
+    /// Generate a proptest strategy for V6 Transactions
+    pub fn v6_strategy(ledger_state: LedgerState) -> BoxedStrategy<Self> {
+        (
+            NetworkUpgrade::nu6_3_branch_id_strategy(),
+            any::<LockTime>(),
+            any::<block::Height>(),
+            transparent::Input::vec_strategy(&ledger_state, MAX_ARBITRARY_ITEMS),
+            vec(any::<transparent::Output>(), 0..MAX_ARBITRARY_ITEMS),
+            option::of(any::<sapling::ShieldedData<sapling::SharedAnchor>>()),
+            option::of(any::<orchard::ShieldedDataV6>()),
+            option::of(any::<ironwood::ShieldedData>()),
+        )
+            .prop_map(
+                move |(
+                    network_upgrade,
+                    lock_time,
+                    expiry_height,
+                    inputs,
+                    outputs,
+                    sapling_shielded_data,
+                    orchard_shielded_data,
+                    ironwood_shielded_data,
+                )| {
+                    Transaction::V6 {
+                        network_upgrade: if ledger_state.transaction_has_valid_network_upgrade() {
+                            ledger_state.network_upgrade()
+                        } else {
+                            network_upgrade
+                        },
+                        lock_time,
+                        expiry_height,
+                        inputs,
+                        outputs,
+                        sapling_shielded_data: if ledger_state.height.is_min() {
+                            // The genesis block should not contain any shielded data.
+                            None
+                        } else {
+                            sapling_shielded_data
+                        },
+                        orchard_shielded_data: if ledger_state.height.is_min() {
+                            // The genesis block should not contain any shielded data.
+                            None
+                        } else {
+                            orchard_shielded_data
+                        },
+                        ironwood_shielded_data: if ledger_state.height.is_min() {
+                            // The genesis block should not contain any shielded data.
+                            None
+                        } else {
+                            ironwood_shielded_data
+                        },
+                    }
+                },
+            )
+            .boxed()
+    }
+
     /// Proptest Strategy for creating a Vector of transactions where the first
     /// transaction is always the only coinbase transaction
     pub fn vec_strategy(
@@ -220,7 +277,7 @@ impl Transaction {
         }
     }
 
-    /// Apply `f` to the sapling value balance and orchard value balance
+    /// Apply `f` to the sapling, orchard, and ironwood value balances
     /// in this transaction, regardless of version.
     pub fn for_each_value_balance_mut<F>(&mut self, mut f: F)
     where
@@ -232,6 +289,10 @@ impl Transaction {
 
         if let Some(orchard_value_balance) = self.orchard_value_balance_mut() {
             f(orchard_value_balance);
+        }
+
+        if let Some(ironwood_value_balance) = self.ironwood_value_balance_mut() {
+            f(ironwood_value_balance);
         }
     }
 
@@ -246,7 +307,8 @@ impl Transaction {
         where
             Amount<C>: Copy,
         {
-            const POOL_COUNT: u64 = 4;
+            // transparent, sprout, sapling, orchard, and ironwood
+            const POOL_COUNT: u64 = 5;
 
             let max_arbitrary_items: u64 = MAX_ARBITRARY_ITEMS.try_into().unwrap();
             let max_partial_chain_blocks: u64 = MAX_PARTIAL_CHAIN_BLOCKS.try_into().unwrap();
@@ -346,6 +408,14 @@ impl Transaction {
             }
         }
 
+        let ironwood_input = self.ironwood_value_balance().constrain::<NonNegative>();
+        if let Ok(ironwood_input) = ironwood_input {
+            match input_chain_value_pools.add_chain_value_pool_change(-ironwood_input) {
+                Ok(new_chain_pools) => input_chain_value_pools = new_chain_pools,
+                Err(_) => *self.ironwood_value_balance_mut().unwrap() = Amount::zero(),
+            }
+        }
+
         let remaining_transaction_value = self.fix_remaining_value(outputs)?;
 
         // check our calculations are correct
@@ -373,7 +443,7 @@ impl Transaction {
     /// Returns the total input value of this transaction's value pool.
     ///
     /// This is the sum of transparent inputs, sprout input values,
-    /// and if positive, the sapling and orchard value balances.
+    /// and if positive, the sapling, orchard, and ironwood value balances.
     ///
     /// `outputs` must contain all the [`transparent::Output`]s spent in this transaction.
     fn input_value_pool(
@@ -409,8 +479,14 @@ impl Transaction {
             .constrain::<NonNegative>()
             .unwrap_or_else(|_| Amount::zero());
 
+        let ironwood_input = self
+            .ironwood_value_balance()
+            .ironwood_amount()
+            .constrain::<NonNegative>()
+            .unwrap_or_else(|_| Amount::zero());
+
         let transaction_input_value_pool =
-            (transparent_inputs + sprout_inputs + sapling_input + orchard_input)
+            (transparent_inputs + sprout_inputs + sapling_input + orchard_input + ironwood_input)
                 .expect("chain is limited to MAX_MONEY");
 
         Ok(transaction_input_value_pool)
@@ -486,6 +562,17 @@ impl Transaction {
         }
 
         if let Some(value_balance) = self.orchard_value_balance_mut() {
+            if let Ok(output_value) = value_balance.neg().constrain::<NonNegative>() {
+                if remaining_input_value >= output_value {
+                    remaining_input_value = (remaining_input_value - output_value)
+                        .expect("input >= output so result is always non-negative");
+                } else {
+                    *value_balance = Amount::zero();
+                }
+            }
+        }
+
+        if let Some(value_balance) = self.ironwood_value_balance_mut() {
             if let Ok(output_value) = value_balance.neg().constrain::<NonNegative>() {
                 if remaining_input_value >= output_value {
                     remaining_input_value = (remaining_input_value - output_value)
@@ -747,6 +834,21 @@ impl Arbitrary for orchard::ShieldedData {
     type Strategy = BoxedStrategy<Self>;
 }
 
+impl Arbitrary for orchard::ShieldedDataV6 {
+    type Parameters = ();
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        // The v6 Orchard-pool bundle reserves `enableCrossAddress` exactly like v5, so the base
+        // `ShieldedData` strategy (which only generates the pre-NU6.3 flag bits) is reused as-is.
+        // Only the Ironwood bundle permits that flag; see the `ironwood::ShieldedData` strategy.
+        any::<orchard::ShieldedData>()
+            .prop_map(orchard::ShieldedDataV6::new)
+            .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 struct BindingSignature(pub(crate) Signature<Binding>);
 
@@ -782,6 +884,7 @@ impl Arbitrary for Transaction {
             Some(3) => return Self::v3_strategy(ledger_state),
             Some(4) => return Self::v4_strategy(ledger_state),
             Some(5) => return Self::v5_strategy(ledger_state),
+            Some(6) => return Self::v6_strategy(ledger_state),
             Some(_) => unreachable!("invalid transaction version in override"),
             None => {}
         }
@@ -798,11 +901,17 @@ impl Arbitrary for Transaction {
             NetworkUpgrade::Nu5
             | NetworkUpgrade::Nu6
             | NetworkUpgrade::Nu6_1
-            | NetworkUpgrade::Nu6_2
-            | NetworkUpgrade::Nu6_3
-            | NetworkUpgrade::Nu7 => prop_oneof![
+            | NetworkUpgrade::Nu6_2 => prop_oneof![
                 Self::v4_strategy(ledger_state.clone()),
                 Self::v5_strategy(ledger_state)
+            ]
+            .boxed(),
+
+            // V6 transactions are only valid from NU6.3; v4 and v5 remain valid alongside them.
+            NetworkUpgrade::Nu6_3 | NetworkUpgrade::Nu7 => prop_oneof![
+                Self::v4_strategy(ledger_state.clone()),
+                Self::v5_strategy(ledger_state.clone()),
+                Self::v6_strategy(ledger_state)
             ]
             .boxed(),
 

--- a/zebra-chain/src/transaction/tests/prop.rs
+++ b/zebra-chain/src/transaction/tests/prop.rs
@@ -1,8 +1,8 @@
 //! Randomised property tests for transactions.
 
-use proptest::prelude::*;
+use proptest::{prelude::*, strategy::ValueTree, test_runner::TestRunner};
 
-use std::io::Cursor;
+use std::{collections::HashSet, io::Cursor};
 
 use zebra_test::prelude::*;
 
@@ -12,38 +12,62 @@ use super::super::*;
 
 use crate::{
     block::Block,
+    parameters::NetworkUpgrade,
     serialization::{ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize},
     transaction::arbitrary::MAX_ARBITRARY_ITEMS,
     LedgerState,
 };
+
+/// Assert that `tx` round-trips through the wire format, or is rejected by the parser if it
+/// is a coinbase transaction with Sapling spends.
+fn assert_transaction_roundtrip(tx: Transaction) -> Result<(), TestCaseError> {
+    let has_coinbase_sapling_spends =
+        tx.is_coinbase() && tx.sapling_spends_per_anchor().count() > 0;
+
+    let data = tx.zcash_serialize_to_vec().expect("tx should serialize");
+
+    if has_coinbase_sapling_spends {
+        // GHSA-rgwx-8r98-p34c fix: the parser now rejects coinbase
+        // transactions with Sapling spends before allocating.
+        data.zcash_deserialize_into::<Transaction>()
+            .expect_err("coinbase with Sapling spends must be rejected");
+    } else {
+        let tx2: Transaction = data
+            .zcash_deserialize_into()
+            .expect("randomized tx should deserialize");
+
+        prop_assert_eq![&tx, &tx2];
+
+        let data2 = tx2
+            .zcash_serialize_to_vec()
+            .expect("vec serialization is infallible");
+
+        prop_assert_eq![data, data2, "data must be equal if structs are equal"];
+    }
+
+    Ok(())
+}
 
 proptest! {
     #[test]
     fn transaction_roundtrip(tx in any::<Transaction>()) {
         let _init_guard = zebra_test::init();
 
-        let has_coinbase_sapling_spends = tx.is_coinbase()
-            && tx.sapling_spends_per_anchor().count() > 0;
+        assert_transaction_roundtrip(tx)?;
+    }
 
-        let data = tx.zcash_serialize_to_vec().expect("tx should serialize");
+    /// Round-trip v6-era transactions specifically: `any::<Transaction>()` uses a mainnet-tip
+    /// ledger state, and NU6.3 is not activated on Mainnet yet, so `transaction_roundtrip`
+    /// does not exercise v6 transactions (including the fail-closed librustzcash round-trip
+    /// in the v6 deserializer).
+    #[test]
+    fn transaction_roundtrip_nu6_3(
+        tx in LedgerState::network_upgrade_strategy(NetworkUpgrade::Nu6_3, None, true)
+            .prop_flat_map(Transaction::arbitrary_with)
+    ) {
+        let _init_guard = zebra_test::init();
 
-        if has_coinbase_sapling_spends {
-            // GHSA-rgwx-8r98-p34c fix: the parser now rejects coinbase
-            // transactions with Sapling spends before allocating.
-            data.zcash_deserialize_into::<Transaction>()
-                .expect_err("coinbase with Sapling spends must be rejected");
-        } else {
-            let tx2 = data.zcash_deserialize_into()
-                .expect("randomized tx should deserialize");
-
-            prop_assert_eq![&tx, &tx2];
-
-            let data2 = tx2
-                .zcash_serialize_to_vec()
-                .expect("vec serialization is infallible");
-
-            prop_assert_eq![data, data2, "data must be equal if structs are equal"];
-        }
+        assert_transaction_roundtrip(tx)?;
     }
 
     #[test]
@@ -133,7 +157,7 @@ fn arbitrary_transaction_version_strategy() -> Result<()> {
     let _init_guard = zebra_test::init();
 
     // Update with new transaction versions as needed
-    let strategy = (1..5u32)
+    let strategy = (1..=6u32)
         .prop_flat_map(|transaction_version| {
             LedgerState::coinbase_strategy(None, transaction_version, false)
         })
@@ -149,6 +173,91 @@ fn arbitrary_transaction_version_strategy() -> Result<()> {
             }
         }
     });
+
+    Ok(())
+}
+
+/// Make sure the arbitrary transaction strategy generates every transaction version that is
+/// valid in each network-upgrade era — and no others.
+///
+/// This is a non-vacuity guard: when a new network upgrade is appended to the strategy dispatch
+/// without adding its new transaction format, every downstream property test of that format
+/// silently passes without ever seeing it. (The v4/v5-only arm did exactly that for v6/Ironwood
+/// when NU6.3 support was added.)
+#[test]
+fn arbitrary_transaction_versions_cover_each_era() -> Result<()> {
+    let _init_guard = zebra_test::init();
+
+    const SAMPLES_PER_ERA: usize = 64;
+
+    // Update with new network upgrades and transaction versions as needed
+    let eras: &[(NetworkUpgrade, &[u32])] = &[
+        (NetworkUpgrade::Genesis, &[1]),
+        (NetworkUpgrade::BeforeOverwinter, &[1]),
+        (NetworkUpgrade::Overwinter, &[2]),
+        (NetworkUpgrade::Sapling, &[3]),
+        (NetworkUpgrade::Blossom, &[4]),
+        (NetworkUpgrade::Heartwood, &[4]),
+        (NetworkUpgrade::Canopy, &[4]),
+        (NetworkUpgrade::Nu5, &[4, 5]),
+        (NetworkUpgrade::Nu6, &[4, 5]),
+        (NetworkUpgrade::Nu6_1, &[4, 5]),
+        (NetworkUpgrade::Nu6_2, &[4, 5]),
+        (NetworkUpgrade::Nu6_3, &[4, 5, 6]),
+        (NetworkUpgrade::Nu7, &[4, 5, 6]),
+    ];
+
+    // A deterministic RNG makes the "every version appears" assertions reliable: with 64
+    // samples over at most 3 equally-likely versions, coverage would also hold with
+    // overwhelming probability for a random seed, but there is no reason to accept flakes.
+    let mut runner = TestRunner::deterministic();
+
+    for (network_upgrade, expected_versions) in eras {
+        let strategy = LedgerState::network_upgrade_strategy(*network_upgrade, None, true)
+            .prop_flat_map(Transaction::arbitrary_with);
+
+        let mut seen_versions = HashSet::new();
+        let mut seen_v6_orchard_bundle = false;
+        let mut seen_ironwood_bundle = false;
+
+        for _ in 0..SAMPLES_PER_ERA {
+            let transaction = strategy
+                .new_tree(&mut runner)
+                .expect("strategy generates values")
+                .current();
+
+            seen_versions.insert(transaction.version());
+
+            if let Transaction::V6 {
+                orchard_shielded_data,
+                ironwood_shielded_data,
+                ..
+            } = &transaction
+            {
+                seen_v6_orchard_bundle |= orchard_shielded_data.is_some();
+                seen_ironwood_bundle |= ironwood_shielded_data.is_some();
+            }
+        }
+
+        let expected_versions: HashSet<u32> = expected_versions.iter().copied().collect();
+        assert_eq!(
+            seen_versions, expected_versions,
+            "generated transaction versions must match the valid versions for {network_upgrade:?}",
+        );
+
+        // Non-vacuity: the generator must be able to produce the NU6.3 bundle types, otherwise
+        // property tests of v6 Orchard and Ironwood behaviour pass without testing anything.
+        if expected_versions.contains(&6) {
+            assert!(
+                seen_v6_orchard_bundle,
+                "generated v6 transactions must include some v6 Orchard bundles for {network_upgrade:?}",
+            );
+            assert!(
+                seen_ironwood_bundle,
+                "generated v6 transactions must include some Ironwood bundles for {network_upgrade:?}",
+            );
+        }
+    }
 
     Ok(())
 }


### PR DESCRIPTION
The `Transaction` Arbitrary dispatch only generated v4/v5 transactions for every upgrade from NU5 onward: the commit that introduced v6 and Ironwood support (#10762) appended `Nu6_3` to the existing v4/v5 arm without adding a v6 strategy. Property tests built on the generator — zebra's own and downstream consumers' — could therefore never observe a v6 transaction or an Ironwood bundle, and passed vacuously. The gap was found when a downstream (zaino) consistency test's non-vacuity guard fired: its "ironwood tree-size delta equals served action count" check was trivially 0 == 0 at every block.

Changes:

- Add `Transaction::v6_strategy`, generating v6 transactions with optional Sapling, v6 Orchard, and Ironwood bundles, and wire it into the `Nu6_3 | Nu7` dispatch arm alongside v4/v5. Accept a transaction version override of 6.
- Add `Arbitrary` impls for `orchard::ShieldedDataV6` (reuses the base Orchard strategy: the v6 Orchard-pool bundle reserves `enableCrossAddress` exactly like v5) and `ironwood::ShieldedData` (re-generates the flag byte over all three defined bits, so the Ironwood-only `enableCrossAddress` flag and the `FlagsV6` codec path are exercised).
- Add `NetworkUpgrade::nu6_3_branch_id_strategy`, emitting only `Nu6_3`: Nu7's consensus branch ID is still a placeholder that librustzcash does not recognise, so Nu7-tagged transactions cannot round-trip through `to_librustzcash`.
- Handle Ironwood value balances in the proptest value fixups (`fix_chain_value_pools`, `fix_remaining_value`, `input_value_pool`, `for_each_value_balance_mut`, new `ironwood_value_balance_mut`), which would otherwise panic when a generated Ironwood bundle drains the empty ironwood chain value pool.

Tests:

- Add `arbitrary_transaction_versions_cover_each_era`, a non-vacuity guard asserting that each network-upgrade era generates exactly its valid transaction versions, and that NU6.3+ generation produces both v6 Orchard and Ironwood bundles. Fails against the previous dispatch arm; protects future upgrades appended to the arm.
- Add `transaction_roundtrip_nu6_3`: `any::<Transaction>()` uses a mainnet-tip ledger state and NU6.3 is testnet-only, so the existing round-trip proptest never exercised v6 (including the fail-closed librustzcash round-trip in the v6 deserializer).
- Extend `arbitrary_transaction_version_strategy` to versions 5 and 6 (its `1..5` range also silently excluded v5).

Closes #10911 
