### PR TITLE
chore(release): finalize changelogs and end-of-support height for v6.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Zebra are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Unreleased]
+## [Zebra 6.2.1](https://github.com/ZcashFoundation/zebra/releases/tag/v6.2.1) - 2026-07-22
 
 ### Changed
 
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   each minimum-difficulty block into a large difficulty drop (tracked in
   [zcash/zips#1321](https://github.com/zcash/zips/issues/1321))
   ([#10873](https://github.com/ZcashFoundation/zebra/pull/10873))
+
+### Security
+
+- Allow chain synchronization to immediately retry an honest block body after rejecting a body
+  with the same header hash, without waiting for a child block to trigger cleanup.
+- Mitigate a peer-driven CPU-exhaustion vector on nodes with NU6.3 (Ironwood) active: reject
+  underpaying and structurally invalid shielded mempool transactions before their expensive proof
+  verification, and disconnect peers that send transactions with invalid shielded proofs.
 
 ## [Zebra 6.2.0](https://github.com/ZcashFoundation/zebra/releases/tag/v6.2.0) - 2026-07-17
 

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -5,13 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [13.0.0] - 2026-07-22
 
-### Breaking Changes
+### Added
 
-- `transaction::Verifier::check_maturity_height` is now private and takes
-  `tx`, `height`, `network`, and `spent_utxos` directly instead of `&Request`.
-  ([#10843](https://github.com/ZcashFoundation/zebra/pull/10843))
+- `error::TransactionError`:
+  - `Halo2VerificationFailed`
+  - `SaplingVerificationFailed`
+
+### Changed
+
+- `transaction::Verifier::check_maturity_height` is now private and takes `tx`, `height`,
+  `network`, and `spent_utxos` directly instead of `&Request`
+  ([#10843](https://github.com/ZcashFoundation/zebra/pull/10843)).
+- `zebra-state` dependency bumped to `11.1.1`.
+
+### Security
+
+- Check the ZIP-317 mempool rules before verifying a transaction's shielded proofs, so an
+  underpaying transaction is rejected before the expensive cryptographic checks run
+  ([#11053](https://github.com/ZcashFoundation/zebra/pull/11053)).
+- Score failed shielded proof and signature verifications, and non-canonical Orchard and
+  Ironwood proof sizes, as mempool misbehaviour, so a peer sending invalid shielded transactions
+  is disconnected instead of repeatedly forcing their verification
+  ([#11054](https://github.com/ZcashFoundation/zebra/pull/11054)).
 
 ## [12.0.1] - 2026-07-17
 

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [13.0.0] - 2026-07-22
+
+### Changed
+
+- Requires `zebra-consensus` 13.0.0. `zebra-consensus`'s `error::TransactionError` appears in this
+  crate's public API (`TransactionTemplate::new_coinbase`), so its new variants are a breaking
+  change here too.
+- `zebra-state` dependency bumped to `11.1.1`.
+
 ## [12.1.0] - 2026-07-17
 
 ### Added

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [11.1.1] - 2026-07-22
 
 ### Security
 

--- a/zebra-utils/CHANGELOG.md
+++ b/zebra-utils/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.1.3] - 2026-07-22
+
+### Changed
+
+- `zebra-rpc` dependency bumped to `13.0.0`.
+
 ## [9.1.2] - 2026-07-17
 
 ### Changed

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_417_000;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_422_000;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.


### PR DESCRIPTION
Release prep for v6.2.1: finalizes the changelogs and end-of-support height so the release can be tagged with the just-merged security fixes (#11052, #11053, #11054).

## Changelogs

Finalize `[Unreleased]` → released versions, dated 2026-07-22:
- **zebra-consensus 13.0.0** — new `TransactionError` variants; ZIP-317 + invalid-proof-ban Security entries.
- **zebra-rpc 13.0.0** — see version note below.
- **zebra-state 11.1.1** — rejected-hash Security fix (#11052).
- **zebra-utils 9.1.3** — dep bump.
- **workspace 6.2.1** — Security entries.

## End-of-support

`ESTIMATED_RELEASE_HEIGHT` 3,417,000 → **3,422,000** (windows unchanged). `end_of_support` tests pass.

## ⚠️ Version note for the release PR (#11013)

release-plz set **zebra-rpc to 12.1.1**, but it needs a **major (13.0.0)**: `zebra-rpc`'s public `TransactionTemplate::new_coinbase() -> Result<_, TransactionError>` re-exposes zebra-consensus's `TransactionError`, which #11054 extends — a breaking change for zebra-rpc's public API. release-plz can't see this (semver_check off; cargo-public-api is blind to the re-exposed foreign type). #11013's `zebra-rpc` version and dependents' refs need bumping to 13.0.0 to match these changelogs.

### AI Disclosure

Changelog finalization and the version-cascade analysis were done with Claude; reviewed manually.