### PR TITLE
fix(release): guard publishing and preserve release channels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,6 +175,11 @@ jobs:
             echo "released=true"
             echo "version=${VERSION}"
             echo "tag=${TAG}"
+            if [[ "${VERSION}" == *-* ]]; then
+              echo "prerelease=true"
+            else
+              echo "prerelease=false"
+            fi
           } >> "${GITHUB_OUTPUT}"
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 #v1.16.1
         if: steps.zebrad-release.outputs.released == 'true'
@@ -300,10 +305,16 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           TARGET_SHA: ${{ github.event.pull_request.merge_commit_sha }}
           TAG: ${{ steps.zebrad-release.outputs.tag }}
+          PRERELEASE: ${{ steps.zebrad-release.outputs.prerelease }}
         run: |
           set -euo pipefail
 
           notes_file="${RUNNER_TEMP}/release-notes.final.md"
+          release_flags=(--latest --prerelease=false)
+
+          if [ "${PRERELEASE}" = "true" ]; then
+            release_flags=(--latest=false --prerelease)
+          fi
 
           if gh release view "${TAG}" --repo "${REPOSITORY}" >/dev/null 2>&1; then
             gh release edit "${TAG}" \
@@ -311,7 +322,7 @@ jobs:
               --title "Zebra ${TAG}" \
               --notes-file "${notes_file}" \
               --target "${TARGET_SHA}" \
-              --latest
+              "${release_flags[@]}"
           else
             gh release create "${TAG}" \
               --repo "${REPOSITORY}" \
@@ -319,5 +330,5 @@ jobs:
               --notes-file "${notes_file}" \
               --target "${TARGET_SHA}" \
               --verify-tag \
-              --latest
+              "${release_flags[@]}"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,10 @@
 #
 # Changelog generation is handled by release-plz + git-cliff.
 #
-# Pipeline (release-pr and release both run on every push to main, independently):
-#   release-pr → creates/updates the single Release PR
-#   release    → on a Release PR merge, publishes crates + tags and creates the
-#                app-authored zebrad GitHub Release; downstream workflows fire
-#                from that release event (exits early on non-release commits)
+# Pipeline:
+#   push to main                  → creates/updates the single Release PR
+#   merged, approved Release PR   → publishes crates + tags and creates the
+#                                   app-authored zebrad GitHub Release
 #
 # Downstream triggers (independent workflows, not managed here):
 #   release:released  → release-binaries.yml (Docker Hub)
@@ -16,6 +15,9 @@ name: Release
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
+    types: [closed]
 
 # Deny all at workflow level — each job declares minimum permissions
 permissions: {}
@@ -28,6 +30,7 @@ jobs:
   # generates per-crate changelogs, and opens/updates a single Release PR.
   release-pr:
     name: Create or update Release PR
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     # Avoid racing updates to the single release-plz Release PR branch when
     # multiple commits land on main while a previous release-pr job is running.
@@ -61,9 +64,9 @@ jobs:
 
   # ── Stage 2: Publish crates and create the public zebrad release ────────
   #
-  # Runs on every push to main, but exits early for non-Release-PR commits
-  # (release_always = false in .release-plz.toml). When a Release PR merge
-  # is detected:
+  # Runs only when an approved Release PR from the release-plz branch is
+  # merged into main. The merged commit is the immutable release target.
+  # The job:
   #   1. Publishes changed crates to crates.io in dependency order
   #   2. Uses trusted publishing (OIDC) — no static API tokens
   #   3. Creates per-crate git tags
@@ -73,17 +76,48 @@ jobs:
   # with a GitHub App installation token because release events created by the
   # repository GITHUB_TOKEN do not trigger downstream workflows.
   #
-  # No `needs: release-pr`: this job self-detects the merge and must publish even
-  # when release-pr's concurrency group cancels its superseded pending run.
   release:
     name: Publish crates and GitHub Release
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'release-plz-') &&
+      contains(github.event.pull_request.labels.*.name, 'A-release')
     runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write
       pull-requests: read
     environment: release
+    concurrency:
+      group: release-publish
+      cancel-in-progress: false
     steps:
+      - name: Verify approved Release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+          TARGET_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+
+          RELEASE_PR="$(gh pr view "${PR_NUMBER}" \
+            --repo "${REPOSITORY}" \
+            --json baseRefName,headRefName,labels,mergeCommit,reviewDecision,state)"
+
+          if ! jq -e --arg target_sha "${TARGET_SHA}" '
+            .state == "MERGED" and
+            .reviewDecision == "APPROVED" and
+            .baseRefName == "main" and
+            (.headRefName | startswith("release-plz-")) and
+            .mergeCommit.oid == $target_sha and
+            any(.labels[]; .name == "A-release")
+          ' <<< "${RELEASE_PR}" >/dev/null; then
+            echo "::error::PR #${PR_NUMBER} is not an approved A-release Release PR merged into main at ${TARGET_SHA}."
+            exit 1
+          fi
       - name: Generate release app token
         id: app-token
         if: vars.RELEASE_APP_ID != ''
@@ -97,27 +131,10 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
-      - name: Detect Release PR merge
-        id: release-pr
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
-          REPOSITORY: ${{ github.repository }}
-          TARGET_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-
-          ASSOCIATED_PRS="$(gh api \
-            -H "Accept: application/vnd.github+json" \
-            "/repos/${REPOSITORY}/commits/${TARGET_SHA}/pulls")"
-
-          if jq -e 'map(select(.head.ref | startswith("release-plz-"))) | length > 0' <<< "${ASSOCIATED_PRS}" >/dev/null; then
-            echo "merged=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "merged=false" >> "${GITHUB_OUTPUT}"
-          fi
       - name: Validate release app token
-        if: steps.release-pr.outputs.merged == 'true' && steps.app-token.outputs.token == ''
+        if: steps.app-token.outputs.token == ''
         run: |
           echo "::error::Configure RELEASE_APP_ID and RELEASE_APP_PRIVATE_KEY before merging a Release PR. The app token is required before crates publish so the zebrad GitHub Release can trigger Docker and GCP workflows."
           exit 1
@@ -281,7 +298,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPOSITORY: ${{ github.repository }}
-          TARGET_SHA: ${{ github.sha }}
+          TARGET_SHA: ${{ github.event.pull_request.merge_commit_sha }}
           TAG: ${{ steps.zebrad-release.outputs.tag }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Motivation

Ordinary pushes to `main` can start publication, and prereleases are always marked as the latest stable release.

## Solution

Publish only after an approved Release PR merges, verify its source and merge commit before creating write credentials, and serialize publication without canceling an active release. Mark prerelease versions as prereleases without changing the latest stable release.

### Tests

Workflow parsing passes, and stable and prerelease versions select the intended GitHub Release flags.

Refs #10964

### AI Disclosure

OpenAI Codex was used to update and validate the workflow and write this description.
