### PR TITLE
refactor(release): separate binary preparation and attachment

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -31,6 +31,8 @@ graph TB
   %% Reusable build
   subgraph Build
     BuildDocker[zfnd-build-docker-image.yml]
+    PrepareBinaries[zfnd-release-binaries.yml]
+    AttachBinaries[zfnd-attach-release-binaries.yml]
   end
 
   %% Release automation
@@ -69,6 +71,8 @@ graph TB
   Manual --> IT & DeployNodes & Cleanup
 
   %% Build dependency
+  ReleaseBinaries --> BuildDocker & PrepareBinaries
+  PrepareBinaries --> AttachBinaries
   BuildDocker --> IT
   IT --> FindDisks --> Deploy
 
@@ -76,7 +80,7 @@ graph TB
   classDef primary fill:#2374ab,stroke:#2374ab,color:white
   classDef secondary fill:#48a9a6,stroke:#48a9a6,color:white
   classDef trigger fill:#95a5a6,stroke:#95a5a6,color:white
-  class BuildDocker primary
+  class BuildDocker,PrepareBinaries,AttachBinaries primary
   class ReleaseWorkflow,ReleaseBinaries primary
   class Unit,Lint,Coverage,DockerCfg,CrateBuild,PRGate,Docs,Security secondary
   class IT,FindDisks,Deploy,DeployNodes,Cleanup secondary
@@ -160,12 +164,14 @@ _The diagram above illustrates the parallel execution patterns in our CI/CD syst
 - **Docs (Book + internal)** (`book.yml`): Builds mdBook and internal rustdoc, publishes to Pages
 - **Security Analysis** (`zizmor.yml`): GitHub Actions security lint (SARIF)
 - **Release** (`release.yml`): Creates or updates Release PRs with release-plz, then uses `ZcashFoundation/cargo-release` and native Cargo to reconcile crates, tags, and one `zebrad` GitHub Release. See the [release process](../../book/src/dev/release-process.md#release-candidate--release-process) for operational instructions.
-- **Release Binaries** (`release-binaries.yml`): Build and publish release artifacts
+- **Release Binaries** (`release-binaries.yml`): Orchestrates release images and prepares and attaches downloadable binaries
 - **Integration Tests on GCP** (`zfnd-ci-integration-tests-gcp.yml`): Stateful tests, E2E tests, cached disks, lwd flows
 
 ### Supporting/Re-usable Workflows
 
 - **Build docker image** (`zfnd-build-docker-image.yml`): Reusable image build with caching and tagging
+- **Prepare release binaries** (`zfnd-release-binaries.yml`): Builds, attests, checksums, signs, and uploads the immutable binary bundle
+- **Attach release binaries** (`zfnd-attach-release-binaries.yml`): Attaches the prepared binary bundle to an existing GitHub Release
 - **Find cached disks** (`zfnd-find-cached-disks.yml`): Discovers GCP disks for stateful tests
 - **Deploy integration tests** (`zfnd-deploy-integration-tests-gcp.yml`): Orchestrates GCP VMs and test runs
 - **Deploy nodes** (`zfnd-deploy-nodes-gcp.yml`): Provision long-lived nodes

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -164,7 +164,7 @@ _The diagram above illustrates the parallel execution patterns in our CI/CD syst
 - **Docs (Book + internal)** (`book.yml`): Builds mdBook and internal rustdoc, publishes to Pages
 - **Security Analysis** (`zizmor.yml`): GitHub Actions security lint (SARIF)
 - **Release** (`release.yml`): Creates or updates Release PRs with release-plz, then uses `ZcashFoundation/cargo-release` and native Cargo to reconcile crates, tags, and one `zebrad` GitHub Release. See the [release process](../../book/src/dev/release-process.md#release-candidate--release-process) for operational instructions.
-- **Release Binaries** (`release-binaries.yml`): Orchestrates release images and prepares and attaches downloadable binaries
+- **Release Binaries** (`release-binaries.yml`): Orchestrates release images, prepares and attaches downloadable binaries, and supports manual preparation validation without release attachment
 - **Integration Tests on GCP** (`zfnd-ci-integration-tests-gcp.yml`): Stateful tests, E2E tests, cached disks, lwd flows
 
 ### Supporting/Re-usable Workflows

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -7,12 +7,14 @@
 # This workflow is triggered if:
 # - A release is published
 # - A pre-release is changed to a release
+# - A maintainer manually validates binary preparation before a release
 name: Release binaries
 
 on:
   release:
     types:
       - released
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -65,7 +67,7 @@ jobs:
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          echo "version=${RELEASE_TAG#v}" >> "${GITHUB_OUTPUT}"
+          printf 'version=%s\n' "${RELEASE_TAG#v}" >> "${GITHUB_OUTPUT}"
 
   prepare-binaries:
     name: Prepare release binaries
@@ -76,8 +78,19 @@ jobs:
       attestations: write # store binary provenance
     uses: ./.github/workflows/zfnd-release-binaries.yml
     with:
-      source_sha: ${{ github.sha }}
       version: ${{ needs.binary-version.outputs.version }}
+      features: default-release-binaries
+
+  validate-binaries:
+    name: Validate release binary preparation
+    if: github.event_name == 'workflow_dispatch' && github.repository_owner == 'ZcashFoundation'
+    permissions:
+      contents: read
+      id-token: write # authenticate test provenance and signatures
+      attestations: write # store test provenance
+    uses: ./.github/workflows/zfnd-release-binaries.yml
+    with:
+      version: 0.0.0-test
       features: default-release-binaries
 
   attach-binaries:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -121,6 +121,8 @@ jobs:
       }}
     needs:
       - build
