### PR TITLE
fix(release): normalize generated changelog spacing

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -105,6 +105,11 @@ body = """
 {% endif %}
 {% endfor %}
 """
+# Normalize template whitespace before prepending source-authored entries.
+postprocessors = [
+  { pattern = '\n{3,}', replace = "\n\n" },
+  { pattern = '\n{2,}$', replace = "\n" },
+]
 
 [[package]]
 name = "zebrad"


### PR DESCRIPTION
## Motivation

The automated update to #11067 generates repeated blank lines in six changelogs, causing Docs Check to fail and blocking the release. The custom changelog template emits control-flow whitespace, which `release-plz` prepends to the source-authored entries without normalizing the boundary.

## Solution

Normalize only the generated changelog fragment with native git-cliff postprocessors:

- collapse runs of three or more newlines to one blank line;
- leave one trailing newline before `release-plz` prepends the fragment to the existing changelog.

This keeps source-authored entries authoritative and avoids adding another validation script or duplicating Markdown rules in the release-readiness check.

### Tests

- The pinned `release-plz 0.3.160` generated the pending workspace release with the proposed configuration in a disposable clone.
- The generated repository passed Zebra's Markdown lint configuration, including the dependency-only `zebra-consensus` changelog.

### Specifications & References

- Fixes #11067
- Related to #10964
- [Failing Docs Check](https://github.com/ZcashFoundation/zebra/actions/runs/30100264451/job/89504279648?pr=11067)

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: OpenAI Codex implemented the configuration fix, reproduced the generated changelogs, and drafted the PR description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
