### PR TITLE
ci: enforce merge commits in Mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -12,6 +12,7 @@ merge_queue:
 defaults:
   # Define our default queue rules
   queue_rule:
+    merge_method: squash
     # Allow to update/rebase the original pull request if possible to check its mergeability,
     # and it does not create a draft PR if not needed
     batch_max_wait_time: "2 minutes"

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -12,7 +12,7 @@ merge_queue:
 defaults:
   # Define our default queue rules
   queue_rule:
-    merge_method: squash
+    merge_method: merge
     # Allow to update/rebase the original pull request if possible to check its mergeability,
     # and it does not create a draft PR if not needed
     batch_max_wait_time: "2 minutes"


### PR DESCRIPTION
## Motivation

Mergify did not specify a merge method, so enabling merge commits in the repository allowed queued PRs to create merge commits. Zebra's merge policy is merge commits.

Refs #10963.

## Solution

Set `merge_method: merge` in the default queue rule so every queue uses the intended strategy explicitly.

### Tests

- Parsed `.github/mergify.yml` as YAML.
- Verified the diff has no whitespace errors.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: OpenAI Codex for the configuration change and PR description

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