+      - binary-version
+      - prepare-binaries
       - attach-binaries
     timeout-minutes: 1
     steps:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -51,15 +51,41 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  # Build and attach downloadable zebrad binaries to the GitHub release.
-  binaries:
-    name: Attach release binaries
+  # Resolve the release tag into the version used in binary asset names.
+  binary-version:
+    name: Resolve release binary version
     if: github.repository_owner == 'ZcashFoundation' && startsWith(github.event.release.tag_name, 'v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - name: Resolve release inputs
+        id: release
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          echo "version=${RELEASE_TAG#v}" >> "${GITHUB_OUTPUT}"
+
+  prepare-binaries:
+    name: Prepare release binaries
+    needs: binary-version
     permissions:
-      contents: write
-      id-token: write
-      attestations: write
+      contents: read
+      id-token: write # authenticate binary provenance and signatures
+      attestations: write # store binary provenance
     uses: ./.github/workflows/zfnd-release-binaries.yml
+    with:
+      source_sha: ${{ github.sha }}
+      version: ${{ needs.binary-version.outputs.version }}
+      features: default-release-binaries
+
+  attach-binaries:
+    name: Attach release binaries
+    needs: prepare-binaries
+    permissions:
+      contents: write # attach assets to the existing release
+    uses: ./.github/workflows/zfnd-attach-release-binaries.yml
     with:
       release_tag: ${{ github.event.release.tag_name }}
 
@@ -95,7 +121,7 @@ jobs:
       }}
     needs:
       - build
-      - binaries
+      - attach-binaries
     timeout-minutes: 1
     steps:
       - name: Decide whether the needed jobs succeeded or failed
@@ -106,7 +132,7 @@ jobs:
   failure-issue:
     name: Open or update issues for release binaries failures
     # When a new job is added to this workflow, add it to this list.
-    needs: [ build, binaries ]
+    needs: [ build, binary-version, prepare-binaries, attach-binaries ]
     # Open tickets for any failed build in this workflow.
     if: failure() || cancelled()
     runs-on: ubuntu-latest

