### PR TITLE
ci: send source_ref in the integration-test dispatch

### DIFF
--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -101,11 +101,16 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           SHA: ${{ steps.pr.outputs.sha || github.event.pull_request.head.sha || github.sha }}
           TEST_SHA: ${{ steps.pr.outputs.test_sha || steps.test-branch.outputs.test_sha }}
+          # Stable per-source key so the integration repo can cancel a superseded
+          # run: the PR number for pull requests and manual dispatches, otherwise
+          # the branch name (e.g. `main`).
+          SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && format('pr-{0}', inputs.pr_number) || (github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref_name) }}
         run: >
           gh api repos/zcash/integration-tests/dispatches
           --field event_type="zebra-interop-request"
           --field client_payload[sha]="${SHA}"
           --field client_payload[test_sha]="${TEST_SHA}"
+          --field client_payload[source_ref]="${SOURCE_REF}"
 
       - name: Post sticky comment on PR (manual dispatch only)
         if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
Adds a stable `source_ref` field to the `repository_dispatch` payload sent to
`zcash/integration-tests` when triggering integration tests: the PR number for
pull requests and the manual `workflow_dispatch` path (`pr-<n>`), otherwise the
branch name.

`zcash/integration-tests` uses this as its workflow concurrency-group key, so a
rapid follow-up push for the same PR cancels the prior, now-superseded interop
run instead of letting it run to completion. Without `source_ref` the run groups
by the per-push-unique head `sha` and never cancels — i.e. this is the enabling
half of that behavior.

Backward compatible: the field is an addition to the payload and is ignored
wherever it is not consumed.

Paired with zcash/integration-tests#178, which consumes the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
