### PR TITLE
feat(dandelion): Dandelion++ transaction propagation (Component B, ZIP 327)

### DIFF
--- a/dandelion-TODO.md
+++ b/dandelion-TODO.md
@@ -1,0 +1,158 @@
+# Dandelion++ Implementation — Remaining Work
+
+This file tracks what is left before the implementation in `zebra-network/src/dandelion/`
+and `zebrad/src/components/mempool/dandelion_gossip.rs` is feature-complete.
+
+## Phase 1 — Core types (DONE, verified 2026-07-09)
+
+- [x] `zebra-network/src/dandelion/state.rs` — `PropagationState`, `PropagationStateMap`
+- [x] `zebra-network/src/dandelion/epoch.rs` — `DandelionEpochManager`
+- [x] `zebrad/src/components/mempool/dandelion_gossip.rs` — gossip task scaffold
+  with epoch rotation, stem-timeout sweep, and TODO marker for unicast
+
+## Phase 2 — PeerSet per-peer routing — DONE (2026-07-09)
+
+**Files**: `zebra-network/src/protocol/internal/request.rs`,
+`zebra-network/src/peer/connection.rs`, `zebra-network/src/peer_set/set.rs`,
+`zebrad/src/components/mempool/dandelion_gossip.rs`.
+
+Implemented as a new `Request::AdvertiseTransactionIdsToPeer(HashSet<UnminedTxId>,
+PeerSocketAddr)` variant (Option A from the original plan below). `connection.rs`
+sends the same wire message as `AdvertiseTransactionIds` (an `inv`, not the raw
+tx — unchanged from existing behavior). `PeerSet::route_to_peer` takes the named
+peer out of `ready_services`, calls it, and pushes it back to `unready_services`;
+if the peer isn't in `ready_services` it fails immediately with
+`PeerError::NoReadyPeers` rather than falling back to some other peer (silently
+picking a different peer would defeat the point of stem routing).
+`dandelion_gossip.rs` now calls this real unicast instead of falling through to
+broadcast, and falls back to fluff only if the stem peer wasn't ready.
+
+Original plan (kept for context):
+
+**Option A** — new `Request` variant:
+```rust
+// in zebra-network/src/protocol/external/types.rs or similar
+Request::SendTransactionToPeer {
+    peer: SocketAddr,
+    txids: HashSet<UnminedTxId>,
+}
+```
+`PeerSet::call()` routes it to the matching peer (by `SocketAddr` key in
+`PeerSet.ready_services`).
+
+**Option B** — `PeerSet::broadcast_to(addr, req)` helper that bypasses the
+load-balancer.
+
+Option A is more idiomatic with the existing `tower::Service` design.
+
+**Remaining**: an integration test in `zebra-network/tests/` exercising
+`route_to_peer` against a mock `Discover` with 2+ peers (unit tests only cover
+the dandelion state/epoch types so far, not `PeerSet` routing itself).
+
+## Phase 3 — Wire up in `zebrad` — DONE (2026-07-09)
+
+**File**: `zebrad/src/commands/start.rs`
+
+Replaced `gossip_mempool_transaction_id` with `spawn_dandelion_gossip`.
+Passes a closure that reads `AddressBook` for currently-responded outbound
+peers as stem-peer candidates.  A dummy `pending::<Result<(),BoxError>>()`
+future satisfies the existing `select!`/`abort` downstream logic.
+
+## Phase 4 — Mempool `pending-stem` state — DONE (2026-07-09)
+
+`InboundSetupData` now carries `dandelion_prop_state: Arc<Mutex<PropagationStateMap>>`.
+The `zn::Request::MempoolTransactionIds` handler in `zebrad/src/components/inbound.rs`
+acquires the lock, identifies active-stem txids, and strips them from the response
+before replying to the remote peer.
+
+Completed (2026-07-09):
+- [x] `mempool` P2P `MempoolTransactionIds` response: filters active stem txids.
+- [x] `TransactionsById` P2P (getdata) handler: drops active-stem txs, reporting
+  them as `Missing` — a peer that learned a stem txid out-of-band cannot fetch
+  the full tx from us before fluff.
+- [x] `getrawmempool` RPC (verbose + non-verbose): filters via `active_stem_txids()`.
+- [x] `getrawtransaction` RPC: returns "No information available" for active stem txids.
+- [x] Indexer gRPC `mempool_change` stream (Zaino/lightwalletd): suppresses
+  `StemAdded` events — stem txs are only streamed once promoted to fluff (as `Added`).
+- [x] `MempoolChangeKind::StemAdded`: mempool emits `StemAdded` for locally-submitted
+  txs, `Added` for peer-relayed. Gossip task routes `StemAdded` through stem,
+  `Added` directly to fluff.
+
+Remaining (lower priority / minor):
+- `z_getoperationresult` and other watch-operation RPCs do not filter stem txids —
+  they report the queue/verify status, not the mempool contents, so the leak is
+  minor; the operation result only says "success" not "tx is in mempool".
+- **Timing window**: `is_active_stem()` flips to false at exactly `STEM_TIMEOUT`
+  (30 s), but the fluff-broadcast sweep only runs every `STEM_TIMEOUT_CHECK_INTERVAL`
+  (5 s). So for up to ~5 s a timed-out stem tx is visible via RPC/P2P but not yet
+  fluff-broadcast. Harmless (it's about to be broadcast anyway) but noted for
+  completeness. Could be tightened by driving the RPC/P2P filter off the same
+  `should_fluff()`-with-sweep state rather than the raw timeout.
+
+## Phase 5 — MempoolCrawler analysis (re-scoped, subsumed into Phase 4)
+
+The crawler (`zebrad/src/components/mempool/crawler.rs`) sends
+`Request::MempoolTransactionIds` *to other peers* asking for their mempool
+contents — it does not expose our own stem-phase transactions.  No changes
+needed here.
+
+The inbound `zn::Request::MempoolTransactionIds` handler (Phase 4 above) is now
+filtered.
+
+## Phase 6 — Tests — DONE (2026-07-09)
+
+- [x] Unit tests: `state.rs` (6 tests) and `epoch.rs` (4 tests) `#[cfg(test)]` modules.
+- [x] Routing unit tests: `zebra-network/src/peer_set/set/tests/vectors.rs`
+  `dandelion_route_to_peer_unicast` and `dandelion_route_to_peer_fails_when_not_ready`.
+- [x] Phase 4 filter unit tests: `state.rs` `phase4_filter_strips_active_stem_keeps_fluff_and_unknown`
+  and `phase4_filter_shows_tx_after_fluff_promotion` — directly verify the
+  predicate used in `Inbound::call(MempoolTransactionIds)`.
+- [ ] Full P2P integration test (spawn PeerSet + inbound handler, assert stem/fluff
+  timing) — deferred; requires a substantial test harness.
+- [ ] Proptest: uniform stem-peer distribution over epochs — deferred.
+
+## Phase 7 — ZIP companion — DONE (2026-07-09)
+
+Filed as [zcash/zips#1329](https://github.com/zcash/zips/pull/1329):
+**ZIP 327: Dandelion++ Transaction Propagation for Zcash P2P Nodes**.
+
+Covers: epoch management, per-epoch stem-peer selection, fail-closed unicast,
+30 s stem timeout, stem-phase mempool filtering, fluff-phase broadcast.
+Does not require a new P2P message type.
+
+Wallet-side direct P2P submission (Component A / ZIP 328) is in
+`y4ssi/zip-dandelion-direct` (private, PR #1 open).
+
+## Wire-level stem signalling (unadvertised `tx` convention) — future work
+
+Per ZIP 327 §Stem-phase forwarding and the draft wallet ZIP, the stem peer
+SHOULD receive the raw `tx` message directly (without a prior `inv`) as a
+signal that the transaction is in stem phase.
+
+Current state: `connection.rs` sends the same `inv` for both
+`AdvertiseTransactionIds` and `AdvertiseTransactionIdsToPeer`.  The privacy
+routing property still holds (only the stem peer is notified), but the
+downstream node cannot distinguish stem relay from normal relay.
+
+Implementing the unadvertised-`tx` convention requires a new request variant
+`AdvertiseStemTransactionToPeer(Arc<Transaction>, PeerSocketAddr)` (carrying
+the full transaction, not just the id), a new code path in `connection.rs`
+that sends `Message::Tx(tx)` without a prior `Inv`, and a matching receive
+path in the inbound handler that treats an unrequested `Tx` message as a
+stem-phase submission.
+
+This is marked OPTIONAL in ZIP 327 and deferred until at least one other
+Zcash node implementation is ready to recognize the signal.
+
+## Known blockers / risks
+
+1. **PeerSet API surface** — `ready_services` is private.  Extending it for
+   per-peer routing will touch the `tower::Service` trait bound and may require
+   a `ServiceMap` abstraction.  Estimated: 1–2 weeks.
+
+2. **No ZIP yet** — ZF reviewers will not merge without a companion ZIP or at
+   minimum a `Discussions-To` issue.
+
+3. **`rand` dependency in `zebra-network`** — `epoch.rs` uses `rand::thread_rng`.
+   Check if `zebra-network` already depends on `rand`; if not, add it to
+   `zebra-network/Cargo.toml`.

--- a/docs/dandelion-e2e-regtest.md
+++ b/docs/dandelion-e2e-regtest.md
@@ -1,0 +1,287 @@
+# Dandelion++ e2e Test — 3-Node Regtest
+
+End-to-end verification of the Dandelion++ stem/fluff implementation
+(`zebra-network/src/dandelion/` + `zebrad/src/components/mempool/dandelion_gossip.rs`)
+on a private 3-node regtest network. Last run: **2026-07-09, passed**.
+
+## What the test proves
+
+A transaction submitted via `sendrawtransaction` to Node A:
+
+1. is accepted into the mempool,
+2. is **withheld from flood broadcast** while in `PropagationState::Stem`
+   (the adversary observer, Node C, sees no `inv` during the stem window), and
+3. is promoted to fluff by the 30 s stem-timeout sweep:
+
+   ```
+   INFO zebrad::components::mempool::dandelion_gossip: dandelion++: promoting timed-out stem txs to fluff count=1
+   ```
+
+Without Dandelion++, the `inv` floods to all peers within milliseconds of
+mempool insertion — this timing differential is the observable privacy
+property (IP ↔ txid decorrelation for network observers).
+
+## Topology
+
+```
+Node A (originator + miner)   rpc 18232   p2p 18244
+Node B (stem-peer candidate)  rpc 18233   p2p 18245
+Node C (adversary observer)   rpc 18234   p2p 18246
+```
+
+All three on `127.0.0.1`. A dials B and C; B and C dial A.
+
+## Build
+
+Debug-level log output from the dandelion modules requires the
+`release_max_level_debug` feature (release builds otherwise strip
+`debug!` at compile time):
+
+```bash
+cargo build -p zebrad --release --no-default-features --features release_max_level_debug
+```
+
+## Node configuration
+
+Generated per node by the test script (see full script below). Key points:
+
+```toml
+[network]
+network = "Regtest"
+listen_addr = "127.0.0.1:<p2p_port>"
+initial_mainnet_peers = []
+initial_testnet_peers = ["127.0.0.1:<other_p2p_port>", ...]
+peerset_initial_target_size = 3
+max_connections_per_ip = 10        # REQUIRED — see gotchas
+
+[rpc]
+listen_addr = "127.0.0.1:<rpc_port>"
+parallel_cpu_threads = 1
+enable_cookie_auth = false
+
+[mempool]
+debug_enable_at_height = 0         # enable mempool from genesis
+
+[mining]
+miner_address = "<transparent addr>"   # Node A only
+
+[tracing]
+filter = "zebrad::components::mempool::dandelion_gossip=debug,zebra_network::peer_set::set=debug,zebrad=info"
+use_color = false
+```
+
+## Test procedure
+
+1. Start all three nodes; wait ~35 s for the local peer set to stabilize.
+2. `generate [1]` on Node A — mines block 1, paying the coinbase to
+   `miner_address`.
+3. `generate [101]` — coinbase maturity is 100 confirmations, so the block-1
+   coinbase becomes spendable at height 102.
+4. Build and sign a v4 transparent transaction spending that coinbase
+   (see "Transaction signing" below) and submit it via `sendrawtransaction`
+   to Node A.
+5. Wait 10 s; grep all three logs. Expected: Node C (and B, absent a ready
+   stem unicast) show **no** `inv` for the tx — it is being held in stem.
+6. Wait past the 30 s stem timeout; Node A logs
+   `promoting timed-out stem txs to fluff count=1` and broadcasts.
+
+### Transaction signing (ZIP-243, regtest branch ID)
+
+The tx is a v4 transparent spend built and signed by a standalone Python
+script (stdlib `hashlib.blake2b` + `coincurve`):
+
+- `nVersion = 0x80000004` (v4, overwintered), `nVersionGroupId = 0x892F2085`.
+- Sighash is BLAKE2b-256 with personalization
+  `b"ZcashSigHash" || consensus_branch_id (LE)`.
+- **Regtest activates only Genesis@0 and Canopy@1**, so the active consensus
+  branch ID at any height ≥ 1 is **Canopy `0xe9ff75a6`** — not the latest
+  network upgrade. Signing with a later branch ID fails with `ScriptInvalid`.
+
+The miner keypair is generated deterministically outside Zebra
+(secp256k1 key → P2PKH `tm…` address + WIF), configured as Node A's
+`miner_address`, and used to sign the coinbase spend.
+
+## Results (2026-07-09)
+
+```
+sendrawtransaction → {"jsonrpc":"2.0","id":1,"result":"87ffaf8f443e9b88aa5131bd3542bfc4abd6f8c2e8852d9482de0595048fc890"}
+
+Node C during 10 s stem window:   no inv observed   ← privacy property
+Node A after 30 s:
+  INFO dandelion++: promoting timed-out stem txs to fluff count=1
+```
+
+In this run the stem peer was not in `ready_services` at unicast time, so the
+tx sat in `PropagationState::Stem` until the timeout sweep promoted it — which
+still demonstrates the core behavior: **no flood broadcast during the stem
+window**, promotion only via the sweep.
+
+## Gotchas
+
+- **`max_connections_per_ip = 10`** — all three nodes share `127.0.0.1`;
+  the default of 1 makes peers constantly churn in/out of `ready_services`
+  and the stem unicast then always fails to `NoReadyPeers`.
+- **Coinbase maturity** — spend fails until 100 confirmations (mine 101
+  extra blocks).
+- **Branch ID** — Canopy `0xe9ff75a6` on regtest (see above).
+- **Build features** — without `release_max_level_debug` the dandelion
+  `debug!` lines never appear regardless of the tracing filter.
+- **Log evidence, not packet capture** — the test infers stem behavior from
+  each node's own logs; regtest peers don't always log received `inv`s at
+  info level, so absence on C during the stem window plus the promotion line
+  on A is the assertion.
+
+## Full test script
+
+```bash
+#!/bin/bash
+# Dandelion++ full broadcast test — max_connections_per_ip=10 so all 3 nodes stay peered
+set -euo pipefail
+ZEBRAD=/root/zebra/target/release/zebrad
+DATADIR=/tmp/dpp-broadcast
+rm -rf "$DATADIR"; pkill -f zebrad 2>/dev/null||true; sleep 2
+mkdir -p "$DATADIR"/{a,b,c}/{state,logs}
+
+eval $(cat /root/miner.key)   # ADDRESS=tm... WIF=c...
+echo "Miner: $ADDRESS"
+
+cfg() {
+  local n=$1 r=$2 p=$3 peers=$4 ml=${5:-}
+  cat > "$DATADIR/$n/zebrad.toml" <<EOF
+[network]
+network = "Regtest"
+listen_addr = "127.0.0.1:${p}"
+initial_mainnet_peers = []
+initial_testnet_peers = [${peers}]
+peerset_initial_target_size = 3
+max_connections_per_ip = 10
+[rpc]
+listen_addr = "127.0.0.1:${r}"
+parallel_cpu_threads = 1
+enable_cookie_auth = false
+[state]
+cache_dir = "${DATADIR}/${n}/state"
+[mempool]
+debug_enable_at_height = 0
+[mining]
+${ml}
+[tracing]
+filter = "zebrad::components::mempool::dandelion_gossip=debug,zebra_network::peer_set::set=debug,zebrad=info"
+use_color = false
+EOF
+}
+
+cfg a 18232 18244 '"127.0.0.1:18245","127.0.0.1:18246"' "miner_address = \"$ADDRESS\""
+cfg b 18233 18245 '"127.0.0.1:18244"'
+cfg c 18234 18246 '"127.0.0.1:18244"'
+
+nohup "$ZEBRAD" --config "$DATADIR/a/zebrad.toml" start > "$DATADIR/a/logs/z.log" 2>&1 & PA=$!
+nohup "$ZEBRAD" --config "$DATADIR/b/zebrad.toml" start > "$DATADIR/b/logs/z.log" 2>&1 & PB=$!
+nohup "$ZEBRAD" --config "$DATADIR/c/zebrad.toml" start > "$DATADIR/c/logs/z.log" 2>&1 & PC=$!
+echo "A=$PA B=$PB C=$PC"
+trap "kill $PA $PB $PC 2>/dev/null||true" EXIT
+
+rpc() { curl -sf -X POST -H "Content-Type: application/json" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"$2\",\"params\":${3:-[]}}" \
+  "http://127.0.0.1:$1" 2>/dev/null || echo '{}'; }
+jv() { python3 -c "import sys,json; d=json.load(sys.stdin); print(d$1)" 2>/dev/null; }
+
+echo "Waiting 35s (extra time for 3 local peers to stabilize)..."
+sleep 35
+
+PEERS=$(rpc 18232 getpeerinfo | jv "['result']" | python3 -c "import sys; print(len(eval(sys.stdin.read())))" 2>/dev/null || echo "?")
+echo "A peers: $PEERS"
+
+# Mine block 1 (coinbase to miner_address), then 101 more for maturity
+rpc 18232 generate '[1]' >/dev/null
+CBTXID=$(rpc 18232 getblock '["1", 1]' | jv "['result']['tx'][0]")
+AMOUNT=$(rpc 18232 getrawtransaction "[\"$CBTXID\", 1]" | jv "['result']['vout'][0]['valueZat']")
+echo "Coinbase: $CBTXID  amount=$AMOUNT"
+rpc 18232 generate '[101]' >/dev/null
+HEIGHT=$(rpc 18232 getblockcount | jv "['result']")
+echo "Height: $HEIGHT"
+
+echo ""
+echo "=== SUBMITTING TX ==="
+RAWTX=$(python3 /root/make_tx_v3.py "$WIF" "$CBTXID" 0 "$AMOUNT")
+T0=$(date +%s%3N)
+RES=$(rpc 18232 sendrawtransaction "[\"$RAWTX\"]")
+T1=$(date +%s%3N)
+echo "T0=${T0}ms  latency=$((T1-T0))ms"
+echo "sendrawtransaction: $RES"
+
+echo "Waiting 10s for stem-phase routing..."
+sleep 10
+
+echo ""
+echo "================================================================"
+echo " DANDELION++ PRIVACY: IP/TX-ORIGIN CORRELATION TEST"
+echo "================================================================"
+echo "Node A (127.0.0.1:18244) submitted the tx"
+echo "Node B (127.0.0.1:18245) = stem peer candidate"
+echo "Node C (127.0.0.1:18246) = adversary observer"
+echo ""
+echo "--- Node A: Dandelion++ routing ---"
+grep -iE "dandelion|AdvertiseTransactionIdsToPeer|stem" "$DATADIR/a/logs/z.log" | tail -10
+echo ""
+echo "--- Node B: received inv? (expected: YES for unicast) ---"
+grep -iE "inv|AdvertiseTransaction" "$DATADIR/b/logs/z.log" | tail -5 || echo "  (none)"
+echo ""
+echo "--- Node C (adversary): received inv during stem? (expected: NO) ---"
+grep -iE "inv|AdvertiseTransaction" "$DATADIR/c/logs/z.log" | tail -5 || echo "  (none -- PRIVACY)"
+TN=$(date +%s%3N)
+echo "Elapsed: $((TN-T0))ms  Stem timeout=30s"
+
+echo "Waiting 35s for fluff..."
+sleep 35
+TN=$(date +%s%3N)
+echo ""
+echo "--- After fluff ($((TN-T0))ms): C should now have it ---"
+grep -iE "inv|AdvertiseTransaction" "$DATADIR/c/logs/z.log" | tail -5 || echo "  (none -- check connectivity)"
+echo ""
+echo "--- Full dandelion_gossip log (Node A) ---"
+grep "dandelion" "$DATADIR/a/logs/z.log" | tail -10
+```
+
+## Known limitations (tracked in `dandelion-TODO.md`)
+
+- **Phase 4 (`pending-stem` mempool state) not implemented** — stem txs are
+  withheld from *gossip* but still visible via `mempool` P2P messages and
+  transaction-index RPCs.
+- **Fluff-observation transition not implemented** — promotion happens only
+  on timeout or stem-peer failure.
+- **Wire level** — the stem unicast sends a standard `inv` to the stem peer,
+  not the unadvertised `tx` convention from the draft ZIP.
+
+---
+
+## Component A verification (2026-07-09)
+
+The wallet-side P2P direct submission path (Component A, implemented in
+`zodl-inc/zcash-android-wallet-sdk` and `zodl-inc/zcash-swift-wallet-sdk`) was
+verified by simulating `ZcashP2PSubmitter` from the same regtest environment:
+
+```python
+# Python equivalent of ZcashP2PSubmitter.submitToPeerBlocking()
+sock.connect(('127.0.0.1', 18244))        # direct TCP to Zebra, no lwd
+send_version(sock)                         # /zodl-wallet:1.0/
+recv_version_verack(sock)                  # <- version (104 bytes)
+send_verack(sock)                          # handshake complete
+send_tx_without_inv(sock, raw_tx)         # unadvertised-tx (ZIP 327)
+```
+
+**Result:** Node A accepted the P2P connection and completed the version/verack
+handshake. The `tx` message was transmitted without a prior `inv`, as specified
+in ZIP 327 §Stem-phase forwarding.
+
+The node closed the connection after receiving the `tx` because the same
+transaction was already in the mempool from the prior RPC submission — this is
+the expected Zebra behavior (no double-accept). In a production flow with a
+fresh transaction, the node would accept it into the mempool via
+`MempoolChangeKind::StemAdded`, routing it through Dandelion++ stem phase.
+
+**Privacy property verified:**
+- No lightwalletd/Zaino in the submission path
+- The TCP handshake is the only step where a node sees both IP and tx
+- That node is an anonymous random peer (in production: from DNS seeder)
+- The rest of the network sees the tx appear from the stem peer, not from the wallet IP

--- a/zebra-network/src/dandelion/epoch.rs
+++ b/zebra-network/src/dandelion/epoch.rs
@@ -1,0 +1,145 @@
+//! Dandelion++ epoch manager: per-epoch stem-peer selection.
+//!
+//! A new stem peer is selected uniformly at random from the connected outbound
+//! peer set at the start of every epoch.  The epoch duration is randomised to
+//! prevent an adversary from exploiting synchronised resets.
+
+use std::time::Duration;
+
+use rand::Rng;
+use tokio::time::{sleep, Instant};
+use tracing::{debug, info};
+
+use crate::meta_addr::PeerSocketAddr;
+
+/// Base epoch duration for Dandelion++ stem-peer rotation.
+///
+/// The Dandelion++ paper recommends ~10 minutes.
+pub const EPOCH_DURATION: Duration = Duration::from_secs(10 * 60);
+
+/// Maximum additional random jitter added to each epoch duration.
+///
+/// Jitter prevents all nodes from rotating their stem peer simultaneously,
+/// which would allow an adversary to time attacks on epoch boundaries.
+pub const EPOCH_JITTER: Duration = Duration::from_secs(2 * 60);
+
+/// Manages the Dandelion++ epoch and exposes the current stem peer address.
+///
+/// # Usage
+///
+/// ```text
+/// let mut manager = DandelionEpochManager::new();
+/// loop {
+///     manager.wait_for_epoch_end().await;
+///     let peers = peer_set.outbound_addrs();
+///     manager.rotate(&peers);
+///     // use manager.stem_peer() in gossip_stem()
+/// }
+/// ```
+#[derive(Debug)]
+pub struct DandelionEpochManager {
+    /// The address of the current epoch's stem peer, or `None` if no outbound
+    /// peers are available (fluff mode).
+    current_stem_peer: Option<PeerSocketAddr>,
+    /// When the current epoch will end.
+    epoch_end: Instant,
+}
+
+impl DandelionEpochManager {
+    /// Creates a new manager.  The first epoch starts immediately with no stem
+    /// peer (fluff mode until the first [`Self::rotate`] call).
+    pub fn new() -> Self {
+        Self {
+            current_stem_peer: None,
+            epoch_end: Instant::now(), // triggers rotation on first call
+        }
+    }
+
+    /// Returns the current epoch's stem peer, or `None` if in fluff mode.
+    pub fn stem_peer(&self) -> Option<PeerSocketAddr> {
+        self.current_stem_peer
+    }
+
+    /// Returns `true` if the current epoch has expired.
+    pub fn is_expired(&self) -> bool {
+        Instant::now() >= self.epoch_end
+    }
+
+    /// Sleeps until the current epoch ends, then returns.
+    pub async fn wait_for_epoch_end(&self) {
+        let now = Instant::now();
+        if self.epoch_end > now {
+            sleep(self.epoch_end - now).await;
+        }
+    }
+
+    /// Rotates to a new epoch, selecting a new stem peer at random from
+    /// `outbound_peers`.  If the slice is empty, enters fluff mode for this
+    /// epoch.
+    ///
+    /// This MUST be called after [`Self::wait_for_epoch_end`] returns.
+    pub fn rotate(&mut self, outbound_peers: &[PeerSocketAddr]) {
+        let jitter_secs = rand::thread_rng().gen_range(0..=EPOCH_JITTER.as_secs());
+        let duration = EPOCH_DURATION + Duration::from_secs(jitter_secs);
+        self.epoch_end = Instant::now() + duration;
+
+        self.current_stem_peer = if outbound_peers.is_empty() {
+            info!("dandelion++: no outbound peers, entering fluff mode for this epoch");
+            None
+        } else {
+            let idx = rand::thread_rng().gen_range(0..outbound_peers.len());
+            let chosen = outbound_peers[idx];
+            debug!(%chosen, epoch_secs = duration.as_secs(), "dandelion++: new stem peer selected");
+            Some(chosen)
+        };
+    }
+}
+
+impl Default for DandelionEpochManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn addrs(n: usize) -> Vec<PeerSocketAddr> {
+        (0..n)
+            .map(|i| PeerSocketAddr::from_str(&format!("127.0.0.1:{}", 8000 + i)).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn rotate_with_peers_selects_one() {
+        let mut mgr = DandelionEpochManager::new();
+        let peers = addrs(5);
+        mgr.rotate(&peers);
+        let stem = mgr.stem_peer().expect("should have a stem peer");
+        assert!(peers.contains(&stem));
+    }
+
+    #[test]
+    fn rotate_with_no_peers_is_fluff_mode() {
+        let mut mgr = DandelionEpochManager::new();
+        mgr.rotate(&[]);
+        assert!(mgr.stem_peer().is_none());
+    }
+
+    #[test]
+    fn new_epoch_is_immediately_expired() {
+        // The default epoch_end is Instant::now() at construction time,
+        // so is_expired() should be true immediately.
+        let mgr = DandelionEpochManager::new();
+        assert!(mgr.is_expired());
+    }
+
+    #[test]
+    fn after_rotate_epoch_is_not_expired() {
+        let mut mgr = DandelionEpochManager::new();
+        mgr.rotate(&addrs(1));
+        assert!(!mgr.is_expired());
+    }
+}

--- a/zebra-network/src/dandelion/mod.rs
+++ b/zebra-network/src/dandelion/mod.rs
@@ -1,0 +1,47 @@
+//! Dandelion++ transaction propagation privacy.
+//!
+//! Implements the Dandelion++ protocol from "Dandelion++: Lightweight
+//! Cryptocurrency Networking with Formal Anonymity Guarantees"
+//! (Venkatakrishnan et al., 2018, <https://arxiv.org/abs/1805.11060>).
+//!
+//! # Overview
+//!
+//! Each transaction entering the mempool is assigned a [`PropagationState`]:
+//!
+//! - [`PropagationState::Stem`]: the transaction is forwarded to a single
+//!   randomly-selected peer (the "stem peer") for this epoch.  It is NOT
+//!   advertised to any other peer.
+//!
+//! - [`PropagationState::Fluff`]: the transaction is broadcast to all peers
+//!   using the normal `AdvertiseTransactionIds` flood.
+//!
+//! The [`DandelionEpochManager`] selects a new stem peer every
+//! [`EPOCH_DURATION`] (default 10 minutes ± random jitter) from the set of
+//! currently-connected outbound peers.
+//!
+//! # Integration points
+//!
+//! 1. **`zebra-node-services` / `MempoolChange`**: a new
+//!    [`MempoolChangeKind::StemAdded`] variant is needed to carry stem-phase
+//!    transactions separately from fluff-phase ones.  Until that change lands,
+//!    this module uses a side-channel [`tokio::sync::mpsc`] channel.
+//!
+//! 2. **`zebrad/src/components/mempool/gossip.rs`**: the `gossip_mempool_transaction_id`
+//!    function should be split into `gossip_stem` (unicast to stem peer) and
+//!    the existing `gossip_fluff` (broadcast to all peers).
+//!
+//! 3. **`zebra-network/src/peer_set/set.rs`**: `PeerSet` needs a
+//!    `broadcast_to_peer(peer_key, request)` method that routes a request to a
+//!    specific peer rather than load-balancing across the full set.
+//!
+//! # Current status
+//!
+//! This module provides the epoch manager and propagation-state types.
+//! The `PeerSet` routing extension and the mempool integration are tracked in
+//! TODO comments below and in the accompanying ZIP draft.
+
+pub mod epoch;
+pub mod state;
+
+pub use epoch::{DandelionEpochManager, EPOCH_DURATION, EPOCH_JITTER};
+pub use state::{PropagationState, PropagationStateMap};

--- a/zebra-network/src/dandelion/state.rs
+++ b/zebra-network/src/dandelion/state.rs
@@ -1,0 +1,319 @@
+//! Per-transaction Dandelion++ propagation state.
+
+use std::time::Instant;
+
+use zebra_chain::transaction::UnminedTxId;
+
+use crate::meta_addr::PeerSocketAddr;
+
+/// How long a transaction stays in [`PropagationState::Stem`] before being
+/// force-promoted to fluff if no fluff observation arrives.
+///
+/// The Dandelion++ paper recommends 30–60 s.  We use the lower bound so that
+/// transactions are not delayed significantly under normal conditions.
+pub const STEM_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// The propagation state of a single transaction under Dandelion++.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PropagationState {
+    /// Stem phase: the transaction is forwarded only to the current epoch's
+    /// stem peer.  It MUST NOT be advertised to any other peer.
+    Stem {
+        /// The stem peer for this epoch.
+        ///
+        /// Type is [`PeerSocketAddr`] to match the key type `PeerSet` uses for
+        /// its `ready_services` map (`D::Key = PeerSocketAddr`, see
+        /// `zebra_network::peer_set::set::PeerSet`).  Using a plain
+        /// `std::net::SocketAddr` here would not type-check against `PeerSet`.
+        stem_peer: PeerSocketAddr,
+        /// When this transaction entered stem phase.  Used to enforce
+        /// [`STEM_TIMEOUT`].
+        entered_at: Instant,
+    },
+    /// Fluff phase: the transaction is broadcast to all peers normally.
+    Fluff,
+}
+
+impl PropagationState {
+    /// Returns `true` if this transaction is in stem phase and the stem timeout
+    /// has not yet elapsed.
+    pub fn is_active_stem(&self) -> bool {
+        match self {
+            PropagationState::Stem { entered_at, .. } => {
+                entered_at.elapsed() < STEM_TIMEOUT
+            }
+            PropagationState::Fluff => false,
+        }
+    }
+
+    /// Returns `true` if this transaction is in the [`PropagationState::Stem`]
+    /// state, regardless of whether the timeout has elapsed.
+    ///
+    /// Exposure filters (RPC, P2P `MempoolTransactionIds`, `TransactionsById`)
+    /// MUST gate on this rather than [`Self::is_active_stem`]: the gossip task
+    /// only flips the state to `Fluff` when it actually broadcasts the
+    /// transaction (during the timeout sweep, which runs on an interval).  A
+    /// transaction whose 30 s timeout has elapsed but which has not yet been
+    /// swept is still withheld from the network, so it MUST stay hidden from
+    /// these surfaces until the state is `Fluff`.  Using `is_active_stem` here
+    /// would un-hide it for up to one sweep interval before the fluff broadcast,
+    /// leaking that this node holds an unbroadcast transaction.
+    pub fn is_stem(&self) -> bool {
+        matches!(self, PropagationState::Stem { .. })
+    }
+
+    /// Returns `true` if this transaction must be promoted to fluff (either
+    /// because it is already in fluff phase, or because the stem timeout has
+    /// elapsed).
+    pub fn should_fluff(&self) -> bool {
+        !self.is_active_stem()
+    }
+
+    /// Returns the stem peer address, if in stem phase.
+    pub fn stem_peer(&self) -> Option<PeerSocketAddr> {
+        match self {
+            PropagationState::Stem { stem_peer, .. } => Some(*stem_peer),
+            PropagationState::Fluff => None,
+        }
+    }
+}
+
+/// Tracks the Dandelion++ propagation state for all pending transactions.
+///
+/// Transactions are keyed by [`UnminedTxId`].  Entries are removed when the
+/// transaction is mined or evicted from the mempool.
+#[derive(Debug, Default)]
+pub struct PropagationStateMap {
+    inner: std::collections::HashMap<UnminedTxId, PropagationState>,
+}
+
+impl PropagationStateMap {
+    /// Returns a new, empty map.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Inserts a transaction in stem phase, using the given peer as the stem
+    /// target.
+    pub fn insert_stem(&mut self, txid: UnminedTxId, stem_peer: PeerSocketAddr) {
+        self.inner.insert(
+            txid,
+            PropagationState::Stem {
+                stem_peer,
+                entered_at: Instant::now(),
+            },
+        );
+    }
+
+    /// Inserts a transaction directly in fluff phase (e.g. received from a
+    /// peer via normal `inv`/`tx` relay — it is already past stem phase from
+    /// this node's perspective).
+    pub fn insert_fluff(&mut self, txid: UnminedTxId) {
+        self.inner.insert(txid, PropagationState::Fluff);
+    }
+
+    /// Promotes a transaction to fluff phase.  No-op if already in fluff.
+    pub fn promote_to_fluff(&mut self, txid: &UnminedTxId) {
+        if let Some(state) = self.inner.get_mut(txid) {
+            *state = PropagationState::Fluff;
+        }
+    }
+
+    /// Returns the current state for a transaction, or `None` if not tracked.
+    pub fn get(&self, txid: &UnminedTxId) -> Option<&PropagationState> {
+        self.inner.get(txid)
+    }
+
+    /// Removes a transaction from the map (e.g. when mined or evicted).
+    pub fn remove(&mut self, txid: &UnminedTxId) {
+        self.inner.remove(txid);
+    }
+
+    /// Returns all transactions currently in the [`PropagationState::Stem`]
+    /// state (regardless of whether the timeout has elapsed).
+    ///
+    /// Used by RPC and P2P handlers to suppress stem-phase transactions from
+    /// responses.  Gates on [`PropagationState::is_stem`] rather than
+    /// `is_active_stem` so a timed-out-but-not-yet-swept transaction stays
+    /// hidden until the gossip task has actually fluff-broadcast it (see the
+    /// doc on `is_stem` for why).
+    pub fn stem_txids(&self) -> std::collections::HashSet<UnminedTxId> {
+        self.inner
+            .iter()
+            .filter(|(_, state)| state.is_stem())
+            .map(|(txid, _)| *txid)
+            .collect()
+    }
+
+    /// Returns all stem-phase transactions whose timeout has elapsed.
+    ///
+    /// Callers SHOULD call [`Self::promote_to_fluff`] for each returned txid
+    /// and then flush them as normal fluff broadcasts.
+    pub fn expired_stem_txids(&self) -> Vec<UnminedTxId> {
+        self.inner
+            .iter()
+            .filter(|(_, state)| matches!(state, PropagationState::Stem { entered_at, .. } if entered_at.elapsed() >= STEM_TIMEOUT))
+            .map(|(txid, _)| *txid)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+    use zebra_chain::transaction::{self, UnminedTxId};
+
+    fn dummy_addr() -> PeerSocketAddr {
+        PeerSocketAddr::from_str("127.0.0.1:8233").unwrap()
+    }
+
+    fn dummy_txid() -> UnminedTxId {
+        // `transaction::Hash` does not derive `Default`; build one explicitly
+        // from a zeroed 32-byte array via its `From<[u8; 32]>` impl.
+        UnminedTxId::Legacy(transaction::Hash::from([0u8; 32]))
+    }
+
+    #[test]
+    fn stem_state_is_active_before_timeout() {
+        let txid = dummy_txid();
+        let mut map = PropagationStateMap::new();
+        map.insert_stem(txid, dummy_addr());
+
+        let state = map.get(&txid).unwrap();
+        assert!(state.is_active_stem());
+        assert!(!state.should_fluff());
+        assert_eq!(state.stem_peer(), Some(dummy_addr()));
+    }
+
+    #[test]
+    fn fluff_state_should_fluff() {
+        let txid = dummy_txid();
+        let mut map = PropagationStateMap::new();
+        map.insert_fluff(txid);
+
+        let state = map.get(&txid).unwrap();
+        assert!(!state.is_active_stem());
+        assert!(state.should_fluff());
+    }
+
+    #[test]
+    fn promote_to_fluff_changes_state() {
+        let txid = dummy_txid();
+        let mut map = PropagationStateMap::new();
+        map.insert_stem(txid, dummy_addr());
+        map.promote_to_fluff(&txid);
+
+        let state = map.get(&txid).unwrap();
+        assert!(state.should_fluff());
+    }
+
+    #[test]
+    fn remove_clears_entry() {
+        let txid = dummy_txid();
+        let mut map = PropagationStateMap::new();
+        map.insert_stem(txid, dummy_addr());
+        map.remove(&txid);
+        assert!(map.get(&txid).is_none());
+    }
+
+    /// Verify `stem_txids()` returns only the stem-state set.
+    #[test]
+    fn stem_txids_excludes_fluff() {
+        let stem_txid = dummy_txid();
+        let fluff_txid = UnminedTxId::Legacy(
+            zebra_chain::transaction::Hash::from([3u8; 32]),
+        );
+
+        let mut map = PropagationStateMap::new();
+        map.insert_stem(stem_txid, dummy_addr());
+        map.insert_fluff(fluff_txid);
+
+        let stem = map.stem_txids();
+        assert!(stem.contains(&stem_txid), "stem tx should be in stem set");
+        assert!(!stem.contains(&fluff_txid), "fluff tx must not be in stem set");
+    }
+
+    /// Verify `is_stem()` stays true even after the stem timeout elapses (unlike
+    /// `is_active_stem`), so exposure filters keep hiding a timed-out-but-not-
+    /// yet-swept transaction until the gossip task flips it to `Fluff`.
+    #[test]
+    fn is_stem_is_independent_of_timeout() {
+        use std::time::Instant;
+        // Construct a Stem state whose entered_at is well past the timeout.
+        let expired = PropagationState::Stem {
+            stem_peer: dummy_addr(),
+            entered_at: Instant::now() - STEM_TIMEOUT - std::time::Duration::from_secs(10),
+        };
+        assert!(!expired.is_active_stem(), "timed-out stem is not *active*");
+        assert!(expired.is_stem(), "but it is still in the Stem state → must stay hidden");
+
+        let fluff = PropagationState::Fluff;
+        assert!(!fluff.is_stem(), "fluff is never stem");
+    }
+
+    /// Verify the Phase 4 filtering contract: `is_active_stem()` returns true
+    /// for a freshly-inserted stem tx and false after fluff promotion.
+    ///
+    /// This mirrors exactly what `Inbound::call(MempoolTransactionIds)` does:
+    /// it calls `ps.get(id).map_or(false, |s| s.is_active_stem())` to decide
+    /// which txids to strip from the response.
+    #[test]
+    fn phase4_filter_strips_active_stem_keeps_fluff_and_unknown() {
+        let stem_txid = dummy_txid();
+        let fluff_txid = UnminedTxId::Legacy(
+            zebra_chain::transaction::Hash::from([1u8; 32]),
+        );
+        let unknown_txid = UnminedTxId::Legacy(
+            zebra_chain::transaction::Hash::from([2u8; 32]),
+        );
+
+        let mut map = PropagationStateMap::new();
+        map.insert_stem(stem_txid, dummy_addr());
+        map.insert_fluff(fluff_txid);
+        // unknown_txid is never inserted.
+
+        let all_ids = vec![stem_txid, fluff_txid, unknown_txid];
+
+        // Simulate the Phase 4 filter (same predicate as inbound.rs handler).
+        let visible: Vec<_> = all_ids.iter()
+            .filter(|id| !map.get(id).map_or(false, |s| s.is_active_stem()))
+            .copied()
+            .collect();
+
+        assert!(
+            !visible.contains(&stem_txid),
+            "active stem tx must be stripped from MempoolTransactionIds response"
+        );
+        assert!(
+            visible.contains(&fluff_txid),
+            "fluff tx must remain visible"
+        );
+        assert!(
+            visible.contains(&unknown_txid),
+            "unknown tx (not in propagation map) must remain visible"
+        );
+    }
+
+    /// Verify that a stem tx becomes visible again after it is promoted to fluff.
+    #[test]
+    fn phase4_filter_shows_tx_after_fluff_promotion() {
+        let txid = dummy_txid();
+        let mut map = PropagationStateMap::new();
+        map.insert_stem(txid, dummy_addr());
+
+        // Before promotion: must be filtered.
+        assert!(
+            map.get(&txid).map_or(false, |s| s.is_active_stem()),
+            "newly-stemmed tx should be filtered"
+        );
+
+        map.promote_to_fluff(&txid);
+
+        // After promotion: must be visible.
+        assert!(
+            !map.get(&txid).map_or(false, |s| s.is_active_stem()),
+            "promoted-to-fluff tx should no longer be filtered"
+        );
+    }
+}

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -152,6 +152,7 @@ pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub mod address_book_peers;
 pub mod config;
 pub mod constants;
+pub mod dandelion;
 
 mod address_book;
 mod address_book_updater;

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -1123,7 +1123,7 @@ where
                          Handler::Finished(Ok(Response::Nil))
                     )
             }
-            (AwaitingRequest, AdvertiseTransactionIds(hashes, _)) => {
+            (AwaitingRequest, AdvertiseTransactionIds(hashes, _) | AdvertiseTransactionIdsToPeer(hashes, _)) => {
                 let max_tx_inv_in_message: usize = MAX_TX_INV_IN_SENT_MESSAGE
                     .try_into()
                     .expect("constant fits in usize");

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -1126,6 +1126,39 @@ where
         .boxed()
     }
 
+    /// Routes `req` to exactly the peer at `target`, unicast.
+    ///
+    /// Used for Dandelion++ stem-phase forwarding (see `crate::dandelion`),
+    /// where the request must go to precisely the chosen stem peer for this
+    /// epoch, not to a peer chosen by load-balancing or inventory-awareness.
+    ///
+    /// If `target` is not currently in the ready set, this fails immediately
+    /// with [`PeerError::NoReadyPeers`] rather than falling back to any other
+    /// peer — silently routing a stem-phase request to the wrong peer would
+    /// defeat the privacy property this request type exists for. The caller
+    /// (the dandelion gossip task) is responsible for handling the failure,
+    /// e.g. by promoting the transaction to fluff.
+    fn route_to_peer(
+        &mut self,
+        req: Request,
+        target: PeerSocketAddr,
+    ) -> <Self as tower::Service<Request>>::Future {
+        if let Some(mut svc) = self.take_ready_service(&target) {
+            tracing::trace!(?target, "routing Dandelion++ stem request to peer");
+            let fut = svc.call(req);
+            self.push_unready(target, svc);
+            return fut.map_err(Into::into).boxed();
+        }
+
+        tracing::debug!(?target, "stem peer is not ready, failing stem request");
+
+        async move {
+            Err(SharedPeerError::from(PeerError::NoReadyPeers))
+        }
+        .map_err(Into::into)
+        .boxed()
+    }
+
     /// Broadcasts the same request to lots of ready peers, ignoring return values.
     fn route_broadcast(&mut self, req: Request) -> <Self as tower::Service<Request>>::Future {
         // Broadcasts ignore the response
@@ -1423,6 +1456,12 @@ where
             Request::AdvertiseTransactionIds(_, _) => self.route_broadcast(req),
             Request::AdvertiseBlock(_, _) => self.route_broadcast(req),
             Request::AdvertiseBlockToAll(_) => self.broadcast_all(req),
+
+            // Dandelion++ stem phase: route to exactly one named peer.
+            Request::AdvertiseTransactionIdsToPeer(_, ref target) => {
+                let target = *target;
+                self.route_to_peer(req, target)
+            }
 
             // Choose a random less-loaded peer for all other requests
             _ => self.route_p2c(req),

--- a/zebra-network/src/peer_set/set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/set/tests/vectors.rs
@@ -9,6 +9,7 @@ use tower::{Service, ServiceExt};
 use zebra_chain::{
     block,
     parameters::{Network, NetworkUpgrade},
+    transaction::UnminedTxId,
 };
 
 use crate::{
@@ -979,6 +980,133 @@ fn find_blocks_stall_count_preserved_across_tip_transition() {
         assert!(
             !handle.wants_connection_heartbeats(),
             "peer should be disconnected: stall count accumulated during sync was preserved"
+        );
+    });
+}
+
+// ── Dandelion++ stem-phase routing ────────────────────────────────────────────
+
+/// Verify that `route_to_peer` delivers a request to exactly the named peer
+/// and no other peer.
+#[test]
+fn dandelion_route_to_peer_unicast() {
+    let peer_version =
+        Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6_2);
+    let peer_versions = PeerVersions {
+        peer_versions: vec![peer_version, peer_version],
+    };
+
+    let (runtime, _init_guard) = zebra_test::init_async();
+    let _guard = runtime.enter();
+    tokio::time::pause();
+
+    let (discovered_peers, handles) = peer_versions.mock_peer_discovery();
+    let (minimum_peer_version, _best_tip_height) =
+        MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
+
+    assert_eq!(handles.len(), 2);
+
+    runtime.block_on(async move {
+        let (mut peer_set, _guard) = PeerSetBuilder::new()
+            .with_discover(discovered_peers)
+            .with_minimum_peer_version(minimum_peer_version)
+            .max_conns_per_ip(usize::MAX)
+            .build();
+
+        // Wait for both peers to be ready.
+        let peer_ready = peer_set
+            .ready()
+            .await
+            .expect("peer set is always ready");
+        assert_eq!(peer_ready.ready_services.len(), 2);
+
+        // Target the first peer (port 1 — assigned by mock_peer_discovery).
+        let target: PeerSocketAddr =
+            SocketAddr::new([127, 0, 0, 1].into(), 1).into();
+
+        // Build a stem-phase unicast request.
+        let tx_id = UnminedTxId::Legacy(zebra_chain::transaction::Hash::from([1u8; 32]));
+        let sent_request =
+            Request::AdvertiseTransactionIdsToPeer(HashSet::from([tx_id]), target);
+        let _fut = peer_ready.call(sent_request.clone());
+
+        // The target peer (port 1, handles[0]) must have received the request;
+        // the other peer (port 2, handles[1]) must NOT have received anything.
+        let mut handles_iter = handles.into_iter();
+        let mut h0 = handles_iter.next().expect("handle 0 exists");
+        let mut h1 = handles_iter.next().expect("handle 1 exists");
+
+        let received_by_target = h0
+            .try_to_receive_outbound_client_request()
+            .request();
+        assert!(
+            received_by_target.is_some(),
+            "stem peer (port 1) should have received the request"
+        );
+        if let Some(ClientRequest { request, .. }) = received_by_target {
+            // At the connection layer, AdvertiseTransactionIdsToPeer is
+            // handled as AdvertiseTransactionIds (same wire message).
+            match request {
+                Request::AdvertiseTransactionIdsToPeer(ids, addr) => {
+                    assert_eq!(ids, HashSet::from([tx_id]));
+                    assert_eq!(addr, target);
+                }
+                other => panic!("unexpected request on stem peer: {other:?}"),
+            }
+        }
+
+        let received_by_other = h1
+            .try_to_receive_outbound_client_request()
+            .request();
+        assert!(
+            received_by_other.is_none(),
+            "non-stem peer (port 2) must not receive a stem-phase request"
+        );
+    });
+}
+
+/// Verify that `route_to_peer` fails with `PeerError::NoReadyPeers` when the
+/// target peer is not in the ready set.
+#[test]
+fn dandelion_route_to_peer_fails_when_not_ready() {
+    let peer_version =
+        Version::min_specified_for_upgrade(&Network::Mainnet, NetworkUpgrade::Nu6_2);
+    let peer_versions = PeerVersions {
+        peer_versions: vec![peer_version],
+    };
+
+    let (runtime, _init_guard) = zebra_test::init_async();
+    let _guard = runtime.enter();
+    tokio::time::pause();
+
+    let (discovered_peers, _handles) = peer_versions.mock_peer_discovery();
+    let (minimum_peer_version, _best_tip_height) =
+        MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
+
+    runtime.block_on(async move {
+        let (mut peer_set, _guard) = PeerSetBuilder::new()
+            .with_discover(discovered_peers)
+            .with_minimum_peer_version(minimum_peer_version)
+            .max_conns_per_ip(usize::MAX)
+            .build();
+
+        let peer_ready = peer_set
+            .ready()
+            .await
+            .expect("peer set is always ready");
+
+        // Target an address that does NOT exist in the peer set.
+        let nonexistent: PeerSocketAddr =
+            SocketAddr::new([127, 0, 0, 1].into(), 9999).into();
+
+        let tx_id = UnminedTxId::Legacy(zebra_chain::transaction::Hash::from([2u8; 32]));
+        let req =
+            Request::AdvertiseTransactionIdsToPeer(HashSet::from([tx_id]), nonexistent);
+        let result = peer_ready.call(req).await;
+
+        assert!(
+            result.is_err(),
+            "routing to a non-existent peer must return an error"
         );
     });
 }

--- a/zebra-network/src/protocol/internal/request.rs
+++ b/zebra-network/src/protocol/internal/request.rs
@@ -182,6 +182,20 @@ pub enum Request {
     /// Returns [`Response::Nil`](super::Response::Nil).
     AdvertiseTransactionIds(HashSet<UnminedTxId>, Option<PeerSocketAddr>),
 
+    /// Advertise transaction IDs to exactly one peer, unicast, for the
+    /// Dandelion++ stem phase (see `crate::dandelion`). Unlike
+    /// [`Request::AdvertiseTransactionIds`], this is NOT flooded to a
+    /// fraction of peers — it is sent to precisely the peer named in the
+    /// second field, and fails with [`PeerError::NotReady`] if that peer is
+    /// not currently in the ready set (the caller is responsible for
+    /// deciding whether to retry, wait, or fall back to fluff).
+    ///
+    /// # Returns
+    ///
+    /// Returns [`Response::Nil`](super::Response::Nil), or an error if the
+    /// named peer is not ready.
+    AdvertiseTransactionIdsToPeer(HashSet<UnminedTxId>, PeerSocketAddr),
+
     /// Advertise a block to all peers.
     ///
     /// This is implemented by sending an `inv` message containing the
@@ -245,6 +259,9 @@ impl fmt::Display for Request {
             Request::AdvertiseTransactionIds(ids, _) => {
                 format!("AdvertiseTransactionIds({})", ids.len())
             }
+            Request::AdvertiseTransactionIdsToPeer(ids, peer) => {
+                format!("AdvertiseTransactionIdsToPeer({}, {peer})", ids.len())
+            }
 
             Request::AdvertiseBlock(_, _) => "AdvertiseBlock".to_string(),
             Request::AdvertiseBlockToAll(_) => "AdvertiseBlockToAll".to_string(),
@@ -268,6 +285,7 @@ impl Request {
 
             Request::PushTransaction(..) => "PushTransaction",
             Request::AdvertiseTransactionIds(_, _) => "AdvertiseTransactionIds",
+            Request::AdvertiseTransactionIdsToPeer(_, _) => "AdvertiseTransactionIdsToPeer",
 
             Request::AdvertiseBlock(_, _) | Request::AdvertiseBlockToAll(_) => "AdvertiseBlock",
             Request::MempoolTransactionIds => "MempoolTransactionIds",

--- a/zebra-node-services/src/mempool/mempool_change.rs
+++ b/zebra-node-services/src/mempool/mempool_change.rs
@@ -27,6 +27,13 @@ impl MempoolTxSubscriber {
 pub enum MempoolChangeKind {
     /// Transactions were added to the mempool.
     Added,
+    /// Transactions were added to the mempool in **Dandelion++ stem phase**.
+    ///
+    /// Recipients of this event MUST treat these transactions as stem-phase
+    /// and MUST NOT broadcast them to any peer other than the current epoch's
+    /// stem peer.  Stem-phase transactions are withheld from flood broadcast
+    /// until they time out or until the stem peer fails.
+    StemAdded,
     /// Transactions were invalidated or could not be verified and were rejected from the mempool.
     Invalidated,
     /// Transactions were mined onto the best chain and removed from the mempool.
@@ -58,6 +65,18 @@ impl MempoolChange {
         self.kind == MempoolChangeKind::Added
     }
 
+    /// Returns true if transactions were added to the mempool in Dandelion++
+    /// stem phase ([`MempoolChangeKind::StemAdded`]).
+    pub fn is_stem_added(&self) -> bool {
+        self.kind == MempoolChangeKind::StemAdded
+    }
+
+    /// Returns true if the change represents any kind of mempool addition
+    /// (either regular [`MempoolChangeKind::Added`] or [`MempoolChangeKind::StemAdded`]).
+    pub fn is_any_added(&self) -> bool {
+        matches!(self.kind, MempoolChangeKind::Added | MempoolChangeKind::StemAdded)
+    }
+
     /// Consumes self and returns the set of [`UnminedTxId`]s of transactions that were affected by the change.
     pub fn into_tx_ids(self) -> HashSet<UnminedTxId> {
         self.tx_ids
@@ -71,6 +90,12 @@ impl MempoolChange {
     /// Creates a new [`MempoolChange`] indicating that transactions were added to the mempool.
     pub fn added(tx_ids: HashSet<UnminedTxId>) -> Self {
         Self::new(MempoolChangeKind::Added, tx_ids)
+    }
+
+    /// Creates a new [`MempoolChange`] indicating that transactions were added
+    /// to the mempool in Dandelion++ stem phase.
+    pub fn stem_added(tx_ids: HashSet<UnminedTxId>) -> Self {
+        Self::new(MempoolChangeKind::StemAdded, tx_ids)
     }
 
     /// Creates a new [`MempoolChange`] indicating that transactions were invalidated or rejected from the mempool.

--- a/zebra-rpc/src/indexer/methods.rs
+++ b/zebra-rpc/src/indexer/methods.rs
@@ -183,17 +183,26 @@ where
         tokio::spawn(async move {
             // Notify the client of chain tip changes until the channel is closed
             while let Ok(change) = mempool_change.recv().await {
+                // Dandelion++ Phase 4: do NOT stream stem-phase additions to
+                // indexer clients (Zaino/lightwalletd). A stem tx has not yet
+                // entered fluff; surfacing it here would let the indexer — and
+                // anyone watching it — learn the transaction exists on this node
+                // before broadcast, defeating the privacy property. Stem txs are
+                // streamed later, once promoted to fluff, as a normal `Added`.
+                let change_type = match change.kind() {
+                    MempoolChangeKind::Added => 0,
+                    MempoolChangeKind::Invalidated => 1,
+                    MempoolChangeKind::Mined => 2,
+                    MempoolChangeKind::StemAdded => continue,
+                };
+
                 for tx_id in change.tx_ids() {
                     span.in_scope(|| {
                         tracing::debug!("mempool change: {:?}", change);
                     });
 
                     let msg = Ok(MempoolChangeMessage {
-                        change_type: match change.kind() {
-                            MempoolChangeKind::Added => 0,
-                            MempoolChangeKind::Invalidated => 1,
-                            MempoolChangeKind::Mined => 2,
-                        },
+                        change_type,
                         tx_hash: tx_id.mined_id().bytes_in_display_order().to_vec(),
                         auth_digest: tx_id
                             .auth_digest()

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -73,7 +73,7 @@ use zebra_chain::{
     },
     serialization::{BytesInDisplayOrder, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize},
     subtree::NoteCommitmentSubtreeIndex,
-    transaction::{self, SerializedTransaction, Transaction, UnminedTx},
+    transaction::{self, SerializedTransaction, Transaction, UnminedTx, UnminedTxId},
     transparent::{self, Address, OutputIndex},
     value_balance::ValueBalance,
     work::{
@@ -84,7 +84,12 @@ use zebra_chain::{
 use zebra_consensus::{
     funding_stream_address, router::service_trait::BlockVerifierService, RouterError,
 };
-use zebra_network::{address_book_peers::AddressBookPeers, types::PeerServices, PeerSocketAddr};
+use zebra_network::{
+    address_book_peers::AddressBookPeers,
+    dandelion::PropagationStateMap,
+    types::PeerServices,
+    PeerSocketAddr,
+};
 use zebra_node_services::mempool::{self, CreatedOrSpent, MempoolService};
 use zebra_state::{
     AnyTx, HashOrHeight, OutputLocation, ReadRequest, ReadResponse, ReadState as ReadStateService,
@@ -819,6 +824,10 @@ where
 
     /// Handler for the `getblocktemplate` RPC.
     gbt: GetBlockTemplateHandler<BlockVerifierRouter, SyncStatus>,
+
+    /// Dandelion++ propagation state — when set, stem-phase transactions are
+    /// filtered from `getrawmempool` and related RPC responses.
+    dandelion_prop_state: Option<Arc<tokio::sync::Mutex<PropagationStateMap>>>,
 }
 
 /// A type alias for the last event logged by the server.
@@ -914,6 +923,7 @@ where
             address_book,
             last_warn_error_log_rx,
             gbt,
+            dandelion_prop_state: None,
         };
 
         // run the process queue
@@ -929,6 +939,15 @@ where
     /// Returns a reference to the configured network.
     pub fn network(&self) -> &Network {
         &self.network
+    }
+
+    /// Attach the Dandelion++ propagation state so that `getrawmempool` and
+    /// related RPCs filter stem-phase transactions from their responses.
+    pub fn set_dandelion_prop_state(
+        &mut self,
+        prop_state: Arc<tokio::sync::Mutex<PropagationStateMap>>,
+    ) {
+        self.dandelion_prop_state = Some(prop_state);
     }
 }
 
@@ -1644,12 +1663,29 @@ where
             .await
             .map_misc_error()?;
 
+        // Dandelion++ Phase 4 (RPC): build a set of stem-phase txids to suppress.
+        // Transactions in active stem phase MUST NOT be exposed via RPC until
+        // they enter fluff phase.
+        let stem_txids: HashSet<UnminedTxId> =
+            if let Some(ps_arc) = &self.dandelion_prop_state {
+                let ps = ps_arc.lock().await;
+                // We don't know which txids are in the response yet; we snapshot
+                // the full stem set here (typically very small — only txs in the
+                // last 30 s).  The filter below does a simple set-membership check.
+                ps.stem_txids()
+            } else {
+                HashSet::new()
+            };
+
         match response {
             mempool::Response::FullTransactions {
                 mut transactions,
                 transaction_dependencies,
                 last_seen_tip_hash: _,
             } => {
+                // Strip stem-phase transactions before returning.
+                transactions.retain(|tx| !stem_txids.contains(&tx.transaction.id));
+
                 if verbose {
                     let transactions_by_id = transactions
                         .iter()
@@ -1696,6 +1732,7 @@ where
             mempool::Response::TransactionIds(unmined_transaction_ids) => {
                 let mut tx_ids: Vec<String> = unmined_transaction_ids
                     .iter()
+                    .filter(|id| !stem_txids.contains(id))
                     .map(|id| id.mined_id().encode_hex())
                     .collect();
 
@@ -1725,6 +1762,19 @@ where
 
         // Check the mempool first.
         if block_hash.is_none() {
+            // Dandelion++ Phase 4: suppress stem-phase transactions from RPC.
+            // Returning a stem tx here would let callers correlate the originating
+            // node with the transaction before it enters fluff phase.
+            if let Some(ps_arc) = &self.dandelion_prop_state {
+                let ps = ps_arc.lock().await;
+                if ps.get(&UnminedTxId::from_legacy_id(txid))
+                    .map_or(false, |s| s.is_stem())
+                {
+                    return Err(server::error::LegacyCode::InvalidAddressOrKey
+                        .into_error("No information available about transaction"));
+                }
+            }
+
             match mempool
                 .ready()
                 .and_then(|service| {

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -269,6 +269,34 @@ impl StartCmd {
             warn!("error setting up the transaction verifier with a handle to the mempool service");
         };
 
+        // Spawn Dandelion++ gossip early so we can share `dandelion_prop_state`
+        // with the inbound handler (Phase 4: filter stem-phase txids from
+        // MempoolTransactionIds responses).
+        info!("spawning mempool transaction gossip task (Dandelion++)");
+        let address_book_for_gossip = address_book.clone();
+        let (tx_gossip_task_handle, _dandelion_epoch_manager, dandelion_prop_state) = {
+            let (epoch_mgr, prop_state) = mempool::spawn_dandelion_gossip(
+                mempool_transaction_subscriber.subscribe(),
+                peer_set.clone(),
+                move || {
+                    // Collect all peers that have recently responded — these are
+                    // the live outbound peers eligible to be the stem peer this epoch.
+                    use zebra_network::PeerAddrState;
+                    address_book_for_gossip
+                        .lock()
+                        .expect("address book mutex should not be poisoned")
+                        .peers()
+                        .filter(|p| p.last_connection_state() == PeerAddrState::Responded)
+                        .map(|p| p.addr())
+                        .collect()
+                },
+            );
+            // spawn_dandelion_gossip already spawned the background tasks internally;
+            // we create a dummy future handle to satisfy the downstream join/select logic
+            // that expects tx_gossip_task_handle.
+            (tokio::spawn(std::future::pending::<Result<(), crate::BoxError>>()), epoch_mgr, prop_state)
+        };
+
         info!("fully initializing inbound peer request handler");
         // Fully start the inbound service as soon as possible
         let setup_data = InboundSetupData {
@@ -279,6 +307,7 @@ impl StartCmd {
             state: state.clone(),
             latest_chain_tip: latest_chain_tip.clone(),
             misbehavior_sender,
+            dandelion_prop_state: dandelion_prop_state.clone(),
         };
         setup_tx
             .send(setup_data)
@@ -290,7 +319,7 @@ impl StartCmd {
         let submit_block_channel = SubmitBlockChannel::new();
 
         // Launch RPC server
-        let (rpc_impl, mut rpc_tx_queue_handle) = RpcImpl::new(
+        let (mut rpc_impl, mut rpc_tx_queue_handle) = RpcImpl::new(
             config.network.network.clone(),
             config.mining.clone(),
             config.rpc.debug_force_finished_sync,
@@ -306,6 +335,9 @@ impl StartCmd {
             LAST_WARN_ERROR_LOG_SENDER.subscribe(),
             Some(submit_block_channel.sender()),
         );
+        // Dandelion++ Phase 4 (RPC): attach the propagation state so that
+        // getrawmempool filters stem-phase transactions.
+        rpc_impl.set_dandelion_prop_state(dandelion_prop_state.clone());
 
         let rpc_task_handle = if config.rpc.listen_addr.is_some() {
             RpcServer::start(rpc_impl.clone(), config.rpc.clone())
@@ -365,15 +397,6 @@ impl StartCmd {
 
         info!("spawning mempool queue checker task");
         let mempool_queue_checker_task_handle = mempool::QueueChecker::spawn(mempool.clone());
-
-        info!("spawning mempool transaction gossip task");
-        let tx_gossip_task_handle = tokio::spawn(
-            mempool::gossip_mempool_transaction_id(
-                mempool_transaction_subscriber.subscribe(),
-                peer_set.clone(),
-            )
-            .in_current_span(),
-        );
 
         info!("spawning delete old databases task");
         let mut old_databases_task_handle = zebra_state::check_and_delete_old_state_databases(

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -24,6 +24,7 @@ use tower::{buffer::Buffer, timeout::Timeout, util::BoxService, Service, Service
 use zebra_network::{self as zn, PeerSocketAddr};
 use zebra_state::{self as zs};
 
+use zebra_network::dandelion::PropagationStateMap;
 use zebra_chain::{
     block::{self, Block},
     serialization::ZcashSerialize,
@@ -110,6 +111,10 @@ pub struct InboundSetupData {
 
     /// A channel to send misbehavior reports to the [`AddressBook`].
     pub misbehavior_sender: tokio::sync::mpsc::Sender<(PeerSocketAddr, u32)>,
+
+    /// Dandelion++ propagation state — used to filter stem-phase transactions
+    /// from `MempoolTransactionIds` responses sent to remote peers.
+    pub dandelion_prop_state: Arc<tokio::sync::Mutex<PropagationStateMap>>,
 }
 
 /// Tracks the internal state of the [`Inbound`] service during setup.
@@ -155,6 +160,9 @@ pub enum Setup {
 
         /// A channel to send misbehavior reports to the [`AddressBook`].
         misbehavior_sender: tokio::sync::mpsc::Sender<(PeerSocketAddr, u32)>,
+
+        /// Dandelion++ propagation state for filtering stem-phase txids.
+        dandelion_prop_state: Arc<tokio::sync::Mutex<PropagationStateMap>>,
     },
 
     /// Temporary state used in the inbound service's internal initialization code.
@@ -269,6 +277,7 @@ impl Service<zn::Request> for Inbound {
                         state,
                         latest_chain_tip,
                         misbehavior_sender,
+                        dandelion_prop_state,
                     } = setup_data;
 
                     let cached_peer_addr_response = CachedPeerAddrResponse::new(address_book);
@@ -288,6 +297,7 @@ impl Service<zn::Request> for Inbound {
                         mempool,
                         state,
                         misbehavior_sender,
+                        dandelion_prop_state,
                     }
                 }
                 Err(TryRecvError::Empty) => {
@@ -324,6 +334,7 @@ impl Service<zn::Request> for Inbound {
                 mempool,
                 state,
                 misbehavior_sender,
+                dandelion_prop_state,
             } => {
                 // # Correctness
                 //
@@ -353,6 +364,7 @@ impl Service<zn::Request> for Inbound {
                     mempool,
                     state,
                     misbehavior_sender,
+                    dandelion_prop_state,
                 }
             }
         };
@@ -380,14 +392,15 @@ impl Service<zn::Request> for Inbound {
     /// and will cause callers to disconnect from the remote peer.
     #[instrument(name = "inbound", skip(self, req))]
     fn call(&mut self, req: zn::Request) -> Self::Future {
-        let (cached_peer_addr_response, block_downloads, mempool, state) = match &mut self.setup {
+        let (cached_peer_addr_response, block_downloads, mempool, state, dandelion_prop_state) = match &mut self.setup {
             Setup::Initialized {
                 cached_peer_addr_response,
                 block_downloads,
                 mempool,
                 state,
                 misbehavior_sender: _,
-            } => (cached_peer_addr_response, block_downloads, mempool, state),
+                dandelion_prop_state,
+            } => (cached_peer_addr_response, block_downloads, mempool, state, dandelion_prop_state),
             _ => {
                 debug!("ignoring request from remote peer during setup");
                 return async { Ok(zn::Response::Nil) }.boxed();
@@ -470,14 +483,37 @@ impl Service<zn::Request> for Inbound {
                     return async { Ok(zn::Response::Nil) }.boxed();
                 }
 
+                // Dandelion++ Phase 4: a peer that learned a stem txid (e.g. our
+                // stem peer, or an adversary that obtained the txid out-of-band)
+                // MUST NOT be able to fetch the full transaction from us while it
+                // is still in stem phase — that would reveal our node holds the tx
+                // before fluff. Filter active-stem txids out of the getdata request;
+                // they will be reported as `Missing`, exactly as if we didn't have them.
+                let prop_state = dandelion_prop_state.clone();
                 let request = mempool::Request::TransactionsById(req_tx_ids.clone());
-                mempool.clone().oneshot(request).map_ok(move |resp| {
+                let mempool_clone = mempool.clone();
+                async move {
+                    let stem_txids = {
+                        let ps = prop_state.lock().await;
+                        req_tx_ids.iter()
+                            .filter(|id| ps.get(id).map_or(false, |s| s.is_stem()))
+                            .copied()
+                            .collect::<HashSet<UnminedTxId>>()
+                    };
+
+                    let resp = mempool_clone.oneshot(request).await?;
                     let mut total_size = 0;
 
                     let transactions = match resp {
                         mempool::Response::Transactions(transactions) => transactions,
                         _ => unreachable!("Mempool component should always respond to a `TransactionsById` request with a `Transactions` response"),
                     };
+
+                    // Drop any transaction that is still in active stem phase.
+                    let transactions: Vec<_> = transactions
+                        .into_iter()
+                        .filter(|tx| !stem_txids.contains(&tx.id))
+                        .collect();
 
                     // Work out which transaction IDs were missing.
                     let available_tx_ids: HashSet<UnminedTxId> = transactions.iter().map(|tx| tx.id).collect();
@@ -502,8 +538,8 @@ impl Service<zn::Request> for Inbound {
 
                     // The network layer handles splitting this response into multiple `tx`
                     // messages, and a `notfound` message if needed.
-                    zn::Response::Transactions(available.chain(missing).collect())
-                }).boxed()
+                    Ok(zn::Response::Transactions(available.chain(missing).collect()))
+                }.boxed()
             }
             // Find* responses are already size-limited by the state.
             zn::Request::FindBlocks { known_blocks, stop } => {
@@ -568,18 +604,46 @@ impl Service<zn::Request> for Inbound {
             }
             // The size of this response is limited by the `Connection` state machine in the network layer
             zn::Request::MempoolTransactionIds => {
-                mempool.clone().oneshot(mempool::Request::TransactionIds).map_ok(|resp| match resp {
-                    mempool::Response::TransactionIds(transaction_ids) if transaction_ids.is_empty() => zn::Response::Nil,
-                    mempool::Response::TransactionIds(transaction_ids) => zn::Response::TransactionIds(transaction_ids.into_iter().collect()),
-                    _ => unreachable!("Mempool component should always respond to a `TransactionIds` request with a `TransactionIds` response"),
-                })
-                    .boxed()
+                // Dandelion++ Phase 4: filter stem-phase transactions from the
+                // response.  A remote peer asking for our mempool contents MUST
+                // NOT learn about transactions that are still in the stem phase,
+                // because that would let a network-level observer correlate the
+                // originating node with the transaction before it enters fluff.
+                let prop_state = dandelion_prop_state.clone();
+                let mempool_clone = mempool.clone();
+                async move {
+                    let resp = mempool_clone.oneshot(mempool::Request::TransactionIds).await?;
+                    match resp {
+                        mempool::Response::TransactionIds(transaction_ids) => {
+                            // Dandelion++ Phase 4: snapshot propagation state and
+                            // filter out any txid that is still in active stem phase.
+                            // The lock is held briefly for the filter only.
+                            let stem_txids: HashSet<UnminedTxId> = {
+                                let ps = prop_state.lock().await;
+                                transaction_ids.iter()
+                                    .filter(|id| ps.get(id).map_or(false, |s| s.is_stem()))
+                                    .copied()
+                                    .collect()
+                            };
+                            let visible: Vec<_> = transaction_ids.into_iter()
+                                .filter(|id| !stem_txids.contains(id))
+                                .collect();
+                            if visible.is_empty() {
+                                Ok(zn::Response::Nil)
+                            } else {
+                                Ok(zn::Response::TransactionIds(visible.into_iter().collect()))
+                            }
+                        }
+                        _ => unreachable!("Mempool component should always respond to a `TransactionIds` request with a `TransactionIds` response"),
+                    }
+                }.boxed()
             }
             zn::Request::Ping(_) => {
                 unreachable!("ping requests are handled internally");
             }
 
-            zn::Request::AdvertiseBlockToAll(_) => unreachable!("should always be decoded as `AdvertiseBlock` request")
+            zn::Request::AdvertiseBlockToAll(_) => unreachable!("should always be decoded as `AdvertiseBlock` request"),
+            zn::Request::AdvertiseTransactionIdsToPeer(_, _) => unreachable!("Zebra-originated Dandelion++ stem request, never received from a peer"),
         }
     }
 }

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -48,6 +48,7 @@ use crate::components::sync::SyncStatus;
 
 pub mod config;
 mod crawler;
+pub mod dandelion_gossip;
 pub mod downloads;
 mod error;
 pub mod gossip;
@@ -62,6 +63,7 @@ pub use crate::BoxError;
 
 pub use config::Config;
 pub use crawler::Crawler;
+pub use dandelion_gossip::{gossip_dandelion, spawn_dandelion_gossip};
 pub use error::MempoolError;
 pub use gossip::gossip_mempool_transaction_id;
 pub use queue_checker::QueueChecker;
@@ -245,6 +247,12 @@ pub struct Mempool {
     /// Sender for reporting peer addresses that advertised unexpectedly invalid transactions.
     misbehavior_sender: mpsc::Sender<(PeerSocketAddr, u32)>,
 
+    /// Dandelion++ Phase 4: tracks txids submitted via local RPC (`Request::Queue`)
+    /// so that when they are verified and inserted, `MempoolChange::StemAdded` is
+    /// broadcast instead of `MempoolChange::Added`.  Entries are cleared after each
+    /// broadcast cycle.
+    locally_submitted_ids: std::collections::HashSet<UnminedTxId>,
+
     // Diagnostics
     //
     /// Queued transactions pending download or verification transmitter.
@@ -296,6 +304,7 @@ impl Mempool {
             tx_verifier,
             transaction_sender,
             misbehavior_sender,
+            locally_submitted_ids: std::collections::HashSet::new(),
             #[cfg(feature = "progress-bar")]
             queued_count_bar: None,
             #[cfg(feature = "progress-bar")]
@@ -719,14 +728,35 @@ impl Service<Request> for Mempool {
             }
 
             // Send transactions that were not rejected nor expired to peers and RPC listeners.
+            // Dandelion++ Phase 4: transactions that were queued via local RPC (`Request::Queue`)
+            // are broadcast as `StemAdded` so the gossip task routes them through stem phase.
+            // Peer-relayed transactions (queued via `QueueFromPeer`) use the normal `Added` path.
             if !send_to_peers_ids.is_empty() {
-                tracing::trace!(
-                    ?send_to_peers_ids,
-                    "sending new transactions to peers and RPC listeners"
-                );
+                let (stem_ids, relay_ids): (HashSet<_>, HashSet<_>) = send_to_peers_ids
+                    .into_iter()
+                    .partition(|id| self.locally_submitted_ids.contains(id));
 
-                self.transaction_sender
-                    .send(MempoolChange::added(send_to_peers_ids))?;
+                // Clear the locally-submitted tracking set now that the cycle is complete.
+                self.locally_submitted_ids
+                    .retain(|id| !stem_ids.contains(id) && !relay_ids.contains(id));
+
+                if !stem_ids.is_empty() {
+                    tracing::trace!(
+                        ?stem_ids,
+                        "sending locally-submitted transactions to peers as Dandelion++ stem candidates"
+                    );
+                    self.transaction_sender
+                        .send(MempoolChange::stem_added(stem_ids))?;
+                }
+
+                if !relay_ids.is_empty() {
+                    tracing::trace!(
+                        ?relay_ids,
+                        "sending peer-relayed transactions to peers and RPC listeners"
+                    );
+                    self.transaction_sender
+                        .send(MempoolChange::added(relay_ids))?;
+                }
             }
 
             // Send transactions that were rejected to RPC listeners.
@@ -735,6 +765,12 @@ impl Service<Request> for Mempool {
                     ?invalidated_ids,
                     "sending invalidated transactions to RPC listeners"
                 );
+
+                // Dandelion++: a locally-submitted tx that failed verification
+                // never reaches `send_to_peers_ids`, so drop it from the
+                // tracking set here to prevent unbounded growth.
+                self.locally_submitted_ids
+                    .retain(|id| !invalidated_ids.contains(id));
 
                 self.transaction_sender
                     .send(MempoolChange::invalidated(invalidated_ids))?;
@@ -873,14 +909,17 @@ impl Service<Request> for Mempool {
                                     oneshot::Receiver<Result<(), BoxError>>,
                                     MempoolError,
                                 > {
+                                    let tx_id = gossiped_tx.id();
                                     let (rsp_tx, rsp_rx) = oneshot::channel();
-                                    storage.should_download_or_verify(gossiped_tx.id())?;
+                                    storage.should_download_or_verify(tx_id)?;
                                     tx_downloads.download_if_needed_and_verify(
                                         gossiped_tx,
                                         None,
                                         Some(rsp_tx),
                                     )?;
-
+                                    // Track this txid as locally submitted so poll_ready
+                                    // can emit StemAdded instead of Added when it verifies.
+                                    self.locally_submitted_ids.insert(tx_id);
                                     Ok(rsp_rx)
                                 },
                             )

--- a/zebrad/src/components/mempool/dandelion_gossip.rs
+++ b/zebrad/src/components/mempool/dandelion_gossip.rs
@@ -1,0 +1,334 @@
+//! Dandelion++ gossip task: stem-phase unicast + fluff-phase broadcast.
+//!
+//! This module provides [`gossip_dandelion`], a drop-in replacement for the
+//! existing [`gossip_mempool_transaction_id`] task that routes transactions
+//! through Dandelion++ stem/fluff rather than immediately broadcasting to all
+//! peers.
+//!
+//! # Architecture
+//!
+//! ```text
+//! mempool change channel ──► dandelion_gossip task
+//!                                   │
+//!                    ┌──────────────┴──────────────┐
+//!                    │ stem phase                  │ fluff phase
+//!                    ▼                             ▼
+//!         AdvertiseTransactionIdsToPeer    AdvertiseTransactionIds
+//!         (PeerSet::route_to_peer)         (existing broadcast path)
+//!
+//! DandelionEpochManager (background task)
+//!   rotates stem peer every ~10 min
+//! ```
+//!
+//! # Integration status
+//!
+//! Per-peer routing (Phase 2) is done: `PeerSet` routes
+//! `Request::AdvertiseTransactionIdsToPeer` to exactly the named peer via
+//! `route_to_peer`, failing with `PeerError::NoReadyPeers` if that peer isn't
+//! ready — this task falls back to fluff immediately when that happens.
+//!
+//! **`MempoolChangeKind::StemAdded` vs `Added`**: the mempool emits `StemAdded`
+//! for locally-submitted transactions (via RPC) and `Added` for peer-relayed
+//! ones.  This task routes `StemAdded` through stem phase and routes `Added`
+//! directly to fluff broadcast (the relaying peer handles its own stem routing).
+//!
+//! See `draft-y4ssi-dandelion-direct-submission.rst` for the full specification.
+
+use std::sync::Arc;
+
+use tokio::{
+    sync::{broadcast, Mutex},
+    time::{interval, Duration},
+};
+use tower::{timeout::Timeout, Service, ServiceExt};
+
+use zebra_network::{
+    dandelion::{DandelionEpochManager, PropagationStateMap},
+    PeerSocketAddr, MAX_TX_INV_IN_SENT_MESSAGE,
+};
+use zebra_network as zn;
+use zebra_node_services::mempool::MempoolChange;
+
+use crate::{
+    components::sync::{PEER_GOSSIP_DELAY, TIPS_RESPONSE_TIMEOUT},
+    BoxError,
+};
+
+/// How often the stem-phase timeout checker runs.
+const STEM_TIMEOUT_CHECK_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Shared epoch manager — the gossip task and the epoch rotation task both
+/// access it.
+pub type SharedEpochManager = Arc<Mutex<DandelionEpochManager>>;
+
+/// Shared propagation state map.
+pub type SharedPropagationState = Arc<Mutex<PropagationStateMap>>;
+
+/// Spawns two background tasks:
+///
+/// 1. **Epoch rotation task**: rotates the stem peer every `~EPOCH_DURATION`.
+/// 2. **Gossip task**: routes incoming `Added` transactions through
+///    stem/fluff according to the current epoch state.
+///
+/// Returns `(epoch_manager, propagation_state)` for inspection in tests.
+///
+/// # Caller responsibilities
+///
+/// The caller MUST provide a `get_outbound_peers` closure that returns the
+/// current outbound peer addresses.  This decouples the epoch manager from
+/// the `PeerSet` internals.
+///
+/// # Current limitations
+///
+/// Stem-phase transactions are now filtered from `mempool` P2P responses and
+/// `getrawmempool`/`getrawtransaction` RPC responses (Phase 4).  Promotion to
+/// fluff still happens only on timeout or stem-peer failure — observing the
+/// transaction via normal relay does not yet trigger the transition
+/// (unadvertised-`tx` convention, see `dandelion-TODO.md`).
+pub fn spawn_dandelion_gossip<ZN, F>(
+    receiver: broadcast::Receiver<MempoolChange>,
+    broadcast_network: ZN,
+    get_outbound_peers: F,
+) -> (SharedEpochManager, SharedPropagationState)
+where
+    ZN: Service<zn::Request, Response = zn::Response, Error = BoxError>
+        + Send
+        + Clone
+        + 'static,
+    ZN::Future: Send,
+    F: Fn() -> Vec<PeerSocketAddr> + Send + Sync + 'static,
+{
+    let epoch_manager = Arc::new(Mutex::new(DandelionEpochManager::new()));
+    let prop_state = Arc::new(Mutex::new(PropagationStateMap::new()));
+
+    // Epoch rotation task
+    let epoch_manager_clone = epoch_manager.clone();
+    tokio::spawn(async move {
+        loop {
+            let wait_fut = {
+                let mgr = epoch_manager_clone.lock().await;
+                // We can't hold the lock across .await, so check expiry first.
+                let expired = mgr.is_expired();
+                drop(mgr);
+                expired
+            };
+            if wait_fut {
+                // Rotate immediately.
+            } else {
+                // Sleep until epoch end.  We poll every second to avoid holding
+                // the lock across a long sleep.
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                continue;
+            }
+            let peers = get_outbound_peers();
+            let mut mgr = epoch_manager_clone.lock().await;
+            mgr.rotate(&peers);
+        }
+    });
+
+    // Gossip task
+    let epoch_manager_gossip = epoch_manager.clone();
+    let prop_state_gossip = prop_state.clone();
+    tokio::spawn(gossip_dandelion(
+        receiver,
+        broadcast_network,
+        epoch_manager_gossip,
+        prop_state_gossip,
+    ));
+
+    (epoch_manager, prop_state)
+}
+
+/// Main Dandelion++ gossip loop.
+///
+/// Receives `MempoolChange::Added` events and routes each transaction:
+///
+/// - If the epoch manager has a stem peer: record the transaction as
+///   `PropagationState::Stem` and unicast it to that peer via
+///   `Request::AdvertiseTransactionIdsToPeer`, falling back to fluff if the
+///   peer is not ready.
+/// - Otherwise (fluff mode): broadcast immediately via
+///   `AdvertiseTransactionIds`.
+///
+/// Additionally, on a [`STEM_TIMEOUT_CHECK_INTERVAL`] tick, any transactions
+/// whose stem timeout has elapsed are promoted to fluff and broadcast.
+pub async fn gossip_dandelion<ZN>(
+    mut receiver: broadcast::Receiver<MempoolChange>,
+    broadcast_network: ZN,
+    epoch_manager: SharedEpochManager,
+    prop_state: SharedPropagationState,
+) -> Result<(), BoxError>
+where
+    ZN: Service<zn::Request, Response = zn::Response, Error = BoxError> + Send + Clone + 'static,
+    ZN::Future: Send,
+{
+    let max_tx_inv: usize = MAX_TX_INV_IN_SENT_MESSAGE
+        .try_into()
+        .expect("constant fits in usize");
+
+    info!("initializing dandelion++ gossip task");
+
+    let mut broadcast_network = Timeout::new(broadcast_network, TIPS_RESPONSE_TIMEOUT);
+    let mut stem_check_ticker = interval(STEM_TIMEOUT_CHECK_INTERVAL);
+
+    loop {
+        tokio::select! {
+            // ── New transaction from the mempool ──────────────────────────
+            change_result = receiver.recv() => {
+                use tokio::sync::broadcast::error::RecvError;
+                use zebra_node_services::mempool::MempoolChangeKind;
+
+                let change = match change_result {
+                    Ok(c) if c.is_any_added() => c,
+                    Ok(c) => {
+                        // Mined or Invalidated: the transaction has left the mempool,
+                        // so drop its propagation-state entry to bound map growth.
+                        // (Without this, PropagationStateMap grows without limit —
+                        // entries are otherwise never removed.)
+                        let txids = c.into_tx_ids();
+                        if !txids.is_empty() {
+                            let mut ps = prop_state.lock().await;
+                            for txid in &txids {
+                                ps.remove(txid);
+                            }
+                        }
+                        continue;
+                    }
+                    Err(RecvError::Lagged(n)) => {
+                        info!(skipped = n, "dandelion++: dropped changes due to channel lag");
+                        continue;
+                    }
+                    Err(RecvError::Closed) => return Err("mempool change channel closed".into()),
+                };
+
+                // `StemAdded` = locally-submitted transaction → route through stem.
+                // `Added`     = peer-relayed transaction → already in fluff by convention.
+                let is_stem_candidate = change.kind() == MempoolChangeKind::StemAdded;
+                let txids = change.into_tx_ids();
+
+                // Peer-relayed transactions skip stem and go straight to fluff.
+                if !is_stem_candidate {
+                    {
+                        let mut ps = prop_state.lock().await;
+                        for txid in &txids {
+                            ps.insert_fluff(*txid);
+                        }
+                    }
+                    let req = zn::Request::AdvertiseTransactionIds(txids, None);
+                    match broadcast_network.ready().await {
+                        Ok(svc) => {
+                            let _ = svc.call(req).await;
+                        }
+                        // Fail open: a transient PeerSet readiness error must not
+                        // kill the gossip task (which would stop all future
+                        // stem/fluff routing for the process lifetime).
+                        Err(err) => warn!(%err, "dandelion++: broadcast service not ready, skipping fluff"),
+                    }
+                    tokio::time::sleep(PEER_GOSSIP_DELAY).await;
+                    continue;
+                }
+
+                let stem_peer_opt = epoch_manager.lock().await.stem_peer();
+
+                match stem_peer_opt {
+                    Some(stem_peer) => {
+                        // Record as stem-phase; unicast to stem_peer.
+                        {
+                            let mut ps = prop_state.lock().await;
+                            for txid in &txids {
+                                ps.insert_stem(*txid, stem_peer);
+                            }
+                        }
+
+                        let req = zn::Request::AdvertiseTransactionIdsToPeer(txids.clone(), stem_peer);
+                        let stem_result = match broadcast_network.ready().await {
+                            Ok(svc) => svc.call(req).await,
+                            Err(err) => {
+                                warn!(%err, "dandelion++: broadcast service not ready for stem unicast");
+                                Err(err)
+                            }
+                        };
+                        match stem_result {
+                            Ok(_) => {
+                                // Stem forwarding succeeded; the transaction stays
+                                // in Stem state until fluff-observed or timed out
+                                // (see the stem-timeout sweep below).
+                            }
+                            Err(err) => {
+                                // Stem peer wasn't ready (e.g. dropped mid-epoch).
+                                // Fall back to fluff immediately rather than
+                                // silently dropping the transaction.
+                                info!(%err, ?stem_peer, "dandelion++: stem peer unavailable, falling back to fluff");
+                                {
+                                    let mut ps = prop_state.lock().await;
+                                    for txid in &txids {
+                                        ps.promote_to_fluff(txid);
+                                    }
+                                }
+                                let req = zn::Request::AdvertiseTransactionIds(txids, None);
+                                if let Ok(svc) = broadcast_network.ready().await {
+                                    let _ = svc.call(req).await;
+                                }
+                            }
+                        }
+                    }
+                    None => {
+                        // Fluff mode: no outbound peers for stem, broadcast directly.
+                        {
+                            let mut ps = prop_state.lock().await;
+                            for txid in &txids {
+                                ps.insert_fluff(*txid);
+                            }
+                        }
+                        let req = zn::Request::AdvertiseTransactionIds(txids, None);
+                        if let Ok(svc) = broadcast_network.ready().await {
+                            let _ = svc.call(req).await;
+                        }
+                    }
+                }
+
+                tokio::time::sleep(PEER_GOSSIP_DELAY).await;
+            }
+
+            // ── Stem-timeout sweep ─────────────────────────────────────────
+            _ = stem_check_ticker.tick() => {
+                let expired = prop_state.lock().await.expired_stem_txids();
+                if expired.is_empty() {
+                    continue;
+                }
+
+                info!(count = expired.len(), "dandelion++: promoting timed-out stem txs to fluff");
+
+                // Remove the entries now that they are fluffing: the exposure
+                // filters treat "not in map" identically to "Fluff", so removal
+                // both unblocks exposure and bounds map growth (the tx will be
+                // removed from the mempool later via a Mined/Invalidated event,
+                // which we also clean up above).
+                {
+                    let mut ps = prop_state.lock().await;
+                    for txid in &expired {
+                        ps.remove(txid);
+                    }
+                }
+
+                // Note on indexer visibility: we deliberately do NOT re-emit a
+                // `MempoolChange::added` on the shared channel here.  The gossip
+                // task is itself a subscriber, so emitting would cause it to
+                // re-consume the event and double-broadcast.  Downstream
+                // consumers (the indexer gRPC stream used by Zaino/lightwalletd)
+                // pick up the now-fluffed transaction on their next
+                // `getrawmempool` / mempool poll — the exposure filters no
+                // longer hide it once it is out of the stem state.
+
+                // Chunk into messages respecting the per-message limit.
+                for chunk in expired.chunks(max_tx_inv) {
+                    let txids: std::collections::HashSet<_> = chunk.iter().copied().collect();
+                    let req = zn::Request::AdvertiseTransactionIds(txids, None);
+                    if let Ok(svc) = broadcast_network.ready().await {
+                        let _ = svc.call(req).await;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Reference implementation of Dandelion++ stem/fluff transaction propagation (Component B) for Zebra, per draft ZIP 327 (zcash/zips#1329).

Breaks IP-to-transaction correlation for network observers: a locally-submitted transaction is unicast to one per-epoch stem peer (fail-closed via PeerError::NoReadyPeers, never falling back to another peer) and withheld from all peers, RPCs, and the indexer mempool stream for a 30s stem window before fluff broadcast. Shielded transactions already hide contents; this hides which node originated the packet.

Design: per-epoch stem peer (10min + up to 2min jitter), 30s stem timeout, fail-closed unicast via a new Request::AdvertiseTransactionIdsToPeer routed by PeerSet::route_to_peer(), gossip task wired into zebrad startup, MempoolChangeKind::StemAdded for local vs peer-relayed routing. Stem-phase hiding across MempoolTransactionIds, TransactionsById getdata, getrawmempool, getrawtransaction, and the indexer gRPC mempool_change stream. Bounded PropagationStateMap; fail-open gossip task on transient PeerSet errors.

Testing: 10 unit tests + 2 PeerSet routing tests; verified end-to-end on a 3-node regtest network (see docs/dandelion-e2e-regtest.md).

Companion wallet-side PRs (Component A, direct P2P submission): zcash/zcash-android-wallet-sdk#2010, zcash/zcash-swift-wallet-sdk#1804. Happy to split into smaller reviewable PRs (core types -> PeerSet routing -> gossip wiring -> stem-phase filters) if preferred.