### PR TITLE
fix(state): clear rejected hashes before known block checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   source, so its generated command works with the published Zebra image
   ([#11008](https://github.com/ZcashFoundation/zebra/pull/11008)).
 
+### Security
+
+- Allow chain synchronization to immediately retry an honest block body after
+  rejecting a body with the same header hash, without waiting for a child block
+  to trigger cleanup.
+
 ## [Zebra 6.1.0](https://github.com/ZcashFoundation/zebra/releases/tag/v6.1.0) - 2026-07-17
 
 ### Added

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- Known block queries now clear notifications for rejected non-finalized blocks before
+  checking sent hashes, allowing an honest block body with the same header hash to be
+  retried immediately.
+
 ## [11.1.0] - 2026-07-17
 
 ### Changed

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1230,6 +1230,9 @@ impl Service<Request> for StateService {
             // before downloading or validating it.
             Request::KnownBlock(hash) => {
                 let timer = CodeTimer::start();
+
+                self.drain_non_finalized_rejected_hashes();
+
                 let sent_hash_response = self.known_sent_hash(&hash);
                 let read_service = self.read_service.clone();
 

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1174,6 +1174,8 @@ impl Service<Request> for StateService {
                 }
 
                 // Check the sent non-finalized blocks
+                self.drain_non_finalized_rejected_hashes();
+
                 if let Some(utxo) = self.non_finalized_block_write_sent_hashes.utxo(&outpoint) {
                     self.pending_utxos.respond(&outpoint, utxo);
 

--- a/zebrad/tests/integration/regtest.rs
+++ b/zebrad/tests/integration/regtest.rs
@@ -158,7 +158,10 @@ async fn rejected_block_does_not_reject_same_hash_block_children() -> Result<()>
         .await
         .map_err(|err| eyre!(err))?;
     assert!(
-        matches!(poisoned_response, SubmitBlockResponse::ErrorResponse(_)),
+        matches!(
+            poisoned_response,
+            SubmitBlockResponse::ErrorResponse(SubmitBlockErrorResponse::Rejected)
+        ),
         "the poisoned block body must be rejected"
     );
 

--- a/zebrad/tests/integration/regtest.rs
+++ b/zebrad/tests/integration/regtest.rs
@@ -162,43 +162,23 @@ async fn rejected_block_does_not_reject_same_hash_block_children() -> Result<()>
         "the poisoned block body must be rejected"
     );
 
-    // The rejected hash is still marked as sent until the state service drains the write task's
-    // rejection notification. For now this same-hash block is considered a duplicate.
     let valid_block_data = hex::encode(valid_block.zcash_serialize_to_vec()?);
-    let first_valid_response: SubmitBlockResponse = client
+    let valid_block_response: SubmitBlockResponse = client
         .json_result_from_call("submitblock", format!(r#"["{valid_block_data}"]"#))
         .await
         .map_err(|err| eyre!(err))?;
     assert_eq!(
-        first_valid_response,
-        SubmitBlockResponse::ErrorResponse(SubmitBlockErrorResponse::Duplicate),
-        "the first valid block submission must wait for the rejected hash to be drained"
+        valid_block_response,
+        SubmitBlockResponse::Accepted,
+        "KnownBlock must drain rejected hashes before checking sent hashes"
     );
 
-    // The child submission below triggers another state request and drains the previous
-    // notification, which means the block can then be resubmitted.
     let valid_child = blocks[3].clone();
     let valid_child_data = hex::encode(valid_child.zcash_serialize_to_vec()?);
-    let submit_child = client.json_result_from_call::<SubmitBlockResponse>(
-        "submitblock",
-        format!(r#"["{valid_child_data}"]"#),
-    );
-
-    let resubmit_valid_block = async {
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        client
-            .json_result_from_call::<SubmitBlockResponse>(
-                "submitblock",
-                format!(r#"["{valid_block_data}"]"#),
-            )
-            .await
-    };
-    let (valid_child_response, valid_block_response) =
-        tokio::join!(submit_child, resubmit_valid_block);
-    let valid_child_response = valid_child_response.map_err(|err| eyre!(err))?;
-    let valid_block_response = valid_block_response.map_err(|err| eyre!(err))?;
-
-    assert_eq!(valid_block_response, SubmitBlockResponse::Accepted);
+    let valid_child_response: SubmitBlockResponse = client
+        .json_result_from_call("submitblock", format!(r#"["{valid_child_data}"]"#))
+        .await
+        .map_err(|err| eyre!(err))?;
     assert_eq!(
         valid_child_response,
         SubmitBlockResponse::Accepted,

--- a/zebrad/tests/integration/regtest.rs
+++ b/zebrad/tests/integration/regtest.rs
@@ -217,6 +217,118 @@ async fn rejected_block_does_not_reject_same_hash_block_children() -> Result<()>
     Ok(())
 }
 
+/// A contextually rejected block must not remain known as sent.
+///
+/// Sync checks [`zebra_state::Request::KnownBlock`] before downloading a block body. If a rejected
+/// block remains in the state's sent hashes, an honest block body with the same header hash is
+/// incorrectly reported as a duplicate and never reaches contextual verification.
+#[tokio::test]
+async fn rejected_block_is_not_known_as_sent() -> Result<()> {
+    const EXTRA_COINBASE_DATA: &str = "zebra-chain-stall-poc";
+
+    let _init_guard = zebra_test::init();
+
+    let network = Network::new_regtest(
+        ConfiguredActivationHeights {
+            nu5: Some(1),
+            ..Default::default()
+        }
+        .into(),
+    );
+    let mut config = os_assigned_rpc_port_config(false, &network)?;
+    config.mempool.debug_enable_at_height = Some(0);
+    config.mining.extra_coinbase_data =
+        Some(ExtraCoinbaseData::try_from(EXTRA_COINBASE_DATA.to_owned())?);
+
+    let mut block_builder = testdir()?
+        .with_config(&mut config)?
+        .spawn_child(args!["start"])?;
+    let rpc_address = read_listen_addr_from_logs(&mut block_builder, OPENED_RPC_ENDPOINT_MSG)?;
+
+    tokio::time::sleep(LAUNCH_DELAY).await;
+
+    let client = RpcRequestClient::new(rpc_address);
+    let mut blocks = Vec::new();
+    for expected_height in 1..=3 {
+        let (block, height) = client.block_from_template(&network).await?;
+        assert_eq!(height.0, expected_height);
+        client.submit_block(block.clone()).await?;
+        blocks.push(block);
+    }
+
+    block_builder.kill(false)?;
+    let output = block_builder.wait_with_output()?;
+    output.assert_failure()?.assert_was_killed()?;
+
+    let mut zebrad = testdir()?
+        .with_config(&mut config)?
+        .spawn_child(args!["start"])?;
+    let rpc_address = read_listen_addr_from_logs(&mut zebrad, OPENED_RPC_ENDPOINT_MSG)?;
+
+    tokio::time::sleep(LAUNCH_DELAY).await;
+
+    let client = RpcRequestClient::new(rpc_address);
+    client.submit_block(blocks[0].clone()).await?;
+    client.submit_block(blocks[1].clone()).await?;
+
+    let valid_block = blocks[2].clone();
+    let mut poisoned_block = valid_block.clone();
+    let coinbase = Arc::make_mut(
+        poisoned_block
+            .transactions
+            .first_mut()
+            .expect("block templates contain a coinbase transaction"),
+    );
+    let transparent::Input::Coinbase { data, .. } = coinbase
+        .inputs_mut()
+        .first_mut()
+        .expect("coinbase transactions contain a transparent input")
+    else {
+        panic!("the first coinbase transaction input must be a coinbase input");
+    };
+    assert!(
+        data.ends_with(EXTRA_COINBASE_DATA.as_bytes()),
+        "the coinbase transaction must contain the configured extra data"
+    );
+    *data
+        .last_mut()
+        .expect("configured extra coinbase data is non-empty") = b'a';
+
+    assert_eq!(
+        poisoned_block.hash(),
+        valid_block.hash(),
+        "changing a NU5 coinbase scriptSig must not change the block header hash"
+    );
+
+    let poisoned_block_data = hex::encode(poisoned_block.zcash_serialize_to_vec()?);
+    let poisoned_response: SubmitBlockResponse = client
+        .json_result_from_call("submitblock", format!(r#"["{poisoned_block_data}"]"#))
+        .await
+        .map_err(|err| eyre!(err))?;
+    assert_eq!(
+        poisoned_response,
+        SubmitBlockResponse::ErrorResponse(SubmitBlockErrorResponse::Rejected),
+        "the poisoned block body must be rejected"
+    );
+
+    let valid_block_data = hex::encode(valid_block.zcash_serialize_to_vec()?);
+    let valid_response: SubmitBlockResponse = client
+        .json_result_from_call("submitblock", format!(r#"["{valid_block_data}"]"#))
+        .await
+        .map_err(|err| eyre!(err))?;
+    assert_eq!(
+        valid_response,
+        SubmitBlockResponse::Accepted,
+        "KnownBlock must drain rejected hashes before checking sent hashes"
+    );
+
+    zebrad.kill(false)?;
+    let output = zebrad.wait_with_output()?;
+    output.assert_failure()?.assert_was_killed()?;
+
+    Ok(())
+}
+
 /// Regression test for <https://github.com/ZcashFoundation/zebra/issues/10470>.
 ///
 /// `getrawtransaction` must count confirmations against the full best-chain tip


### PR DESCRIPTION
_Base of a 3-PR stack: this → #11053  → #11054._

## Motivation

When a block body fails contextual verification, the non-finalized write task notifies `StateService` that its header hash should be removed from `SentHashes`.

However, `Request::KnownBlock` checked `SentHashes` without first draining these notifications. An honest block body sharing the rejected body's header hash could therefore be reported as already present in the write channel.

Sync and the inbound downloader use `Request::KnownBlock` to decide whether to download a block. The stale entry could prevent the honest body from reaching verification, stalling chain synchronization at the tip until further commit activity occurred.

## Solution

Drain pending non-finalized rejection notifications before `Request::KnownBlock` checks `SentHashes`, mirroring the cleanup already performed by `queue_and_commit_to_non_finalized_state()` before its sent-hash check. The next known-block query after a rejection now removes the stale sent hash, so an honest body with the same header hash can be requested and verified without waiting for a child block.

### Tests

A focused regression test submits a contextually invalid body, then an honest body with the same header hash, and confirms the honest body is accepted immediately. The broader same-hash regression test is updated to drop its child-triggered cleanup workaround.

### AI Disclosure

AI tools were used (GPT 5.6 Sol, to implement and write documentation).