### PR TITLE
fix(release): stabilize binary publication

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -71,7 +71,7 @@ jobs:
           persist-credentials: false
 
       - name: Docker Hub Description
-        # Image publication is complete before this metadata-only update runs.
+        # This metadata-only update is advisory.
         continue-on-error: true
         uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa #v5.0.0
         with:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -64,9 +64,6 @@ jobs:
 
   dockerhub-description:
     if: github.repository_owner == 'ZcashFoundation' && startsWith(github.event.release.tag_name, 'v')
-    # Updating Docker Hub metadata must not turn a successfully published
-    # release image into a failed release.
-    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
@@ -74,10 +71,12 @@ jobs:
           persist-credentials: false
 
       - name: Docker Hub Description
+        # Image publication is complete before this metadata-only update runs.
+        continue-on-error: true
         uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa #v5.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: zfnd/zebra
           short-description: ${{ github.event.repository.description }}
 

--- a/.github/workflows/zfnd-release-binaries.yml
+++ b/.github/workflows/zfnd-release-binaries.yml
@@ -61,8 +61,9 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          sudo apt-get -qq update
-          sudo apt-get -qq install -y --no-install-recommends \
+          sudo sed -i 's|http://ports.ubuntu.com/ubuntu-ports|https://ports.ubuntu.com/ubuntu-ports|g' /etc/apt/sources.list
+          sudo apt-get -o Acquire::Retries=3 -qq update
+          sudo apt-get -o Acquire::Retries=3 -qq install -y --no-install-recommends \
             clang libclang-dev cmake protobuf-compiler
 
       # Toolchain version comes from rust-toolchain.toml.


### PR DESCRIPTION
## Motivation

The release workflow can report failure after publishing Docker images because its metadata-only Docker Hub update uses a separate credential. The latest ARM binary build also failed while downloading dependencies over the runner's HTTP Ubuntu mirror.

## Solution

Reuse the Docker Hub token already used for image publication and keep only the metadata step advisory. Use the Ubuntu ports HTTPS endpoint with apt retries for release-binary dependencies.

### Tests

`actionlint`, `zizmor`, and an Ubuntu 22.04 ARM dependency-resolution probe pass.

Closes #10317
Closes #10649
Refs #10964

### AI Disclosure

OpenAI Codex was used for diagnosis, implementation, testing, and this description.
