### PR TITLE
fix(zebrad): handle EvictionList re-insertion gracefully instead of asserting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- Re-inserting a transaction into the mempool eviction list no longer panics; a still-present
+  entry has its timestamp refreshed in place instead of tripping an assertion
+  ([#10690](https://github.com/ZcashFoundation/zebra/issues/10690)).
+
 - `getblocksubsidy` now returns NU6-era funding stream metadata (recipient names and
   specification URLs) for NU6.1 and later upgrades. Amounts and addresses were never
   affected ([#11172](https://github.com/ZcashFoundation/zebra/pull/11172)).

--- a/zebrad/src/components/mempool/storage/eviction_list.rs
+++ b/zebrad/src/components/mempool/storage/eviction_list.rs
@@ -39,10 +39,9 @@ impl EvictionList {
     ///
     /// All entries older than [`EvictionList::eviction_memory_time`] will be removed.
     ///
-    /// # Panics
-    ///
-    /// If the TXID is already in the list.
-    ///
+    /// If the TXID is already present (not expected via the normal mempool path;
+    /// see the note in the body), its timestamp is refreshed in place rather than
+    /// adding a duplicate entry.
     pub fn insert(&mut self, key: transaction::Hash) {
         // From https://zips.z.cash/zip-0401#specification:
         // > Nodes SHOULD remove transactions from RecentlyEvicted that were evicted more than
@@ -55,16 +54,23 @@ impl EvictionList {
             self.pop_front();
         }
         let value = Instant::now();
+        // `prune_old` above removes any expired entry for this key, and while a
+        // non-expired entry exists `contains_key` keeps the transaction rejected,
+        // so it cannot re-enter the mempool to be re-evicted. A key that is still
+        // present here is therefore not expected through the normal mempool path.
+        // Handle it gracefully rather than panicking, to stay robust to future
+        // callers or refactors: the timestamp is refreshed in place by the
+        // `insert` below, and a new `ordered_entries` slot is only appended for a
+        // genuinely new key. This keeps the two collections consistent in
+        // membership. It does not move a refreshed key to the back, so
+        // `ordered_entries` may briefly not be in timestamp order; the only
+        // effect is that entries behind a refreshed key are pruned no earlier
+        // than the refreshed key itself, which is harmless on this unexpected
+        // path. See #10690.
         let old_value = self.unique_entries.insert(key, value);
-        // It should be impossible for an already-evicted transaction to be evicted
-        // again since transactions are not added to the mempool if they are evicted,
-        // and the mempool doesn't allow inserting two transactions with the same
-        // hash (they would conflict).
-        assert_eq!(
-            old_value, None,
-            "an already-evicted transaction should not be evicted again"
-        );
-        self.ordered_entries.push_back(key)
+        if old_value.is_none() {
+            self.ordered_entries.push_back(key);
+        }
     }
 
     /// Checks if the given TXID is in the list.
@@ -141,5 +147,56 @@ impl EvictionList {
     fn has_expired(&self, evicted_at: &Instant) -> bool {
         let now = Instant::now();
         (now - *evicted_at) > self.eviction_memory_time
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_hash(byte: u8) -> transaction::Hash {
+        transaction::Hash([byte; 32])
+    }
+
+    /// Regression test for #10690: re-inserting a key whose entry is still live
+    /// must not panic, and must keep `unique_entries` and `ordered_entries`
+    /// consistent (no phantom ordered entry that would later panic `pop_front`).
+    #[test]
+    fn reinsert_live_key_is_graceful() {
+        let mut list = EvictionList::new(10, Duration::from_secs(3600));
+        let key = dummy_hash(1);
+
+        list.insert(key);
+        // Re-insert the same key while its entry is still live. Before the fix
+        // this tripped an `assert_eq!`.
+        list.insert(key);
+
+        assert!(list.contains_key(&key));
+        // Exactly one logical entry, with both backing collections in agreement.
+        assert_eq!(list.unique_entries.len(), 1);
+        assert_eq!(list.ordered_entries.len(), 1);
+        assert_eq!(list.len(), 1);
+    }
+
+    /// A re-insert of a live key followed by evictions must not desync the two
+    /// backing collections: `pop_front` asserts every ordered entry still exists
+    /// in `unique_entries`, so a phantom duplicate would panic here.
+    #[test]
+    fn reinsert_then_fill_past_max_size_does_not_panic() {
+        let max_size = 4;
+        let mut list = EvictionList::new(max_size, Duration::from_secs(3600));
+        let key = dummy_hash(1);
+
+        list.insert(key);
+        list.insert(key);
+
+        // Insert enough distinct keys to evict past `max_size`, exercising
+        // `pop_front` over the earlier re-inserted key.
+        for byte in 2..=(max_size as u8 + 3) {
+            list.insert(dummy_hash(byte));
+        }
+
+        assert_eq!(list.len(), max_size);
+        assert_eq!(list.unique_entries.len(), list.ordered_entries.len());
     }
 }

--- a/zebrad/src/components/mempool/storage/tests/prop.rs
+++ b/zebrad/src/components/mempool/storage/tests/prop.rs
@@ -1210,14 +1210,17 @@ proptest! {
         prop_assert_eq!(e.len(), 0);
     }
 
-    /// Check if EvictionList panics if entries are added multiple times.
+    /// Check that `EvictionList` re-inserts a still-live key gracefully instead
+    /// of panicking, keeping a single entry (see #10690).
     #[test]
-    #[should_panic]
     fn eviction_list_refresh(
         txid in any::<UnminedTxId>()
     ) {
         let mut e = EvictionList::new(2, EVICTION_MEMORY_TIME);
         e.insert(txid.mined_id());
         e.insert(txid.mined_id());
+
+        prop_assert!(e.contains_key(&txid.mined_id()));
+        prop_assert_eq!(e.len(), 1);
     }
 }


### PR DESCRIPTION
## Motivation

Closes #10690.

`EvictionList::insert` (`zebrad/src/components/mempool/storage/eviction_list.rs`) asserted the key was never already present. That invariant holds only via an undocumented combination of prune-before-insert, insertion-ordered expiry, and the `contains_key` re-entry gate, so a future caller or refactor could turn it into a node panic.

## Solution

Replace the `assert_eq!` with graceful handling: a still-present key refreshes its timestamp in place, and only a genuinely new key appends an `ordered_entries` slot. This keeps `unique_entries` and `ordered_entries` consistent in membership (so `pop_front`'s `assert!` can't be tripped). It deliberately does not move a refreshed key to the back, so on this not-expected path `ordered_entries` may briefly not be in timestamp order — harmless, and cheaper than an O(n) reorder. The doc comment now states the real invariant (the old `# Panics` note is gone). The `assert!`/`panic!` in `pop_front`/`prune_old` are left as-is: they guard the membership invariant, which this change preserves.

Low risk, confined to the mempool eviction list: no consensus, network, RPC, state-format, or config change.

### Tests

Two unit tests in `eviction_list.rs` (re-insert of a live key stays consistent; re-insert then evict past `max_size` exercises `pop_front` over the re-inserted key) — both fail before the fix (the second `insert` panics on the old `assert_eq!`) and pass after. The existing `eviction_list_refresh` prop test is converted from `#[should_panic]` to assert the graceful path. `cargo test -p zebrad --lib -- components::mempool::storage` = 34 passed; `cargo fmt`/`clippy` clean.

### Specifications & References

None.

### Follow-up Work

None.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude (Claude Code) — wrote the fix and the tests.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
