### PR TITLE
ci(deps): pin cargo-release to v0.1.0

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Check desired release state
         id: cargo-release
         continue-on-error: true
-        uses: ZcashFoundation/cargo-release@34a37595755444456ce0e2d2b1258d9a29c14fac
+        uses: ZcashFoundation/cargo-release@0083006dfd267ed560b4cf1aed347ef2f326162e # v0.1.0
         with:
           phase: check
           base-sha: ${{ steps.release-target.outputs.base_sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,7 +254,7 @@ jobs:
       - name: Check desired release state
         id: cargo-release
         continue-on-error: true
-        uses: ZcashFoundation/cargo-release@34a37595755444456ce0e2d2b1258d9a29c14fac
+        uses: ZcashFoundation/cargo-release@0083006dfd267ed560b4cf1aed347ef2f326162e #v0.1.0
         with:
           phase: check
           source-directory: release-source
@@ -363,7 +363,7 @@ jobs:
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 #v1.0.5
       - name: Publish and verify missing crates
         id: cargo-release-publish
-        uses: ZcashFoundation/cargo-release@34a37595755444456ce0e2d2b1258d9a29c14fac
+        uses: ZcashFoundation/cargo-release@0083006dfd267ed560b4cf1aed347ef2f326162e #v0.1.0
         with:
           phase: publish
           source-directory: release-source
@@ -409,7 +409,7 @@ jobs:
           exit 1
       - name: Create missing tags and GitHub Release
         id: cargo-release-finalize
-        uses: ZcashFoundation/cargo-release@34a37595755444456ce0e2d2b1258d9a29c14fac
+        uses: ZcashFoundation/cargo-release@0083006dfd267ed560b4cf1aed347ef2f326162e #v0.1.0
         with:
           phase: finalize
           source-directory: release-source


### PR DESCRIPTION
Moves all four `ZcashFoundation/cargo-release` call sites to the action's first tagged release, **v0.1.0** (`0083006dfd267ed560b4cf1aed347ef2f326162e`), from `34a37595755444456ce0e2d2b1258d9a29c14fac`.

## What the new pin brings

The previous pin predates that repo's supply-chain hardening. v0.1.0 includes:

- `ignore-scripts=true`, so dependency install lifecycle hooks are refused during `npm install` — the execution path a ChainDrop-class worm uses.
- `npm audit` split into its own CI job, so a newly published advisory can no longer short-circuit the bundle drift check (it previously masked a stale `dist/` for ~12 hours).
- Bundled undici moved to 6.28.0, fixing GHSA-8xcm-r25x-g524, GHSA-m8rv-5g2x-5cg5 and GHSA-v3r7-h72x-cjcm.

## This is behaviourally inert

```
git diff --stat 34a3759 0083006 -- src/ action.yml   →  (empty)
```

`src/` and `action.yml` are **byte-identical** between the two commits, so none of the release logic, inputs, or outputs change. Across the whole 8-commit range the only runtime delta in `dist/index.js` is the undici bump; everything else was CI config, docs, or dev dependencies.

That is why this is safe to land ahead of the open v7.0.0 release PR (#11219) rather than after it — v7.0.0 then publishes using the hardened, attested bundle, with no change to how the release behaves.

## Call sites

| File | Step | Phase |
|---|---|---|
| `pr-gate.yml` | Check desired release state | `check` |
| `release.yml` | Check desired release state | `check` |
| `release.yml` | Publish and verify missing crates | `publish` |
| `release.yml` | Create missing tags and GitHub Release | `finalize` |

## Also adds the version comment

These four lines were the only SHA pins in the workflows lacking a trailing `# vX.Y.Z` comment (200 of 204 carry one) — because until now the action had no release to reference. Each file's existing style is matched (`# v` in `pr-gate.yml`, `#v` in `release.yml`). The comment is also what lets Dependabot track this action going forward; with no tags published it previously had nothing to compare against.

## Verification

- Pin resolves to `v0.1.0` and is fetchable on the remote as both `refs/heads/main` and `refs/tags/v0.1.0^{}`.
- That bundle is attested: `gh attestation verify dist/index.js --repo ZcashFoundation/cargo-release` passes, signed by `.github/workflows/attest.yml` (SLSA buildType v1).
- Old SHA no longer appears anywhere in the repo; no SHA pin is left without a version comment; both workflows still parse as valid YAML.
- **This PR verifies itself**: `pr-gate.yml`'s "Check desired release state" step is one of the four call sites and `pr-gate-result` is a required check, so a green run means the new pin actually executed in Zebra CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)