### PR TITLE
test(ci): serialize live Mainnet tests to prevent peer contention

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -25,6 +25,10 @@ filter = 'test(=integration::network::disconnects_from_misbehaving_peers)'
 retries = 2
 slow-timeout = { period = "5m", terminate-after = 2 }
 
+[[profile.ci.overrides]]
+filter = 'test(/^integration::sync::/)'
+test-group = 'serial-live-mainnet'
+
 # These tests sync mainnet to genesis from live peers; they normally finish in
 # ~10-30s, but a slow/unreachable peer can stall them. Fail fast after 10m and
 # retry instead of hanging near the old 30m hard limit, where they flaked.
@@ -52,10 +56,20 @@ slow-timeout = { period = "30m", terminate-after = 2 }
 
 [test-groups]
 serial-state = { max-threads = 1 }
+# Live Mainnet tests compete for the same limited set of usable peers when they
+# connect concurrently from one public IP.
+serial-live-mainnet = { max-threads = 1 }
 # zcashd-compat integration tests each spawn a zebrad + zcashd on
 # bind-probed-then-released ports, so they must never run concurrently, even
 # under a parallel profile invoked with --run-ignored=all.
 serial-zcashd-compat = { max-threads = 1 }
+
+# Force tests that start fresh live Mainnet nodes to run serially in local
+# parallel test runs. The CI overrides above assign the same test group while
+# preserving their profile-specific retries and timeouts.
+[[profile.default.overrides]]
+filter = 'test(/^integration::sync::/)'
+test-group = 'serial-live-mainnet'
 
 # Force zcashd-compat integration tests serial in every profile, so a parallel
 # --run-ignored=all run cannot collide on their released RPC/P2P ports.

--- a/zebrad/tests/integration/sync.rs
+++ b/zebrad/tests/integration/sync.rs
@@ -1,15 +1,80 @@
+use std::{
+    path::Path,
+    time::{Duration, Instant},
+};
+
 use color_eyre::eyre::Result;
 
 use zebra_chain::{
     block,
     parameters::Network::{self, *},
 };
-use zebra_test::prelude::*;
+use zebra_test::{args, prelude::*};
 
