### PR TITLE
test(ci): serialize live-network tests and remove shared cache-dir coupling

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -76,6 +76,18 @@ test-group = 'serial-live-mainnet'
 
 # Force live Testnet peer-limit tests to run serially with each other, while
 # allowing them to run concurrently with live Mainnet tests.
+#
+# This split is only safe while no other running test dials live Testnet peers.
+# `integration::sync::sync_one_checkpoint_testnet` and the Testnet half of
+# `integration::sync::restart_stop_at_height` are currently disabled; if they are
+# re-enabled, they join 'serial-live-mainnet' via the filter above and can then
+# contend with this group for Testnet connections. A test can only belong to one
+# group, and `restart_stop_at_height` syncs both networks, so re-enabling them
+# means merging these two groups back into one live-peer group.
+#
+# Keep the 'profile.default' and 'profile.ci' copies of each filter below in
+# sync: nextest is invoked with '--profile ci' by the test workflows, and with
+# the default profile by the coverage workflow.
 [[profile.default.overrides]]
 filter = 'test(/^peer_set::initialize::tests::vectors::peer_limit_(one|two)_testnet$/)'
 test-group = 'serial-live-testnet'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -59,6 +59,9 @@ serial-state = { max-threads = 1 }
 # Live Mainnet tests compete for the same limited set of usable peers when they
 # connect concurrently from one public IP.
 serial-live-mainnet = { max-threads = 1 }
+# Live Testnet tests have the same per-IP connection limit, but use a separate
+# peer set from Mainnet, so they can run concurrently with Mainnet tests.
+serial-live-testnet = { max-threads = 1 }
 # zcashd-compat integration tests each spawn a zebrad + zcashd on
 # bind-probed-then-released ports, so they must never run concurrently, even
 # under a parallel profile invoked with --run-ignored=all.
@@ -71,6 +74,16 @@ serial-zcashd-compat = { max-threads = 1 }
 filter = 'test(/^integration::sync::/)'
 test-group = 'serial-live-mainnet'
 
+# Force live Testnet peer-limit tests to run serially with each other, while
+# allowing them to run concurrently with live Mainnet tests.
+[[profile.default.overrides]]
+filter = 'test(/^peer_set::initialize::tests::vectors::peer_limit_(one|two)_testnet$/)'
+test-group = 'serial-live-testnet'
+
+[[profile.ci.overrides]]
+filter = 'test(/^peer_set::initialize::tests::vectors::peer_limit_(one|two)_testnet$/)'
+test-group = 'serial-live-testnet'
+
 # Force zcashd-compat integration tests serial in every profile, so a parallel
 # --run-ignored=all run cannot collide on their released RPC/P2P ports.
 [[profile.default.overrides]]
@@ -81,18 +94,17 @@ test-group = 'serial-zcashd-compat'
 filter = 'test(~integration::zcashd_compat::)'
 test-group = 'serial-zcashd-compat'
 
-# All other tests that dial live Mainnet/Testnet peers: zebra-network's crawler
-# and peer-cache tests, and every zebrad test that starts a node without
-# clearing the default DNS seeders. Remote Zebra peers accept then drop any
-# second connection from the same IP within ~2 minutes (max_connections_per_ip
-# is 1 by default), so concurrent live tests on one runner reject each other's
-# handshakes. These overrides set only the test-group; retries and timeouts
-# fall through to earlier overrides or profile defaults.
+# All other tests that dial live Mainnet peers: zebra-network's crawler and
+# peer-cache tests, and every zebrad test that starts a node without clearing
+# the default DNS seeders. Remote Zebra peers accept then drop any second
+# connection from the same IP within ~2 minutes (max_connections_per_ip is 1 by
+# default), so concurrent live tests on one runner reject each other's
+# handshakes. These overrides set only the test-group; retries and timeouts fall
+# through to earlier overrides or profile defaults.
 [[profile.default.overrides]]
 filter = '''
-test(/^peer_set::initialize::tests::vectors::peer_limit_(one|two)_(mainnet|testnet)$/)
+test(/^peer_set::initialize::tests::vectors::peer_limit_(one|two)_mainnet$/)
 or test(/^peer_set::initialize::tests::vectors::written_peer_cache_/)
-or test(=peer_set::initialize::tests::vectors::add_initial_peers_deadlock)
 or test(/^unit::cli::(start_no_args|start_args|external_address)$/)
 or test(/^unit::config::(misconfigured_)?ephemeral_(existing|missing)_directory$/)
 or test(=unit::config::config_tests)
@@ -106,9 +118,8 @@ test-group = 'serial-live-mainnet'
 
 [[profile.ci.overrides]]
 filter = '''
