### PR TITLE
docs(security): update disclosure contacts and reporting requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,22 @@ The contribution gate already defines discussion/issue requirements. Additional 
 - Missing test evidence for behavior changes
 - Inability to explain the logic or design tradeoffs of the changes when asked
 
+## Security Vulnerability Reports
+
+If you or the user believe you have found a security vulnerability in Zebra,
+do not open a public issue or PR. Follow the reporting process in
+[SECURITY.md](SECURITY.md).
+
+Before helping a user submit a report, hold it to the same standard as
+SECURITY.md's "Before You Report" section:
+
+- Verify the issue reproduces against the latest Zebra release or the current
+  `main` branch — not an older release, fork, or modified build.
+- Run any proof of concept against one of those two versions and include the
+  exact release version or `main` commit hash tested in the report.
+- Do not submit speculative findings. "This code looks vulnerable" without a
+  reproduction against current code wastes triage time and may be dismissed.
+
 ## AI Disclosure
 
 If AI tools were used to write code, tests, or PR descriptions, disclose this in the PR description. Specify the tool and scope (e.g., "Used Claude for test boilerplate"). The contributor is the sole responsible author — "the AI generated it" is not a justification during review.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,6 +24,18 @@ appropriate timeline and perform a coordinated release, giving credit to the
 reporter if they would like. We align our reporting channels with the broader
 Zcash ecosystem disclosure process.
 
