### PR TITLE
chore: combined fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+
+### Security
+
+- Avoid quadratic validation work when checking the remaining transparent value of blocks with
+  many transactions ([GHSA-4g24-549m-hp75](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-4g24-549m-hp75)).
+
 ## [Zebra 6.0.0](https://github.com/ZcashFoundation/zebra/releases/tag/v6.0.0) - 2026-07-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+
+### Security
+
+- Score misbehavior for peers that directly push consensus-invalid transactions, matching the
+  treatment of peers that advertise them
+  ([GHSA-g7c4-2w6c-cr3r](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-g7c4-2w6c-cr3r)).
+
 ## [Zebra 6.0.0](https://github.com/ZcashFoundation/zebra/releases/tag/v6.0.0) - 2026-07-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+
+### Security
+
+- Reserve space for the block header and transaction count when selecting block template
+  transactions, so blocks mined from Zebra's templates can no longer exceed the consensus size
+  limit ([GHSA-95m2-vx53-v2jw](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-95m2-vx53-v2jw)).
+
 ## [Zebra 6.0.0](https://github.com/ZcashFoundation/zebra/releases/tag/v6.0.0) - 2026-07-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+
+### Security
+
+- Prevent a peer from stalling chain synchronization by delivering a rejected
+  block body that shares its header hash with a later valid block
+  ([GHSA-8gxx-hc65-vv82](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-8gxx-hc65-vv82)).
+
 ## [Zebra 6.0.0](https://github.com/ZcashFoundation/zebra/releases/tag/v6.0.0) - 2026-07-10
 
 ### Added

--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `block::Header::serialized_size`
-- `work::equihash::Solution::serialized_size`
+- `block::Header::{SERIALIZED_SIZE, REGTEST_SERIALIZED_SIZE, serialized_size}`
+- `work::equihash::Solution::{SERIALIZED_SIZE, REGTEST_SERIALIZED_SIZE, serialized_size}`
 
 ## [11.1.0] - 2026-07-10
 

--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `block::Header::serialized_size`
+- `work::equihash::Solution::serialized_size`
+
 ## [11.1.0] - 2026-07-10
 
 ### Added

--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- Computing `transaction::Transaction::value_balance` no longer clones the entire UTXO map per
+  call (GHSA-4g24-549m-hp75).
+
 ## [11.1.0] - 2026-07-10
 
 ### Added

--- a/zebra-chain/src/block/header.rs
+++ b/zebra-chain/src/block/header.rs
@@ -140,13 +140,26 @@ impl Header {
         Hash::from(self)
     }
 
+    /// The serialized size of a block header on Mainnet and Testnet (except Regtest), in bytes:
+    /// the fields before the nonce, the 32-byte nonce, and the length-prefixed solution.
+    pub const SERIALIZED_SIZE: usize = Solution::INPUT_LENGTH + 32 + Solution::SERIALIZED_SIZE;
+
+    /// The serialized size of a block header on Regtest, in bytes:
+    /// the fields before the nonce, the 32-byte nonce, and the length-prefixed solution.
+    pub const REGTEST_SERIALIZED_SIZE: usize =
+        Solution::INPUT_LENGTH + 32 + Solution::REGTEST_SERIALIZED_SIZE;
+
     /// Returns the size of a serialized block header on `network`, in bytes.
     ///
     /// Every header field has a fixed size, except the Equihash solution,
-    /// whose size is constant per network, so this is also constant per network.
+    /// whose size is constant per network, so this is also constant per network:
+    /// [`Self::REGTEST_SERIALIZED_SIZE`] on Regtest, [`Self::SERIALIZED_SIZE`] everywhere else.
     pub fn serialized_size(network: &Network) -> usize {
-        // The fields before the nonce, the 32-byte nonce, and the length-prefixed solution.
-        Solution::INPUT_LENGTH + 32 + Solution::serialized_size(network)
+        if network.is_regtest() {
+            Self::REGTEST_SERIALIZED_SIZE
+        } else {
+            Self::SERIALIZED_SIZE
+        }
     }
 }
 

--- a/zebra-chain/src/block/header.rs
+++ b/zebra-chain/src/block/header.rs
@@ -139,6 +139,15 @@ impl Header {
     pub fn hash(&self) -> Hash {
         Hash::from(self)
     }
+
+    /// Returns the size of a serialized block header on `network`, in bytes.
+    ///
+    /// Every header field has a fixed size, except the Equihash solution,
+    /// whose size is constant per network, so this is also constant per network.
+    pub fn serialized_size(network: &Network) -> usize {
+        // The fields before the nonce, the 32-byte nonce, and the length-prefixed solution.
+        Solution::INPUT_LENGTH + 32 + Solution::serialized_size(network)
+    }
 }
 
 /// A header with a count of the number of transactions in its block.

