### PR TITLE
refactor(ci): derive Mergify queue gates from the main ruleset and drop the PR Gate requirement

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,6 +7,23 @@
 merge_queue:
   max_parallel_checks: 5
 
+# Holds the YAML anchors reused below
+shared:
+  # Mergify reads the rulesets that apply to the base branch and injects their
+  # rules as queue conditions, so the `PR Requirements` ruleset is the single
+  # source of truth for the required status checks, the one-approval
+  # requirement, and conversation resolution. Mergify is a bypass actor in
+  # `always` mode, which still injects those rules as conditions.
+  # https://docs.mergify.com/merge-queue/github-rulesets/
+  #
+  # Only gates that GitHub cannot express belong here.
+  queue_gates: &queue_gates
+    - base=main
+    # is not in draft
+    - -draft
+    # does not include the do-not-merge label
+    - label!=do-not-merge
+
 # Provides a means to set configuration values that act as fallbacks
 # for queue_rules and pull_request_rules
 defaults:
@@ -16,28 +33,7 @@ defaults:
     # Allow to update/rebase the original pull request if possible to check its mergeability,
     # and it does not create a draft PR if not needed
     batch_max_wait_time: "2 minutes"
-    queue_conditions:
-      # Mergify can auto-mirror classic branch protection, but not GitHub
-      # Rulesets. The conditions below restate the gates we actually rely on
-      # so PRs cannot be queued past failing required checks or unresolved
-      # change-requests.
-      # https://docs.mergify.com/conditions/#about-branch-protection
-      - base=main
-      # is not in draft
-      - -draft
-      # does not include the do-not-merge label
-      - label!=do-not-merge
-      # has at least one approving reviewer
-      - "#approved-reviews-by >= 1"
-      # no reviewer has requested changes
-      - "#changes-requested-reviews-by = 0"
-      # The four required aggregator check runs must pass. After the
-      # `changes` + paths-filter refactor (#10637), each aggregator is
-      # produced by exactly one workflow, so the names below are stable.
-      - check-success=lint
-      - check-success=unit-tests
-      - check-success=test-crates
-      - check-success=pr-gate-result
+    queue_conditions: *queue_gates
 
 
 # Allows to define the rules that reign over our merge queues
@@ -47,19 +43,11 @@ queue_rules:
     # Wait a short time to embark hotfixes together in a merge train
     batch_max_wait_time: "2 minutes"
     # A queue_rule's `queue_conditions` REPLACES the value from
-    # `defaults.queue_rule.queue_conditions` rather than extending it. Restate
-    # the same gates here so a P-Critical label cannot bypass the approval,
-    # changes-requested, base-branch, and required-check checks.
+    # `defaults.queue_rule.queue_conditions` rather than extending it, so reuse
+    # the shared anchor instead of restating the gates. A P-Critical label must
+    # raise priority, not remove protections.
     queue_conditions:
-      - base=main
-      - -draft
-      - label!=do-not-merge
-      - "#approved-reviews-by >= 1"
-      - "#changes-requested-reviews-by = 0"
-      - check-success=lint
-      - check-success=unit-tests
-      - check-success=test-crates
-      - check-success=pr-gate-result
+      - and: *queue_gates
       # is labeled with Critical priority
       - 'label~=^P-Critical'
 

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,4 +1,4 @@
-# Required source-PR gate verifying that a conventional-commit declaration is consistent with its code and changelog entries.
+# Source-PR gate verifying that a conventional-commit declaration is consistent with its code and changelog entries.
 # Mergify queue candidates skip these policy jobs because their generated metadata does not describe a source change.
 name: PR Gate
 
@@ -9,19 +9,19 @@ on:
     branches: [main]
   push:
     branches: [main]
-  # Keeps this aggregator reporting if GitHub's native merge queue is ever enabled,
-  # matching the sibling required-check workflows; jobs skip and the result skip-passes.
+  # Keeps this aggregator reporting inside a merge queue, matching the sibling
+  # aggregator workflows; jobs skip and the result skip-passes.
   merge_group:
 
 # Cancel obsolete gate runs after new commits. Unrelated label events use a
-# separate group so they cannot cancel the required PR Gate run.
+# separate group so they cannot cancel an in-progress PR Gate run.
 concurrency:
   group: >-
     ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{
       (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
       github.event.label.name != 'A-release' &&
       'ignored-label' ||
-      'required'
+      'gate'
     }}
   cancel-in-progress: true
 
@@ -162,7 +162,7 @@ jobs:
           bash .github/scripts/validate-pr-changelogs.sh \
             "$merge_base" HEAD "$CONVENTIONAL" "$DECLARED_TYPE" "$BREAKING"
 
-  # No branch rule or Mergify condition pins this worker's display name; Mergify consumes `pr-gate-result`.
+  # Nothing downstream pins this worker's display name; `pr-gate-result` aggregates it.
   release-readiness:
     name: Release readiness
     if: >-
@@ -264,7 +264,7 @@ jobs:
           fi
 
   pr-gate-result:
-    # Keep skipped unrelated-label runs from replacing the required check.
+    # Keep skipped unrelated-label runs from posting a misleading green result.
     name: >-
       ${{
         (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

Closes https://github.com/ZcashFoundation/zebra/issues/11175

## Solution

Rely on the injected checks (you can see in e.g. [here](https://github.com/ZcashFoundation/zebra/pull/11095/checks?check_run_id=91292985078) that they were indeed being injected, see how the rules are duplicated), and also remove redundancy between the urgent and normal queue by using YAML anchors.

**This PR has another important side-effect: since pr-gate-result is not on the GH ruleset, if will no longer be a required check**. I did this on purpose, since I believe there are many scenarios where we might want pr-gate-result to be bypassed (i.e. not everything needs to be included in the changelog). If you disagree let's discuss it, I'm happy to add pr-gate-result to the ruleset if we decide it is indeed worth it

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
-->

### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [ ] No AI tools were used in this PR
- [x] AI tools were used: written with Claude, reviewed manually

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [ ] The solution is tested.
- [x] The documentation and changelogs are up to date.
