### PR TITLE
feat(rpc): add stream and keepalive limits to indexer gRPC server

### DIFF
--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The indexer gRPC server now bounds concurrent HTTP/2 streams per connection (20)
+  and closes dead connections via HTTP/2 keepalive pings (30s interval, 10s timeout)
+  ([#10980](https://github.com/ZcashFoundation/zebra/pull/10980)).
+
 ### Fixed
 
 - Clarified the error message returned by `getrawtransaction` for transactions

--- a/zebra-rpc/src/indexer/server.rs
+++ b/zebra-rpc/src/indexer/server.rs
@@ -1,6 +1,6 @@
 //! A tonic RPC server for Zebra's indexer API.
 
-use std::net::SocketAddr;
+use std::{net::SocketAddr, time::Duration};
 
 use tokio::task::JoinHandle;
 use tonic::transport::{server::TcpIncoming, Server};
@@ -10,6 +10,19 @@ use zebra_node_services::mempool::MempoolTxSubscriber;
 use zebra_state::ReadState;
 
 use crate::{indexer::indexer_server::IndexerServer, server::OPENED_RPC_ENDPOINT_MSG};
+
+/// Maximum concurrent HTTP/2 streams per connection.
+///
+/// The primary clients (Zaino and Zallet) each open 1-2 streams via
+/// `init_read_state_with_syncer`. 20 provides generous headroom while
+/// bounding resource usage from untrusted clients.
+const MAX_CONCURRENT_STREAMS: u32 = 20;
+
+/// Interval between HTTP/2 keepalive pings sent to detect dead connections.
+const HTTP2_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Timeout for HTTP/2 keepalive pings before the connection is closed.
+const HTTP2_KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(10);
 
 type ServerTask = JoinHandle<Result<(), BoxError>>;
 
@@ -56,6 +69,9 @@ where
 
     let server_task: JoinHandle<Result<(), BoxError>> = tokio::spawn(async move {
         Server::builder()
+            .max_concurrent_streams(Some(MAX_CONCURRENT_STREAMS))
+            .http2_keepalive_interval(Some(HTTP2_KEEPALIVE_INTERVAL))
+            .http2_keepalive_timeout(Some(HTTP2_KEEPALIVE_TIMEOUT))
             .add_service(reflection_service)
             .add_service(IndexerServer::new(indexer_service))
             .serve_with_incoming(TcpIncoming::from(tcp_listener))


### PR DESCRIPTION
## Summary

- Closes #10734
- Add `max_concurrent_streams`, `http2_keepalive_interval`, and `http2_keepalive_timeout` to the indexer gRPC server
- Values are hardcoded constants — the primary clients (Zaino and Zallet) each need 1-2 streams, no use case for user configuration
- Intentionally omits `max_connection_age` — both clients use long-lived syncer connections that would break if the server forced disconnection
- Omits `tcp_keepalive` — tonic ignores it when using `serve_with_incoming`, and HTTP/2 keepalive already detects dead connections at the application layer
- Note: #10953 adds a second tonic server that would benefit from the same limits