### PR TITLE
fix(ci): stop Mergify label events from cancelling required PR Gate runs

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -13,11 +13,16 @@ on:
   # matching the sibling required-check workflows; jobs skip and the result skip-passes.
   merge_group:
 
-# Ensures that only one workflow task will run at a time. Previous builds, if
-# already in process, will get cancelled. Only the latest commit will be allowed
-# to run, cancelling any workflows in between
+# Cancel obsolete gate runs after new commits. Unrelated label events use a
+# separate group so they cannot cancel the required PR Gate run.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: >-
+    ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{
+      (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+      github.event.label.name != 'A-release' &&
+      'ignored-label' ||
+      'required'
+    }}
   cancel-in-progress: true
 
 permissions:
@@ -29,6 +34,10 @@ env:
 
 jobs:
   changes:
+    # Only the A-release label affects gate results; other label events are no-ops.
+    if: >-
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      github.event.label.name == 'A-release'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -158,6 +167,8 @@ jobs:
     name: Release readiness
     if: >-
       github.event_name == 'pull_request' &&
+      ((github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      github.event.label.name == 'A-release') &&
       startsWith(github.event.pull_request.head.ref, 'release-plz-') &&
       contains(github.event.pull_request.labels.*.name, 'A-release')
     runs-on: ubuntu-latest-xl
@@ -253,8 +264,19 @@ jobs:
           fi
 
   pr-gate-result:
+    # Keep skipped unrelated-label runs from replacing the required check.
+    name: >-
+      ${{
+        (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
+        github.event.label.name != 'A-release' &&
+        'Label does not affect the PR gate' ||
+        'pr-gate-result'
+      }}
     runs-on: ubuntu-latest
-    if: always()
+    if: >-
+      always() &&
+      ((github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      github.event.label.name == 'A-release')
     needs: [changes, semver-checks, changelog-gate, release-readiness]
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## Motivation

Mergify merge-queue requeues currently fail systematically. On every requeue, Mergify flips labels on the source PR (`queued` added, then the stale `dequeued` label removed ~40 s later). `pr-gate.yml` triggers on `labeled`/`unlabeled` and uses a single concurrency group with `cancel-in-progress: true`, so the second label event cancels the first PR Gate run mid-flight. The cancelled run's `pr-gate-result` aggregator still executes (`if: always()`) and posts a **failure** check on the PR head. Mergify's stay-in-queue condition `check-success=pr-gate-result` then dequeues the PR within ~2 minutes, before the queue draft's CI (which is green) can complete.

Observed on #11146: queue attempts on 2026-07-31 at 14:42 and 18:12 UTC were both dequeued "with no time running CI". The `pr-gate-result` check-run history on head `2c187ad6` shows failures at 14:43:28, 14:45:41, 18:14:19, and 18:15:56 — each seconds after a `queued`/`dequeued` label event — recovering to success once the label churn settles. The first queue attempt (2026-07-30) survived because no stale `dequeued` label existed yet, so only one label event fired.

`tests-unit.yml` already guards against this exact hazard ("Unrelated label events use a separate group so they cannot cancel the required unit test run"). `lint.yml` and `test-crates.yml` use the default `pull_request` types and are not exposed.

## Solution

Mirror the `tests-unit.yml` pattern in `pr-gate.yml`, extended to cover `unlabeled` (PR Gate subscribes to both label event types; the only label the gate actually reacts to is `A-release`):

- **Concurrency group**: unrelated label events get an `ignored-label` group suffix so they cannot cancel the required run; all other events (including `A-release` label changes) stay in the `required` group.
- **`changes` job**: skips on unrelated label events, so `semver-checks` and `changelog-gate` skip too (this also stops re-running a full semver-checks pass on every label flip).
- **`release-readiness` job**: same guard, so a Mergify label flip on a release PR (which carries `A-release`) doesn't spawn a redundant readiness run. Adding/removing `A-release` still re-evaluates readiness in the `required` group.
- **`pr-gate-result` job**: skips on unrelated label events and gets a dynamic `name` (mirroring the `unit-tests` aggregator) so the skipped run's check posts under a different name and cannot replace the required `pr-gate-result` check that Mergify and branch protection consume.

Net effect on a Mergify requeue: both label events land in the `ignored-label` group, every job skips, the run completes in seconds, no check named `pr-gate-result` is posted, and the latest required-gate result on the head is untouched.

### Tests

- YAML validated locally; expression constructs (group suffix, guard, dynamic aggregator name) are copied from the battle-tested `tests-unit.yml` pattern.
- On this PR (workflows run from the PR head for `pull_request` events): applying/removing an arbitrary label should produce a fast skipped run under the alternate check name, without cancelling the required PR Gate run or perturbing `pr-gate-result`.
- End-to-end after merge: requeue #11146 (it still carries the stale `dequeued` label, so the failure scenario replays exactly) and confirm it survives past the ~2-minute mark.

### Specifications & References

- Dequeue evidence: #11146 Mergify status comments (attempts at 2026-07-31 14:42 and 18:12 UTC, drafts #11160/#11163, both "no time running CI" while the drafts' own `pr-gate-result` was green).
- Existing guard pattern: `.github/workflows/tests-unit.yml` concurrency group and `unit-tests` aggregator.

### Follow-up Work

- Rapid `edited` events (Mergify editing queue-draft bodies) can still race-cancel a gate run on queue drafts; the window is ~25 s and it was not the cause of the observed dequeues. Can be addressed separately if it ever bites.

### AI Disclosure

- [x] AI tools were used: Claude Code for the CI-failure investigation and the workflow change; reviewed and tested by the author.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
