### PR TITLE
fix(ci): drop the release dry-run pre-check that breaks multi-crate releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,13 +229,11 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
       - name: Install libclang for librocksdb-sys bindgen
         run: sudo apt-get update && sudo apt-get install -y libclang-dev
-      - name: Validate release packages without publishing
-        uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 #v0.5.130
-        with:
-          command: release
-          dry_run: true
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+      # No `release --dry-run` pre-check: it packages each crate and resolves its dependencies
+      # against crates.io, so a release that bumps interdependent workspace crates together fails
+      # (a crate's being-released dependency, e.g. zebra-consensus needing the new zebra-state, is
+      # not on crates.io yet). The publish step below is topologically ordered and handles this,
+      # and `Verify published package versions` checks the result. See the v6.2.1 release.
       - name: Publish crates and create tags
         id: release-plz
         uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 #v0.5.130


### PR DESCRIPTION
## Motivation

The v6.2.1 release job failed at **Validate release packages without publishing** (`release-plz release --dry-run`):

```
failed to publish zebra-consensus: failed to select a version for `zebra-state = ^11.1.1`
candidate versions: 11.1.0, 11.0.0, ...  (11.1.1 not on crates.io)
```

The dry-run packages each crate and resolves its dependencies against crates.io. When a release bumps interdependent workspace crates together, a crate's being-released dependency (here zebra-consensus 13.0.0 needing zebra-state 11.1.1) isn't on crates.io yet, so the dry-run fails even though the release is valid. It forced a fully manual publish for v6.2.1.

## Solution

Remove the dry-run pre-check step. The **Publish crates and create tags** step (`release-plz release`) publishes in topological order and handles cross-dependencies, and **Verify published package versions** validates the outcome afterward. A comment records why the pre-check was dropped.

### Tests

CI-config change; validated the YAML parses. The real test is the next multi-crate release.

### AI Disclosure

Diagnosed and fixed by Claude during the v6.2.1 release.