### PR TITLE
fix(ci): support PR gates in private repositories

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -117,8 +117,8 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
-          git fetch --no-tags origin "$BASE_REF"
-          echo "rev=$(git merge-base FETCH_HEAD HEAD)" >> "$GITHUB_OUTPUT"
+          # `fetch-depth: 0` populates the base branch without persisting credentials.
+          echo "rev=$(git merge-base "origin/$BASE_REF" HEAD)" >> "$GITHUB_OUTPUT"
       - uses: ./.github/actions/setup-zebra-build
       - uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9
         with:
@@ -152,8 +152,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          git fetch --no-tags origin "$BASE_REF"
-          merge_base="$(git merge-base FETCH_HEAD HEAD)"
+          # `fetch-depth: 0` populates the base branch without persisting credentials.
+          merge_base="$(git merge-base "origin/$BASE_REF" HEAD)"
 
           allowed_type=false
           case "$DECLARED_TYPE" in


### PR DESCRIPTION
## Motivation

The PR gate checks out contributor branches without persisting credentials, then performs a second fetch to compute the branch-point baseline. Anonymous fetching makes this work in the public repository, but repositories that reuse the workflow privately fail before the semantic-version and changelog checks can run.

## Solution

Compute each merge base from the `origin/main` remote-tracking reference that `fetch-depth: 0` already populated. This removes the redundant authenticated fetch while preserving `persist-credentials: false`.

### Tests

- `actionlint` passes for `.github/workflows/pr-gate.yml`.
- `zizmor` reports no findings.
- [Zebra-private PR #168](https://github.com/ZcashFoundation/zebra-private/pull/168) confirms that `changelog-gate` passes and `semver-checks` computes its fork-point baseline in a private repository.

### Specifications & References

- [Private-repository failure before this change](https://github.com/ZcashFoundation/zebra-private/actions/runs/29632081480)
- [Private-repository validation run](https://github.com/ZcashFoundation/zebra-private/actions/runs/29919383511)

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Codex diagnosed the private-repository failure, implemented the workflow change, and drafted this description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
