### PR TITLE
fix(network): retry the first peer cache write, de-flake persistent_mode

### DIFF
--- a/zebra-network/CHANGELOG.md
+++ b/zebra-network/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- The first peer disk-cache write is retried every 20 seconds until it succeeds, instead of
+  waiting the full 5-minute update interval, so a cold-started node caches its peers soon after
+  finding them ([#11073](https://github.com/ZcashFoundation/zebra/pull/11073)).
+
 ## [10.2.0] - 2026-07-17
 
 ### Added

--- a/zebra-network/src/peer_cache_updater.rs
+++ b/zebra-network/src/peer_cache_updater.rs
@@ -27,26 +27,45 @@ pub async fn peer_cache_updater(
     //       and allow it to be set in tests
     sleep(DNS_LOOKUP_TIMEOUT * 4).await;
 
+    let mut wrote_cache = false;
+
     loop {
         // Ignore errors because updating the cache is optional.
         // Errors are already logged by the functions we're calling.
-        let _ = update_peer_cache_once(&config, &address_book).await;
+        wrote_cache |= update_peer_cache_once(&config, &address_book)
+            .await
+            .unwrap_or(false);
 
-        sleep(PEER_DISK_CACHE_UPDATE_INTERVAL).await;
+        // Right after a cold start, the address book can still be empty at the first attempt,
+        // and the cache is only written once there are cacheable peers. Retry soon until the
+        // first write, so the cache exists shortly after the node finds its first peers.
+        let interval = if wrote_cache {
+            PEER_DISK_CACHE_UPDATE_INTERVAL
+        } else {
+            DNS_LOOKUP_TIMEOUT * 4
+        };
+
+        sleep(interval).await;
     }
 }
 
 /// Caches peers from the current `address_book` to disk, based on `config`.
+///
+/// Returns `true` if the cache was written, and `false` if the cacheable peer list was empty,
+/// keeping any previous cache.
 pub async fn update_peer_cache_once(
     config: &Config,
     address_book: &Arc<Mutex<AddressBook>>,
-) -> io::Result<()> {
-    let peer_list = cacheable_peers(address_book)
+) -> io::Result<bool> {
+    let peer_list: std::collections::HashSet<_> = cacheable_peers(address_book)
         .iter()
         .map(|meta_addr| meta_addr.addr)
         .collect();
+    let has_peers = !peer_list.is_empty();
 
-    config.update_peer_cache(peer_list).await
+    config.update_peer_cache(peer_list).await?;
+
+    Ok(has_peers)
 }
 
 /// Returns a list of cacheable peers, blocking for as short a time as possible.

--- a/zebrad/tests/unit/config.rs
+++ b/zebrad/tests/unit/config.rs
@@ -1,5 +1,10 @@
 use std::{
-    collections::HashSet, env, fs, io::Write as _, path::PathBuf, sync::Mutex, time::Duration,
+    collections::HashSet,
+    env, fs,
+    io::Write as _,
+    path::{Path, PathBuf},
+    sync::Mutex,
+    time::{Duration, Instant},
 };
 
 use color_eyre::eyre::{eyre, Result, WrapErr};
@@ -22,6 +27,13 @@ use crate::common::{
 use zebra_node_services::rpc_client::RpcRequestClient;
 use zebra_rpc::server::OPENED_RPC_ENDPOINT_MSG;
 
+/// The maximum time to wait for the persistent state and network caches to be created.
+///
+/// The peer cache is only written once the node has cacheable peers, and the peer cache updater
+/// retries every 20 seconds until its first write, so this needs to cover several attempts on a
+/// slow network.
+const PERSISTENT_CACHE_CREATION_TIMEOUT: Duration = Duration::from_secs(90);
+
 /// Check that the block state and peer list caches are written to disk.
 #[test]
 fn persistent_mode() -> Result<()> {
@@ -32,29 +44,43 @@ fn persistent_mode() -> Result<()> {
 
     let mut child = testdir.spawn_child(args!["-v", "start"])?;
 
-    // Run the program and kill it after a few seconds
-    std::thread::sleep(EXTENDED_LAUNCH_DELAY);
+    // Wait for both caches to be created and populated, polling instead of sleeping for a
+    // fixed time: the peer cache write depends on finding live peers, which can take several
+    // attempts on a slow network (#11072).
+    let state_dir = testdir.path().join("state");
+    let network_dir = testdir.path().join("network");
+    let deadline = Instant::now() + PERSISTENT_CACHE_CREATION_TIMEOUT;
+    while Instant::now() < deadline
+        && !(dir_is_populated(&state_dir) && dir_is_populated(&network_dir))
+    {
+        std::thread::sleep(Duration::from_secs(1));
+    }
+
+    // Kill the node and make sure it was killed
     child.kill(false)?;
     let output = child.wait_with_output()?;
-
-    // Make sure the command was killed
     output.assert_was_killed()?;
 
-    let cache_dir = testdir.path().join("state");
     assert_with_context!(
-        cache_dir.read_dir()?.count() > 0,
+        dir_is_populated(&state_dir),
         &output,
-        "state directory empty despite persistent state config"
+        "state directory missing or empty despite persistent state config"
     );
-
-    let cache_dir = testdir.path().join("network");
     assert_with_context!(
-        cache_dir.read_dir()?.count() > 0,
+        dir_is_populated(&network_dir),
         &output,
-        "network directory empty despite persistent network config"
+        "network directory missing or empty despite persistent network config"
     );
 
     Ok(())
+}
+
+/// Returns `true` if `dir` exists and contains at least one entry.
+fn dir_is_populated(dir: &Path) -> bool {
+    matches!(
+        dir.read_dir().map(|mut entries| entries.next().is_some()),
+        Ok(true)
+    )
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

Closes #11072.

## Solution

The peer cache updater attempted its first disk write exactly once, 20 s after startup, then not
again for 5 minutes — and `Config::update_peer_cache` skips the write (never creating the cache
directory) while the cacheable peer list is empty. On a cold start under the current peer
landscape (#11061), `unit::config::persistent_mode` — which killed the node after a fixed 45 s —
often found no `network` directory and failed with a bare ENOENT.

- `peer_cache_updater` retries the first write every 20 s (`DNS_LOOKUP_TIMEOUT * 4`) until one
  succeeds, then switches to the 5-minute update interval; `update_peer_cache_once` now reports
  whether the cache was written.
- The test polls for both cache directories (1 s interval, 90 s deadline) instead of sleeping a
  fixed 45 s, and its assertions tolerate a missing directory, so failures report the assert
  context instead of "No such file or directory".

### Tests

- `unit::config::persistent_mode` passes locally in ~25 s (previously always 45 s), and passes on
  a machine where it reproducibly failed before the change.
- Full local CI gate (fmt, clippy `-D warnings`, check `--locked`, docs, feature powerset,
  nextest ci profile, udeps, deny, MSRV); the only failure is the known env-blocked
  `unit::config::config_tests` on a machine with a running node.

### AI Disclosure

- [x] AI tools were used: Claude diagnosed the flake and implemented the fix and tests; reviewed
  by the author.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
