### PR TITLE
fix(zebrad): release the per-peer mempool slot on verification timeout

### DIFF
--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -265,12 +265,15 @@ where
                     (Ok(Err(Box::new((hash, e)))), Some(hash))
                 }
                 Err((txid, elapsed)) => {
-                    // Remove the cancel handle so the spawned task's queued `Gossip`
-                    // doesn't stay resident in `cancel_handles` after a verification
-                    // timeout. Without this, a peer that gets each transaction to
-                    // hit `RATE_LIMIT_DELAY` can leak ~2 MB per tx until OOM.
-                    this.cancel_handles.remove(&txid);
-                    (Err((txid, elapsed)), None)
+                    // Treat a verification timeout as a terminal completion so the
+                    // shared cleanup below removes the `cancel_handles` entry — the
+                    // GHSA-65jj fix, which drops the resident `Gossip` (~2 MB per tx)
+                    // so it can't leak until OOM — and releases the per-peer queue
+                    // slot. A bare handle removal here left the slot pinned, so a
+                    // peer that timed out `MAX_INBOUND_CONCURRENCY_PER_PEER`
+                    // transactions could no longer queue any from that source.
+                    // See #10684.
+                    (Err((txid, elapsed)), Some(txid))
                 }
             };
 

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -2380,3 +2380,85 @@ async fn cancel_handles_drained_after_verification_timeout() {
         "regression GHSA-65jj-fmw8-468q: cancel_handles must be drained after timeout"
     );
 }
+
+/// Regression test for #10684: the mempool verification-timeout path must
+/// release the per-peer queue slot, not just remove the cancel handle.
+///
+/// Before the fix, a peer whose `MAX_INBOUND_CONCURRENCY_PER_PEER` transactions
+/// all hit the verification timeout kept its per-peer count pinned at the cap
+/// even though no tasks remained, so any further transaction from that source
+/// was rejected with `FullQueue`.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn verification_timeout_releases_peer_slot() {
+    use std::net::SocketAddr;
+
+    use futures::stream::StreamExt;
+    use tower::timeout::Timeout;
+    use zebra_node_services::mempool::Gossip;
+
+    use crate::components::mempool::{
+        crawler::RATE_LIMIT_DELAY,
+        downloads::{
+            Downloads, MAX_INBOUND_CONCURRENCY_PER_PEER, TRANSACTION_DOWNLOAD_TIMEOUT,
+            TRANSACTION_VERIFY_TIMEOUT,
+        },
+    };
+
+    let _init_guard = zebra_test::init();
+
+    let peer_set: MockPeerSet = MockService::build().for_unit_tests();
+    let state: MockService<zs::Request, zs::Response, PanicAssertion> =
+        MockService::build().for_unit_tests();
+    let tx_verifier: MockTxVerifier = MockService::build().for_unit_tests();
+
+    let mut downloads = Box::pin(Downloads::new(
+        Timeout::new(peer_set, TRANSACTION_DOWNLOAD_TIMEOUT),
+        Timeout::new(tx_verifier, TRANSACTION_VERIFY_TIMEOUT),
+        state,
+    ));
+
+    let source: SocketAddr = "127.0.0.1:8233".parse().expect("valid socket addr");
+
+    let mut iter = Network::Mainnet.unmined_transactions_in_blocks(1..=10);
+
+    // Fill the per-peer slot with `MAX_INBOUND_CONCURRENCY_PER_PEER` peer-sourced
+    // transactions from a single source.
+    for i in 0..MAX_INBOUND_CONCURRENCY_PER_PEER {
+        let tx = iter.next().expect("enough vector txs").transaction;
+        downloads
+            .as_mut()
+            .download_if_needed_and_verify(Gossip::Tx(tx), Some(source), None)
+            .unwrap_or_else(|e| panic!("queue tx {i} failed: {e:?}"));
+    }
+
+    assert_eq!(downloads.in_flight(), MAX_INBOUND_CONCURRENCY_PER_PEER);
+
+    // Advance past `RATE_LIMIT_DELAY` so every spawned task hits the verification
+    // timeout (the mocked services never make progress).
+    time::advance(RATE_LIMIT_DELAY + Duration::from_secs(5)).await;
+    tokio::task::yield_now().await;
+
+    for _ in 0..MAX_INBOUND_CONCURRENCY_PER_PEER {
+        match downloads.as_mut().next().await {
+            Some(Err(_)) => {}
+            Some(Ok(_)) => panic!("expected a verification timeout error"),
+            None => panic!("Downloads stream ended before all tasks resolved"),
+        }
+    }
+
+    assert_eq!(downloads.in_flight(), 0, "pending should be drained");
+    assert_eq!(
+        downloads.transaction_requests().count(),
+        0,
+        "cancel_handles must be drained after timeout (GHSA-65jj)"
+    );
+
+    // The per-peer slots must have been released: a further transaction from the
+    // same source must queue successfully. Before the fix this returned
+    // `FullQueue` because the timeout path never released the slots.
+    let tx = iter.next().expect("enough vector txs").transaction;
+    downloads
+        .as_mut()
+        .download_if_needed_and_verify(Gossip::Tx(tx), Some(source), None)
+        .expect("a further transaction from the same source should queue after slots are freed");
+}


### PR DESCRIPTION
## Motivation

Closes #10684.

The mempool downloader's verification-timeout arm (`Downloads::poll_next`, `zebrad/src/components/mempool/downloads.rs`) removed the `cancel_handles` entry with a bare `remove` (the GHSA-65jj-fmw8-468q memory fix) but discarded the stored `source` and never released the peer's `pending_per_peer` slot. After `MAX_INBOUND_CONCURRENCY_PER_PEER` (5) timed-out transactions from one source, that source's count stayed pinned at the cap with no tasks left, so further queueing from it returned `FullQueue`.

## Solution

Route the timeout arm through the shared terminal-cleanup path (`completed_txid = Some(txid)`) instead of a bare `cancel_handles.remove`. That shared block already removes the handle (dropping the resident `Gossip`, preserving the GHSA-65jj fix, for all sources) and calls `release_peer_slot`, so success, verifier-error, and timeout now share one uniform path. `completed_txid` only drives cleanup; the returned `Err((txid, elapsed))` is unchanged.

Low risk, confined to mempool inbound-download accounting: no consensus, state-format, RPC, or config change; no DB format bump.

### Tests

`verification_timeout_releases_peer_slot` (`mempool/tests/vector.rs`) times out `MAX_INBOUND_CONCURRENCY_PER_PEER` peer-sourced transactions under `start_paused`, drains them, then queues another from the same source and asserts it succeeds. Fails before the fix (`FullQueue`), passes after; the GHSA-65jj test still passes. `cargo fmt`/`clippy` clean.

### Specifications & References

Preserves the GHSA-65jj-fmw8-468q memory fix.

### Follow-up Work

None.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude (Claude Code) — wrote the fix and the regression test.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
