### PR TITLE
fix(ci): install libclang before publishing crates in the release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,8 @@ jobs:
         run: |
           echo "::error::Configure RELEASE_APP_ID and RELEASE_APP_PRIVATE_KEY before merging a Release PR. The app token is required before crates publish so the zebrad GitHub Release can trigger Docker and GCP workflows."
           exit 1
+      - name: Install libclang for librocksdb-sys bindgen
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev
       - name: Publish crates and create tags
         id: release-plz
         uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 #v0.5.130


### PR DESCRIPTION
## Motivation

The v6.0.0 release job failed publishing `zebra-state`: `cargo publish`'s verification build compiles the packaged tarball from a clean checkout with no cache, and `librocksdb-sys` now always runs `bindgen` to generate its FFI bindings (since the rocksdb 0.24 bump), which needs `libclang` at build time. The `release` job never installed it.

`zebra-consensus`, `zebra-rpc`, and `zebrad` all depend on `zebra-state`, so they hit the same failure on their own verification builds.

## Solution

Install `libclang-dev` in the `release` job before the publish step.

### Tests

`actionlint` and `zizmor` both pass on the changed workflow.

### AI Disclosure

- [x] AI tools were used: Claude Code, diagnosis of the failing release job and drafting this fix.

### PR Checklist

- [x] The PR title follows conventional commits format
- [x] The PR follows the contribution guidelines
- [x] This change was discussed with the team beforehand (direct fix for an active release incident)
- [x] The solution is tested (actionlint, zizmor)
- [x] The documentation and changelogs are up to date (CI-only fix, no changelog entry needed)