### PR TITLE
ci: allow the non-local variant of the semicolon-in-expressions lint in tests

### DIFF
--- a/tower-batch-control/tests/worker.rs
+++ b/tower-batch-control/tests/worker.rs
@@ -1,5 +1,10 @@
 //! Fixed test cases for batch worker tasks.
 
+// `tokio-test`'s macro expansion trips this lint, and each toolchain knows only one of its two names: https://github.com/rust-lang/rust/issues/79813
+#![allow(unknown_lints)]
+#![allow(semicolon_in_expressions_from_macros)]
+#![allow(semicolon_in_expressions_from_non_local_macros)]
+
 use std::time::Duration;
 
 use tokio_test::{assert_pending, assert_ready, assert_ready_err, task};

--- a/zebra-rpc/src/methods/tests/snapshot.rs
+++ b/zebra-rpc/src/methods/tests/snapshot.rs
@@ -5,6 +5,11 @@
 //! cargo insta test --review --release -p zebra-rpc --lib -- test_rpc_response_data
 //! ```
 
+// `insta`'s macro expansion trips this lint, and each toolchain knows only one of its two names: https://github.com/rust-lang/rust/issues/79813
+#![allow(unknown_lints)]
+#![allow(semicolon_in_expressions_from_macros)]
+#![allow(semicolon_in_expressions_from_non_local_macros)]
+
 use std::{
     collections::BTreeMap,
     net::{IpAddr, Ipv4Addr, SocketAddr},


### PR DESCRIPTION
## Motivation

The `Nightly unused dependencies` job in Advisory Checks fails to compile `tower-batch-control` and `zebra-rpc`:

```
error: trailing semicolon in macro used in expression position
   --> tower-batch-control/tests/worker.rs:39:15
   = note: `-D semicolon-in-expressions-from-non-local-macros` implied by `-D warnings`
```

Same compiler change as #11131. rustc split `semicolon_in_expressions_from_macros` by macro locality, and macros from external crates moved into the new non-local variant. #11131 covered `uint::construct_uint!` in `zebra-chain`. These are the remaining two sites: `tokio-test`'s `assert_ready_err!` and `insta`'s `assert_json_snapshot!`, both used in expression position.

They only surface in jobs that compile test targets under `-D warnings`, which is why the docs build went green without them.

## Solution

Same three-attribute pattern as #11131, applied at each affected file.

`unknown_lints` is required: only nightly knows the new lint name, so naming it directly makes stable and the MSRV toolchains emit `unknown_lints`, which is warn-by-default and therefore fatal under clippy's `-D warnings`.

### Tests

Found by compiling the whole workspace rather than grepping, since cargo stops scheduling work after the first failing unit and masks later ones. It took three passes to reach a clean build; the `zebra-rpc` site was hidden behind the `tower-batch-control` failure.

- `cargo +nightly check --workspace --all-targets --all-features` under `RUSTFLAGS=-D warnings`: clean. This is the first pass over the workspace with no instances of this lint remaining.
- `cargo +stable clippy -p tower-batch-control -p zebra-rpc --all-features --all-targets -- -D warnings`: clean, confirming no `unknown_lints` regression.
- `cargo test -p tower-batch-control --test worker`: 2 passed.
- `cargo test -p zebra-rpc --lib --all-features -- test_rpc_response_data`: passed.
- `cargo fmt --all -- --check`: clean.

### Specifications & References

- https://github.com/rust-lang/rust/issues/79813
- Same lint, first two sites: #11131, #10986

### Follow-up Work

`book.yml` and `advisory.yml` pair an unpinned `nightly` toolchain with `-D warnings`, so any rustc lint addition or split turns these jobs red without a code change. Worth deciding separately whether to pin.

### AI Disclosure

- [x] AI tools were used: Claude Code for the workspace lint sweep, the fixes, and this description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date. CI-only fix with no user-visible change, matching #11131.
