### PR TITLE
docs(changelog): finalize [Unreleased] headings for the v6.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Unreleased]
+## [Zebra 6.0.0](https://github.com/ZcashFoundation/zebra/releases/tag/v6.0.0) - 2026-07-10
 
 ### Added
 

--- a/tower-batch-control/CHANGELOG.md
+++ b/tower-batch-control/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.0] - 2026-07-10
 
 ### Added
 

--- a/tower-fallback/CHANGELOG.md
+++ b/tower-fallback/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.42] - 2026-07-10
 
 ### Changed
 

--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [11.1.0] - 2026-07-10
 
 ### Added
 

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [11.0.0] - 2026-07-10
 
 ### Added
 

--- a/zebra-network/CHANGELOG.md
+++ b/zebra-network/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [10.1.0] - 2026-07-10
 
 ### Changed
 

--- a/zebra-node-services/CHANGELOG.md
+++ b/zebra-node-services/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [9.1.0] - 2026-07-10
 
 ### Added
 

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [11.1.0] - 2026-07-10
 
 ### Changed
 

--- a/zebra-script/CHANGELOG.md
+++ b/zebra-script/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [10.1.0] - 2026-07-10
 
 ### Added
 

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [10.1.0] - 2026-07-10
 
 ### Added
 

--- a/zebra-utils/CHANGELOG.md
+++ b/zebra-utils/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [9.1.0] - 2026-07-10
 
 ### Changed
 


### PR DESCRIPTION
## Motivation

release-plz is configured with `changelog_update = false`, so it does **not** rename crate
`[Unreleased]` sections to release headings. Without this, the v6.0.0 crates would publish with
`[Unreleased]` changelogs instead of versioned ones.

## Solution

Rename `## [Unreleased]` → `## [<version>] - 2026-07-10` in each released crate's changelog, and
`## [Zebra 6.0.0](…) - 2026-07-10` in the workspace changelog, using the versions the Release PR
#10811 publishes.

Two of these differ from #10811's current (release-plz) proposal and should be aligned there:

- **`zebrad` → 6.0.0** (release-plz proposes `6.0.0-rc.1`; it auto-increments the pre-release and
  won't promote rc → final).
- **`zebra-script` → 10.1.0** (release-plz proposes major `11.0.0`, inherited from #10936's
  `fix(consensus)!` marker, but zebra-script's only change — making `p2sh_input_sigop_count`
  public — is additive → minor).

### Follow-up Work

- Align #10811 to `zebrad 6.0.0` and `zebra-script 10.1.0`, then merge #10811 to publish.
- The date (`2026-07-10`) should match the actual publish day if the release slips.

### AI Disclosure

- [x] AI tools were used: Claude Code generated the changelog heading renames.
