### PR TITLE
fix(state): make read_only_open_with_ephemeral_config_returns_error more robust

### DIFF
--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `init_read_only()` now returns `StateInitError::ReadOnlyEphemeralConflict` for a config with
+  `ephemeral = true`, even when the configured `cache_dir` is missing or unreadable. Previously the
+  cache directory was checked first, so this configuration error surfaced as
+  `StateInitError::ReadOnlyCacheDirUnreadable`.
+
 ## [12.0.1] - 2026-07-27
 
 ### Changed

--- a/zebra-state/src/service/finalized_state/zebra_db.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db.rs
@@ -107,6 +107,14 @@ impl ZebraDb {
         // checked for readability first, so a missing or unreadable directory returns a typed
         // `ReadOnlyCacheDirUnreadable` error here instead of panicking on the version-file read.
         let disk_version = if read_only {
+            // While this check is also done in `DiskDB::new()` below, we must
+            // repeat it here because the `check_cache_dir_readable()` call just
+            // after this will look into `cache_dir` but that should be ignored
+            // when `ephemeral` is true.
+            if config.ephemeral {
+                return Err(StateInitError::ReadOnlyEphemeralConflict);
+            }
+
             DiskDb::check_cache_dir_readable(&config.cache_dir)?;
 
             database_format_version_on_disk(config, &db_kind, format_version_in_code.major, network)

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -667,8 +667,14 @@ fn read_only_open_with_unreadable_cache_dir_returns_error() {
 fn read_only_open_with_ephemeral_config_returns_error() {
     let network = Network::Mainnet;
 
+    // While `ephemeral: true` should make `cache_dir` irrelevant, we had
+    // instances where a bug would try to read the `cache_dir` before checking
+    // `ephemeral`, so we use a missing directory to ensure that `ephemeral` is
+    // checked first.
+    let parent = tempfile::tempdir().expect("creating a temporary directory should succeed");
     let config = Config {
         ephemeral: true,
+        cache_dir: parent.path().join("missing"),
         ..Config::default()
     };
 


### PR DESCRIPTION
## Motivation

Closes #11147


## Solution

The issue was actually in the code, we improve error checking which makes the test reliable and not dependent on a specific folder existing or not during testing

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
-->

### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [ ] No AI tools were used in this PR
- [ ] AI tools were used: Claude, comments were cleaned up manually

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
