### PR TITLE
fix(rpc): use NU6 subsidy metadata for NU6.1 and later upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- `getblocksubsidy` now returns NU6-era funding stream metadata for every upgrade from NU6
+  onwards. An exact comparison against NU6 meant heights governed by NU6.1 and later were
+  labelled with pre-NU6 recipient names and specification URLs, even though they are inside the
+  NU6-style funding and lockbox regime. Funding stream amounts were never affected
+  ([#11029](https://github.com/ZcashFoundation/zebra/issues/11029))
+
 - Reject blocks whose total chain value pool balance would exceed `MAX_MONEY`,
   enforcing the cap on the total monetary base
   ([#10817](https://github.com/ZcashFoundation/zebra/pull/10817))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
-- `getblocksubsidy` now returns NU6-era funding stream metadata for every upgrade from NU6
-  onwards. An exact comparison against NU6 meant heights governed by NU6.1 and later were
-  labelled with pre-NU6 recipient names and specification URLs, even though they are inside the
-  NU6-style funding and lockbox regime. Funding stream amounts were never affected
-  ([#11029](https://github.com/ZcashFoundation/zebra/issues/11029))
+- `getblocksubsidy` now returns NU6-era funding stream metadata (recipient names and
+  specification URLs) for NU6.1 and later upgrades. Amounts and addresses were never
+  affected ([#11172](https://github.com/ZcashFoundation/zebra/pull/11172)).
 
 - Reject blocks whose total chain value pool balance would exceed `MAX_MONEY`,
   enforcing the cap on the total monetary base

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `getblocksubsidy` returns NU6-era funding stream metadata for every network upgrade from NU6
+  onwards. The active upgrade was compared against NU6 for exact equality, so heights governed by
+  NU6.1 and later fell back to pre-NU6 recipient names and specification URLs. Funding stream
+  amounts and addresses were never affected
+  ([#11029](https://github.com/ZcashFoundation/zebra/issues/11029)).
 - Clarified the error message returned by `getrawtransaction` for transactions
   that are not in the mempool or best chain
   ([#11014](https://github.com/ZcashFoundation/zebra/pull/11014)).

--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -27,11 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `getblocksubsidy` returns NU6-era funding stream metadata for every network upgrade from NU6
-  onwards. The active upgrade was compared against NU6 for exact equality, so heights governed by
-  NU6.1 and later fell back to pre-NU6 recipient names and specification URLs. Funding stream
-  amounts and addresses were never affected
-  ([#11029](https://github.com/ZcashFoundation/zebra/issues/11029)).
+- `getblocksubsidy` now returns NU6-era funding stream metadata (recipient names and
+  specification URLs) for NU6.1 and later upgrades. Amounts and addresses were never
+  affected ([#11172](https://github.com/ZcashFoundation/zebra/pull/11172)).
 - Clarified the error message returned by `getrawtransaction` for transactions
   that are not in the mempool or best chain
   ([#11014](https://github.com/ZcashFoundation/zebra/pull/11014)).

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -3029,9 +3029,7 @@ where
                 .position(|zcashd_receiver| zcashd_receiver == receiver)
         });
 
-        // Every upgrade from NU6 onwards uses the NU6-era funding stream metadata, so this is an
-        // ordering comparison: an exact match would fall back to pre-NU6 metadata on NU6.1 and
-        // later. `NetworkUpgrade`'s variants are ordered by activation height.
+        // NU6.1 and later minor upgrades keep the NU6 funding stream structure (ZIP 1015).
         let is_post_nu6 = NetworkUpgrade::current(&net, height) >= NetworkUpgrade::Nu6;
 
         // Format the funding streams and lockbox streams

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -3029,7 +3029,10 @@ where
                 .position(|zcashd_receiver| zcashd_receiver == receiver)
         });
 
-        let is_nu6 = NetworkUpgrade::current(&net, height) == NetworkUpgrade::Nu6;
+        // Every upgrade from NU6 onwards uses the NU6-era funding stream metadata, so this is an
+        // ordering comparison: an exact match would fall back to pre-NU6 metadata on NU6.1 and
+        // later. `NetworkUpgrade`'s variants are ordered by activation height.
+        let is_post_nu6 = NetworkUpgrade::current(&net, height) >= NetworkUpgrade::Nu6;
 
         // Format the funding streams and lockbox streams
         let [funding_streams, lockbox_streams] =
@@ -3039,7 +3042,10 @@ where
                     .map(|(receiver, value)| {
                         let address = funding_stream_address(height, &net, receiver);
                         types::subsidy::FundingStream::new_internal(
-                            is_nu6, receiver, value, address,
+                            is_post_nu6,
+                            receiver,
+                            value,
+                            address,
                         )
                     })
                     .collect()

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -3533,3 +3533,128 @@ async fn rpc_get_standard_fee() {
     assert_eq!(response.standard_fee(), 5000);
     assert_eq!(response.version(), 0);
 }
+
+/// Every upgrade from NU6 onwards must use the NU6-era funding stream metadata.
+///
+/// An exact `== Nu6` comparison falls back to pre-NU6 metadata on NU6.1 and later, which became
+/// the default Mainnet behaviour at the NU6.3 activation height.
+#[tokio::test(flavor = "multi_thread")]
+async fn rpc_getblocksubsidy_uses_nu6_metadata_for_nu6_and_later() {
+    let _init_guard = zebra_test::init();
+
+    let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, _rpc_tx_queue) = RpcImpl::new(
+        Mainnet,
+        Default::default(),
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool.clone(), 1),
+        Buffer::new(state.clone(), 1),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        MockSyncStatus::default(),
+        NoChainTip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    // The label that `FundingStreamReceiver::MajorGrants` carries in each era.
+    const POST_NU6_MAJOR_GRANTS: &str = "Zcash Community Grants NU6";
+    const PRE_NU6_MAJOR_GRANTS: &str = "Major Grants";
+
+    for upgrade in [
+        NetworkUpgrade::Nu6,
+        NetworkUpgrade::Nu6_1,
+        NetworkUpgrade::Nu6_2,
+        NetworkUpgrade::Nu6_3,
+    ] {
+        let Some(height) = upgrade.activation_height(&Mainnet) else {
+            continue;
+        };
+
+        let response = rpc
+            .get_block_subsidy(Some(height.0))
+            .await
+            .expect("getblocksubsidy should succeed at an activated upgrade height");
+
+        // Without this the assertions below would vacuously pass on an empty response.
+        let major_grants = response
+            .funding_streams()
+            .iter()
+            .find(|stream| stream.recipient() == POST_NU6_MAJOR_GRANTS)
+            .or_else(|| {
+                response
+                    .funding_streams()
+                    .iter()
+                    .find(|stream| stream.recipient() == PRE_NU6_MAJOR_GRANTS)
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "{upgrade:?} at height {height:?} must return a major grants funding stream, \
+                     otherwise this test cannot detect the metadata era; got: {:?}",
+                    response.funding_streams()
+                )
+            });
+
+        assert_eq!(
+            major_grants.recipient(),
+            POST_NU6_MAJOR_GRANTS,
+            "{upgrade:?} at height {height:?} is in the NU6 funding regime, so it must use \
+             NU6-era metadata, not the pre-NU6 label"
+        );
+    }
+}
+
+/// Upgrades before NU6 must keep the pre-NU6 funding stream metadata.
+///
+/// Guards against widening the NU6 check so far that it also captures earlier upgrades.
+#[tokio::test(flavor = "multi_thread")]
+async fn rpc_getblocksubsidy_keeps_pre_nu6_metadata_before_nu6() {
+    let _init_guard = zebra_test::init();
+
+    let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, _rpc_tx_queue) = RpcImpl::new(
+        Mainnet,
+        Default::default(),
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool.clone(), 1),
+        Buffer::new(state.clone(), 1),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        MockSyncStatus::default(),
+        NoChainTip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    let nu5_height = NetworkUpgrade::Nu5
+        .activation_height(&Mainnet)
+        .expect("NU5 is activated on Mainnet");
+
+    let response = rpc
+        .get_block_subsidy(Some(nu5_height.0))
+        .await
+        .expect("getblocksubsidy should succeed at the NU5 activation height");
+
+    assert!(
+        response
+            .funding_streams()
+            .iter()
+            .any(|stream| stream.recipient() == "Major Grants"),
+        "NU5 predates the NU6 funding regime, so it must keep the pre-NU6 label; got: {:?}",
+        response.funding_streams()
+    );
+}

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -3534,12 +3534,14 @@ async fn rpc_get_standard_fee() {
     assert_eq!(response.version(), 0);
 }
 
-/// Every upgrade from NU6 onwards must use the NU6-era funding stream metadata.
+/// `getblocksubsidy` must report the funding stream metadata era of the height's active upgrade,
+/// on both sides of the NU6 boundary.
 ///
 /// An exact `== Nu6` comparison falls back to pre-NU6 metadata on NU6.1 and later, which became
-/// the default Mainnet behaviour at the NU6.3 activation height.
+/// the default Mainnet behaviour at the NU6.3 activation height. The NU5 row pins the other side
+/// of the boundary, so the check cannot be widened past NU6 either.
 #[tokio::test(flavor = "multi_thread")]
-async fn rpc_getblocksubsidy_uses_nu6_metadata_for_nu6_and_later() {
+async fn rpc_getblocksubsidy_major_grants_metadata_across_nu6_boundary() {
     let _init_guard = zebra_test::init();
 
     let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
@@ -3565,14 +3567,15 @@ async fn rpc_getblocksubsidy_uses_nu6_metadata_for_nu6_and_later() {
     );
 
     // The label that `FundingStreamReceiver::MajorGrants` carries in each era.
-    const POST_NU6_MAJOR_GRANTS: &str = "Zcash Community Grants NU6";
     const PRE_NU6_MAJOR_GRANTS: &str = "Major Grants";
+    const POST_NU6_MAJOR_GRANTS: &str = "Zcash Community Grants NU6";
 
-    for upgrade in [
-        NetworkUpgrade::Nu6,
-        NetworkUpgrade::Nu6_1,
-        NetworkUpgrade::Nu6_2,
-        NetworkUpgrade::Nu6_3,
+    for (upgrade, expected_recipient) in [
+        (NetworkUpgrade::Nu5, PRE_NU6_MAJOR_GRANTS),
+        (NetworkUpgrade::Nu6, POST_NU6_MAJOR_GRANTS),
+        (NetworkUpgrade::Nu6_1, POST_NU6_MAJOR_GRANTS),
+        (NetworkUpgrade::Nu6_2, POST_NU6_MAJOR_GRANTS),
+        (NetworkUpgrade::Nu6_3, POST_NU6_MAJOR_GRANTS),
     ] {
         let Some(height) = upgrade.activation_height(&Mainnet) else {
             continue;
@@ -3583,16 +3586,14 @@ async fn rpc_getblocksubsidy_uses_nu6_metadata_for_nu6_and_later() {
             .await
             .expect("getblocksubsidy should succeed at an activated upgrade height");
 
-        // Without this the assertions below would vacuously pass on an empty response.
+        // Match on either label, so a response with no major grants stream fails loudly instead
+        // of letting the assertion below pass vacuously.
         let major_grants = response
             .funding_streams()
             .iter()
-            .find(|stream| stream.recipient() == POST_NU6_MAJOR_GRANTS)
-            .or_else(|| {
-                response
-                    .funding_streams()
-                    .iter()
-                    .find(|stream| stream.recipient() == PRE_NU6_MAJOR_GRANTS)
+            .find(|stream| {
+                stream.recipient() == PRE_NU6_MAJOR_GRANTS
+                    || stream.recipient() == POST_NU6_MAJOR_GRANTS
             })
             .unwrap_or_else(|| {
                 panic!(
@@ -3604,57 +3605,8 @@ async fn rpc_getblocksubsidy_uses_nu6_metadata_for_nu6_and_later() {
 
         assert_eq!(
             major_grants.recipient(),
-            POST_NU6_MAJOR_GRANTS,
-            "{upgrade:?} at height {height:?} is in the NU6 funding regime, so it must use \
-             NU6-era metadata, not the pre-NU6 label"
+            expected_recipient,
+            "{upgrade:?} at height {height:?} must use the {expected_recipient:?} label"
         );
     }
-}
-
-/// Upgrades before NU6 must keep the pre-NU6 funding stream metadata.
-///
-/// Guards against widening the NU6 check so far that it also captures earlier upgrades.
-#[tokio::test(flavor = "multi_thread")]
-async fn rpc_getblocksubsidy_keeps_pre_nu6_metadata_before_nu6() {
-    let _init_guard = zebra_test::init();
-
-    let mempool: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
-    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
-    let read_state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
-
-    let (_tx, rx) = tokio::sync::watch::channel(None);
-    let (rpc, _rpc_tx_queue) = RpcImpl::new(
-        Mainnet,
-        Default::default(),
-        Default::default(),
-        "0.0.1",
-        "RPC test",
-        Buffer::new(mempool.clone(), 1),
-        Buffer::new(state.clone(), 1),
-        Buffer::new(read_state.clone(), 1),
-        MockService::build().for_unit_tests(),
-        MockSyncStatus::default(),
-        NoChainTip,
-        MockAddressBookPeers::default(),
-        rx,
-        None,
-    );
-
-    let nu5_height = NetworkUpgrade::Nu5
-        .activation_height(&Mainnet)
-        .expect("NU5 is activated on Mainnet");
-
-    let response = rpc
-        .get_block_subsidy(Some(nu5_height.0))
-        .await
-        .expect("getblocksubsidy should succeed at the NU5 activation height");
-
-    assert!(
-        response
-            .funding_streams()
-            .iter()
-            .any(|stream| stream.recipient() == "Major Grants"),
-        "NU5 predates the NU6 funding regime, so it must keep the pre-NU6 label; got: {:?}",
-        response.funding_streams()
-    );
 }


### PR DESCRIPTION
## Motivation

Closes #11029.

`get_block_subsidy` decides which funding stream metadata to return by comparing the height's
active upgrade against NU6 with an exact match:

```rust
let is_nu6 = NetworkUpgrade::current(&net, height) == NetworkUpgrade::Nu6;
```

Heights governed by NU6.1, NU6.2 and NU6.3 are squarely inside the NU6-style funding and lockbox
regime, but an exact match makes them fall through to the pre-NU6 branch, so they are labelled
with pre-NU6 recipient names and specification URLs.

Two things make this more than a cosmetic mismatch:

- The receiving function already declares the intended semantics. `FundingStream::new_internal`
  names its parameter `is_post_nu6`, and passes it to `FundingStreamReceiver::info(is_post_nu6)`,
  which selects `"Zcash Community Grants NU6"` + `LOCKBOX_SPECIFICATION` versus `"Major Grants"` +
  `FUNDING_STREAM_SPECIFICATION`. The call site was passing an exact-match result into a parameter
  that asks for "NU6 or later".
- This is already live on Mainnet, and has been since **NU6.1** at height 3,146,400 — earlier than
  the NU6.3 activation the issue points at. Every `getblocksubsidy` call above that height has been
  taking the pre-NU6 branch.

Amounts are unaffected: they come from `funding_stream_values`, which is consensus code and does
not consult this flag. Only the labels and specification URLs were wrong.

## Solution

Make it an ordering comparison, and rename the local to match the parameter it feeds:

```rust
let is_post_nu6 = NetworkUpgrade::current(&net, height) >= NetworkUpgrade::Nu6;
```

`NetworkUpgrade`'s variants are documented as ordered by activation height ("Enum variants must be
ordered by activation height"), and the enum derives `Ord`/`PartialOrd`, so `>=` is the comparison
that expresses "NU6 or later" without introducing a new helper or new semantics.

The issue also asks to audit `zebra-rpc` for other exact `== NetworkUpgrade::Nu6` comparisons.
There are none — this call site was the only one in the workspace.

## Test evidence

One table-driven regression test in `zebra-rpc/src/methods/tests/vectors.rs`:

- `rpc_getblocksubsidy_major_grants_metadata_across_nu6_boundary` — walks NU5, NU6, NU6.1, NU6.2
  and NU6.3 at their Mainnet activation heights and asserts the major grants stream carries the
  label of that height's era. The NU5 row pins the pre-NU6 side, so the check cannot be widened
  past the NU6 boundary either.

The test looks the stream up by *either* label and panics if neither is present, so it fails
loudly rather than passing vacuously if a height ever returns no funding streams.

Reverting the fix to `==` fails on the value, at the earliest affected upgrade:

```
assertion `left == right` failed: Nu6_1 at height Height(3146400) must use the
"Zcash Community Grants NU6" label
  left: "Major Grants"
 right: "Zcash Community Grants NU6"
```

The NU5 row still passes under that revert, so the table is pinning the boundary rather than the
fix.

Checks (all debug):

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p zebra-rpc --all-targets -- -D warnings` — clean
- `cargo test -p zebra-rpc --lib` — **87 passed, 0 failed, 1 ignored** (includes the
  `getblocksubsidy` snapshot tests, which are unchanged)

## AI disclosure

Claude Code was used for code navigation, to draft the tests and this description, and to run the
checks above. Mechanism, the ordering-comparison choice, and the negative control were verified
against the source by the contributor, who is the sole responsible author.
