### PR TITLE
fix(network): remove every address book entry for a banned peer IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Reject blocks whose total chain value pool balance would exceed `MAX_MONEY`,
   enforcing the cap on the total monetary base
   ([#10817](https://github.com/ZcashFoundation/zebra/pull/10817))
+- Banning a misbehaving peer now removes every address book entry for that IP, and a banned IP is
+  never selected as a reconnection candidate. Previously an entry for the banned IP on a different
+  port could survive the ban and then occupy the first candidate slot until the node restarted,
+  producing a burst of `attempted to add a banned peer addr to address book` warnings on every
+  crawl cycle ([#11134](https://github.com/ZcashFoundation/zebra/issues/11134)).
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   enforcing the cap on the total monetary base
   ([#10817](https://github.com/ZcashFoundation/zebra/pull/10817))
 - Banning a misbehaving peer now removes every address book entry for that IP, and a banned IP is
-  never selected as a reconnection candidate. Previously an entry for the banned IP on a different
-  port could survive the ban and then occupy the first candidate slot until the node restarted,
-  producing a burst of `attempted to add a banned peer addr to address book` warnings on every
-  crawl cycle ([#11134](https://github.com/ZcashFoundation/zebra/issues/11134)).
+  never selected as a reconnection candidate. Previously an entry on a different port could survive
+  the ban and occupy the first candidate slot until the node restarted
+  ([#11134](https://github.com/ZcashFoundation/zebra/issues/11134)).
 
 ### Security
 

--- a/zebra-network/CHANGELOG.md
+++ b/zebra-network/CHANGELOG.md
@@ -23,20 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Peer-set, crawler-handshake, and address-book gauges now include a `network` label, so multiple
   network instances in one process do not overwrite each other's values.
-- `AddressBook::update()` logs a rejected change for a banned peer IP at `debug` level instead of
-  `warn`. Remote peers can gossip a banned address at any time, so the level of this message was
-  effectively chosen by them ([#11134](https://github.com/ZcashFoundation/zebra/issues/11134)).
+- `AddressBook::update()` logs a change rejected for a banned peer IP at `debug` instead of `warn`,
+  since remote peers control how often it fires
+  ([#11134](https://github.com/ZcashFoundation/zebra/issues/11134)).
 
 ### Fixed
 
 - Banning a peer IP now removes every address book entry for that IP, and `reconnection_peers()`
-  never returns an address whose IP is banned. Previously the ban path scanned `by_addr` with
-  `skip_while(...).take_while(...)`, which stops at the first entry for a different IP. Because
-  `by_addr` is ordered by reconnection order rather than grouped by IP, an entry for the banned IP
-  on another port could survive the ban, and then stay at the front of the reconnection order for
-  the lifetime of the process: it was selected as a candidate on every crawl, the ban check
-  rejected the resulting `UpdateAttempt`, and so its state never changed
-  ([#11134](https://github.com/ZcashFoundation/zebra/issues/11134)).
+  never returns an address whose IP is banned. Previously an entry for the banned IP on another
+  port could survive the ban and stay at the front of the reconnection order for the lifetime of
+  the process ([#11134](https://github.com/ZcashFoundation/zebra/issues/11134)).
 
 ### Security
 

--- a/zebra-network/CHANGELOG.md
+++ b/zebra-network/CHANGELOG.md
@@ -23,6 +23,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Peer-set, crawler-handshake, and address-book gauges now include a `network` label, so multiple
   network instances in one process do not overwrite each other's values.
+- `AddressBook::update()` logs a rejected change for a banned peer IP at `debug` level instead of
+  `warn`. Remote peers can gossip a banned address at any time, so the level of this message was
+  effectively chosen by them ([#11134](https://github.com/ZcashFoundation/zebra/issues/11134)).
+
+### Fixed
+
+- Banning a peer IP now removes every address book entry for that IP, and `reconnection_peers()`
+  never returns an address whose IP is banned. Previously the ban path scanned `by_addr` with
+  `skip_while(...).take_while(...)`, which stops at the first entry for a different IP. Because
+  `by_addr` is ordered by reconnection order rather than grouped by IP, an entry for the banned IP
+  on another port could survive the ban, and then stay at the front of the reconnection order for
+  the lifetime of the process: it was selected as a candidate on every crawl, the ban check
+  rejected the resulting `UpdateAttempt`, and so its state never changed
+  ([#11134](https://github.com/ZcashFoundation/zebra/issues/11134)).
 
 ### Security
 

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -416,7 +416,10 @@ impl AddressBook {
     #[allow(clippy::unwrap_in_result)]
     pub fn update(&mut self, change: MetaAddrChange) -> Option<MetaAddr> {
         if self.bans_by_ip.contains_key(&change.addr().ip()) {
-            tracing::warn!(
+            // This is a routine rejection, not an error: remote peers can gossip
+            // a banned address at any time, so logging it at `warn` lets them
+            // choose how much of the operator's log this fills (#11134).
+            tracing::debug!(
                 ?change,
                 "attempted to add a banned peer addr to address book"
             );
@@ -461,11 +464,15 @@ impl AddressBook {
                     most_recent_by_ip.remove(&banned_ip);
                 }
 
+                // `by_addr` is ordered by reconnection order, not grouped by IP,
+                // so entries for the banned IP can be separated by other IPs.
+                // Scan the whole book, otherwise a surviving entry is selected as
+                // a candidate forever, because the ban check above stops its state
+                // from ever changing (#11134).
                 let banned_addrs: Vec<_> = self
                     .by_addr
                     .descending_keys()
-                    .skip_while(|addr| addr.ip() != banned_ip)
-                    .take_while(|addr| addr.ip() == banned_ip)
+                    .filter(|addr| addr.ip() == banned_ip)
                     .cloned()
                     .collect();
 
@@ -647,12 +654,13 @@ impl AddressBook {
     ) -> impl DoubleEndedIterator<Item = MetaAddr> + '_ {
         let _guard = self.span.enter();
 
-        // Skip live peers, and peers pending a reconnect attempt.
+        // Skip live peers, banned peers, and peers pending a reconnect attempt.
         // The peers are already stored in sorted order.
         self.by_addr
             .descending_values()
             .filter(move |peer| {
-                peer.is_ready_for_connection_attempt(instant_now, chrono_now, &self.network)
+                !self.bans_by_ip.contains_key(&peer.addr.ip())
+                    && peer.is_ready_for_connection_attempt(instant_now, chrono_now, &self.network)
                     && self.is_ready_for_connection_attempt_with_ip(&peer.addr.ip(), chrono_now)
             })
             .cloned()

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -416,9 +416,7 @@ impl AddressBook {
     #[allow(clippy::unwrap_in_result)]
     pub fn update(&mut self, change: MetaAddrChange) -> Option<MetaAddr> {
         if self.bans_by_ip.contains_key(&change.addr().ip()) {
-            // This is a routine rejection, not an error: remote peers can gossip
-            // a banned address at any time, so logging it at `warn` lets them
-            // choose how much of the operator's log this fills (#11134).
+            // Remote peers control how often this fires, so keep it below `warn` (#11134).
             tracing::debug!(
                 ?change,
                 "attempted to add a banned peer addr to address book"
@@ -464,11 +462,6 @@ impl AddressBook {
                     most_recent_by_ip.remove(&banned_ip);
                 }
 
-                // `by_addr` is ordered by reconnection order, not grouped by IP,
-                // so entries for the banned IP can be separated by other IPs.
-                // Scan the whole book, otherwise a surviving entry is selected as
-                // a candidate forever, because the ban check above stops its state
-                // from ever changing (#11134).
                 let banned_addrs: Vec<_> = self
                     .by_addr
                     .descending_keys()

--- a/zebra-network/src/address_book/tests/vectors.rs
+++ b/zebra-network/src/address_book/tests/vectors.rs
@@ -250,3 +250,122 @@ fn test_reconnection_peers_skips_recently_updated_ip<
         assert_ne!(next_reconnection_peer, None,);
     }
 }
+
+/// Helper: seed a book with two entries on one IP, separated in reconnection
+/// order by an entry on a different IP.
+///
+/// `MetaAddr`'s `Ord` sorts more recently gossiped addresses first, and all
+/// three entries are `NeverAttemptedGossiped`, so the last-seen times below
+/// place the unrelated IP between the two same-IP entries. Returns the book and
+/// the addresses in that order.
+fn book_with_non_contiguous_same_ip_entries() -> (
+    AddressBook,
+    crate::PeerSocketAddr,
+    crate::PeerSocketAddr,
+    crate::PeerSocketAddr,
+) {
+    let banned_addr: crate::PeerSocketAddr = "127.0.0.1:8233".parse().unwrap();
+    let unrelated_addr: crate::PeerSocketAddr = "127.0.0.2:8233".parse().unwrap();
+    // An ephemeral-port entry for the same IP, like the one in #11134.
+    let zombie_addr: crate::PeerSocketAddr = "127.0.0.1:43562".parse().unwrap();
+
+    // `max_connections_per_ip` is above one, so `reconnection_peers` does not
+    // skip the second entry on the banned IP for being a duplicate IP.
+    let mut address_book =
+        AddressBook::new("0.0.0.0:0".parse().unwrap(), &Mainnet, 2, Span::current());
+
+    address_book.update(gossiped_change(
+        banned_addr,
+        PeerServices::NODE_NETWORK,
+        DateTime32::MIN.saturating_add(Duration32::from_seconds(2)),
+    ));
+    address_book.update(gossiped_change(
+        unrelated_addr,
+        PeerServices::NODE_NETWORK,
+        DateTime32::MIN.saturating_add(Duration32::from_seconds(1)),
+    ));
+    address_book.update(gossiped_change(
+        zombie_addr,
+        PeerServices::NODE_NETWORK,
+        DateTime32::MIN,
+    ));
+
+    // Without this ordering both tests below would pass even before the fix,
+    // because a contiguous scan removes contiguous entries correctly.
+    assert_eq!(
+        address_book.by_addr.descending_keys().collect::<Vec<_>>(),
+        vec![&banned_addr, &unrelated_addr, &zombie_addr],
+        "test setup: the unrelated IP must sort between the two same-IP entries",
+    );
+
+    (address_book, banned_addr, unrelated_addr, zombie_addr)
+}
+
+/// Regression test for <https://github.com/ZcashFoundation/zebra/issues/11134>.
+///
+/// `by_addr` is ordered by reconnection order, not grouped by IP. The ban path
+/// used to collect the banned IP's entries with
+/// `skip_while(ip != banned).take_while(ip == banned)`, which stops at the first
+/// entry for a different IP, so any later entry on the banned IP survived.
+#[test]
+fn ban_removes_non_contiguous_same_ip_entries() {
+    let (mut address_book, banned_addr, unrelated_addr, zombie_addr) =
+        book_with_non_contiguous_same_ip_entries();
+
+    address_book.update(MetaAddrChange::UpdateMisbehavior {
+        addr: banned_addr,
+        score_increment: MAX_PEER_MISBEHAVIOR_SCORE,
+    });
+
+    assert!(
+        address_book.bans().contains_key(&banned_addr.ip()),
+        "ban-threshold misbehavior should ban the peer IP",
+    );
+    assert!(
+        address_book.get(banned_addr).is_none(),
+        "the banned address itself should be removed",
+    );
+    assert!(
+        address_book.get(zombie_addr).is_none(),
+        "a same-IP entry that does not sort next to the banned address \
+         should also be removed",
+    );
+    assert!(
+        address_book.get(unrelated_addr).is_some(),
+        "entries for other IPs should be untouched",
+    );
+}
+
+/// Regression test for <https://github.com/ZcashFoundation/zebra/issues/11134>.
+///
+/// A banned IP must never be returned as a reconnection candidate. Otherwise
+/// `CandidateSet::next()` keeps selecting it, `update()` rejects the resulting
+/// `UpdateAttempt` because the IP is banned, and the entry is never marked
+/// `AttemptPending` — so its state never changes and it stays at the front of
+/// the reconnection order for the lifetime of the process.
+#[test]
+fn banned_ip_is_never_a_reconnection_candidate() {
+    let (mut address_book, banned_addr, unrelated_addr, _zombie_addr) =
+        book_with_non_contiguous_same_ip_entries();
+
+    address_book.update(MetaAddrChange::UpdateMisbehavior {
+        addr: banned_addr,
+        score_increment: MAX_PEER_MISBEHAVIOR_SCORE,
+    });
+
+    let candidates: Vec<_> = address_book
+        .reconnection_peers(Instant::now(), Utc::now())
+        .collect();
+
+    assert!(
+        candidates
+            .iter()
+            .all(|peer| peer.addr.ip() != banned_addr.ip()),
+        "a banned IP must not be a reconnection candidate, but got: {candidates:?}",
+    );
+    assert_eq!(
+        candidates.iter().map(|peer| peer.addr).collect::<Vec<_>>(),
+        vec![unrelated_addr],
+        "the unrelated IP should still be a candidate",
+    );
+}

--- a/zebra-network/src/address_book/tests/vectors.rs
+++ b/zebra-network/src/address_book/tests/vectors.rs
@@ -251,66 +251,43 @@ fn test_reconnection_peers_skips_recently_updated_ip<
     }
 }
 
-/// Helper: seed a book with two entries on one IP, separated in reconnection
-/// order by an entry on a different IP.
+/// Regression test for <https://github.com/ZcashFoundation/zebra/issues/11134>.
 ///
-/// `MetaAddr`'s `Ord` sorts more recently gossiped addresses first, and all
-/// three entries are `NeverAttemptedGossiped`, so the last-seen times below
-/// place the unrelated IP between the two same-IP entries. Returns the book and
-/// the addresses in that order.
-fn book_with_non_contiguous_same_ip_entries() -> (
-    AddressBook,
-    crate::PeerSocketAddr,
-    crate::PeerSocketAddr,
-    crate::PeerSocketAddr,
-) {
+/// `by_addr` is ordered by reconnection order, not grouped by IP, so the ban path's old
+/// `skip_while(ip != banned).take_while(ip == banned)` scan stopped at the first entry for a
+/// different IP, and any later entry on the banned IP survived. That survivor then stayed at the
+/// front of the reconnection order for the lifetime of the process: it was selected as a candidate
+/// on every crawl, and `update()` rejected the resulting `UpdateAttempt` because the IP was
+/// banned, so its state never changed.
+#[test]
+fn ban_removes_every_entry_for_the_banned_ip() {
     let banned_addr: crate::PeerSocketAddr = "127.0.0.1:8233".parse().unwrap();
     let unrelated_addr: crate::PeerSocketAddr = "127.0.0.2:8233".parse().unwrap();
     // An ephemeral-port entry for the same IP, like the one in #11134.
     let zombie_addr: crate::PeerSocketAddr = "127.0.0.1:43562".parse().unwrap();
 
-    // `max_connections_per_ip` is above one, so `reconnection_peers` does not
-    // skip the second entry on the banned IP for being a duplicate IP.
+    // `max_connections_per_ip` is above one, so `reconnection_peers` does not skip the second
+    // entry on the banned IP for being a duplicate IP.
     let mut address_book =
         AddressBook::new("0.0.0.0:0".parse().unwrap(), &Mainnet, 2, Span::current());
 
-    address_book.update(gossiped_change(
-        banned_addr,
-        PeerServices::NODE_NETWORK,
-        DateTime32::MIN.saturating_add(Duration32::from_seconds(2)),
-    ));
-    address_book.update(gossiped_change(
-        unrelated_addr,
-        PeerServices::NODE_NETWORK,
-        DateTime32::MIN.saturating_add(Duration32::from_seconds(1)),
-    ));
-    address_book.update(gossiped_change(
-        zombie_addr,
-        PeerServices::NODE_NETWORK,
-        DateTime32::MIN,
-    ));
+    // `MetaAddr`'s `Ord` sorts more recently gossiped addresses first, so these last seen times
+    // place the unrelated IP between the two entries for the banned IP.
+    for (addr, last_seen) in [(banned_addr, 2), (unrelated_addr, 1), (zombie_addr, 0)] {
+        address_book.update(gossiped_change(
+            addr,
+            PeerServices::NODE_NETWORK,
+            DateTime32::MIN.saturating_add(Duration32::from_seconds(last_seen)),
+        ));
+    }
 
-    // Without this ordering both tests below would pass even before the fix,
-    // because a contiguous scan removes contiguous entries correctly.
+    // Without this ordering the test would also pass before the fix, because a contiguous scan
+    // removes contiguous entries correctly.
     assert_eq!(
         address_book.by_addr.descending_keys().collect::<Vec<_>>(),
         vec![&banned_addr, &unrelated_addr, &zombie_addr],
-        "test setup: the unrelated IP must sort between the two same-IP entries",
+        "test setup: the unrelated IP must sort between the two entries for the banned IP",
     );
-
-    (address_book, banned_addr, unrelated_addr, zombie_addr)
-}
-
-/// Regression test for <https://github.com/ZcashFoundation/zebra/issues/11134>.
-///
-/// `by_addr` is ordered by reconnection order, not grouped by IP. The ban path
-/// used to collect the banned IP's entries with
-/// `skip_while(ip != banned).take_while(ip == banned)`, which stops at the first
-/// entry for a different IP, so any later entry on the banned IP survived.
-#[test]
-fn ban_removes_non_contiguous_same_ip_entries() {
-    let (mut address_book, banned_addr, unrelated_addr, zombie_addr) =
-        book_with_non_contiguous_same_ip_entries();
 
     address_book.update(MetaAddrChange::UpdateMisbehavior {
         addr: banned_addr,
@@ -321,51 +298,21 @@ fn ban_removes_non_contiguous_same_ip_entries() {
         address_book.bans().contains_key(&banned_addr.ip()),
         "ban-threshold misbehavior should ban the peer IP",
     );
-    assert!(
-        address_book.get(banned_addr).is_none(),
-        "the banned address itself should be removed",
+    assert_eq!(
+        address_book.by_addr.descending_keys().collect::<Vec<_>>(),
+        vec![&unrelated_addr],
+        "the ban should remove every entry for the banned IP, including the one that does not \
+         sort next to the banned address",
     );
-    assert!(
-        address_book.get(zombie_addr).is_none(),
-        "a same-IP entry that does not sort next to the banned address \
-         should also be removed",
-    );
-    assert!(
-        address_book.get(unrelated_addr).is_some(),
-        "entries for other IPs should be untouched",
-    );
-}
-
-/// Regression test for <https://github.com/ZcashFoundation/zebra/issues/11134>.
-///
-/// A banned IP must never be returned as a reconnection candidate. Otherwise
-/// `CandidateSet::next()` keeps selecting it, `update()` rejects the resulting
-/// `UpdateAttempt` because the IP is banned, and the entry is never marked
-/// `AttemptPending` — so its state never changes and it stays at the front of
-/// the reconnection order for the lifetime of the process.
-#[test]
-fn banned_ip_is_never_a_reconnection_candidate() {
-    let (mut address_book, banned_addr, unrelated_addr, _zombie_addr) =
-        book_with_non_contiguous_same_ip_entries();
-
-    address_book.update(MetaAddrChange::UpdateMisbehavior {
-        addr: banned_addr,
-        score_increment: MAX_PEER_MISBEHAVIOR_SCORE,
-    });
 
     let candidates: Vec<_> = address_book
         .reconnection_peers(Instant::now(), Utc::now())
+        .map(|peer| peer.addr)
         .collect();
 
-    assert!(
-        candidates
-            .iter()
-            .all(|peer| peer.addr.ip() != banned_addr.ip()),
-        "a banned IP must not be a reconnection candidate, but got: {candidates:?}",
-    );
     assert_eq!(
-        candidates.iter().map(|peer| peer.addr).collect::<Vec<_>>(),
+        candidates,
         vec![unrelated_addr],
-        "the unrelated IP should still be a candidate",
+        "a banned IP must never be a reconnection candidate",
     );
 }


### PR DESCRIPTION
## Motivation

Closes #11134.

After a peer IP is banned, an address book entry for that same IP on a different port could
survive the ban and then stay at the front of the reconnection order for the lifetime of the
process, producing a burst of `attempted to add a banned peer addr to address book` warnings on
every crawl cycle. This was observed on Mainnet shortly after NU6.3 activation, when the wave of
misbehavior bans made it easy to hit.

## Solution

Three changes in `zebra-network`, matching the three defects in the issue:

1. **`AddressBook::update()` scans the whole book when removing a banned IP's entries.**
   `by_addr` is an `OrderedMap` keyed by reconnection order, not grouped by IP, so entries for one
   IP can be separated by entries for other IPs. The previous
   `skip_while(ip != banned).take_while(ip == banned)` scan stops at the first entry for a
   different IP, leaving any later same-IP entry behind. Replaced with a `filter` over all keys.

2. **`reconnection_peers()` skips banned IPs.** A surviving entry was selected as a candidate on
   every crawl; the ban check at the top of `update()` then rejected the resulting `UpdateAttempt`,
   so the entry was never marked `AttemptPending` and its position never changed. Filtering
   `bans_by_ip` here means a banned IP cannot be handed out even if an entry does reach the book.

3. **The rejected-change log moved from `warn` to `debug`.** Remote peers can gossip a banned
   address at any time, so the volume of this message was effectively chosen by them.

### Tests

One regression test in `zebra-network/src/address_book/tests/vectors.rs`,
`ban_removes_every_entry_for_the_banned_ip`. It builds a book where an unrelated IP sorts *between*
two entries that share the banned IP, and asserts that ordering before doing anything else —
with contiguous entries the test would pass against the old code and prove nothing. After the ban
it asserts the book holds exactly the unrelated entry, and that `reconnection_peers()` yields
exactly the unrelated address.

Negative controls, reverting the real implementation rather than reimplementing it, one change at a
time:

| Implementation state | `ban_removes_every_entry_for_the_banned_ip` |
| --- | --- |
| Both changes (this PR) | pass |
| Change 1 reverted | **FAIL** |
| Change 2 reverted | pass |
| Both reverted (`main`) | **FAIL** |

Change 1 is pinned directly by the test. Change 2 is defence in depth: with change 1 in place the
surviving-entry state is not reachable through `update()`, so no test can isolate it. That is why
the two earlier tests are now one — the second could only fail when the first also failed.

Gates run locally on this branch, all in debug:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean, for both the `default-release-binaries`
  and the `proptest-impl lightwalletd-grpc-tests zebra-checkpoints` feature sets
- `cargo clippy -p zebra-network --all-targets -- -D warnings` and `cargo build -p zebra-network`,
  for each of the four feature combinations CI runs per crate — clean
- `cargo test -p zebra-network --lib` — 216 passed, 0 failed (217 before the two tests became one)
- `.github/scripts/validate-pr-changelogs.sh <merge-base> HEAD true fix false` — exit 0

### Specifications & References

- #11134 — the issue, including the Mainnet log signature and the three-defect breakdown.
- #9201 — introduced the misbehavior ban tracking and this warning.

### Follow-up Work

The issue's third defect also has a structural half that this PR does not touch: when `update()`
returns `None`, `CandidateSet::next()` returns before the
`MIN_OUTBOUND_PEER_CONNECTION_INTERVAL` sleep, so queued crawler demand drains in a tight loop.
With the two changes above, a ban no longer drives that loop. The general fix belongs with the
`CandidateSet`/`AddressBook` refactor in #1976, as the issue notes.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude Code, for the code, the tests, and this description. All of it was
      reviewed and verified by hand, including the negative-control runs in the table above.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
