### PR TITLE
ci: allow the non-local variant of the semicolon-in-expressions lint in u256

### DIFF
--- a/zebra-chain/src/work/u256.rs
+++ b/zebra-chain/src/work/u256.rs
@@ -5,8 +5,10 @@
 #![allow(clippy::range_plus_one)]
 #![allow(clippy::fallible_impl_from)]
 #![allow(missing_docs)]
-// `uint`'s macro expansion trips this lint on newer nightlies: https://github.com/rust-lang/rust/issues/79813
+// `uint`'s macro expansion trips this lint, and each toolchain knows only one of its two names: https://github.com/rust-lang/rust/issues/79813
+#![allow(unknown_lints)]
 #![allow(semicolon_in_expressions_from_macros)]
+#![allow(semicolon_in_expressions_from_non_local_macros)]
 
 use uint::construct_uint;
 


### PR DESCRIPTION
## Motivation

The Book workflow has been red on every push to `main` since 2026-07-27, and the weekly Advisory Checks workflow fails the same way. Both build docs on nightly with `-D warnings`, and `zebra-chain` no longer compiles under it:

```
error: trailing semicolon in macro used in expression position
  --> zebra-chain/src/work/u256.rs:13:1
   = note: `-D semicolon-in-expressions-from-non-local-macros` implied by `-D warnings`
```

No Zebra change caused this. rustc split `semicolon_in_expressions_from_macros` into two lints, by where the macro is defined:

| lint | default | covers |
| --- | --- | --- |
| `semicolon_in_expressions_from_macros` | deny | macros defined in this crate |
| `semicolon_in_expressions_from_non_local_macros` | warn | macros from other crates |

`uint::construct_uint!` comes from an external crate, so it moved out from under the existing allow and into a lint nothing was silencing. `uint 0.10.0` is the latest release, so no upstream version fixes the expansion.

This is a hotfix for red `main`, so it has no prior issue.

## Solution

Allow both lint names in `u256.rs`, together with `unknown_lints`.

All three are required. Only nightly knows the new name, so naming it directly makes stable emit `unknown_lints`, which is warn-by-default and therefore fatal under clippy's `-D warnings`.

A single `#![allow(future_incompatible)]` would have covered both names and survived any future split, but rustc rejects it here: `allow(future_incompatible) is ignored unless specified at crate level`, and crate level is far too broad.

### Tests

Checked against the three toolchains CI uses:

| variant | nightly 1.99 | stable 1.97 | stable 1.91 (MSRV) |
| --- | --- | --- | --- |
| before this change | fail | pass | pass |
| both names, without `unknown_lints` | pass | fail | fail |
| this change | pass | pass | pass |

- The verbatim `book.yml` docs command (`cargo doc --no-deps --workspace --all-features --document-private-items` under the full CI `RUSTDOCFLAGS`) exits 0 on nightly 1.99.0.
- `cargo clippy -p zebra-chain --all-features --all-targets -- -D warnings` is clean on stable.
- `cargo test -p zebra-chain --lib work::` passes, 43 tests.

### Specifications & References

- https://github.com/rust-lang/rust/issues/79813
- Same lint, previous occurrence: #10986

### Follow-up Work

`book.yml` and `advisory.yml` pair an unpinned `nightly` toolchain with `-D warnings`, so any rustc lint addition or split turns `main` red. This is the second occurrence in ten days. Pinning the nightly is a trade-off worth its own discussion.

`book.yml` also points readers to `lint.yml:jobs.docs`, which no longer exists.

### AI Disclosure

- [x] AI tools were used: Claude Code for the root cause analysis, the toolchain test matrix, and this description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date. CI-only fix with no user-visible change, matching #10986.
