### PR TITLE
chore(release): prep 6.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7366,7 +7366,7 @@ dependencies = [
 
 [[package]]
 name = "zebra-consensus"
-version = "13.0.1"
+version = "14.0.0"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [13.0.1] - 2026-07-24
+## [14.0.0] - 2026-07-24
 
 ### Changed
 
-- Updated the following local packages: zebra-state
+- Requires `zebra-state` 12.0.0, whose types appear in this crate's public API
+  (`error::BlockError`, `error::TransactionError`, and the state service bounds on
+  `router::init` and the verifiers).
 
 ## [13.0.0] - 2026-07-22
 

--- a/zebra-consensus/Cargo.toml
+++ b/zebra-consensus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zebra-consensus"
-version = "13.0.1"
+version = "14.0.0"
 authors.workspace = true
 description = "Implementation of Zcash consensus checks"
 license.workspace = true

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `getblock` verbosity 2 now returns transaction objects for side-chain blocks with `height` set to `-1` and `confirmations` set to `0`, instead of panicking while serializing them ([#10606](https://github.com/ZcashFoundation/zebra/pull/10606)).
 
+### Changed
+
+- Requires `zebra-consensus` 14.0.0 and `zebra-state` 12.0.0, whose types appear in this
+  crate's public API (`methods::RpcImpl`, `indexer::server::IndexerRPC`).
+- `zebra-network` dependency bumped to `10.2.1`.
+
 ### Fixed
 
 - `getblock`, `getblockheader`, and `gettxout` now bind follow-up state queries to the block hash or chain tip resolved by the first read, so responses do not combine state from different best chains during a reorg or tip advance ([#10606](https://github.com/ZcashFoundation/zebra/pull/10606)).

--- a/zebra-rpc/Cargo.toml
+++ b/zebra-rpc/Cargo.toml
@@ -112,7 +112,7 @@ proptest = { workspace = true, optional = true }
 zebra-chain = { path = "../zebra-chain", version = "11.2.0", features = [
     "json-conversion",
 ] }
-zebra-consensus = { path = "../zebra-consensus", version = "13.0.1" }
+zebra-consensus = { path = "../zebra-consensus", version = "14.0.0" }
 zebra-network = { path = "../zebra-network", version = "10.2.1" }
 zebra-node-services = { path = "../zebra-node-services", version = "9.1.1", features = [
     "rpc-client",

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -22,16 +22,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   needs `.into()`. Only applies to builds with the `elasticsearch` feature
   ([#11051](https://github.com/ZcashFoundation/zebra/pull/11051))
 
-### Security
-
-- The startup config dump no longer prints the Elasticsearch password. It previously appeared
-  in cleartext in logs and journald on `elasticsearch`-feature builds with a password set
-  ([#11051](https://github.com/ZcashFoundation/zebra/pull/11051))
-
 ### Added
 
 - `RedactedString`, a `String` wrapper whose `Debug` output is `[REDACTED]`, for config fields
   that hold secrets
+  ([#11051](https://github.com/ZcashFoundation/zebra/pull/11051))
+
+### Security
+
+- The startup config dump no longer prints the Elasticsearch password. It previously appeared
+  in cleartext in logs and journald on `elasticsearch`-feature builds with a password set
   ([#11051](https://github.com/ZcashFoundation/zebra/pull/11051))
 
 ## [11.1.1] - 2026-07-22

--- a/zebra-utils/CHANGELOG.md
+++ b/zebra-utils/CHANGELOG.md
@@ -9,16 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [9.1.4] - 2026-07-24
 
-### Security
-
-- `zebrad-log-filter` no longer runs log text as a shell command. Previously a log line
-  containing a single quote could execute arbitrary commands as the user running the filter
-  ([#11050](https://github.com/ZcashFoundation/zebra/pull/11050))
-
 ### Changed
 
 - `zebrad-log-filter` no longer requires GNU sed, and no longer reads the `GNU_SED`
   environment variable. Backslashes in log lines are now printed as-is
+  ([#11050](https://github.com/ZcashFoundation/zebra/pull/11050))
+- `zebra-rpc` dependency bumped to `14.0.0`.
+
+### Security
+
+- `zebrad-log-filter` no longer runs log text as a shell command. Previously a log line
+  containing a single quote could execute arbitrary commands as the user running the filter
   ([#11050](https://github.com/ZcashFoundation/zebra/pull/11050))
 
 ## [9.1.3] - 2026-07-22

--- a/zebrad/Cargo.toml
+++ b/zebrad/Cargo.toml
@@ -158,7 +158,7 @@ comparison-interpreter = ["zebra-script/comparison-interpreter"]
 
 [dependencies]
 zebra-chain = { path = "../zebra-chain", version = "11.2.0" }
-zebra-consensus = { path = "../zebra-consensus", version = "13.0.1" }
+zebra-consensus = { path = "../zebra-consensus", version = "14.0.0" }
 zebra-network = { path = "../zebra-network", version = "10.2.1" }
 zebra-node-services = { path = "../zebra-node-services", version = "9.1.1", features = ["rpc-client"] }
 zebra-rpc = { path = "../zebra-rpc", version = "14.0.0" }

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -13,7 +13,7 @@ use zebra_chain::{
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
-pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_422_000;
+pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_425_000;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.


### PR DESCRIPTION
## Motivation

Reference for tuning the release-plz Release PR (#11084): this is what the finalized v6.2.2
release PR should look like after curation. Each delta below is a gap in the current automation.

## Solution

Built on #11084's generated commit, plus one curation commit with the fixes the automation missed:

1. **`zebra-consensus` 14.0.0, not 13.0.1.** `zebra-state` is a *public* dependency of
   `zebra-consensus` — its types appear in the public API (`error::BlockError::AlreadyInChain`,
   `error::TransactionError::ValidateContextError`, and the state service bounds on
   `router::init` and the verifiers) — so the `zebra-state` major bump must cascade to a
   `zebra-consensus` major. release-plz computes a patch because `semver_check = false`; shipping
   13.0.1 would repeat the zebra-state 10.1.0 under-bump. Includes the dependency-requirement
   ripple in `zebra-rpc`, `zebrad`, and `Cargo.lock`.
2. **Dependency-bump changelog entries.** The generator only writes its "Updated the following
   local packages" line for dependency-only releases; crates with their own changes get nothing.
   Added the house-style entries: "Requires `X` …, whose types appear in this crate's public
   API (…)" when the dependency is public, "`x` dependency bumped to `y`." otherwise
   (`zebra-consensus`, `zebra-rpc`, `zebra-utils`).
3. ~~Restored the `## [Unreleased]` heading the changelog finalizer consumed in
   `zebra-consensus/CHANGELOG.md`.~~ Fixed upstream by #11086; this branch is rebased on the
   regenerated release PR head that includes it.
4. **Keep a Changelog section order** per the [changelog
   guidelines](https://github.com/ZcashFoundation/zebra/blob/main/book/src/dev/changelog-guidelines.md):
   `Changed` before `Security` in `zebra-utils` 9.1.4, `Added` before `Security` in
   `zebra-state` 12.0.0.
5. **End-of-support height**: `ESTIMATED_RELEASE_HEIGHT` 3_422_000 → 3_425_000 (Mainnet tip
   3,423,603 on 2026-07-24 plus ~1 day of lead, rounded up — same convention as v6.2.1).

### Tests

Full local CI gate on the curation commit: fmt, clippy (`-D warnings`, all-features and
no-default), `check --locked`, doc, feature powerset, nextest `ci` profile (1214/1215 passed —
the one failure is `unit::config::config_tests` hitting a port/cache conflict with a zebrad node
running on the build host, unrelated to this diff), udeps, deny, and the MSRV 1.91 build. The
end-of-support unit tests derive their probes from the constants, so the height bump is covered.

### AI Disclosure

- [x] AI tools were used: Claude Code (semver-cascade verification via zc/cargo-public-api,
  changelog curation, this description).

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
