### PR TITLE
fix(network): increase the near-tip tolerance for stall detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Zebra now sends up to half of its address book in response to a `getaddr` request, up from
   a quarter, so peers can find more of the network from each response
   ([#11103](https://github.com/ZcashFoundation/zebra/issues/11103)).
+- The peer stall detector no longer disconnects peers for empty `FindBlocks` or `FindHeaders`
+  responses while the node is within 1,000 estimated blocks of the network tip, avoiding false
+  stall detection during long gaps between blocks
+  ([#11122](https://github.com/ZcashFoundation/zebra/pull/11122)).
 
 ### Fixed
 

--- a/zebra-chain/CHANGELOG.md
+++ b/zebra-chain/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `parameters::NetworkUpgrade::nu6_3_branch_id_strategy`
   - `transaction::Transaction::ironwood_value_balance_mut`
 
+### Changed
+
+- `AT_OR_NEAR_TIP_THRESHOLD` is now 1,000 blocks, keeping peer stall detection disabled during
+  long gaps between blocks ([#11122](https://github.com/ZcashFoundation/zebra/pull/11122)).
+
 ### Fixed
 
 - With the `proptest-impl` feature, the arbitrary `Transaction` strategy now generates v6

--- a/zebra-chain/src/chain_tip.rs
+++ b/zebra-chain/src/chain_tip.rs
@@ -18,9 +18,13 @@ pub use network_chain_tip_height_estimator::NetworkChainTipHeightEstimator;
 /// The maximum estimated distance to the network chain tip that is considered "at or near tip".
 ///
 /// Allows for normal block-time variance and propagation delay. Considering the 75 second target
-/// for the time between blocks on mainnet, this equals approximately 6 minutes of time the node
-/// can stay without receiving a new block before being considered far from the tip.
-pub const AT_OR_NEAR_TIP_THRESHOLD: block::HeightDiff = 5;
+/// for the time between blocks on mainnet, the node is considered far from the tip once the
+/// estimated distance exceeds this threshold, after approximately 20 hours and 51 minutes without
+/// a new block.
+///
+/// Since block production is approximately a Poisson process, this larger tolerance avoids
+/// enabling peer stall detection during normal long gaps between blocks.
+pub const AT_OR_NEAR_TIP_THRESHOLD: block::HeightDiff = 1_000;
 
 /// An interface for querying the chain tip.
 ///

--- a/zebra-chain/src/chain_tip/tests.rs
+++ b/zebra-chain/src/chain_tip/tests.rs
@@ -1,3 +1,4 @@
 #![allow(clippy::unwrap_in_result)]
 
 mod prop;
+mod vectors;

--- a/zebra-chain/src/chain_tip/tests/vectors.rs
+++ b/zebra-chain/src/chain_tip/tests/vectors.rs
@@ -1,0 +1,22 @@
+use crate::{
+    block,
+    chain_tip::{mock::MockChainTip, ChainTip, AT_OR_NEAR_TIP_THRESHOLD},
+    parameters::Network,
+};
+
+/// Check that the at-or-near-tip threshold is inclusive.
+#[test]
+fn at_or_near_network_tip_threshold_is_inclusive() {
+    let network = Network::Mainnet;
+    let (chain_tip, mock_chain_tip_sender) = MockChainTip::new();
+
+    mock_chain_tip_sender.send_best_tip_height(block::Height(2_500_000));
+    mock_chain_tip_sender.send_estimated_distance_to_network_chain_tip(AT_OR_NEAR_TIP_THRESHOLD);
+
+    assert!(chain_tip.is_at_or_near_network_tip(&network));
+
+    mock_chain_tip_sender
+        .send_estimated_distance_to_network_chain_tip(AT_OR_NEAR_TIP_THRESHOLD + 1);
+
+    assert!(!chain_tip.is_at_or_near_network_tip(&network));
+}

--- a/zebra-network/CHANGELOG.md
+++ b/zebra-network/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a quarter, so peers can find more of the network from each response. The maximum address
   book size is now pinned at 5000 instead of being derived from the response fraction
   ([#11103](https://github.com/ZcashFoundation/zebra/issues/11103)).
+- The peer stall detector no longer disconnects peers for empty `FindBlocks` or `FindHeaders`
+  responses while the node is within 1,000 estimated blocks of the network tip
+  ([#11122](https://github.com/ZcashFoundation/zebra/pull/11122)).
 
 ## [10.2.1] - 2026-07-24
 

--- a/zebra-network/src/peer_set/set/tests/vectors.rs
+++ b/zebra-network/src/peer_set/set/tests/vectors.rs
@@ -15,6 +15,7 @@ use tower::{discover::Change, Service, ServiceExt};
 
 use zebra_chain::{
     block,
+    chain_tip::AT_OR_NEAR_TIP_THRESHOLD,
     parameters::{Network, NetworkUpgrade},
     serialization::ZcashDeserializeInto,
 };
@@ -721,9 +722,9 @@ fn find_blocks_stall_not_tracked_when_at_tip() {
     let (minimum_peer_version, best_tip) =
         MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
 
-    // Simulate being at the chain tip.
+    // Simulate being at the maximum estimated distance that is still considered near the tip.
     best_tip.send_best_tip_height(Some(block::Height(2_500_000)));
-    best_tip.send_estimated_distance_to_network_chain_tip(Some(0));
+    best_tip.send_estimated_distance_to_network_chain_tip(Some(AT_OR_NEAR_TIP_THRESHOLD));
 
     let mut handle = handles.into_iter().next().expect("there is one peer");
 
@@ -784,9 +785,9 @@ fn find_blocks_stall_tracked_when_syncing() {
     let (minimum_peer_version, best_tip) =
         MinimumPeerVersion::with_mock_chain_tip(&Network::Mainnet);
 
-    // Simulate being far behind the chain tip, as during initial sync.
+    // Simulate being just beyond the maximum estimated distance considered near the tip.
     best_tip.send_best_tip_height(Some(block::Height(2_490_000)));
-    best_tip.send_estimated_distance_to_network_chain_tip(Some(10_000));
+    best_tip.send_estimated_distance_to_network_chain_tip(Some(AT_OR_NEAR_TIP_THRESHOLD + 1));
 
     let mut handle = handles.into_iter().next().expect("there is one peer");
 


### PR DESCRIPTION
## Motivation

Zebra enables the `FindBlocks`/`FindHeaders` stall detector when its local chain tip is more than `AT_OR_NEAR_TIP_THRESHOLD` blocks behind the estimated network tip. Because the estimate advances using the 75-second target block spacing, a normal long gap in Poisson-distributed block production can make a synced node appear to be behind.

With the current threshold of 5, stall detection can become active after an approximately 7.5-minute gap. Healthy peers at the same tip can then legitimately return empty responses and be disconnected after reaching the response-stall threshold.

Closes #11116

## Solution

Increase `AT_OR_NEAR_TIP_THRESHOLD` from 5 to 1,000.

Since the threshold comparison is inclusive, stall detection now remains disabled until the estimated distance reaches 1,001 blocks, corresponding to approximately 20 hours and 51 minutes at the 75-second target spacing. This makes ordinary variance in Poisson-distributed block production insufficient to activate the detector while preserving it for initial and deep synchronization.

Update the constant documentation to describe the effective time boundary and the Poisson-variance rationale.

Update the peer-set tests to exercise the exact boundary: an estimated distance of 1,000 keeps stall tracking disabled, while a distance of 1,001 enables it. Add a `zebra-chain` test confirming that the near-tip threshold is inclusive.

Add changelog entries for node operators and `zebra-chain` and `zebra-network` library users.

### Tests

- `cargo fmt --all -- --check`
- `cargo test -p zebra-chain at_or_near_network_tip_threshold_is_inclusive`
- `cargo test -p zebra-network find_blocks_stall_not_tracked_when_at_tip`
- `cargo test -p zebra-network find_blocks_stall_tracked_when_syncing`
- `git diff --check`

### Specifications & References

Zcash's post-Blossom target block spacing is 75 seconds. For exponentially distributed block intervals with mean 75 seconds, the probability of a gap of at least `t` seconds is `exp(-t / 75)`.

### Follow-up Work

This change mitigates false stall-detector activation during normal long block gaps. It does not address the broader classification issue (#11101) where the detector uses local estimated sync state rather than fresh peer-specific evidence and classifies both empty successful responses and request errors as stalls.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: OpenAI Codex was used to analyze the stall-detection behavior and Poisson probabilities, implement and update tests, and draft the issue and PR descriptions.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
