### PR TITLE
fix(sync): remove obsolete zcashd trailing hash handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- Chain synchronization now retains the final block hash returned by peers in `FindBlocks`
+  responses, rather than discarding it to work around obsolete `zcashd` behavior
+  ([#11093](https://github.com/ZcashFoundation/zebra/pull/11093)).
+
 ## [Zebra 6.2.2](https://github.com/ZcashFoundation/zebra/releases/tag/v6.2.2) - 2026-07-24
 
 ### Changed

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -932,9 +932,9 @@ where
                         debug!(first = ?hashes.first(), len = ?hashes.len());
                         trace!(?hashes);
 
-                        // zcashd sometimes appends an unrelated hash at the
-                        // start or end of its response. Check the first hash
-                        // against the previous response, and discard mismatches.
+                        // Legacy zcashd nodes could prepend an unrelated hash
+                        // to their response. Check the first hash against the
+                        // previous response, and discard mismatches.
                         let unknown_hashes = match hashes.as_slice() {
                             [expected_hash, rest @ ..] if expected_hash == &tip.expected_next => {
                                 rest

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -805,33 +805,7 @@ where
                 Ok(zn::Response::BlockHashes(hashes)) => {
                     trace!(?hashes);
 
-                    // zcashd sometimes appends an unrelated hash at the start
-                    // or end of its response.
-                    //
-                    // We can't discard the first hash, because it might be a
-                    // block we want to download. So we just accept any
-                    // out-of-order first hashes.
-
-                    // We use the last hash for the tip, and we want to avoid bad
-                    // tips from zcashd's quirk of appending an unrelated hash.
-                    // So we discard the last hash on mainnet/testnet.
-                    // (We don't need to worry about missed downloads, because we
-                    // will pick them up again in ExtendTips.)
-                    //
-                    // In regtest we only connect to Zebra nodes, not zcashd,
-                    // so we trust all hashes in the response and keep them all.
-                    // This is necessary when there are only a small number of
-                    // blocks to sync (e.g. 2 new blocks), where stripping the
-                    // last hash leaves only 1 unknown hash and rchunks_exact(2)
-                    // would discard the entire response.
-                    let hashes = if self.is_regtest {
-                        hashes.as_slice()
-                    } else {
-                        match hashes.as_slice() {
-                            [] => continue,
-                            [rest @ .., _last] => rest,
-                        }
-                    };
+                    let hashes = hashes.as_slice();
                     if hashes.is_empty() {
                         continue;
                     }
@@ -993,15 +967,6 @@ where
                                                 "discarding response that starts with two unexpected hashes");
                                 continue;
                             }
-                        };
-
-                        // We use the last hash for the tip, and we want to avoid
-                        // bad tips. So we discard the last hash. (We don't need
-                        // to worry about missed downloads, because we will pick
-                        // them up again in the next ExtendTips.)
-                        let unknown_hashes = match unknown_hashes {
-                            [] => continue,
-                            [rest @ .., _last] => rest,
                         };
 
                         let new_tip = if let Some(end) = unknown_hashes.rchunks_exact(2).next() {

--- a/zebrad/src/components/sync/tests/vectors.rs
+++ b/zebrad/src/components/sync/tests/vectors.rs
@@ -70,9 +70,6 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
     let block4: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_4_BYTES.zcash_deserialize_into()?;
     let block4_hash = block4.hash();
 
-    let block5: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_5_BYTES.zcash_deserialize_into()?;
-    let block5_hash = block5.hash();
-
     // Start the syncer
     let chain_sync_task_handle = tokio::spawn(chain_sync_future);
 
@@ -127,7 +124,6 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
         .respond(zn::Response::BlockHashes(vec![
             block1_hash, // tip
             block2_hash, // expected_next
-            block3_hash, // (discarded - last hash, possibly incorrect)
         ]));
 
     // State is checked for the first unknown block (block 1)
@@ -213,7 +209,6 @@ async fn sync_blocks_ok() -> Result<(), crate::BoxError> {
             block2_hash, // tip (discarded - already fetched)
             block3_hash, // expected_next
             block4_hash,
-            block5_hash, // (discarded - last hash, possibly incorrect)
         ]));
 
     // Clear remaining block locator requests
@@ -312,9 +307,6 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
     let block4: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_4_BYTES.zcash_deserialize_into()?;
     let block4_hash = block4.hash();
 
-    let block5: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_5_BYTES.zcash_deserialize_into()?;
-    let block5_hash = block5.hash();
-
     // Start the syncer
     let chain_sync_task_handle = tokio::spawn(chain_sync_future);
 
@@ -371,7 +363,6 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
             block1_hash,
             block1_hash, // tip
             block2_hash, // expected_next
-            block3_hash, // (discarded - last hash, possibly incorrect)
         ]));
 
     // State is checked for the first unknown block (block 1)
