### PR TITLE
ci: run link checks weekly

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,6 +1,8 @@
 name: Docs Check
 
 on:
+  schedule:
+    - cron: "0 8 * * 2"
   push:
     branches: [main]
   pull_request:
@@ -34,44 +36,42 @@ jobs:
         with:
           filters: .github/path-filters.yml
 
-  # TODO: this always ends up failing due to random issues. Possibly move to a weekly job
-  # link-check:
-  #   name: link-check
-  #   permissions:
-  #     contents: read
-  #     pull-requests: read
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 15
-  #   steps:
-  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-  #       with:
-  #         persist-credentials: false
+  link-check:
+    name: link-check
+    if: github.event_name == 'schedule'
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-  #     - name: Restore lychee cache
-  #       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5
-  #       with:
-  #         path: .lycheecache
-  #         key: cache-lychee-${{ github.sha }}
-  #         restore-keys: cache-lychee-
+      - name: Restore lychee cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
 
-  #     - name: Link Checker
-  #       uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 #v2.8.0
-  #       with:
-  #         args: >-
-  #           --verbose
-  #           --no-progress
-  #           --cache
-  #           --max-cache-age 1d
-  #           --config .lychee.toml
-  #           "**/*.md"
-  #         fail: true
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: >-
+            --verbose
+            --no-progress
+            --cache
+            --config .lychee.toml
+            "**/*.md"
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   spell-check:
     name: spell-check
     needs: changes
-    if: needs.changes.outputs.docs_check == 'true'
+    if: github.event_name != 'schedule' && needs.changes.outputs.docs_check == 'true'
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -90,7 +90,7 @@ jobs:
   markdown-lint:
     name: markdown-lint
     needs: changes
-    if: needs.changes.outputs.docs_check == 'true'
+    if: github.event_name != 'schedule' && needs.changes.outputs.docs_check == 'true'
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -121,7 +121,7 @@ jobs:
     if: always()
     needs:
       - changes
-      # - link-check
+      - link-check
       - spell-check
       - markdown-lint
     timeout-minutes: 5
@@ -130,4 +130,4 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe #v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: spell-check, markdown-lint
+          allowed-skips: link-check, spell-check, markdown-lint

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -15,6 +15,8 @@ exclude = [
     "^https?://example\\.com",
     # Rate-limited or auth-required
     "^https://crates\\.io/crates/",
+    # Arti GitLab rejects automated link checks
+    "^https://gitlab\\.torproject\\.org/tpo/core/arti/-/blob/main/CONTRIBUTING\\.md",
     # GitHub pages requiring authentication
     "^https://github.com/.*/settings",
     "^https://github.com/organizations/.*/settings",

--- a/book/src/dev/rfcs/drafts/xxxx-basic-integration-testing.md
+++ b/book/src/dev/rfcs/drafts/xxxx-basic-integration-testing.md
@@ -25,7 +25,7 @@ On `main` branch merge:
 
 For an up-to-date list, see:
 
-- <https://github.com/ZcashFoundation/zebra/blob/main/zebrad/tests/acceptance.rs>
+- <https://github.com/ZcashFoundation/zebra/blob/main/zebrad/tests/main.rs>
 - <https://github.com/ZcashFoundation/zebra/tree/main/.github/workflows>
 
 Design strategies:

--- a/book/src/user/lightwalletd.md
+++ b/book/src/user/lightwalletd.md
@@ -162,7 +162,7 @@ To run all the Zebra `lightwalletd` tests:
 2. install `protoc`
 3. build Zebra with `--features=lightwalletd-grpc-tests`
 
-Please refer to [acceptance](https://github.com/ZcashFoundation/zebra/blob/main/zebrad/tests/acceptance.rs) tests documentation in the `Lightwalletd tests` section. When running tests that use a cached lightwalletd state, the test harness will use a platform default cache directory (for example, `~/.cache/lwd` on Linux) unless overridden via the `LWD_CACHE_DIR` environment variable.
+See the [zebrad test entry point](https://github.com/ZcashFoundation/zebra/blob/main/zebrad/tests/main.rs) for the current test categories and commands. When running tests that use a cached lightwalletd state, the test harness will use a platform default cache directory (for example, `~/.cache/lwd` on Linux) unless overridden via the `LWD_CACHE_DIR` environment variable.
 
 ## Connect a wallet to lightwalletd
 

--- a/docs/decisions/devops/0007-reproducible-builds.md
+++ b/docs/decisions/devops/0007-reproducible-builds.md
@@ -66,4 +66,4 @@ cosign verify docker.io/zfnd/zebra:<version> \
 
 - Reproducible Builds: <https://reproducible-builds.org/docs/>
 - SLSA v1.0: <https://slsa.dev/spec/v1.0/levels>
-- BuildKit reproducibility: <https://docs.docker.com/build/building/reproducible-builds/>
+- BuildKit reproducibility: <https://docs.docker.com/build/ci/github-actions/reproducible-builds/>


### PR DESCRIPTION
## Motivation

Link checking was disabled because transient external failures blocked unrelated PRs, leaving broken documentation links undetected.

## Solution

Run Lychee at 08:00 UTC every Tuesday in the existing Docs Check workflow. Skip it on PRs, merge queues, and main branch pushes, and do not rerun the other docs jobs on schedule. Repair the stale links found by the restored check and exclude one Arti URL that rejects automated requests.

### Tests

The workflow checks and full repository link scan pass.

Closes #10632

### AI Disclosure

OpenAI Codex was used for workflow changes, link validation, and this description.