### PR TITLE
docs(changelog): link GHSA-x93j and remove duplicate entry 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Security
 
 - Allow chain synchronization to immediately retry an honest block body after rejecting a body
-  with the same header hash, without waiting for a child block to trigger cleanup.
+  with the same header hash, without waiting for a child block to trigger cleanup
+  ([GHSA-x93j-mj2f-q338](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-x93j-mj2f-q338)).
 - Mitigate a peer-driven CPU-exhaustion vector on nodes with NU6.3 (Ironwood) active: reject
   underpaying and structurally invalid shielded mempool transactions before their expensive proof
   verification, and disconnect peers that send transactions with invalid shielded proofs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,12 +63,6 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   source, so its generated command works with the published Zebra image
   ([#11008](https://github.com/ZcashFoundation/zebra/pull/11008)).
 
-### Security
-
-- Allow chain synchronization to immediately retry an honest block body after
-  rejecting a body with the same header hash, without waiting for a child block
-  to trigger cleanup.
-
 ## [Zebra 6.1.0](https://github.com/ZcashFoundation/zebra/releases/tag/v6.1.0) - 2026-07-17
 
 ### Added

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Known block queries now clear notifications for rejected non-finalized blocks before
   checking sent hashes, allowing an honest block body with the same header hash to be
-  retried immediately.
+  retried immediately
+  ([GHSA-x93j-mj2f-q338](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-x93j-mj2f-q338)).
 
 ## [11.1.0] - 2026-07-17
 


### PR DESCRIPTION
## Motivation

Closes #11063

A changelog item was missing its link to the respective [security advisory](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-x93j-mj2f-q338), and during merge it was also duplicated in the wrong version (6.2.0).

## Solution

Remove the duplicate entry and link the items to the GHSA.

### Tests

None needed, only affects the changelog.

### Specifications & References

- [GHSA-x93j-mj2f-q338](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-x93j-mj2f-q338)


### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: GPT 5.6 Sol generated the PR title

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [ ] The solution is tested.
- [x] The documentation and changelogs are up to date.
