### PR TITLE
docs(book): update stale content overtaken by releases and refactors

### DIFF
--- a/book/src/dev/continuous-delivery.md
+++ b/book/src/dev/continuous-delivery.md
@@ -24,7 +24,7 @@ Each push and each release fans out to six `deploy-nodes` jobs (2 networks × 3 
 4. If the zonal MIG does not exist, create it with `--size=1` and apply the stateful policy.
 5. Assign the static IP (push and release only; workflow_dispatch uses ephemeral). Zone-to-IP mapping is deterministic: zone `b` → primary, zone `c` → secondary, zone `d` → tertiary.
 
-Cache images come from `zfnd-ci-integration-tests-gcp.yml`'s `create-state-image` job. Image names encode branch, commit, state-DB version, network, and timestamp. One image per network seeds all three zones. Lookup priority in `gcp-get-cached-disks.sh`: current branch, then `main`, then any branch; most recent first.
+Cache images come from `zfnd-deploy-integration-tests-gcp.yml`'s `create-state-image` job. Image names encode branch, commit, state-DB version, network, and timestamp. One image per network seeds all three zones. Lookup priority in `gcp-get-cached-disks.sh`: current branch, then `main`, then any branch; most recent first.
 
 Deploy success has two channels: `deploy-nodes` reports infrastructure, `verify-nodes` reports application health. See the [runbook](gcp-deployment-operations.md#deploy-success-has-two-channels) for details.
 

--- a/book/src/dev/ecc-updates.md
+++ b/book/src/dev/ecc-updates.md
@@ -1,8 +1,8 @@
 # Updating the ECC dependencies
 
-Zebra relies on numerous dependencies maintained by ZODL, and updating them can be a complex task. This guide will help you navigate the process.
+Zebra relies on numerous dependencies maintained by ZODL (formerly the Electric Coin Company), and updating them can be a complex task. This guide will help you navigate the process.
 
-The main dependency that influences that is [zcash](https://github.com/zcash/zcash) itself. This is because [zebra_script](https://github.com/ZcashFoundation/zcash_script) links to specific files from it (zcash_script.cpp and all on which it depends). Due to the architecture of zcash, this requires linking to a lot of seemingly unrelated dependencies like orchard, halo2, etc (which are all Rust crates).
+The main dependency that influences that is [zcash](https://github.com/zcash/zcash) itself. This is because `zebra-script` depends on the [zcash_script](https://github.com/ZcashFoundation/zcash_script) project, which is now split into two crates (see `zebra-script/Cargo.toml`): `libzcash_script`, which links to specific files from zcash (zcash_script.cpp and all on which it depends), and the higher-level `zcash_script` crate. Due to the architecture of zcash, this requires linking to a lot of seemingly unrelated dependencies like orchard, halo2, etc (which are all Rust crates).
 
 ## Steps for upgrading
 
@@ -32,7 +32,7 @@ Notes:
 
 - Use `crate-name@version` to upgrade to a specific version of that crate, instead of just the highest version.
 
-- You need to have [cargo upgrade](https://crates.io/crates/cargo-upgrades) and [cargo edit](https://crates.io/crates/cargo-edit) installed for this command to work.
+- You need to have [cargo-edit](https://crates.io/crates/cargo-edit) installed for this command to work — it is the crate that provides the `cargo upgrade` subcommand.
 
 ### Version consistency check
 

--- a/book/src/dev/gcp-deployment-operations.md
+++ b/book/src/dev/gcp-deployment-operations.md
@@ -62,6 +62,11 @@ Apply one of two labels:
 - `keep_until=YYYY-MM-DD` — self-expiring; eligible for reaping after the date passes.
 - `delete_protection=true` — indefinite; requires manual removal before reaping.
 
+> **Warning:** the daily cleanup workflow (`zfnd-delete-gcp-resources.yml`) sweeps PR-deploy
+> resources by age and name and does **not** honor these labels. They only take effect with
+> the label-aware [sweep recipe](#sweep-expired) below, so don't rely on a label alone to
+> protect a PR deploy from the daily sweep.
+
 Apply to the instance and disk now if you need protection immediately (labels propagate to new instances on the next template swap):
 
 ```bash
@@ -244,7 +249,7 @@ Repeat for Testnet. After all six (2 networks × 3 zones) zonal MIGs are HEALTHY
 
 The workflow assigns them via per-instance configs for push and release deploys; workflow_dispatch deploys use ephemeral IPs. Reserve new ones manually with `gcloud compute addresses create` before adding capacity.
 
-**Cache images** are produced by `zfnd-ci-integration-tests-gcp.yml`'s `create-state-image` job. Naming pattern: `{prefix}-{branch}-{sha}-v{state-version}-{network}-{tip|checkpoint}[-u]-{HHMMSS}`. One image per network seeds all three zones. Lookup priority: current branch, then `main`, then any branch; most recent first. List recent:
+**Cache images** are produced by `zfnd-deploy-integration-tests-gcp.yml`'s `create-state-image` job. Naming pattern: `{prefix}-{branch}-{sha}-v{state-version}-{network}-{tip|checkpoint}[-u]-{HHMMSS}`. One image per network seeds all three zones. Lookup priority: current branch, then `main`, then any branch; most recent first. List recent:
 
 ```bash
 gcloud compute images list --project zfnd-dev-zebra \

--- a/book/src/dev/private-testnet.md
+++ b/book/src/dev/private-testnet.md
@@ -152,6 +152,11 @@ Heartwood = 903_800
 Canopy = 1_028_500
 NU5 = 1_842_420
 NU6 = 2_969_920
+"NU6.1" = 3_536_500
+"NU6.2" = 4_052_000
+"NU6.3" = 4_134_000
+# NU7 has no scheduled activation height yet; this is an example value.
+NU7 = 4_200_000
 
 [rpc]
 debug_force_finished_sync = false

--- a/book/src/dev/release-process.md
+++ b/book/src/dev/release-process.md
@@ -15,14 +15,6 @@ For example, version `3.1.11` indicates major version 3, minor version 1, and pa
 
 The version number is incremented based on the level of change included in the release.
 
-<div class="alert pre-release">
-
-**NOTE**: <br />
-As Zebra is in a `pre-release` state (is unstable and might not satisfy the intended compatibility requirements as denoted by its associated normal version).
-The pre-release version is denoted by appending a hyphen and a series of dot separated identifiers immediately following the patch version.
-
-</div>
-
 | Level of change | Details                                                                                                                                                                                                                                                              |
 | :-------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Major release   | Contains significant new features, and commonly correspond to network upgrades; some technical assistance may be needed during the update. When updating to a major release, you may need to follow the specific upgrade instructions provided in the release notes. |
@@ -33,7 +25,7 @@ The pre-release version is denoted by appending a hyphen and a series of dot sep
 
 ### Supported Releases
 
-Every Zebra version released by the Zcash Foundation is supported up to a specific height. Currently we support each version for about **16 weeks** but this can change from release to release.
+Every Zebra version released by the Zcash Foundation is supported up to a specific height. Currently we support each version for about **15 weeks** (see `EOS_PANIC_AFTER` in `zebrad/src/components/sync/end_of_support.rs`) but this can change from release to release.
 
 When the Zcash chain reaches this end of support height, `zebrad` will shut down and the binary will refuse to start.
 

--- a/book/src/dev/state-db-upgrades.md
+++ b/book/src/dev/state-db-upgrades.md
@@ -332,6 +332,7 @@ We use the following rocksdb column families:
 | `tx_loc_by_transparent_addr_loc`   | `AddressTransaction`   | `()`                          | Create  |
 | `utxo_by_out_loc`                  | `OutputLocation`       | `transparent::Output`         | Delete  |
 | `utxo_loc_by_transparent_addr_loc` | `AddressUnspentOutput` | `()`                          | Delete  |
+| `tx_loc_by_spent_out_loc`          | `OutputLocation`       | `TransactionLocation`         | Create  |
 | _Sprout_                           |                        |                               |         |
 | `sprout_nullifiers`                | `sprout::Nullifier`    | `()`                          | Create  |
 | `sprout_anchors`                   | `sprout::tree::Root`   | `sprout::NoteCommitmentTree`  | Create  |
@@ -346,23 +347,31 @@ We use the following rocksdb column families:
 | `orchard_anchors`                  | `orchard::tree::Root`  | `()`                          | Create  |
 | `orchard_note_commitment_tree`     | `block::Height`        | `orchard::NoteCommitmentTree` | Create  |
 | `orchard_note_commitment_subtree`  | `block::Height`        | `NoteCommitmentSubtreeData`   | Create  |
+| _Ironwood_                         |                        |                               |         |
+| `ironwood_nullifiers`              | `ironwood::Nullifier`  | `()`                          | Create  |
+| `ironwood_anchors`                 | `orchard::tree::Root`  | `()`                          | Create  |
+| `ironwood_note_commitment_tree`    | `block::Height`        | `orchard::NoteCommitmentTree` | Create  |
+| `ironwood_note_commitment_subtree` | `block::Height`        | `NoteCommitmentSubtreeData`   | Create  |
 | _Chain_                            |                        |                               |         |
 | `history_tree`                     | `()`                   | `NonEmptyHistoryTree`         | Update  |
 | `tip_chain_value_pool`             | `()`                   | `ValueBalance`                | Update  |
 | `block_info`                       | `block::Height`        | `BlockInfo`                   | Create  |
 
-With the following additional modifications when compiled with the `indexer` feature:
+With the following additional modifications when compiled with the `indexer` feature
+(the column families themselves are always registered — see `STATE_COLUMN_FAMILIES_IN_CODE`
+in `zebra-state/src/service/finalized_state.rs` — but the nullifier column families store
+these richer values instead of `()`):
 
 | Column Family             | Keys                 | Values                | Changes |
 | ------------------------- | -------------------- | --------------------- | ------- |
-| _Transparent_             |                      |                       |         |
-| `tx_loc_by_spent_out_loc` | `OutputLocation`     | `TransactionLocation` | Create  |
 | _Sprout_                  |                      |                       |         |
 | `sprout_nullifiers`       | `sprout::Nullifier`  | `TransactionLocation` | Create  |
 | _Sapling_                 |                      |                       |         |
 | `sapling_nullifiers`      | `sapling::Nullifier` | `TransactionLocation` | Create  |
 | _Orchard_                 |                      |                       |         |
 | `orchard_nullifiers`      | `orchard::Nullifier` | `TransactionLocation` | Create  |
+| _Ironwood_                |                      |                       |         |
+| `ironwood_nullifiers`     | `ironwood::Nullifier` | `TransactionLocation` | Create |
 
 ### Data Formats
 
@@ -493,7 +502,8 @@ So ReadStateService queries that only access a single key or value will always s
 a consistent view of the database.
 
 If a ReadStateService query only uses column families that have keys and values appended
-(`Never` in the Updates table above), it should ignore extra appended values.
+(`Create` in the Changes column of the tables above — entries are never updated or deleted),
+it should ignore extra appended values.
 Most queries do this by default.
 
 For more complex queries, there are several options:

--- a/book/src/user/custom-testnets.md
+++ b/book/src/user/custom-testnets.md
@@ -107,6 +107,10 @@ Canopy = 1_046_400
 NU5 = 1_687_104
 NU6 = 2_726_400
 "NU6.1" = 3_146_400
+"NU6.2" = 3_364_600
+"NU6.3" = 3_428_143
+# NU7 has no scheduled activation height yet; this is an example value.
+NU7 = 3_500_000
 
 # This section may be omitted if it's not necessary to
 # add transactions to Zebra's mempool

--- a/book/src/user/fork-zebra-testnet.md
+++ b/book/src/user/fork-zebra-testnet.md
@@ -81,7 +81,7 @@ Here we are making changes to create an isolated network version of Zebra. In ad
   ```
 
 - Make fixes needed to compile.
-- Ignore how far we are from the tip in get block template: `zebra-rpc/src/methods/get_block_template_rpcs/get_block_template.rs`
+- Ignore how far we are from the tip in get block template: `zebra-rpc/src/methods/types/get_block_template.rs`
 
 Unclean test commit for Zebra: [Zebra commit](https://github.com/ZcashFoundation/zebra/commit/d05af154c897d4820999fcb968b7b62d10b26aa8)
 
@@ -106,7 +106,6 @@ cache_dir = false
 initial_testnet_peers = [
   "dnsseed.testnet.z.cash:18233",
   "testnet.seeder.zfnd.org:18233",
-  "testnet.is.yolo.money:18233",
 ]
 listen_addr = "0.0.0.0:18233"
 network = "Testnet"

--- a/book/src/user/fork-zebra-testnet.md
+++ b/book/src/user/fork-zebra-testnet.md
@@ -105,6 +105,7 @@ miner_address = 't27eWDgjFYJGVXmzrXeVjnb5J3uXDM9xH9v'
 cache_dir = false
 initial_testnet_peers = [
   "dnsseed.testnet.z.cash:18233",
+  "seeder.testnet.zec.rocks:18233",
   "testnet.seeder.zfnd.org:18233",
 ]
 listen_addr = "0.0.0.0:18233"

--- a/book/src/user/mining-testnet-s-nomp.md
+++ b/book/src/user/mining-testnet-s-nomp.md
@@ -39,9 +39,11 @@ The `zebra-mining` branch of the ZcashFoundation s-nomp fork includes fixes that
        'dnsseed.z.cash:8233',
        'mainnet.seeder.shieldedinfra.net:8233',
        'mainnet.seeder.zfnd.org:8233',
+       'seeder.zec.rocks:8233',
    ]
    initial_testnet_peers = [
        'dnsseed.testnet.z.cash:18233',
+       'seeder.testnet.zec.rocks:18233',
        'testnet.seeder.zfnd.org:18233',
    ]
    listen_addr = '0.0.0.0:18233'

--- a/book/src/user/mining-testnet-s-nomp.md
+++ b/book/src/user/mining-testnet-s-nomp.md
@@ -35,15 +35,14 @@ The `zebra-mining` branch of the ZcashFoundation s-nomp fork includes fixes that
    [network]
    crawl_new_peer_interval = '1m 1s'
    initial_mainnet_peers = [
-       'dnsseed.z.cash:8233',
        'dnsseed.str4d.xyz:8233',
+       'dnsseed.z.cash:8233',
+       'mainnet.seeder.shieldedinfra.net:8233',
        'mainnet.seeder.zfnd.org:8233',
-       'mainnet.is.yolo.money:8233',
    ]
    initial_testnet_peers = [
        'dnsseed.testnet.z.cash:18233',
        'testnet.seeder.zfnd.org:18233',
-       'testnet.is.yolo.money:18233',
    ]
    listen_addr = '0.0.0.0:18233'
    network = 'Testnet'

--- a/book/src/user/startup.md
+++ b/book/src/user/startup.md
@@ -39,13 +39,13 @@ zebrad::commands::start: config=ZebradConfig {
     network: Mainnet,
     initial_mainnet_peers: {
       "dnsseed.z.cash:8233",
-      "mainnet.is.yolo.money:8233",
+      "mainnet.seeder.shieldedinfra.net:8233",
       "mainnet.seeder.zfnd.org:8233",
       "dnsseed.str4d.xyz:8233"
     },
     peerset_initial_target_size: 25, ...
   },
-  state: Config { cache_dir: "/home/user/.cache/state/v24/mainnet", ... },
+  state: Config { cache_dir: "/home/user/.cache/state/v28/mainnet", ... },
   rpc: Config { listen_addr: Some(127.0.0.1:8232) }, ...
 }
 ```
@@ -57,7 +57,7 @@ Zebra opens the configured cached state, or creates a new empty state.
 ```text
 zebrad::commands::start: initializing node state
 zebra_state::service::finalized_state::disk_db: the open file limit is high enough for Zebra current_limit=1048576 min_limit=512 ideal_limit=1024
-zebra_state::service::finalized_state::disk_db: Opened Zebra state cache at /home/user/.cache/state/v24/mainnet
+zebra_state::service::finalized_state::disk_db: Opened Zebra state cache at /home/user/.cache/state/v28/mainnet
 zebra_state::service::finalized_state: loaded Zebra state cache tip=None
 zebra_state::service: created new read-only state service
 ...

--- a/book/src/user/startup.md
+++ b/book/src/user/startup.md
@@ -38,9 +38,11 @@ zebrad::commands::start: config=ZebradConfig {
     listen_addr: 127.0.0.1:8233,
     network: Mainnet,
     initial_mainnet_peers: {
+      "dnsseed.str4d.xyz:8233",
       "dnsseed.z.cash:8233",
       "mainnet.seeder.shieldedinfra.net:8233",
-      "mainnet.seeder.zfnd.org:8233"
+      "mainnet.seeder.zfnd.org:8233",
+      "seeder.zec.rocks:8233"
     },
     peerset_initial_target_size: 25, ...
   },

--- a/book/src/user/startup.md
+++ b/book/src/user/startup.md
@@ -40,8 +40,7 @@ zebrad::commands::start: config=ZebradConfig {
     initial_mainnet_peers: {
       "dnsseed.z.cash:8233",
       "mainnet.seeder.shieldedinfra.net:8233",
-      "mainnet.seeder.zfnd.org:8233",
-      "dnsseed.str4d.xyz:8233"
+      "mainnet.seeder.zfnd.org:8233"
     },
     peerset_initial_target_size: 25, ...
   },

--- a/book/src/user/troubleshooting.md
+++ b/book/src/user/troubleshooting.md
@@ -51,12 +51,12 @@ Make sure you're using a release build on your native architecture.
 ### Syncer Lookahead Limit
 
 If your connection is slow, try
-[downloading fewer blocks at a time](https://docs.rs/zebrad/latest/zebrad/components/sync/struct.Config.html#structfield.lookahead_limit):
+[downloading fewer blocks at a time](https://docs.rs/zebrad/latest/zebrad/components/sync/struct.Config.html#structfield.checkpoint_verify_concurrency_limit):
 
 ```toml
 [sync]
-lookahead_limit = 1000
-max_concurrent_block_requests = 25
+checkpoint_verify_concurrency_limit = 1000
+download_concurrency_limit = 25
 ```
 
 ### Peer Set Size


### PR DESCRIPTION
## Motivation

Closes #10948. The 2026-07-14 book audit found content overtaken by releases and refactors. I re-verified every item against the current `main` right before finalizing this (the branch was rebased onto latest `main`, and a couple of facts had moved underneath it, noted below), so what's here matches the tree at the tip.

## Solution

- **`release-process.md`** dropped the pre-release note (v6.0.0 is out) and corrected the support window to 15 weeks (`EOS_PANIC_AFTER = 105` days in `zebrad/src/components/sync/end_of_support.rs`). The audit also flagged the release-plz changelog wording, but that whole section was rewritten on `main` in the meantime and now describes the automated finalization correctly, so I left it to the rewrite rather than re-touching it.
- **`state-db-upgrades.md`** added the four Ironwood (NU6.3) column families to the format table (`ironwood_nullifiers` / `_anchors` / `_note_commitment_tree` / `_note_commitment_subtree`, types mirroring Orchard per `zebra_db/shielded.rs`); moved `tx_loc_by_spent_out_loc` into the main table since it's registered unconditionally in `STATE_COLUMN_FAMILIES_IN_CODE`; reframed the indexer-feature table as a value-format change and added `ironwood_nullifiers` to it (per `ironwood_revealing_tx_loc`); and fixed the dangling "'Never' in the Updates table" reference to describe the `Create` semantics that actually exist on the page.
- **`gcp-deployment-operations.md` / `continuous-delivery.md`** added a warning that the daily cleanup ignores `keep_until` / `delete_protection` on PR deploys, and fixed the `create-state-image` attribution to `zfnd-deploy-integration-tests-gcp.yml` in both files.
- **`custom-testnets.md` / `private-testnet.md`** extended the activation-height examples: mainnet heights (NU6.2 = 3,364,600 / NU6.3 = 3,428,143) in the former, testnet heights (NU6.1 = 3,536,500 / NU6.2 = 4,052,000 / NU6.3 = 4,134,000) in the latter, plus an explicitly-example `NU7` entry in both. Stayed clear of the branch-id / subversion guidance (#9844's territory).
- **`fork-zebra-testnet.md`** pointed at the moved `zebra-rpc/src/methods/types/get_block_template.rs` and refreshed the testnet seeder list (dropped the defunct `yolo.money`, added `seeder.testnet.zec.rocks`).
- **`mining-testnet-s-nomp.md`** replaced the seeder lists with the current defaults from `zebra-network/src/config.rs` (drops `yolo.money`, adds `mainnet.seeder.shieldedinfra.net` and `seeder.zec.rocks`, plus `seeder.testnet.zec.rocks` on testnet).
- **`startup.md`** refreshed the example logs: the current five mainnet seeders (`dnsseed.str4d.xyz`, `dnsseed.z.cash`, `mainnet.seeder.shieldedinfra.net`, `mainnet.seeder.zfnd.org`, `seeder.zec.rocks`) and `state/v28` (current `DATABASE_FORMAT_VERSION = 28`).
- **`troubleshooting.md`** used the canonical `checkpoint_verify_concurrency_limit` / `download_concurrency_limit` config names (the old `lookahead_limit` / `max_concurrent_block_requests` are now serde aliases) and a live docs.rs anchor.
- **`ecc-updates.md`** expanded "ZODL (formerly the Electric Coin Company)", documented the `libzcash_script` + `zcash_script` crate split per `zebra-script/Cargo.toml`, and pointed `cargo upgrade` at `cargo-edit` (the crate that actually provides it).

### Tests

Built the book locally with `mdbook build` and all eleven touched pages render correctly. Note: the `mdbook-mermaid` preprocessor fails to start in my environment (a version mismatch that also fails on an unmodified `main`, so it's not from these changes); I confirmed the pages render by building with that preprocessor disabled. CI is the authoritative check.

### Specifications & References

- Issue #10948 (2026-07-14 book audit); heights from `zebra-chain/src/parameters/constants.rs`; seeders from `zebra-network/src/config.rs`; column families from `zebra-state/src/service/finalized_state.rs`; sync config fields from `zebrad/src/components/sync.rs`.

### Follow-up Work

#10949 (broken links / orphaned pages / undocumented config options) is the natural next one; I've asked a couple of scoping questions on that issue and will pick it up once they're answered.

---

**AI disclosure** (per CONTRIBUTING.md): prepared with Claude, used for verifying each claim against the codebase, drafting the edits, and building the book. I reviewed every line and can speak to each change.
