### PR TITLE
fix(ci): improve merge queue throughput

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -82,14 +82,14 @@ priority_rules:
     conditions:
       # is labeled with Critical priority
       - 'label~=^P-Critical'
-    allow_checks_interruption: true
+    allow_checks_interruption: false
     priority: high
 
   - name: low
     conditions:
       # is labeled with Optional or Low priority
       - 'label~=^P-(Optional|Low)'
-    allow_checks_interruption: true
+    allow_checks_interruption: false
     priority: low
 merge_protections_settings:
   reporting_method: check-runs

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -14,7 +14,7 @@ defaults:
   queue_rule:
     # Allow to update/rebase the original pull request if possible to check its mergeability,
     # and it does not create a draft PR if not needed
-    batch_max_wait_time: "10 minutes"
+    batch_max_wait_time: "2 minutes"
     queue_conditions:
       # Mergify can auto-mirror classic branch protection, but not GitHub
       # Rulesets. The conditions below restate the gates we actually rely on
@@ -63,7 +63,9 @@ queue_rules:
       - 'label~=^P-Critical'
 
   - name: batched
-    batch_size: 20
+    batch_size:
+      min: 1
+      max: 5
 
 pull_request_rules:
   - name: move to any queue if GitHub Rulesets are satisfied


### PR DESCRIPTION
## Motivation

Routine PRs can wait up to 10 minutes for batches of 20, and priority changes can discard checks already running. Both behaviors waste CI time and delay the queue.

## Solution

Reduce the routine wait to 2 minutes, use dynamic batches of 1 to 5 PRs, and preserve active checks when priorities change. Critical PRs still move ahead of queued work, while checks already running finish first. Urgent wait and batch settings remain unchanged.

### Tests

Mergify accepted the updated configuration.

Refs #10963

### AI Disclosure

OpenAI Codex was used for Mergify research, configuration changes, validation, and this description.
