### PR TITLE
test(rpc): cover Ironwood coinbase output recovery

### DIFF
--- a/zebra-rpc/src/methods/types/get_block_template/tests.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/tests.rs
@@ -202,7 +202,8 @@ fn coinbase_cache_reuses_built_coinbase() {
 }
 
 /// From NU6.3 onward, a shielded coinbase paid to a Unified miner address with an Orchard
-/// receiver routes newly minted value into the Ironwood pool, not the Orchard pool.
+/// receiver routes newly minted value into the Ironwood pool, not the Orchard pool, and remains
+/// recoverable with the consensus-required all-zero outgoing viewing key.
 #[test]
 fn coinbase_at_nu6_3_routes_shielded_output_to_ironwood() {
     let net = Network::new_default_testnet();
@@ -232,4 +233,6 @@ fn coinbase_at_nu6_3_routes_shielded_output_to_ironwood() {
         coinbase.orchard_shielded_data().is_none(),
         "coinbase must not create Orchard components on NU6.3"
     );
+    zebra_consensus::transaction::check::coinbase_outputs_are_decryptable(&coinbase, &net, height)
+        .expect("Ironwood coinbase output is recoverable with the zero outgoing viewing key");
 }


### PR DESCRIPTION
## Motivation

The NU6.3 coinbase regression test verified pool routing but did not exercise the encrypted Ironwood output through the consensus-required all-zero outgoing viewing key. A note-plaintext version regression could therefore preserve the expected bundle layout while producing an unrecoverable coinbase output.

## Solution

Exercise the generated coinbase through the same consensus decryptability check used during block validation. The check selects `IronwoodDomain`, so successful recovery covers the V3 plaintext and `0x03` lead-byte path without duplicating encryption logic in `zebra-rpc`.

### Tests

The focused Zebra RPC test, workspace formatting, and workspace Clippy pass. The full workspace test run passed the changed test and all affected crates, but 3 unrelated `zebrad` end-of-support tests collided over the process-global tracing subscriber; each passed when rerun in isolation.

### Specifications & References

- [ZIP 2005: Ironwood Quantum Recoverability](https://zips.z.cash/zip-2005)

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Codex for the regression test and PR description

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
