### PR TITLE
chore(release): finalize changelogs and end-of-support height for v6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Unreleased]
+## [Zebra 6.1.0](https://github.com/ZcashFoundation/zebra/releases/tag/v6.1.0) - 2026-07-17
+
+### Added
+
+- Added the `getstandardfee` RPC, a parameterless method returning the
+  recommended standard fee per logical action (the ZIP-317 marginal fee, 5000
+  zatoshis) with a `version` field for future dynamic fee estimation
+  ([#10717](https://github.com/ZcashFoundation/zebra/pull/10717)).
 
 ### Security
 
@@ -73,10 +80,6 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Added
 
-- Added the `getstandardfee` RPC, a parameterless method returning the
-  recommended standard fee per logical action (the ZIP-317 marginal fee, 5000
-  zatoshis) with a `version` field for future dynamic fee estimation
-  ([#10717](https://github.com/ZcashFoundation/zebra/pull/10717))
 - Support for the NU6.3 "Ironwood" shielded pool and v6 transaction format,
   activating on Testnet at height 4,134,000. The consensus parameters (v6 version
   group ID, consensus branch ID, and Testnet activation height) match

--- a/tower-fallback/CHANGELOG.md
+++ b/tower-fallback/CHANGELOG.md
@@ -5,19 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.0] - 2026-07-17
+## [0.2.43] - 2026-07-17
 
 ### Added
 
 - `Fallback::new_with_policy`, which selects fallback behavior using a `FallbackPolicy`.
-- `FallbackPolicy` trait with an `OnError` implementation matching the previous
+- `FallbackPolicy` trait with an `OnError` implementation matching the default
   fall-back-on-error behavior.
-
-### Changed
-
-- `Fallback` and `future::ResponseFuture` now carry a fallback-policy type parameter. The
-  `Fallback::new` constructor keeps the previous fall-back-on-error semantics via the
-  default policy.
+- `Fallback` and `future::ResponseFuture` gained an optional fallback-policy type
+  parameter that defaults to `OnError`, so existing `Fallback<S1, S2>` uses and
+  `Fallback::new` are unchanged.
 
 ## [0.2.42] - 2026-07-10
 

--- a/tower-fallback/CHANGELOG.md
+++ b/tower-fallback/CHANGELOG.md
@@ -5,12 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0] - 2026-07-17
 
 ### Added
 
-- Added `Fallback::new_with_policy()` for selecting fallback behavior based on
-  the first service's result.
+- `Fallback::new_with_policy`, which selects fallback behavior using a `FallbackPolicy`.
+- `FallbackPolicy` trait with an `OnError` implementation matching the previous
+  fall-back-on-error behavior.
+
+### Changed
+
+- `Fallback` and `future::ResponseFuture` now carry a fallback-policy type parameter. The
+  `Fallback::new` constructor keeps the previous fall-back-on-error semantics via the
+  default policy.
 
 ## [0.2.42] - 2026-07-10
 

--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -5,17 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [11.2.0] - 2026-07-17
+
+### Added
+
+- `block::Header::{SERIALIZED_SIZE, REGTEST_SERIALIZED_SIZE, serialized_size}`
+- `transaction::zip317::MARGINAL_FEE`
+- `work::equihash::Solution::{SERIALIZED_SIZE, REGTEST_SERIALIZED_SIZE, serialized_size}`
 
 ### Security
 
 - Computing `transaction::Transaction::value_balance` no longer clones the entire UTXO map per
   call (GHSA-4g24-549m-hp75).
-
-### Added
-
-- `block::Header::{SERIALIZED_SIZE, REGTEST_SERIALIZED_SIZE, serialized_size}`
-- `work::equihash::Solution::{SERIALIZED_SIZE, REGTEST_SERIALIZED_SIZE, serialized_size}`
 
 ## [11.1.0] - 2026-07-10
 

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [12.0.0] - 2026-07-17
+
+### Added
+
+- `methods::RpcServer::get_standard_fee`, the `getstandardfee` RPC returning the ZIP-317
+  marginal fee ([#10717](https://github.com/ZcashFoundation/zebra/pull/10717)).
 
 ### Fixed
 

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [10.1.1] - 2026-07-17
 
 ### Security
 

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_408_000;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_417_000;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.


### PR DESCRIPTION
## Motivation

Prepare the v6.1.0 release: finalize changelog headings and the end-of-support height on `main` before the release-plz Release PR (#10946) is approved.

## Solution

- Finalize each crate's `[Unreleased]` section to its release heading, dated 2026-07-17.
- Move the mis-filed `getstandardfee` entry (#10717) out of `[Zebra 6.0.0-rc.0]` into `[Zebra 6.1.0]` — the RPC shipped after v6.0.0.
- Add the `transaction::zip317::MARGINAL_FEE` and `getstandardfee` API entries that `zc` flagged as public-but-undocumented.
- Document tower-fallback's breaking `FallbackPolicy` change (#10923).
- Bump `ESTIMATED_RELEASE_HEIGHT` to 3,417,000 (Mainnet tip 3,415,610 + ~1 day).

### Follow-up Work

#10946 version bumps need correcting to match these headings, per `zc`: zebra-chain `11.2.0` (release-plz over-bumped to 12.0.0), tower-fallback `0.3.0` (under-bumped to 0.2.43), zebrad `6.1.0` (under-bumped to 6.0.1); zebra-rpc `12.0.0` stands.

### AI Disclosure

- [x] AI tools were used: Claude Code ran `zc`, determined the versions, and wrote these changelog/EOS edits.