### PR TITLE
fix(zebrad): score inbound gossip block failures via RouterError downcast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   peer's IPv4 address did not disconnect it while it stayed connected, and the same peer counted
   twice towards the per-IP inbound connection limit
   ([#10695](https://github.com/ZcashFoundation/zebra/issues/10695)).
+- Invalid blocks received through inbound gossip now correctly increase the sending peer's
+  misbehavior score, so a peer serving a clearly-invalid block (for example, one with an invalid
+  difficulty) is penalised and eventually banned. Previously only the sync download path scored
+  these failures; the gossip path downcast the verification error to the wrong type and silently
+  skipped scoring ([#10616](https://github.com/ZcashFoundation/zebra/issues/10616)).
 
 ## [Zebra 6.2.3](https://github.com/ZcashFoundation/zebra/releases/tag/v6.2.3) - 2026-07-27
 

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -79,6 +79,25 @@ type BlockDownloadPeerSet =
     Buffer<BoxService<zn::Request, zn::Response, zn::BoxError>, zn::Request>;
 type State = Buffer<BoxService<zs::Request, zs::Response, zs::BoxError>, zs::Request>;
 type Mempool = Buffer<BoxService<mempool::Request, mempool::Response, BoxError>, mempool::Request>;
+
+/// Returns the peer misbehavior score for a completed inbound block download error.
+///
+/// The inbound block verifier is the consensus router, which returns
+/// [`RouterError`], so that downcast is tried first. The [`VerifyBlockError`]
+/// branch is a defensive fallback in case a verifier ever surfaces that error
+/// directly; it is not reached on the current router path. Downcasting only to
+/// `VerifyBlockError` (as before) missed router failures and silently skipped
+/// scoring gossiped invalid blocks, unlike the sync download path. Unrecognised
+/// errors score 0. See #10616.
+fn block_download_misbehavior_score(err: BoxError) -> u32 {
+    match err.downcast::<RouterError>() {
+        Ok(router_err) => router_err.misbehavior_score(),
+        Err(err) => match err.downcast::<VerifyBlockError>() {
+            Ok(block_err) => block_err.misbehavior_score(),
+            Err(_) => 0,
+        },
+    }
+}
 type SemanticBlockVerifier = Buffer<
     BoxService<zebra_consensus::Request, block::Hash, RouterError>,
     zebra_consensus::Request,
@@ -335,13 +354,9 @@ impl Service<zn::Request> for Inbound {
                         continue;
                     };
 
-                    let Ok(err) = err.downcast::<VerifyBlockError>() else {
-                        continue;
-                    };
-
-                    if err.misbehavior_score() != 0 {
-                        let _ =
-                            misbehavior_sender.try_send((advertiser_addr, err.misbehavior_score()));
+                    let score = block_download_misbehavior_score(err);
+                    if score != 0 {
+                        let _ = misbehavior_sender.try_send((advertiser_addr, score));
                     }
                 }
 

--- a/zebrad/src/components/inbound/tests.rs
+++ b/zebrad/src/components/inbound/tests.rs
@@ -2,3 +2,43 @@
 
 mod fake_peer_set;
 mod real_peer_set;
+
+use zebra_chain::parameters::subsidy::SubsidyError;
+use zebra_consensus::{router::RouterError, VerifyBlockError};
+
+use crate::BoxError;
+
+use super::block_download_misbehavior_score;
+
+/// A `VerifyBlockError` whose `misbehavior_score()` is 100.
+fn score_100_block_error() -> VerifyBlockError {
+    VerifyBlockError::Subsidy(SubsidyError::NoCoinbase)
+}
+
+/// Regression test for #10616: an inbound block-download error that is a
+/// `RouterError` (what the consensus router returns) must still yield its
+/// misbehavior score. Before the fix the code downcast only to
+/// `VerifyBlockError`, so router failures scored zero and gossiped invalid
+/// blocks went unpenalised.
+#[test]
+fn router_error_yields_misbehavior_score() {
+    let router_err: RouterError = score_100_block_error().into();
+    assert_eq!(router_err.misbehavior_score(), 100);
+
+    let boxed: BoxError = Box::new(router_err);
+    assert_eq!(block_download_misbehavior_score(boxed), 100);
+}
+
+/// A `VerifyBlockError` surfaced directly is still scored (fallback path).
+#[test]
+fn verify_block_error_yields_misbehavior_score() {
+    let boxed: BoxError = Box::new(score_100_block_error());
+    assert_eq!(block_download_misbehavior_score(boxed), 100);
+}
+
+/// An unrelated error scores zero.
+#[test]
+fn unrelated_error_scores_zero() {
+    let boxed: BoxError = "some unrelated error".into();
+    assert_eq!(block_download_misbehavior_score(boxed), 0);
+}


### PR DESCRIPTION
> **Closed as a duplicate.** #10616 is already fixed on `main` via the merged advisory fix GHSA-8hh2-hrf2-cqf4 (the inbound cleanup now downcasts to `RouterError`). This PR is redundant.

## Summary

Closes #10616.

- `zebrad/src/components/inbound.rs`: the inbound gossip cleanup path in `poll_ready` now scores a completed block-download failure by trying a `RouterError` downcast first, falling back to `VerifyBlockError`. The extraction moves into a `block_download_misbehavior_score` helper.
- `CHANGELOG.md`: Security entry.
- Unit tests in `zebrad/src/components/inbound/tests.rs`.

## Approach & Key Decisions

The inbound block verifier is the consensus router (`inbound.rs`: `BoxService<…, RouterError>`), so a verification failure arriving through gossip boxes a `RouterError`. The old code downcast that box only to `VerifyBlockError`, which never matches a `RouterError`, so scoring was silently skipped — a peer serving a score-100 invalid block was banned when the block came via sync but not via gossip. The sync path (`sync/downloads.rs:569`, `sync.rs:1194`) already works with `RouterError` and `RouterError::misbehavior_score()`; this change gives inbound the same behavior.

The scoring logic is pulled into `block_download_misbehavior_score(err: BoxError) -> u32` so it can be unit-tested directly rather than through the full `Inbound` service. The `VerifyBlockError` branch is kept as a defensive fallback (not reached on the current router path). `RouterError::misbehavior_score()` delegates to the wrapped block error, so the scores match the sync path exactly. Only errors carrying `Some(advertiser_addr)` reach this code; timeouts and other non-attributable failures downcast to neither type and score 0, as before.

## Testing & Verification

Three unit tests in `inbound/tests.rs`, using `RouterError::from(VerifyBlockError::Subsidy(SubsidyError::NoCoinbase))` (score 100 — the same `RouterError::Block { .. }` shape the router emits):

- `router_error_yields_misbehavior_score` — fails before the fix (returns 0), passes after (100). This is the regression.
- `verify_block_error_yields_misbehavior_score` — fallback path returns 100.
- `unrelated_error_scores_zero` — an unrelated boxed error returns 0.

```
cargo test -p zebrad --lib -- components::inbound::tests
test result: ok. 3 passed
```

`cargo fmt` and `cargo clippy -p zebrad --lib --all-features` are clean.

## Risk & Impact

Behavior change confined to peer misbehavior scoring: invalid blocks gossiped by a peer now raise its score (and can lead to a ban), matching what already happens on the sync path. No consensus, state-format, RPC, or config change; no DB format bump. A misbehavior score is advisory input to ban logic, so the blast radius is limited to peer connection management.

## Changelog

Added under `### Security` in `CHANGELOG.md`: inbound gossiped invalid blocks now increase the sending peer's misbehavior score.

## AI Disclosure

Claude (Claude Code) wrote the fix, the helper refactor, and the tests.

## PR Checklist

- [x] `CHANGELOG.md` updated (Security)
- [x] DB format version unchanged (no state-format change)
- [x] Linked issue exists and was acknowledged by the team before work started

