### PR TITLE
fix(mempool): avoid scoring NU6.2 branch IDs during NU6.3 activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Changed
 
+- Mempool transaction relay no longer penalizes peers for adjacent NU6.2 and
+  NU6.3 branch ID mismatches during the 40 heights on either side of NU6.3
+  activation, avoiding bans caused by temporary chain-tip divergence
+  ([#11113](https://github.com/ZcashFoundation/zebra/pull/11113)).
 - Chain synchronization now retains the final block hash returned by peers in `FindBlocks`
   responses, rather than discarding it to work around obsolete `zcashd` behavior
   ([#11093](https://github.com/ZcashFoundation/zebra/pull/11093)).

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -420,6 +420,7 @@ impl StartCmd {
 
         info!("initializing mempool");
         let (mempool, mempool_transaction_subscriber) = Mempool::new(
+            &config.network.network,
             &config.mempool,
             peer_set.clone(),
             state.clone(),

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -1093,6 +1093,7 @@ async fn setup(
 
     let (misbehavior_tx, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
     let (mut mempool_service, transaction_subscriber) = Mempool::new(
+        &network,
         &MempoolConfig::default(),
         buffered_peer_set.clone(),
         state_service.clone(),

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -700,6 +700,7 @@ async fn setup(
     let (misbehavior_tx, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
     let mempool_config = MempoolConfig::default();
     let (mut mempool_service, transaction_subscriber) = Mempool::new(
+        &network,
         &mempool_config,
         peer_set.clone(),
         state_service.clone(),

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -34,6 +34,7 @@ use zebra_chain::{
     block::{self, Height},
     chain_sync_status::ChainSyncStatus,
     chain_tip::ChainTip,
+    parameters::{Network, NetworkUpgrade},
     transaction::UnminedTxId,
 };
 use zebra_consensus::{error::TransactionError, transaction};
@@ -84,6 +85,41 @@ type TxVerifier = Buffer<
     transaction::Request,
 >;
 type InboundTxDownloads = TxDownloads<Timeout<Outbound>, Timeout<TxVerifier>, State>;
+
+/// The number of NU6.3 heights where stale NU6.2 branch IDs receive no peer score.
+const NU6_3_BRANCH_ID_GRACE_PERIOD: i64 = 40;
+
+/// Returns the mempool peer score after applying branch ID activation policy.
+fn adjusted_mempool_misbehavior_score(
+    error: &TransactionError,
+    transaction_upgrade: Option<NetworkUpgrade>,
+    verification_height: Height,
+    network: &Network,
+) -> u32 {
+    let is_nu6_3_grace_mismatch = matches!(error, TransactionError::WrongConsensusBranchId)
+        && NetworkUpgrade::Nu6_3
+            .activation_height(network)
+            .is_some_and(|activation_height| {
+                let expected_upgrade = NetworkUpgrade::current(network, verification_height);
+                let height_offset = verification_height - activation_height;
+
+                match (transaction_upgrade, expected_upgrade) {
+                    (Some(NetworkUpgrade::Nu6_2), NetworkUpgrade::Nu6_3) => {
+                        (0..NU6_3_BRANCH_ID_GRACE_PERIOD).contains(&height_offset)
+                    }
+                    (Some(NetworkUpgrade::Nu6_3), NetworkUpgrade::Nu6_2) => {
+                        (-NU6_3_BRANCH_ID_GRACE_PERIOD..0).contains(&height_offset)
+                    }
+                    _ => false,
+                }
+            });
+
+    if is_nu6_3_grace_mismatch {
+        0
+    } else {
+        error.mempool_misbehavior_score()
+    }
+}
 
 /// The state of the mempool.
 ///
@@ -207,6 +243,9 @@ impl ActiveState {
 /// of that have yet to be confirmed by the Zcash network. A transaction is
 /// confirmed when it has been included in a block ('mined').
 pub struct Mempool {
+    /// The configured Zcash network.
+    network: Network,
+
     /// The configurable options for the mempool, persisted between states.
     config: Config,
 
@@ -271,6 +310,7 @@ pub struct Mempool {
 impl Mempool {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
+        network: &Network,
         config: &Config,
         outbound: Outbound,
         state: State,
@@ -285,6 +325,7 @@ impl Mempool {
         let transaction_subscriber = MempoolTxSubscriber::new(transaction_sender.clone());
 
         let mut service = Mempool {
+            network: network.clone(),
             config: config.clone(),
             active_state: ActiveState::Disabled,
             sync_status,
@@ -686,13 +727,19 @@ impl Service<Request> for Mempool {
                         if let TransactionDownloadVerifyError::Invalid {
                             error,
                             advertiser_addr: Some(advertiser_addr),
+                            transaction_upgrade,
+                            verification_height,
                         } = &error
                         {
-                            if error.mempool_misbehavior_score() != 0 {
-                                let _ = self.misbehavior_sender.try_send((
-                                    *advertiser_addr,
-                                    error.mempool_misbehavior_score(),
-                                ));
+                            let score = adjusted_mempool_misbehavior_score(
+                                error,
+                                *transaction_upgrade,
+                                *verification_height,
+                                &self.network,
+                            );
+
+                            if score != 0 {
+                                let _ = self.misbehavior_sender.try_send((*advertiser_addr, score));
                             }
                         };
 

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -47,6 +47,7 @@ use tracing_futures::Instrument;
 
 use zebra_chain::{
     block::Height,
+    parameters::NetworkUpgrade,
     transaction::{self, UnminedTxId, VerifiedUnminedTx},
     transparent,
 };
@@ -139,6 +140,10 @@ pub enum TransactionDownloadVerifyError {
     Invalid {
         error: zebra_consensus::error::TransactionError,
         advertiser_addr: Option<PeerSocketAddr>,
+        /// The transaction's consensus branch upgrade, if its version contains one.
+        transaction_upgrade: Option<NetworkUpgrade>,
+        /// The candidate block height used for mempool consensus verification.
+        verification_height: Height,
     },
 }
 
@@ -438,6 +443,7 @@ where
 
             trace!(?txid, "got tx");
 
+            let transaction_upgrade = tx.transaction.network_upgrade();
             let result = verifier
                 .oneshot(tx::Request::Mempool {
                     transaction: tx.clone(),
@@ -455,7 +461,12 @@ where
             // Hide the transaction data to avoid filling the logs
             trace!(?txid, result = ?result.as_ref().map(|_tx| ()), "verified transaction for the mempool");
 
-            result.map_err(|e| TransactionDownloadVerifyError::Invalid { error: e.into(), advertiser_addr } )
+            result.map_err(|error| TransactionDownloadVerifyError::Invalid {
+                error: error.into(),
+                advertiser_addr,
+                transaction_upgrade,
+                verification_height: next_height,
+            })
         }
         .map_ok(|(tx, spent_mempool_outpoints, tip_height)| {
             metrics::counter!(

--- a/zebrad/src/components/mempool/downloads/tests.rs
+++ b/zebrad/src/components/mempool/downloads/tests.rs
@@ -85,6 +85,7 @@ async fn pushed_transaction_attributes_invalid_error_to_peer() {
         .next()
         .expect("at least one test transaction")
         .transaction;
+    let transaction_upgrade = transaction.transaction.network_upgrade();
 
     type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
@@ -122,9 +123,12 @@ async fn pushed_transaction_attributes_invalid_error_to_peer() {
             error,
             TransactionDownloadVerifyError::Invalid {
                 advertiser_addr: Some(addr),
+                transaction_upgrade: actual_upgrade,
+                verification_height: Height(0),
                 ..
             } if addr == PeerSocketAddr::from(peer_addr)
+                && actual_upgrade == transaction_upgrade
         ),
-        "expected the pushed transaction failure to carry the peer address, got {error:?}"
+        "expected the pushed transaction failure to carry its peer, branch, and height, got {error:?}"
     );
 }

--- a/zebrad/src/components/mempool/tests/prop.rs
+++ b/zebrad/src/components/mempool/tests/prop.rs
@@ -14,7 +14,10 @@ use tower::{buffer::Buffer, util::BoxService};
 use zebra_chain::{
     block::{self, Block},
     fmt::{DisplayToDebug, TypeNameToDebug},
-    parameters::{Network, NetworkUpgrade},
+    parameters::{
+        testnet::{ConfiguredActivationHeights, Parameters},
+        Network, NetworkUpgrade,
+    },
     serialization::ZcashDeserializeInto,
     transaction::VerifiedUnminedTx,
 };
@@ -26,7 +29,7 @@ use zs::CheckpointVerifiedBlock;
 
 use crate::components::{
     mempool::tests::standard_verified_unmined_tx_strategy,
-    mempool::{config::Config, Mempool},
+    mempool::{adjusted_mempool_misbehavior_score, config::Config, Mempool},
     sync::{RecentSyncLengths, SyncStatus},
 };
 
@@ -57,6 +60,37 @@ proptest! {
                                           .ok()
                                           .and_then(|v| v.parse().ok())
                                           .unwrap_or(DEFAULT_MEMPOOL_PROPTEST_CASES)))]
+
+    /// Checks that NU6.2 branch IDs have no peer score during the NU6.3 grace period.
+    #[test]
+    fn nu6_2_branch_id_has_no_score_during_nu6_3_grace(
+        activation_height in 100u32..1_000_000,
+        height_offset in 0i64..40,
+    ) {
+        let network = Parameters::build()
+            .with_activation_heights(ConfiguredActivationHeights {
+                nu6_2: Some(activation_height - 1),
+                nu6_3: Some(activation_height),
+                ..Default::default()
+            })
+            .expect("generated activation heights are valid")
+            .clear_funding_streams()
+            .to_network()
+            .expect("configured testnet is valid");
+        let activation_height = block::Height(activation_height);
+        let height = (activation_height + height_offset)
+            .expect("generated activation heights are far below Height::MAX");
+
+        prop_assert_eq!(
+            adjusted_mempool_misbehavior_score(
+                &TransactionError::WrongConsensusBranchId,
+                Some(NetworkUpgrade::Nu6_2),
+                height,
+                &network,
+            ),
+            0,
+        );
+    }
 
     /// Test if the mempool storage is cleared on a chain reset.
     #[test]

--- a/zebrad/src/components/mempool/tests/prop.rs
+++ b/zebrad/src/components/mempool/tests/prop.rs
@@ -271,6 +271,7 @@ fn setup(
 
     let (misbehavior_tx, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
     let (mempool, mempool_transaction_subscriber) = Mempool::new(
+        network,
         &Config {
             tx_cost_limit: 160_000_000,
             ..Default::default()

--- a/zebrad/src/components/mempool/tests/prop.rs
+++ b/zebrad/src/components/mempool/tests/prop.rs
@@ -92,6 +92,37 @@ proptest! {
         );
     }
 
+    /// Checks that NU6.3 branch IDs have no peer score just before activation.
+    #[test]
+    fn nu6_3_branch_id_has_no_score_before_activation(
+        activation_height in 100u32..1_000_000,
+        height_offset in -40i64..0,
+    ) {
+        let network = Parameters::build()
+            .with_activation_heights(ConfiguredActivationHeights {
+                nu6_2: Some(activation_height - 41),
+                nu6_3: Some(activation_height),
+                ..Default::default()
+            })
+            .expect("generated activation heights are valid")
+            .clear_funding_streams()
+            .to_network()
+            .expect("configured testnet is valid");
+        let activation_height = block::Height(activation_height);
+        let height = (activation_height + height_offset)
+            .expect("generated activation heights are above Height::MIN");
+
+        prop_assert_eq!(
+            adjusted_mempool_misbehavior_score(
+                &TransactionError::WrongConsensusBranchId,
+                Some(NetworkUpgrade::Nu6_3),
+                height,
+                &network,
+            ),
+            0,
+        );
+    }
+
     /// Checks that NU6.2 branch IDs regain their peer score at the grace cutoff.
     #[test]
     fn nu6_2_branch_id_keeps_score_after_nu6_3_grace(

--- a/zebrad/src/components/mempool/tests/prop.rs
+++ b/zebrad/src/components/mempool/tests/prop.rs
@@ -92,6 +92,37 @@ proptest! {
         );
     }
 
+    /// Checks that NU6.2 branch IDs regain their peer score at the grace cutoff.
+    #[test]
+    fn nu6_2_branch_id_keeps_score_after_nu6_3_grace(
+        activation_height in 100u32..1_000_000,
+        height_offset in 40i64..1_000,
+    ) {
+        let network = Parameters::build()
+            .with_activation_heights(ConfiguredActivationHeights {
+                nu6_2: Some(activation_height - 1),
+                nu6_3: Some(activation_height),
+                ..Default::default()
+            })
+            .expect("generated activation heights are valid")
+            .clear_funding_streams()
+            .to_network()
+            .expect("configured testnet is valid");
+        let activation_height = block::Height(activation_height);
+        let height = (activation_height + height_offset)
+            .expect("generated activation heights are far below Height::MAX");
+
+        prop_assert_eq!(
+            adjusted_mempool_misbehavior_score(
+                &TransactionError::WrongConsensusBranchId,
+                Some(NetworkUpgrade::Nu6_2),
+                height,
+                &network,
+            ),
+            100,
+        );
+    }
+
     /// Test if the mempool storage is cleared on a chain reset.
     #[test]
     fn storage_is_cleared_on_single_chain_reset(

--- a/zebrad/src/components/mempool/tests/prop.rs
+++ b/zebrad/src/components/mempool/tests/prop.rs
@@ -123,6 +123,44 @@ proptest! {
         );
     }
 
+
+    /// Checks that other mismatched branch IDs retain their normal peer score.
+    #[test]
+    fn other_branch_ids_keep_mempool_score(
+        activation_height in 100u32..1_000_000,
+        height_offset in -1i64..41,
+        transaction_upgrade in any::<NetworkUpgrade>(),
+    ) {
+        prop_assume!(transaction_upgrade != NetworkUpgrade::Nu6_2);
+        prop_assume!(transaction_upgrade != NetworkUpgrade::Nu6_3);
+
+        let network = Parameters::build()
+            .with_activation_heights(ConfiguredActivationHeights {
+                nu6_2: Some(activation_height - 1),
+                nu6_3: Some(activation_height),
+                ..Default::default()
+            })
+            .expect("generated activation heights are valid")
+            .clear_funding_streams()
+            .to_network()
+            .expect("configured testnet is valid");
+        let activation_height = block::Height(activation_height);
+        let height = (activation_height + height_offset)
+            .expect("generated activation heights are far below Height::MAX");
+
+        prop_assume!(transaction_upgrade != NetworkUpgrade::current(&network, height));
+
+        prop_assert_eq!(
+            adjusted_mempool_misbehavior_score(
+                &TransactionError::WrongConsensusBranchId,
+                Some(transaction_upgrade),
+                height,
+                &network,
+            ),
+            100,
+        );
+    }
+
     /// Test if the mempool storage is cleared on a chain reset.
     #[test]
     fn storage_is_cleared_on_single_chain_reset(

--- a/zebrad/src/components/mempool/tests/prop.rs
+++ b/zebrad/src/components/mempool/tests/prop.rs
@@ -123,6 +123,37 @@ proptest! {
         );
     }
 
+    /// Checks that early NU6.3 branch IDs retain their score before the grace window.
+    #[test]
+    fn nu6_3_branch_id_keeps_score_before_grace(
+        activation_height in 200u32..1_000_000,
+        height_offset in -100i64..-40,
+    ) {
+        let network = Parameters::build()
+            .with_activation_heights(ConfiguredActivationHeights {
+                nu6_2: Some(activation_height - 101),
+                nu6_3: Some(activation_height),
+                ..Default::default()
+            })
+            .expect("generated activation heights are valid")
+            .clear_funding_streams()
+            .to_network()
+            .expect("configured testnet is valid");
+        let activation_height = block::Height(activation_height);
+        let height = (activation_height + height_offset)
+            .expect("generated activation heights are above Height::MIN");
+
+        prop_assert_eq!(
+            adjusted_mempool_misbehavior_score(
+                &TransactionError::WrongConsensusBranchId,
+                Some(NetworkUpgrade::Nu6_3),
+                height,
+                &network,
+            ),
+            100,
+        );
+    }
+
     /// Checks that NU6.2 branch IDs regain their peer score at the grace cutoff.
     #[test]
     fn nu6_2_branch_id_keeps_score_after_nu6_3_grace(

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -58,6 +58,40 @@ fn stale_branch_id_at_nu6_3_has_no_mempool_score() {
     );
 }
 
+/// A stale NU6.2 branch ID at a maximum-height NU6.3 activation does not panic.
+#[test]
+fn stale_branch_id_at_max_nu6_3_height_has_no_mempool_score() {
+    let network = ParametersBuilder::default()
+        .with_activation_heights(ConfiguredActivationHeights {
+            before_overwinter: Some(1),
+            overwinter: Some(2),
+            sapling: Some(3),
+            blossom: Some(4),
+            heartwood: Some(5),
+            canopy: Some(6),
+            nu5: Some(7),
+            nu6: Some(8),
+            nu6_1: Some(9),
+            nu6_2: Some(Height::MAX.0 - 1),
+            nu6_3: Some(Height::MAX.0),
+            nu7: None,
+        })
+        .expect("activation heights at Height::MAX are valid")
+        .clear_funding_streams()
+        .to_network()
+        .expect("configured network is valid");
+
+    assert_eq!(
+        adjusted_mempool_misbehavior_score(
+            &TransactionError::WrongConsensusBranchId,
+            Some(NetworkUpgrade::Nu6_2),
+            Height::MAX,
+            &network,
+        ),
+        0,
+    );
+}
+
 #[tokio::test]
 async fn mempool_service_basic() -> Result<(), Report> {
     // Test multiple times to catch intermittent bugs since eviction is randomized

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -2104,6 +2104,7 @@ async fn setup_with_mempool_config(
     let (sync_status, recent_syncs) = SyncStatus::new();
     let (misbehavior_tx, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
     let (mempool, mempool_transaction_subscriber) = Mempool::new(
+        network,
         &mempool_config,
         Buffer::new(BoxService::new(peer_set.clone()), 1),
         state_service.clone(),

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -15,7 +15,7 @@ use zebra_chain::{
     fmt::humantime_seconds,
     parameters::{
         testnet::{ConfiguredActivationHeights, ParametersBuilder},
-        Network,
+        Network, NetworkUpgrade,
     },
     serialization::ZcashDeserializeInto,
     transaction::{Transaction, VerifiedUnminedTx},
@@ -38,6 +38,25 @@ type StateService = Buffer<BoxService<zs::Request, zs::Response, zs::BoxError>, 
 
 /// A [`MockService`] representing the Zebra transaction verifier service.
 type MockTxVerifier = MockService<tx::Request, tx::Response, PanicAssertion, TransactionError>;
+
+/// A stale NU6.2 branch ID has no peer score at NU6.3 activation.
+#[test]
+fn stale_branch_id_at_nu6_3_has_no_mempool_score() {
+    let network = Network::Mainnet;
+    let height = NetworkUpgrade::Nu6_3
+        .activation_height(&network)
+        .expect("NU6.3 has a mainnet activation height");
+
+    assert_eq!(
+        adjusted_mempool_misbehavior_score(
+            &TransactionError::WrongConsensusBranchId,
+            Some(NetworkUpgrade::Nu6_2),
+            height,
+            &network,
+        ),
+        0,
+    );
+}
 
 #[tokio::test]
 async fn mempool_service_basic() -> Result<(), Report> {

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -58,6 +58,28 @@ fn stale_branch_id_at_nu6_3_has_no_mempool_score() {
     );
 }
 
+/// An early NU6.3 branch ID has no peer score just before NU6.3 activation.
+#[test]
+fn early_branch_id_before_nu6_3_has_no_mempool_score() {
+    let network = Network::Mainnet;
+    let activation_height = NetworkUpgrade::Nu6_3
+        .activation_height(&network)
+        .expect("NU6.3 has a mainnet activation height");
+    let height = activation_height
+        .previous()
+        .expect("NU6.3 activates above Height::MIN");
+
+    assert_eq!(
+        adjusted_mempool_misbehavior_score(
+            &TransactionError::WrongConsensusBranchId,
+            Some(NetworkUpgrade::Nu6_3),
+            height,
+            &network,
+        ),
+        0,
+    );
+}
+
 /// A stale NU6.2 branch ID at a maximum-height NU6.3 activation does not panic.
 #[test]
 fn stale_branch_id_at_max_nu6_3_height_has_no_mempool_score() {


### PR DESCRIPTION
## Motivation

Closes #11100 

Zebra assigns 100 peer-misbehavior points when a mempool transaction has the wrong consensus branch ID. Around NU6.3 activation, an honest peer whose tip is temporarily on the adjacent side of the activation can relay an otherwise valid NU6.2 transaction and be banned.

Consensus validation should continue rejecting the transaction, but this expected consequence of temporary tip divergence should not be treated as peer misbehavior.

## Solution

Preserve the transaction's network upgrade and verification height when mempool verification fails.

When attributing the failure to a peer, assign no misbehavior points for an NU6.3 branch ID during the 40 heights before activation or an NU6.2 branch ID during the first 40 NU6.3 heights. Keep the existing score
outside these grace windows and for all unrelated branch ID mismatches.

This policy is limited to zebrad's mempool peer scoring. It does not change consensus validation, block validation, or the public zebra-consensus API. The configured network is used so custom activation heights behave consistently.

### Tests

Added a focused unit test at NU6.3 activation and property tests covering:

- NU6.2 branch IDs throughout the grace period;
- NU6.2 branch IDs at and after the grace-period cutoff; and
- NU6.3 branch IDs before activation and before that grace cutoff;
- other mismatched branch IDs around NU6.3 activation.

Validated with:

```console
cargo fmt --all -- --check
PROPTEST_CASES=64 cargo test -p zebrad components::mempool::
PROPTEST_CASES=256 cargo test -p zebrad \
    nu6_2_branch_id_keeps_score_after_nu6_3_grace
cargo clippy -p zebra-consensus -p zebrad --all-targets -- -D warnings
```

### Specifications & References

This follows the narrowly scoped NU6.2-to-NU6.3 grace policy implemented by Zakura:

- https://github.com/zakura-core/zakura/pull/273

### Follow-up Work

Handling transaction gossip when a node is substantially behind the network tip can be considered separately using a freshness-aware sync signal.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: OpenAI Codex was used to review the issue, discuss the design, implement tests and code, run validation, and draft  this PR description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
