### PR TITLE
docs(changelog): classify check_maturity_height under Removed

### DIFF
--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -15,10 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `transaction::Verifier::check_maturity_height` is now private and takes `tx`, `height`,
-  `network`, and `spent_utxos` directly instead of `&Request`
-  ([#10843](https://github.com/ZcashFoundation/zebra/pull/10843)).
 - `zebra-state` dependency bumped to `11.1.1`.
+
+### Removed
+
+- `transaction::Verifier::check_maturity_height` is now private
+  ([#10843](https://github.com/ZcashFoundation/zebra/pull/10843)).
 
 ### Security
 


### PR DESCRIPTION
## Motivation

zc flagged `transaction::Verifier::check_maturity_height` as a `### Removed` item, but the v6.2.1 `zebra-consensus` changelog listed it under `### Changed`. Making a public method private removes it from the public API, so `### Removed` is the correct Keep-a-Changelog category.

## Solution

Move the entry to a `### Removed` section in the `[13.0.0]` changelog block. Post-release changelog accuracy fix; no code change.

### AI Disclosure

Found by Claude while reconciling the release changelog against zc.