### PR TITLE
refactor(release): expose immutable image identity

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -33,6 +33,7 @@ jobs:
       attestations: write
     uses: ./.github/workflows/zfnd-build-docker-image.yml
     with:
+      source_sha: ${{ github.sha }}
       dockerfile_path: ./docker/Dockerfile
       dockerfile_target: runtime
       image_name: zebra

--- a/.github/workflows/zfnd-build-docker-image.yml
+++ b/.github/workflows/zfnd-build-docker-image.yml
@@ -296,7 +296,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
-          name: digests-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          name: digests-${{ inputs.image_name }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -323,7 +323,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
         with:
           path: /tmp/digests
-          pattern: digests-*
+          pattern: digests-${{ inputs.image_name }}-*
           merge-multiple: true
 
       # Docker meta for tag generation

--- a/.github/workflows/zfnd-build-docker-image.yml
+++ b/.github/workflows/zfnd-build-docker-image.yml
@@ -10,6 +10,10 @@ name: Build docker image
 on:
   workflow_call:
     inputs:
+      source_sha:
+        description: The immutable commit to build
+        required: true
+        type: string
       image_name:
         required: true
         type: string
@@ -20,7 +24,7 @@ on:
         required: true
         type: string
       short_sha:
-        description: "Git short SHA to embed in the build. Defaults to GITHUB_SHA_SHORT. Pass empty string to disable."
+        description: "Git short SHA to embed in the build. Defaults to the short source_sha. Pass empty string to disable."
         required: false
         type: string
         default: auto
@@ -60,6 +64,9 @@ on:
         required: false
 
     outputs:
+      image:
+        description: The immutable Google Artifact Registry image reference
+        value: ${{ jobs.merge.outputs.image }}
       image_digest:
         description: The image digest to be used on a caller workflow
         value: ${{ jobs.merge.outputs.image_digest }}
@@ -106,15 +113,16 @@ jobs:
     steps:
       - name: Set build matrix
         id: set-matrix
+        env:
+          AMD64_RUNNER: ${{ vars.DOCKER_BUILD_RUNNER_AMD64 || 'ubuntu-latest' }}
+          ARM64_RUNNER: ${{ vars.DOCKER_BUILD_RUNNER_ARM64 || 'ubuntu-24.04-arm' }}
+          DOCKERFILE_TARGET: ${{ inputs.dockerfile_target }}
         run: |
           # Runners are configurable via repository variables to allow larger runners
           # for ZcashFoundation (more disk space) while forks use default runners.
-          AMD64_RUNNER="${{ vars.DOCKER_BUILD_RUNNER_AMD64 || 'ubuntu-latest' }}"
-          ARM64_RUNNER="${{ vars.DOCKER_BUILD_RUNNER_ARM64 || 'ubuntu-24.04-arm' }}"
-
           # Runtime builds: AMD64 + ARM64 (multi-arch)
           # Other targets: AMD64 only (lightwalletd dependency)
-          if [[ "${{ inputs.dockerfile_target }}" == "runtime" ]]; then
+          if [[ "$DOCKERFILE_TARGET" == "runtime" ]]; then
             MATRIX='{"include":[{"platform":"linux/amd64","runner":"'"$AMD64_RUNNER"'"},{"platform":"linux/arm64","runner":"'"$ARM64_RUNNER"'"}]}'
           else
             MATRIX='{"include":[{"platform":"linux/amd64","runner":"'"$AMD64_RUNNER"'"}]}'
@@ -145,15 +153,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: false
+          ref: ${{ inputs.source_sha }}
 
-      - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@e6f261660910b273384c5c42b17a0217881b217a #v5.6.0
-        with:
-          short-length: 7
-
-      # Pin image timestamps to the commit time for reproducible builds
-      - name: Set SOURCE_DATE_EPOCH from the commit
-        run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
+      - name: Set source metadata
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          echo "SOURCE_SHA_SHORT=${SOURCE_SHA:0:7}" >> "$GITHUB_ENV"
+          echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
 
       # Automatic tag management and OCI Image Format Specification for labels
       - name: Docker meta
@@ -169,6 +176,8 @@ jobs:
           images: |
             us-docker.pkg.dev/${{ vars.GCP_PROJECT }}/zebra/${{ inputs.image_name }}
             zfnd/${{ inputs.image_name }},enable=${{ inputs.publish_to_dockerhub && github.event_name == 'release' && !github.event.release.prerelease }}
+          labels: |
+            org.opencontainers.image.revision=${{ inputs.source_sha }}
           # generate Docker tags based on the following events/attributes
           tags: |
             # These DockerHub release tags support the following use cases:
@@ -238,7 +247,7 @@ jobs:
           file: ${{ inputs.dockerfile_path }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            SHORT_SHA=${{ inputs.short_sha == 'auto' && env.GITHUB_SHA_SHORT || inputs.short_sha }}
+            SHORT_SHA=${{ inputs.short_sha == 'auto' && env.SOURCE_SHA_SHORT || inputs.short_sha }}
             RUST_LOG=${{ env.RUST_LOG }}
             CARGO_INCREMENTAL=${{ env.CARGO_INCREMENTAL }}
             FEATURES=${{ env.FEATURES }}
@@ -265,7 +274,7 @@ jobs:
           file: ${{ inputs.dockerfile_path }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            SHORT_SHA=${{ inputs.short_sha == 'auto' && env.GITHUB_SHA_SHORT || inputs.short_sha }}
+            SHORT_SHA=${{ inputs.short_sha == 'auto' && env.SOURCE_SHA_SHORT || inputs.short_sha }}
             RUST_LOG=${{ env.RUST_LOG }}
             CARGO_INCREMENTAL=${{ env.CARGO_INCREMENTAL }}
             FEATURES=${{ env.FEATURES }}
@@ -277,10 +286,11 @@ jobs:
 
       # Export digest for multi-arch manifest merge
       - name: Export digest
+        env:
+          IMAGE_DIGEST: ${{ steps.docker_build.outputs.digest || steps.docker_build_no_attestations.outputs.digest }}
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.docker_build.outputs.digest || steps.docker_build_no_attestations.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
+          touch "/tmp/digests/${IMAGE_DIGEST#sha256:}"
 
       # Upload digest as artifact for merge job
       - name: Upload digest
@@ -305,17 +315,9 @@ jobs:
       pull-requests: write
       attestations: write
     outputs:
+      image: ${{ steps.create.outputs.image }}
       image_digest: ${{ steps.create.outputs.digest }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@e6f261660910b273384c5c42b17a0217881b217a #v5.6.0
-        with:
-          short-length: 7
-
       # Download all platform digests
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
@@ -372,17 +374,23 @@ jobs:
         id: create
         working-directory: /tmp/digests
         run: |
-          # The -t flags and the per-arch image refs expand to separate args.
+          image_sources=()
+          for digest in *; do
+            image_sources+=("${IMAGE_REPOSITORY}@sha256:${digest}")
+          done
+
+          # The -t flags expand to separate args.
           # shellcheck disable=SC2046
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf 'us-docker.pkg.dev/${{ vars.GCP_PROJECT }}/zebra/${{ inputs.image_name }}@sha256:%s ' *)
+            --metadata-file /tmp/manifest-metadata.json \
+            "${image_sources[@]}"
 
-          # Get digest of the merged manifest
-          docker buildx imagetools inspect us-docker.pkg.dev/${{ vars.GCP_PROJECT }}/zebra/${{ inputs.image_name }}:${{ steps.meta.outputs.version }} \
-            --format '{{json .Manifest}}' | jq -r '.digest' | tee /tmp/digest.txt
-          echo "digest=$(cat /tmp/digest.txt)" >> "$GITHUB_OUTPUT"
+          digest=$(jq -er '."containerimage.descriptor".digest' /tmp/manifest-metadata.json)
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "image=${IMAGE_REPOSITORY}@${digest}" >> "$GITHUB_OUTPUT"
         env:
           DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
+          IMAGE_REPOSITORY: us-docker.pkg.dev/${{ vars.GCP_PROJECT }}/zebra/${{ inputs.image_name }}
 
       # Sign + attest the released image
       - name: Attest build provenance

--- a/.github/workflows/zfnd-ci-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-ci-integration-tests-gcp.yml
@@ -135,6 +135,7 @@ jobs:
       attestations: write # required by the called build workflow's merge job
     uses: ./.github/workflows/zfnd-build-docker-image.yml
     with:
+      source_sha: ${{ github.sha }}
       dockerfile_path: ./docker/Dockerfile
       dockerfile_target: tests
       image_name: ${{ vars.CI_IMAGE_NAME }}

--- a/.github/workflows/zfnd-deploy-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-nodes-gcp.yml
@@ -274,6 +274,7 @@ jobs:
         (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v'))
       }}
     with:
+      source_sha: ${{ github.sha }}
       dockerfile_path: ./docker/Dockerfile
       dockerfile_target: runtime
       image_name: zebrad


### PR DESCRIPTION
## Motivation

The image build workflow exposes only a digest, leaving each consumer to reconstruct a registry reference and making it harder for later release jobs to pass one exact published image to deployment. The build also relies on the caller context implicitly instead of accepting the immutable source commit as part of its contract.

Part of #11092.

## Solution

Make the existing reusable image workflow own immutable image identity:

- Require `source_sha` and use it for checkout, the embedded short commit, reproducible timestamps, and the OCI revision label.
- Return the exact Google Artifact Registry `repository@digest` reference created by the manifest operation.
- Read the digest from Buildx's `--metadata-file` output instead of resolving it through a mutable tag.
- Namespace temporary platform-digest artifacts by the existing image name so independent image calls can run in the same workflow.
- Preserve the existing tags, public and GCP image names, feature sets, build matrix, publication behavior, and digest output.

All existing callers now pass their current `${{ github.sha }}` source explicitly. This PR adds no alternate build path or lifecycle mode.

### Tests

- `actionlint` passed for all four changed workflows.
- `zizmor` passed for the reusable image workflow with no findings.
- `git diff --check` passed.
- Existing caller feature sets were compared against `main` and are unchanged.
- The two unrelated existing `zizmor` findings in the GCP deployment workflow remain unchanged.
- The hosted [Deploy Nodes to GCP run](https://github.com/ZcashFoundation/zebra/actions/runs/30298881631) successfully built both architectures, pushed their digests, and created the multi-architecture manifest using the new metadata output.
- Targeted `actionlint` passed after namespacing concurrent image artifacts.

### Specifications & References

- [Docker Buildx `imagetools create --metadata-file`](https://docs.docker.com/reference/cli/docker/buildx/imagetools/create/#write-create-result-metadata-to-a-file---metadata-file)

### Follow-up Work

A stacked PR will consume the immutable image output so GCP deployment uses the release image built by the publication path instead of rebuilding it.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: OpenAI Codex implemented and reviewed the workflow changes.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
