### PR TITLE
fix(release): give release-plz a tracked branch so publish/tag doesn't abort

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,17 @@ jobs:
           exit 1
       - name: Install libclang for librocksdb-sys bindgen
         run: sudo apt-get update && sudo apt-get install -y libclang-dev
+      - name: Put the release commit on a tracked main branch for release-plz
+        # `command: release` resolves the current branch via `git rev-parse @{upstream}`
+        # to enforce `allow-branch`. The `ref: merge_commit_sha` checkout above leaves a
+        # detached HEAD with no upstream, so release-plz aborts with "cannot determine
+        # current branch" before publishing or tagging (this failed the v6.1.0 release).
+        # Recreate `main` at the exact release commit, with an upstream, so the check passes.
+        run: |
+          git fetch --no-tags origin main
+          git branch --force main "${{ github.event.pull_request.merge_commit_sha }}"
+          git switch main
+          git branch --set-upstream-to=origin/main main
       - name: Publish crates and create tags
         id: release-plz
         uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 #v0.5.130


### PR DESCRIPTION
## Motivation

The v6.1.0 release's publish job failed: nothing was published to crates.io and no tags were created. release-plz's `command: release` aborted at startup with:

```
ERROR cannot determine current branch
  error while running git ... ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"]
```

## Solution

The `release` job checks out `ref: ${{ github.event.pull_request.merge_commit_sha }}` — a **detached HEAD** with no upstream. release-plz resolves the current branch via `git rev-parse @{upstream}` (to enforce `allow-branch = ["main"]`), which fails on a detached HEAD, so it bails before publishing or tagging.

This adds a step that recreates `main` at the exact release commit with an upstream, so the branch check passes while still releasing the intended commit.

### Tests

Not directly testable without cutting a release. The v6.1.0 crates were published manually as recovery; this prevents a recurrence on the next release. Worth a close review of the git setup before the next release relies on it.

### AI Disclosure

- [x] AI tools were used: Claude Code diagnosed the failure from the run logs and wrote this fix.