### PR TITLE
feat(network): keep dialing peers until the outbound connection limit is reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Chain synchronization now retains the final block hash returned by peers in `FindBlocks`
   responses, rather than discarding it to work around obsolete `zcashd` behavior
   ([#11093](https://github.com/ZcashFoundation/zebra/pull/11093)).
+- The peer crawler now queues a connection attempt on each crawl interval for every spare
+  outbound connection slot that has a ready address book candidate, so dropped outbound
+  connections are proactively replaced until the outbound connection limit is reached.
+  Previously, new connections were only attempted when the peer set ran out of ready peers,
+  when a crawl found new addresses, or when the node had no outbound connections at all
+  ([#11102](https://github.com/ZcashFoundation/zebra/issues/11102)).
 
 ## [Zebra 6.2.2](https://github.com/ZcashFoundation/zebra/releases/tag/v6.2.2) - 2026-07-24
 

--- a/zebra-network/proptest-regressions/peer_set/set/tests/prop.txt
+++ b/zebra-network/proptest-regressions/peer_set/set/tests/prop.txt
@@ -1,7 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc 000eed8d1771cbcfa390028a9d71096417438c8b1594693de180ab7bf60c283a # shrinks to total_number_of_peers = 2

--- a/zebra-network/proptest-regressions/peer_set/set/tests/prop.txt
+++ b/zebra-network/proptest-regressions/peer_set/set/tests/prop.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 000eed8d1771cbcfa390028a9d71096417438c8b1594693de180ab7bf60c283a # shrinks to total_number_of_peers = 2

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -435,6 +435,30 @@ where
         Some(next_peer)
     }
 
+    /// Returns the number of candidate peers that are currently ready for a
+    /// connection attempt, as selected by [`Self::next`].
+    ///
+    /// The returned count is a snapshot: candidates can become ready or be
+    /// attempted by other tasks immediately afterwards.
+    pub async fn ready_peer_count(&self) -> usize {
+        let address_book = self.address_book.clone();
+        let ready_peer_count = move || -> usize {
+            let guard = address_book.lock().unwrap();
+
+            // Now we have the lock, get the current time
+            let instant_now = std::time::Instant::now();
+            let chrono_now = Utc::now();
+
+            guard.reconnection_peers(instant_now, chrono_now).count()
+        };
+
+        // Correctness: Spawn address book accesses on a blocking thread, to avoid deadlocks (see #1976).
+        let span = Span::current();
+        tokio::task::spawn_blocking(move || span.in_scope(ready_peer_count))
+            .wait_for_panics()
+            .await
+    }
+
     /// Returns the address book for this `CandidateSet`.
     #[cfg(any(test, feature = "proptest-impl"))]
     #[allow(dead_code)]

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -855,7 +855,8 @@ enum CrawlerAction {
     ///
     /// If there are no available candidates, crawl existing peers.
     DemandHandshakeOrCrawl,
-    /// Crawl existing peers for more peers in response to a timer `tick`.
+    /// Crawl existing peers for more peers, and queue dial attempts to fill
+    /// any spare outbound connection capacity, in response to a timer `tick`.
     TimerCrawl { tick: Instant },
     /// Clear a finished handshake.
     HandshakeFinished,
@@ -872,6 +873,11 @@ enum CrawlerAction {
 /// Crawl for new peers every `config.crawl_new_peer_interval`.
 /// Also crawl whenever there is demand, but no new peers in `candidates`.
 /// After crawling, try to connect to one new peer using `outbound_connector`.
+///
+/// On every crawl timer tick, also queue a dial attempt for each spare outbound
+/// connection slot that has a candidate ready to dial, so the peer set keeps
+/// growing until it reaches `config.peerset_outbound_connection_limit()` or
+/// runs out of ready candidates.
 ///
 /// If a handshake fails, restore the unused demand signal by sending it to
 /// `demand_tx`.
@@ -1043,7 +1049,7 @@ where
                             // There weren't any peers, so try to get more peers.
                             debug!("demand for peers but no available candidates");
 
-                            crawl(candidates, demand_tx, false).await?;
+                            crawl(candidates, demand_tx).await?;
 
                             Ok(DemandCrawlFinished)
                         }
@@ -1056,17 +1062,37 @@ where
             }
             Ok(TimerCrawl { tick }) => {
                 let candidates = candidates.clone();
-                let demand_tx = demand_tx.clone();
-                let should_always_dial = active_outbound_connections.update_count() == 0;
+                let crawl_demand_tx = demand_tx.clone();
+                let spare_capacity = config
+                    .peerset_outbound_connection_limit()
+                    .saturating_sub(active_outbound_connections.update_count());
 
                 let crawl_handle = tokio::spawn(
                     async move {
                         debug!(
                             ?tick,
+                            spare_capacity,
                             "crawling for more peers in response to the crawl timer"
                         );
 
-                        crawl(candidates, demand_tx, should_always_dial).await?;
+                        // Queue a dial attempt for each free outbound slot that has a
+                        // candidate ready to dial, so the crawler keeps trying to fill
+                        // the peer set up to the outbound connection limit.
+                        //
+                        // Capping the queued attempts at the ready candidate count avoids
+                        // spawning fallback crawls for demand that can't be met. The
+                        // demand handler re-checks the connection limit before each
+                        // handshake, so excess signals are dropped, and failed handshakes
+                        // restore their demand signal.
+                        let ready_candidates = { candidates.lock().await.ready_peer_count().await };
+                        let mut fill_demand_tx = crawl_demand_tx.clone();
+                        for _ in 0..spare_capacity.min(ready_candidates) {
+                            if fill_demand_tx.try_send(MorePeers).is_err() {
+                                break;
+                            }
+                        }
+
+                        crawl(candidates, crawl_demand_tx).await?;
 
                         Ok(TimerCrawlFinished)
                     }
@@ -1105,12 +1131,11 @@ where
 }
 
 /// Try to get more peers using `candidates`, then queue a connection attempt using `demand_tx`.
-/// If there were no new peers and `should_always_dial` is false, the connection attempt is skipped.
+/// If there were no new peers, the connection attempt is skipped.
 #[instrument(skip(candidates, demand_tx))]
 async fn crawl<S>(
     candidates: Arc<futures::lock::Mutex<CandidateSet<S>>>,
     mut demand_tx: futures::channel::mpsc::Sender<MorePeers>,
-    should_always_dial: bool,
 ) -> Result<(), BoxError>
 where
     S: Service<Request, Response = Response, Error = BoxError> + Send + Sync + 'static,
@@ -1125,7 +1150,7 @@ where
         result
     };
     let more_peers = match result {
-        Ok(more_peers) => more_peers.or_else(|| should_always_dial.then_some(MorePeers)),
+        Ok(more_peers) => more_peers,
         Err(e) => {
             info!(
                 ?e,

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -734,6 +734,156 @@ async fn crawler_peer_limit_default_connect_ok_stay_open() {
     );
 }
 
+/// Test that the crawler timer fills the peer set up to the outbound connection limit
+/// using existing address book candidates, without any demand signals, and even when
+/// crawls return no new addresses. Then test that it replaces dropped connections,
+/// and doesn't dial over the limit once it is reached.
+#[tokio::test]
+async fn crawler_refills_spare_outbound_capacity_on_timer() {
+    let _init_guard = zebra_test::init();
+
+    // This test does not require network access, because the outbound connector
+    // and peer set are fake.
+
+    let config = Config {
+        peerset_initial_target_size: 1,
+        // Tick often enough that the crawler gets multiple chances to fill spare capacity.
+        crawl_new_peer_interval: Duration::from_millis(200),
+        ..Config::default()
+    };
+
+    let outbound_limit = config.peerset_outbound_connection_limit();
+
+    let (
+        address_book,
+        _bans_receiver,
+        address_book_updater,
+        _address_metrics,
+        _address_book_updater_guard,
+    ) = AddressBookUpdater::spawn(&config, config.listen_addr);
+
+    // Add enough candidates for the initial fill and the replacement dials.
+    let candidate_count = outbound_limit * 2 + 1;
+    for address_number in 0..candidate_count {
+        let addr = SocketAddr::new(Ipv4Addr::new(127, 1, 1, address_number as _).into(), 1);
+        let addr = MetaAddr::new_gossiped_meta_addr(
+            addr.into(),
+            PeerServices::NODE_NETWORK,
+            DateTime32::now(),
+        )
+        .new_gossiped_change()
+        .expect("created MetaAddr contains enough information to represent a gossiped address");
+
+        address_book
+            .lock()
+            .expect("panic in previous thread while accessing the address book")
+            .update(addr);
+    }
+
+    // A peer set whose crawl responses never contain any addresses,
+    // so the crawler can only dial existing address book candidates.
+    let empty_peer_set = service_fn(|req| async move {
+        let rsp = match req {
+            Request::Peers => Response::Peers(Vec::new()),
+            _ => unreachable!("unexpected request: {:?}", req),
+        };
+
+        Ok(rsp)
+    });
+
+    let (peer_tracker_tx, mut peer_tracker_rx) = mpsc::unbounded();
+
+    let success_stay_open_outbound_connector = service_fn(move |req: OutboundConnectorRequest| {
+        let peer_tracker_tx = peer_tracker_tx.clone();
+        async move {
+            let OutboundConnectorRequest {
+                addr,
+                connection_tracker,
+            } = req;
+
+            let (fake_client, _harness) = ClientTestHarness::build().finish();
+
+            // Make the connection stay open.
+            peer_tracker_tx
+                .unbounded_send(connection_tracker)
+                .expect("unexpected error sending to unbounded channel");
+
+            Ok((addr, fake_client))
+        }
+    });
+
+    let (peerset_tx, mut peerset_rx) = mpsc::channel::<DiscoveredPeer>(candidate_count);
+    // The demand channel starts empty: all dials must come from the crawler timer.
+    let (demand_tx, demand_rx) = mpsc::channel::<MorePeers>(candidate_count);
+
+    let candidates = CandidateSet::new(address_book.clone(), empty_peer_set);
+    let active_outbound_connections = ActiveConnectionCounter::new_counter();
+
+    let crawl_task_handle = tokio::spawn(crawl_and_dial(
+        config.clone(),
+        demand_tx,
+        demand_rx,
+        candidates,
+        success_stay_open_outbound_connector,
+        peerset_tx,
+        active_outbound_connections,
+        address_book_updater,
+    ));
+
+    // Let the crawler fill the peer set from the timer.
+    tokio::time::sleep(CRAWLER_TEST_DURATION / 2).await;
+
+    let mut initial_peer_count: usize = 0;
+    while peerset_rx.try_recv().is_ok() {
+        initial_peer_count += 1;
+    }
+
+    assert_eq!(
+        initial_peer_count, outbound_limit,
+        "expected the timer to fill the peer set to the outbound limit without demand",
+    );
+
+    // Hold the initial connections open, then drop some to make spare capacity.
+    let mut peer_trackers: Vec<ConnectionTracker> = Vec::new();
+    while let Ok(peer_tracker) = peer_tracker_rx.try_recv() {
+        peer_trackers.push(peer_tracker);
+    }
+    assert_eq!(
+        peer_trackers.len(),
+        outbound_limit,
+        "expected one held connection tracker per successful handshake",
+    );
+
+    let dropped_count = outbound_limit.div_ceil(2);
+    for peer_tracker in peer_trackers.drain(..dropped_count) {
+        std::mem::drop(peer_tracker);
+    }
+
+    // Let the crawler replace the dropped connections.
+    tokio::time::sleep(CRAWLER_TEST_DURATION / 2).await;
+
+    let mut replacement_peer_count: usize = 0;
+    while peerset_rx.try_recv().is_ok() {
+        replacement_peer_count += 1;
+    }
+
+    assert_eq!(
+        replacement_peer_count, dropped_count,
+        "expected the crawler to replace exactly the dropped connections, \
+         without dialing over the limit",
+    );
+
+    // Stop the crawler and check for panics or errors.
+    crawl_task_handle.abort();
+    tokio::task::yield_now().await;
+
+    let crawl_result = crawl_task_handle.now_or_never();
+    assert!(
+        crawl_result.is_none() || matches!(crawl_result, Some(Err(ref e)) if e.is_cancelled()),
+        "unexpected error or panic in peer crawler task: {crawl_result:?}",
+    );
+}
+
 /// Test the listener with an inbound peer limit of zero peers, and a handshaker that panics.
 #[tokio::test]
 async fn listener_peer_limit_zero_handshake_panic() {


### PR DESCRIPTION
## Motivation

Zebra only attempts new outbound connections when the peer set runs out of ready peers, when a crawl discovers new addresses, or when the node has zero outbound connections. After partial peer loss, a node can sit well below its outbound connection limit indefinitely, because none of those triggers fire.

Closes #11102.

## Solution

On every crawl timer tick, the crawler now queues a `MorePeers` demand signal for each spare outbound connection slot (`peerset_outbound_connection_limit() - active_outbound_connections`). The existing demand machinery does the rest:

- The demand handler re-checks the connection limit before each handshake and drops excess signals, so over-signaling can never over-dial.
- Failed handshakes already restore their demand signal, so the crawler keeps retrying, and each tick tops demand back up to the remaining spare capacity.
- Demand with no available candidates already falls back to a crawl, which is rate-limited inside `CandidateSet::update()`, and per-peer retry backoff and per-IP limits are unchanged.

Since the fill loop strictly subsumes the old zero-connections special case, the now-redundant `should_always_dial` parameter is removed from `crawl()`.

### Tests

- New `crawler_refills_spare_outbound_capacity_on_timer` test: with an empty demand channel and a peer set service whose crawl responses never contain addresses, the timer alone fills the peer set to the outbound limit from existing address book candidates; after dropping some connection trackers, the crawler dials exactly enough replacements, without exceeding the limit. The test fails against the previous behavior, which stalls at one connection.
- Existing `crawler_peer_limit_*` tests still pass, confirming the connection limit is respected.
- `cargo fmt --all -- --check`, `cargo clippy -p zebra-network --all-targets -- -D warnings`, and `cargo nextest run -p zebra-network --release` (199 tests) all pass locally.

### Follow-up Work

None planned.

### AI Disclosure

- [x] AI tools were used: Claude Code (implementation, test, and changelog entry, reviewed by the author)

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.