### PR TITLE
fix(release): omit workspace dev-dependencies from packages

### DIFF
--- a/tower-batch-control/Cargo.toml
+++ b/tower-batch-control/Cargo.toml
@@ -46,10 +46,10 @@ rand = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tokio-test = { workspace = true }
-tower-fallback = { path = "../tower-fallback/", version = "0.2.42" }
+tower-fallback = { path = "../tower-fallback/" }
 tower-test = { workspace = true }
 
-zebra-test = { path = "../zebra-test/", version = "4.0.0" }
+zebra-test = { path = "../zebra-test/" }
 
 [lints]
 workspace = true

--- a/tower-fallback/Cargo.toml
+++ b/tower-fallback/Cargo.toml
@@ -25,7 +25,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zebra-test = { path = "../zebra-test/", version = "4.0.0" }
+zebra-test = { path = "../zebra-test/" }
 
 [lints]
 workspace = true

--- a/zebra-chain/Cargo.toml
+++ b/zebra-chain/Cargo.toml
@@ -154,7 +154,7 @@ rand_chacha = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zebra-test = { path = "../zebra-test/", version = "4.0.0" }
+zebra-test = { path = "../zebra-test/" }
 
 [[bench]]
 name = "block"

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -95,9 +95,9 @@ tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-zebra-state = { path = "../zebra-state", version = "10.1.0", features = ["proptest-impl"] }
-zebra-chain = { path = "../zebra-chain", version = "11.1.0", features = ["proptest-impl"] }
-zebra-test = { path = "../zebra-test/", version = "4.0.0" }
+zebra-state = { path = "../zebra-state", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
+zebra-test = { path = "../zebra-test/" }
 
 criterion = { workspace = true, features = ["html_reports"] }
 

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -136,20 +136,20 @@ proptest = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zebra-chain = { path = "../zebra-chain", version = "11.1.0", features = [
+zebra-chain = { path = "../zebra-chain", features = [
     "proptest-impl",
 ] }
-zebra-consensus = { path = "../zebra-consensus", version = "11.0.0", features = [
+zebra-consensus = { path = "../zebra-consensus", features = [
     "proptest-impl",
 ] }
-zebra-network = { path = "../zebra-network", version = "10.1.0", features = [
+zebra-network = { path = "../zebra-network", features = [
     "proptest-impl",
 ] }
-zebra-state = { path = "../zebra-state", version = "10.1.0", features = [
+zebra-state = { path = "../zebra-state", features = [
     "proptest-impl",
 ] }
 
-zebra-test = { path = "../zebra-test", version = "4.0.0" }
+zebra-test = { path = "../zebra-test" }
 
 [lints]
 workspace = true

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -37,7 +37,7 @@ lazy_static = { workspace = true }
 ripemd = { workspace = true }
 secp256k1 = { workspace = true }
 sha2 = { workspace = true }
-zebra-test = { path = "../zebra-test", version = "4.0.0" }
+zebra-test = { path = "../zebra-test" }
 
 [lints]
 workspace = true

--- a/zebra-state/Cargo.toml
+++ b/zebra-state/Cargo.toml
@@ -108,8 +108,8 @@ jubjub = { workspace = true }
 
 tokio = { workspace = true, features = ["full", "tracing", "test-util"] }
 
-zebra-chain = { path = "../zebra-chain", version = "11.1.0", features = ["proptest-impl"] }
-zebra-test = { path = "../zebra-test/", version = "4.0.0" }
+zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
+zebra-test = { path = "../zebra-test/" }
 
 [lints]
 workspace = true

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -302,12 +302,12 @@ proptest-derive = { workspace = true }
 # enable span traces and track caller in tests
 color-eyre = { workspace = true }
 
-zebra-chain = { path = "../zebra-chain", version = "11.1.0", features = ["proptest-impl"] }
-zebra-consensus = { path = "../zebra-consensus", version = "11.0.0", features = ["proptest-impl"] }
-zebra-network = { path = "../zebra-network", version = "10.1.0", features = ["proptest-impl"] }
-zebra-state = { path = "../zebra-state", version = "10.1.0", features = ["proptest-impl"] }
+zebra-chain = { path = "../zebra-chain", features = ["proptest-impl"] }
+zebra-consensus = { path = "../zebra-consensus", features = ["proptest-impl"] }
+zebra-network = { path = "../zebra-network", features = ["proptest-impl"] }
+zebra-state = { path = "../zebra-state", features = ["proptest-impl"] }
 
-zebra-test = { path = "../zebra-test", version = "4.0.0" }
+zebra-test = { path = "../zebra-test" }
 
 # Used by the checkpoint generation tests via the zebra-checkpoints feature
 # (the binaries in this crate won't be built unless their features are enabled).
@@ -318,7 +318,7 @@ zebra-test = { path = "../zebra-test", version = "4.0.0" }
 # When `-Z bindeps` is stabilised, enable this binary dependency instead:
 # https://github.com/rust-lang/cargo/issues/9096
 # zebra-utils { path = "../zebra-utils", artifact = "bin:zebra-checkpoints" }
-zebra-utils = { path = "../zebra-utils", version = "9.1.0" }
+zebra-utils = { path = "../zebra-utils" }
 
 [package.metadata.cargo-udeps.ignore]
 # These dependencies are false positives - they are actually used


### PR DESCRIPTION
## Motivation

release-plz does not use dev-dependencies when ordering crate publication, but Cargo keeps versioned dev-dependencies in packaged manifests. This caused the v6.0.0 release to publish `tower-batch-control` before its required `tower-fallback` version existed.

## Solution

Make every local dev-dependency path-only. Cargo still resolves these dependencies for workspace tests but omits them from published manifests, removing the registry ordering constraint.

### Tests

All affected crates package without local dev-dependencies, and the `tower-batch-control` and `tower-fallback` tests pass.

Refs #10964

### AI Disclosure

OpenAI Codex was used to update and validate the manifests and write this description.
