### PR TITLE
fix(ci): preserve unit test result on label events

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -8,11 +8,16 @@ on:
     branches: [main]
   merge_group:
 
-# Ensures that only one workflow task will run at a time. Previous builds, if
-# already in process, will get cancelled. Only the latest commit will be allowed
-# to run, cancelling any workflows in between
+# Cancel obsolete test runs after new commits. Unrelated label events use a
+# separate group so they cannot cancel the required unit test run.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: >-
+    ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{
+      github.event.action == 'labeled' &&
+      github.event.label.name != 'A-release' &&
+      'ignored-label' ||
+      'required'
+    }}
   cancel-in-progress: true
 
 permissions:
@@ -98,6 +103,14 @@ jobs:
         run: cargo nextest run --profile check-no-git-dependencies --locked --run-ignored=only
 
   unit-tests:
+    # Keep skipped unrelated-label runs from replacing the required check.
+    name: >-
+      ${{
+        github.event.action == 'labeled' &&
+        github.event.label.name != 'A-release' &&
+        'Label does not require unit tests' ||
+        'unit-tests'
+      }}
     runs-on: ubuntu-latest
     if: >-
       always() &&


### PR DESCRIPTION
## Motivation

Unrelated pull-request labels can replace a successful `unit-tests` check with a skipped result. When Mergify adds `queued`, the PR is immediately dequeued even though its tests and approval are valid, as seen in #10993.

## Solution

Keep unrelated label events separate from required test runs:

- Use a separate concurrency group so they cannot cancel an in-progress unit-test run.
- Report their skipped aggregator under a different check name so the successful `unit-tests` result remains authoritative.

`A-release` events still rerun the existing release dependency check through the required `unit-tests` path.

### Tests

`actionlint`, `zizmor`, formatting, and clippy pass. The workspace suite reaches the existing v6.0.0 end-of-support failures on current `main`.

### AI Disclosure

- [x] AI tools were used: OpenAI Codex diagnosed the queue interaction, updated the workflow, ran validation, and drafted this description.