--- a/.github/workflows/zfnd-attach-release-binaries.yml
+++ b/.github/workflows/zfnd-attach-release-binaries.yml
@@ -1,0 +1,38 @@
+# Attaches a prepared `release-binaries` workflow artifact to an existing
+# GitHub release. Binary construction and signing belong to
+# `zfnd-release-binaries.yml`.
+name: Attach release binaries (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: "Existing GitHub release tag that receives the binaries"
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  attach:
+    name: Attach release binaries
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write # attach assets to the existing release
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      REPOSITORY: ${{ github.repository }}
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
+        with:
+          name: release-binaries
+          path: dist
+
+      - name: Upload binaries to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${RELEASE_TAG}" \
+            dist/*.tar.gz dist/*.sha256 dist/SHA256SUMS dist/SHA256SUMS.sigstore.json \
+            --repo "${REPOSITORY}" --clobber

--- a/.github/workflows/zfnd-attach-release-binaries.yml
+++ b/.github/workflows/zfnd-attach-release-binaries.yml
@@ -16,6 +16,14 @@ permissions: {}
 jobs:
   attach:
     name: Attach release binaries
+    if: >-
+      ${{
+        github.repository == 'ZcashFoundation/zebra' &&
+        github.event_name == 'release' &&
+        github.event.action == 'released' &&
+        startsWith(inputs.release_tag, 'v') &&
+        inputs.release_tag == github.event.release.tag_name
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/zfnd-release-binaries.yml
+++ b/.github/workflows/zfnd-release-binaries.yml
@@ -54,6 +54,17 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.source_sha }}
 
+      # GitHub's provenance predicate records the caller's GITHUB_SHA.
+      # Keep that claim identical to the source this job actually builds.
+      - name: Bind source to provenance
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          if [[ "${SOURCE_SHA}" != "${GITHUB_SHA}" ]]; then
+            echo "::error::source_sha must match the caller commit recorded in build provenance"
+            exit 1
+          fi
+
       - name: Install build dependencies
         run: |
           sudo sed -i 's|http://ports.ubuntu.com/ubuntu-ports|https://ports.ubuntu.com/ubuntu-ports|g' /etc/apt/sources.list

--- a/.github/workflows/zfnd-release-binaries.yml
+++ b/.github/workflows/zfnd-release-binaries.yml
@@ -70,6 +70,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          if [ -z "${VERSION}" ]; then
+            echo "::error::version must not be empty"
+            exit 1
+          fi
+
           SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)"
           export SOURCE_DATE_EPOCH
           # Keep build-host paths out of the binary.

--- a/.github/workflows/zfnd-release-binaries.yml
+++ b/.github/workflows/zfnd-release-binaries.yml
@@ -132,7 +132,7 @@ jobs:
           jq -n \
             --arg event_name "${EVENT_NAME}" \
             --arg invocation_id "${SERVER_URL}/${REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}" \
-            --arg job_workflow_ref "${WORKFLOW_REF}" \
+            --arg job_workflow_ref "${REPOSITORY}/.github/workflows/zfnd-release-binaries.yml@${REF}" \
             --arg ref "${REF}" \
             --arg repository "${REPOSITORY}" \
             --arg repository_id "${REPOSITORY_ID}" \

--- a/.github/workflows/zfnd-release-binaries.yml
+++ b/.github/workflows/zfnd-release-binaries.yml
@@ -1,31 +1,26 @@
-# Builds the zebrad binary for Linux and packages it into signed, checksummed
-# `.tar.gz` archives. Reused by the release path and by the validation harness.
+# Builds zebrad for Linux and packages it into signed, checksummed `.tar.gz`
+# archives. The completed bundle is uploaded as the `release-binaries`
+# workflow artifact for a separate attachment job to consume.
 #
 # Binaries are built on Ubuntu 22.04 for a low glibc floor, with RocksDB and the
 # zcash FFI linked statically, so they run on most current distributions.
-#
-# With `release_tag`, the archives are uploaded to that GitHub release; without
-# it, they are uploaded as a CI artifact for inspection.
-name: Release binaries (reusable)
+name: Prepare release binaries (reusable)
 
 on:
   workflow_call:
     inputs:
-      release_tag:
-        description: "Release tag to upload assets to; empty uploads a CI artifact instead"
-        required: false
+      source_sha:
+        description: "Immutable source commit to build"
+        required: true
         type: string
-        default: ""
       version:
-        description: "Version used in asset filenames; defaults to release_tag without its `v`"
-        required: false
+        description: "Version used in asset filenames"
+        required: true
         type: string
-        default: ""
       features:
         description: "Cargo features to build zebrad with"
-        required: false
+        required: true
         type: string
