### PR TITLE
docs(changelog): finalize v6.2.0 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- On Testnet, the `getblocktemplate` RPC no longer switches to a
+  minimum-difficulty block template early. Zebra previously treated a template
+  as minimum-difficulty as soon as its `cur_time` came within a fixed 150
+  seconds (`2 * PoWTargetSpacing` after Blossom) of the consensus
+  minimum-difficulty threshold, clamping `cur_time` up to just past the
+  threshold. On Testnet this future-dated the block's timestamp and produced
+  spurious minimum-difficulty blocks that depress difficulty far below its
+  equilibrium. Templates now switch to minimum difficulty only once `cur_time`
+  reaches the consensus threshold itself. This is a Testnet-only,
+  template-construction (non-consensus) change: it does not alter block
+  validity, and it does not change the difficulty-averaging rule that amplifies
+  each minimum-difficulty block into a large difficulty drop (tracked in
+  [zcash/zips#1321](https://github.com/zcash/zips/issues/1321))
+  ([#10873](https://github.com/ZcashFoundation/zebra/pull/10873))
+
+## [Zebra 6.2.0](https://github.com/ZcashFoundation/zebra/releases/tag/v6.2.0) - 2026-07-17
+
 ### Added
 
 - New regtest-only `generatetoaddress` RPC that mines blocks paying the coinbase
@@ -29,28 +48,11 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   [zakura](https://github.com/zakura-core/zakura) authors for the major part of
   this implementation.
 
-### Changed
+### Fixed
 
-- On Testnet, the `getblocktemplate` RPC no longer switches to a
-  minimum-difficulty block template early. Zebra previously treated a template
-  as minimum-difficulty as soon as its `cur_time` came within a fixed 150
-  seconds (`2 * PoWTargetSpacing` after Blossom) of the consensus
-  minimum-difficulty threshold, clamping `cur_time` up to just past the
-  threshold. On Testnet this future-dated the block's timestamp and produced
-  spurious minimum-difficulty blocks that depress difficulty far below its
-  equilibrium. Templates now switch to minimum difficulty only once `cur_time`
-  reaches the consensus threshold itself. This is a Testnet-only,
-  template-construction (non-consensus) change: it does not alter block
-  validity, and it does not change the difficulty-averaging rule that amplifies
-  each minimum-difficulty block into a large difficulty drop (tracked in
-  [zcash/zips#1321](https://github.com/zcash/zips/issues/1321))
-  ([#10873](https://github.com/ZcashFoundation/zebra/pull/10873))
-
-### Removed
-
-- The public constant `EXTRA_TIME_TO_MINE_A_BLOCK` in `zebra-state`, made unused by
-  the Testnet `getblocktemplate` change above
-  ([#10873](https://github.com/ZcashFoundation/zebra/pull/10873))
+- The installer's `docker-supervised` mode now configures the embedded sidecar
+  source, so its generated command works with the published Zebra image
+  ([#11008](https://github.com/ZcashFoundation/zebra/pull/11008)).
 
 ## [Zebra 6.1.0](https://github.com/ZcashFoundation/zebra/releases/tag/v6.1.0) - 2026-07-17
 

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tx`, `height`, `network`, and `spent_utxos` directly instead of `&Request`.
   ([#10843](https://github.com/ZcashFoundation/zebra/pull/10843))
 
+## [12.0.1] - 2026-07-17
+
+### Changed
+
+- `zebra-state` dependency bumped to `11.1.0`.
+
 ## [12.0.0] - 2026-07-17
 
 ### Changed

--- a/zebra-network/CHANGELOG.md
+++ b/zebra-network/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.2.0] - 2026-07-17
+
+### Added
+
+- `init_with_block_gossip_peer_ips`, an `init` variant that treats inbound peers
+  from the listed IP addresses as trusted zcashd-compat sidecars: they always receive
+  `AdvertiseBlock` inventory broadcasts (queued while the peer is busy), share a
+  reserved inbound connection pool of one slot per listed IP (falling back to public
+  slots and the normal rate limits when the pool is full), bypass the recent-IP
+  reconnection rate limit while a reserved slot is free, and are exempt from the
+  `FindBlocks`/`FindHeaders` stall detector. Callers must only list IPs where every
+  process is trusted
+  ([#10952](https://github.com/ZcashFoundation/zebra/pull/10952)).
+
 ## [10.1.1] - 2026-07-17
 
 ### Changed
@@ -33,15 +47,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   controlling whether coinbase outputs may be spent into transparent outputs. Setting it
   on a configured Testnet is rejected with an error
   ([#10698](https://github.com/ZcashFoundation/zebra/pull/10698)).
-- Added `init_with_block_gossip_peer_ips`, an `init` variant that treats inbound peers
-  from the listed IP addresses as trusted zcashd-compat sidecars: they always receive
-  `AdvertiseBlock` inventory broadcasts (queued while the peer is busy), share a
-  reserved inbound connection pool of one slot per listed IP (falling back to public
-  slots and the normal rate limits when the pool is full), bypass the recent-IP
-  reconnection rate limit while a reserved slot is free, and are exempt from the
-  `FindBlocks`/`FindHeaders` stall detector. Callers must only list IPs where every
-  process is trusted
-  ([#10952](https://github.com/ZcashFoundation/zebra/pull/10952)).
 
 ## [9.0.0] - 2026-06-10
 

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -5,14 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [12.1.0] - 2026-07-17
 
 ### Added
 
 - `methods::RpcServer::generate_to_address`, the regtest-only
   `generatetoaddress` RPC handler that mines a requested number of blocks paying
   coinbase to a caller-supplied address
-  ([#10952](https://github.com/ZcashFoundation/zebra/pull/10952))
+  ([#10952](https://github.com/ZcashFoundation/zebra/pull/10952)).
+- `GetBlockTemplateHandler::set_miner_params`, which overrides the miner
+  parameters used to build coinbase transactions on a cloned handler, so
+  `generatetoaddress` can mine to a caller-specified address without changing the
+  configured default
+  ([#10952](https://github.com/ZcashFoundation/zebra/pull/10952)).
 
 ## [12.0.0] - 2026-07-17
 

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [11.1.0] - 2026-07-17
+
+### Changed
+
+- On Regtest, `expected_difficulty_threshold` now returns the fixed minimum
+  difficulty (the `powLimit`) with no retargeting, matching zcashd's
+  `fPowNoRetargeting`. Every Regtest block stays at the `powLimit`, so a zcashd
+  sidecar following a Zebra Regtest chain accepts its headers instead of
+  rejecting them as `bad-diffbits`
+  ([#10952](https://github.com/ZcashFoundation/zebra/pull/10952)).
+- Regtest now advances the block time minimally, keeping mined timestamps just
+  above the median-time-past instead of clamping the current time into the valid
+  range. This stops Regtest chain time from racing ~90 minutes per block and
+  outrunning a following zcashd sidecar's acceptable block-time window
+  ([#10952](https://github.com/ZcashFoundation/zebra/pull/10952)).
+
 ## [11.0.0] - 2026-07-17
 
 ### Changed

--- a/zebra-utils/CHANGELOG.md
+++ b/zebra-utils/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.1.2] - 2026-07-17
+
+### Changed
+
+- `zebra-rpc` dependency bumped to `12.1.0`.
+
 ## [9.1.1] - 2026-07-17
 
 ### Changed


### PR DESCRIPTION
## Motivation

Zebra v6.2.0 was published before its root and affected crate changelogs were finalized. Changes merged after v6.2.0 now share those files, so they must remain separate from the published release.

## Solution

- Add the Zebra v6.2.0 section and the crate versions published with it.
- Move the zcashd-compat entries into the versions that shipped them.
- Keep changes merged after the v6.2.0 tag under `Unreleased`.

### Tests

The release headings match the v6.2.0 tag, and all changed files pass markdownlint.

### AI Disclosure

- [x] Codex compared the release boundary, resolved the changelog conflicts, and edited this description.

Related to #11009