### PR TITLE
fix(ci): skip duplicate merge queue workflows

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -27,6 +27,14 @@ env:
 
 jobs:
   changes:
+    # Docker validation runs on source PRs, not temporary Mergify queue candidates.
+    if: >-
+      ${{
+        github.event_name != 'pull_request' ||
+        github.event.pull_request.user.login != 'mergify[bot]' ||
+        github.event.pull_request.head.repo.full_name != github.repository ||
+        !startsWith(github.event.pull_request.head.ref, 'mergify/merge-queue/')
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -210,7 +218,7 @@ jobs:
 
   test-docker:
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && needs.changes.result != 'skipped'
     needs:
       - changes
       - build-docker-image

--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -38,7 +38,21 @@ jobs:
     # Fork PRs do not receive repository secrets on pull_request events.
     # Skip the job on fork PRs; maintainers can still run it manually via
     # workflow_dispatch with the PR number as input.
-    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch' }}
+    # Mergify queue candidates reuse the source PR's integration result.
+    if: >-
+      ${{
+        (
+          github.event_name != 'pull_request' ||
+          github.event.pull_request.user.login != 'mergify[bot]' ||
+          github.event.pull_request.head.repo.full_name != github.repository ||
+          !startsWith(github.event.pull_request.head.ref, 'mergify/merge-queue/')
+        ) &&
+        (
+          (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork) ||
+          (github.event_name == 'push' && github.ref_name == 'main') ||
+          github.event_name == 'workflow_dispatch'
+        )
+      }}
     runs-on: ubuntu-latest
     permissions:
       # Needed to post a sticky comment on the PR when triggered manually.

--- a/.github/workflows/zfnd-deploy-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-nodes-gcp.yml
@@ -136,6 +136,14 @@ jobs:
   # the trigger. Downstream jobs read `set-matrix` outputs so the event →
   # environment mapping is computed once.
   set-matrix:
+    # Deployment image tests run on source PRs, not temporary Mergify queue candidates.
+    if: >-
+      ${{
+        github.event_name != 'pull_request' ||
+        github.event.pull_request.user.login != 'mergify[bot]' ||
+        github.event.pull_request.head.repo.full_name != github.repository ||
+        !startsWith(github.event.pull_request.head.ref, 'mergify/merge-queue/')
+      }}
     runs-on: ubuntu-latest
     outputs:
       networks: ${{ steps.set-matrix.outputs.networks }}


### PR DESCRIPTION
## Motivation

Mergify queue candidates repeat Docker configuration, deployment-image, and external integration workflows that already ran on the source PRs and are not required queue signals.

## Solution

Skip those 3 workflows only for candidates that match the Mergify author, repository, and branch prefix. Required queue checks and fast docs and zizmor checks remain unchanged.

### Tests

Workflow syntax, security checks, and the candidate predicate pass. Current Docker failures are fixed by #10967.

Refs #10963

### AI Disclosure

OpenAI Codex was used for workflow implementation, testing, and this description.