-        default: "default-release-binaries"
 
 permissions: {}
 
@@ -47,17 +42,17 @@ jobs:
     # ubuntu-22.04-arm), not the downstream publisher's runner.
     permissions:
       contents: read
-      id-token: write
-      attestations: write
+      id-token: write # authenticate build provenance
+      attestations: write # store build provenance
     env:
       TARGET: ${{ matrix.target }}
-      RELEASE_TAG: ${{ inputs.release_tag }}
-      VERSION_INPUT: ${{ inputs.version }}
+      VERSION: ${{ inputs.version }}
       FEATURES: ${{ inputs.features }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: false
+          ref: ${{ inputs.source_sha }}
 
       - name: Install build dependencies
         run: |
@@ -74,9 +69,6 @@ jobs:
       - name: Build and package zebrad
         run: |
           set -euo pipefail
-          version="${VERSION_INPUT}"
-          if [ -z "${version}" ]; then version="${RELEASE_TAG#v}"; fi
-          if [ -z "${version}" ]; then echo "::error::no version or release_tag provided"; exit 1; fi
 
           SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)"
           export SOURCE_DATE_EPOCH
@@ -103,7 +95,7 @@ jobs:
             exit 1
           fi
 
-          stage="zebrad-${version}-${TARGET}"
+          stage="zebrad-${VERSION}-${TARGET}"
           mkdir -p "dist/${stage}"
           cp target/release/zebrad "dist/${stage}/zebrad"
           cp LICENSE-APACHE LICENSE-MIT README.md "dist/${stage}/"
@@ -116,10 +108,7 @@ jobs:
 
       # Generated in the build job so the attestation reflects the matrix
       # runner (ubuntu-22.04 / ubuntu-22.04-arm), not the publish job's runner.
-      # Gated to release runs so the test harness cannot mint attestations
-      # under the same --signer-workflow path users are told to trust.
       - name: Attest build provenance
