### PR TITLE
fix(consensus)!: reject non-std txs before verifying scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   had caught up past the node's non-finalized root would re-subscribe endlessly
   instead of syncing, advancing only one block per newly mined block
   ([#10841](https://github.com/ZcashFoundation/zebra/pull/10841))
+- Mempool transactions with non-standard transparent inputs are now rejected
+  _before_ script verification, to avoid the more expensive script verification
+  and reduce DoS surface
+  ([GHSA-84j3-rw4c-gqmj](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-84j3-rw4c-gqmj)).
+  Thanks to @ouicate for reporting the issue.
+- Related to the previous item, script verification now runs on the shared Rayon
+  thread pool to avoid blocking the runtime.
 
 ## [Zebra 6.0.0-rc.0](https://github.com/ZcashFoundation/zebra/releases/tag/v6.0.0-rc.0) - 2026-07-02
 

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Breaking Changes
+
+- Added new variants of `error::TransactionError`:
+  - `NonStandardScriptSigSize`
+  - `NonStandardScriptSigNotPushOnly`
+  - `NonStandardInputs`
+
+### Added
+
+- `transaction::check`:
+  - `mempool_standard_input_scripts`, the pre-verification mempool input-script gate
+  - `are_inputs_standard` and `standard_script_kind` (zcashd's `AreInputsStandard()` and
+    scriptPubKey classifier, moved here from `zebrad`)
+  - the `MAX_P2SH_SIGOPS` and `MAX_STANDARD_SCRIPTSIG_SIZE` policy constants
+
+### Fixed
+
+- Mempool transactions with non-standard transparent inputs are now rejected
+  _before_ script verification, to avoid the more expensive script verification
+  and reduce DoS surface
+  ([GHSA-84j3-rw4c-gqmj](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-84j3-rw4c-gqmj)).
+  Thanks to @ouicate for reporting the issue.
+- Related to the previous item, script verification now runs on the shared Rayon
+  thread pool to avoid blocking the runtime.
+
 ## [10.0.0] - 2026-07-02
 
 ### Added

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -19,7 +19,7 @@ use zebra_chain::{
 };
 use zebra_state::ValidateContextError;
 
-use crate::{block::MAX_BLOCK_SIGOPS, BoxError};
+use crate::{block::MAX_BLOCK_SIGOPS, transaction::check::MAX_STANDARD_SCRIPTSIG_SIZE, BoxError};
 
 #[cfg(any(test, feature = "proptest-impl"))]
 use proptest_derive::Arbitrary;
@@ -242,6 +242,20 @@ pub enum TransactionError {
     #[cfg_attr(any(test, feature = "proptest-impl"), proptest(skip))]
     Zip317(#[from] zebra_chain::transaction::zip317::Error),
 
+    // Mempool standardness (policy) rejections, applied before script verification.
+    // These are not consensus rules: the same input scripts are valid in blocks.
+    #[error(
+        "mempool transaction input {input_index} has a {size} byte scriptSig, \
+         above the {MAX_STANDARD_SCRIPTSIG_SIZE} byte standardness limit"
+    )]
+    NonStandardScriptSigSize { input_index: usize, size: usize },
+
+    #[error("mempool transaction input {input_index} has a non-push-only scriptSig")]
+    NonStandardScriptSigNotPushOnly { input_index: usize },
+
+    #[error("mempool transaction has non-standard transparent inputs")]
+    NonStandardInputs,
+
     #[error("transaction uses an incorrect consensus branch id")]
     WrongConsensusBranchId,
 
@@ -390,6 +404,9 @@ impl TransactionError {
             | LockedUntilAfterBlockHeight(_)
             | LockedUntilAfterBlockTime(_) => 100,
 
+            // Standardness (policy) rejections must not be punished: non-standard
+            // transactions are consensus-valid, and zcashd relays a reject message
+            // without a DoS score for them.
             _other => 0,
         }
     }

--- a/zebra-consensus/src/script.rs
+++ b/zebra-consensus/src/script.rs
@@ -5,7 +5,7 @@ use tracing::Instrument;
 use zebra_chain::transparent;
 use zebra_script::CachedFfiTransaction;
 
-use crate::BoxError;
+use crate::{primitives::spawn_fifo_and_convert, BoxError};
 
 #[cfg(test)]
 mod tests;
@@ -58,7 +58,7 @@ impl tower::Service<Request> for Verifier {
 
         let span = tracing::trace_span!("script");
         async move {
-            let input = &cached_ffi_transaction
+            let input = cached_ffi_transaction
                 .inputs()
                 .get(input_index)
                 .ok_or_else(|| {
@@ -69,8 +69,9 @@ impl tower::Service<Request> for Verifier {
                 transparent::Input::PrevOut { outpoint, .. } => {
                     let outpoint = *outpoint;
 
-                    // Avoid calling the state service if the utxo is already known
-                    cached_ffi_transaction.is_valid(input_index)?;
+                    // Script verification is CPU-bound so run in Rayon thread
+                    spawn_fifo_and_convert(move || cached_ffi_transaction.is_valid(input_index))
+                        .await?;
                     tracing::trace!(?outpoint, "script verification succeeded");
 
                     Ok(())

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -456,6 +456,12 @@ where
             //       the state once #2336 has been implemented?
             if req.is_mempool() {
                 Self::check_maturity_height(&network, &req, &spent_utxos)?;
+
+                // Reject non-standard input scripts (oversized or non-push-only
+                // scriptSigs, and high-sigop P2SH redeem scripts) *before*
+                // doing expensive script verification, to avoid DoS attacks on
+                // the script interpreter.
+                check::mempool_standard_input_scripts(tx.as_ref(), &spent_outputs)?;
             }
 
             let nu = req.upgrade(&network);

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -11,6 +11,11 @@ use std::{
 
 use chrono::{DateTime, Utc};
 
+use zcash_script::{
+    opcode::PossiblyBad,
+    script::{self, Evaluable as _},
+    solver, Opcode,
+};
 use zebra_chain::{
     amount::{Amount, NegativeAllowed, NonNegative},
     block::Height,
@@ -625,6 +630,220 @@ pub fn tx_transparent_coinbase_spends_maturity(
         let spend_restriction = tx.coinbase_spend_restriction(network, height);
 
         zebra_state::check::transparent_coinbase_spend(spend, spend_restriction, &utxo)?;
+    }
+
+    Ok(())
+}
+
+/// The maximum number of signature operations in the redeem script of a standard P2SH input.
+///
+/// This is zcashd's `MAX_P2SH_SIGOPS` standardness (policy) constant:
+/// <https://github.com/zcash/zcash/blob/v6.11.0/src/policy/policy.h#L20>
+pub const MAX_P2SH_SIGOPS: u32 = 15;
+
+/// The maximum size in bytes of the scriptSig of a standard transaction input.
+///
+/// This is zcashd's `MAX_STANDARD_SCRIPTSIG_SIZE` standardness (policy) constant:
+/// <https://github.com/zcash/zcash/blob/v6.11.0/src/policy/policy.cpp#L92-L99>
+pub const MAX_STANDARD_SCRIPTSIG_SIZE: usize = 1650;
+
+/// Classify a script using the `zcash_script` solver.
+///
+/// Returns `Some(kind)` for standard script types, `None` for non-standard.
+///
+/// Mirrors the classification done by zcashd's `Solver()`.
+pub fn standard_script_kind(lock_script: &transparent::Script) -> Option<solver::ScriptKind> {
+    let code = script::Code(lock_script.as_raw_bytes().to_vec());
+    let component = code.to_component().ok()?.refine().ok()?;
+    solver::standard(&component)
+}
+
+/// Returns the expected number of scriptSig arguments for a given script kind.
+///
+/// Mirrors zcashd's `ScriptSigArgsExpected()`:
+/// <https://github.com/zcash/zcash/blob/v6.11.0/src/script/standard.cpp#L135>
+///
+/// Returns `None` for non-standard types (TX_NONSTANDARD, TX_NULL_DATA).
+pub(super) fn script_sig_args_expected(kind: &solver::ScriptKind) -> Option<usize> {
+    match kind {
+        solver::ScriptKind::PubKey { .. } => Some(1),
+        solver::ScriptKind::PubKeyHash { .. } => Some(2),
+        solver::ScriptKind::ScriptHash { .. } => Some(1),
+        solver::ScriptKind::MultiSig { required, .. } => Some(*required as usize + 1),
+        solver::ScriptKind::NullData { .. } => None,
+    }
+}
+
+/// Extract the redeemed script bytes from a P2SH scriptSig.
+///
+/// The redeemed script is the last data push in the scriptSig.
+/// Returns `None` if the scriptSig has no push operations.
+///
+/// # Precondition
+///
+/// The scriptSig should be push-only (enforced by [`mempool_standard_input_scripts`] before this
+/// function is reached). Non-push opcodes are silently ignored.
+pub(super) fn extract_p2sh_redeemed_script(unlock_script: &transparent::Script) -> Option<Vec<u8>> {
+    let code = script::Code(unlock_script.as_raw_bytes().to_vec());
+    let mut last_push_data: Option<Vec<u8>> = None;
+    for opcode in code.parse().flatten() {
+        if let PossiblyBad::Good(Opcode::PushValue(pv)) = opcode {
+            last_push_data = Some(pv.value());
+        }
+    }
+    last_push_data
+}
+
+/// Count the number of push operations in a script.
+///
+/// For a push-only script (already enforced for mempool scriptSigs),
+/// this equals the stack depth after evaluation.
+pub(super) fn count_script_push_ops(script_bytes: &[u8]) -> usize {
+    let code = script::Code(script_bytes.to_vec());
+    code.parse()
+        .filter(|op| matches!(op, Ok(PossiblyBad::Good(Opcode::PushValue(_)))))
+        .count()
+}
+
+/// Returns `true` if all of a transaction's transparent inputs are standard.
+///
+/// Mirrors zcashd's `AreInputsStandard()`:
+/// <https://github.com/zcash/zcash/blob/v6.11.0/src/policy/policy.cpp#L136>
+///
+/// For each input:
+/// 1. The spent output's scriptPubKey must be a known standard type (via the `zcash_script`
+///    solver). Non-standard scripts and OP_RETURN outputs are rejected.
+/// 2. The scriptSig stack depth must match `ScriptSigArgsExpected()`.
+/// 3. For P2SH inputs:
+///    - If the redeemed script is standard, its expected args are added to the total.
+///    - If the redeemed script is non-standard, it must have at most [`MAX_P2SH_SIGOPS`] sigops.
+///
+/// # Correctness
+///
+/// Callers must ensure `spent_outputs.len()` matches the number of transparent inputs.
+/// If the lengths differ, `false` is returned.
+pub fn are_inputs_standard(tx: &Transaction, spent_outputs: &[transparent::Output]) -> bool {
+    if tx.inputs().len() != spent_outputs.len() {
+        return false;
+    }
+    for (input, spent_output) in tx.inputs().iter().zip(spent_outputs.iter()) {
+        let unlock_script = match input {
+            transparent::Input::PrevOut { unlock_script, .. } => unlock_script,
+            transparent::Input::Coinbase { .. } => continue,
+        };
+
+        // Step 1: Classify the spent output's scriptPubKey via the zcash_script solver.
+        let script_kind = match standard_script_kind(&spent_output.lock_script) {
+            Some(kind) => kind,
+            None => return false,
+        };
+
+        // Step 2: Get expected number of scriptSig arguments.
+        // Returns None for TX_NONSTANDARD and TX_NULL_DATA.
+        let mut n_args_expected = match script_sig_args_expected(&script_kind) {
+            Some(n) => n,
+            None => return false,
+        };
+
+        // Step 3: Count actual push operations in scriptSig.
+        // For push-only scripts (enforced before this function), this equals the stack depth.
+        let stack_size = count_script_push_ops(unlock_script.as_raw_bytes());
+
+        // Step 4: P2SH-specific checks.
+        if matches!(script_kind, solver::ScriptKind::ScriptHash { .. }) {
+            let Some(redeemed_bytes) = extract_p2sh_redeemed_script(unlock_script) else {
+                return false;
+            };
+
+            let redeemed_code = script::Code(redeemed_bytes);
+
+            // Classify the redeemed script using the zcash_script solver.
+            let redeemed_kind = {
+                let component = redeemed_code
+                    .to_component()
+                    .ok()
+                    .and_then(|c| c.refine().ok());
+                component.and_then(|c| solver::standard(&c))
+            };
+
+            match redeemed_kind {
+                Some(ref inner_kind) => {
+                    // Standard redeemed script: add its expected args.
+                    match script_sig_args_expected(inner_kind) {
+                        Some(inner) => n_args_expected += inner,
+                        None => return false,
+                    }
+                }
+                None => {
+                    // Non-standard redeemed script: accept if sigops <= limit.
+                    // Matches zcashd: "Any other Script with less than 15 sigops OK:
+                    // ... extra data left on the stack after execution is OK, too"
+                    let sigops = redeemed_code.sig_op_count(true);
+                    if sigops > MAX_P2SH_SIGOPS {
+                        return false;
+                    }
+
+                    // This input is acceptable; move on to the next input.
+                    continue;
+                }
+            }
+        }
+
+        // Step 5: Reject if scriptSig has wrong number of stack items.
+        if stack_size != n_args_expected {
+            return false;
+        }
+    }
+    true
+}
+
+/// Standardness (policy) checks on a mempool transaction's transparent input scripts, applied
+/// *before* the transaction is dispatched to script verification. The goal is to avoid the
+/// expensive verification for non-standard transactions which would be rejected anyway
+/// by `Storage::reject_if_non_standard_tx()`; this is a subset of the checks
+/// in that function.
+///
+/// `spent_outputs` must contain the output spent by each of the transaction's transparent inputs,
+/// in input order.
+///
+/// # Correctness
+///
+/// `spent_outputs.len()` must equal the number of transparent inputs in `tx`: if the lengths
+/// differ, `zip()` silently truncates, and some inputs are not checked.
+pub fn mempool_standard_input_scripts(
+    tx: &Transaction,
+    spent_outputs: &[transparent::Output],
+) -> Result<(), TransactionError> {
+    if tx.inputs().len() != spent_outputs.len() {
+        return Err(TransactionError::Other(format!(
+            "spent_outputs must align with transaction inputs for non-coinbase txs: inputs={}, spent_outputs={}",
+            tx.inputs().len(),
+            spent_outputs.len(),
+        )));
+    }
+
+    for (input_index, input) in tx.inputs().iter().enumerate() {
+        let unlock_script = match input {
+            transparent::Input::PrevOut { unlock_script, .. } => unlock_script,
+            transparent::Input::Coinbase { .. } => continue,
+        };
+
+        // Rule: the scriptSig must be within the standard size limit.
+        let size = unlock_script.as_raw_bytes().len();
+        if size > MAX_STANDARD_SCRIPTSIG_SIZE {
+            return Err(TransactionError::NonStandardScriptSigSize { input_index, size });
+        }
+
+        // Rule: the scriptSig must be push-only.
+        if !script::Code(unlock_script.as_raw_bytes().to_vec()).is_push_only() {
+            return Err(TransactionError::NonStandardScriptSigNotPushOnly { input_index });
+        }
+    }
+
+    // Rule: all transparent inputs must pass `AreInputsStandard()` checks:
+    // https://github.com/zcash/zcash/blob/v6.11.0/src/policy/policy.cpp#L137
+    if !are_inputs_standard(tx, spent_outputs) {
+        return Err(TransactionError::NonStandardInputs);
     }
 
     Ok(())

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -3643,9 +3643,25 @@ fn mock_transparent_transfer(
     transparent::Output,
     HashMap<transparent::OutPoint, transparent::OrderedUtxo>,
 ) {
-    // A script with a single opcode that accepts the transaction (pushes true on the stack)
-    let accepting_script = transparent::Script::new(&[1, 1]);
-    // A script with a single opcode that rejects the transaction (OP_FALSE)
+    // A standard, signature-free P2SH input that the script interpreter accepts. The redeem
+    // script is OP_TRUE, so the spend is valid without a signature, while the spent output is a
+    // standard P2SH `scriptPubKey`. This lets the input pass the mempool `AreInputsStandard`
+    // gate (`check::mempool_standard_input_scripts`) that now runs before script verification,
+    // as well as the interpreter itself.
+    const OP_TRUE: u8 = 0x51;
+    // `scriptSig`: a single push of the OP_TRUE redeem script (push-only, one stack item).
+    let accepting_unlock_script = transparent::Script::new(&[0x01, OP_TRUE]);
+    // `scriptPubKey`: OP_HASH160 <HASH160(OP_TRUE)> OP_EQUAL. The 20-byte hash is precomputed
+    // (RIPEMD160(SHA256([OP_TRUE]))) so the P2SH hash check passes during verification.
+    let mut p2sh_lock_bytes = vec![0xa9, 0x14];
+    p2sh_lock_bytes.extend_from_slice(&[
+        0xda, 0x17, 0x45, 0xe9, 0xb5, 0x49, 0xbd, 0x0b, 0xfa, 0x1a, 0x56, 0x99, 0x71, 0xc7, 0x7e,
+        0xba, 0x30, 0xcd, 0x5a, 0x4b,
+    ]);
+    p2sh_lock_bytes.push(0x87);
+    let accepting_lock_script = transparent::Script::new(&p2sh_lock_bytes);
+    // A script with a single opcode that rejects the transaction (OP_FALSE). Only used for block
+    // requests (the standardness gate is mempool-only), so it need not be a standard type.
     let rejecting_script = transparent::Script::new(&[0]);
 
     // Mock an unspent transaction output
@@ -3654,10 +3670,12 @@ fn mock_transparent_transfer(
         index: outpoint_index,
     };
 
-    let lock_script = if script_should_succeed {
-        accepting_script.clone()
+    let (lock_script, unlock_script) = if script_should_succeed {
+        (accepting_lock_script, accepting_unlock_script)
     } else {
-        rejecting_script.clone()
+        // The spent output's OP_FALSE `scriptPubKey` makes verification fail regardless of the
+        // `scriptSig`, so the `scriptSig` value is irrelevant here.
+        (rejecting_script.clone(), accepting_unlock_script)
     };
 
     let previous_output = transparent::Output {
@@ -3670,7 +3688,7 @@ fn mock_transparent_transfer(
     // Use the `previous_outpoint` as input
     let input = transparent::Input::PrevOut {
         outpoint: previous_outpoint,
-        unlock_script: accepting_script,
+        unlock_script,
         sequence: 0,
     };
 
@@ -4461,4 +4479,296 @@ async fn mempool_cached_result_bypasses_expiry_check_for_block_at_next_height() 
          with nExpiryHeight {mempool_height:?} via mempool cache; \
          got: {tx_err:?}"
     );
+}
+
+/// Test the mempool standardness gate that runs before script verification:
+/// a P2SH input whose redeem script exceeds `MAX_P2SH_SIGOPS` (15) must be rejected,
+/// while a redeem script at the limit is accepted.
+#[test]
+fn mempool_standard_input_scripts_limits_p2sh_redeem_sigops() {
+    let _init_guard = zebra_test::init();
+
+    const OP_CHECKSIG: u8 = 0xac;
+
+    // scriptPubKey: OP_HASH160 <20 bytes> OP_EQUAL
+    let mut p2sh_lock_bytes = vec![0xa9, 0x14];
+    p2sh_lock_bytes.extend_from_slice(&[0u8; 20]);
+    p2sh_lock_bytes.push(0x87);
+
+    let spent_output = transparent::Output {
+        value: Amount::try_from(1_000_000).expect("valid amount"),
+        lock_script: transparent::Script::new(&p2sh_lock_bytes),
+    };
+
+    // A scriptSig with a single direct push of `sigops` OP_CHECKSIGs: for a P2SH spend, the pushed
+    // data is the (non-standard) redeem script, and each OP_CHECKSIG counts as one accurate sigop.
+    let unlock_bytes_with_sigops = |sigops: usize| {
+        let mut unlock_bytes = vec![u8::try_from(sigops).expect("small test count")];
+        unlock_bytes.extend_from_slice(&vec![OP_CHECKSIG; sigops]);
+        unlock_bytes
+    };
+
+    let tx_spending = |unlock_bytes: &[u8]| Transaction::V5 {
+        network_upgrade: NetworkUpgrade::Nu5,
+        inputs: vec![transparent::Input::PrevOut {
+            outpoint: transparent::OutPoint {
+                hash: Hash([0u8; 32]),
+                index: 0,
+            },
+            unlock_script: transparent::Script::new(unlock_bytes),
+            sequence: u32::MAX,
+        }],
+        outputs: vec![spent_output.clone()],
+        lock_time: LockTime::unlocked(),
+        expiry_height: Height(0),
+        sapling_shielded_data: None,
+        orchard_shielded_data: None,
+    };
+
+    // A non-standard redeem script at the standardness limit is accepted.
+    let tx = tx_spending(&unlock_bytes_with_sigops(15));
+    assert_eq!(
+        check::mempool_standard_input_scripts(&tx, std::slice::from_ref(&spent_output)),
+        Ok(()),
+        "P2SH redeem script with MAX_P2SH_SIGOPS sigops should be standard"
+    );
+
+    // One sigop above the limit is rejected before script verification.
+    let tx = tx_spending(&unlock_bytes_with_sigops(16));
+    assert_eq!(
+        check::mempool_standard_input_scripts(&tx, std::slice::from_ref(&spent_output)),
+        Err(TransactionError::NonStandardInputs),
+        "P2SH redeem script above MAX_P2SH_SIGOPS should be rejected"
+    );
+}
+
+/// Test the mempool standardness gate that runs before script verification:
+/// spending a non-standard (high-sigop) scriptPubKey must be rejected via `AreInputsStandard`,
+/// so the interpreter is never asked to run its signature operations; a genuinely standard
+/// P2PKH input is accepted.
+#[test]
+fn mempool_standard_input_scripts_rejects_nonstandard_spent_output() {
+    let _init_guard = zebra_test::init();
+
+    let tx_spending = |unlock_bytes: &[u8], spent_output: &transparent::Output| Transaction::V5 {
+        network_upgrade: NetworkUpgrade::Nu5,
+        inputs: vec![transparent::Input::PrevOut {
+            outpoint: transparent::OutPoint {
+                hash: Hash([0u8; 32]),
+                index: 0,
+            },
+            unlock_script: transparent::Script::new(unlock_bytes),
+            sequence: u32::MAX,
+        }],
+        outputs: vec![spent_output.clone()],
+        lock_time: LockTime::unlocked(),
+        expiry_height: Height(0),
+        sapling_shielded_data: None,
+        orchard_shielded_data: None,
+    };
+
+    // A non-standard spent scriptPubKey (50 x OP_CHECKSIG) is not a recognized standard type, so
+    // the input is rejected before verification would run its 50 signature checks. This is the
+    // non-P2SH counterpart of the P2SH redeem-script limit: without classifying the spent output,
+    // a peer could plant such a UTXO and drive expensive verification with a cheap spend.
+    let nonstandard_output = transparent::Output {
+        value: Amount::try_from(1_000_000).expect("valid amount"),
+        lock_script: transparent::Script::new(&[0xac; 50]),
+    };
+    let tx = tx_spending(&[0x01, 0xaa], &nonstandard_output);
+    assert_eq!(
+        check::mempool_standard_input_scripts(&tx, std::slice::from_ref(&nonstandard_output)),
+        Err(TransactionError::NonStandardInputs),
+        "spending a non-standard scriptPubKey should be rejected before script verification"
+    );
+
+    // A genuinely standard P2PKH input (2 scriptSig pushes: sig + pubkey) is accepted.
+    let mut p2pkh_lock_bytes = vec![0x76, 0xa9, 0x14];
+    p2pkh_lock_bytes.extend_from_slice(&[0u8; 20]);
+    p2pkh_lock_bytes.extend_from_slice(&[0x88, 0xac]);
+    let p2pkh_output = transparent::Output {
+        value: Amount::try_from(1_000_000).expect("valid amount"),
+        lock_script: transparent::Script::new(&p2pkh_lock_bytes),
+    };
+    let tx = tx_spending(&[0x01, 0xaa, 0x01, 0xbb], &p2pkh_output);
+    assert_eq!(
+        check::mempool_standard_input_scripts(&tx, std::slice::from_ref(&p2pkh_output)),
+        Ok(()),
+        "a standard P2PKH input with the correct stack depth should be accepted"
+    );
+}
+
+/// Test the mempool standardness gate that runs before script verification:
+/// non-push-only and oversized scriptSigs must be rejected, so signature operations
+/// can't be hidden in a scriptSig that the interpreter would execute.
+#[test]
+fn mempool_standard_input_scripts_rejects_nonstandard_script_sigs() {
+    let _init_guard = zebra_test::init();
+
+    // scriptPubKey: OP_DUP OP_HASH160 <20 bytes> OP_EQUALVERIFY OP_CHECKSIG
+    let mut p2pkh_lock_bytes = vec![0x76, 0xa9, 0x14];
+    p2pkh_lock_bytes.extend_from_slice(&[0u8; 20]);
+    p2pkh_lock_bytes.extend_from_slice(&[0x88, 0xac]);
+
+    let spent_output = transparent::Output {
+        value: Amount::try_from(1_000_000).expect("valid amount"),
+        lock_script: transparent::Script::new(&p2pkh_lock_bytes),
+    };
+
+    let tx_spending = |unlock_bytes: &[u8]| Transaction::V5 {
+        network_upgrade: NetworkUpgrade::Nu5,
+        inputs: vec![transparent::Input::PrevOut {
+            outpoint: transparent::OutPoint {
+                hash: Hash([0u8; 32]),
+                index: 0,
+            },
+            unlock_script: transparent::Script::new(unlock_bytes),
+            sequence: u32::MAX,
+        }],
+        outputs: vec![spent_output.clone()],
+        lock_time: LockTime::unlocked(),
+        expiry_height: Height(0),
+        sapling_shielded_data: None,
+        orchard_shielded_data: None,
+    };
+
+    // A scriptSig containing an operation (OP_CHECKSIG) instead of only pushes is rejected.
+    let tx = tx_spending(&[0xac]);
+    assert_eq!(
+        check::mempool_standard_input_scripts(&tx, std::slice::from_ref(&spent_output)),
+        Err(TransactionError::NonStandardScriptSigNotPushOnly { input_index: 0 }),
+        "non-push-only scriptSig should be rejected"
+    );
+
+    // A push-only scriptSig above MAX_STANDARD_SCRIPTSIG_SIZE (1650) bytes is rejected:
+    // OP_PUSHDATA2 <1648 little-endian> <1648 bytes> is 1651 bytes in total.
+    let mut oversized_unlock_bytes = vec![0x4d, 0x70, 0x06];
+    oversized_unlock_bytes.extend_from_slice(&[0u8; 1648]);
+    let tx = tx_spending(&oversized_unlock_bytes);
+    assert_eq!(
+        check::mempool_standard_input_scripts(&tx, std::slice::from_ref(&spent_output)),
+        Err(TransactionError::NonStandardScriptSigSize {
+            input_index: 0,
+            size: 1651,
+        }),
+        "oversized scriptSig should be rejected"
+    );
+}
+
+// Unit tests for the private scriptSig-analysis helpers used by `check::are_inputs_standard`.
+
+#[test]
+fn count_script_push_ops_counts_pushes() {
+    let _init_guard = zebra_test::init();
+    // OP_0 <push 1 byte> <push 1 byte>
+    assert_eq!(
+        check::count_script_push_ops(&[0x00, 0x01, 0xaa, 0x01, 0xbb]),
+        3
+    );
+}
+
+#[test]
+fn count_script_push_ops_empty_script() {
+    let _init_guard = zebra_test::init();
+    assert_eq!(check::count_script_push_ops(&[]), 0);
+}
+
+#[test]
+fn count_script_push_ops_pushdata_variants() {
+    let _init_guard = zebra_test::init();
+    // OP_PUSHDATA1 <len=3> <3 bytes>
+    assert_eq!(
+        check::count_script_push_ops(&[0x4c, 0x03, 0xaa, 0xbb, 0xcc]),
+        1
+    );
+    // OP_PUSHDATA2 <len=3 LE> <3 bytes>
+    assert_eq!(
+        check::count_script_push_ops(&[0x4d, 0x03, 0x00, 0xaa, 0xbb, 0xcc]),
+        1
+    );
+    // OP_PUSHDATA4 <len=2 LE> <2 bytes>
+    assert_eq!(
+        check::count_script_push_ops(&[0x4e, 0x02, 0x00, 0x00, 0x00, 0xaa, 0xbb]),
+        1
+    );
+}
+
+#[test]
+fn count_script_push_ops_truncated_script() {
+    let _init_guard = zebra_test::init();
+    // OP_PUSHBYTES_10 with only 3 bytes: the incomplete push errors and is filtered out.
+    assert_eq!(check::count_script_push_ops(&[0x0a, 0xaa, 0xbb, 0xcc]), 0);
+}
+
+#[test]
+fn extract_p2sh_redeemed_script_extracts_last_push() {
+    let _init_guard = zebra_test::init();
+    // <push "abc"> <push "de">: the redeemed script is the last push.
+    let unlock_script = transparent::Script::new(&[0x03, 0x61, 0x62, 0x63, 0x02, 0x64, 0x65]);
+    assert_eq!(
+        check::extract_p2sh_redeemed_script(&unlock_script),
+        Some(vec![0x64, 0x65])
+    );
+}
+
+#[test]
+fn extract_p2sh_redeemed_script_empty_script() {
+    let _init_guard = zebra_test::init();
+    assert!(check::extract_p2sh_redeemed_script(&transparent::Script::new(&[])).is_none());
+}
+
+#[test]
+fn script_sig_args_expected_values() {
+    use zcash_script::solver::ScriptKind;
+
+    let _init_guard = zebra_test::init();
+
+    // Build a P2PK lock script: <compressed_pubkey> OP_CHECKSIG
+    fn p2pk_lock_script(pubkey: &[u8; 33]) -> transparent::Script {
+        let mut s = Vec::with_capacity(1 + 33 + 1);
+        s.push(0x21); // OP_PUSHBYTES_33
+        s.extend_from_slice(pubkey);
+        s.push(0xac); // OP_CHECKSIG
+        transparent::Script::new(&s)
+    }
+
+    // Build a bare multisig lock script: OP_<required> <pubkeys...> OP_<total> OP_CHECKMULTISIG
+    fn multisig_lock_script(required: u8, pubkeys: &[&[u8; 33]]) -> transparent::Script {
+        let mut s = Vec::new();
+        s.push(0x50 + required); // OP_1..=OP_16
+        for pk in pubkeys {
+            s.push(0x21); // OP_PUSHBYTES_33
+            s.extend_from_slice(*pk);
+        }
+        s.push(0x50 + pubkeys.len() as u8); // OP_N total
+        s.push(0xae); // OP_CHECKMULTISIG
+        transparent::Script::new(&s)
+    }
+
+    // P2PKH: sig + pubkey.
+    assert_eq!(
+        check::script_sig_args_expected(&ScriptKind::PubKeyHash { hash: [0xaa; 20] }),
+        Some(2)
+    );
+    // P2SH: the redeemed script push.
+    assert_eq!(
+        check::script_sig_args_expected(&ScriptKind::ScriptHash { hash: [0xbb; 20] }),
+        Some(1)
+    );
+    // OP_RETURN: non-standard to spend.
+    assert_eq!(
+        check::script_sig_args_expected(&ScriptKind::NullData { data: vec![] }),
+        None
+    );
+
+    // P2PK: sig only (classified via the solver).
+    let p2pk_kind = check::standard_script_kind(&p2pk_lock_script(&[0x02; 33]))
+        .expect("P2PK should be a standard script kind");
+    assert_eq!(check::script_sig_args_expected(&p2pk_kind), Some(1));
+
+    // 1-of-1 multisig: OP_0 + 1 sig.
+    let ms_kind = multisig_lock_script(1, &[&[0x02; 33]]);
+    let ms_kind = check::standard_script_kind(&ms_kind)
+        .expect("1-of-1 multisig should be a standard script kind");
+    assert_eq!(check::script_sig_args_expected(&ms_kind), Some(2));
 }

--- a/zebra-script/CHANGELOG.md
+++ b/zebra-script/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- The per-input P2SH sigop counter `p2sh_input_sigop_count` is now public, so callers
+  can apply per-input standardness limits (zcashd's `MAX_P2SH_SIGOPS`) in addition to
+  the existing transaction-wide `p2sh_sigop_count` total.
+
 ## [10.0.0] - 2026-07-02
 
 ### Changed

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -378,9 +378,19 @@ fn extract_p2sh_redeem_script(unlock_script: &transparent::Script) -> Option<Vec
 
 /// Returns the P2SH sigop count for a single input.
 ///
+/// `spent_output` must be the output spent by `input`.
+///
 /// Returns 0 for non-P2SH inputs, coinbase inputs, and P2SH inputs where no redeem script can be
-/// extracted from the scriptSig.
-fn p2sh_input_sigop_count(input: &transparent::Input, spent_output: &transparent::Output) -> u32 {
+/// extracted from the scriptSig (mirroring zcashd's `CScript::GetSigOpCount(scriptSig)`, which
+/// returns 0 when the scriptSig is not push-only).
+///
+/// This is the per-input counting used by [`p2sh_sigop_count`] for the block-wide consensus sigop
+/// total, and by the mempool standardness gate that rejects high-sigop P2SH inputs before script
+/// verification.
+pub fn p2sh_input_sigop_count(
+    input: &transparent::Input,
+    spent_output: &transparent::Output,
+) -> u32 {
     let unlock_script = match input {
         transparent::Input::PrevOut { unlock_script, .. } => unlock_script,
         transparent::Input::Coinbase { .. } => return 0,

--- a/zebrad/src/components/mempool/storage/policy.rs
+++ b/zebrad/src/components/mempool/storage/policy.rs
@@ -1,186 +1,31 @@
-//! Mempool transaction standardness policy checks.
+//! Mempool transaction standardness policy constants and helpers.
 //!
-//! These functions implement zcashd's mempool policy for rejecting non-standard
-//! transactions. They mirror the logic in zcashd's `IsStandardTx()` and
-//! `AreInputsStandard()`.
+//! These mirror zcashd's mempool policy for rejecting non-standard transactions
+//! (`IsStandardTx()` and `AreInputsStandard()`). The transparent-input checks now live in
+//! `zebra-consensus`, where the transaction verifier applies them before script verification;
+//! they are re-exported here and used by the storage-time policy in the parent module.
 
-use zcash_script::opcode::PossiblyBad;
-use zcash_script::{script, solver, Opcode};
-use zebra_chain::{transaction::Transaction, transparent};
+#[cfg(test)]
+use zebra_chain::transparent;
 
-/// Maximum sigops allowed in a P2SH redeemed script (zcashd `MAX_P2SH_SIGOPS`).
-/// <https://github.com/zcash/zcash/blob/v6.11.0/src/policy/policy.h#L20>
-pub(super) const MAX_P2SH_SIGOPS: u32 = 15;
+// The transparent-input standardness checks (`AreInputsStandard()` and the spent-output
+// classifier) live in `zebra-consensus`, where the transaction verifier also applies them to
+// mempool transactions *before* script verification (`check::mempool_standard_input_scripts`).
+// They are re-exported here for the storage-time policy checks, so the two paths can't drift apart.
+pub(super) use zebra_consensus::transaction::check::{
+    are_inputs_standard, standard_script_kind, MAX_STANDARD_SCRIPTSIG_SIZE,
+};
 
 /// Maximum number of signature operations allowed per standard transaction (zcashd `MAX_STANDARD_TX_SIGOPS`).
 /// <https://github.com/zcash/zcash/blob/v6.11.0/src/policy/policy.h#L22>
 pub(super) const MAX_STANDARD_TX_SIGOPS: u32 = 4000;
 
-/// Maximum size in bytes of a standard transaction's scriptSig (zcashd `MAX_STANDARD_SCRIPTSIG_SIZE`).
-/// <https://github.com/zcash/zcash/blob/v6.11.0/src/policy/policy.cpp#L92-L99>
-pub(super) const MAX_STANDARD_SCRIPTSIG_SIZE: usize = 1650;
-
 /// Maximum number of public keys allowed in a standard multisig script.
 /// <https://github.com/zcash/zcash/blob/v6.11.0/src/policy/policy.cpp#L46-L48>
 pub(super) const MAX_STANDARD_MULTISIG_PUBKEYS: usize = 3;
 
-/// Classify a script using the `zcash_script` solver.
-///
-/// Returns `Some(kind)` for standard script types, `None` for non-standard.
-pub(super) fn standard_script_kind(
-    lock_script: &transparent::Script,
-) -> Option<solver::ScriptKind> {
-    let code = script::Code(lock_script.as_raw_bytes().to_vec());
-    let component = code.to_component().ok()?.refine().ok()?;
-    solver::standard(&component)
-}
-
-/// Extract the redeemed script bytes from a P2SH scriptSig.
-///
-/// The redeemed script is the last data push in the scriptSig.
-/// Returns `None` if the scriptSig has no push operations.
-///
-/// # Precondition
-///
-/// The scriptSig should be push-only (enforced by `reject_if_non_standard_tx`
-/// before this function is called). Non-push opcodes are silently ignored.
-fn extract_p2sh_redeemed_script(unlock_script: &transparent::Script) -> Option<Vec<u8>> {
-    let code = script::Code(unlock_script.as_raw_bytes().to_vec());
-    let mut last_push_data: Option<Vec<u8>> = None;
-    for opcode in code.parse() {
-        if let Ok(PossiblyBad::Good(Opcode::PushValue(pv))) = opcode {
-            last_push_data = Some(pv.value());
-        }
-    }
-    last_push_data
-}
-
-/// Count the number of push operations in a script.
-///
-/// For a push-only script (already enforced for mempool scriptSigs),
-/// this equals the stack depth after evaluation.
-fn count_script_push_ops(script_bytes: &[u8]) -> usize {
-    let code = script::Code(script_bytes.to_vec());
-    code.parse()
-        .filter(|op| matches!(op, Ok(PossiblyBad::Good(Opcode::PushValue(_)))))
-        .count()
-}
-
-/// Returns the expected number of scriptSig arguments for a given script kind.
-///
-/// TODO: Consider upstreaming to `zcash_script` crate alongside `ScriptKind::req_sigs()`.
-///
-/// Mirrors zcashd's `ScriptSigArgsExpected()`:
-/// <https://github.com/zcash/zcash/blob/v6.11.0/src/script/standard.cpp#L135>
-///
-/// Returns `None` for non-standard types (TX_NONSTANDARD, TX_NULL_DATA).
-fn script_sig_args_expected(kind: &solver::ScriptKind) -> Option<usize> {
-    match kind {
-        solver::ScriptKind::PubKey { .. } => Some(1),
-        solver::ScriptKind::PubKeyHash { .. } => Some(2),
-        solver::ScriptKind::ScriptHash { .. } => Some(1),
-        solver::ScriptKind::MultiSig { required, .. } => Some(*required as usize + 1),
-        solver::ScriptKind::NullData { .. } => None,
-    }
-}
-
 #[cfg(test)]
 pub(super) use zebra_script::p2sh_sigop_count;
-
-/// Returns `true` if all transparent inputs are standard.
-///
-/// Mirrors zcashd's `AreInputsStandard()`:
-/// <https://github.com/zcash/zcash/blob/v6.11.0/src/policy/policy.cpp#L136>
-///
-/// For each input:
-/// 1. The spent output's scriptPubKey must be a known standard type (via the `zcash_script` solver).
-///    Non-standard scripts and OP_RETURN outputs are rejected.
-/// 2. The scriptSig stack depth must match `ScriptSigArgsExpected()`.
-/// 3. For P2SH inputs:
-///    - If the redeemed script is standard, its expected args are added to the total.
-///    - If the redeemed script is non-standard, it must have <= [`MAX_P2SH_SIGOPS`] sigops.
-///
-/// # Correctness
-///
-/// Callers must ensure `spent_outputs.len()` matches the number of transparent inputs.
-/// If the lengths differ, `zip()` silently truncates the longer iterator, which may
-/// cause incorrect standardness decisions.
-pub(super) fn are_inputs_standard(tx: &Transaction, spent_outputs: &[transparent::Output]) -> bool {
-    debug_assert_eq!(
-        tx.inputs().len(),
-        spent_outputs.len(),
-        "spent_outputs must align with transaction inputs"
-    );
-    for (input, spent_output) in tx.inputs().iter().zip(spent_outputs.iter()) {
-        let unlock_script = match input {
-            transparent::Input::PrevOut { unlock_script, .. } => unlock_script,
-            transparent::Input::Coinbase { .. } => continue,
-        };
-
-        // Step 1: Classify the spent output's scriptPubKey via the zcash_script solver.
-        let script_kind = match standard_script_kind(&spent_output.lock_script) {
-            Some(kind) => kind,
-            None => return false,
-        };
-
-        // Step 2: Get expected number of scriptSig arguments.
-        // Returns None for TX_NONSTANDARD and TX_NULL_DATA.
-        let mut n_args_expected = match script_sig_args_expected(&script_kind) {
-            Some(n) => n,
-            None => return false,
-        };
-
-        // Step 3: Count actual push operations in scriptSig.
-        // For push-only scripts (enforced by reject_if_non_standard_tx), this equals the stack depth.
-        let stack_size = count_script_push_ops(unlock_script.as_raw_bytes());
-
-        // Step 4: P2SH-specific checks.
-        if matches!(script_kind, solver::ScriptKind::ScriptHash { .. }) {
-            let Some(redeemed_bytes) = extract_p2sh_redeemed_script(unlock_script) else {
-                return false;
-            };
-
-            let redeemed_code = script::Code(redeemed_bytes);
-
-            // Classify the redeemed script using the zcash_script solver.
-            let redeemed_kind = {
-                let component = redeemed_code
-                    .to_component()
-                    .ok()
-                    .and_then(|c| c.refine().ok());
-                component.and_then(|c| solver::standard(&c))
-            };
-
-            match redeemed_kind {
-                Some(ref inner_kind) => {
-                    // Standard redeemed script: add its expected args.
-                    match script_sig_args_expected(inner_kind) {
-                        Some(inner) => n_args_expected += inner,
-                        None => return false,
-                    }
-                }
-                None => {
-                    // Non-standard redeemed script: accept if sigops <= limit.
-                    // Matches zcashd: "Any other Script with less than 15 sigops OK:
-                    // ... extra data left on the stack after execution is OK, too"
-                    let sigops = redeemed_code.sig_op_count(true);
-                    if sigops > MAX_P2SH_SIGOPS {
-                        return false;
-                    }
-
-                    // This input is acceptable; move on to the next input.
-                    continue;
-                }
-            }
-        }
-
-        // Step 5: Reject if scriptSig has wrong number of stack items.
-        if stack_size != n_args_expected {
-            return false;
-        }
-    }
-    true
-}
 
 // -- Test helper functions shared across test modules --
 
@@ -223,22 +68,6 @@ mod tests {
     use super::*;
 
     // -- Helper functions --
-
-    /// Build a bare multisig lock script: OP_<required> <pubkeys...> OP_<total> OP_CHECKMULTISIG
-    fn multisig_lock_script(required: u8, pubkeys: &[&[u8; 33]]) -> transparent::Script {
-        let mut s = Vec::new();
-        // OP_1 through OP_16 are 0x51 through 0x60
-        s.push(0x50 + required);
-        for pk in pubkeys {
-            s.push(0x21); // OP_PUSHBYTES_33
-            s.extend_from_slice(*pk);
-        }
-        // OP_N for total pubkeys, safe because pubkeys.len() <= 3 for standard
-        s.push(0x50 + pubkeys.len() as u8);
-        // OP_CHECKMULTISIG
-        s.push(0xae);
-        transparent::Script::new(&s)
-    }
 
     /// Build a scriptSig with the specified number of push operations.
     /// Each push is a 1-byte constant value.
@@ -304,131 +133,6 @@ mod tests {
             value: 100_000u64.try_into().unwrap(),
             lock_script,
         }
-    }
-
-    // -- count_script_push_ops tests --
-
-    #[test]
-    fn count_script_push_ops_counts_pushes() {
-        let _init_guard = zebra_test::init();
-        // Script with 3 push operations: OP_0 <push 1 byte> <push 1 byte>
-        let script_bytes = vec![0x00, 0x01, 0xaa, 0x01, 0xbb];
-        let count = count_script_push_ops(&script_bytes);
-        assert_eq!(count, 3, "should count 3 push operations");
-    }
-
-    #[test]
-    fn count_script_push_ops_empty_script() {
-        let _init_guard = zebra_test::init();
-        let count = count_script_push_ops(&[]);
-        assert_eq!(count, 0, "empty script should have 0 push ops");
-    }
-
-    #[test]
-    fn count_script_push_ops_pushdata1() {
-        let _init_guard = zebra_test::init();
-        // OP_PUSHDATA1 <length=3> <3 bytes of data>
-        let script_bytes = vec![0x4c, 0x03, 0xaa, 0xbb, 0xcc];
-        let count = count_script_push_ops(&script_bytes);
-        assert_eq!(count, 1, "OP_PUSHDATA1 should count as 1 push operation");
-    }
-
-    #[test]
-    fn count_script_push_ops_pushdata2() {
-        let _init_guard = zebra_test::init();
-        // OP_PUSHDATA2 <length=3 as 2 little-endian bytes> <3 bytes of data>
-        let script_bytes = vec![0x4d, 0x03, 0x00, 0xaa, 0xbb, 0xcc];
-        let count = count_script_push_ops(&script_bytes);
-        assert_eq!(count, 1, "OP_PUSHDATA2 should count as 1 push operation");
-    }
-
-    #[test]
-    fn count_script_push_ops_pushdata4() {
-        let _init_guard = zebra_test::init();
-        // OP_PUSHDATA4 <length=2 as 4 little-endian bytes> <2 bytes of data>
-        let script_bytes = vec![0x4e, 0x02, 0x00, 0x00, 0x00, 0xaa, 0xbb];
-        let count = count_script_push_ops(&script_bytes);
-        assert_eq!(count, 1, "OP_PUSHDATA4 should count as 1 push operation");
-    }
-
-    #[test]
-    fn count_script_push_ops_mixed_push_types() {
-        let _init_guard = zebra_test::init();
-        // OP_0, then OP_PUSHBYTES_1 <byte>, then OP_PUSHDATA1 <len=1> <byte>
-        let script_bytes = vec![0x00, 0x01, 0xaa, 0x4c, 0x01, 0xbb];
-        let count = count_script_push_ops(&script_bytes);
-        assert_eq!(
-            count, 3,
-            "mixed push types should each count as 1 push operation"
-        );
-    }
-
-    #[test]
-    fn count_script_push_ops_truncated_script() {
-        let _init_guard = zebra_test::init();
-        // OP_PUSHBYTES_10 followed by only 3 bytes (truncated) -- parser should
-        // produce an error for the incomplete push, which is filtered out.
-        let script_bytes = vec![0x0a, 0xaa, 0xbb, 0xcc];
-        let count = count_script_push_ops(&script_bytes);
-        assert_eq!(
-            count, 0,
-            "truncated script should count 0 successful push operations"
-        );
-    }
-
-    // -- extract_p2sh_redeemed_script tests --
-
-    #[test]
-    fn extract_p2sh_redeemed_script_extracts_last_push() {
-        let _init_guard = zebra_test::init();
-        // scriptSig: <sig> <redeemed_script>
-        // OP_PUSHDATA with 3 bytes "abc" then OP_PUSHDATA with 2 bytes "de"
-        let unlock_script = transparent::Script::new(&[0x03, 0x61, 0x62, 0x63, 0x02, 0x64, 0x65]);
-        let redeemed = extract_p2sh_redeemed_script(&unlock_script);
-        assert_eq!(
-            redeemed,
-            Some(vec![0x64, 0x65]),
-            "should extract the last push data"
-        );
-    }
-
-    #[test]
-    fn extract_p2sh_redeemed_script_empty_script() {
-        let _init_guard = zebra_test::init();
-        let unlock_script = transparent::Script::new(&[]);
-        let redeemed = extract_p2sh_redeemed_script(&unlock_script);
-        assert!(redeemed.is_none(), "empty scriptSig should return None");
-    }
-
-    // -- script_sig_args_expected tests --
-
-    #[test]
-    fn script_sig_args_expected_values() {
-        let _init_guard = zebra_test::init();
-
-        // P2PKH expects 2 args (sig + pubkey)
-        let pkh_kind = solver::ScriptKind::PubKeyHash { hash: [0xaa; 20] };
-        assert_eq!(script_sig_args_expected(&pkh_kind), Some(2));
-
-        // P2SH expects 1 arg (the redeemed script)
-        let sh_kind = solver::ScriptKind::ScriptHash { hash: [0xbb; 20] };
-        assert_eq!(script_sig_args_expected(&sh_kind), Some(1));
-
-        // NullData expects None (non-standard to spend)
-        let nd_kind = solver::ScriptKind::NullData { data: vec![] };
-        assert_eq!(script_sig_args_expected(&nd_kind), None);
-
-        // P2PK expects 1 arg (sig only) -- test via script classification
-        let p2pk_script = p2pk_lock_script(&[0x02; 33]);
-        let p2pk_kind =
-            standard_script_kind(&p2pk_script).expect("P2PK should be a standard script kind");
-        assert_eq!(script_sig_args_expected(&p2pk_kind), Some(1));
-
-        // MultiSig 1-of-1 expects 2 args (OP_0 + 1 sig) -- test via script classification
-        let ms_script = multisig_lock_script(1, &[&[0x02; 33]]);
-        let ms_kind = standard_script_kind(&ms_script)
-            .expect("1-of-1 multisig should be a standard script kind");
-        assert_eq!(script_sig_args_expected(&ms_kind), Some(2));
     }
 
     // -- are_inputs_standard tests --


### PR DESCRIPTION
## Motivation

Closes [GHSA-84j3-rw4c-gqmj](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-84j3-rw4c-gqmj).

## Solution

Reject mempool transactions with non-standard transparent inputs *before* running
script verification, avoiding the more expensive script checks and reducing DoS
surface. As part of this, script verification now runs on the shared Rayon thread
pool so it no longer blocks the async runtime.

Developed as a private security fix by @conradoplg; this replays it onto public
`main`.

### Tests

New cases in `zebra-consensus/src/transaction/tests.rs`. The full
`zebra-consensus`, `zebra-script`, and `zebrad` mempool suites pass locally, along
with `clippy -D warnings` (workspace, all-features) and `cargo doc`.

### Specifications & References

- GHSA-84j3-rw4c-gqmj
- Thanks to @ouicate for reporting the issue.

### AI Disclosure

- [x] AI tools were used: Claude replayed the private fix onto public `main`
  (3-way apply, CHANGELOG merge resolution, verification). The fix itself was
  authored by @conradoplg.
