### PR TITLE
docs(changelog): complete v6.1.0 dependency-bump entries

### DIFF
--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Requires `zebra-state` 11.0.0. `zebra-state` types (`error::ValidateContextError`,
   `request::Request`, `response::{Response, KnownBlock}`) appear in this crate's public API,
   so `zebra-state`'s major bump is breaking here too.
+- `tower-batch-control` dependency bumped to `1.1.1`.
+- `tower-fallback` dependency bumped to `0.2.43`.
+- `zebra-chain` dependency bumped to `11.2.0`.
+- `zebra-node-services` dependency bumped to `9.1.1`.
+- `zebra-script` dependency bumped to `10.1.1`.
 
 ## [11.0.0] - 2026-07-10
 

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Requires `zebra-state` 11.0.0 and `zebra-consensus` 12.0.0, whose types appear in this
   crate's public API (`methods::RpcImpl`, `indexer::server::IndexerRPC`).
+- `zebra-chain` dependency bumped to `11.2.0`.
+- `zebra-network` dependency bumped to `10.1.1`.
+- `zebra-node-services` dependency bumped to `9.1.1`.
+- `zebra-script` dependency bumped to `10.1.1`.
 
 ### Fixed
 

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ZebraDb`'s public API, so the rocksdb 0.22 → 0.24 bump is a breaking change; 10.1.0
   shipped it without a major and is yanked. Downstream code pinning an older rocksdb must
   upgrade.
+- `zebra-chain` dependency bumped to `11.2.0`.
+- `zebra-node-services` dependency bumped to `9.1.1`.
 
 ### Security
 


### PR DESCRIPTION
## Motivation

The v6.1.0 sections of zebra-state, zebra-consensus, and zebra-rpc are missing their per-crate dependency-bump entries. The reconciliation was pushed to the release PR branch (#11003) *after* it was squash-merged, so it never landed on `main` or in the published crates.

## Solution

Add the missing dependency-bump lines (per `zc`'s dependency diff) to the v6.1.0 sections:
- **zebra-state 11.0.0** — `zebra-chain` 11.2.0, `zebra-node-services` 9.1.1
- **zebra-consensus 12.0.0** — `tower-batch-control` 1.1.1, `tower-fallback` 0.2.43, `zebra-chain` 11.2.0, `zebra-node-services` 9.1.1, `zebra-script` 10.1.1
- **zebra-rpc 12.0.0** — `zebra-chain` 11.2.0, `zebra-network` 10.1.1, `zebra-node-services` 9.1.1, `zebra-script` 10.1.1

Docs-only; brings these three in line with the other crates' v6.1.0 entries. The published `.crate` files are immutable and unaffected.

### AI Disclosure

- [x] AI tools were used: Claude Code identified the gap and wrote these entries.