### PR TITLE
fix(installer): make the docker-supervised command work with the published Zebra image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   [zakura](https://github.com/zakura-core/zakura) authors for the major part of
   this implementation.
 
+### Fixed
+
+- The `docker-supervised` mode of `scripts/install-zebra.sh` now prints a
+  `docker run` command that works with the published Zebra Docker image: it sets
+  `zcashd_source = "embedded"` so `zebrad` downloads the SHA256-pinned sidecar
+  `zcashd` into the mounted state cache at first start. Previously the printed
+  command only worked on images with a vendored `zcashd` binary and failed at
+  startup otherwise. Images with a vendored `zcashd` keep using it without a
+  download ([#11008](https://github.com/ZcashFoundation/zebra/pull/11008)).
+
 ## [Zebra 6.1.0](https://github.com/ZcashFoundation/zebra/releases/tag/v6.1.0) - 2026-07-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,16 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   [zakura](https://github.com/zakura-core/zakura) authors for the major part of
   this implementation.
 
-### Fixed
-
-- The `docker-supervised` mode of `scripts/install-zebra.sh` now prints a
-  `docker run` command that works with the published Zebra Docker image: it sets
-  `zcashd_source = "embedded"` so `zebrad` downloads the SHA256-pinned sidecar
-  `zcashd` into the mounted state cache at first start. Previously the printed
-  command only worked on images with a vendored `zcashd` binary and failed at
-  startup otherwise. Images with a vendored `zcashd` keep using it without a
-  download ([#11008](https://github.com/ZcashFoundation/zebra/pull/11008)).
-
 ## [Zebra 6.1.0](https://github.com/ZcashFoundation/zebra/releases/tag/v6.1.0) - 2026-07-17
 
 ### Added

--- a/book/src/user/zcashd-compat.md
+++ b/book/src/user/zcashd-compat.md
@@ -57,7 +57,7 @@ zcashd-compat modes:
 | `split-binary` (default)  | Downloads `zebrad` and the sidecar `zcashd`; prints two start commands  |
 | `supervised`              | Downloads `zebrad`; Zebra downloads hash-pinned `zcashd` at startup and supervises it |
 | `docker-split-containers` | Pulls the Zebra and zcashd images; prints two `docker run` commands     |
-| `docker-supervised`       | Pulls the compat image; prints one supervised `docker run` command       |
+| `docker-supervised`       | Pulls the Zebra image; prints one supervised `docker run` command (Zebra downloads hash-pinned `zcashd` at first start unless the image vendors it) |
 | `build-from-source`       | Validates source trees and toolchains; prints build and start commands   |
 
 The installer:

--- a/scripts/install-zebra.sh
+++ b/scripts/install-zebra.sh
@@ -2156,8 +2156,12 @@ compat_print_docker_supervised_command() {
   local container_zcashd_datadir="/home/zebra/.cache/zcashd"
   local p2p_port
   p2p_port="$(compat_p2p_port_from_addr "$ZEBRA_P2P_ADDR")"
-  # ZCASHD_COMPAT_ENABLED is the compat image's entrypoint opt-in: it enables
-  # the mode AND points zcashd_source at the vendored /usr/local/bin/zcashd.
+  # ZCASHD_COMPAT_ENABLED is the image entrypoint's opt-in. On compat images
+  # the entrypoint also sets zcashd_path to the vendored /usr/local/bin/zcashd,
+  # and an explicit zcashd_path always wins over zcashd_source. On the standard
+  # zebra image there is no vendored zcashd, so zcashd_source=embedded makes
+  # zebrad download the SHA256-pinned sidecar into the mounted state cache at
+  # first start; without it, the default path source fails at startup.
   # With --network host, keep the sidecar's wallet RPC on loopback: binding
   # 0.0.0.0 with rpcallowip=0.0.0.0/0 would expose it on every host interface.
   cat <<EOF
@@ -2168,6 +2172,7 @@ docker run --rm -it --network host \\
   -e ZEBRA_NETWORK__MAX_CONNECTIONS_PER_IP=8 \\
   -e ZEBRA_STATE__CACHE_DIR=$container_zebra_state_dir \\
   -e ZEBRA_ZCASHD_COMPAT__MANAGE_ZCASHD=true \\
+  -e ZEBRA_ZCASHD_COMPAT__ZCASHD_SOURCE=embedded \\
   -e ZEBRA_ZCASHD_COMPAT__ZCASHD_DATADIR=$container_zcashd_datadir \\
   -e ZEBRA_ZCASHD_COMPAT__ZCASHD_EXTRA_ARGS='["-rpcbind=127.0.0.1","-rpcallowip=127.0.0.1"]' \\
   --mount type=bind,src=$(shell_quote "$ZEBRA_STATE_DIR"),dst=$container_zebra_state_dir \\


### PR DESCRIPTION
## Motivation

The `docker-supervised` mode of `scripts/install-zebra.sh` prints a `docker run` command that fails at startup against the images we actually publish. The installer's primary compat image is the standard `zfnd/zebra` release image, which pulls successfully, so the `zfnd/zebra:zcashd-compat-latest` fallback (not currently published) is never tried. On the standard image there is no vendored `/usr/local/bin/zcashd`, so the entrypoint leaves `zcashd_source` at its default (`path`) with no `zcashd_path`, and `zebrad` exits with:

```
zcashd_compat.zcashd_source=path requires zcashd_compat.zcashd_path to be set
```

Found while reviewing the v6.2.0 release, which is the first release to ship zcashd-compat mode (#10952).

## Solution

Add `-e ZEBRA_ZCASHD_COMPAT__ZCASHD_SOURCE=embedded` to the printed `docker run` command, matching the non-Docker `supervised` mode. This is correct for both image variants:

- **Standard image**: no vendored `zcashd`, so `zebrad` downloads the SHA256-pinned sidecar from its embedded manifest at first start. The download lands under the state cache dir, which the printed command bind-mounts, so it persists across container restarts. The slim image's missing system CA certificates don't matter because `zebrad`'s reqwest uses `rustls-tls` with compiled-in webpki roots.
- **`runtime-zcashd-compat` image**: the entrypoint sets `zcashd_path` to the vendored binary, and an explicit `zcashd_path` always wins over `zcashd_source` (`effective_zcashd_source()`), so the vendored binary is still used with no download.

Also corrects the `docker-supervised` row in the Zebra Book's installer mode table, which claimed the mode pulls the compat image.

### Tests

Dry run prints the fixed command:

```console
$ scripts/install-zebra.sh --install-profile zcashd-compat --mode docker-supervised \
    --network Mainnet --non-interactive --dry-run --unsafe-low-specs \
    --zebra-state-dir /tmp/zs --zcashd-datadir /tmp/zd
...
docker run --rm -it --network host \
  -e ZCASHD_COMPAT_ENABLED=true \
  ...
  -e ZEBRA_ZCASHD_COMPAT__MANAGE_ZCASHD=true \
  -e ZEBRA_ZCASHD_COMPAT__ZCASHD_SOURCE=embedded \
  ...
```

`bash -n` passes on the modified script. The precedence claims above were verified against `docker/entrypoint.sh` and `zebrad/src/components/zcashd_compat/managed.rs`.

### Follow-up Work

- Decide whether to publish the `runtime-zcashd-compat` image stage per release (the installer already references `zfnd/zebra:zcashd-compat-latest` as a fallback tag that nothing publishes). Publishing it would avoid the runtime download and needs a tag-suffix input in `zfnd-build-docker-image.yml`.
- The main Docker book page doesn't mention zcashd-compat mode; a manual (non-installer) `docker run` example could be added.

### AI Disclosure

- [x] AI tools were used: Claude Code for the investigation, fix, docs, and PR description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.