-use crate::common::sync::{
-    sync_until, MempoolBehavior, STOP_AT_HEIGHT_REGEX, STOP_ON_LOAD_TIMEOUT,
-    TINY_CHECKPOINT_TEST_HEIGHT, TINY_CHECKPOINT_TIMEOUT,
+use crate::common::{
+    config::{persistent_test_config, testdir},
+    launch::ZebradTestDirExt,
+    sync::{
+        sync_until, MempoolBehavior, STOP_AT_HEIGHT_REGEX, STOP_ON_LOAD_TIMEOUT,
+        TINY_CHECKPOINT_TEST_HEIGHT, TINY_CHECKPOINT_TIMEOUT,
+    },
 };
+
+/// The maximum time to wait for the persistent state and network caches to be created.
+///
+/// The peer cache is only written once the node has cacheable peers, and the peer cache updater
+/// retries every 20 seconds until its first write, so this needs to cover several attempts on a
+/// slow network.
+const PERSISTENT_CACHE_CREATION_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// Check that the block state and peer list caches are written to disk.
+#[test]
+fn persistent_mode() -> Result<()> {
+    let _init_guard = zebra_test::init();
+
+    let testdir = testdir()?.with_config(&mut persistent_test_config(&Mainnet)?)?;
+    let testdir = &testdir;
+
+    let mut child = testdir.spawn_child(args!["-v", "start"])?;
+
+    // Wait for both caches to be created and populated, polling instead of sleeping for a
+    // fixed time: the peer cache write depends on finding live peers, which can take several
+    // attempts on a slow network (#11072).
+    let state_dir = testdir.path().join("state");
+    let network_dir = testdir.path().join("network");
+    let deadline = Instant::now() + PERSISTENT_CACHE_CREATION_TIMEOUT;
+    while Instant::now() < deadline
+        && !(dir_is_populated(&state_dir) && dir_is_populated(&network_dir))
+    {
+        std::thread::sleep(Duration::from_secs(1));
+    }
+
+    // Kill the node and make sure it was killed
+    child.kill(false)?;
+    let output = child.wait_with_output()?;
+    output.assert_was_killed()?;
+
+    assert_with_context!(
+        dir_is_populated(&state_dir),
+        &output,
+        "state directory missing or empty despite persistent state config"
+    );
+    assert_with_context!(
+        dir_is_populated(&network_dir),
+        &output,
+        "network directory missing or empty despite persistent network config"
+    );
+
+    Ok(())
+}
+
+/// Returns `true` if `dir` exists and contains at least one entry.
+fn dir_is_populated(dir: &Path) -> bool {
+    matches!(
+        dir.read_dir().map(|mut entries| entries.next().is_some()),
+        Ok(true)
+    )
+}
 
 /// Test if `zebrad` can sync the first checkpoint on mainnet.
 ///

--- a/zebrad/tests/unit/config.rs
+++ b/zebrad/tests/unit/config.rs
@@ -1,10 +1,5 @@
 use std::{
-    collections::HashSet,
-    env, fs,
-    io::Write as _,
-    path::{Path, PathBuf},
-    sync::Mutex,
-    time::{Duration, Instant},
+    collections::HashSet, env, fs, io::Write as _, path::PathBuf, sync::Mutex, time::Duration,
 };
 
 use color_eyre::eyre::{eyre, Result, WrapErr};
@@ -26,62 +21,6 @@ use crate::common::{
 };
 use zebra_node_services::rpc_client::RpcRequestClient;
 use zebra_rpc::server::OPENED_RPC_ENDPOINT_MSG;
-
-/// The maximum time to wait for the persistent state and network caches to be created.
-///
-/// The peer cache is only written once the node has cacheable peers, and the peer cache updater
-/// retries every 20 seconds until its first write, so this needs to cover several attempts on a
-/// slow network.
-const PERSISTENT_CACHE_CREATION_TIMEOUT: Duration = Duration::from_secs(90);
-
-/// Check that the block state and peer list caches are written to disk.
-#[test]
-fn persistent_mode() -> Result<()> {
-    let _init_guard = zebra_test::init();
-
-    let testdir = testdir()?.with_config(&mut persistent_test_config(&Mainnet)?)?;
-    let testdir = &testdir;
-
-    let mut child = testdir.spawn_child(args!["-v", "start"])?;
-
-    // Wait for both caches to be created and populated, polling instead of sleeping for a
-    // fixed time: the peer cache write depends on finding live peers, which can take several
-    // attempts on a slow network (#11072).
-    let state_dir = testdir.path().join("state");
-    let network_dir = testdir.path().join("network");
-    let deadline = Instant::now() + PERSISTENT_CACHE_CREATION_TIMEOUT;
-    while Instant::now() < deadline
-        && !(dir_is_populated(&state_dir) && dir_is_populated(&network_dir))
-    {
-        std::thread::sleep(Duration::from_secs(1));
-    }
-
-    // Kill the node and make sure it was killed
-    child.kill(false)?;
-    let output = child.wait_with_output()?;
-    output.assert_was_killed()?;
-
-    assert_with_context!(
-        dir_is_populated(&state_dir),
-        &output,
-        "state directory missing or empty despite persistent state config"
-    );
-    assert_with_context!(
-        dir_is_populated(&network_dir),
-        &output,
-        "network directory missing or empty despite persistent network config"
-    );
-
-    Ok(())
-}
-
-/// Returns `true` if `dir` exists and contains at least one entry.
-fn dir_is_populated(dir: &Path) -> bool {
-    matches!(
-        dir.read_dir().map(|mut entries| entries.next().is_some()),
-        Ok(true)
-    )
-}
 
 #[test]
 fn ephemeral_existing_directory() -> Result<()> {


### PR DESCRIPTION
## Motivation

The integration tests that start fresh nodes and connect to live Mainnet peers can run concurrently under nextest. Because they connect from the same public IP and select peers from the same DNS seeder results, they compete for the limited set of currently usable Mainnet peers.

This caused `persistent_mode` to fail consistently in CI while the Mainnet sync tests stalled until their retries. A local A/B reproduction confirmed the interaction: `persistent_mode` passed alone in 30 seconds, failed after 91 seconds when run concurrently with the two Mainnet sync tests, and all three tests passed when run serially.

Closes #11098

## Solution

Move `persistent_mode` from `unit::config` to `integration::sync`, since it starts a real Mainnet node and depends on live peers.

Add a `serial-live-mainnet` nextest test group with a single execution thread, and assign `integration::sync::*` to it in the default and CI profiles. This keeps the tests serial relative to each other without reducing parallelism for the rest of the suite.

Keep the existing CI retries and timeouts scoped to `sync_one_checkpoint_mainnet` and `restart_stop_at_height`. `persistent_mode` only receives the serialization group because it already polls for its caches for up to 90 seconds.

### Tests

- Parallel/serial A/B reproduction before the fix:
  - `persistent_mode` alone passed in 30.0 seconds.
  - In a parallel three-test run, `sync_one_checkpoint_mainnet` passed in 15.7 seconds, `persistent_mode` failed after 91.3 seconds, and `restart_stop_at_height` remained stalled after 224.8 seconds.
  - With the identical selector and `--test-threads=1`, all three passed in 71.7 seconds.
- A CI-profile run using the new test group passed all three tests sequentially.
- `cargo nextest show-config test-groups` confirms all three `integration::sync` tests are assigned to `serial-live-mainnet` with `max-threads = 1` in both the default and CI profiles.
- `cargo fmt --all -- --check`
- `git diff --check`

### Specifications & References

- #11061 documents the reduced availability of usable Mainnet peers.
- #11072 documents the earlier `persistent_mode` peer-cache timing failure.

### Follow-up Work

None.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: OpenAI Codex was used to investigate the CI failure, run the parallel and serial reproductions, implement and validate the nextest configuration, move the test, and draft the PR description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.