### PR TITLE
fix(zebrad): key the mempool per-peer download cap on IpAddr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   peer's IPv4 address did not disconnect it while it stayed connected, and the same peer counted
   twice towards the per-IP inbound connection limit
   ([#10695](https://github.com/ZcashFoundation/zebra/issues/10695)).
+- The mempool per-peer inbound-download cap is now keyed on the peer's IP address instead of its
+  full socket address, so a single host can no longer exceed the cap by opening connections from
+  multiple source ports. This matches the inbound-block download cap
+  ([#10685](https://github.com/ZcashFoundation/zebra/issues/10685)).
 
 ## [Zebra 6.2.3](https://github.com/ZcashFoundation/zebra/releases/tag/v6.2.3) - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- The mempool now releases a peer's per-peer download slot when a transaction verification times
+  out, instead of only on success or verifier error. Previously a peer whose transactions timed out
+  could pin its per-peer slots at the cap and be unable to queue any further transactions from that
+  address ([#10684](https://github.com/ZcashFoundation/zebra/issues/10684)).
+
 - `getblocksubsidy` now returns NU6-era funding stream metadata (recipient names and
   specification URLs) for NU6.1 and later upgrades. Amounts and addresses were never
   affected ([#11172](https://github.com/ZcashFoundation/zebra/pull/11172)).

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -27,7 +27,7 @@
 //! [`Mempool::poll_ready`]: super::Mempool::poll_ready
 use std::{
     collections::{HashMap, HashSet},
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     pin::Pin,
     task::{Context, Poll},
     time::Duration,
@@ -206,12 +206,19 @@ where
         ),
     >,
 
-    /// The number of currently in-flight download tasks per advertising peer.
+    /// The number of currently in-flight download tasks per advertising host,
+    /// keyed on the peer's [`IpAddr`].
     ///
-    /// Invariant: a peer is present here iff some entry in [`Self::cancel_handles`]
-    /// has it as the third tuple element. Enforces
+    /// Keyed on the host IP rather than the full `SocketAddr` so that all
+    /// connections from one host share a single budget: the `source` is a
+    /// transient `(IP, ephemeral port)`, so per-`SocketAddr` keying would give
+    /// each connection its own bucket. This matches the inbound-block download
+    /// cap (`in_flight_ips`). See #10685.
+    ///
+    /// Invariant: an IP is present here with count `n` iff exactly `n` entries in
+    /// [`Self::cancel_handles`] have a source with that IP. Enforces
     /// [`MAX_INBOUND_CONCURRENCY_PER_PEER`]. See `GHSA-4fc2-h7jh-287c`.
-    pending_per_peer: HashMap<SocketAddr, usize>,
+    pending_per_peer: HashMap<IpAddr, usize>,
 }
 
 impl<ZN, ZV, ZS> Stream for Downloads<ZN, ZV, ZS>
@@ -371,10 +378,10 @@ where
             return Err(MempoolError::FullQueue);
         }
 
-        // Per-peer cap: a single advertising peer cannot saturate the queue
-        // with attacker-supplied fake txids. See `GHSA-4fc2-h7jh-287c`.
+        // Per-peer cap: a single advertising host (keyed by IP) cannot saturate
+        // the queue with attacker-supplied fake txids. See `GHSA-4fc2-h7jh-287c`.
         if let Some(source) = source {
-            let count = self.pending_per_peer.get(&source).copied().unwrap_or(0);
+            let count = self.pending_per_peer.get(&source.ip()).copied().unwrap_or(0);
             if count >= MAX_INBOUND_CONCURRENCY_PER_PEER {
                 debug!(
                     ?txid,
@@ -550,7 +557,7 @@ where
         if let Some(source) = source {
             // The per-peer cap check above ensures this can't exceed
             // `MAX_INBOUND_CONCURRENCY_PER_PEER`.
-            *self.pending_per_peer.entry(source).or_insert(0) += 1;
+            *self.pending_per_peer.entry(source.ip()).or_insert(0) += 1;
         }
 
         debug!(
@@ -604,13 +611,14 @@ where
         metrics::gauge!("mempool.currently.queued.transactions",).set(self.pending.len() as f64);
     }
 
-    /// Decrement the per-peer pending count for `source`, removing the entry
+    /// Decrement the per-host pending count for `source`'s IP, removing the entry
     /// when it reaches zero.
-    fn release_peer_slot(pending_per_peer: &mut HashMap<SocketAddr, usize>, source: SocketAddr) {
-        if let Some(count) = pending_per_peer.get_mut(&source) {
+    fn release_peer_slot(pending_per_peer: &mut HashMap<IpAddr, usize>, source: SocketAddr) {
+        let ip = source.ip();
+        if let Some(count) = pending_per_peer.get_mut(&ip) {
             *count = count.saturating_sub(1);
             if *count == 0 {
-                pending_per_peer.remove(&source);
+                pending_per_peer.remove(&ip);
             }
         }
     }

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -265,12 +265,15 @@ where
                     (Ok(Err(Box::new((hash, e)))), Some(hash))
                 }
                 Err((txid, elapsed)) => {
-                    // Remove the cancel handle so the spawned task's queued `Gossip`
-                    // doesn't stay resident in `cancel_handles` after a verification
-                    // timeout. Without this, a peer that gets each transaction to
-                    // hit `RATE_LIMIT_DELAY` can leak ~2 MB per tx until OOM.
-                    this.cancel_handles.remove(&txid);
-                    (Err((txid, elapsed)), None)
+                    // Treat a verification timeout as a terminal completion so the
+                    // shared cleanup below removes the `cancel_handles` entry — the
+                    // GHSA-65jj fix, which drops the resident `Gossip` (~2 MB per tx)
+                    // so it can't leak until OOM — and releases the per-peer queue
+                    // slot. A bare handle removal here left the slot pinned, so a
+                    // peer that timed out `MAX_INBOUND_CONCURRENCY_PER_PEER`
+                    // transactions could no longer queue any from that source.
+                    // See #10684.
+                    (Err((txid, elapsed)), Some(txid))
                 }
             };
 

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -2284,3 +2284,85 @@ async fn cancel_handles_drained_after_verification_timeout() {
         "regression GHSA-65jj-fmw8-468q: cancel_handles must be drained after timeout"
     );
 }
+
+/// Regression test for #10684: the mempool verification-timeout path must
+/// release the per-peer queue slot, not just remove the cancel handle.
+///
+/// Before the fix, a peer whose `MAX_INBOUND_CONCURRENCY_PER_PEER` transactions
+/// all hit the verification timeout kept its per-peer count pinned at the cap
+/// even though no tasks remained, so any further transaction from that source
+/// was rejected with `FullQueue`.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn verification_timeout_releases_peer_slot() {
+    use std::net::SocketAddr;
+
+    use futures::stream::StreamExt;
+    use tower::timeout::Timeout;
+    use zebra_node_services::mempool::Gossip;
+
+    use crate::components::mempool::{
+        crawler::RATE_LIMIT_DELAY,
+        downloads::{
+            Downloads, MAX_INBOUND_CONCURRENCY_PER_PEER, TRANSACTION_DOWNLOAD_TIMEOUT,
+            TRANSACTION_VERIFY_TIMEOUT,
+        },
+    };
+
+    let _init_guard = zebra_test::init();
+
+    let peer_set: MockPeerSet = MockService::build().for_unit_tests();
+    let state: MockService<zs::Request, zs::Response, PanicAssertion> =
+        MockService::build().for_unit_tests();
+    let tx_verifier: MockTxVerifier = MockService::build().for_unit_tests();
+
+    let mut downloads = Box::pin(Downloads::new(
+        Timeout::new(peer_set, TRANSACTION_DOWNLOAD_TIMEOUT),
+        Timeout::new(tx_verifier, TRANSACTION_VERIFY_TIMEOUT),
+        state,
+    ));
+
+    let source: SocketAddr = "127.0.0.1:8233".parse().expect("valid socket addr");
+
+    let mut iter = Network::Mainnet.unmined_transactions_in_blocks(1..=10);
+
+    // Fill the per-peer slot with `MAX_INBOUND_CONCURRENCY_PER_PEER` peer-sourced
+    // transactions from a single source.
+    for i in 0..MAX_INBOUND_CONCURRENCY_PER_PEER {
+        let tx = iter.next().expect("enough vector txs").transaction;
+        downloads
+            .as_mut()
+            .download_if_needed_and_verify(Gossip::Tx(tx), Some(source), None)
+            .unwrap_or_else(|e| panic!("queue tx {i} failed: {e:?}"));
+    }
+
+    assert_eq!(downloads.in_flight(), MAX_INBOUND_CONCURRENCY_PER_PEER);
+
+    // Advance past `RATE_LIMIT_DELAY` so every spawned task hits the verification
+    // timeout (the mocked services never make progress).
+    time::advance(RATE_LIMIT_DELAY + Duration::from_secs(5)).await;
+    tokio::task::yield_now().await;
+
+    for _ in 0..MAX_INBOUND_CONCURRENCY_PER_PEER {
+        match downloads.as_mut().next().await {
+            Some(Err(_)) => {}
+            Some(Ok(_)) => panic!("expected a verification timeout error"),
+            None => panic!("Downloads stream ended before all tasks resolved"),
+        }
+    }
+
+    assert_eq!(downloads.in_flight(), 0, "pending should be drained");
+    assert_eq!(
+        downloads.transaction_requests().count(),
+        0,
+        "cancel_handles must be drained after timeout (GHSA-65jj)"
+    );
+
+    // The per-peer slots must have been released: a further transaction from the
+    // same source must queue successfully. Before the fix this returned
+    // `FullQueue` because the timeout path never released the slots.
+    let tx = iter.next().expect("enough vector txs").transaction;
+    downloads
+        .as_mut()
+        .download_if_needed_and_verify(Gossip::Tx(tx), Some(source), None)
+        .expect("a further transaction from the same source should queue after slots are freed");
+}

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -2366,3 +2366,61 @@ async fn verification_timeout_releases_peer_slot() {
         .download_if_needed_and_verify(Gossip::Tx(tx), Some(source), None)
         .expect("a further transaction from the same source should queue after slots are freed");
 }
+
+/// Regression test for #10685: the mempool per-peer download cap must be keyed
+/// on the peer's `IpAddr`, not the full `SocketAddr`.
+///
+/// The `source` is a transient `(IP, ephemeral port)`, so keying on the whole
+/// `SocketAddr` gave every connection from one host its own budget. Two sources
+/// with the same IP and different ports must share a single
+/// `MAX_INBOUND_CONCURRENCY_PER_PEER` bucket.
+#[tokio::test(flavor = "current_thread")]
+async fn per_peer_cap_is_keyed_on_ip_not_socket_addr() {
+    use std::net::SocketAddr;
+
+    use tower::timeout::Timeout;
+    use zebra_node_services::mempool::Gossip;
+
+    use crate::components::mempool::downloads::{
+        Downloads, MAX_INBOUND_CONCURRENCY_PER_PEER, TRANSACTION_DOWNLOAD_TIMEOUT,
+        TRANSACTION_VERIFY_TIMEOUT,
+    };
+
+    let _init_guard = zebra_test::init();
+
+    let peer_set: MockPeerSet = MockService::build().for_unit_tests();
+    let state: MockService<zs::Request, zs::Response, PanicAssertion> =
+        MockService::build().for_unit_tests();
+    let tx_verifier: MockTxVerifier = MockService::build().for_unit_tests();
+
+    let mut downloads = Box::pin(Downloads::new(
+        Timeout::new(peer_set, TRANSACTION_DOWNLOAD_TIMEOUT),
+        Timeout::new(tx_verifier, TRANSACTION_VERIFY_TIMEOUT),
+        state,
+    ));
+
+    let mut iter = Network::Mainnet.unmined_transactions_in_blocks(1..=10);
+
+    // Fill the per-host budget from one `(IP, port)`.
+    let first: SocketAddr = "127.0.0.1:8233".parse().expect("valid socket addr");
+    for i in 0..MAX_INBOUND_CONCURRENCY_PER_PEER {
+        let tx = iter.next().expect("enough vector txs").transaction;
+        downloads
+            .as_mut()
+            .download_if_needed_and_verify(Gossip::Tx(tx), Some(first), None)
+            .unwrap_or_else(|e| panic!("queue tx {i} failed: {e:?}"));
+    }
+
+    // A further transaction from the SAME IP but a DIFFERENT port must be
+    // rejected, because the cap is keyed on the host IP. Before the fix it
+    // landed in a separate `SocketAddr` bucket and was accepted.
+    let tx = iter.next().expect("enough vector txs").transaction;
+    let same_ip_other_port: SocketAddr = "127.0.0.1:9999".parse().expect("valid socket addr");
+    let result = downloads
+        .as_mut()
+        .download_if_needed_and_verify(Gossip::Tx(tx), Some(same_ip_other_port), None);
+    assert!(
+        matches!(result, Err(MempoolError::FullQueue)),
+        "a transaction from the same IP on a different port must share the per-peer bucket, got {result:?}"
+    );
+}


### PR DESCRIPTION
> [!WARNING]
> ⛔ **Blocked on #11229 (#10684).** This PR is stacked on the `mempool_timeout_peer_slot_10684` branch, not `main`, and must not merge before #11229 (see Solution). Merge #11229 first — GitHub then auto-retargets this PR to `main` and its `Closes #10685` link activates.

## Motivation

Closes #10685.

The mempool per-peer download cap (`MAX_INBOUND_CONCURRENCY_PER_PEER`) was keyed on the full `SocketAddr` in `zebrad/src/components/mempool/downloads.rs`. The `source` is the peer's transient `(IP, ephemeral port)` (not a permanent identifier), so two connections from one host landed in two separate 5-slot buckets and a single host could exceed the intended per-host bound. The sibling inbound-block path already keys on `IpAddr`.

## Solution

Re-key `pending_per_peer` from `HashMap<SocketAddr, usize>` to `HashMap<IpAddr, usize>`, using `source.ip()` at the cap check, the increment, and `release_peer_slot`. `cancel_handles` still stores the `Option<SocketAddr>`; only its `.ip()` is used for the map, so metrics/logging/error paths are unaffected.

**Dependency:** this must not ship without #10684 (#11229). The verification-timeout arm releases the per-peer slot only via that fix; without it, re-keying on IP turns a harmless per-`SocketAddr` slot leak into a permanent per-IP lockout (each timed-out transaction leaves a residual `+1` on the host's IP bucket). Stacking on #11229 guarantees the timeout path releases the slot, so the map invariant holds. Once #11229 merges this PR retargets to `main`.

Low risk, confined to mempool inbound-download accounting; tightens a per-host DoS control. No consensus, state-format, RPC, or config change.

### Tests

`per_peer_cap_is_keyed_on_ip_not_socket_addr` (`mempool/tests/vector.rs`) queues `MAX_INBOUND_CONCURRENCY_PER_PEER` from one `IP:port`, then queues one more from the same IP on a different port and asserts it is rejected with `FullQueue`. Fails before the fix (different-port request returned `Ok`), passes after; the #10684 timeout-release test and the GHSA-65jj test both still pass on the combined branch. `cargo fmt`/`clippy` clean.

### Specifications & References

Stacked on #11229. Matches the inbound-block download cap (`in_flight_ips`). Related: `GHSA-4fc2-h7jh-287c`.

### Follow-up Work

Retarget to `main` after #11229 merges.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude (Claude Code) — wrote the fix and the regression test.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
