### PR TITLE
fix(zebra-state): keep the Elasticsearch password out of the config dump

### DIFF
--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Breaking Changes
+
+- `Config::elasticsearch_password` is now a `RedactedString` instead of a `String`. Config
+  files are unaffected; code that reads the field needs `.as_str()`, and code that sets it
+  needs `.into()`. Only applies to builds with the `elasticsearch` feature
+  ([#11051](https://github.com/ZcashFoundation/zebra/pull/11051))
+
+### Security
+
+- The startup config dump no longer prints the Elasticsearch password. It previously appeared
+  in cleartext in logs and journald on `elasticsearch`-feature builds with a password set
+  ([#11051](https://github.com/ZcashFoundation/zebra/pull/11051))
+
+### Added
+
+- `RedactedString`, a `String` wrapper whose `Debug` output is `[REDACTED]`, for config fields
+  that hold secrets
+  ([#11051](https://github.com/ZcashFoundation/zebra/pull/11051))
+
 ## [11.1.1] - 2026-07-22
 
 ### Security

--- a/zebra-state/src/config.rs
+++ b/zebra-state/src/config.rs
@@ -1,6 +1,7 @@
 //! Cached state configuration for Zebra.
 
 use std::{
+    fmt,
     fs::{self, canonicalize, remove_dir_all, DirEntry, ReadDir},
     io::ErrorKind,
     path::{Path, PathBuf},
@@ -19,6 +20,37 @@ use crate::{
     service::finalized_state::restorable_db_versions,
     state_database_format_version_in_code, BoxError,
 };
+
+/// A wrapper for [`String`] which hides its contents from `Debug` output, so that secrets
+/// are not written to logs by types that derive `Debug`.
+///
+/// Serialization is unaffected, so the value still round-trips through the config file. Use
+/// [`RedactedString::as_str()`] to reach the contents deliberately.
+#[derive(Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct RedactedString(String);
+
+impl fmt::Debug for RedactedString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("[REDACTED]")
+    }
+}
+
+impl RedactedString {
+    /// Return the wrapped string, which exposes its sensitive contents.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<S> From<S> for RedactedString
+where
+    S: Into<String>,
+{
+    fn from(value: S) -> Self {
+        Self(value.into())
+    }
+}
 
 /// Configuration for the state service.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
@@ -137,7 +169,7 @@ pub struct Config {
 
     #[cfg(feature = "elasticsearch")]
     /// The elasticsearch database password.
-    pub elasticsearch_password: String,
+    pub elasticsearch_password: RedactedString,
 }
 
 fn gen_temp_path(prefix: &str) -> PathBuf {
@@ -224,7 +256,7 @@ impl Default for Config {
             #[cfg(feature = "elasticsearch")]
             elasticsearch_username: "elastic".to_string(),
             #[cfg(feature = "elasticsearch")]
-            elasticsearch_password: "".to_string(),
+            elasticsearch_password: RedactedString::default(),
         }
     }
 }
@@ -566,5 +598,29 @@ pub(crate) mod hidden {
         )??;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacted_string_hides_contents_from_debug() {
+        let secret = RedactedString::from("hunter2");
+
+        assert_eq!(format!("{secret:?}"), "[REDACTED]");
+        assert_eq!(secret.as_str(), "hunter2");
+    }
+
+    #[cfg(feature = "elasticsearch")]
+    #[test]
+    fn config_debug_does_not_contain_elasticsearch_password() {
+        let config = Config {
+            elasticsearch_password: RedactedString::from("hunter2"),
+            ..Config::default()
+        };
+
+        assert!(!format!("{config:?}").contains("hunter2"));
     }
 }

--- a/zebra-state/src/lib.rs
+++ b/zebra-state/src/lib.rs
@@ -37,7 +37,7 @@ mod tests;
 
 pub use config::{
     check_and_delete_old_databases, check_and_delete_old_state_databases,
-    database_format_version_on_disk, state_database_format_version_on_disk, Config,
+    database_format_version_on_disk, state_database_format_version_on_disk, Config, RedactedString,
 };
 pub use constants::{
     state_database_format_version_in_code, MAX_BLOCK_REORG_HEIGHT, MAX_NON_FINALIZED_CHAIN_FORKS,

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -198,8 +198,8 @@ impl FinalizedState {
             let transport = TransportBuilder::new(conn_pool)
                 .cert_validation(CertificateValidation::None)
                 .auth(Basic(
-                    config.clone().elasticsearch_username,
-                    config.clone().elasticsearch_password,
+                    config.elasticsearch_username.clone(),
+                    config.elasticsearch_password.as_str().to_string(),
                 ))
                 .build()
                 .expect("elasticsearch transport builder should not fail");


### PR DESCRIPTION
## Motivation

Closes #10753.

`Config` derives `Debug`, `elasticsearch_password` was a plain `String`, and
`zebrad/src/application.rs:470` logs `info!("{config:?}")` at startup. So on
`elasticsearch`-feature builds with a password set, the password went to stdout and journald
in cleartext.

## Solution

The issue offered two options — a redacting `Debug` for the field, or a secret type. I went
with the secret type because there is already a precedent for it in the tree: `PeerSocketAddr`
(`zebra-network/src/meta_addr/peer_addr.rs`) is a `#[serde(transparent)]` newtype with a
redacting `Debug`, used to keep peer IPs out of logs. This follows that shape rather than
adding a second convention.

`RedactedString` wraps a `String`, renders as `[REDACTED]` under `Debug`, and exposes
`as_str()` as the deliberate way to reach the contents. `Config` keeps `derive(Debug)`.

The alternative — a hand-written `Debug` for `Config` — would need updating for every field
added in future, and silently leaks anything a contributor forgets. The type-level approach
makes the guarantee hold wherever the field travels.

Because `RedactedString` is `#[serde(transparent)]`, config files and the on-disk format are
unchanged; `elasticsearch_password = "..."` in `zebrad.toml` parses exactly as before.

Two small things came along with it:

- `Basic(config.clone().elasticsearch_username, ...)` in `finalized_state.rs` was cloning the
  entire `Config` twice to read two fields. Since the line had to change anyway, it now clones
  just the two values.
- `RedactedString` is re-exported from `zebra-state`, since it appears in a public field type
  and callers need it to construct a `Config`.

Note this is complementary to the existing sensitive-key handling in `zebrad/src/config.rs`,
which already treats a `password` suffix as sensitive — but only for environment-variable
overrides, not for the `Debug` dump.

### Breaking change

`Config::elasticsearch_password` changes from `String` to `RedactedString`. Reads need
`.as_str()`, writes need `.into()`. This only affects consumers building with the
`elasticsearch` feature, which is off by default.

If you'd rather not take the API break, I'm happy to switch to a manual `Debug` impl for
`Config` instead — say the word and I'll rework it.

### Tests

Two unit tests added in `zebra-state/src/config.rs`:

- `redacted_string_hides_contents_from_debug` — `Debug` renders `[REDACTED]` while `as_str()`
  still returns the secret
- `config_debug_does_not_contain_elasticsearch_password` (feature-gated) — the full `Config`
  debug output does not contain the password

Verified locally:

- `cargo test -p zebra-state --features elasticsearch --lib config::` — 2 passed
- `cargo clippy -p zebra-state --features elasticsearch --all-targets -- -D warnings` — clean
- `cargo clippy -p zebra-state --all-targets -- -D warnings` — clean (feature off)
- `cargo check -p zebrad --features elasticsearch` — builds
- `cargo fmt -p zebra-state -- --check` — clean

I did not exercise a live Elasticsearch instance, so the credential path itself is covered by
compilation and the existing code path only.

### Specifications & References

Precedent for the newtype: `zebra-network/src/meta_addr/peer_addr.rs`.

### Follow-up Work

`RedactedString` is deliberately scoped to this one field. If you'd like, it could also cover
other secrets in the config tree later — I didn't want to widen this PR unprompted.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude Code, for drafting the implementation, the tests and this description. The design choice, the precedent search and the verification runs above were carried out and checked against real output.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