-test(/^peer_set::initialize::tests::vectors::peer_limit_(one|two)_(mainnet|testnet)$/)
+test(/^peer_set::initialize::tests::vectors::peer_limit_(one|two)_mainnet$/)
 or test(/^peer_set::initialize::tests::vectors::written_peer_cache_/)
-or test(=peer_set::initialize::tests::vectors::add_initial_peers_deadlock)
 or test(/^unit::cli::(start_no_args|start_args|external_address)$/)
 or test(/^unit::config::(misconfigured_)?ephemeral_(existing|missing)_directory$/)
 or test(=unit::config::config_tests)

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -81,6 +81,45 @@ test-group = 'serial-zcashd-compat'
 filter = 'test(~integration::zcashd_compat::)'
 test-group = 'serial-zcashd-compat'
 
+# All other tests that dial live Mainnet/Testnet peers: zebra-network's crawler
+# and peer-cache tests, and every zebrad test that starts a node without
+# clearing the default DNS seeders. Remote Zebra peers accept then drop any
+# second connection from the same IP within ~2 minutes (max_connections_per_ip
+# is 1 by default), so concurrent live tests on one runner reject each other's
+# handshakes. These overrides set only the test-group; retries and timeouts
+# fall through to earlier overrides or profile defaults.
+[[profile.default.overrides]]
+filter = '''
+test(/^peer_set::initialize::tests::vectors::peer_limit_(one|two)_(mainnet|testnet)$/)
+or test(/^peer_set::initialize::tests::vectors::written_peer_cache_/)
+or test(=peer_set::initialize::tests::vectors::add_initial_peers_deadlock)
+or test(/^unit::cli::(start_no_args|start_args|external_address)$/)
+or test(/^unit::config::(misconfigured_)?ephemeral_(existing|missing)_directory$/)
+or test(=unit::config::config_tests)
+or test(=unit::config::non_blocking_logger)
+or test(=unit::end_of_support::end_of_support_is_checked_at_start)
+or test(/^integration::network::zebra_(zcash_listener|metrics|tracing|rpc)_conflict$/)
+or test(/^integration::rpc::(metrics_endpoint|tracing_endpoint|rpc_endpoint_single_thread|rpc_endpoint_parallel_threads|rpc_endpoint_client_content_type)$/)
+or test(/^integration::database::(zebra_state_conflict|delete_old_databases)$/)
+'''
+test-group = 'serial-live-mainnet'
+
+[[profile.ci.overrides]]
+filter = '''
+test(/^peer_set::initialize::tests::vectors::peer_limit_(one|two)_(mainnet|testnet)$/)
+or test(/^peer_set::initialize::tests::vectors::written_peer_cache_/)
+or test(=peer_set::initialize::tests::vectors::add_initial_peers_deadlock)
+or test(/^unit::cli::(start_no_args|start_args|external_address)$/)
+or test(/^unit::config::(misconfigured_)?ephemeral_(existing|missing)_directory$/)
+or test(=unit::config::config_tests)
+or test(=unit::config::non_blocking_logger)
+or test(=unit::end_of_support::end_of_support_is_checked_at_start)
+or test(/^integration::network::zebra_(zcash_listener|metrics|tracing|rpc)_conflict$/)
+or test(/^integration::rpc::(metrics_endpoint|tracing_endpoint|rpc_endpoint_single_thread|rpc_endpoint_parallel_threads|rpc_endpoint_client_content_type)$/)
+or test(/^integration::database::(zebra_state_conflict|delete_old_databases)$/)
+'''
+test-group = 'serial-live-mainnet'
+
 # Stateful tests share on-disk state, so run them serially. This override sets
 # only the test-group: adding slow-timeout here would shadow every per-test
 # timeout below, since nextest applies the first matching override per setting.

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -1785,6 +1785,8 @@ async fn add_initial_peers_deadlock() {
     let config = Config {
         initial_mainnet_peers: peers,
         peerset_initial_target_size: PEERSET_INITIAL_TARGET_SIZE,
+        // Only use the configured dummy peers, not addresses from the default peer cache.
+        cache_dir: CacheDir::disabled(),
 
         network: Network::Mainnet,
         listen_addr: unused_v4,

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -366,8 +366,14 @@ async fn written_peer_cache_can_be_read_manually() {
 
     let nil_inbound_service = service_fn(|_| async { Ok(Response::Nil) });
 
-    // The default config should have an active peer cache
-    let config = Config::default();
+    // Use a temporary peer cache directory, so this test doesn't read or write the default
+    // peer cache directory, which is shared with other tests and local zebrad instances.
+    let peer_cache_dir =
+        tempfile::tempdir().expect("creating a temporary cache directory should succeed");
+    let config = Config {
+        cache_dir: CacheDir::custom_path(peer_cache_dir.path()),
+        ..Config::default()
+    };
     let address_book =
         init_with_peer_limit(25, nil_inbound_service, Mainnet, None, config.clone()).await;
 
@@ -403,8 +409,14 @@ async fn written_peer_cache_is_automatically_read_on_startup() {
 
     let nil_inbound_service = service_fn(|_| async { Ok(Response::Nil) });
 
-    // The default config should have an active peer cache
-    let mut config = Config::default();
+    // Use a temporary peer cache directory, so this test doesn't read or write the default
+    // peer cache directory, which is shared with other tests and local zebrad instances.
+    let peer_cache_dir =
+        tempfile::tempdir().expect("creating a temporary cache directory should succeed");
+    let mut config = Config {
+        cache_dir: CacheDir::custom_path(peer_cache_dir.path()),
+        ..Config::default()
+    };
     let address_book =
         init_with_peer_limit(25, nil_inbound_service, Mainnet, None, config.clone()).await;
 

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -390,17 +390,19 @@ async fn written_peer_cache_is_automatically_read_on_startup() {
         cache_dir: CacheDir::custom_path(peer_cache_dir.path()),
         ..Config::default()
     };
-    let address_book =
+    let _address_book =
         init_with_peer_limit(25, nil_inbound_service, Mainnet, None, config.clone()).await;
 
     // Let the peer cache updater run for a while.
     tokio::time::sleep(PEER_CACHE_UPDATER_TEST_DURATION).await;
 
-    let approximate_peer_count = address_book
-        .lock()
-        .expect("previous thread panicked while holding address book lock")
-        .len();
-    if approximate_peer_count > 0 {
+    // The address book also contains unverified DNS seed addresses, so only test automatic
+    // loading when the peer cache updater actually wrote at least one cacheable peer.
+    let cached_peers = config
+        .load_peer_cache()
+        .await
+        .expect("unexpected error reading peer cache");
+    if !cached_peers.is_empty() {
         // Make sure our only peers are coming from the disk cache
         config.initial_mainnet_peers = Default::default();
 

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -2147,6 +2147,8 @@ async fn add_initial_peers_deadlock() {
     let config = Config {
         initial_mainnet_peers: peers,
         peerset_initial_target_size: PEERSET_INITIAL_TARGET_SIZE,
+        // Only use the configured dummy peers, not addresses from the default peer cache.
+        cache_dir: CacheDir::disabled(),
 
         network: Network::Mainnet,
         listen_addr: unused_v4,

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -417,17 +417,19 @@ async fn written_peer_cache_is_automatically_read_on_startup() {
         cache_dir: CacheDir::custom_path(peer_cache_dir.path()),
         ..Config::default()
     };
-    let address_book =
+    let _address_book =
         init_with_peer_limit(25, nil_inbound_service, Mainnet, None, config.clone()).await;
 
     // Let the peer cache updater run for a while.
     tokio::time::sleep(PEER_CACHE_UPDATER_TEST_DURATION).await;
 
-    let approximate_peer_count = address_book
-        .lock()
-        .expect("previous thread panicked while holding address book lock")
-        .len();
-    if approximate_peer_count > 0 {
+    // The address book also contains unverified DNS seed addresses, so only test automatic
+    // loading when the peer cache updater actually wrote at least one cacheable peer.
+    let cached_peers = config
+        .load_peer_cache()
+        .await
+        .expect("unexpected error reading peer cache");
+    if !cached_peers.is_empty() {
         // Make sure our only peers are coming from the disk cache
         config.initial_mainnet_peers = Default::default();
 

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -339,8 +339,14 @@ async fn written_peer_cache_can_be_read_manually() {
 
     let nil_inbound_service = service_fn(|_| async { Ok(Response::Nil) });
 
-    // The default config should have an active peer cache
-    let config = Config::default();
+    // Use a temporary peer cache directory, so this test doesn't read or write the default
+    // peer cache directory, which is shared with other tests and local zebrad instances.
+    let peer_cache_dir =
+        tempfile::tempdir().expect("creating a temporary cache directory should succeed");
+    let config = Config {
+        cache_dir: CacheDir::custom_path(peer_cache_dir.path()),
+        ..Config::default()
+    };
     let address_book =
         init_with_peer_limit(25, nil_inbound_service, Mainnet, None, config.clone()).await;
 
@@ -376,8 +382,14 @@ async fn written_peer_cache_is_automatically_read_on_startup() {
 
     let nil_inbound_service = service_fn(|_| async { Ok(Response::Nil) });
 
-    // The default config should have an active peer cache
-    let mut config = Config::default();
+    // Use a temporary peer cache directory, so this test doesn't read or write the default
+    // peer cache directory, which is shared with other tests and local zebrad instances.
+    let peer_cache_dir =
+        tempfile::tempdir().expect("creating a temporary cache directory should succeed");
+    let mut config = Config {
+        cache_dir: CacheDir::custom_path(peer_cache_dir.path()),
+        ..Config::default()
+    };
     let address_book =
         init_with_peer_limit(25, nil_inbound_service, Mainnet, None, config.clone()).await;
 

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -667,7 +667,13 @@ fn read_only_open_with_unreadable_cache_dir_returns_error() {
 fn read_only_open_with_ephemeral_config_returns_error() {
     let network = Network::Mainnet;
 
+    // An existing, readable cache directory, so the open gets past the cache-dir readability
+    // check and reaches the ephemeral conflict check. The default cache directory may not
+    // exist, which returns `ReadOnlyCacheDirUnreadable` instead.
+    let cache_dir =
+        tempfile::tempdir().expect("creating a temporary cache directory should succeed");
     let config = Config {
+        cache_dir: cache_dir.path().to_path_buf(),
         ephemeral: true,
         ..Config::default()
     };

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -673,6 +673,7 @@ fn read_only_open_with_ephemeral_config_returns_error() {
     // checked first.
     let parent = tempfile::tempdir().expect("creating a temporary directory should succeed");
     let config = Config {
+        cache_dir: cache_dir.path().to_path_buf(),
         ephemeral: true,
         ..Config::default()
     };

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -673,7 +673,7 @@ fn read_only_open_with_ephemeral_config_returns_error() {
     // checked first.
     let parent = tempfile::tempdir().expect("creating a temporary directory should succeed");
     let config = Config {
-        cache_dir: cache_dir.path().to_path_buf(),
+        cache_dir: parent.path().join("missing"),
         ephemeral: true,
         ..Config::default()
     };

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -673,8 +673,8 @@ fn read_only_open_with_ephemeral_config_returns_error() {
     // checked first.
     let parent = tempfile::tempdir().expect("creating a temporary directory should succeed");
     let config = Config {
-        cache_dir: parent.path().join("missing"),
         ephemeral: true,
+        cache_dir: parent.path().join("missing"),
         ..Config::default()
     };
 

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -667,13 +667,7 @@ fn read_only_open_with_unreadable_cache_dir_returns_error() {
 fn read_only_open_with_ephemeral_config_returns_error() {
     let network = Network::Mainnet;
 
-    // An existing, readable cache directory, so the open gets past the cache-dir readability
-    // check and reaches the ephemeral conflict check. The default cache directory may not
-    // exist, which returns `ReadOnlyCacheDirUnreadable` instead.
-    let cache_dir =
-        tempfile::tempdir().expect("creating a temporary cache directory should succeed");
     let config = Config {
-        cache_dir: cache_dir.path().to_path_buf(),
         ephemeral: true,
         ..Config::default()
     };

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -674,7 +674,6 @@ fn read_only_open_with_ephemeral_config_returns_error() {
     let parent = tempfile::tempdir().expect("creating a temporary directory should succeed");
     let config = Config {
         ephemeral: true,
-        cache_dir: parent.path().join("missing"),
         ..Config::default()
     };
 


### PR DESCRIPTION
## Motivation

Part of #10737. The unit-test CI job intermittently fails on tests that dial live Mainnet peers (`integration::sync::persistent_mode` and `written_peer_cache_*`). Root-cause analysis (posted in #10737) shows remote Zebra peers accept then drop any second connection from the same source IP within ~2 minutes (`max_connections_per_ip` defaults to 1, `zebra-network/src/peer_set/initialize.rs`), and the ci-profile nextest run contains 26 tests that dial the same ~78 seeder-derived peers concurrently from one runner IP — so live tests burn each other's per-IP slots, producing the `successes=0` handshake signature seen in failed runs.

This PR is the immediate, low-risk mitigation. Follow-up tracks that remove the live-network dependence entirely are proposed in #10737.

## Solution

- Expand the existing `serial-live-mainnet` nextest group (max 1 thread) — whose comment already described this failure mode but which only covered 3 `integration::sync::*` tests — to all 26 tests that dial live Mainnet peers in the normal CI configuration, in both the `default` and `ci` profiles.
- Add a separate `serial-live-testnet` group for the 2 Testnet peer-limit tests, so they run serially with each other but can run concurrently with Mainnet tests.
- Disable the default peer cache in `add_initial_peers_deadlock`, so it only uses its configured dummy loopback peers and does not need a live-network group.
- `written_peer_cache_can_be_read_manually` / `written_peer_cache_is_automatically_read_on_startup` (zebra-network): use a tempdir cache dir, so they stop reading and writing the real user cache directory.

Known limitation: serialization still leaves up to ~119 s "shadow windows" in which a finished test's dials block the next test's handshakes at the same peers, so this reduces — not eliminates — the failure mode. Wall-time tradeoff: worst case roughly +8–10 min in the unit-test job, well within its 120 min limit.

### Tests

- `cargo fmt --all -- --check` and `cargo clippy -p zebra-network --tests -- -D warnings` pass.
- `cargo test -p zebra-network add_initial_peers_deadlock`: passes with the default peer cache disabled.
- `cargo nextest run -p zebra-network -E 'test(/written_peer_cache/)'`: 2/2 pass end-to-end against live peers, writing and re-reading the cache from the tempdir.
- `cargo nextest show-config test-groups --profile ci --features default-release-binaries` confirms `serial-live-mainnet` contains 26 Mainnet tests, `serial-live-testnet` contains exactly the 2 Testnet tests, and `add_initial_peers_deadlock` is in neither group.
- `cargo nextest show-config test-groups --profile default --features default-release-binaries` confirms the same membership for local nextest runs.

### Specifications & References

- #10737 (analysis comments with file/line receipts)
- Failed run exhibiting the signature: https://github.com/ZcashFoundation/zebra/actions/runs/30591238131/job/91033850428

### Follow-up Work

Tracked in #10737: stop ~20 tests dialing Mainnet incidentally (no-network configs), move the genuine network tests to deterministic local peers (two-node Regtest / loopback handshake fixtures), and a separate robustness track for the GCP integration tier.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude Code for the root-cause analysis, initial patch, and initial PR description; Codex for review and the follow-up test-group and cache-isolation changes; reviewed and tested by the author.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date. (Test/CI-only change; no changelog entry required.)
