### PR TITLE
docs(changelog): major-bump zebra-state (11.0.0) and zebra-consensus (12.0.0)

### DIFF
--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [12.0.0] - 2026-07-17
+
+### Changed
+
+- Requires `zebra-state` 11.0.0. `zebra-state` types (`error::ValidateContextError`,
+  `request::Request`, `response::{Response, KnownBlock}`) appear in this crate's public API,
+  so `zebra-state`'s major bump is breaking here too.
+
 ## [11.0.0] - 2026-07-10
 
 ### Added

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `methods::RpcServer::get_standard_fee`, the `getstandardfee` RPC returning the ZIP-317
   marginal fee ([#10717](https://github.com/ZcashFoundation/zebra/pull/10717)).
 
+### Changed
+
+- Requires `zebra-state` 11.0.0 and `zebra-consensus` 12.0.0, whose types appear in this
+  crate's public API (`methods::RpcImpl`, `indexer::server::IndexerRPC`).
+
 ### Fixed
 
 - Block template transaction selection now reserves space for the block header and the

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [10.1.1] - 2026-07-17
+## [11.0.0] - 2026-07-17
+
+### Changed
+
+- Major version bump for the rocksdb 0.24 upgrade. `rocksdb::Error` is reachable through
+  `ZebraDb`'s public API, so the rocksdb 0.22 → 0.24 bump is a breaking change; 10.1.0
+  shipped it without a major and is yanked. Downstream code pinning an older rocksdb must
+  upgrade.
 
 ### Security
 


### PR DESCRIPTION
## Motivation

zebra-state 10.1.0 shipped the rocksdb 0.24 upgrade — reachable through `ZebraDb`'s public API (`rocksdb::Error`) — as a **minor**, but it is a breaking change. Correct the semver: ship 11.0.0 and yank 10.1.0.

## Solution

- zebra-state → **11.0.0** (rocksdb-0.24 public-API break).
- zebra-state is a public dependency of zebra-consensus (`ValidateContextError`, `request::Request`, `response::{Response, KnownBlock}`) and zebra-rpc (`State`/`ReadState` traits), so the major cascades:
  - zebra-consensus → **12.0.0**,
  - zebra-rpc stays **12.0.0** (already majoring for `getstandardfee`; absorbs the public-dep majors).
- Finalizes the changelog headings; the matching `Cargo.toml` version bumps go into the release-plz PR (#10946).

### Follow-up Work

- Correct #10946's versions to match, then after publish: `cargo yank --version 10.1.0 zebra-state`.

### AI Disclosure

- [x] AI tools were used: Claude Code did the public-dependency analysis (cargo-public-api) and wrote these entries.