### PR TITLE
fix(zebrad): pin the NU6.3-ready zcashd-compat sidecar v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- The embedded zcashd-compat release manifest and the installer script now pin sidecar
+  `zebra-compat-v1.1.0`, which follows Mainnet past the NU6.3 (Ironwood) activation at block
+  3,428,143. The previous `zebra-compat-v1.0.0` sidecar predates the activation height and stops
+  following the chain at that block. Supervised deployments using `zcashd_source = "embedded"`
+  must upgrade (or set `zcashd_path` to a current sidecar binary) before activation.
+
 ## [Zebra 6.2.2](https://github.com/ZcashFoundation/zebra/releases/tag/v6.2.2) - 2026-07-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   `zebra-compat-v1.1.0`, which follows Mainnet past the NU6.3 (Ironwood) activation at block
   3,428,143. The previous `zebra-compat-v1.0.0` sidecar predates the activation height and stops
   following the chain at that block. Supervised deployments using `zcashd_source = "embedded"`
-  must upgrade (or set `zcashd_path` to a current sidecar binary) before activation.
+  must upgrade (or set `zcashd_path` to a current sidecar binary) before activation
+  ([#11112](https://github.com/ZcashFoundation/zebra/pull/11112)).
 
 ## [Zebra 6.2.2](https://github.com/ZcashFoundation/zebra/releases/tag/v6.2.2) - 2026-07-24
 

--- a/book/src/user/zcashd-compat.md
+++ b/book/src/user/zcashd-compat.md
@@ -161,9 +161,9 @@ Zebra's embedded release manifest; use `zcashd_source = "path"` plus
 > [!WARNING]
 > The `embedded` source is **experimental**: it downloads a pinned `zcashd`
 > build from [ZcashFoundation/zcashd](https://github.com/ZcashFoundation/zcashd)
-> releases. The current `zebra-compat-v1.0.0` artifact is re-hosted from
-> valargroup's build and has not yet been rebuilt by the foundation's own CI.
-> Until then, production deployments should build the sidecar from source (or
+> releases. The current `zebra-compat-v1.1.0` artifact is built by the
+> foundation's own CI from the `zcashd-compat` branch. Production deployments
+> that need stronger guarantees should still build the sidecar from source (or
 > otherwise verify it) and use `zcashd_source = "path"`.
 
 On start, Zebra:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -251,8 +251,8 @@ CMD ["zebrad"]
 # Override the ARGs to bake in a different sidecar release.
 FROM runtime AS runtime-zcashd-compat
 
-ARG ZCASHD_COMPAT_ARCHIVE_URL="https://github.com/ZcashFoundation/zcashd/releases/download/zebra-compat-v1.0.0/zcashd-zebra-compat-v1.0.0-linux-x86_64.tar.gz"
-ARG ZCASHD_COMPAT_ARCHIVE_SHA256="b861ea94215647a69a944ded7c9d6c7c3dfd836e54e3e194103242935e6879f2"
+ARG ZCASHD_COMPAT_ARCHIVE_URL="https://github.com/ZcashFoundation/zcashd/releases/download/zebra-compat-v1.1.0/zcashd-zebra-compat-v1.1.0-linux-x86_64.tar.gz"
+ARG ZCASHD_COMPAT_ARCHIVE_SHA256="92f47c6ff84a99cf6c911f47c03d70d4a5181870cdc87dcb49036d1d4c346567"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/scripts/install-zebra.sh
+++ b/scripts/install-zebra.sh
@@ -31,10 +31,10 @@ ZEBRA_DOCKER_RUNTIME_GID=10001
 
 MANIFEST_PATH="$REPO_ROOT/zebrad/zcashd-compat-manifest.json"
 TARGET_TRIPLE="x86_64-pc-linux-gnu"
-ZCASHD_RUNTIME_ARCHIVE_URL="https://github.com/ZcashFoundation/zcashd/releases/download/zebra-compat-v1.0.0/zcashd-zebra-compat-v1.0.0-linux-x86_64.tar.gz"
-ZCASHD_RUNTIME_ARCHIVE_SHA256="b861ea94215647a69a944ded7c9d6c7c3dfd836e54e3e194103242935e6879f2"
+ZCASHD_RUNTIME_ARCHIVE_URL="https://github.com/ZcashFoundation/zcashd/releases/download/zebra-compat-v1.1.0/zcashd-zebra-compat-v1.1.0-linux-x86_64.tar.gz"
+ZCASHD_RUNTIME_ARCHIVE_SHA256="92f47c6ff84a99cf6c911f47c03d70d4a5181870cdc87dcb49036d1d4c346567"
 ZCASHD_RUNTIME_ARCHIVE_MEMBER_BINARY_PATH="./bin/zcashd"
-ZCASHD_DEFAULT_DOCKER_IMAGE="zfnd/zcashd:zebra-compat-v1.0.0"
+ZCASHD_DEFAULT_DOCKER_IMAGE="zfnd/zcashd:zebra-compat-v1.1.0"
 
 INSTALL_PROFILE=""
 MODE=""

--- a/zebrad/zcashd-compat-manifest.json
+++ b/zebrad/zcashd-compat-manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": 1,
-  "release_tag": "zebra-compat-v1.0.0",
+  "release_tag": "zebra-compat-v1.1.0",
   "artifacts": [
     {
       "target_triple": "x86_64-pc-linux-gnu",
-      "runtime_archive_url": "https://github.com/ZcashFoundation/zcashd/releases/download/zebra-compat-v1.0.0/zcashd-zebra-compat-v1.0.0-linux-x86_64.tar.gz",
-      "runtime_archive_sha256": "b861ea94215647a69a944ded7c9d6c7c3dfd836e54e3e194103242935e6879f2",
+      "runtime_archive_url": "https://github.com/ZcashFoundation/zcashd/releases/download/zebra-compat-v1.1.0/zcashd-zebra-compat-v1.1.0-linux-x86_64.tar.gz",
+      "runtime_archive_sha256": "92f47c6ff84a99cf6c911f47c03d70d4a5181870cdc87dcb49036d1d4c346567",
       "runtime_archive_member_binary_path": "./bin/zcashd"
     }
   ]


### PR DESCRIPTION
## Motivation

The embedded zcashd-compat release manifest and the installer script pin sidecar
`zebra-compat-v1.0.0`, which was built before the NU6.3 mainnet activation height was set: its
`chainparams.cpp` has `NO_ACTIVATION_HEIGHT` for NU6.3 on Mainnet, so it stops following the
chain at block 3,428,143 (~2026-07-28) while continuing to serve wallet RPCs from a frozen tip.

## Solution

Pin the ZF-built [`zebra-compat-v1.1.0`](https://github.com/ZcashFoundation/zcashd/releases/tag/zebra-compat-v1.1.0)
release (ZcashFoundation/zcashd#7, built by the `release-zcashd-compat-assets` workflow from
`zcashd-compat` @ `34c81b0`, which sets the Mainnet activation height to 3,428,143):

- `zebrad/zcashd-compat-manifest.json`: release tag, archive URL, and SHA256
  (`92f47c6f…`, matching both the GitHub asset digest and the release's generated manifest).
- `scripts/install-zebra.sh`: the same URL/SHA256 constants, and the default zcashd Docker image
  tag (`zfnd/zcashd:zebra-compat-v1.1.0` — note this Docker repository doesn't exist yet, same
  as before the change; the installer errors cleanly and accepts `--zcashd-docker-image`).
- The book's provenance warning: the artifact is now built by the foundation's CI, no longer
  re-hosted from valargroup's build.
- `docker/Dockerfile`: the `runtime-zcashd-compat` stage's default sidecar archive URL and
  SHA256 (the tarball's `./bin/zcashd` and `./bin/zcash-cli` member paths are unchanged, per the
  release's generated manifest).

### Tests

- All 82 `zcashd_compat` unit tests pass, including the embedded-manifest parse/validation.
- Verified the pinned artifact end-to-end: the release asset digest matches the manifest SHA256,
  and the build commit's `chainparams.cpp` contains the Mainnet activation height.
- Full local CI gate; the only failures are the two known env-blocked `unit::config` tests on a
  machine with a running node.

### Follow-up Work

Deployments with `zcashd_source = "embedded"` only pick this up via a new zebrad release (the
manifest is compiled in); v6.2.2 shipped without it, so this should ride the next release —
ideally before activation. Until then, those deployments can set `zcashd_path` to the released
binary.

### AI Disclosure

- [x] AI tools were used: Claude prepared the pin bump and verified the artifact; reviewed by
  the author.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