-        if: inputs.release_tag != ''
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: dist/*.tar.gz
@@ -130,17 +119,16 @@ jobs:
           path: dist/
           retention-days: 1
 
-  publish:
-    name: Sign and publish binaries
+  bundle:
+    name: Sign release binary bundle
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: write
-      id-token: write
-      attestations: read
+      contents: read
+      id-token: write # authenticate the checksum signature
+      attestations: read # verify archive provenance
     env:
-      RELEASE_TAG: ${{ inputs.release_tag }}
       REPOSITORY: ${{ github.repository }}
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
@@ -157,16 +145,13 @@ jobs:
           ( cd dist && sha256sum -- *.tar.gz > SHA256SUMS )
 
       - name: Install Cosign
-        if: inputs.release_tag != ''
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign the checksum manifest
-        if: inputs.release_tag != ''
         working-directory: dist
         run: cosign sign-blob --yes --bundle SHA256SUMS.sigstore.json SHA256SUMS
 
       - name: Verify signatures
-        if: inputs.release_tag != ''
         working-directory: dist
         env:
           GH_TOKEN: ${{ github.token }}
@@ -183,17 +168,7 @@ jobs:
               --signer-workflow "${REPOSITORY}/.github/workflows/zfnd-release-binaries.yml"
           done
 
-      - name: Upload binaries to the release
-        if: inputs.release_tag != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release upload "${RELEASE_TAG}" \
-            dist/*.tar.gz dist/*.sha256 dist/SHA256SUMS dist/SHA256SUMS.sigstore.json \
-            --repo "${REPOSITORY}" --clobber
-
-      - name: Upload binaries as a CI artifact
-        if: inputs.release_tag == ''
+      - name: Upload release binary bundle
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
           name: release-binaries

--- a/.github/workflows/zfnd-release-binaries.yml
+++ b/.github/workflows/zfnd-release-binaries.yml
@@ -128,7 +128,7 @@ jobs:
           WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           workflow_path="${WORKFLOW_REF#"${REPOSITORY}/"}"
-          workflow_path="${workflow_path%@"${REF}"}"
+          workflow_path="${workflow_path%@*}"
           jq -n \
             --arg event_name "${EVENT_NAME}" \
             --arg invocation_id "${SERVER_URL}/${REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}" \

--- a/.github/workflows/zfnd-release-binaries.yml
+++ b/.github/workflows/zfnd-release-binaries.yml
@@ -9,10 +9,6 @@ name: Prepare release binaries (reusable)
 on:
   workflow_call:
     inputs:
-      source_sha:
-        description: "Immutable source commit to build"
-        required: true
-        type: string
       version:
         description: "Version used in asset filenames"
         required: true
@@ -52,7 +48,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: false
-          ref: ${{ inputs.source_sha }}
 
       - name: Install build dependencies
         run: |
@@ -111,80 +106,12 @@ jobs:
           rm -rf "dist/${stage}"
           ( cd dist && sha256sum "${stage}.tar.gz" > "${stage}.tar.gz.sha256" )
 
-      # GitHub's default provenance records the workflow event commit. Add the
-      # separately checked-out release source as an explicit dependency so
-      # manual recovery runs preserve the same source claim.
-      - name: Describe release source for provenance
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          REF: ${{ github.ref }}
-          REPOSITORY: ${{ github.repository }}
-          REPOSITORY_ID: ${{ github.repository_id }}
-          REPOSITORY_OWNER_ID: ${{ github.repository_owner_id }}
-          RUNNER_ENVIRONMENT: ${{ runner.environment }}
-          SERVER_URL: ${{ github.server_url }}
-          SOURCE_SHA: ${{ inputs.source_sha }}
-          WORKFLOW_REF: ${{ github.workflow_ref }}
-          WORKFLOW_SHA: ${{ github.workflow_sha }}
-        run: |
-          workflow_path="${WORKFLOW_REF#"${REPOSITORY}/"}"
-          workflow_path="${workflow_path%@*}"
-          jq -n \
-            --arg event_name "${EVENT_NAME}" \
-            --arg invocation_id "${SERVER_URL}/${REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}" \
-            --arg job_workflow_ref "${REPOSITORY}/.github/workflows/zfnd-release-binaries.yml@${REF}" \
-            --arg ref "${REF}" \
-            --arg repository "${REPOSITORY}" \
-            --arg repository_id "${REPOSITORY_ID}" \
-            --arg repository_owner_id "${REPOSITORY_OWNER_ID}" \
-            --arg runner_environment "${RUNNER_ENVIRONMENT}" \
-            --arg server_url "${SERVER_URL}" \
-            --arg source_sha "${SOURCE_SHA}" \
-            --arg workflow_path "${workflow_path}" \
-            --arg workflow_sha "${WORKFLOW_SHA}" \
-            '{
-              buildDefinition: {
-                buildType: "https://actions.github.io/buildtypes/workflow/v1",
-                externalParameters: {
-                  workflow: {
-                    ref: $ref,
-                    repository: ($server_url + "/" + $repository),
-                    path: $workflow_path
-                  }
-                },
-                internalParameters: {
-                  github: {
-                    event_name: $event_name,
-                    repository_id: $repository_id,
-                    repository_owner_id: $repository_owner_id,
-                    runner_environment: $runner_environment
-                  }
-                },
-                resolvedDependencies: [
-                  {
-                    uri: ("git+" + $server_url + "/" + $repository + "@" + $ref),
-                    digest: { gitCommit: $workflow_sha }
-                  },
-                  {
-                    uri: ("git+" + $server_url + "/" + $repository + "@" + $source_sha),
-                    digest: { gitCommit: $source_sha }
-                  }
-                ]
-              },
-              runDetails: {
-                builder: { id: ($server_url + "/" + $job_workflow_ref) },
-                metadata: { invocationId: $invocation_id }
-              }
-            }' > "${RUNNER_TEMP}/release-binary-provenance.json"
-
       # Generated in the build job so the attestation reflects the matrix
       # runner (ubuntu-22.04 / ubuntu-22.04-arm), not the publish job's runner.
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: dist/*.tar.gz
-          predicate-type: https://slsa.dev/provenance/v1
-          predicate-path: ${{ runner.temp }}/release-binary-provenance.json
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
@@ -203,7 +130,6 @@ jobs:
       attestations: read # verify archive provenance
     env:
       REPOSITORY: ${{ github.repository }}
-      SOURCE_SHA: ${{ inputs.source_sha }}
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
         with:
@@ -234,16 +160,13 @@ jobs:
           set -euo pipefail
           cosign verify-blob SHA256SUMS \
             --bundle SHA256SUMS.sigstore.json \
-            --certificate-identity-regexp="^https://github\\.com/${REPOSITORY}/\\.github/workflows/zfnd-release-binaries\\.yml@" \
+            --certificate-identity="https://github.com/${REPOSITORY}/.github/workflows/zfnd-release-binaries.yml@${GITHUB_REF}" \
             --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
           for archive in *.tar.gz; do
             gh attestation verify "${archive}" \
               --repo "${REPOSITORY}" \
               --signer-workflow "${REPOSITORY}/.github/workflows/zfnd-release-binaries.yml" \
-              --format json \
-              | jq -e --arg source_sha "${SOURCE_SHA}" \
-                'any(.[].verificationResult.statement.predicate.buildDefinition.resolvedDependencies[]?;
-                  .digest.gitCommit == $source_sha)' >/dev/null
+              --source-digest "${GITHUB_SHA}"
           done
 
       - name: Upload release binary bundle

--- a/.github/workflows/zfnd-release-binaries.yml
+++ b/.github/workflows/zfnd-release-binaries.yml
@@ -132,7 +132,7 @@ jobs:
           jq -n \
             --arg event_name "${EVENT_NAME}" \
             --arg invocation_id "${SERVER_URL}/${REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}" \
-            --arg job_workflow_ref "${REPOSITORY}/.github/workflows/zfnd-release-binaries.yml@${WORKFLOW_SHA}" \
+            --arg job_workflow_ref "${REPOSITORY}/.github/workflows/zfnd-release-binaries.yml@${REF}" \
             --arg ref "${REF}" \
             --arg repository "${REPOSITORY}" \
             --arg repository_id "${REPOSITORY_ID}" \

--- a/.github/workflows/zfnd-release-binaries.yml
+++ b/.github/workflows/zfnd-release-binaries.yml
@@ -54,17 +54,6 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.source_sha }}
 
-      # GitHub's provenance predicate records the caller's GITHUB_SHA.
-      # Keep that claim identical to the source this job actually builds.
-      - name: Bind source to provenance
-        env:
-          SOURCE_SHA: ${{ inputs.source_sha }}
-        run: |
-          if [[ "${SOURCE_SHA}" != "${GITHUB_SHA}" ]]; then
-            echo "::error::source_sha must match the caller commit recorded in build provenance"
-            exit 1
-          fi
-
       - name: Install build dependencies
         run: |
           sudo sed -i 's|http://ports.ubuntu.com/ubuntu-ports|https://ports.ubuntu.com/ubuntu-ports|g' /etc/apt/sources.list
@@ -117,12 +106,80 @@ jobs:
           rm -rf "dist/${stage}"
           ( cd dist && sha256sum "${stage}.tar.gz" > "${stage}.tar.gz.sha256" )
 
+      # GitHub's default provenance records the workflow event commit. Add the
+      # separately checked-out release source as an explicit dependency so
+      # manual recovery runs preserve the same source claim.
+      - name: Describe release source for provenance
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          REPOSITORY: ${{ github.repository }}
+          REPOSITORY_ID: ${{ github.repository_id }}
+          REPOSITORY_OWNER_ID: ${{ github.repository_owner_id }}
+          RUNNER_ENVIRONMENT: ${{ runner.environment }}
+          SERVER_URL: ${{ github.server_url }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          workflow_path="${WORKFLOW_REF#"${REPOSITORY}/"}"
+          workflow_path="${workflow_path%@"${REF}"}"
+          jq -n \
+            --arg event_name "${EVENT_NAME}" \
+            --arg invocation_id "${SERVER_URL}/${REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}" \
+            --arg job_workflow_ref "${REPOSITORY}/.github/workflows/zfnd-release-binaries.yml@${WORKFLOW_SHA}" \
+            --arg ref "${REF}" \
+            --arg repository "${REPOSITORY}" \
+            --arg repository_id "${REPOSITORY_ID}" \
+            --arg repository_owner_id "${REPOSITORY_OWNER_ID}" \
+            --arg runner_environment "${RUNNER_ENVIRONMENT}" \
+            --arg server_url "${SERVER_URL}" \
+            --arg source_sha "${SOURCE_SHA}" \
+            --arg workflow_path "${workflow_path}" \
+            --arg workflow_sha "${WORKFLOW_SHA}" \
+            '{
+              buildDefinition: {
+                buildType: "https://actions.github.io/buildtypes/workflow/v1",
+                externalParameters: {
+                  workflow: {
+                    ref: $ref,
+                    repository: ($server_url + "/" + $repository),
+                    path: $workflow_path
+                  }
+                },
+                internalParameters: {
+                  github: {
+                    event_name: $event_name,
+                    repository_id: $repository_id,
+                    repository_owner_id: $repository_owner_id,
+                    runner_environment: $runner_environment
+                  }
+                },
+                resolvedDependencies: [
+                  {
+                    uri: ("git+" + $server_url + "/" + $repository + "@" + $ref),
+                    digest: { gitCommit: $workflow_sha }
+                  },
+                  {
+                    uri: ("git+" + $server_url + "/" + $repository + "@" + $source_sha),
+                    digest: { gitCommit: $source_sha }
+                  }
+                ]
+              },
+              runDetails: {
+                builder: { id: ($server_url + "/" + $job_workflow_ref) },
+                metadata: { invocationId: $invocation_id }
+              }
+            }' > "${RUNNER_TEMP}/release-binary-provenance.json"
+
       # Generated in the build job so the attestation reflects the matrix
       # runner (ubuntu-22.04 / ubuntu-22.04-arm), not the publish job's runner.
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: dist/*.tar.gz
+          predicate-type: https://slsa.dev/provenance/v1
+          predicate-path: ${{ runner.temp }}/release-binary-provenance.json
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
         with:
@@ -141,6 +198,7 @@ jobs:
       attestations: read # verify archive provenance
     env:
       REPOSITORY: ${{ github.repository }}
+      SOURCE_SHA: ${{ inputs.source_sha }}
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
         with:
@@ -176,7 +234,11 @@ jobs:
           for archive in *.tar.gz; do
             gh attestation verify "${archive}" \
               --repo "${REPOSITORY}" \
-              --signer-workflow "${REPOSITORY}/.github/workflows/zfnd-release-binaries.yml"
+              --signer-workflow "${REPOSITORY}/.github/workflows/zfnd-release-binaries.yml" \
+              --format json \
+              | jq -e --arg source_sha "${SOURCE_SHA}" \
+                'any(.[].verificationResult.statement.predicate.buildDefinition.resolvedDependencies[]?;
+                  .digest.gitCommit == $source_sha)' >/dev/null
           done
 
       - name: Upload release binary bundle

--- a/.github/workflows/zfnd-release-binaries.yml
+++ b/.github/workflows/zfnd-release-binaries.yml
@@ -132,7 +132,7 @@ jobs:
           jq -n \
             --arg event_name "${EVENT_NAME}" \
             --arg invocation_id "${SERVER_URL}/${REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}" \
-            --arg job_workflow_ref "${REPOSITORY}/.github/workflows/zfnd-release-binaries.yml@${REF}" \
+            --arg job_workflow_ref "${WORKFLOW_REF}" \
             --arg ref "${REF}" \
             --arg repository "${REPOSITORY}" \
             --arg repository_id "${REPOSITORY_ID}" \

--- a/book/src/user/install.md
+++ b/book/src/user/install.md
@@ -24,10 +24,11 @@ Or download an archive, verify it, and extract `zebrad`:
 ```bash
 gh attestation verify zebrad-<version>-x86_64-unknown-linux-gnu.tar.gz \
   --repo ZcashFoundation/zebra \
-  --signer-workflow ZcashFoundation/zebra/.github/workflows/zfnd-release-binaries.yml
+  --signer-workflow ZcashFoundation/zebra/.github/workflows/zfnd-release-binaries.yml \
+  --source-ref 'refs/tags/v<version>'
 cosign verify-blob SHA256SUMS \
   --bundle SHA256SUMS.sigstore.json \
-  --certificate-identity-regexp='^https://github\.com/ZcashFoundation/zebra/\.github/workflows/zfnd-release-binaries\.yml@' \
+  --certificate-identity='https://github.com/ZcashFoundation/zebra/.github/workflows/zfnd-release-binaries.yml@refs/tags/v<version>' \
   --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
 sha256sum --ignore-missing -c SHA256SUMS
 tar xzf zebrad-<version>-x86_64-unknown-linux-gnu.tar.gz

--- a/docs/decisions/devops/0008-release-binary-artifacts.md
+++ b/docs/decisions/devops/0008-release-binary-artifacts.md
@@ -29,7 +29,7 @@ Per release, for `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu`:
 - `zebrad-<version>-<target>.tar.gz` (the binary plus `LICENSE-APACHE`, `LICENSE-MIT`, `README.md`) and a `.tar.gz.sha256` sidecar.
 - One `SHA256SUMS` manifest covering both archives.
 - `SHA256SUMS.sigstore.json`: a Cosign keyless (Sigstore) signature over the manifest, with the Fulcio certificate identity pinned to the release workflow.
-- SLSA v1 build provenance per archive via `actions/attest-build-provenance`, stored in GitHub's attestation API and verified with `gh attestation verify --signer-workflow`.
+- SLSA v1 build provenance per archive via `actions/attest-build-provenance`, stored in GitHub's attestation API and verified against the expected signer workflow and release source ref.
 
 Six assets. Integrity and provenance for the whole release rest on one signed manifest plus one attestation per archive, not on per-file signatures. `cargo binstall zebrad` consumes these archives, giving a package-manager-style one-liner with no hosted repository to operate.
 
@@ -86,6 +86,7 @@ That augmentation has to be re-validated on every bump of those crates, and the 
 gh attestation verify <archive> \
   --repo ZcashFoundation/zebra \
   --signer-workflow ZcashFoundation/zebra/.github/workflows/zfnd-release-binaries.yml \
+  --source-ref 'refs/tags/v<version>' \
   --predicate-type https://spdx.dev/Document/v2.3
 ```
 


### PR DESCRIPTION
## Motivation

Release binaries cannot be prepared before the GitHub Release exists because the current reusable workflow combines building, signing, and release mutation. This keeps binary builds serialized behind crate publication even though preparation does not depend on the published release.

Part of #11092.

## Solution

Split the existing reusable binary workflow at the external mutation boundary:

- `zfnd-release-binaries.yml` requires an immutable source commit, version, and feature set, then builds, attests, signs, verifies, and uploads one `release-binaries` workflow artifact.
- `zfnd-attach-release-binaries.yml` downloads that artifact and owns the only GitHub Release mutation.
- `release-binaries.yml` preserves the current `release: released` behavior by composing preparation followed by attachment.
- Preparation records the checked-out `source_sha` as an explicit resolved dependency in GitHub's SLSA provenance and verifies that claim before bundling. The source remains accurate when a later manual recovery run uses a different workflow event commit.

The existing build runners, glibc compatibility ceiling, asset names, checksums, provenance, signatures, and rerun behavior remain unchanged.

### Tests

- `actionlint` passed for all changed workflows with ShellCheck enabled.
- `zizmor` passed for the changed workflows with no findings.
- Repository Markdown lint passed for the workflow documentation.
- `git diff --check` passed.
- The current six-asset release contract was compared with the latest release.
- The generated SLSA predicate was exercised with distinct workflow and release-source commits and retained the release source dependency.

The reusable-workflow handoff and OIDC signing path still require a hosted Actions run because they depend on GitHub-hosted runners and artifact attestations.

### Specifications & References

- [Workflow artifacts](https://docs.github.com/en/actions/concepts/workflows-and-actions/workflow-artifacts)
- [Release event context](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#release)

### Follow-up Work

The final release cutover will invoke binary preparation in parallel with crate publication and attach the prepared artifact after the GitHub Release exists.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: OpenAI Codex implemented and reviewed the workflow changes.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
