### PR TITLE
fix(zebra-state): start without backup instead of aborting on unusable backup dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 ### Fixed
 
 - `zebrad start` no longer crashes on startup when the non-finalized state backup directory path
-  exists as a regular file. Zebra now logs an actionable error and starts without the non-finalized
-  backup instead of aborting ([#10544](https://github.com/ZcashFoundation/zebra/issues/10544)).
+  exists as a regular file or as a directory Zebra cannot read. Zebra now logs an actionable error
+  and starts without the non-finalized backup instead of aborting
+  ([#10544](https://github.com/ZcashFoundation/zebra/issues/10544)).
 
 - `getblocksubsidy` now returns NU6-era funding stream metadata (recipient names and
   specification URLs) for NU6.1 and later upgrades. Amounts and addresses were never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Fixed
 
+- `zebrad start` no longer crashes on startup when the non-finalized state backup directory path
+  exists as a regular file. Zebra now logs an actionable error and starts without the non-finalized
+  backup instead of aborting ([#10544](https://github.com/ZcashFoundation/zebra/issues/10544)).
+
 - `getblocksubsidy` now returns NU6-era funding stream metadata (recipient names and
   specification URLs) for NU6.1 and later upgrades. Amounts and addresses were never
   affected ([#11172](https://github.com/ZcashFoundation/zebra/pull/11172)).

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `NonFinalizedState::with_backup` no longer panics when the non-finalized state backup path cannot
+  be created (for example, it already exists as a regular file). It now logs an error and starts
+  without the non-finalized backup instead of aborting the process
+  ([#10544](https://github.com/ZcashFoundation/zebra/issues/10544)).
+
 - `init_read_only()` now returns `StateInitError::ReadOnlyEphemeralConflict` for a config with
   `ephemeral = true`, even when the configured `cache_dir` is missing or unreadable. Previously the
   cache directory was checked first, so this configuration error surfaced as

--- a/zebra-state/CHANGELOG.md
+++ b/zebra-state/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `NonFinalizedState::with_backup` no longer panics when the non-finalized state backup path cannot
-  be created (for example, it already exists as a regular file). It now logs an error and starts
-  without the non-finalized backup instead of aborting the process
-  ([#10544](https://github.com/ZcashFoundation/zebra/issues/10544)).
+  be created or read (for example, it already exists as a regular file, or as a directory Zebra
+  cannot read). It now logs an error and starts without the non-finalized backup instead of aborting
+  the process ([#10544](https://github.com/ZcashFoundation/zebra/issues/10544)).
 
 - `init_read_only()` now returns `StateInitError::ReadOnlyEphemeralConflict` for a config with
   `ephemeral = true`, even when the configured `cache_dir` is missing or unreadable. Previously the

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -194,14 +194,34 @@ impl NonFinalizedState {
             );
         }
 
+        // Ensure the backup directory exists and is usable before restoring from
+        // or writing to it. If it can't be created or read — for example, the
+        // path already exists as a regular file, or as a directory we can't read
+        // — log a clear, actionable error and start without the non-finalized
+        // backup rather than aborting. (`create_dir_all` succeeds for a directory
+        // that already exists but is unreadable, so we also probe it with
+        // `read_dir`, matching the access `restore_backup` needs next.) The
+        // backup is a resilience optimisation, not required for correct
+        // operation, and `panic = "abort"` would otherwise turn a recoverable
+        // filesystem state into a startup crash loop. See #10544.
+        let backup_dir_usable = std::fs::create_dir_all(&backup_dir_path)
+            .and_then(|()| std::fs::read_dir(&backup_dir_path).map(drop));
+        if let Err(error) = backup_dir_usable {
+            tracing::error!(
+                ?backup_dir_path,
+                %error,
+                "the non-finalized state backup directory could not be created or read; starting \
+                 without the non-finalized state backup. If this path exists as a file, or is a \
+                 directory Zebra cannot read, remove or relocate it and restart zebrad to re-enable \
+                 backups",
+            );
+            return with_watch_channel(self);
+        }
+
         let non_finalized_state = {
             let backup_dir_path = backup_dir_path.clone();
             let finalized_state = finalized_state.clone();
             tokio::task::spawn_blocking(move || {
-                // Create a new backup directory if none exists
-                std::fs::create_dir_all(&backup_dir_path)
-                    .expect("failed to create non-finalized state backup directory");
-
                 if should_restore_backup {
                     backup::restore_backup(self, &backup_dir_path, &finalized_state)
                 } else {

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -1179,3 +1179,34 @@ fn commit_new_chain_sets_chain_value_pools_deferred_amount() -> Result<()> {
 
     Ok(())
 }
+
+/// Regression test for #10544: `with_backup` must not panic (which aborts under
+/// `panic = "abort"`) when the backup path already exists as a regular file; it
+/// should log an error and start without the non-finalized backup.
+#[tokio::test]
+async fn with_backup_starts_without_backup_when_path_is_a_file() {
+    let _init_guard = zebra_test::init();
+
+    let network = Network::Mainnet;
+    let finalized_state = FinalizedState::new(
+        &Config::ephemeral(),
+        &network,
+        #[cfg(feature = "elasticsearch")]
+        false,
+    )
+    .expect("opening an ephemeral database should succeed");
+
+    // Put a regular file where the backup directory is expected.
+    let temp = tempfile::tempdir().expect("can create temp dir");
+    let backup_path = temp.path().join("mainnet");
+    std::fs::write(&backup_path, b"not a directory").expect("can write file");
+
+    // Before the fix this panicked in `create_dir_all(...).expect(...)`, aborting
+    // the process under `panic = "abort"`. It must now return gracefully.
+    let (_state, _sender, _receiver) = NonFinalizedState::new(&network)
+        .with_backup(Some(backup_path.clone()), &finalized_state.db, false, true)
+        .await;
+
+    // The conflicting file is left untouched (not deleted).
+    assert!(backup_path.is_file());
+}


### PR DESCRIPTION
## Motivation

Closes #10544.

`NonFinalizedState::with_backup` (`zebra-state/src/service/non_finalized_state.rs`) created the backup directory with `create_dir_all(...).expect(...)` inside a `spawn_blocking`. When the path already exists as a regular file, `create_dir_all` errors and the `expect` panics; under the workspace's `panic = "abort"` that aborts the process on every startup — a crash loop until the file is removed by hand.

## Solution

Probe the path (`create_dir_all` then `read_dir`) out of the blocking task and, on error, log a clear actionable message and start without the non-finalized backup, routing to the existing no-backup path. The backup is a re-downloadable resilience cache, not consensus data, so degrading is preferable to a crash loop. `read_dir` is also probed because `create_dir_all` succeeds for a directory that already exists but is unreadable, which would otherwise abort deeper in `restore_backup`.

A graceful hard-fail instead would have to thread `Result` through the public `zebra_state::init` API and all its callers — a much larger change, so this degrades in place. No consensus, RPC, config, or DB-format change.

### Tests

`with_backup_starts_without_backup_when_path_is_a_file` (`non_finalized_state/tests/vectors.rs`) opens an ephemeral finalized DB, writes a regular file at the backup path, calls `with_backup`, and asserts it returns (rather than aborting under `panic = "abort"`) and leaves the file untouched. `cargo fmt`/`clippy` clean. (An unreadable-directory test isn't included — creating one portably in CI, and its no-op as root, is unreliable; that branch is covered by the same `read_dir` probe.)

### Specifications & References

None.

### Follow-up Work

`run_backup_task` and `restore_backup` still call `read_dir(...).expect(...)` in `backup.rs`, so a backup directory that becomes unreadable *while zebrad runs* can still abort. Pre-existing and out of scope here; worth a follow-up to convert those to warn-and-skip.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude (Claude Code) — wrote the fix and the regression test.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