@@ -459,7 +450,6 @@ async fn sync_blocks_duplicate_hashes_ok() -> Result<(), crate::BoxError> {
             block4_hash,
             block3_hash,
             block4_hash,
-            block5_hash, // (discarded - last hash, possibly incorrect)
         ]));
 
     // Clear remaining block locator requests
@@ -607,9 +597,6 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
     let block2: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_2_BYTES.zcash_deserialize_into()?;
     let block2_hash = block2.hash();
 
-    let block3: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_3_BYTES.zcash_deserialize_into()?;
-    let block3_hash = block3.hash();
-
     // Also get a block that is a long way away from genesis
     let block982k: Arc<Block> =
         zebra_test::vectors::BLOCK_MAINNET_982681_BYTES.zcash_deserialize_into()?;
@@ -670,7 +657,6 @@ async fn sync_block_too_high_obtain_tips() -> Result<(), crate::BoxError> {
             block982k_hash,
             block1_hash, // tip
             block2_hash, // expected_next
-            block3_hash, // (discarded - last hash, possibly incorrect)
         ]));
 
     // State is checked for the first unknown block (block 982k)
@@ -780,9 +766,6 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
     let block4: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_4_BYTES.zcash_deserialize_into()?;
     let block4_hash = block4.hash();
 
-    let block5: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_5_BYTES.zcash_deserialize_into()?;
-    let block5_hash = block5.hash();
-
     // Also get a block that is a long way away from genesis
     let block982k: Arc<Block> =
         zebra_test::vectors::BLOCK_MAINNET_982681_BYTES.zcash_deserialize_into()?;
@@ -842,7 +825,6 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
         .respond(zn::Response::BlockHashes(vec![
             block1_hash, // tip
             block2_hash, // expected_next
-            block3_hash, // (discarded - last hash, possibly incorrect)
         ]));
 
     // State is checked for the first unknown block (block 1)
@@ -929,7 +911,6 @@ async fn sync_block_too_high_extend_tips() -> Result<(), crate::BoxError> {
             block3_hash, // expected_next
             block4_hash,
             block982k_hash,
-            block5_hash, // (discarded - last hash, possibly incorrect)
         ]));
 
     // Clear remaining block locator requests


### PR DESCRIPTION
## Motivation

Closes #11091

Zebra discards the final hash from `FindBlocks` responses on Mainnet and Testnet as a workaround for a deprecated zcashd behavior that could append an unrelated hash.

The workaround was originally added in #991 for a zcashd bug that combined responses. Since zcashd has been deprecated, Zebra no longer needs to discard otherwise valid trailing hashes.

## Solution

Remove trailing-hash stripping from both sync stages:

- `obtain_tips()` now considers the complete `FindBlocks` response on every network.
- `extend_tips()` retains the final new hash after removing the expected overlap hash.

The general overlap handling in `extend_tips()` remains unchanged.

Update the existing sync test vectors to omit their artificial sacrificial trailing hashes. The existing download assertions now verify that the final valid hash is retained and downloaded.

### Tests

- `cargo fmt --all -- --check`
- `cargo nextest run -p zebrad 'components::sync::tests::vectors'`
  - 10 tests passed
- `git diff --check`

### Specifications & References

- #991 originally introduced the trailing-hash workaround for a zcashd bug.

### Follow-up Work

Handle valid singleton `FindBlocks` responses independently. Removing the trailing-hash workaround alone does not allow the syncer to construct a `CheckedTip` from a single unknown hash.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: OpenAI Codex was used to investigate the sync behavior and history, implement the change, update tests, run validation, and draft the PR description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
