### PR TITLE
feat(rpc)!: Expose the end of support height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- New `getdeprecationinfo` RPC returning the block height and estimated time at which this
+  release will halt for end of support, in zcashd's `end_of_service` format. The `end_of_service`
+  object is only present on Mainnet, where end of support is enforced
+  ([#11097](https://github.com/ZcashFoundation/zebra/pull/11097)).
+
 ### Added
 
 - Added `seeder.zec.rocks` and `seeder.testnet.zec.rocks` as default DNS seeders

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- The `Rpc` trait has a new required `get_deprecation_info` method. Downstream implementers of
+  the trait must add it; callers of `RpcImpl` are unaffected
+  ([#11097](https://github.com/ZcashFoundation/zebra/pull/11097)).
+
+### Added
+
+- New `getdeprecationinfo` RPC method and `GetDeprecationInfoResponse` type. The reported end of
+  support height is set with `RpcImpl::with_end_of_support_height`; without it the response omits
+  the `end_of_service` object ([#11097](https://github.com/ZcashFoundation/zebra/pull/11097)).
+
 ### Changed
 
 - The indexer gRPC server now bounds concurrent HTTP/2 streams per connection (20)

--- a/zebra-rpc/src/client.rs
+++ b/zebra-rpc/src/client.rs
@@ -37,12 +37,12 @@ pub use crate::methods::{
         validate_address::ValidateAddressResponse,
         z_validate_address::{ZValidateAddressResponse, ZValidateAddressType},
     },
-    AddressStrings, BlockHeaderObject, BlockObject, GetAddressBalanceRequest,
+    AddressStrings, BlockHeaderObject, BlockObject, EndOfService, GetAddressBalanceRequest,
     GetAddressBalanceResponse, GetAddressTxIdsRequest, GetAddressUtxosResponse,
     GetAddressUtxosResponseObject, GetBlockHashResponse, GetBlockHeaderResponse,
     GetBlockHeightAndHashResponse, GetBlockResponse, GetBlockTransaction, GetBlockTrees,
-    GetBlockchainInfoResponse, GetInfoResponse, GetRawTransactionResponse, Hash,
-    SendRawTransactionResponse, Utxo,
+    GetBlockchainInfoResponse, GetDeprecationInfoResponse, GetInfoResponse,
+    GetRawTransactionResponse, Hash, SendRawTransactionResponse, Utxo,
 };
 
 /// Constants needed by clients of Zebra's RPC server

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -194,6 +194,28 @@ pub trait Rpc {
     #[method(name = "getinfo")]
     async fn get_info(&self) -> Result<GetInfoResponse>;
 
+    /// Returns end of support information for this node release, as a
+    /// [`GetDeprecationInfoResponse`] JSON struct.
+    ///
+    /// zcashd reference: [`getdeprecationinfo`](https://zcash.github.io/rpc/getdeprecationinfo.html)
+    /// method: post
+    /// tags: network
+    ///
+    /// # Notes
+    ///
+    /// As in zcashd, the `end_of_service` object is only present on Mainnet, where end of
+    /// support is enforced. Zebra reports the estimated last height this release supports in
+    /// `end_of_service.block_height`; the node halts when the tip goes past it.
+    ///
+    /// Some fields from the zcashd reference are missing from Zebra's response: `version` and
+    /// `subversion` are available from `getinfo`, `deprecationheight` is deprecated in zcashd,
+    /// and Zebra does not have zcashd's feature deprecation framework.
+    ///
+    /// The estimate assumes the node is synced to the network tip; during initial sync it is
+    /// significantly overestimated.
+    #[method(name = "getdeprecationinfo")]
+    async fn get_deprecation_info(&self) -> Result<GetDeprecationInfoResponse>;
+
     /// Returns blockchain state information, as a [`GetBlockchainInfoResponse`] JSON struct.
     ///
     /// zcashd reference: [`getblockchaininfo`](https://zcash.github.io/rpc/getblockchaininfo.html)
@@ -836,6 +858,10 @@ where
     /// no matter what the estimated height or local clock is.
     debug_force_finished_sync: bool,
 
+    /// The estimated last height this node release supports before its end of support halt,
+    /// if end of support is enforced on `network`. Reported by the `getdeprecationinfo` RPC.
+    end_of_support_height: Option<Height>,
+
     // Services
     //
     /// A handle to the mempool service.
@@ -950,6 +976,7 @@ where
             user_agent,
             network: network.clone(),
             debug_force_finished_sync,
+            end_of_support_height: None,
             mempool: mempool.clone(),
             state: state.clone(),
             read_state: read_state.clone(),
@@ -973,6 +1000,14 @@ where
     /// Returns a reference to the configured network.
     pub fn network(&self) -> &Network {
         &self.network
+    }
+
+    /// Sets the estimated end of support height reported by the `getdeprecationinfo` RPC.
+    ///
+    /// When unset, or set to `None`, `getdeprecationinfo` omits the `end_of_service` object.
+    pub fn with_end_of_support_height(mut self, end_of_support_height: Option<Height>) -> Self {
+        self.end_of_support_height = end_of_support_height;
+        self
     }
 }
 
@@ -1037,6 +1072,44 @@ where
         };
 
         Ok(response)
+    }
+
+    async fn get_deprecation_info(&self) -> Result<GetDeprecationInfoResponse> {
+        let end_of_service = self
+            .end_of_support_height
+            // End of support is only enforced on Mainnet, and the zcashd-compatible response
+            // omits `end_of_service` on other networks, even if a height was configured.
+            .filter(|_| self.network == Network::Mainnet)
+            .map(|end_of_support_height| {
+                // Estimate the halt time from the current tip and target block spacing. If the
+                // tip is not available yet, fall back to the highest compiled-in checkpoint,
+                // which is close to the network tip at release time.
+                let tip_height = self
+                    .latest_chain_tip
+                    .best_tip_height()
+                    .unwrap_or_else(|| self.network.checkpoint_list().max_height());
+                // Use the spacing at the end of support height: it is always post-Blossom, so
+                // this stays correct even when the tip is missing or before Blossom.
+                let target_block_spacing =
+                    NetworkUpgrade::target_spacing_for_height(&self.network, end_of_support_height);
+                // If the tip is already past the end of support height, the estimate is in the
+                // past, but never negative.
+                let remaining_blocks = i64::from(end_of_support_height.0) - i64::from(tip_height.0);
+                let estimated_time = Utc::now()
+                    .timestamp()
+                    .saturating_add(
+                        remaining_blocks.saturating_mul(target_block_spacing.num_seconds()),
+                    )
+                    .saturating_sub(END_OF_SERVICE_ESTIMATE_SAFETY_MARGIN)
+                    .max(0);
+
+                EndOfService {
+                    block_height: end_of_support_height.0,
+                    estimated_time,
+                }
+            });
+
+        Ok(GetDeprecationInfoResponse { end_of_service })
     }
 
     #[allow(clippy::unwrap_in_result)]
@@ -3506,6 +3579,41 @@ impl GetInfoResponse {
 
         Some(version_number)
     }
+}
+
+/// The number of seconds subtracted from the `end_of_service.estimated_time` reported by
+/// `getdeprecationinfo`.
+///
+/// Block times vary, so the halt can happen earlier than a spacing-based estimate. Reporting the
+/// estimate a day early gives consumers time to act before the actual halt.
+const END_OF_SERVICE_ESTIMATE_SAFETY_MARGIN: i64 = 24 * 60 * 60;
+
+/// Response to a `getdeprecationinfo` RPC request.
+///
+/// See the notes for the [`Rpc::get_deprecation_info` method].
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, Getters, new)]
+pub struct GetDeprecationInfoResponse {
+    /// End of service information for this node release. Only present on Mainnet, where end of
+    /// support is enforced.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    end_of_service: Option<EndOfService>,
+}
+
+/// The `end_of_service` object in a [`GetDeprecationInfoResponse`].
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, Getters, new)]
+pub struct EndOfService {
+    /// The estimated last height this server version supports, matching zcashd's threshold
+    /// semantics. The node halts when the chain tip goes past this height.
+    #[getter(copy)]
+    block_height: u32,
+
+    /// The approximate time of the end of support halt, in seconds since epoch, estimated from
+    /// the current chain tip height and the target block spacing.
+    ///
+    /// Reported 24 hours earlier than the spacing-based estimate, so consumers are warned early
+    /// rather than late when block times vary.
+    #[getter(copy)]
+    estimated_time: i64,
 }
 
 /// Type alias for the array of `GetBlockchainInfoBalance` objects

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -116,6 +116,189 @@ async fn rpc_getinfo() {
     assert!(rpc_tx_queue_task_result.is_none());
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn rpc_getdeprecationinfo() {
+    let _init_guard = zebra_test::init();
+
+    let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, _rpc_tx_queue) = RpcImpl::new(
+        Mainnet,
+        Default::default(),
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool.clone(), 1),
+        Buffer::new(state.clone(), 1),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        MockSyncStatus::default(),
+        NoChainTip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    // Without a configured end of support height, `end_of_service` is not present.
+    let deprecation_info = rpc
+        .get_deprecation_info()
+        .await
+        .expect("getdeprecationinfo should succeed");
+    assert_eq!(deprecation_info.end_of_service, None);
+
+    let end_of_support_height = 3_546_440;
+    let rpc = rpc.with_end_of_support_height(Some(Height(end_of_support_height)));
+    let end_of_service = rpc
+        .get_deprecation_info()
+        .await
+        .expect("getdeprecationinfo should succeed")
+        .end_of_service
+        .expect("end_of_service should be present when an end of support height is set");
+
+    assert_eq!(end_of_service.block_height, end_of_support_height);
+    // This node has no tip, so the estimate counts the blocks remaining after the highest
+    // compiled-in checkpoint, not after genesis.
+    let checkpoint_height = Mainnet.checkpoint_list().max_height();
+    let remaining_blocks = i64::from(end_of_support_height - checkpoint_height.0);
+    let expected_offset = remaining_blocks * 75 - 24 * 60 * 60;
+    assert!(end_of_service.estimated_time > Utc::now().timestamp());
+    assert!(end_of_service.estimated_time <= Utc::now().timestamp() + expected_offset);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rpc_getdeprecationinfo_estimates_time_from_tip_with_safety_margin() {
+    let _init_guard = zebra_test::init();
+
+    let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+
+    let (latest_chain_tip, latest_chain_tip_sender) = MockChainTip::new();
+    let tip_height = Height(3_000_000);
+    latest_chain_tip_sender.send_best_tip_height(tip_height);
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, _rpc_tx_queue) = RpcImpl::new(
+        Mainnet,
+        Default::default(),
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool.clone(), 1),
+        Buffer::new(state.clone(), 1),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        MockSyncStatus::default(),
+        latest_chain_tip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    let end_of_support_height = Height(3_546_440);
+    let rpc = rpc.with_end_of_support_height(Some(end_of_support_height));
+
+    // Both heights are after Blossom, so every remaining block is expected to take 75 seconds,
+    // and the estimate is reported 24 hours early.
+    let remaining_blocks = i64::from(end_of_support_height.0 - tip_height.0);
+    let expected_offset = remaining_blocks * 75 - 24 * 60 * 60;
+
+    let before = Utc::now().timestamp();
+    let end_of_service = rpc
+        .get_deprecation_info()
+        .await
+        .expect("getdeprecationinfo should succeed")
+        .end_of_service
+        .expect("end_of_service should be present when an end of support height is set");
+    let after = Utc::now().timestamp();
+
+    assert_eq!(end_of_service.block_height, end_of_support_height.0);
+    assert!(end_of_service.estimated_time >= before + expected_offset);
+    assert!(end_of_service.estimated_time <= after + expected_offset);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rpc_getdeprecationinfo_omits_end_of_service_off_mainnet() {
+    let _init_guard = zebra_test::init();
+
+    let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, _rpc_tx_queue) = RpcImpl::new(
+        Network::new_default_testnet(),
+        Default::default(),
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool.clone(), 1),
+        Buffer::new(state.clone(), 1),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        MockSyncStatus::default(),
+        NoChainTip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    // Even if an end of support height is configured, `end_of_service` is only reported on
+    // Mainnet, matching zcashd and the RPC documentation.
+    let rpc = rpc.with_end_of_support_height(Some(Height(100)));
+    let deprecation_info = rpc
+        .get_deprecation_info()
+        .await
+        .expect("getdeprecationinfo should succeed");
+    assert_eq!(deprecation_info.end_of_service, None);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rpc_getdeprecationinfo_estimated_time_is_never_negative() {
+    let _init_guard = zebra_test::init();
+
+    let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+
+    // A tip so far past the end of support height that an unclamped estimate would be negative.
+    let (latest_chain_tip, latest_chain_tip_sender) = MockChainTip::new();
+    latest_chain_tip_sender.send_best_tip_height(Height::MAX);
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, _rpc_tx_queue) = RpcImpl::new(
+        Mainnet,
+        Default::default(),
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool.clone(), 1),
+        Buffer::new(state.clone(), 1),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        MockSyncStatus::default(),
+        latest_chain_tip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+    let rpc = rpc.with_end_of_support_height(Some(Height(1)));
+
+    let end_of_service = rpc
+        .get_deprecation_info()
+        .await
+        .expect("getdeprecationinfo should succeed")
+        .end_of_service
+        .expect("end_of_service should be present when an end of support height is set");
+
+    assert_eq!(end_of_service.block_height, 1);
+    // The estimate is clamped to zero instead of going negative.
+    assert_eq!(end_of_service.estimated_time, 0);
+}
+
 // Helper function that returns the nonce, final sapling root and
 // block commitments of a given Block.
 async fn get_block_data(

--- a/zebra-rpc/tests/serialization_tests.rs
+++ b/zebra-rpc/tests/serialization_tests.rs
@@ -23,14 +23,14 @@ use zebra_rpc::client::zebra_chain::{
     work::difficulty::{CompactDifficulty, ExpandedDifficulty},
 };
 use zebra_rpc::client::{
-    BlockHeaderObject, BlockObject, BlockTemplateResponse, Commitments, DefaultRoots,
+    BlockHeaderObject, BlockObject, BlockTemplateResponse, Commitments, DefaultRoots, EndOfService,
     FundingStream, GetAddressBalanceRequest, GetAddressBalanceResponse, GetAddressTxIdsRequest,
     GetAddressUtxosResponse, GetAddressUtxosResponseObject, GetBlockHashResponse,
     GetBlockHeaderResponse, GetBlockHeightAndHashResponse, GetBlockResponse,
     GetBlockSubsidyResponse, GetBlockTemplateParameters, GetBlockTemplateRequestMode,
     GetBlockTemplateResponse, GetBlockTransaction, GetBlockTrees, GetBlockchainInfoBalance,
-    GetBlockchainInfoResponse, GetInfoResponse, GetMiningInfoResponse, GetNetworkInfoResponse,
-    GetPeerInfoResponse, GetRawMempoolResponse, GetRawTransactionResponse,
+    GetBlockchainInfoResponse, GetDeprecationInfoResponse, GetInfoResponse, GetMiningInfoResponse,
+    GetNetworkInfoResponse, GetPeerInfoResponse, GetRawMempoolResponse, GetRawTransactionResponse,
     GetSubtreesByIndexResponse, GetTreestateResponse, Hash, Input, JoinSplit, MempoolObject,
     Orchard, OrchardAction, OrchardFlags, Output, ScriptPubKey, ScriptSig,
     SendRawTransactionResponse, ShieldedOutput, ShieldedSpend, SubmitBlockErrorResponse,
@@ -87,6 +87,43 @@ fn test_get_info() -> Result<(), Box<dyn std::error::Error>> {
         errors_timestamp,
     );
 
+    assert_eq!(obj, new_obj);
+
+    Ok(())
+}
+
+#[test]
+fn test_get_deprecation_info() -> Result<(), Box<dyn std::error::Error>> {
+    // On Mainnet, the response contains an `end_of_service` object.
+    let json = r#"
+{
+  "end_of_service": {
+    "block_height": 3546440,
+    "estimated_time": 1769900000
+  }
+}"#;
+    let obj: GetDeprecationInfoResponse = serde_json::from_str(json)?;
+
+    let end_of_service = obj
+        .end_of_service()
+        .clone()
+        .expect("end_of_service is present in the JSON");
+    let block_height = end_of_service.block_height();
+    let estimated_time = end_of_service.estimated_time();
+
+    assert_eq!(block_height, 3546440);
+    assert_eq!(estimated_time, 1769900000);
+
+    let new_obj =
+        GetDeprecationInfoResponse::new(Some(EndOfService::new(block_height, estimated_time)));
+    assert_eq!(obj, new_obj);
+
+    // On other networks, the `end_of_service` object is omitted entirely.
+    let obj: GetDeprecationInfoResponse = serde_json::from_str("{}")?;
+    assert_eq!(*obj.end_of_service(), None);
+    assert_eq!(serde_json::to_string(&obj)?, "{}");
+
+    let new_obj = GetDeprecationInfoResponse::new(None);
     assert_eq!(obj, new_obj);
 
     Ok(())

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -476,6 +476,9 @@ impl StartCmd {
             LAST_WARN_ERROR_LOG_SENDER.subscribe(),
             Some(submit_block_channel.sender()),
         );
+        let rpc_impl = rpc_impl.with_end_of_support_height(
+            sync::end_of_support::end_of_support_height(&config.network.network),
+        );
 
         let rpc_task_handle = if config.rpc.listen_addr.is_some() {
             RpcServer::start(rpc_impl.clone(), config.rpc.clone())

--- a/zebrad/src/components/sync/end_of_support.rs
+++ b/zebrad/src/components/sync/end_of_support.rs
@@ -7,13 +7,19 @@ use color_eyre::Report;
 use zebra_chain::{
     block::Height,
     chain_tip::ChainTip,
-    parameters::{Network, NetworkUpgrade},
+    parameters::{Network, POST_BLOSSOM_POW_TARGET_SPACING},
 };
 
 use crate::application::release_version;
 
 /// The estimated height that this release will be published.
 pub const ESTIMATED_RELEASE_HEIGHT: u32 = 3_425_000;
+
+/// The estimated number of blocks per day, with the post-Blossom 75-second target spacing.
+///
+/// All Zebra releases ship after Blossom, so this matches the spacing `check()` sees at any
+/// reachable tip height.
+pub const ESTIMATED_BLOCKS_PER_DAY: u32 = 24 * 60 * 60 / POST_BLOSSOM_POW_TARGET_SPACING;
 
 /// The maximum number of days after `ESTIMATED_RELEASE_HEIGHT` where a Zebra server will run
 /// without halting.
@@ -61,22 +67,30 @@ pub async fn start(
     }
 }
 
+/// Returns the estimated last supported height for this release, or `None` on networks where
+/// end of support is not enforced.
+///
+/// The node runs up to and including this height, and halts with an end of support panic when
+/// the tip goes past it. This matches zcashd, where `end_of_service.block_height` is also the
+/// threshold rather than the first halted block.
+pub fn end_of_support_height(network: &Network) -> Option<Height> {
+    if network != &Network::Mainnet {
+        return None;
+    }
+
+    Some(Height(
+        ESTIMATED_RELEASE_HEIGHT + (EOS_PANIC_AFTER * ESTIMATED_BLOCKS_PER_DAY),
+    ))
+}
+
 /// Check if the current release is too old and panic if so.
-pub fn check(tip_height: Height, network: &Network) {
+pub fn check(tip_height: Height, _network: &Network) {
     info!("Checking if Zebra release is inside support range ...");
 
-    // Get the current block spacing
-    let target_block_spacing = NetworkUpgrade::target_spacing_for_height(network, tip_height);
-
-    // Get the number of blocks per day
-    let estimated_blocks_per_day =
-        u32::try_from(chrono::Duration::days(1).num_seconds() / target_block_spacing.num_seconds())
-            .expect("number is always small enough to fit");
-
     let panic_height =
-        Height(ESTIMATED_RELEASE_HEIGHT + (EOS_PANIC_AFTER * estimated_blocks_per_day));
+        Height(ESTIMATED_RELEASE_HEIGHT + (EOS_PANIC_AFTER * ESTIMATED_BLOCKS_PER_DAY));
     let warn_height =
-        Height(ESTIMATED_RELEASE_HEIGHT + (EOS_WARN_AFTER * estimated_blocks_per_day));
+        Height(ESTIMATED_RELEASE_HEIGHT + (EOS_WARN_AFTER * ESTIMATED_BLOCKS_PER_DAY));
 
     if tip_height > panic_height {
         panic!(

--- a/zebrad/tests/unit/end_of_support.rs
+++ b/zebrad/tests/unit/end_of_support.rs
@@ -9,16 +9,13 @@ use zebra_chain::{
 };
 use zebra_test::{args, prelude::*};
 use zebrad::components::sync::end_of_support::{
-    self, EOS_PANIC_AFTER, EOS_WARN_AFTER, ESTIMATED_RELEASE_HEIGHT,
+    self, EOS_PANIC_AFTER, EOS_WARN_AFTER, ESTIMATED_BLOCKS_PER_DAY, ESTIMATED_RELEASE_HEIGHT,
 };
 
 use crate::common::{
     config::{default_test_config, testdir},
     launch::ZebradTestDirExt,
 };
-
-// Estimated blocks per day with the current 75 seconds block spacing.
-const ESTIMATED_BLOCKS_PER_DAY: u32 = 1152;
 
 /// Check that the end of support code is called at least once.
 #[test]
@@ -94,6 +91,26 @@ fn end_of_support_function() {
     ));
 
     // Panic is tested in `end_of_support_panic`
+}
+
+/// Test that the end of support height is reported on Mainnet and not on test networks.
+#[test]
+fn end_of_support_height_per_network() {
+    // The reported height is the last supported height: `check()` runs at it without panicking
+    // and halts one block after it (covered by `end_of_support_panic`).
+    let last_supported_height =
+        Height(ESTIMATED_RELEASE_HEIGHT + (EOS_PANIC_AFTER * ESTIMATED_BLOCKS_PER_DAY));
+    assert_eq!(
+        end_of_support::end_of_support_height(&Network::Mainnet),
+        Some(last_supported_height)
+    );
+    end_of_support::check(last_supported_height, &Network::Mainnet);
+
+    // End of support is not enforced on test networks, so no height is reported.
+    assert_eq!(
+        end_of_support::end_of_support_height(&Network::new_default_testnet()),
+        None
+    );
 }
 
 /// Test that we are never in end of support warning or panic.


### PR DESCRIPTION
## Motivation

Teams running blockchain nodes are often surprised to see Zebra stop running at its end of support height, a very unusual feature across blockchains. Currently there is no way to point observability tools at Zebra to receive automated alerts when the height is near.

## Solution

This PR ports the relevant end_of_support structure over from the zcashd `getdeprecationinfo` RPC.

The only major divergence from zcashd is that it includes a safety margin of 24 hours in its estimate to alert teams early, given that it is an estimate and real-world block times are variable.

For discussion: 
- This would also be useful to have on the health endpoints for unauthenticated access, happy to add that if requested.
- I would personally also switch ready to false 24 hours early to give teams a loud awakening, but that might be too loud.

### Tests

The new RPC feature has test coverage.

### Specifications & References

- https://zcash.github.io/rpc/getdeprecationinfo.html
- zcashd's src/rpc/net.cpp, line 429

### Follow-up Work

None.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [X] AI tools were used: Norm Code (pre-release)

### PR Checklist

- [X] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [X] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [X] This change was discussed in an issue or with the team beforehand.
- [X] The solution is tested.
- [X] The documentation and changelogs are up to date.