### PR TITLE
fix(release): preserve branch context for publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,12 @@ jobs:
           persist-credentials: false
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+      - name: Restore main branch context
+        env:
+          TARGET_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          git switch --force-create main "${TARGET_SHA}"
+          git branch --set-upstream-to=origin/main main
       - name: Validate release app token
         if: steps.app-token.outputs.token == ''
         run: |


### PR DESCRIPTION
## Motivation

The release publisher checks out the approved Release PR merge commit by SHA, leaving `HEAD` detached. `release-plz` requires an upstream branch and aborts before publishing.

## Solution

Restore the local `main` branch at the verified merge commit and set `origin/main` as its upstream before running `release-plz`. Publication remains pinned to the approved commit.

Related to #10964.

### Tests

- The workflow passes `actionlint`.
- The checkout sequence preserves the target SHA and makes `@{upstream}` resolve to `origin/main`.

### AI Disclosure

- [x] AI tools were used: OpenAI Codex for diagnosis, implementation, and the PR description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`.
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
