### PR TITLE
ci: fix yanked `spin` crate and `reclaculated` typo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5332,9 +5332,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]

--- a/zebra-state/src/service/finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/finalized_state/tests/vectors.rs
@@ -455,7 +455,7 @@ fn sprout_checks(incremental_tree: SproutNoteCommitmentTree, expected_serialized
         deserialized_legacy_tree_as_new.recalculate_root()
     );
 
-    // Check reclaculated and cached roots are the same
+    // Check recalculated and cached roots are the same
     assert_eq!(
         incremental_tree.recalculate_root(),
         deserialized_tree
@@ -509,7 +509,7 @@ fn sapling_checks(
         deserialized_legacy_tree_as_new.recalculate_root()
     );
 
-    // Check reclaculated and cached roots are the same
+    // Check recalculated and cached roots are the same
     assert_eq!(
         incremental_tree.recalculate_root(),
         deserialized_tree
@@ -585,7 +585,7 @@ fn orchard_checks(
         deserialized_legacy_tree_as_new.recalculate_root()
     );
 
-    // Check reclaculated and cached roots are the same
+    // Check recalculated and cached roots are the same
     assert_eq!(
         incremental_tree.recalculate_root(),
         deserialized_tree


### PR DESCRIPTION
## Summary

- Update `spin` 0.9.8 → 0.9.9 (0.9.8 was yanked, failing `cargo deny` on all PRs)
- Fix `reclaculated` → `recalculated` typo in `zebra-state` test comments (3 occurrences, failing spell-check on all PRs)

Closes #10959