+### Before You Report
+
+Before submitting a report, confirm that the issue affects the latest Zebra
+release (<https://github.com/ZcashFoundation/zebra/releases/latest>) or the
+current `main` branch. Any proof of concept must be tested against one of
+those two versions — reports reproduced only on older releases, forks, or
+modified builds may not represent a vulnerability in current code and take
+substantially longer to triage.
+
+In your report, state the exact release version or `main` commit hash you
+tested against.
+
 For critical vulnerabilities, notify us on Signal. Create a new Signal group
 (do not reuse a previous group for a separate issue) that includes:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,9 +37,12 @@ In your report, state the exact release version or `main` commit hash you
 tested against.
 
 For critical vulnerabilities, notify us on Signal. Create a new Signal group
-(do not reuse a previous group for a separate issue) that includes:
+(do not reuse a previous group for a separate issue) that includes all of the
+following handles:
 
 - `pilizcash.01`
+- `conrado.42`
+- `dc_zf.77`
 
 Treat a vulnerability as critical if it could cause consensus divergence or a
 chain split, loss or counterfeiting of funds, a persistent node halt, state
@@ -54,31 +57,24 @@ primary or fully reliable reporting channel, so use it only when the channels
 above are unavailable. The key may also be used to encrypt follow-up material
 once contact is established.
 
+The key is `Zcash Foundation Security Team <security@zfnd.org>`, fingerprint
+`7550 C36C 3DF6 16A6 9F1E FE00 6046 DDEF 94CF 99B5`, valid until 2028-03-03.
+Verify the fingerprint before encrypting to this key.
+
 ```
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 
-mDMEaXswoxYJKwYBBAHaRw8BAQdA/CQqZ79S7A9OWZeYhY3AbMuTx2d41/pcehNc
-Z1ZF7r6IeAQgFgoAIBYhBOezJEDaeE6/uKooRf1tVVkb+SvKBQJpezIJAh0AAAoJ
-EP1tVVkb+SvKmqQBAMzp/pOZ/ifM0Tjuqzy4nTo8HT5xZwTfL84A40VURuElAP91
-/9wi+5ZKW09pdjHjag6tz0FhheinX1BEDbgww2u3CbQkWmNhc2ggRm91bmRhdGlv
-biA8c2VjdXJpdHlAemZuZC5vcmc+iJYEExYKAD4WIQTnsyRA2nhOv7iqKEX9bVVZ
-G/krygUCaXswowIbAwUJACeNAAULCQgHAwUVCgkICwUWAgMBAAIeAQIXgAAKCRD9
-bVVZG/kryrS4AQCiyknTREsLCICWdbaJUARuZifhDxXIKH0oest8y8HQQwD9HuRd
-936Cg5FbXHpBuF71fGU213OSgulG4+hr7rXdfgy4OARpezCjEgorBgEEAZdVAQUB
-AQdAw5WBljp9hoqi8lu2KU5QzNuv/1lpeGWoESdWg/GZKUIDAQgHiH4EGBYKACYW
-IQTnsyRA2nhOv7iqKEX9bVVZG/krygUCaXswowIbDAUJACeNAAAKCRD9bVVZG/kr
-yjsWAQCiRiecQ9P3DPyQ/E/N0Dl3z4jE2fM2NjhROnX4jB/lDgD8Cru6rg2sdxTc
-RHrjNOriwH3PxwALJorvERC1gl47jQ2YMwRpqByGFgkrBgEEAdpHDwEBB0DV0fxs
-U5skejT0UERNZbec7GGe7Vs7s1h0moC4vkuY87QyWmNhc2ggRm91bmRhdGlvbiBT
-ZWN1cml0eSBUZWFtIDxzZWN1cml0eUB6Zm5kLm9yZz6IlgQTFgoAPhYhBHVQw2w9
-9hamnx7+AGBG3e+Uz5m1BQJpqByGAhsDBQkDwmcABQsJCAcDBRUKCQgLBRYCAwEA
-Ah4BAheAAAoJEGBG3e+Uz5m18MoBAOulghTZ717buHwBKBZupdXMdYPZcNSxlFC1
-+ROt3iYAAP0RfQPw/UYLQlsnc5JEov2pExVpdXJH4waJjh+r26ZQCbg4BGmoHIYS
-CisGAQQBl1UBBQEBB0BXtdSydYIV586tkyNwAefvnQM0pJapklUbVD9f9AmQHAMB
-CAeIfgQYFgoAJhYhBHVQw2w99hamnx7+AGBG3e+Uz5m1BQJpqByGAhsMBQkDwmcA
-AAoJEGBG3e+Uz5m14rEA/0x/2XNwKd4buCm1tOGpTMaLQRoWhos6L/0wV9LExEKG
-AQC1Wmyb9ul/2QNi//8sKNDfaYbn3h6OU45BTAWggp+ACQ==
-=RIK0
+mDMEaagchhYJKwYBBAHaRw8BAQdA1dH8bFObJHo09FBETWW3nOxhnu1bO7NYdJqA
+uL5LmPO0MlpjYXNoIEZvdW5kYXRpb24gU2VjdXJpdHkgVGVhbSA8c2VjdXJpdHlA
+emZuZC5vcmc+iJYEExYKAD4WIQR1UMNsPfYWpp8e/gBgRt3vlM+ZtQUCaagchgIb
+AwUJA8JnAAULCQgHAwUVCgkICwUWAgMBAAIeAQIXgAAKCRBgRt3vlM+ZtfDKAQDr
+pYIU2e9e27h8ASgWbqXVzHWD2XDUsZRQtfkTrd4mAAD9EX0D8P1GC0JbJ3OSRKL9
+qRMVaXVyR+MGiY4fq9umUAm4OARpqByGEgorBgEEAZdVAQUBAQdAV7XUsnWCFefO
+rZMjcAHn750DNKSWqZJVG1Q/X/QJkBwDAQgHiH4EGBYKACYWIQR1UMNsPfYWpp8e
+/gBgRt3vlM+ZtQUCaagchgIbDAUJA8JnAAAKCRBgRt3vlM+ZteKxAP9Mf9lzcCne
+G7gptbThqUzGi0EaFoaLOi/9MFfSxMRChgEAtVpsm/bpf9kDYv//LCjQ32mG594e
+jlOOQUwFoIKfgAk=
+=K4Oq
 -----END PGP PUBLIC KEY BLOCK-----
 ```
 
@@ -92,11 +88,10 @@ In the case where we fix a security issue in Zebra or Zcash that also affects th
 
 We have set up agreements with the following neighboring projects to share vulnerability information, subject to the deviations described in the next section.
 
-Specifically, we have agreed to engage in responsible disclosures for security issues affecting Zebra or Zcash technology with the following contacts:
+Specifically, we have agreed to engage in responsible disclosures for security issues affecting Zebra or Zcash technology with the following teams:
 
-- Zcash Open Development Lab (ZODL), which maintains the `zcash/zcash` core
-  node, `librustzcash`, `zallet`, and related software, via its security
-  disclosure process at <https://github.com/zcash/.github/blob/main/SECURITY.md>
+- Zcash Open Development Lab (ZODL), which maintains the `zcash/zcash` core node, `librustzcash`, `zallet`, and related software, via its security disclosure process at <https://github.com/zcash/.github/blob/main/SECURITY.md>
+- Shielded Labs, which maintains the Crosslink proof-of-stake and Network Sustainability Mechanism work and its associated Zebra and `librustzcash` forks.
 
 ## Deviations from the Standard
 


### PR DESCRIPTION
## Motivation

Two problems with `SECURITY.md`.

**Reports arrive untested against current code.** Triage time is wasted when a
vulnerability report's proof of concept was never tested against a current
version of Zebra. `SECURITY.md` did not tell reporters which version to test
against, or to say which version they tested.

**The published contacts had gaps.** A review of the contacts turned up three
issues:

- `pilizcash.01` was the only handle on the Signal channel for *critical*
  vulnerabilities. If that person is unavailable, a consensus-split or
  counterfeiting report has no fast path in.
- The PGP block contained two concatenated primary keys. `E7B32440DA784EBFB8AA2845FD6D55591BF92BCA`
  (`Zcash Foundation <security@zfnd.org>`, created 2026-01-29) is self-revoked
  and expired on 2026-02-28; only `7550C36C3DF616A69F1EFE006046DDEF94CF99B5`
  (`Zcash Foundation Security Team`, expires 2028-03-03) is live. Both were
  published together in #10460. A reporter importing the block could encrypt
  to the dead key, or read the revocation and conclude the ZF key is gone.
- The bilateral disclosure agreement with Shielded Labs was not listed.

## Solution

Add a "Before You Report" subsection at the top of "Receiving Disclosures" in
`SECURITY.md`, before the reporting-channel instructions. It asks reporters to:

- confirm the issue affects the latest Zebra release or the current `main`
  branch before submitting,
- test any proof of concept against one of those two versions,
- state the exact release version or `main` commit hash tested in the report.

Also add a "Security Vulnerability Reports" section to `AGENTS.md` (which
`CLAUDE.md` symlinks to) so AI coding agents hold agent-assisted reports to the
same standard: route suspected vulnerabilities through SECURITY.md instead of
public issues or PRs, reproduce against the latest release or current `main`,
include the version tested, and don't submit speculative findings without a
reproduction.

Then update the published contacts:

- Add `conrado.42` and `dc_zf.77` to the Signal list, and state that the group
  must include all of the listed handles rather than any one of them.
- Re-emit the PGP block with only the live `7550C36C…` key and its Curve25519
  encryption subkey, and publish that fingerprint in plain text so a reporter
  can verify the armor without importing it first.
- Add Shielded Labs to the bilateral responsible disclosure agreement list.

The Signal handles here are deliberately ZF-side only. The ecosystem policy at
`zcash/.github/SECURITY.md` lists `dairaemma.31`, `pilizcash.01`, and
`nuttycom.01`; this document aligns with that process rather than duplicating
its contacts.

### Tests

Documentation-only change; verified markdown heading structure renders
correctly.

The re-emitted key block was verified two ways, since a broken armor block
would silently take the email fallback channel offline:

1. OpenPGP packet walk over the edited file — exactly one primary key, v4
   fingerprint `7550C36C3DF616A69F1EFE006046DDEF94CF99B5`, one encryption
   subkey, no revocation signature, recomputed CRC24 matching the `=K4Oq`
   armor checksum.
2. `gpg` round-trip in a throwaway homedir — imports as a single non-revoked
   `ed25519 [SC]` + `cv25519 [E]` pair expiring 2028-03-03, and
   `gpg -e -r security@zfnd.org` succeeds against subkey `E9AE3777E154032C`,
   confirming the key is actually usable for encryption.

`markdownlint` passes with `.trunk/configs/.markdownlint.yaml`. `codespell`
was not run locally (not installed on this host); CI covers it.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude Code drafted the SECURITY.md wording and PR
      description, and audited the published PGP key block and contacts.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
