### PR TITLE
fix(ci): tolerate Debian package revision updates

### DIFF
--- a/.github/workflows/zfnd-build-docker-image.yml
+++ b/.github/workflows/zfnd-build-docker-image.yml
@@ -134,7 +134,7 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare-matrix.outputs.matrix) }}
     outputs:
       image_digest: ${{ steps.docker_build.outputs.digest || steps.docker_build_no_attestations.outputs.digest }}
-      image_name: ${{ fromJSON(steps.docker_build.outputs.metadata || steps.docker_build_no_attestations.outputs.metadata)['image.name'] }}
+      image_name: ${{ fromJSON(steps.docker_build.outputs.metadata || steps.docker_build_no_attestations.outputs.metadata || '{}')['image.name'] }}
     permissions:
       contents: read
       id-token: write

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,8 +40,8 @@ ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
 # Install zebra build deps
 RUN apt-get -qq update && \
     apt-get -qq install -y --no-install-recommends \
-    libclang-dev=1:19.0-63 \
-    protobuf-compiler=3.21.12-11 \
+    libclang-dev=1:19.0-* \
+    protobuf-compiler=3.21.12-* \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/log/* /var/cache/ldconfig/aux-cache
 
 # Build arguments and variables
@@ -92,7 +92,7 @@ ARG CARGO_TARGET_DIR
 
 # Download and install cargo-nextest, curl and librocksdb-dev.
 RUN apt-get -qq update && \
-    apt-get -qq install -y --no-install-recommends librocksdb-dev=9.10.0-1+b1 curl=8.14.1-2+deb13u3 && \
+    apt-get -qq install -y --no-install-recommends librocksdb-dev=9.10.0-* curl=8.14.1-* && \
     mkdir -p "${CARGO_HOME}/bin" && \
     case ${BUILDPLATFORM:-linux/$(uname -m)} in \
         "linux/amd64"|"linux/x86_64") ARCH="linux" ;; \
@@ -209,8 +209,8 @@ ENV HOME=${HOME}
 # Install curl for healtchecks and adduser for user/group creation
 RUN apt-get -q update && \
     apt-get -q install -y --no-install-recommends \
-    adduser=3.152 \
-    curl=8.14.1-2+deb13u3 \
+    adduser=3.152* \
+    curl=8.14.1-* \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/log/* /var/cache/ldconfig/aux-cache
 
 RUN addgroup --quiet --gid ${GID} ${USER} && \


### PR DESCRIPTION
## Motivation

Docker builds fail when Debian replaces pinned Trixie package revisions that are no longer available. Failed builds also produce a secondary `fromJSON('')` error that hides the original failure.

## Solution

Keep upstream package versions pinned while allowing Debian security and rebuild revisions, and treat missing Docker metadata as an empty object so the original build error remains visible.

### Tests

Package resolution was verified for `linux/amd64` and `linux/arm64`, and the changed files pass workflow and Dockerfile linting.

Closes #10957

### AI Disclosure

OpenAI Codex was used for diagnosis, implementation, testing, and this description.
