### PR TITLE
perf(release): accelerate Cargo release jobs

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - ubuntu-latest-xl

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -195,12 +195,12 @@ jobs:
           cache-on-failure: true
       - name: Install libclang for librocksdb-sys bindgen
         run: |
-          sudo timeout --foreground 180s apt-get \
+          sudo timeout --kill-after=10s --foreground 180s apt-get \
             -o Acquire::Retries=3 \
             -o Acquire::http::Timeout=30 \
             -o Acquire::https::Timeout=30 \
             update
-          sudo timeout --foreground 180s apt-get \
+          sudo timeout --kill-after=10s --foreground 180s apt-get \
             -o Acquire::Retries=3 \
             -o Acquire::http::Timeout=30 \
             -o Acquire::https::Timeout=30 \

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -160,7 +160,7 @@ jobs:
       github.event_name == 'pull_request' &&
       startsWith(github.event.pull_request.head.ref, 'release-plz-') &&
       contains(github.event.pull_request.labels.*.name, 'A-release')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-xl
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -194,7 +194,17 @@ jobs:
           toolchain: 1.91.0
           cache-on-failure: true
       - name: Install libclang for librocksdb-sys bindgen
-        run: sudo apt-get update && sudo apt-get install -y libclang-dev
+        run: |
+          sudo timeout --foreground 180s apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            update
+          sudo timeout --foreground 180s apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            install -y libclang-dev
       - name: Check desired release state
         id: cargo-release
         continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,12 +241,12 @@ jobs:
           cache-on-failure: true
       - name: Install libclang for librocksdb-sys bindgen
         run: |
-          sudo timeout --foreground 180s apt-get \
+          sudo timeout --kill-after=10s --foreground 180s apt-get \
             -o Acquire::Retries=3 \
             -o Acquire::http::Timeout=30 \
             -o Acquire::https::Timeout=30 \
             update
-          sudo timeout --foreground 180s apt-get \
+          sudo timeout --kill-after=10s --foreground 180s apt-get \
             -o Acquire::Retries=3 \
             -o Acquire::http::Timeout=30 \
             -o Acquire::https::Timeout=30 \
@@ -335,12 +335,12 @@ jobs:
           cache-on-failure: true
       - name: Install libclang for librocksdb-sys bindgen
         run: |
-          sudo timeout --foreground 180s apt-get \
+          sudo timeout --kill-after=10s --foreground 180s apt-get \
             -o Acquire::Retries=3 \
             -o Acquire::http::Timeout=30 \
             -o Acquire::https::Timeout=30 \
             update
-          sudo timeout --foreground 180s apt-get \
+          sudo timeout --kill-after=10s --foreground 180s apt-get \
             -o Acquire::Retries=3 \
             -o Acquire::http::Timeout=30 \
             -o Acquire::https::Timeout=30 \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,7 +210,7 @@ jobs:
     name: Check release without publishing
     needs: release-target
     if: needs.release-target.outputs.operation == 'check'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-xl
     timeout-minutes: 90
     permissions:
       contents: read
@@ -237,9 +237,20 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
         with:
           toolchain: 1.91.0
+          cache-workspaces: release-source -> target
           cache-on-failure: true
       - name: Install libclang for librocksdb-sys bindgen
-        run: sudo apt-get update && sudo apt-get install -y libclang-dev
+        run: |
+          sudo timeout --foreground 180s apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            update
+          sudo timeout --foreground 180s apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            install -y libclang-dev
       - name: Check desired release state
         id: cargo-release
         continue-on-error: true
@@ -293,7 +304,7 @@ jobs:
     name: Publish crates and GitHub Release
     needs: release-target
     if: needs.release-target.outputs.operation == 'resume'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-xl
     timeout-minutes: 120
     permissions:
       contents: read # inspect release state; the app token performs finalization
@@ -320,9 +331,20 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 #v1.17.0
         with:
           toolchain: 1.91.0
+          cache-workspaces: release-source -> target
           cache-on-failure: true
       - name: Install libclang for librocksdb-sys bindgen
-        run: sudo apt-get update && sudo apt-get install -y libclang-dev
+        run: |
+          sudo timeout --foreground 180s apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            update
+          sudo timeout --foreground 180s apt-get \
+            -o Acquire::Retries=3 \
+            -o Acquire::http::Timeout=30 \
+            -o Acquire::https::Timeout=30 \
+            install -y libclang-dev
       - name: Generate release app token
         id: app-token
         if: vars.RELEASE_APP_ID != ''


### PR DESCRIPTION
## Motivation

The Cargo release check is the longest serialized part of release readiness. Recent `ubuntu-latest` runs took 23–24 minutes, delaying both the release PR gate and the later publish path.

Part of #11092. This PR is stacked on #11094 because it accelerates the release jobs introduced by that transition gate.

## Solution

Run only the Cargo-intensive release readiness and release check/publish jobs on the repository's existing `ubuntu-latest-xl` runner. Keep release PR generation on `ubuntu-latest`.

Point the existing Rust toolchain action at the actual `release-source/target` workspace so its built-in cache is restored between release checks. Bound the existing APT setup with retry and timeout options so infrastructure stalls fail promptly.

This adds no runner-selection fallback, retry workflow, custom image, or additional cache action.

### Tests

The current release PR was checked twice with the changed workflow:

| Run | Runner/cache | Cargo check | Job total |
| --- | --- | ---: | ---: |
| [standard baseline](https://github.com/ZcashFoundation/zebra/actions/runs/30298123663) | `ubuntu-latest` | 23m 07s | 23m 49s |
| [XL cold cache](https://github.com/ZcashFoundation/zebra/actions/runs/30299902175) | `ubuntu-latest-xl`, cold | 7m 59s | 8m 57s |
| [XL warm cache](https://github.com/ZcashFoundation/zebra/actions/runs/30300590758) | `ubuntu-latest-xl`, hit | 1m 49s | 2m 51s |

Both XL runs completed successfully. The repeat restored the exact `release-source/target` cache on the `larger runners` group.

### Specifications & References

- #11092
- #11094
- [`actions-rust-lang/setup-rust-toolchain` cache inputs](https://github.com/actions-rust-lang/setup-rust-toolchain#inputs)

### Follow-up Work

The final release-controller cutover will compose these accelerated Cargo jobs with binary preparation and immutable image builds.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: OpenAI Codex for workflow analysis, implementation, and benchmark review

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
