### PR TITLE
fix(ci): silence semicolon-in-expressions-from-macros in u256

### DIFF
--- a/zebra-chain/src/work/u256.rs
+++ b/zebra-chain/src/work/u256.rs
@@ -5,6 +5,8 @@
 #![allow(clippy::range_plus_one)]
 #![allow(clippy::fallible_impl_from)]
 #![allow(missing_docs)]
+// `uint`'s macro expansion trips this lint on newer nightlies: https://github.com/rust-lang/rust/issues/79813
+#![allow(semicolon_in_expressions_from_macros)]
 
 use uint::construct_uint;
 


### PR DESCRIPTION
## Motivation

The `Book` workflow's `Build internal docs` step and `lint.yml`'s `docs` job both fail to compile `zebra-chain`: https://github.com/ZcashFoundation/zebra/actions/runs/29574523489/job/87865852429

## Solution

Add `#![allow(semicolon_in_expressions_from_macros)]` to `u256.rs`, alongside its existing module-level clippy allows for the same macro. An `#[allow]` on the macro invocation itself is silently ignored by rustc (attributes don't propagate into a macro's expansion) and is rejected as `unused_attributes` under `-D warnings` in regular builds, so the allow has to be module-level.

### AI Disclosure

- [x] AI tools were used: Claude Code diagnosed the CI failure, wrote the fix, and drafted this PR description.

### PR Checklist

- [x] The PR title follows conventional commits format.
- [x] The PR follows the contribution guidelines.
- [x] This change was discussed in an issue or with the team beforehand. (Maintainer-authored CI fix.)
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date. (No changelog entry: CI-only fix, not user-visible.)