### PR TITLE
fix(zebrad): keep active mempool through sync noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- Keep an already-active mempool and `getblocktemplate` mining RPCs running
+  when the sync status temporarily reports Zebra is far from the tip.
 - Don't disconnect from peers that return empty `FindBlocks` or `FindHeaders`
   responses when the local node is at or near the chain tip
   ([#10732](https://github.com/ZcashFoundation/zebra/pull/10732))

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -365,11 +365,14 @@ impl Mempool {
         };
     }
 
-    /// Update the mempool state (enabled / disabled) depending on how close to
-    /// the tip is the synchronization, including side effects to state changes.
+    /// Activate the mempool once Zebra is close enough to the tip.
     ///
-    /// Accepts an optional [`TipAction`] for setting the `last_seen_tip_hash` field
-    /// when enabling the mempool state, it will not enable the mempool if this is None.
+    /// Sync status only gates initial activation. Once the mempool is active,
+    /// this method does not disable it.
+    ///
+    /// Accepts an optional [`TipAction`] for setting the `last_seen_tip_hash`
+    /// field when enabling the mempool state. It will not enable the mempool if
+    /// this is [`None`].
     ///
     /// Returns `true` if the state changed.
     fn update_state(&mut self, tip_action: Option<&TipAction>) -> bool {

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -388,7 +388,7 @@ impl Mempool {
             // state proves Zebra is behind a higher-work chain that follows
             // this node's consensus rules.
             //
-            // The legacy sync status can be triggered by lower-work forks,
+            // The sync status can be triggered by lower-work forks,
             // stale peers, or peers on incompatible consensus rules, so
             // it is strong enough to delay initial activation but not to shut
             // down a working mempool.

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -341,6 +341,30 @@ impl Mempool {
         is_debug_enabled
     }
 
+    /// Returns `true` if Zebra is caught up enough to start the mempool.
+    fn is_caught_up_to_start(&self) -> bool {
+        self.sync_status.is_close_to_tip() || self.is_enabled_by_debug()
+    }
+
+    /// Replaces the active state with a freshly-initialised [`ActiveState::Enabled`],
+    /// using `tip_action`'s best tip hash as the `last_seen_tip_hash`.
+    fn enable_at_tip(&mut self, tip_action: &TipAction) {
+        let (last_seen_tip_hash, tip_height) = tip_action.best_tip_hash_and_height();
+
+        info!(?tip_height, "activating mempool: Zebra is close to the tip");
+
+        let tx_downloads = Box::pin(TxDownloads::new(
+            Timeout::new(self.outbound.clone(), TRANSACTION_DOWNLOAD_TIMEOUT),
+            Timeout::new(self.tx_verifier.clone(), TRANSACTION_VERIFY_TIMEOUT),
+            self.state.clone(),
+        ));
+        self.active_state = ActiveState::Enabled {
+            storage: storage::Storage::new(&self.config),
+            tx_downloads,
+            last_seen_tip_hash,
+        };
+    }
+
     /// Update the mempool state (enabled / disabled) depending on how close to
     /// the tip is the synchronization, including side effects to state changes.
     ///
@@ -349,40 +373,27 @@ impl Mempool {
     ///
     /// Returns `true` if the state changed.
     fn update_state(&mut self, tip_action: Option<&TipAction>) -> bool {
-        let is_close_to_tip = self.sync_status.is_close_to_tip() || self.is_enabled_by_debug();
+        let is_caught_up_to_start = self.is_caught_up_to_start();
 
-        match (is_close_to_tip, self.is_enabled(), tip_action) {
+        // TODO: revisit these state transitions when sync status can prove
+        // whether Zebra is behind the network tip.
+        match (is_caught_up_to_start, self.is_enabled(), tip_action) {
             // the active state is up to date, or there is no tip action to activate the mempool
             (false, false, _) | (true, true, _) | (true, false, None) => return false,
 
             // Enable state - there should be a chain tip when Zebra is close to the network tip
-            (true, false, Some(tip_action)) => {
-                let (last_seen_tip_hash, tip_height) = tip_action.best_tip_hash_and_height();
+            (true, false, Some(tip_action)) => self.enable_at_tip(tip_action),
 
-                info!(?tip_height, "activating mempool: Zebra is close to the tip");
-
-                let tx_downloads = Box::pin(TxDownloads::new(
-                    Timeout::new(self.outbound.clone(), TRANSACTION_DOWNLOAD_TIMEOUT),
-                    Timeout::new(self.tx_verifier.clone(), TRANSACTION_VERIFY_TIMEOUT),
-                    self.state.clone(),
-                ));
-                self.active_state = ActiveState::Enabled {
-                    storage: storage::Storage::new(&self.config),
-                    tx_downloads,
-                    last_seen_tip_hash,
-                };
-            }
-
-            // Disable state
+            // TODO: only disable an already-active mempool when validated sync
+            // state proves Zebra is behind a higher-work chain that follows
+            // this node's consensus rules.
+            //
+            // The legacy sync status can be triggered by lower-work forks,
+            // stale peers, or peers on incompatible consensus rules, so
+            // it is strong enough to delay initial activation but not to shut
+            // down a working mempool.
             (false, true, _) => {
-                info!(
-                    tip_height = ?self.latest_chain_tip.best_tip_height(),
-                    "deactivating mempool: Zebra is syncing lots of blocks"
-                );
-
-                // This drops the previous ActiveState::Enabled, cancelling its download tasks.
-                // We don't preserve the previous transactions, because we are syncing lots of blocks.
-                self.active_state = ActiveState::Disabled;
+                return false;
             }
         };
 
@@ -526,7 +537,10 @@ impl Service<Request> for Mempool {
         Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        let tip_action = self.chain_tip_change.last_tip_change();
+        let should_check_tip = self.is_enabled() || self.is_caught_up_to_start();
+        let tip_action = should_check_tip
+            .then(|| self.chain_tip_change.last_tip_change())
+            .flatten();
 
         // TODO: Consider broadcasting a `MempoolChange` when the mempool is disabled.
         let is_state_changed = self.update_state(tip_action.as_ref());
@@ -563,7 +577,17 @@ impl Service<Request> for Mempool {
             std::mem::drop(previous_state);
 
             // Re-initialise an empty state.
-            self.update_state(tip_action.as_ref());
+            //
+            // This deliberately bypasses the initial-activation gate in `update_state()`:
+            // the mempool was already active when the reset arrived, and the legacy
+            // far-from-tip sync status must not disable an already-active mempool
+            // (it can be triggered by lower-work forks, stale peers, or peers on
+            // incompatible consensus rules).
+            self.enable_at_tip(
+                tip_action
+                    .as_ref()
+                    .expect("this branch only matches when tip_action is a Reset"),
+            );
 
             // Re-verify the transactions that were pending or valid at the previous tip.
             // This saves us the time and data needed to re-download them.

--- a/zebrad/src/components/mempool/tests.rs
+++ b/zebrad/src/components/mempool/tests.rs
@@ -47,11 +47,11 @@ impl Mempool {
         self.dummy_call().await;
     }
 
-    /// Disable the mempool by pretending the synchronization is far from the tip.
-    pub async fn disable(&mut self, recent_syncs: &mut RecentSyncLengths) {
+    /// Pretend the synchronization is far from the tip and poll the mempool.
+    async fn sync_far_from_tip(&mut self, recent_syncs: &mut RecentSyncLengths) {
         // Pretend we're far from the tip
         SyncStatus::sync_far_from_tip(recent_syncs);
-        // Make a dummy request to poll the mempool and make it disable itself
+        // Make a dummy request to poll the mempool.
         self.dummy_call().await;
     }
 

--- a/zebrad/src/components/mempool/tests/prop.rs
+++ b/zebrad/src/components/mempool/tests/prop.rs
@@ -190,9 +190,9 @@ proptest! {
         })?;
     }
 
-    /// Test if the mempool storage is cleared if the syncer falls behind and starts to catch up.
+    /// Test if the mempool storage is kept if legacy sync status falls behind.
     #[test]
-    fn storage_is_cleared_if_syncer_falls_behind(
+    fn storage_is_kept_if_legacy_sync_status_falls_behind(
         network in any::<Network>(),
         transaction in standard_verified_unmined_tx_strategy(),
     ) {
@@ -205,7 +205,7 @@ proptest! {
                 mut state_service,
                 mut tx_verifier,
                 mut recent_syncs,
-                mut chain_tip_sender,
+                _chain_tip_sender,
             ) = setup(&network);
 
             time::pause();
@@ -223,19 +223,15 @@ proptest! {
 
             prop_assert_eq!(mempool.storage().transaction_count(), 1);
 
-            // Simulate the synchronizer catching up to the network chain tip.
-            mempool.disable(&mut recent_syncs).await;
+            // Simulate legacy sync discovery reporting a large gap. That signal
+            // can be caused by lower-work forks or incompatible peers, so it
+            // should not shut down an already-active mempool.
+            mempool.sync_far_from_tip(&mut recent_syncs).await;
 
-            // This time a call to `poll_ready` should clear the storage.
+            // This time a call to `poll_ready` should keep the storage.
             mempool.dummy_call().await;
 
-            // sends a new fake chain tip so that the mempool can be enabled
-            chain_tip_sender.set_finalized_tip(block1_chain_tip());
-
-            // Enable the mempool again so the storage can be accessed.
-            mempool.enable(&mut recent_syncs).await;
-
-            prop_assert_eq!(mempool.storage().transaction_count(), 0);
+            prop_assert_eq!(mempool.storage().transaction_count(), 1);
 
             peer_set.expect_no_requests().await?;
             state_service.expect_no_requests().await?;
@@ -248,14 +244,6 @@ proptest! {
 
 fn genesis_chain_tip() -> Option<ChainTipBlock> {
     zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
-        .zcash_deserialize_into::<Arc<Block>>()
-        .map(CheckpointVerifiedBlock::from)
-        .map(ChainTipBlock::from)
-        .ok()
-}
-
-fn block1_chain_tip() -> Option<ChainTipBlock> {
-    zebra_test::vectors::BLOCK_MAINNET_1_BYTES
         .zcash_deserialize_into::<Arc<Block>>()
         .map(CheckpointVerifiedBlock::from)
         .map(ChainTipBlock::from)

--- a/zebrad/src/components/mempool/tests/prop.rs
+++ b/zebrad/src/components/mempool/tests/prop.rs
@@ -190,9 +190,9 @@ proptest! {
         })?;
     }
 
-    /// Test if the mempool storage is kept if legacy sync status falls behind.
+    /// Test if the mempool storage is kept if sync status falls behind.
     #[test]
-    fn storage_is_kept_if_legacy_sync_status_falls_behind(
+    fn storage_is_kept_if_sync_status_falls_behind(
         network in any::<Network>(),
         transaction in standard_verified_unmined_tx_strategy(),
     ) {
@@ -223,7 +223,7 @@ proptest! {
 
             prop_assert_eq!(mempool.storage().transaction_count(), 1);
 
-            // Simulate legacy sync discovery reporting a large gap. That signal
+            // Simulate sync status reporting a large gap. That signal
             // can be caused by lower-work forks or incompatible peers, so it
             // should not shut down an already-active mempool.
             mempool.sync_far_from_tip(&mut recent_syncs).await;

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -332,8 +332,7 @@ async fn mempool_queue_single() -> Result<(), Report> {
 }
 
 #[tokio::test]
-async fn mempool_service_stays_enabled_when_legacy_sync_status_falls_behind() -> Result<(), Report>
-{
+async fn mempool_service_stays_enabled_when_sync_status_falls_behind() -> Result<(), Report> {
     // Using the mainnet for now
     let network = Network::Mainnet;
 
@@ -398,7 +397,7 @@ async fn mempool_service_stays_enabled_when_legacy_sync_status_falls_behind() ->
     assert!(queued_responses[0].is_ok());
     assert_eq!(service.tx_downloads().in_flight(), 1);
 
-    // Pretend legacy sync discovery is far from tip. Once active, the mempool
+    // Pretend sync status is far from tip. Once active, the mempool
     // should not shut down based on that heuristic alone.
     service.sync_far_from_tip(&mut recent_syncs).await;
 
@@ -406,8 +405,8 @@ async fn mempool_service_stays_enabled_when_legacy_sync_status_falls_behind() ->
     assert!(service.is_enabled());
     assert_eq!(service.tx_downloads().in_flight(), 1);
 
-    // Test if the mempool keeps returning its transactions when legacy sync
-    // status falls behind.
+    // Test if the mempool keeps returning its transactions when sync status
+    // falls behind.
     let response = service
         .ready()
         .await
@@ -420,13 +419,13 @@ async fn mempool_service_stays_enabled_when_legacy_sync_status_falls_behind() ->
             assert_eq!(
                 ids.len(),
                 1,
-                "mempool should keep transactions when legacy sync status falls behind"
+                "mempool should keep transactions when sync status falls behind"
             )
         }
         _ => unreachable!("will never happen in this test"),
     };
 
-    // Test if mempool returns QueueStats correctly when legacy sync status
+    // Test if mempool returns QueueStats correctly when sync status
     // falls behind.
     let response = service
         .ready()
@@ -448,7 +447,7 @@ async fn mempool_service_stays_enabled_when_legacy_sync_status_falls_behind() ->
 
     assert_eq!(
         size, 1,
-        "size should not be cleared when legacy sync status falls behind"
+        "size should not be cleared when sync status falls behind"
     );
     assert!(bytes > 0, "bytes should not be cleared");
     assert!(usage > 0, "usage should not be cleared");
@@ -461,14 +460,14 @@ async fn mempool_service_stays_enabled_when_legacy_sync_status_falls_behind() ->
 }
 
 /// Check that a disabled mempool does not consume the latest tip action until
-/// legacy sync status says Zebra is close enough to activate it.
+/// sync status says Zebra is close enough to activate it.
 ///
 /// Regression test: `poll_ready()` used to call `last_tip_change()` before
 /// checking the initial-activation gate. If Zebra was still far from tip, that
 /// consumed the only available tip action and left the disabled mempool unable
 /// to activate when sync status later caught up without another tip change.
 #[tokio::test]
-async fn disabled_mempool_keeps_tip_action_until_legacy_sync_catches_up() -> Result<(), Report> {
+async fn disabled_mempool_keeps_tip_action_until_sync_status_catches_up() -> Result<(), Report> {
     let network = Network::Mainnet;
 
     let (
@@ -483,7 +482,7 @@ async fn disabled_mempool_keeps_tip_action_until_legacy_sync_catches_up() -> Res
 
     assert!(!service.is_enabled());
 
-    // Poll while legacy sync discovery says Zebra is far from tip. The mempool
+    // Poll while sync status says Zebra is far from tip. The mempool
     // must remain disabled, but it must not consume the latest chain-tip action.
     SyncStatus::sync_far_from_tip(&mut recent_syncs);
     service.dummy_call().await;
@@ -788,7 +787,7 @@ async fn mempool_cancel_downloads_after_network_upgrade() -> Result<(), Report> 
 /// `update_state()`, whose initial-activation gate refused to re-enable the mempool while
 /// far-from-tip, silently leaving it disabled and dropping the collected retries.
 #[tokio::test(flavor = "multi_thread")]
-async fn mempool_reset_keeps_active_state_when_legacy_sync_falls_behind() -> Result<(), Report> {
+async fn mempool_reset_keeps_active_state_when_sync_status_falls_behind() -> Result<(), Report> {
     // Use a configured Testnet where a network upgrade activates at height 2.
     //
     // The mempool resets when the chain tip reaches the block before a network
@@ -880,7 +879,7 @@ async fn mempool_reset_keeps_active_state_when_legacy_sync_falls_behind() -> Res
     // Ignore all the previous network requests.
     while let Some(_request) = peer_set.try_next_request().await {}
 
-    // Pretend legacy sync discovery is far from tip, without polling the
+    // Pretend sync status is far from tip, without polling the
     // mempool yet, so the reset and the far-from-tip status are observed in
     // the same `poll_ready()` call.
     SyncStatus::sync_far_from_tip(&mut recent_syncs);
@@ -915,11 +914,11 @@ async fn mempool_reset_keeps_active_state_when_legacy_sync_falls_behind() -> Res
     // Query the mempool to make it poll chain_tip_change and handle the reset.
     mempool.dummy_call().await;
 
-    // The reset must not disable the already-active mempool, even though the legacy sync
+    // The reset must not disable the already-active mempool, even though sync
     // status says Zebra is far from the tip.
     assert!(
         mempool.is_enabled(),
-        "mempool must stay enabled through a chain tip reset while legacy sync status is far \
+        "mempool must stay enabled through a chain tip reset while sync status is far \
          from tip"
     );
 

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -27,7 +27,7 @@ use zebra_test::mock_service::{MockService, PanicAssertion};
 
 use crate::components::{
     mempool::{self, *},
-    sync::RecentSyncLengths,
+    sync::{RecentSyncLengths, SyncStatus},
 };
 
 /// A [`MockService`] representing the network service.
@@ -332,7 +332,8 @@ async fn mempool_queue_single() -> Result<(), Report> {
 }
 
 #[tokio::test]
-async fn mempool_service_disabled() -> Result<(), Report> {
+async fn mempool_service_stays_enabled_when_legacy_sync_status_falls_behind() -> Result<(), Report>
+{
     // Using the mainnet for now
     let network = Network::Mainnet;
 
@@ -397,13 +398,16 @@ async fn mempool_service_disabled() -> Result<(), Report> {
     assert!(queued_responses[0].is_ok());
     assert_eq!(service.tx_downloads().in_flight(), 1);
 
-    // Disable the mempool
-    service.disable(&mut recent_syncs).await;
+    // Pretend legacy sync discovery is far from tip. Once active, the mempool
+    // should not shut down based on that heuristic alone.
+    service.sync_far_from_tip(&mut recent_syncs).await;
 
-    // Test if mempool is disabled again
-    assert!(!service.is_enabled());
+    // Test if mempool stays enabled.
+    assert!(service.is_enabled());
+    assert_eq!(service.tx_downloads().in_flight(), 1);
 
-    // Test if the mempool returns no transactions when disabled
+    // Test if the mempool keeps returning its transactions when legacy sync
+    // status falls behind.
     let response = service
         .ready()
         .await
@@ -415,37 +419,15 @@ async fn mempool_service_disabled() -> Result<(), Report> {
         Response::TransactionIds(ids) => {
             assert_eq!(
                 ids.len(),
-                0,
-                "mempool should return no transactions when disabled"
+                1,
+                "mempool should keep transactions when legacy sync status falls behind"
             )
         }
         _ => unreachable!("will never happen in this test"),
     };
 
-    // Test if the mempool returns to Queue requests correctly when disabled
-    let response = service
-        .ready()
-        .await
-        .unwrap()
-        .call(Request::Queue(vec![txid.into()]))
-        .await
-        .unwrap();
-    let queued_responses = match response {
-        Response::Queued(queue_responses) => queue_responses,
-        _ => unreachable!("will never happen in this test"),
-    };
-
-    assert_eq!(queued_responses.len(), 1);
-    assert_eq!(
-        queued_responses
-            .into_iter()
-            .next()
-            .unwrap()
-            .unbox_mempool_error(),
-        MempoolError::Disabled
-    );
-
-    // Test if mempool returns to QueueStats request correctly when disabled
+    // Test if mempool returns QueueStats correctly when legacy sync status
+    // falls behind.
     let response = service
         .ready()
         .await
@@ -464,13 +446,54 @@ async fn mempool_service_disabled() -> Result<(), Report> {
         _ => unreachable!("expected QueueStats response"),
     };
 
-    assert_eq!(size, 0, "size should be zero when mempool is disabled");
-    assert_eq!(bytes, 0, "bytes should be zero when mempool is disabled");
-    assert_eq!(usage, 0, "usage should be zero when mempool is disabled");
+    assert_eq!(
+        size, 1,
+        "size should not be cleared when legacy sync status falls behind"
+    );
+    assert!(bytes > 0, "bytes should not be cleared");
+    assert!(usage > 0, "usage should not be cleared");
     assert_eq!(
         fully_notified, None,
-        "fully_notified should be None when mempool is disabled"
+        "fully_notified is not implemented for active mempool stats yet"
     );
+
+    Ok(())
+}
+
+/// Check that a disabled mempool does not consume the latest tip action until
+/// legacy sync status says Zebra is close enough to activate it.
+///
+/// Regression test: `poll_ready()` used to call `last_tip_change()` before
+/// checking the initial-activation gate. If Zebra was still far from tip, that
+/// consumed the only available tip action and left the disabled mempool unable
+/// to activate when sync status later caught up without another tip change.
+#[tokio::test]
+async fn disabled_mempool_keeps_tip_action_until_legacy_sync_catches_up() -> Result<(), Report> {
+    let network = Network::Mainnet;
+
+    let (
+        mut service,
+        _peer_set,
+        _state_service,
+        _chain_tip_change,
+        _tx_verifier,
+        mut recent_syncs,
+        _mempool_transaction_receiver,
+    ) = setup(&network, u64::MAX, true).await;
+
+    assert!(!service.is_enabled());
+
+    // Poll while legacy sync discovery says Zebra is far from tip. The mempool
+    // must remain disabled, but it must not consume the latest chain-tip action.
+    SyncStatus::sync_far_from_tip(&mut recent_syncs);
+    service.dummy_call().await;
+    assert!(!service.is_enabled());
+
+    // Now catch up without committing another block. The same tip action should
+    // still be available for initial activation.
+    SyncStatus::sync_close_to_tip(&mut recent_syncs);
+    service.dummy_call().await;
+    assert!(service.is_enabled());
 
     Ok(())
 }
@@ -743,6 +766,164 @@ async fn mempool_cancel_downloads_after_network_upgrade() -> Result<(), Report> 
     mempool.dummy_call().await;
 
     // Check if download was cancelled and transaction was retried.
+    let request = peer_set
+        .try_next_request()
+        .await
+        .expect("unexpected missing mempool retry");
+
+    assert_eq!(
+        request.request(),
+        &zebra_network::Request::TransactionsById(iter::once(txid).collect()),
+    );
+    assert_eq!(mempool.tx_downloads().in_flight(), 1);
+
+    Ok(())
+}
+
+/// Check that a chain tip reset does not disable an already-active mempool when the legacy
+/// sync status says Zebra is far from the tip, and that pending transactions are still
+/// requeued for download.
+///
+/// Regression test: the reset path used to re-initialise the active state through
+/// `update_state()`, whose initial-activation gate refused to re-enable the mempool while
+/// far-from-tip, silently leaving it disabled and dropping the collected retries.
+#[tokio::test(flavor = "multi_thread")]
+async fn mempool_reset_keeps_active_state_when_legacy_sync_falls_behind() -> Result<(), Report> {
+    // Use a configured Testnet where a network upgrade activates at height 2.
+    //
+    // The mempool resets when the chain tip reaches the block before a network
+    // upgrade activation height, because that next height is what the next block
+    // is verified against (see [`ChainTipChange::action`]).
+    let network = ParametersBuilder::default()
+        .with_activation_heights(ConfiguredActivationHeights {
+            before_overwinter: Some(1),
+            overwinter: Some(2),
+            sapling: Some(3),
+            blossom: Some(4),
+            heartwood: Some(5),
+            canopy: Some(6),
+            nu5: Some(7),
+            nu6: Some(8),
+            nu6_1: Some(9),
+            nu6_2: Some(10),
+            nu6_3: Some(11),
+            nu7: Some(12),
+        })
+        .expect("activation heights are valid")
+        .extend_funding_streams()
+        .to_network()
+        .expect("configured network is valid");
+
+    let genesis_block: Arc<Block> = zebra_test::vectors::BLOCK_TESTNET_GENESIS_BYTES
+        .zcash_deserialize_into()
+        .unwrap();
+    let block1: Arc<Block> = zebra_test::vectors::BLOCK_TESTNET_1_BYTES
+        .zcash_deserialize_into()
+        .unwrap();
+    let block2: Arc<Block> = zebra_test::vectors::BLOCK_TESTNET_2_BYTES
+        .zcash_deserialize_into()
+        .unwrap();
+
+    // Don't commit the default mainnet genesis block; we commit Testnet blocks
+    // instead.
+    let (
+        mut mempool,
+        mut peer_set,
+        mut state_service,
+        mut chain_tip_change,
+        _tx_verifier,
+        mut recent_syncs,
+        _mempool_transaction_receiver,
+    ) = setup(&network, u64::MAX, false).await;
+
+    // Commit the genesis block so the mempool can be enabled.
+    state_service
+        .ready()
+        .await
+        .unwrap()
+        .call(zebra_state::Request::CommitCheckpointVerifiedBlock(
+            genesis_block.clone().into(),
+        ))
+        .await
+        .unwrap();
+    chain_tip_change
+        .wait_for_tip_change()
+        .await
+        .expect("unexpected chain tip update failure");
+
+    // Enable the mempool now that there is a chain tip.
+    mempool.enable(&mut recent_syncs).await;
+    assert!(mempool.is_enabled());
+
+    // Queue a transaction from block 2 for download. Block 2 is never committed,
+    // so the transaction is never mined and the download can be retried after
+    // the reset.
+    let txid = block2.transactions[0].unmined_id();
+    let response = mempool
+        .ready()
+        .await
+        .unwrap()
+        .call(Request::Queue(vec![txid.into()]))
+        .await
+        .unwrap();
+    let queued_responses = match response {
+        Response::Queued(queue_responses) => queue_responses,
+        _ => unreachable!("will never happen in this test"),
+    };
+    assert_eq!(queued_responses.len(), 1);
+    assert!(queued_responses[0].is_ok());
+    assert_eq!(mempool.tx_downloads().in_flight(), 1);
+
+    // Query the mempool to make it poll chain_tip_change.
+    mempool.dummy_call().await;
+
+    // Ignore all the previous network requests.
+    while let Some(_request) = peer_set.try_next_request().await {}
+
+    // Pretend legacy sync discovery is far from tip, without polling the
+    // mempool yet, so the reset and the far-from-tip status are observed in
+    // the same `poll_ready()` call.
+    SyncStatus::sync_far_from_tip(&mut recent_syncs);
+
+    // Push block 1 to the state. Its next height (2) is the Overwinter
+    // activation height, so this triggers a network-upgrade reset.
+    state_service
+        .ready()
+        .await
+        .unwrap()
+        .call(zebra_state::Request::CommitCheckpointVerifiedBlock(
+            block1.clone().into(),
+        ))
+        .await
+        .unwrap();
+
+    // Wait for the chain tip update.
+    if let Err(timeout_error) = timeout(
+        CHAIN_TIP_UPDATE_WAIT_LIMIT,
+        chain_tip_change.wait_for_tip_change(),
+    )
+    .await
+    .map(|change_result| change_result.expect("unexpected chain tip update failure"))
+    {
+        info!(
+            timeout = ?humantime_seconds(CHAIN_TIP_UPDATE_WAIT_LIMIT),
+            ?timeout_error,
+            "timeout waiting for chain tip change after committing block"
+        )
+    }
+
+    // Query the mempool to make it poll chain_tip_change and handle the reset.
+    mempool.dummy_call().await;
+
+    // The reset must not disable the already-active mempool, even though the legacy sync
+    // status says Zebra is far from the tip.
+    assert!(
+        mempool.is_enabled(),
+        "mempool must stay enabled through a chain tip reset while legacy sync status is far \
+         from tip"
+    );
+
+    // Check that the download was cancelled and the transaction was retried.
     let request = peer_set
         .try_next_request()
         .await

--- a/zebrad/src/components/sync/status.rs
+++ b/zebrad/src/components/sync/status.rs
@@ -23,9 +23,9 @@ impl SyncStatus {
     /// The threshold that determines if the synchronization is at the chain
     /// tip.
     ///
-    /// This is based on the fact that sync lengths are around 2-20 blocks long
-    /// once Zebra reaches the tip.
-    const MIN_DIST_FROM_TIP: usize = 20;
+    /// This uses a strict less-than check, so 101 means Zebra is close to the
+    /// tip when the average recent sync length is at most 100 blocks.
+    const MIN_DIST_FROM_TIP: usize = 101;
 
     /// Create an instance of [`SyncStatus`] for a specific network.
     ///

--- a/zebrad/src/components/sync/status/tests.rs
+++ b/zebrad/src/components/sync/status/tests.rs
@@ -161,6 +161,18 @@ fn zero_sync_lengths() {
     assert!(status.is_close_to_tip());
 }
 
+/// Test if sync lengths exactly at the close-to-tip threshold are near tip.
+#[test]
+fn threshold_sync_lengths() {
+    let (status, mut recent_sync_lengths) = SyncStatus::new();
+
+    for _ in 0..RecentSyncLengths::MAX_RECENT_LENGTHS {
+        recent_sync_lengths.push_extend_tips_length(100);
+    }
+
+    assert!(status.is_close_to_tip());
+}
+
 /// Test if sync lengths array with high values is not near tip.
 #[test]
 fn high_sync_lengths() {


### PR DESCRIPTION
Keep an already-active mempool running when the legacy sync-status heuristic temporarily reports that Zebra is far from the tip.

The initial activation gate still waits for near-tip sync status, but once active, transient sync noise no longer drops mempool storage or cancels queued transaction verification. Chain tip resets reinitialize the active mempool directly so pending transactions can be requeued and reverified.

Also raise the close-to-tip threshold to accept recent sync batches averaging up to 100 blocks, matching the intended near-tip behavior covered by the updated tests.

(cherry picked from commit 78d1a5e21c0007359d2bc238707d9fa33d482869)

### PR Checklist

- [ ] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [ ] The solution is tested.
- [ ] The documentation and changelogs are up to date.
