### PR TITLE
docs(book): remove dead "Keeping Up-to-Date" link from the release process page

### DIFF
--- a/book/src/dev/release-process.md
+++ b/book/src/dev/release-process.md
@@ -50,8 +50,6 @@ You can update to any version of Zebra, provided that the following criteria are
 - The version you want to update _to_ is supported.
 - The version you want to update _from_ is within one major version of the version you want to upgrade to.
 
-See [Keeping Up-to-Date](guide/updating "Updating your projects") for more information about updating your Zebra projects to the most recent version.
-
 <a id="previews"></a>
 
 ### Preview releases


### PR DESCRIPTION
## Motivation

Closes #10106.

The "Supported update paths" section of `book/src/dev/release-process.md` linked `[Keeping Up-to-Date](guide/updating)`, a target that has never existed in the Zebra book — it was copied from a template in #4917.

## Solution

Remove the dangling sentence and its dead link. There is no equivalent "Keeping Up-to-Date" guide in Zebra, so the sentence is deleted rather than repointed.

### Tests

Grepped the book for `guide/updating` and `Keeping Up-to-Date` — no remaining references. mdbook is not installed locally; the change only deletes a broken-link sentence and leaves the surrounding section intact.

### Specifications & References

Introduced by #4917.

### Follow-up Work

None.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude (Claude Code) — made this change.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
