### PR TITLE
perf(consensus): batch block transaction UTXO lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   ([#11165](https://github.com/ZcashFoundation/zebra/pull/11165)).
 - Peer-set, crawler-handshake, and address-book gauges now include a `network` label, so Mainnet
   and Testnet values no longer overwrite each other in processes that run both networks.
+- Verifying a block transaction with many transparent inputs now asks the state for its spent
+  outputs in batches of up to 64, rather than one at a time, reducing the round trips needed to
+  verify a block. Outputs that have not reached the state yet are still awaited individually
+  ([#11185](https://github.com/ZcashFoundation/zebra/issues/11185)).
 
 ### Fixed
 

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -31,7 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `transaction::BlockTxVerifier` and `transaction::MempoolTxVerifier`.
 - `transaction::BlockRequest`, `transaction::BlockResponse`,
   `transaction::MempoolRequest`, and `transaction::MempoolResponse`.
-  
+
+### Changed
+
+- Block transaction verification now looks up spent outpoints in batches, sending
+  `zebra_state::Request::AnyChainUtxos` for up to 64 outpoints at a time instead of one
+  `zebra_state::Request::AwaitUtxo` per input, and falling back to `AwaitUtxo` for outpoints
+  that have not reached the state yet. Embedders that answer state requests with their own
+  service need to handle the new request.
+
 ## [14.0.1] - 2026-07-27
 
 ### Changed

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -78,6 +78,22 @@ const MEMPOOL_OUTPUT_LOOKUP_TIMEOUT: std::time::Duration = std::time::Duration::
 /// response from the transaction verifier.
 const POLL_MEMPOOL_DELAY: std::time::Duration = Duration::from_millis(50);
 
+/// How many outpoints a block transaction's UTXO lookups ask the state for at a time.
+///
+/// Lookups are batched so that a transaction with many inputs does not need one state request
+/// per input. They are chunked rather than sent as one request so that batching cannot make a
+/// transaction cost the state more lookups than verifying it sequentially used to: lookups
+/// stop at the first chunk that isn't fully present in the state, so at most one chunk of them
+/// is speculative.
+///
+/// This bounds the extra work additively, by one chunk. It does not make the work independent
+/// of the input count: a transaction that references many outputs which really are in the
+/// state still costs one lookup per input, exactly as it did before batching.
+///
+/// The exact value trades round trips against the size of that additive bound. It matches the
+/// cryptographic batch size in [`crate::primitives`], which is the same kind of tradeoff.
+pub(crate) const UTXO_LOOKUP_CHUNK_SIZE: usize = 64;
+
 /// Asynchronous verification of block transactions.
 ///
 /// # Correctness
@@ -400,6 +416,15 @@ where
     /// Looks up UTXOs spent by `tx` from the best chain state, also checking
     /// `known_utxos` for UTXOs from earlier transactions in the same block.
     ///
+    /// Looks up the outpoints that aren't in `known_utxos` in batches of
+    /// [`UTXO_LOOKUP_CHUNK_SIZE`], so a transaction whose inputs are already verified costs
+    /// one state request per chunk rather than one per input.
+    ///
+    /// Any outpoints that haven't reached the state yet are then awaited one at a time, as
+    /// [`zebra_state::Request::AwaitUtxo`] registers a pending request per outpoint. Waiting
+    /// for them sequentially bounds how many pending requests one transaction can create,
+    /// and the first wait to time out fails the whole transaction.
+    ///
     /// Returns an `OutPoint -> Utxo` map and a vec of `Output`s in the same
     /// order as the matching inputs in `tx`.
     async fn block_spent_utxos(
@@ -417,34 +442,102 @@ where
         let mut spent_utxos = HashMap::new();
         // Pre-allocate with None so we can fill each slot by input index, preserving input order.
         let mut spent_outputs: Vec<Option<transparent::Output>> = vec![None; inputs.len()];
+        // Stores (input_idx, outpoint) for the outpoints that need a state lookup.
+        let mut lookups: Vec<(usize, transparent::OutPoint)> = Vec::new();
 
         for (input_idx, input) in inputs.iter().enumerate() {
             if let transparent::Input::PrevOut { outpoint, .. } = input {
-                tracing::trace!("awaiting outpoint lookup");
+                if let Some(ordered_utxo) = known_utxos.get(outpoint) {
+                    tracing::trace!(?outpoint, "UTXO in known_utxos, discarding query");
 
-                let utxo = if let Some(output) = known_utxos.get(outpoint) {
-                    tracing::trace!("UTXO in known_utxos, discarding query");
-                    output.utxo.clone()
+                    spent_outputs[input_idx] = Some(ordered_utxo.utxo.output.clone());
+                    spent_utxos.insert(*outpoint, ordered_utxo.utxo.clone());
                 } else {
+                    lookups.push((input_idx, *outpoint));
+                }
+            }
+        }
+
+        if lookups.is_empty() {
+            let spent_outputs = spent_outputs.into_iter().flatten().collect();
+
+            return Ok((spent_utxos, spent_outputs));
+        }
+
+        tracing::trace!(count = lookups.len(), "looking up outpoints");
+
+        // Look the outpoints up a chunk at a time, stopping at the first chunk that isn't
+        // fully present in the state.
+        //
+        // # Correctness
+        //
+        // Stopping early bounds how much of this is speculative: the sequential loop below
+        // fails on the outpoint this chunk didn't find, so looking up any later chunk would be
+        // wasted work. A transaction whose inputs are all unknown therefore costs one chunk of
+        // lookups rather than one per input.
+        //
+        // This is an additive bound, not input-count independence. A transaction that
+        // references outputs which really are in the state still costs one lookup per input,
+        // as it did when each input was looked up on its own.
+        let mut found = HashMap::new();
+
+        for chunk in lookups.chunks(UTXO_LOOKUP_CHUNK_SIZE) {
+            let response = state
+                .clone()
+                .oneshot(zebra_state::Request::AnyChainUtxos(
+                    chunk.iter().map(|&(_, outpoint)| outpoint).collect(),
+                ))
+                .await
+                .map_err(|boxed_error| match boxed_error.downcast::<Elapsed>() {
+                    Ok(_) => TransactionError::TransparentInputNotFound,
+                    Err(boxed_error) => TransactionError::from(boxed_error),
+                })?;
+
+            let zebra_state::Response::AnyChainUtxos(utxos) = response else {
+                unreachable!("AnyChainUtxos always responds with AnyChainUtxos")
+            };
+
+            let chunk_is_complete = chunk
+                .iter()
+                .all(|(_, outpoint)| utxos.contains_key(outpoint));
+
+            found.extend(utxos);
+
+            if !chunk_is_complete {
+                break;
+            }
+        }
+
+        for (input_idx, outpoint) in lookups {
+            let utxo = match found.remove(&outpoint) {
+                Some(utxo) => utxo,
+                // The block creating this UTXO is still in the verification pipeline, so wait
+                // for it to arrive. `AwaitUtxo` re-checks the state as it registers the wait,
+                // so a block that arrived since the lookup above is not missed.
+                None => {
+                    tracing::trace!(?outpoint, "awaiting outpoint lookup");
+
                     let response = state
                         .clone()
-                        .oneshot(zebra_state::Request::AwaitUtxo(*outpoint))
+                        .oneshot(zebra_state::Request::AwaitUtxo(outpoint))
                         .await
                         .map_err(|boxed_error| match boxed_error.downcast::<Elapsed>() {
                             Ok(_) => TransactionError::TransparentInputNotFound,
                             Err(boxed_error) => TransactionError::from(boxed_error),
                         })?;
 
-                    if let zebra_state::Response::Utxo(utxo) = response {
-                        utxo
-                    } else {
+                    let zebra_state::Response::Utxo(utxo) = response else {
                         unreachable!("AwaitUtxo always responds with Utxo")
-                    }
-                };
-                tracing::trace!(?utxo, "got UTXO");
-                spent_outputs[input_idx] = Some(utxo.output.clone());
-                spent_utxos.insert(*outpoint, utxo);
-            }
+                    };
+
+                    utxo
+                }
+            };
+
+            tracing::trace!(?outpoint, ?utxo, "got UTXO");
+
+            spent_outputs[input_idx] = Some(utxo.output.clone());
+            spent_utxos.insert(outpoint, utxo);
         }
 
         let spent_outputs: Vec<transparent::Output> = spent_outputs.into_iter().flatten().collect();

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -40,7 +40,10 @@ use zebra_node_services::mempool;
 use zebra_state::ValidateContextError;
 use zebra_test::mock_service::MockService;
 
-use crate::{error::TransactionError, transaction::POLL_MEMPOOL_DELAY};
+use crate::{
+    error::TransactionError,
+    transaction::{POLL_MEMPOOL_DELAY, UTXO_LOOKUP_CHUNK_SIZE},
+};
 
 use super::{check, BlockRequest, BlockTxVerifier, MempoolRequest, MempoolTxVerifier};
 
@@ -1110,22 +1113,27 @@ async fn block_verification_does_not_use_mempool_verified_state() {
 
     // The mempool has already verified this transaction, and it is now submitted twice as a block
     // request. Each request runs full block verification independently, which for this transaction
-    // means fetching the spent UTXO from the state service, so two AwaitUtxo responses are queued
-    // below. Reuse of the mempool's result — or of the first block request's result — is prevented
-    // structurally: BlockTxVerifier holds no mempool handle and caches nothing across requests.
+    // means fetching the spent UTXO from the state service, so two AnyChainUtxos responses are
+    // queued below. Reuse of the mempool's result — or of the first block request's result — is
+    // prevented structurally: BlockTxVerifier holds no mempool handle and caches nothing across
+    // requests.
     let utxo_clone = utxo.clone();
     tokio::spawn(async move {
         state
-            .expect_request(zebra_state::Request::AwaitUtxo(input_outpoint))
+            .expect_request(zebra_state::Request::AnyChainUtxos(vec![input_outpoint]))
             .await
             .expect("verifier should call mock state service with correct request")
-            .respond(zebra_state::Response::Utxo(utxo_clone));
+            .respond(zebra_state::Response::AnyChainUtxos(
+                [(input_outpoint, utxo_clone)].into_iter().collect(),
+            ));
 
         state
-            .expect_request(zebra_state::Request::AwaitUtxo(input_outpoint))
+            .expect_request(zebra_state::Request::AnyChainUtxos(vec![input_outpoint]))
             .await
             .expect("verifier should call mock state service with correct request")
-            .respond(zebra_state::Response::Utxo(utxo));
+            .respond(zebra_state::Response::AnyChainUtxos(
+                [(input_outpoint, utxo)].into_iter().collect(),
+            ));
     });
 
     // Briefly yield and sleep so the spawned task can first expect the requests.
@@ -1151,6 +1159,265 @@ async fn block_verification_does_not_use_mempool_verified_state() {
         2,
         "the mempool service should have been polled twice"
     );
+}
+
+/// The number of external transparent inputs used by the bulk UTXO lookup tests that fit in a
+/// single chunk.
+const BULK_LOOKUP_INPUT_COUNT: u32 = 3;
+
+/// Builds a non-coinbase V5 transaction spending `input_count` transparent outputs, none of
+/// which are in the transaction's own block, so the block verifier has to look all of them up
+/// in the state.
+///
+/// Returns the transaction, its hash, the outpoints it spends in input order, and the UTXOs
+/// those outpoints point to.
+fn mock_multi_input_block_tx(
+    height: block::Height,
+    input_count: u32,
+) -> (
+    Transaction,
+    Hash,
+    Vec<transparent::OutPoint>,
+    HashMap<transparent::OutPoint, transparent::Utxo>,
+) {
+    let fund_height = (height - 1).expect("fake source fund block height is too small");
+
+    let mut inputs = Vec::new();
+    let mut outputs = Vec::new();
+    let mut outpoints = Vec::new();
+    let mut utxos = HashMap::new();
+
+    for outpoint_index in 0..input_count {
+        // Each call uses a different outpoint index, so the inputs spend distinct outputs.
+        let (input, output, known_utxos) = mock_transparent_transfer(
+            fund_height,
+            true,
+            outpoint_index,
+            Amount::try_from(10001).expect("invalid value"),
+        );
+
+        let outpoint = match &input {
+            transparent::Input::PrevOut { outpoint, .. } => *outpoint,
+            transparent::Input::Coinbase { .. } => panic!("requires a non-coinbase transaction"),
+        };
+
+        utxos.extend(
+            known_utxos
+                .into_iter()
+                .map(|(outpoint, ordered_utxo)| (outpoint, ordered_utxo.utxo)),
+        );
+
+        inputs.push(input);
+        outputs.push(output);
+        outpoints.push(outpoint);
+    }
+
+    let tx = Transaction::V5 {
+        network_upgrade: NetworkUpgrade::Nu6,
+        inputs,
+        outputs,
+        lock_time: LockTime::min_lock_time_timestamp(),
+        expiry_height: height,
+        sapling_shielded_data: None,
+        orchard_shielded_data: None,
+    };
+
+    let tx_hash = tx.hash();
+
+    (tx, tx_hash, outpoints, utxos)
+}
+
+/// The block transaction verifier must look up every outpoint that is missing from
+/// `known_utxos` with a single [`zebra_state::Request::AnyChainUtxos`], so a transaction with
+/// many inputs does not need one state request per input.
+///
+/// Duplicate outpoints cannot reach this lookup: `check::spend_conflicts` rejects them first,
+/// which `v4_transaction_with_conflicting_transparent_spend_is_rejected` proves by failing if
+/// the state service is called at all.
+#[tokio::test(flavor = "multi_thread")]
+async fn block_utxo_lookups_use_one_bulk_request() {
+    let _init_guard = zebra_test::init();
+
+    let network = Network::Mainnet;
+
+    let mut state: MockService<_, _, _, _> = MockService::build().for_unit_tests();
+    let verifier = BlockTxVerifier::new(&network, state.clone());
+
+    let height = NetworkUpgrade::Nu6
+        .activation_height(&network)
+        .expect("Nu6 activation height is specified");
+
+    let (tx, tx_hash, outpoints, utxos) =
+        mock_multi_input_block_tx(height, BULK_LOOKUP_INPUT_COUNT);
+
+    // One request, carrying every spent outpoint in input order.
+    let expected_request = zebra_state::Request::AnyChainUtxos(outpoints.clone());
+
+    let mut state_clone = state.clone();
+    tokio::spawn(async move {
+        state_clone
+            .expect_request(expected_request)
+            .await
+            // `for_unit_tests()` panics on an unexpected request, so there is nothing to unwrap.
+            .respond(zebra_state::Response::AnyChainUtxos(utxos));
+    });
+
+    let response = timeout(
+        test_timeout(),
+        verifier.oneshot(BlockRequest {
+            transaction_hash: tx_hash,
+            transaction: Arc::new(tx),
+            // Empty, so every input needs a state lookup.
+            known_utxos: Arc::new(HashMap::new()),
+            height,
+            time: Utc::now(),
+        }),
+    )
+    .await
+    .expect("block request should not time out")
+    .expect("transaction spending valid transparent outputs should verify");
+
+    let crate::transaction::BlockResponse { .. } = response;
+
+    // The bulk lookup answered everything, so there must be no per-input `AwaitUtxo` requests.
+    state.expect_no_requests().await;
+}
+
+/// When the bulk lookup does not find every outpoint, the block transaction verifier must wait
+/// for the missing ones with [`zebra_state::Request::AwaitUtxo`], and only those.
+///
+/// Awaiting them one at a time is what bounds the number of pending UTXO requests a single
+/// transaction can register in the state: the first wait to time out fails the transaction
+/// before any later outpoint is registered.
+#[tokio::test(flavor = "multi_thread")]
+async fn block_utxo_lookups_await_only_the_missing_outpoints() {
+    let _init_guard = zebra_test::init();
+
+    let network = Network::Mainnet;
+
+    let mut state: MockService<_, _, _, _> = MockService::build().for_unit_tests();
+    let verifier = BlockTxVerifier::new(&network, state.clone());
+
+    let height = NetworkUpgrade::Nu6
+        .activation_height(&network)
+        .expect("Nu6 activation height is specified");
+
+    let (tx, tx_hash, outpoints, mut utxos) =
+        mock_multi_input_block_tx(height, BULK_LOOKUP_INPUT_COUNT);
+
+    // Withhold one outpoint from the bulk response, as if the block creating it were still in
+    // the verification pipeline.
+    let missing_outpoint = outpoints[1];
+    let missing_utxo = utxos
+        .remove(&missing_outpoint)
+        .expect("mock UTXOs should contain every spent outpoint");
+
+    let expected_request = zebra_state::Request::AnyChainUtxos(outpoints.clone());
+
+    let mut state_clone = state.clone();
+    tokio::spawn(async move {
+        state_clone
+            .expect_request(expected_request)
+            .await
+            // `for_unit_tests()` panics on an unexpected request, so there is nothing to unwrap.
+            .respond(zebra_state::Response::AnyChainUtxos(utxos));
+
+        state_clone
+            .expect_request(zebra_state::Request::AwaitUtxo(missing_outpoint))
+            .await
+            // `for_unit_tests()` panics on an unexpected request, so there is nothing to unwrap.
+            .respond(zebra_state::Response::Utxo(missing_utxo));
+    });
+
+    let response = timeout(
+        test_timeout(),
+        verifier.oneshot(BlockRequest {
+            transaction_hash: tx_hash,
+            transaction: Arc::new(tx),
+            known_utxos: Arc::new(HashMap::new()),
+            height,
+            time: Utc::now(),
+        }),
+    )
+    .await
+    .expect("block request should not time out")
+    .expect("transaction spending valid transparent outputs should verify");
+
+    let crate::transaction::BlockResponse { .. } = response;
+
+    // The outpoints the bulk lookup did find must not be awaited as well.
+    state.expect_no_requests().await;
+}
+
+/// The block transaction verifier must stop looking outpoints up after the first chunk that
+/// isn't fully present in the state.
+///
+/// This bounds the speculative part of batching to one chunk. Without it, a transaction whose
+/// inputs are all unknown would make the state look up every one of them before the sequential
+/// fallback failed on the first, which is more work than looking each input up on its own used
+/// to cost.
+///
+/// It does not make the work independent of the input count: a transaction that references
+/// outputs which really are in the state is still looked up in full, as it was before batching.
+#[tokio::test(flavor = "multi_thread")]
+async fn block_utxo_lookups_stop_at_the_first_chunk_with_misses() {
+    let _init_guard = zebra_test::init();
+
+    let network = Network::Mainnet;
+
+    let mut state: MockService<_, _, _, _> = MockService::build().for_unit_tests();
+    let verifier = BlockTxVerifier::new(&network, state.clone());
+
+    let height = NetworkUpgrade::Nu6
+        .activation_height(&network)
+        .expect("Nu6 activation height is specified");
+
+    // More inputs than fit in one chunk, so a second chunk is available to look up.
+    let input_count = u32::try_from(UTXO_LOOKUP_CHUNK_SIZE)
+        .expect("chunk size fits in a u32")
+        .checked_add(8)
+        .expect("input count is not too large");
+
+    let (tx, tx_hash, outpoints, _utxos) = mock_multi_input_block_tx(height, input_count);
+
+    // Only the first chunk may be looked up, and none of its outpoints are in the state.
+    let first_chunk: Vec<_> = outpoints[..UTXO_LOOKUP_CHUNK_SIZE].to_vec();
+    let first_outpoint = outpoints[0];
+
+    let mut state_clone = state.clone();
+    tokio::spawn(async move {
+        state_clone
+            .expect_request(zebra_state::Request::AnyChainUtxos(first_chunk))
+            .await
+            .respond(zebra_state::Response::AnyChainUtxos(HashMap::new()));
+
+        // The fallback fails on the first outpoint, so no later chunk is ever looked up.
+        state_clone
+            .expect_request(zebra_state::Request::AwaitUtxo(first_outpoint))
+            .await
+            .respond_error("no such UTXO".into());
+    });
+
+    let result = timeout(
+        test_timeout(),
+        verifier.oneshot(BlockRequest {
+            transaction_hash: tx_hash,
+            transaction: Arc::new(tx),
+            known_utxos: Arc::new(HashMap::new()),
+            height,
+            time: Utc::now(),
+        }),
+    )
+    .await
+    .expect("block request should not time out");
+
+    assert!(
+        result.is_err(),
+        "transaction spending unknown outpoints must not verify, got: {result:?}"
+    );
+
+    // Exactly one chunk was looked up: the outpoints after it were never requested.
+    state.expect_no_requests().await;
 }
 
 /// Tests that calls to the transaction verifier with a mempool request that spends

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Request::AnyChainUtxos` and `Response::AnyChainUtxos`, which look up a list of outpoints in
+  one request and return only the ones already in the state. Unlike `Request::AwaitUtxo`, they
+  never wait for a UTXO to arrive and never register a pending request, so callers must follow
+  up with `Request::AwaitUtxo` for the outpoints that were not found.
+- `ReadRequest::AnyChainUtxos`
+- `ReadResponse::AnyChainUtxos`
+
+### Removed
+
+- `ReadRequest::AnyChainUtxo` and `ReadResponse::AnyChainUtxo`, replaced by the `AnyChainUtxos`
+  forms, which take a list of outpoints and return a map of the ones that were found.
+
 ### Fixed
 
 - `init_read_only()` now returns `StateInitError::ReadOnlyEphemeralConflict` for a config with

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -943,6 +943,32 @@ pub enum Request {
     /// Outdated requests are pruned on a regular basis.
     AwaitUtxo(transparent::OutPoint),
 
+    /// Looks up the UTXOs identified by the given [`OutPoint`](transparent::OutPoint)s,
+    /// returning only the ones that are already available.
+    ///
+    /// Checks the finalized chain, all non-finalized chains, and queued unverified blocks.
+    /// Unlike [`Request::AwaitUtxo`], this request never waits for a UTXO to arrive, and
+    /// never registers a pending request, so the number of outpoints it is given does not
+    /// affect how much state it can hold.
+    ///
+    /// Callers that need to wait for the outpoints this request did not find should follow
+    /// up with [`Request::AwaitUtxo`], which re-checks the state as it registers each wait.
+    ///
+    /// The outpoints are resolved together, so a transaction whose inputs are all already
+    /// verified costs one request instead of one per input.
+    ///
+    /// Every outpoint still costs a lookup, so callers whose outpoints come from untrusted
+    /// data should send them in bounded chunks and stop at the first chunk with a miss, rather
+    /// than passing an entire transaction's inputs at once. Zebra's block transaction verifier
+    /// does this with its `UTXO_LOOKUP_CHUNK_SIZE`.
+    ///
+    /// This request is purely informational, and there are no guarantees about
+    /// whether the UTXOs remain unspent or are on the best chain, or any chain.
+    ///
+    /// Returns [`Response::AnyChainUtxos`]; outpoints that were not found are absent from
+    /// the map.
+    AnyChainUtxos(Vec<transparent::OutPoint>),
+
     /// Finds the first hash that's in the peer's `known_blocks` and the local best chain.
     /// Returns a list of hashes that follow that intersection, from the best chain.
     ///
@@ -1047,6 +1073,7 @@ impl Request {
             Request::CommitSemanticallyVerifiedBlock(_) => "commit_semantically_verified_block",
             Request::CommitCheckpointVerifiedBlock(_) => "commit_checkpoint_verified_block",
             Request::AwaitUtxo(_) => "await_utxo",
+            Request::AnyChainUtxos(_) => "any_chain_utxos",
             Request::Depth(_) => "depth",
             Request::Tip => "tip",
             Request::BlockLocator => "block_locator",
@@ -1204,14 +1231,14 @@ pub enum ReadRequest {
     /// Checks verified blocks in the finalized chain and the _best_ non-finalized chain.
     UnspentBestChainUtxo(transparent::OutPoint),
 
-    /// Looks up a UTXO identified by the given [`OutPoint`](transparent::OutPoint),
-    /// returning `None` immediately if it is unknown.
+    /// Looks up the UTXOs identified by the given [`OutPoint`](transparent::OutPoint)s,
+    /// omitting any that are unknown instead of waiting for them.
     ///
     /// Checks verified blocks in the finalized chain and _all_ non-finalized chains.
     ///
     /// This request is purely informational, there is no guarantee that
-    /// the UTXO remains unspent in the best chain.
-    AnyChainUtxo(transparent::OutPoint),
+    /// the UTXOs remain unspent in the best chain.
+    AnyChainUtxos(Vec<transparent::OutPoint>),
 
     /// Computes a block locator object based on the current best chain.
     ///
@@ -1487,7 +1514,7 @@ impl ReadRequest {
             ReadRequest::TransactionIdsForBlock(_) => "transaction_ids_for_block",
             ReadRequest::AnyChainTransactionIdsForBlock(_) => "any_chain_transaction_ids_for_block",
             ReadRequest::UnspentBestChainUtxo { .. } => "unspent_best_chain_utxo",
-            ReadRequest::AnyChainUtxo { .. } => "any_chain_utxo",
+            ReadRequest::AnyChainUtxos { .. } => "any_chain_utxos",
             ReadRequest::BlockLocator => "block_locator",
             ReadRequest::FindBlockHashes { .. } => "find_block_hashes",
             ReadRequest::FindBlockHeaders { .. } => "find_block_headers",
@@ -1571,8 +1598,12 @@ impl TryFrom<Request> for ReadRequest {
             | Request::ReconsiderBlock(_) => Err("ReadService does not write blocks"),
 
             Request::AwaitUtxo(_) => Err("ReadService does not track pending UTXOs. \
-                     Manually convert the request to ReadRequest::AnyChainUtxo, \
+                     Manually convert the request to ReadRequest::AnyChainUtxos, \
                      and handle pending UTXOs"),
+
+            Request::AnyChainUtxos(_) => Err("ReadService does not track queued blocks. \
+                     Manually convert the request to ReadRequest::AnyChainUtxos, \
+                     and check the queued blocks"),
 
             Request::KnownBlock(_) => Err("ReadService does not track queued blocks"),
 

--- a/zebra-state/src/response.rs
+++ b/zebra-state/src/response.rs
@@ -1,7 +1,7 @@
 //! State [`tower::Service`] response types.
 
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     sync::Arc,
 };
 
@@ -92,6 +92,12 @@ pub enum Response {
     /// The response to a `AwaitUtxo` request, from any non-finalized chains, finalized chain,
     /// pending unverified blocks, or blocks received after the request was sent.
     Utxo(transparent::Utxo),
+
+    /// The response to an `AnyChainUtxos` request, from any non-finalized chains, finalized
+    /// chain, or pending unverified blocks.
+    ///
+    /// Outpoints that were not found are absent from the map.
+    AnyChainUtxos(HashMap<transparent::OutPoint, transparent::Utxo>),
 
     /// The response to a `FindBlockHashes` request.
     BlockHashes(Vec<block::Hash>),
@@ -447,12 +453,14 @@ pub enum ReadResponse {
     /// _best_ non-finalized chain, or the finalized chain.
     UnspentBestChainUtxo(Option<transparent::Utxo>),
 
-    /// The response to an `AnyChainUtxo` request, from verified blocks in
+    /// The response to an `AnyChainUtxos` request, from verified blocks in
     /// _any_ non-finalized chain, or the finalized chain.
     ///
+    /// Outpoints that were not found are absent from the map.
+    ///
     /// This response is purely informational, there is no guarantee that
-    /// the UTXO remains unspent in the best chain.
-    AnyChainUtxo(Option<transparent::Utxo>),
+    /// the UTXOs remain unspent in the best chain.
+    AnyChainUtxos(HashMap<transparent::OutPoint, transparent::Utxo>),
 
     /// Response to [`ReadRequest::SaplingTree`] with the specified Sapling note commitment tree.
     SaplingTree(Option<Arc<sapling::tree::NoteCommitmentTree>>),
@@ -599,8 +607,8 @@ impl TryFrom<ReadResponse> for Response {
             ReadResponse::UnspentBestChainUtxo(utxo) => Ok(Response::UnspentBestChainUtxo(utxo)),
 
 
-            ReadResponse::AnyChainUtxo(_) => Err("ReadService does not track pending UTXOs. \
-                                                  Manually unwrap the response, and handle pending UTXOs."),
+            ReadResponse::AnyChainUtxos(_) => Err("ReadService does not track pending UTXOs. \
+                                                   Manually unwrap the response, and handle pending UTXOs."),
 
             ReadResponse::BlockLocator(hashes) => Ok(Response::BlockLocator(hashes)),
             ReadResponse::BlockHashes(hashes) => Ok(Response::BlockHashes(hashes)),

--- a/zebra-state/src/service.rs
+++ b/zebra-state/src/service.rs
@@ -1207,7 +1207,7 @@ impl Service<Request> for StateService {
 
                 // Run the request in an async block, so we can await the response.
                 async move {
-                    let req = ReadRequest::AnyChainUtxo(outpoint);
+                    let req = ReadRequest::AnyChainUtxos(vec![outpoint]);
 
                     let rsp = read_service.oneshot(req).await?;
 
@@ -1223,11 +1223,13 @@ impl Service<Request> for StateService {
                     //
                     // And if the block is in the finalized queue,
                     // that's rare enough that a retry is ok.
-                    if let ReadResponse::AnyChainUtxo(Some(utxo)) = rsp {
-                        // We got a UTXO, so we replace the response future with the result own.
-                        timer.finish_desc("AwaitUtxo/any-chain");
+                    if let ReadResponse::AnyChainUtxos(mut utxos) = rsp {
+                        if let Some(utxo) = utxos.remove(&outpoint) {
+                            // We got a UTXO, so we replace the response future with the result own.
+                            timer.finish_desc("AwaitUtxo/any-chain");
 
-                        return Ok(Response::Utxo(utxo));
+                            return Ok(Response::Utxo(utxo));
+                        }
                     }
 
                     // We're finished, but the returned future is waiting on the respond() channel.
@@ -1235,6 +1237,67 @@ impl Service<Request> for StateService {
 
                     response_fut.await
                 }
+                .boxed()
+            }
+
+            // Uses non_finalized_state_queued_blocks and the sent block hashes in the
+            // StateService, then looks up the rest using the ReadStateService.
+            //
+            // Unlike AwaitUtxo, this never waits for a UTXO to arrive, so it never registers a
+            // pending request. That keeps the state it can hold independent of how many
+            // outpoints it is given.
+            Request::AnyChainUtxos(outpoints) => {
+                let timer = CodeTimer::start();
+
+                let mut utxos = HashMap::with_capacity(outpoints.len());
+                let mut unknown = Vec::new();
+
+                // Check the sent non-finalized blocks.
+                self.drain_non_finalized_rejected_hashes();
+
+                for outpoint in outpoints {
+                    // Check the queued blocks, then the blocks already sent to the write task.
+                    if let Some(utxo) = self
+                        .non_finalized_state_queued_blocks
+                        .utxo(&outpoint)
+                        .or_else(|| self.non_finalized_block_write_sent_hashes.utxo(&outpoint))
+                    {
+                        utxos.insert(outpoint, utxo);
+                    } else {
+                        unknown.push(outpoint);
+                    }
+                }
+
+                // We ignore any UTXOs in FinalizedState.finalized_state_queued_blocks,
+                // because it is only used during checkpoint verification.
+                //
+                // This creates a rare race condition, but it doesn't seem to happen much in practice.
+                // See #5126 for details.
+
+                if unknown.is_empty() {
+                    timer.finish_desc("AnyChainUtxos/queued-non-finalized");
+
+                    return async move { Ok(Response::AnyChainUtxos(utxos)) }.boxed();
+                }
+
+                let read_service = self.read_service.clone();
+
+                async move {
+                    let rsp = read_service
+                        .oneshot(ReadRequest::AnyChainUtxos(unknown))
+                        .await?;
+
+                    let ReadResponse::AnyChainUtxos(found) = rsp else {
+                        unreachable!("AnyChainUtxos always responds with AnyChainUtxos")
+                    };
+
+                    utxos.extend(found);
+
+                    timer.finish_desc("AnyChainUtxos/any-chain");
+
+                    Ok(Response::AnyChainUtxos(utxos))
+                }
+                .instrument(span)
                 .boxed()
             }
 
@@ -1534,12 +1597,11 @@ impl Service<ReadRequest> for ReadStateService {
                 read::unspent_utxo(state.latest_best_chain(), &state.db, outpoint),
             )),
 
-            // Manually used by the StateService to implement part of AwaitUtxo.
-            ReadRequest::AnyChainUtxo(outpoint) => Ok(ReadResponse::AnyChainUtxo(read::any_utxo(
-                state.latest_non_finalized_state(),
-                &state.db,
-                outpoint,
-            ))),
+            // Manually used by the StateService to implement Request::AnyChainUtxos, and part
+            // of Request::AwaitUtxo.
+            ReadRequest::AnyChainUtxos(outpoints) => Ok(ReadResponse::AnyChainUtxos(
+                read::any_utxos(state.latest_non_finalized_state(), &state.db, outpoints),
+            )),
 
             // Used by the StateService.
             ReadRequest::BlockLocator => Ok(ReadResponse::BlockLocator(

--- a/zebra-state/src/service/read.rs
+++ b/zebra-state/src/service/read.rs
@@ -29,7 +29,7 @@ pub use address::{
     utxo::{address_utxos, AddressUtxos},
 };
 pub use block::{
-    any_block, any_transaction, any_utxo, block, block_and_size, block_header, block_info,
+    any_block, any_transaction, any_utxos, block, block_and_size, block_header, block_info,
     mined_transaction, transaction_hashes_for_any_block, transaction_hashes_for_block,
     unspent_utxo,
 };

--- a/zebra-state/src/service/read/block.rs
+++ b/zebra-state/src/service/read/block.rs
@@ -12,7 +12,7 @@
 //! - the cached [`Chain`] or [`NonFinalizedState`], and
 //! - the shared finalized [`ZebraDb`] reference.
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use chrono::{DateTime, Utc};
 
@@ -323,8 +323,14 @@ where
         .or_else(|| db.spending_transaction_hash(&spend))
 }
 
-/// Returns the [`Utxo`] for [`transparent::OutPoint`], if it exists in any chain
-/// in the `non_finalized_state`, or in the finalized `db`.
+/// Returns the [`Utxo`]s for every [`transparent::OutPoint`] in `outpoints` that exists in
+/// any chain in the `non_finalized_state`, or in the finalized `db`.
+///
+/// Outpoints that were not found are absent from the returned map, so the caller can tell
+/// which ones still have to arrive in the state.
+///
+/// Resolving the whole set in one call means a transaction with many inputs does not need
+/// one request per input.
 ///
 /// Non-finalized UTXOs are returned regardless of whether they have been spent.
 ///
@@ -335,8 +341,23 @@ where
 ///
 /// UTXO spends are checked once the block reaches the non-finalized state,
 /// by [`check::utxo::transparent_spend()`](crate::service::check::utxo::transparent_spend).
-pub fn any_utxo(
+pub fn any_utxos(
     non_finalized_state: NonFinalizedState,
+    db: &ZebraDb,
+    outpoints: impl IntoIterator<Item = transparent::OutPoint>,
+) -> HashMap<transparent::OutPoint, Utxo> {
+    outpoints
+        .into_iter()
+        .filter_map(|outpoint| {
+            any_utxo_in(&non_finalized_state, db, outpoint).map(|utxo| (outpoint, utxo))
+        })
+        .collect()
+}
+
+/// Returns the [`Utxo`] for `outpoint`, if it exists in any chain in `non_finalized_state`,
+/// or in the finalized `db`.
+fn any_utxo_in(
+    non_finalized_state: &NonFinalizedState,
     db: &ZebraDb,
     outpoint: transparent::OutPoint,
 ) -> Option<Utxo> {

--- a/zebra-state/src/service/tests.rs
+++ b/zebra-state/src/service/tests.rs
@@ -114,7 +114,12 @@ async fn test_populated_state_responds_correctly(
                         from_coinbase,
                     };
 
-                    transcript.push((Request::AwaitUtxo(outpoint), Ok(Response::Utxo(utxo))));
+                    transcript.push((
+                        Request::AnyChainUtxos(vec![outpoint]),
+                        Ok(Response::AnyChainUtxos(
+                            [(outpoint, utxo)].into_iter().collect(),
+                        )),
+                    ));
                 }
             }
         }


### PR DESCRIPTION
## Motivation

Closes #11185.

## Solution

`block_spent_utxos` issued one `zebra_state::Request::AwaitUtxo` per transparent input and awaited
each before starting the next, so a transaction with many inputs serialized that many round trips
through the state service.

Adds `zebra_state::Request::AnyChainUtxos`, which takes a list of outpoints and returns only the ones
already in the queued blocks, any non-finalized chain, or the finalized state. Unlike `AwaitUtxo` it
never waits and never registers a pending UTXO request, so the block verifier uses it for the bulk of
its lookups and falls back to `AwaitUtxo` only for outpoints that have not reached the state yet.

Lookups go out in chunks of 64 and stop at the first chunk that is not fully present. That bound is
the reason for chunking rather than sending one request: without it, a transaction whose inputs are
all unknown would make the state look up every input before the sequential fallback failed on the
first, which is *more* work than the one lookup the old loop did before its timeout. With it, at most
one chunk is speculative.

To be precise about what that bound is and is not: it is additive. A transaction that references
outputs which really are in the state is still looked up in full, exactly as before. The worst case
is old cost plus one chunk, never a multiple of the input count.

### Tests

Three new tests in `zebra-consensus/src/transaction/tests.rs`, each built with a multi-input
transaction and a `MockService` state, so they assert the request sequence rather than just the
outcome:

- `block_utxo_lookups_use_one_bulk_request` — one `AnyChainUtxos` carrying every outpoint in input
  order, then no further state requests.
- `block_utxo_lookups_await_only_the_missing_outpoints` — one outpoint withheld from the bulk
  response is awaited with `AwaitUtxo`, and the found ones are not.
- `block_utxo_lookups_stop_at_the_first_chunk_with_misses` — with 72 inputs and an empty bulk
  response, only the first 64 are ever requested.

Each was checked against the mutation it is meant to catch, and fails without the fix: reversing the
expected outpoint order, withholding a second outpoint, and removing the early `break` respectively.

### Specifications & References

- #10697 is the mempool-path sibling of this issue, covering the same shape in
  `mempool_spent_utxos` (`UnspentBestChainUtxo` per input). This PR deliberately leaves that path
  untouched.
- AGENTS.md "Security": bound all loops and allocations over attacker-controlled data.

### Follow-up Work

- The per-lookup cost is still unmeasured. This reduces request round trips; it does not establish
  how much of block verification's wall clock they account for. #11041 is the benchmark task that
  should answer it, and its baseline should decide whether the chunk size of 64 is right.
- The lookups within one batch are still serial inside a single blocking task: `read::any_utxos`
  loops over the outpoints. There is no multi-get in `ReadDisk`, and `ZebraDb::utxo` is two dependent
  lookups (`tx_loc_by_hash` then `utxo_by_out_loc`), so a genuinely batched DB read is a separate
  change and should also wait for #11041's measurement.
- The mempool path (#10697) can reuse `AnyChainUtxos` once someone measures whether it needs the
  same treatment.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