--- a/zebra-chain/src/block/tests/vectors.rs
+++ b/zebra-chain/src/block/tests/vectors.rs
@@ -188,6 +188,46 @@ fn blockheader_serialization() {
     }
 }
 
+/// Checks that [`Header::serialized_size`] matches the actual size of serialized headers
+/// on every network.
+#[test]
+fn blockheader_serialized_size() {
+    let _init_guard = zebra_test::init();
+
+    // `BLOCKS` contains Mainnet and Testnet blocks, whose headers have the same size.
+    for block in zebra_test::vectors::BLOCKS.iter() {
+        let mut header = block[..Header::serialized_size(&Network::Mainnet)]
+            .zcash_deserialize_into::<Header>()
+            .expect("blockheader test vector should deserialize");
+
+        let serialized_header = header
+            .zcash_serialize_to_vec()
+            .expect("blockheader test vector should serialize");
+
+        assert_eq!(
+            serialized_header.len(),
+            Header::serialized_size(&Network::Mainnet),
+            "serialized header size should match Header::serialized_size on Mainnet"
+        );
+
+        // Regtest headers only differ in the size of the Equihash solution.
+        header.solution = crate::work::equihash::Solution::from_bytes(
+            &[0; crate::work::equihash::REGTEST_SOLUTION_SIZE],
+        )
+        .expect("Regtest solution size should be valid");
+
+        let serialized_header = header
+            .zcash_serialize_to_vec()
+            .expect("Regtest blockheader should serialize");
+
+        assert_eq!(
+            serialized_header.len(),
+            Header::serialized_size(&Network::new_regtest(Default::default())),
+            "serialized header size should match Header::serialized_size on Regtest"
+        );
+    }
+}
+
 #[test]
 fn round_trip_blocks() {
     let _init_guard = zebra_test::init();

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -50,7 +50,7 @@ use crate::{
     serialization::ZcashSerialize,
     sprout,
     transparent::{
-        self, outputs_from_utxos,
+        self,
         CoinbaseSpendRestriction::{self, *},
     },
     value_balance::{ValueBalance, ValueBalanceError},
@@ -1562,7 +1562,16 @@ impl Transaction {
         &self,
         utxos: &HashMap<transparent::OutPoint, transparent::Utxo>,
     ) -> Result<ValueBalance<NegativeAllowed>, ValueBalanceError> {
-        self.value_balance_from_outputs(&outputs_from_utxos(utxos.clone()))
+        let outputs = self
+            .spent_outpoints()
+            .filter_map(|outpoint| {
+                utxos
+                    .get(&outpoint)
+                    .map(|utxo| (outpoint, utxo.output.clone()))
+            })
+            .collect();
+
+        self.value_balance_from_outputs(&outputs)
     }
 
     /// Converts [`Transaction`] to [`zcash_primitives::transaction::Transaction`].

--- a/zebra-chain/src/work/equihash.rs
+++ b/zebra-chain/src/work/equihash.rs
@@ -113,17 +113,24 @@ impl Solution {
         }
     }
 
+    /// The serialized size of a solution on Mainnet and Testnet (except Regtest), in bytes:
+    /// the 1344-byte solution and its 3-byte CompactSize length prefix (`0xfd` + `u16`).
+    pub const SERIALIZED_SIZE: usize = 3 + SOLUTION_SIZE;
+
+    /// The serialized size of a solution on Regtest, in bytes:
+    /// the 36-byte solution and its 1-byte CompactSize length prefix.
+    pub const REGTEST_SERIALIZED_SIZE: usize = 1 + REGTEST_SOLUTION_SIZE;
+
     /// Returns the size of the serialized solution on `network`, in bytes,
     /// including its CompactSize length prefix.
     ///
-    /// The solution size is constant per network, so this is also constant per network.
+    /// The solution size is constant per network, so this is also constant per network:
+    /// [`Self::REGTEST_SERIALIZED_SIZE`] on Regtest, [`Self::SERIALIZED_SIZE`] everywhere else.
     pub fn serialized_size(network: &Network) -> usize {
         if network.is_regtest() {
-            // The 36-byte Regtest solution has a 1-byte CompactSize length prefix.
-            1 + REGTEST_SOLUTION_SIZE
+            Self::REGTEST_SERIALIZED_SIZE
         } else {
-            // The 1344-byte solution has a 3-byte CompactSize length prefix (`0xfd` + `u16`).
-            3 + SOLUTION_SIZE
+            Self::SERIALIZED_SIZE
         }
     }
 

--- a/zebra-chain/src/work/equihash.rs
+++ b/zebra-chain/src/work/equihash.rs
@@ -7,6 +7,7 @@ use serde_big_array::BigArray;
 
 use crate::{
     block::Header,
+    parameters::Network,
     serialization::{
         zcash_deserialize_bytes_external_count, zcash_serialize_bytes, CompactSizeMessage,
         SerializationError, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize,
@@ -109,6 +110,20 @@ impl Solution {
             _unexpected_len => Err(SerializationError::Parse(
                 "incorrect equihash solution size",
             )),
+        }
+    }
+
+    /// Returns the size of the serialized solution on `network`, in bytes,
+    /// including its CompactSize length prefix.
+    ///
+    /// The solution size is constant per network, so this is also constant per network.
+    pub fn serialized_size(network: &Network) -> usize {
+        if network.is_regtest() {
+            // The 36-byte Regtest solution has a 1-byte CompactSize length prefix.
+            1 + REGTEST_SOLUTION_SIZE
+        } else {
+            // The 1344-byte solution has a 3-byte CompactSize length prefix (`0xfd` + `u16`).
+            3 + SOLUTION_SIZE
         }
     }
 

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Block template transaction selection now reserves space for the block header and the
+  transaction count, so assembled blocks can no longer exceed the consensus size limit
+  (GHSA-95m2-vx53-v2jw).
+
 ## [11.1.0] - 2026-07-10
 
 ### Changed

--- a/zebra-rpc/src/methods/types/get_block_template/zip317.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/zip317.rs
@@ -15,9 +15,12 @@ use rand::{
 
 use zebra_chain::{
     amount::Amount,
-    block::{Height, MAX_BLOCK_BYTES},
+    block::{Header, Height, MAX_BLOCK_BYTES},
     parameters::Network,
-    transaction::{self, zip317::BLOCK_UNPAID_ACTION_LIMIT, VerifiedUnminedTx},
+    serialization::{CompactSizeMessage, ZcashSerialize},
+    transaction::{
+        self, zip317::BLOCK_UNPAID_ACTION_LIMIT, VerifiedUnminedTx, MIN_TRANSPARENT_TX_SIZE,
+    },
 };
 use zebra_consensus::MAX_BLOCK_SIGOPS;
 use zebra_node_services::mempool::TransactionDependencies;
@@ -96,6 +99,12 @@ pub fn select_mempool_transactions(
     let mut remaining_block_sigops = MAX_BLOCK_SIGOPS;
     let mut remaining_block_unpaid_actions: u32 = BLOCK_UNPAID_ACTION_LIMIT;
 
+    // `MAX_BLOCK_BYTES` limits the whole serialized block, so reserve space for the block header
+    // and the transaction count before budgeting transactions, or the assembled block could
+    // exceed the consensus size limit (GHSA-95m2-vx53-v2jw).
+    remaining_block_bytes -= Header::serialized_size(net);
+    remaining_block_bytes -= max_transaction_count_size();
+
     // Adjust the limits based on the coinbase transaction
     remaining_block_bytes -= fake_coinbase_tx.data.as_ref().len();
     remaining_block_sigops -= fake_coinbase_tx.sigops;
@@ -136,6 +145,25 @@ pub fn select_mempool_transactions(
     }
 
     selected_txs
+}
+
+/// Returns the maximum possible serialized size of a block's transaction count, in bytes.
+///
+/// The transaction count is a CompactSize whose width grows with the count. A serialized
+/// transaction takes at least [`MIN_TRANSPARENT_TX_SIZE`] bytes, so a block can never contain
+/// more than `MAX_BLOCK_BYTES / MIN_TRANSPARENT_TX_SIZE` transactions, which bounds the width.
+fn max_transaction_count_size() -> usize {
+    let max_transaction_count: usize = (MAX_BLOCK_BYTES / MIN_TRANSPARENT_TX_SIZE)
+        .try_into()
+        .expect("fits in memory");
+
+    let max_transaction_count = CompactSizeMessage::try_from(max_transaction_count)
+        .expect("the maximum transaction count is below the CompactSize message limit");
+
+    max_transaction_count
+        .zcash_serialize_to_vec()
+        .expect("serialization into a vec can't fail")
+        .len()
 }
 
 /// Returns a fee-weighted index and the total weight of `transactions`.

--- a/zebra-rpc/src/methods/types/get_block_template/zip317/tests.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/zip317/tests.rs
@@ -5,12 +5,18 @@
 use zcash_keys::address::Address;
 use zcash_transparent::address::TransparentAddress;
 
-use zebra_chain::{block::Height, parameters::Network, transaction, transparent::OutPoint};
+use zebra_chain::{
+    amount::Amount,
+    block::{Header, Height, MAX_BLOCK_BYTES},
+    parameters::Network,
+    transaction,
+    transparent::OutPoint,
+};
 use zebra_node_services::mempool::TransactionDependencies;
 
-use crate::methods::types::get_block_template::MinerParams;
+use crate::methods::types::{get_block_template::MinerParams, transaction::TransactionTemplate};
 
-use super::select_mempool_transactions;
+use super::{max_transaction_count_size, select_mempool_transactions};
 
 #[test]
 fn excludes_tx_with_unselected_dependencies() {
@@ -103,5 +109,64 @@ fn includes_tx_with_selected_dependencies() {
     assert_eq!(
         *dependency_depth, 1,
         "should return a dependency depth of 1 for the dependent tx"
+    );
+}
+
+/// Checks that transaction selection reserves space for the block header and the transaction
+/// count, which [`MAX_BLOCK_BYTES`] covers: a transaction exactly filling the remaining safe
+/// budget is selected, and a transaction one byte larger is not (GHSA-95m2-vx53-v2jw).
+#[test]
+fn reserves_space_for_block_header_and_transaction_count() {
+    let network = Network::Mainnet;
+    let height = Height(1_000_000);
+    let miner_params =
+        MinerParams::from(Address::from(TransparentAddress::PublicKeyHash([0x7e; 20])));
+
+    let coinbase_tx_size =
+        TransactionTemplate::new_coinbase(&network, height, &miner_params, Amount::zero())
+            .expect("valid coinbase transaction template")
+            .data
+            .as_ref()
+            .len();
+
+    let safe_budget = usize::try_from(MAX_BLOCK_BYTES).expect("fits in memory")
+        - Header::serialized_size(&network)
+        - max_transaction_count_size()
+        - coinbase_tx_size;
+
+    let mut unmined_tx = network
+        .unmined_transactions_in_blocks(..)
+        .next()
+        .expect("should not be empty");
+
+    unmined_tx.transaction.size = safe_budget;
+
+    assert_eq!(
+        select_mempool_transactions(
+            &network,
+            height,
+            &miner_params,
+            vec![unmined_tx.clone()],
+            TransactionDependencies::default(),
+            None,
+        )
+        .len(),
+        1,
+        "should select a transaction exactly filling the safe block budget"
+    );
+
+    unmined_tx.transaction.size = safe_budget + 1;
+
+    assert_eq!(
+        select_mempool_transactions(
+            &network,
+            height,
+            &miner_params,
+            vec![unmined_tx],
+            TransactionDependencies::default(),
+            None,
+        ),
+        vec![],
+        "should not select a transaction one byte over the safe block budget"
     );
 }

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- The state service now accepts children of a block that was accepted and has the same
+  block header hash (due to [ZIP-244](https://zips.z.cash/zip-0244)) as a block that
+  was previously rejected
+  ([GHSA-8gxx-hc65-vv82](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-8gxx-hc65-vv82)).
+
 ## [10.1.0] - 2026-07-10
 
 ### Added

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- Checking the remaining transaction value of a block is no longer quadratic in the number of
+  transactions (GHSA-4g24-549m-hp75).
+
 ## [10.1.0] - 2026-07-10
 
 ### Added

--- a/zebra-state/src/service/check/tests/utxo.rs
+++ b/zebra-state/src/service/check/tests/utxo.rs
@@ -1,6 +1,6 @@
 //! Test vectors and randomised property tests for UTXO contextual validation
 
-use std::{env, sync::Arc};
+use std::{collections::HashMap, env, sync::Arc, time::Instant};
 
 use proptest::prelude::*;
 
@@ -21,7 +21,7 @@ use crate::{
         write::validate_and_commit_non_finalized,
     },
     tests::setup::{new_state_with_mainnet_genesis, transaction_v4_from_coinbase},
-    CheckpointVerifiedBlock,
+    CheckpointVerifiedBlock, SemanticallyVerifiedBlock,
     ValidateContextError::{
         DuplicateTransparentSpend, EarlyTransparentSpend, ImmatureTransparentCoinbaseSpend,
         MissingTransparentOutput, UnshieldedTransparentCoinbaseSpend,
@@ -116,6 +116,101 @@ fn reject_immature_coinbase_utxo_spend() {
             min_spend_height,
             created_height
         })
+    );
+}
+
+/// Verify that `remaining_transaction_value` scales linearly with the number
+/// of transactions in a block, completing well under 4 seconds for 10,000
+/// one-input transactions even in debug mode.
+#[test]
+fn remaining_transaction_value_scales_linearly() {
+    let _init_guard = zebra_test::init();
+
+    const TX_COUNT: usize = 10_000;
+    const MAX_SECONDS: u64 = 4;
+
+    let one_zatoshi: Amount<zebra_chain::amount::NonNegative> =
+        1.try_into().expect("1 zatoshi is valid");
+
+    let coinbase = Arc::new(Transaction::V4 {
+        inputs: vec![transparent::Input::Coinbase {
+            height: Height(1),
+            data: Vec::new(),
+            sequence: u32::MAX,
+        }],
+        outputs: vec![transparent::Output {
+            value: one_zatoshi,
+            lock_script: transparent::Script::new(&[]),
+        }],
+        lock_time: LockTime::min_lock_time_timestamp(),
+        expiry_height: Height(0),
+        joinsplit_data: None,
+        sapling_shielded_data: None,
+    });
+
+    let mut transactions = Vec::with_capacity(TX_COUNT + 1);
+    let mut spent_utxos = HashMap::with_capacity(TX_COUNT);
+    transactions.push(coinbase);
+
+    for i in 0..TX_COUNT {
+        let mut hash_bytes = [0u8; 32];
+        hash_bytes[..8].copy_from_slice(&(i as u64 + 1).to_le_bytes());
+        let outpoint = transparent::OutPoint {
+            hash: transaction::Hash(hash_bytes),
+            index: 0,
+        };
+
+        let output = transparent::Output {
+            value: one_zatoshi,
+            lock_script: transparent::Script::new(&[]),
+        };
+
+        let tx = Transaction::V4 {
+            inputs: vec![transparent::Input::PrevOut {
+                outpoint,
+                unlock_script: transparent::Script::new(&[]),
+                sequence: u32::MAX,
+            }],
+            outputs: vec![output.clone()],
+            lock_time: LockTime::min_lock_time_timestamp(),
+            expiry_height: Height(0),
+            joinsplit_data: None,
+            sapling_shielded_data: None,
+        };
+
+        spent_utxos.insert(
+            outpoint,
+            transparent::OrderedUtxo::new(output, Height(0), 0),
+        );
+        transactions.push(Arc::new(tx));
+    }
+
+    let genesis = zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
+        .zcash_deserialize_into::<Block>()
+        .expect("genesis block must deserialize");
+
+    let block = Arc::new(Block {
+        header: genesis.header,
+        transactions,
+    });
+
+    let prepared = SemanticallyVerifiedBlock {
+        block: block.clone(),
+        hash: block.hash(),
+        height: Height(1),
+        new_outputs: HashMap::new(),
+        transaction_hashes: vec![transaction::Hash([0; 32]); TX_COUNT + 1].into(),
+    };
+
+    let start = Instant::now();
+    let result = check::utxo::remaining_transaction_value(&prepared, &spent_utxos);
+    let elapsed = start.elapsed();
+
+    assert!(result.is_ok(), "value balance check should succeed");
+    assert!(
+        elapsed.as_secs() < MAX_SECONDS,
+        "remaining_transaction_value with {TX_COUNT} transactions took {elapsed:.2?}, \
+         expected under {MAX_SECONDS}s (possible O(N^2) regression)"
     );
 }
 

--- a/zebra-state/src/service/check/utxo.rs
+++ b/zebra-state/src/service/check/utxo.rs
@@ -232,6 +232,8 @@ pub fn remaining_transaction_value(
     semantically_verified: &SemanticallyVerifiedBlock,
     utxos: &HashMap<transparent::OutPoint, transparent::OrderedUtxo>,
 ) -> Result<(), ValidateContextError> {
+    let utxos = utxos_from_ordered_utxos(utxos.clone());
+
     for (tx_index_in_block, transaction) in
         semantically_verified.block.transactions.iter().enumerate()
     {
@@ -240,7 +242,7 @@ pub fn remaining_transaction_value(
         }
 
         // Check the remaining transparent value pool for this transaction
-        let value_balance = transaction.value_balance(&utxos_from_ordered_utxos(utxos.clone()));
+        let value_balance = transaction.value_balance(&utxos);
         match value_balance {
             Ok(vb) => match vb.remaining_transaction_value() {
                 Ok(_) => Ok(()),

--- a/zebra-state/src/service/write.rs
+++ b/zebra-state/src/service/write.rs
@@ -432,6 +432,10 @@ impl WriteBlockWorkerTask {
                 continue;
             }
 
+            // A successfully committed block supersedes any contextual error
+            // recorded for a different block body with the same header hash.
+            parent_error_map.shift_remove(&child_hash);
+
             // Committing blocks to the finalized state keeps the same chain,
             // so we can update the chain seen by the rest of the application now.
             //

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -376,6 +376,7 @@ where
         let network = self.network.clone();
         let verifier = self.verifier.clone();
         let mut state = self.state.clone();
+        let pushed_advertiser_addr = source.map(PeerSocketAddr::from);
 
         let gossiped_tx_req = gossiped_tx.clone();
 
@@ -431,7 +432,7 @@ where
                         "mempool.pushed.transactions.total",
                         "version" => format!("{}",tx.transaction.version()),
                     ).increment(1);
-                    (tx, None)
+                    (tx, pushed_advertiser_addr)
                 }
             };
 

--- a/zebrad/src/components/mempool/downloads/tests.rs
+++ b/zebrad/src/components/mempool/downloads/tests.rs
@@ -1,5 +1,10 @@
 //! Fixed test vectors for the mempool transaction downloader.
 
+use std::time::Duration;
+
+use futures::StreamExt as _;
+use tower::{service_fn, util::BoxCloneService};
+
 use zebra_chain::parameters::Network;
 use zebra_test::mock_service::{MockService, PanicAssertion};
 
@@ -62,4 +67,64 @@ async fn per_peer_cap_applies_to_pushed_transactions() {
 
     // Don't leave spawned download tasks behind when the runtime shuts down.
     downloads.cancel_all();
+}
+
+/// A directly pushed transaction from a peer must keep that peer's address on
+/// the `Invalid` verification error, so the mempool can score the peer's
+/// misbehavior. Regression test for `GHSA-g7c4-2w6c-cr3r`.
+#[tokio::test]
+async fn pushed_transaction_attributes_invalid_error_to_peer() {
+    use zebra_consensus::error::TransactionError;
+
+    let _init_guard = zebra_test::init();
+
+    let network = Network::Mainnet;
+    let peer_addr: SocketAddr = "203.0.113.7:8233".parse().unwrap();
+    let transaction = network
+        .unmined_transactions_in_blocks(1..=1)
+        .next()
+        .expect("at least one test transaction")
+        .transaction;
+
+    type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+    let mut downloads = Downloads::new(
+        BoxCloneService::new(service_fn(|_request| async move {
+            panic!("pushed transactions must not be downloaded");
+        })),
+        BoxCloneService::new(service_fn(|_request| async move {
+            Err(Box::new(TransactionError::WrongVersion) as BoxError)
+        })),
+        BoxCloneService::new(service_fn(|request| async move {
+            match request {
+                zs::Request::Transaction(_) => Ok(zs::Response::Transaction(None)),
+                zs::Request::Tip => Ok(zs::Response::Tip(None)),
+                request => Err(format!("unexpected state request: {request:?}").into()),
+            }
+        })),
+    );
+
+    downloads
+        .download_if_needed_and_verify(Gossip::Tx(transaction), Some(peer_addr), None)
+        .expect("download is queued");
+
+    let result = tokio::time::timeout(Duration::from_secs(1), downloads.next())
+        .await
+        .expect("pushed transaction should complete")
+        .expect("download stream should yield an item")
+        .expect("pushed transaction should not time out");
+
+    let error = result
+        .expect_err("invalid pushed transaction should fail verification")
+        .1;
+    assert!(
+        matches!(
+            error,
+            TransactionDownloadVerifyError::Invalid {
+                advertiser_addr: Some(addr),
+                ..
+            } if addr == PeerSocketAddr::from(peer_addr)
+        ),
+        "expected the pushed transaction failure to carry the peer address, got {error:?}"
+    );
 }

--- a/zebrad/tests/integration/regtest.rs
+++ b/zebrad/tests/integration/regtest.rs
@@ -6,9 +6,15 @@ use tower::ServiceExt;
 use zebra_chain::{
     block::{genesis::regtest_genesis_block, Height},
     parameters::{testnet::ConfiguredActivationHeights, Network},
+    serialization::ZcashSerialize as _,
+    transparent,
 };
 use zebra_node_services::rpc_client::RpcRequestClient;
-use zebra_rpc::server::OPENED_RPC_ENDPOINT_MSG;
+use zebra_rpc::{
+    client::{SubmitBlockErrorResponse, SubmitBlockResponse},
+    config::mining::ExtraCoinbaseData,
+    server::OPENED_RPC_ENDPOINT_MSG,
+};
 use zebra_test::{args, prelude::*};
 
 use crate::common::{
@@ -52,6 +58,162 @@ async fn validate_regtest_genesis_block() {
 #[tokio::test]
 async fn regtest_block_templates_are_valid_block_submissions() -> Result<()> {
     crate::common::regtest::submit_blocks_test().await?;
+    Ok(())
+}
+
+/// A rejected block body must not poison the children of a later valid block with the same header
+/// hash.
+///
+/// This is a regression test for [GHSA-8gxx-hc65-vv82][ghsa-8gxx]. Under the transaction digest
+/// scheme defined by [ZIP-244][zip-244], two different block bodies can share the same header hash.
+/// `zebra-state` previously retained the contextual validation error from the poisoned body and
+/// incorrectly propagated it to children of the later valid block, causing them to be incorrectly
+/// rejected.
+///
+/// [ghsa-8gxx]: https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-8gxx-hc65-vv82
+/// [zip-244]: https://zips.z.cash/zip-0244
+#[tokio::test]
+async fn rejected_block_does_not_reject_same_hash_block_children() -> Result<()> {
+    const EXTRA_COINBASE_DATA: &str = "zebra-chain-stall-poc";
+
+    let _init_guard = zebra_test::init();
+
+    let network = Network::new_regtest(
+        ConfiguredActivationHeights {
+            nu5: Some(1),
+            ..Default::default()
+        }
+        .into(),
+    );
+    let mut config = os_assigned_rpc_port_config(false, &network)?;
+    config.mempool.debug_enable_at_height = Some(0);
+    config.mining.extra_coinbase_data =
+        Some(ExtraCoinbaseData::try_from(EXTRA_COINBASE_DATA.to_owned())?);
+
+    let mut block_builder = testdir()?
+        .with_config(&mut config)?
+        .spawn_child(args!["start"])?;
+    let rpc_address = read_listen_addr_from_logs(&mut block_builder, OPENED_RPC_ENDPOINT_MSG)?;
+
+    tokio::time::sleep(LAUNCH_DELAY).await;
+
+    let client = RpcRequestClient::new(rpc_address);
+    let mut blocks = Vec::new();
+    for expected_height in 1..=4 {
+        let (block, height) = client.block_from_template(&network).await?;
+        assert_eq!(height.0, expected_height);
+        client.submit_block(block.clone()).await?;
+        blocks.push(block);
+    }
+
+    block_builder.kill(false)?;
+    let output = block_builder.wait_with_output()?;
+    output.assert_failure()?.assert_was_killed()?;
+
+    let mut zebrad = testdir()?
+        .with_config(&mut config)?
+        .spawn_child(args!["start"])?;
+    let rpc_address = read_listen_addr_from_logs(&mut zebrad, OPENED_RPC_ENDPOINT_MSG)?;
+
+    tokio::time::sleep(LAUNCH_DELAY).await;
+
+    let client = RpcRequestClient::new(rpc_address);
+    client.submit_block(blocks[0].clone()).await?;
+    client.submit_block(blocks[1].clone()).await?;
+
+    let valid_block = blocks[2].clone();
+
+    let mut poisoned_block = valid_block.clone();
+    let coinbase = Arc::make_mut(
+        poisoned_block
+            .transactions
+            .first_mut()
+            .expect("block templates contain a coinbase transaction"),
+    );
+    let transparent::Input::Coinbase { data, .. } = coinbase
+        .inputs_mut()
+        .first_mut()
+        .expect("coinbase transactions contain a transparent input")
+    else {
+        panic!("the first coinbase transaction input must be a coinbase input");
+    };
+    assert!(
+        data.ends_with(EXTRA_COINBASE_DATA.as_bytes()),
+        "the coinbase transaction must contain the configured extra data"
+    );
+    let last_data_byte = data
+        .last_mut()
+        .expect("configured extra coinbase data is non-empty");
+    *last_data_byte = b'a';
+
+    assert_eq!(
+        poisoned_block.hash(),
+        valid_block.hash(),
+        "changing a NU5 coinbase scriptSig must not change the block header hash"
+    );
+
+    let poisoned_block_data = hex::encode(poisoned_block.zcash_serialize_to_vec()?);
+    let poisoned_response: SubmitBlockResponse = client
+        .json_result_from_call("submitblock", format!(r#"["{poisoned_block_data}"]"#))
+        .await
+        .map_err(|err| eyre!(err))?;
+    assert!(
+        matches!(poisoned_response, SubmitBlockResponse::ErrorResponse(_)),
+        "the poisoned block body must be rejected"
+    );
+
+    // The rejected hash is still marked as sent until the state service drains the write task's
+    // rejection notification. For now this same-hash block is considered a duplicate.
+    let valid_block_data = hex::encode(valid_block.zcash_serialize_to_vec()?);
+    let first_valid_response: SubmitBlockResponse = client
+        .json_result_from_call("submitblock", format!(r#"["{valid_block_data}"]"#))
+        .await
+        .map_err(|err| eyre!(err))?;
+    assert_eq!(
+        first_valid_response,
+        SubmitBlockResponse::ErrorResponse(SubmitBlockErrorResponse::Duplicate),
+        "the first valid block submission must wait for the rejected hash to be drained"
+    );
+
+    // The child submission below triggers another state request and drains the previous
+    // notification, which means the block can then be resubmitted.
+    let valid_child = blocks[3].clone();
+    let valid_child_data = hex::encode(valid_child.zcash_serialize_to_vec()?);
+    let submit_child = client.json_result_from_call::<SubmitBlockResponse>(
+        "submitblock",
+        format!(r#"["{valid_child_data}"]"#),
+    );
+
+    let resubmit_valid_block = async {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        client
+            .json_result_from_call::<SubmitBlockResponse>(
+                "submitblock",
+                format!(r#"["{valid_block_data}"]"#),
+            )
+            .await
+    };
+    let (valid_child_response, valid_block_response) =
+        tokio::join!(submit_child, resubmit_valid_block);
+    let valid_child_response = valid_child_response.map_err(|err| eyre!(err))?;
+    let valid_block_response = valid_block_response.map_err(|err| eyre!(err))?;
+
+    assert_eq!(valid_block_response, SubmitBlockResponse::Accepted);
+    assert_eq!(
+        valid_child_response,
+        SubmitBlockResponse::Accepted,
+        "the valid child must not inherit the rejected block body's contextual error"
+    );
+    assert_eq!(
+        client.blockchain_info().await?.blocks(),
+        Height(4),
+        "the valid child must not inherit the rejected block body error"
+    );
+
+    zebrad.kill(false)?;
+    let output = zebrad.wait_with_output()?;
+    output.assert_failure()?.assert_was_killed()?;
+
     Ok(())
 }
 
@@ -152,7 +314,6 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
                 ConfiguredFundingStreams,
             },
         },
-        serialization::ZcashSerialize,
         work::difficulty::U256,
     };
     use zebra_network::address_book_peers::MockAddressBookPeers;
@@ -163,8 +324,7 @@ async fn nu6_funding_streams_and_coinbase_balance() -> Result<()> {
     use zebra_rpc::{
         client::{
             BlockTemplateResponse, DefaultRoots, GetBlockTemplateParameters,
-            GetBlockTemplateRequestMode, GetBlockTemplateResponse, SubmitBlockErrorResponse,
-            SubmitBlockResponse, TransactionTemplate,
+            GetBlockTemplateRequestMode, GetBlockTemplateResponse, TransactionTemplate,
         },
         fetch_chain_info,
         methods::{RpcImpl, RpcServer},
@@ -513,7 +673,6 @@ async fn nu6_3_block_template_proposal() -> Result<()> {
     use zebra_chain::{
         chain_sync_status::MockSyncStatus,
         parameters::testnet::{self, ConfiguredActivationHeights, ConfiguredFundingStreams},
-        serialization::ZcashSerialize,
         work::difficulty::U256,
     };
     use zebra_network::address_book_peers::MockAddressBookPeers;
@@ -524,7 +683,6 @@ async fn nu6_3_block_template_proposal() -> Result<()> {
     use zebra_rpc::{
         client::{
             GetBlockTemplateParameters, GetBlockTemplateRequestMode, GetBlockTemplateResponse,
-            SubmitBlockResponse,
         },
         methods::{RpcImpl, RpcServer},
         proposal_block_from_template, SubmitBlockChannel,


### PR DESCRIPTION
## Motivation

Land the pre-release security fixes on `main` and run the full public CI suite on them.

## Solution

Merges the four fix branches from the private repo:

- Reserve block header and transaction count space in block templates (GHSA-95m2-vx53-v2jw)
- Avoid quadratic transparent UTXO validation (GHSA-4g24-549m-hp75)
- Don't stall because of a poisoned same-hash block (GHSA-8gxx-hc65-vv82)
- Attribute peer-pushed invalid transactions for misbehavior scoring (GHSA-g7c4-2w6c-cr3r)

### AI Disclosure

- [x] AI tools were used: Claude Code wrote the GHSA-95m2-vx53-v2jw fix, tests, and changelogs; GPT 5.6 Sol contributed the GHSA-8gxx-hc65-vv82 fix and test. All changes were reviewed by maintainers in the private PRs.
