### PR TITLE
chore(release): normalize unreleased changelog headings

### DIFF
--- a/tower-batch-control/CHANGELOG.md
+++ b/tower-batch-control/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [1.1.0] - 2026-07-10
 
 ### Added

--- a/tower-fallback/CHANGELOG.md
+++ b/tower-fallback/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.2.43] - 2026-07-17
 
 ### Added

--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [11.2.0] - 2026-07-17
 
 ### Added

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [13.0.0] - 2026-07-22
 
 ### Added

--- a/zebra-node-services/CHANGELOG.md
+++ b/zebra-node-services/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [9.1.1] - 2026-07-17
 
 ### Changed

--- a/zebra-script/CHANGELOG.md
+++ b/zebra-script/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [10.1.1] - 2026-07-17
 
 ### Changed

--- a/zebra-test/CHANGELOG.md
+++ b/zebra-test/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [4.0.0] - 2026-07-02
 
 ### Removed


### PR DESCRIPTION
## Motivation

Release-plz preserves each changelog's existing header. Seven publishable changelogs lost their empty `[Unreleased]` section during earlier manual release finalization, so a dependency-only release can place its version directly at the top, as seen in #11084.

## Solution

Restore an empty `[Unreleased]` section in every affected publishable changelog. Release-plz retains these headings when it generates later releases, keeping direct and dependency-only changelogs consistent.

The `chore(release)` commit type is outside Zebra's release-trigger regex, so this normalization does not add packages to the pending release.

### Tests

- The pinned `release-plz 0.3.160` reproduced the same six-package release plan after this change.
- Generated changelogs retained exactly one `[Unreleased]` heading and passed Zebra's Markdown lint configuration.

### Specifications & References

- Unblocks #11084
- [Review finding](https://github.com/ZcashFoundation/zebra/pull/11084#discussion_r3646129555)

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: OpenAI Codex diagnosed the release-plz header behavior, implemented the changelog normalization, validated the generated release, and drafted the PR description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
