### PR TITLE
ci: add queue integration shadow check

### DIFF
--- a/.github/workflows/queue-integration.yml
+++ b/.github/workflows/queue-integration.yml
@@ -1,0 +1,58 @@
+name: Queue Integration
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, closed]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  queue-integration:
+    name: queue-integration
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.action != 'closed' &&
+      startsWith(github.head_ref, 'mergify/merge-queue/'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          toolchain: 1.97.0
+          cache-key: queue-integration-1.97.0-default-release-binaries
+          cache-on-failure: true
+      - uses: taiki-e/install-action@65851e10cd6c377f11a60e600abc07cb08643468 # v2.79.3
+        with:
+          tool: cargo-nextest
+      - uses: ./.github/actions/setup-zebra-build
+
+      - name: Resolve locked workspace dependency graph
+        run: cargo metadata --locked --format-version 1 > /dev/null
+
+      - name: Compile release workspace
+        run: cargo build --workspace --locked --release --features default-release-binaries
+
+      - name: Run cross-crate integration tests
+        run: |
+          cargo nextest run \
+            --profile ci \
+            --locked \
+            --release \
+            --features default-release-binaries \
+            --package zebrad \
+            --test zebrad-tests \
+            --filter-expr 'test(=integration::regtest::validate_regtest_genesis_block) or test(=integration::network::zebra_zcash_listener_conflict) or test(=integration::rpc::rpc_endpoint_single_thread)'


### PR DESCRIPTION
## Motivation

Mergify validates the combined tree through temporary pull requests, but those candidates currently rerun the broad source-PR suite. In recent candidate #10944, the unit-test workflow alone ran for about 32 minutes. Zebra needs a bounded integration signal before repeated queue checks can be removed safely.

## Solution

- Add a non-required `queue-integration` job for temporary `mergify/merge-queue/` branches.
- Resolve the locked workspace graph and compile the release workspace with Rust 1.97.0 and the production feature set.
- Run three named tests covering the chain/consensus/state, network/zebrad, and RPC/zebrad boundaries.
- Cancel the focused run when Mergify closes or replaces its temporary pull request.
- Allow manual dispatch for benchmarking and diagnosis.

### Tests

- `actionlint .github/workflows/queue-integration.yml`
- `zizmor --pedantic .github/workflows/queue-integration.yml`
- Verified that the nextest filter selects exactly the three intended tests.
- Ran the three selected tests locally: 3 passed in 43 seconds after compilation.

### Specifications & References

- Advances #10963.
- [Mergify batch pull requests](https://docs.mergify.com/merge-queue/batches/)

### Follow-up Work

Observe at least 20 queue candidates over one work week. Make the check required only if it catches every combined-tree failure observed in the existing queue suite and at least 95% of runs finish within 10 minutes. Remove redundant queue checks in a separate change after those conditions are met.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: OpenAI Codex for workflow research, implementation, validation, and the PR description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in #10963.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.