### PR TITLE
fix(security): batch peer-scoring fixes for Zebra 6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,6 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - `getblocksubsidy` now returns NU6-era funding stream metadata (recipient names and
   specification URLs) for NU6.1 and later upgrades. Amounts and addresses were never
   affected ([#11172](https://github.com/ZcashFoundation/zebra/pull/11172)).
-
 - Reject blocks whose total chain value pool balance would exceed `MAX_MONEY`,
   enforcing the cap on the total monetary base
   ([#10817](https://github.com/ZcashFoundation/zebra/pull/10817))
@@ -63,15 +62,22 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   peer's IPv4 address did not disconnect it while it stayed connected, and the same peer counted
   twice towards the per-IP inbound connection limit
   ([#10695](https://github.com/ZcashFoundation/zebra/issues/10695)).
+- Prevent a peer from delaying tip discovery by answering a block download with a canonical header
+  and a rewritten coinbase height. Zebra now re-requests the hash immediately instead of waiting for
+  a later sync round to rediscover it, and scores the peer when a parent block Zebra already holds
+  proves the claimed height wrong
+  ([GHSA-g95h-hw6g-pvgv](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-g95h-hw6g-pvgv)).
+  Thanks to @zakura-security for reporting the issue.
 - Blocks above the sync lookahead height limit no longer score the peer that served
   them, since that request is routed to an unrelated honest peer — scoring it let a
   malicious `FindBlocks` responder get honest peers banned during initial block
-  download (GHSA-qhr3-cvch-5fh2)
-
+  download
+  ([GHSA-qhr3-cvch-5fh2](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-qhr3-cvch-5fh2)).
 - Peers that gossip consensus-invalid blocks are scored for misbehavior again. The inbound
   download cleanup only recognized `VerifyBlockError`, but the gossiped block verifier is a
   `BlockVerifierRouter`, which returns `RouterError`, so no score was ever applied and such
-  peers were never banned (GHSA-8hh2-hrf2-cqf4)
+  peers were never banned
+  ([GHSA-8hh2-hrf2-cqf4](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-8hh2-hrf2-cqf4)).
 
 ## [Zebra 6.2.3](https://github.com/ZcashFoundation/zebra/releases/tag/v6.2.3) - 2026-07-27
 
@@ -168,12 +174,6 @@ penalizes them for briefly disagreeing about the NU6.3 activation.
 - Mitigate a peer-driven CPU-exhaustion vector on nodes with NU6.3 (Ironwood) active: reject
   underpaying and structurally invalid shielded mempool transactions before their expensive proof
   verification, and disconnect peers that send transactions with invalid shielded proofs.
-- Prevent a peer from delaying tip discovery by answering a block download with a canonical header
-  and a rewritten coinbase height. Zebra now re-requests the hash immediately instead of waiting for
-  a later sync round to rediscover it, and scores the peer when a parent block Zebra already holds
-  proves the claimed height wrong
-  ([GHSA-g95h-hw6g-pvgv](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-g95h-hw6g-pvgv)).
-  Thanks to @zakura-security for reporting the issue.
 
 ## [Zebra 6.2.0](https://github.com/ZcashFoundation/zebra/releases/tag/v6.2.0) - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,11 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   malicious `FindBlocks` responder get honest peers banned during initial block
   download (GHSA-qhr3-cvch-5fh2)
 
+- Peers that gossip consensus-invalid blocks are scored for misbehavior again. The inbound
+  download cleanup only recognized `VerifyBlockError`, but the gossiped block verifier is a
+  `BlockVerifierRouter`, which returns `RouterError`, so no score was ever applied and such
+  peers were never banned (GHSA-8hh2-hrf2-cqf4)
+
 ## [Zebra 6.2.3](https://github.com/ZcashFoundation/zebra/releases/tag/v6.2.3) - 2026-07-27
 
 This is an optional release with network hardenings for operators that experience issues with their nodes peer set connectivity or otherwise want to be proactive about avoiding such issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,10 +63,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   peer's IPv4 address did not disconnect it while it stayed connected, and the same peer counted
   twice towards the per-IP inbound connection limit
   ([#10695](https://github.com/ZcashFoundation/zebra/issues/10695)).
-- Blocks above the sync lookahead height limit no longer score the peer that served them.
-  A `FindBlocks` response does not record who supplied its hashes, so the block request is
-  routed to an unrelated honest peer, and scoring it let a malicious peer get honest peers
-  banned throughout initial block download (GHSA-qhr3-cvch-5fh2)
+- Blocks above the sync lookahead height limit no longer score the peer that served
+  them, since that request is routed to an unrelated honest peer — scoring it let a
+  malicious `FindBlocks` responder get honest peers banned during initial block
+  download (GHSA-qhr3-cvch-5fh2)
 
 ## [Zebra 6.2.3](https://github.com/ZcashFoundation/zebra/releases/tag/v6.2.3) - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   peer's IPv4 address did not disconnect it while it stayed connected, and the same peer counted
   twice towards the per-IP inbound connection limit
   ([#10695](https://github.com/ZcashFoundation/zebra/issues/10695)).
+- Blocks above the sync lookahead height limit no longer score the peer that served them.
+  A `FindBlocks` response does not record who supplied its hashes, so the block request is
+  routed to an unrelated honest peer, and scoring it let a malicious peer get honest peers
+  banned throughout initial block download (GHSA-qhr3-cvch-5fh2)
 
 ## [Zebra 6.2.3](https://github.com/ZcashFoundation/zebra/releases/tag/v6.2.3) - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,12 @@ penalizes them for briefly disagreeing about the NU6.3 activation.
 - Mitigate a peer-driven CPU-exhaustion vector on nodes with NU6.3 (Ironwood) active: reject
   underpaying and structurally invalid shielded mempool transactions before their expensive proof
   verification, and disconnect peers that send transactions with invalid shielded proofs.
+- Prevent a peer from delaying tip discovery by answering a block download with a canonical header
+  and a rewritten coinbase height. Zebra now re-requests the hash immediately instead of waiting for
+  a later sync round to rediscover it, and scores the peer when a parent block Zebra already holds
+  proves the claimed height wrong
+  ([GHSA-g95h-hw6g-pvgv](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-g95h-hw6g-pvgv)).
+  Thanks to @zakura-security for reporting the issue.
 
 ## [Zebra 6.2.0](https://github.com/ZcashFoundation/zebra/releases/tag/v6.2.0) - 2026-07-17
 

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -414,6 +414,7 @@ impl StartCmd {
             peer_set.clone(),
             block_verifier_router.clone(),
             state.clone(),
+            read_only_state_service.clone(),
             latest_chain_tip.clone(),
             misbehavior_sender.clone(),
         );

--- a/zebrad/src/components/inbound.rs
+++ b/zebrad/src/components/inbound.rs
@@ -335,13 +335,29 @@ impl Service<zn::Request> for Inbound {
                         continue;
                     };
 
-                    let Ok(err) = err.downcast::<VerifyBlockError>() else {
+                    // # Security
+                    //
+                    // The gossiped block verifier is a `BlockVerifierRouter`, so a failed
+                    // verification is boxed as a `RouterError`. `Box<dyn Error>::downcast`
+                    // is an exact type match, so downcasting to `VerifyBlockError` alone
+                    // never matched, and misbehaving peers were never scored.
+                    // (`VerifyBlockError` only appears nested inside `RouterError::Block`.)
+                    //
+                    // `VerifyBlockError` is still handled, so scoring keeps working if the
+                    // verifier stack is ever rewired to skip the router.
+                    //
+                    // Any other error (a tower `Elapsed` timeout, a transport failure) is a
+                    // local problem rather than peer misbehavior, so it stays unscored.
+                    let score = if let Some(err) = err.downcast_ref::<RouterError>() {
+                        err.misbehavior_score()
+                    } else if let Some(err) = err.downcast_ref::<VerifyBlockError>() {
+                        err.misbehavior_score()
+                    } else {
                         continue;
                     };
 
-                    if err.misbehavior_score() != 0 {
-                        let _ =
-                            misbehavior_sender.try_send((advertiser_addr, err.misbehavior_score()));
+                    if score != 0 {
+                        let _ = misbehavior_sender.try_send((advertiser_addr, score));
                     }
                 }
 

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -17,7 +17,10 @@ use zebra_chain::{
     serialization::{DateTime32, ZcashDeserializeInto},
     transaction::{UnminedTx, UnminedTxId, VerifiedUnminedTx},
 };
-use zebra_consensus::{error::TransactionError, transaction, Config as ConsensusConfig};
+use zebra_consensus::{
+    error::TransactionError, router::RouterError, transaction, Config as ConsensusConfig,
+    VerifyBlockError,
+};
 use zebra_network::{
     constants::{
         ADDR_RESPONSE_LIMIT_DENOMINATOR, DEFAULT_MAX_CONNS_PER_IP, MAX_ADDRS_IN_ADDRESS_BOOK,
@@ -37,7 +40,7 @@ use crate::{
             gossip_mempool_transaction_id, Config as MempoolConfig, Mempool, MempoolError,
             SameEffectsChainRejectionError, UnboxMempoolError,
         },
-        sync::{self, BlockGossipError, SyncStatus, PEER_GOSSIP_DELAY},
+        sync::{self, BlockGossipError, SyncStatus, BLOCK_VERIFY_TIMEOUT, PEER_GOSSIP_DELAY},
     },
     BoxError,
 };
@@ -1197,4 +1200,273 @@ fn add_some_stuff_to_mempool(
         .unwrap();
 
     vec![last_transaction]
+}
+
+/// The semantic block verifier type the [`Inbound`] service is wired with in production.
+///
+/// The concrete service inside the [`BoxService`] is a
+/// [`zebra_consensus::router::BlockVerifierRouter`], so its error type is
+/// [`RouterError`] — a bare [`VerifyBlockError`] never escapes this stack, it only
+/// ever appears nested inside [`RouterError::Block`].
+type SemanticBlockVerifierStub = Buffer<
+    BoxService<zebra_consensus::Request, zebra_chain::block::Hash, RouterError>,
+    zebra_consensus::Request,
+>;
+
+/// Wires up an [`Inbound`] service with a stub semantic block verifier, using the same
+/// service types as production, and returns the misbehaviour report receiver.
+///
+/// Unlike the other tests in this module, the returned receiver is *retained* by the
+/// caller, so misbehaviour reports emitted by the gossiped block download cleanup loop
+/// can be asserted on. See `GHSA-8hh2-hrf2-cqf4`.
+async fn setup_gossiped_block_misbehavior(
+    block_verifier: SemanticBlockVerifierStub,
+) -> (
+    Inbound,
+    MockService<Request, Response, PanicAssertion>,
+    tokio::sync::mpsc::Receiver<(PeerSocketAddr, u32)>,
+) {
+    let network = Mainnet;
+    let state_config = StateConfig::ephemeral();
+
+    let address_book = AddressBook::new(
+        SocketAddr::from_str("0.0.0.0:0").unwrap(),
+        &network,
+        DEFAULT_MAX_CONNS_PER_IP,
+        Span::none(),
+    );
+    let address_book = Arc::new(std::sync::Mutex::new(address_book));
+
+    // An empty state, so gossiped blocks are always unknown, and the lookahead limit is
+    // measured from the genesis height.
+    let (state, _read_only_state_service, latest_chain_tip, _chain_tip_change) =
+        zebra_state::init(state_config, &network, Height::MAX, 0).await;
+    let state_service = ServiceBuilder::new().buffer(1).service(state);
+
+    let peer_set = MockService::build()
+        .with_max_request_delay(MAX_PEER_SET_REQUEST_DELAY)
+        .for_unit_tests();
+    let buffered_peer_set = Buffer::new(BoxService::new(peer_set.clone()), 10);
+
+    let mempool_service: MockService<mempool::Request, mempool::Response, PanicAssertion> =
+        MockService::build().for_unit_tests();
+    let buffered_mempool = Buffer::new(BoxService::new(mempool_service), 10);
+
+    let (setup_tx, setup_rx) = oneshot::channel();
+
+    // The `Inbound` service is used directly, without a `Buffer` or `load_shed` wrapper,
+    // so the test can drive `poll_ready()` — and therefore the download cleanup loop —
+    // deterministically.
+    let inbound = Inbound::new(MAX_INBOUND_CONCURRENCY, setup_rx);
+
+    let (misbehavior_sender, misbehavior_rx) = tokio::sync::mpsc::channel(10);
+
+    let setup_data = InboundSetupData {
+        address_book,
+        block_download_peer_set: buffered_peer_set,
+        block_verifier,
+        mempool: buffered_mempool,
+        state: state_service,
+        latest_chain_tip,
+        misbehavior_sender,
+    };
+    let r = setup_tx.send(setup_data);
+    // We can't expect or unwrap because the returned Result does not implement Debug.
+    assert!(r.is_ok(), "unexpected setup channel send failure");
+
+    (inbound, peer_set, misbehavior_rx)
+}
+
+/// Repeatedly polls the [`Inbound`] service, so its gossiped block download cleanup loop
+/// drains any finished downloads, and returns the first misbehaviour report, if any.
+async fn poll_for_misbehavior_report(
+    inbound: &mut Inbound,
+    misbehavior_rx: &mut tokio::sync::mpsc::Receiver<(PeerSocketAddr, u32)>,
+) -> Option<(PeerSocketAddr, u32)> {
+    for _ in 0..60 {
+        let _ = std::future::poll_fn(|cx| inbound.poll_ready(cx)).await;
+
+        if let Ok(report) = misbehavior_rx.try_recv() {
+            return Some(report);
+        }
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    None
+}
+
+/// Sends the gossiped block advertisement, and serves the block to the download task.
+async fn advertise_and_serve_block(
+    inbound: &mut Inbound,
+    peer_set: &mut MockService<Request, Response, PanicAssertion>,
+    block: Arc<Block>,
+    peer: PeerSocketAddr,
+) -> Result<(), BoxError> {
+    let hash = block.hash();
+
+    let response = inbound
+        .ready()
+        .await?
+        .call(Request::AdvertiseBlock(hash, Some(peer)))
+        .await?;
+    assert_eq!(
+        response,
+        Response::Nil,
+        "`AdvertiseBlock` requests should always respond `Ok(Nil)`",
+    );
+
+    peer_set
+        .expect_request(Request::BlocksByHash(iter::once(hash).collect()))
+        .await
+        .respond(Response::Blocks(vec![Available((block, Some(peer)))]));
+
+    Ok(())
+}
+
+/// A peer that gossips a consensus-invalid block must have its misbehaviour score raised.
+///
+/// The production inbound block verifier is a `BlockVerifierRouter`, so a failed
+/// verification is boxed as a [`RouterError`]. The cleanup loop in `Inbound::poll_ready()`
+/// downcast the boxed error to [`VerifyBlockError`] instead, and `Box<dyn Error>::downcast`
+/// is an exact `TypeId` match, so the downcast always failed and no peer was ever scored
+/// for serving an invalid gossiped block.
+///
+/// Note that this test *retains* the misbehaviour receiver. Every other test in this module
+/// drops it, which is why the bug went unnoticed.
+///
+/// Regression test for `GHSA-8hh2-hrf2-cqf4`.
+#[tokio::test(flavor = "multi_thread")]
+async fn gossiped_block_router_error_scores_advertising_peer() -> Result<(), BoxError> {
+    let _init_guard = zebra_test::init();
+
+    let block: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
+    let peer = PeerSocketAddr::from(([192, 168, 180, 9], 10_000));
+
+    // A misbehaviour-scoring consensus failure, wrapped exactly like the router wraps it.
+    let block_verifier = Buffer::new(
+        BoxService::new(tower::service_fn(|_req: zebra_consensus::Request| async {
+            Err::<zebra_chain::block::Hash, RouterError>(RouterError::Block {
+                source: Box::new(VerifyBlockError::Subsidy(
+                    zebra_chain::parameters::subsidy::SubsidyError::NoCoinbase,
+                )),
+            })
+        })),
+        10,
+    );
+
+    let (mut inbound, mut peer_set, mut misbehavior_rx) =
+        setup_gossiped_block_misbehavior(block_verifier).await;
+
+    advertise_and_serve_block(&mut inbound, &mut peer_set, block, peer).await?;
+
+    let report = poll_for_misbehavior_report(&mut inbound, &mut misbehavior_rx).await;
+
+    assert_eq!(
+        report,
+        Some((peer, 100)),
+        "a peer that gossips a consensus-invalid block must be reported for misbehaviour",
+    );
+
+    Ok(())
+}
+
+/// A verification failure that is not peer misbehaviour must not raise any score.
+///
+/// Guards against over-banning after the `GHSA-8hh2-hrf2-cqf4` fix: only errors whose
+/// `misbehavior_score()` is non-zero may be reported.
+#[tokio::test(flavor = "multi_thread")]
+async fn gossiped_block_benign_router_error_does_not_score_advertising_peer() -> Result<(), BoxError>
+{
+    let _init_guard = zebra_test::init();
+
+    let block: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
+    let peer = PeerSocketAddr::from(([192, 168, 180, 10], 10_000));
+
+    // `VerifyBlockError::ValidateProposal` has a misbehaviour score of zero.
+    let block_verifier = Buffer::new(
+        BoxService::new(tower::service_fn(|_req: zebra_consensus::Request| async {
+            Err::<zebra_chain::block::Hash, RouterError>(RouterError::Block {
+                source: Box::new(VerifyBlockError::ValidateProposal(
+                    "not peer misbehaviour".into(),
+                )),
+            })
+        })),
+        10,
+    );
+
+    let (mut inbound, mut peer_set, mut misbehavior_rx) =
+        setup_gossiped_block_misbehavior(block_verifier).await;
+
+    advertise_and_serve_block(&mut inbound, &mut peer_set, block, peer).await?;
+
+    let report = poll_for_misbehavior_report(&mut inbound, &mut misbehavior_rx).await;
+
+    assert_eq!(
+        report, None,
+        "a verification failure with a zero misbehaviour score must not be reported",
+    );
+
+    Ok(())
+}
+
+/// A block verification timeout must not raise the advertising peer's misbehaviour score.
+///
+/// The inbound verifier is wrapped in a tower [`tower::timeout::Timeout`], so a slow
+/// verification produces a boxed `tower::timeout::error::Elapsed`, not a [`RouterError`].
+/// That is a local failure, not evidence that the peer misbehaved.
+///
+/// Negative control for `GHSA-8hh2-hrf2-cqf4`.
+#[tokio::test]
+async fn gossiped_block_verify_timeout_does_not_score_advertising_peer() -> Result<(), BoxError> {
+    let _init_guard = zebra_test::init();
+
+    let block: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
+    let peer = PeerSocketAddr::from(([192, 168, 180, 11], 10_000));
+
+    // Signals that the download task has reached the verifier, and is now parked inside
+    // the `Timeout` layer.
+    let (verifier_called_tx, mut verifier_called_rx) = tokio::sync::mpsc::channel(1);
+
+    let block_verifier = Buffer::new(
+        BoxService::new(tower::service_fn(move |_req: zebra_consensus::Request| {
+            let verifier_called_tx = verifier_called_tx.clone();
+            async move {
+                let _ = verifier_called_tx.send(()).await;
+                std::future::pending::<Result<zebra_chain::block::Hash, RouterError>>().await
+            }
+        })),
+        10,
+    );
+
+    let (mut inbound, mut peer_set, mut misbehavior_rx) =
+        setup_gossiped_block_misbehavior(block_verifier).await;
+
+    advertise_and_serve_block(&mut inbound, &mut peer_set, block.clone(), peer).await?;
+
+    verifier_called_rx
+        .recv()
+        .await
+        .expect("the download task should reach the block verifier");
+
+    // Fast-forward past the verification timeout, so tower's `Timeout` layer produces a
+    // real `Elapsed` error at exactly the position a `RouterError` would appear.
+    tokio::time::pause();
+    tokio::time::advance(BLOCK_VERIFY_TIMEOUT + Duration::from_secs(1)).await;
+    tokio::time::resume();
+
+    let report = poll_for_misbehavior_report(&mut inbound, &mut misbehavior_rx).await;
+
+    assert_eq!(
+        report, None,
+        "a block verification timeout must not be reported as peer misbehaviour",
+    );
+
+    // Make sure the assertion above isn't vacuous: the timed-out download must actually
+    // have been drained by the cleanup loop. If it were still in flight, the per-IP and
+    // per-hash caps would drop this second advertisement, and no `BlocksByHash` request
+    // would reach the peer set.
+    advertise_and_serve_block(&mut inbound, &mut peer_set, block, peer).await?;
+
+    Ok(())
 }

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -1297,18 +1297,22 @@ async fn poll_for_misbehavior_report(
 }
 
 /// Sends the gossiped block advertisement, and serves the block to the download task.
+///
+/// The advertisement is attributed to `advertiser`, and the `Blocks` response to
+/// `serving_peer` — the address a misbehaviour report is attached to.
 async fn advertise_and_serve_block(
     inbound: &mut Inbound,
     peer_set: &mut MockService<Request, Response, PanicAssertion>,
     block: Arc<Block>,
-    peer: PeerSocketAddr,
+    advertiser: PeerSocketAddr,
+    serving_peer: PeerSocketAddr,
 ) -> Result<(), BoxError> {
     let hash = block.hash();
 
     let response = inbound
         .ready()
         .await?
-        .call(Request::AdvertiseBlock(hash, Some(peer)))
+        .call(Request::AdvertiseBlock(hash, Some(advertiser)))
         .await?;
     assert_eq!(
         response,
@@ -1319,7 +1323,10 @@ async fn advertise_and_serve_block(
     peer_set
         .expect_request(Request::BlocksByHash(iter::once(hash).collect()))
         .await
-        .respond(Response::Blocks(vec![Available((block, Some(peer)))]));
+        .respond(Response::Blocks(vec![Available((
+            block,
+            Some(serving_peer),
+        ))]));
 
     Ok(())
 }
@@ -1334,7 +1341,8 @@ fn invalid_gossiped_block_router_error() -> RouterError {
     }
 }
 
-/// A peer that gossips a consensus-invalid block must have its misbehaviour score raised.
+/// A peer that serves a consensus-invalid gossiped block must have its misbehaviour score
+/// raised.
 ///
 /// The production inbound block verifier is a `BlockVerifierRouter`, so a failed
 /// verification is boxed as a [`RouterError`]. The cleanup loop in `Inbound::poll_ready()`
@@ -1347,7 +1355,7 @@ fn invalid_gossiped_block_router_error() -> RouterError {
 ///
 /// Regression test for `GHSA-8hh2-hrf2-cqf4`.
 #[tokio::test(flavor = "multi_thread")]
-async fn gossiped_block_router_error_scores_advertising_peer() -> Result<(), BoxError> {
+async fn gossiped_block_router_error_scores_serving_peer() -> Result<(), BoxError> {
     let _init_guard = zebra_test::init();
 
     let block: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
@@ -1372,14 +1380,59 @@ async fn gossiped_block_router_error_scores_advertising_peer() -> Result<(), Box
     let (mut inbound, mut peer_set, mut misbehavior_rx) =
         setup_gossiped_block_misbehavior(block_verifier).await;
 
-    advertise_and_serve_block(&mut inbound, &mut peer_set, block, peer).await?;
+    advertise_and_serve_block(&mut inbound, &mut peer_set, block, peer, peer).await?;
 
     let report = poll_for_misbehavior_report(&mut inbound, &mut misbehavior_rx).await;
 
     assert_eq!(
         report,
         Some((peer, expected_score)),
-        "a peer that gossips a consensus-invalid block must be reported for misbehaviour",
+        "a peer that serves a consensus-invalid gossiped block must be reported for misbehaviour",
+    );
+
+    Ok(())
+}
+
+/// The misbehaviour report is attached to the peer that served the invalid block, not to
+/// the advertiser that announced it: the download task takes the reported address from the
+/// `Blocks` response, which is set by the connection that actually delivered the bytes.
+#[tokio::test(flavor = "multi_thread")]
+async fn gossiped_block_scores_serving_peer_not_advertiser() -> Result<(), BoxError> {
+    let _init_guard = zebra_test::init();
+
+    let block: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
+    let advertiser = PeerSocketAddr::from(([192, 168, 180, 12], 10_000));
+    let serving_peer = PeerSocketAddr::from(([192, 168, 180, 13], 10_000));
+
+    let expected_score = invalid_gossiped_block_router_error().misbehavior_score();
+    assert_ne!(
+        expected_score, 0,
+        "the test error must have a non-zero misbehaviour score",
+    );
+
+    let block_verifier = Buffer::new(
+        BoxService::new(tower::service_fn(|_req: zebra_consensus::Request| async {
+            Err::<zebra_chain::block::Hash, RouterError>(invalid_gossiped_block_router_error())
+        })),
+        10,
+    );
+
+    let (mut inbound, mut peer_set, mut misbehavior_rx) =
+        setup_gossiped_block_misbehavior(block_verifier).await;
+
+    advertise_and_serve_block(&mut inbound, &mut peer_set, block, advertiser, serving_peer).await?;
+
+    let report = poll_for_misbehavior_report(&mut inbound, &mut misbehavior_rx).await;
+
+    assert_eq!(
+        report,
+        Some((serving_peer, expected_score)),
+        "the peer that served the invalid block must be scored, not the advertiser",
+    );
+    assert_eq!(
+        misbehavior_rx.try_recv().ok(),
+        None,
+        "no other peer may be reported for this download",
     );
 
     Ok(())
@@ -1390,8 +1443,7 @@ async fn gossiped_block_router_error_scores_advertising_peer() -> Result<(), Box
 /// Guards against over-banning after the `GHSA-8hh2-hrf2-cqf4` fix: only errors whose
 /// `misbehavior_score()` is non-zero may be reported.
 #[tokio::test(flavor = "multi_thread")]
-async fn gossiped_block_benign_router_error_does_not_score_advertising_peer() -> Result<(), BoxError>
-{
+async fn gossiped_block_benign_router_error_does_not_score_serving_peer() -> Result<(), BoxError> {
     let _init_guard = zebra_test::init();
 
     let block: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
@@ -1412,7 +1464,7 @@ async fn gossiped_block_benign_router_error_does_not_score_advertising_peer() ->
     let (mut inbound, mut peer_set, mut misbehavior_rx) =
         setup_gossiped_block_misbehavior(block_verifier).await;
 
-    advertise_and_serve_block(&mut inbound, &mut peer_set, block, peer).await?;
+    advertise_and_serve_block(&mut inbound, &mut peer_set, block, peer, peer).await?;
 
     let report = poll_for_misbehavior_report(&mut inbound, &mut misbehavior_rx).await;
 
@@ -1424,7 +1476,7 @@ async fn gossiped_block_benign_router_error_does_not_score_advertising_peer() ->
     Ok(())
 }
 
-/// A block verification timeout must not raise the advertising peer's misbehaviour score.
+/// A block verification timeout must not raise the serving peer's misbehaviour score.
 ///
 /// The inbound verifier is wrapped in a tower [`tower::timeout::Timeout`], so a slow
 /// verification produces a boxed `tower::timeout::error::Elapsed`, not a [`RouterError`].
@@ -1432,7 +1484,7 @@ async fn gossiped_block_benign_router_error_does_not_score_advertising_peer() ->
 ///
 /// Negative control for `GHSA-8hh2-hrf2-cqf4`.
 #[tokio::test]
-async fn gossiped_block_verify_timeout_does_not_score_advertising_peer() -> Result<(), BoxError> {
+async fn gossiped_block_verify_timeout_does_not_score_serving_peer() -> Result<(), BoxError> {
     let _init_guard = zebra_test::init();
 
     let block: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
@@ -1456,7 +1508,7 @@ async fn gossiped_block_verify_timeout_does_not_score_advertising_peer() -> Resu
     let (mut inbound, mut peer_set, mut misbehavior_rx) =
         setup_gossiped_block_misbehavior(block_verifier).await;
 
-    advertise_and_serve_block(&mut inbound, &mut peer_set, block.clone(), peer).await?;
+    advertise_and_serve_block(&mut inbound, &mut peer_set, block.clone(), peer, peer).await?;
 
     verifier_called_rx
         .recv()
@@ -1480,7 +1532,7 @@ async fn gossiped_block_verify_timeout_does_not_score_advertising_peer() -> Resu
     // have been drained by the cleanup loop. If it were still in flight, the per-IP and
     // per-hash caps would drop this second advertisement, and no `BlocksByHash` request
     // would reach the peer set.
-    advertise_and_serve_block(&mut inbound, &mut peer_set, block, peer).await?;
+    advertise_and_serve_block(&mut inbound, &mut peer_set, block, peer, peer).await?;
 
     Ok(())
 }

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -1324,6 +1324,16 @@ async fn advertise_and_serve_block(
     Ok(())
 }
 
+/// The [`RouterError`] served by the misbehaving stub verifier: a misbehaviour-scoring
+/// consensus failure, wrapped exactly like the router wraps it.
+fn invalid_gossiped_block_router_error() -> RouterError {
+    RouterError::Block {
+        source: Box::new(VerifyBlockError::Subsidy(
+            zebra_chain::parameters::subsidy::SubsidyError::NoCoinbase,
+        )),
+    }
+}
+
 /// A peer that gossips a consensus-invalid block must have its misbehaviour score raised.
 ///
 /// The production inbound block verifier is a `BlockVerifierRouter`, so a failed
@@ -1343,14 +1353,18 @@ async fn gossiped_block_router_error_scores_advertising_peer() -> Result<(), Box
     let block: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_1_BYTES.zcash_deserialize_into()?;
     let peer = PeerSocketAddr::from(([192, 168, 180, 9], 10_000));
 
-    // A misbehaviour-scoring consensus failure, wrapped exactly like the router wraps it.
+    // Derive the expected score, so the test tracks scoring policy changes. If the sample
+    // error's score ever drops to zero, the guard fails loudly instead of the report
+    // assertion becoming vacuous.
+    let expected_score = invalid_gossiped_block_router_error().misbehavior_score();
+    assert_ne!(
+        expected_score, 0,
+        "the test error must have a non-zero misbehaviour score",
+    );
+
     let block_verifier = Buffer::new(
         BoxService::new(tower::service_fn(|_req: zebra_consensus::Request| async {
-            Err::<zebra_chain::block::Hash, RouterError>(RouterError::Block {
-                source: Box::new(VerifyBlockError::Subsidy(
-                    zebra_chain::parameters::subsidy::SubsidyError::NoCoinbase,
-                )),
-            })
+            Err::<zebra_chain::block::Hash, RouterError>(invalid_gossiped_block_router_error())
         })),
         10,
     );
@@ -1364,7 +1378,7 @@ async fn gossiped_block_router_error_scores_advertising_peer() -> Result<(), Box
 
     assert_eq!(
         report,
-        Some((peer, 100)),
+        Some((peer, expected_score)),
         "a peer that gossips a consensus-invalid block must be reported for misbehaviour",
     );
 

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -329,7 +329,7 @@ struct CheckedTip {
     expected_next: block::Hash,
 }
 
-pub struct ChainSync<ZN, ZS, ZV, ZSTip>
+pub struct ChainSync<ZN, ZS, ZSR, ZV, ZSTip>
 where
     ZN: Service<zn::Request, Response = zn::Response, Error = BoxError>
         + Send
@@ -343,6 +343,12 @@ where
         + Clone
         + 'static,
     ZS::Future: Send,
+    ZSR: Service<zs::ReadRequest, Response = zs::ReadResponse, Error = BoxError>
+        + Send
+        + Sync
+        + Clone
+        + 'static,
+    ZSR::Future: Send,
     ZV: Service<zebra_consensus::Request, Response = block::Hash, Error = BoxError>
         + Send
         + Sync
@@ -383,6 +389,7 @@ where
             Downloads<
                 Hedge<ConcurrencyLimit<Retry<zn::RetryLimit, Timeout<ZN>>>, AlwaysHedge>,
                 Timeout<ZV>,
+                ZSR,
                 ZSTip,
             >,
         >,
@@ -424,7 +431,7 @@ where
 /// This component is used for initial block sync, but the `Inbound` service is
 /// responsible for participating in the gossip protocols used for block
 /// diffusion.
-impl<ZN, ZS, ZV, ZSTip> ChainSync<ZN, ZS, ZV, ZSTip>
+impl<ZN, ZS, ZSR, ZV, ZSTip> ChainSync<ZN, ZS, ZSR, ZV, ZSTip>
 where
     ZN: Service<zn::Request, Response = zn::Response, Error = BoxError>
         + Send
@@ -438,6 +445,12 @@ where
         + Clone
         + 'static,
     ZS::Future: Send,
+    ZSR: Service<zs::ReadRequest, Response = zs::ReadResponse, Error = BoxError>
+        + Send
+        + Sync
+        + Clone
+        + 'static,
+    ZSR::Future: Send,
     ZV: Service<zebra_consensus::Request, Response = block::Hash, Error = BoxError>
         + Send
         + Sync
@@ -451,15 +464,18 @@ where
     ///  - peers: the zebra-network peers to contact for downloads
     ///  - verifier: the zebra-consensus verifier that checks the chain
     ///  - state: the zebra-state that stores the chain
+    ///  - read_state: a read-only handle to the zebra-state, used to check downloaded block heights
     ///  - latest_chain_tip: the latest chain tip from `state`
     ///
     /// Also returns a [`SyncStatus`] to check if the syncer has likely reached the chain tip.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         config: &ZebradConfig,
         max_checkpoint_height: Height,
         peers: ZN,
         verifier: ZV,
         state: ZS,
+        read_state: ZSR,
         latest_chain_tip: ZSTip,
         misbehavior_sender: mpsc::Sender<(PeerSocketAddr, u32)>,
     ) -> (Self, SyncStatus) {
@@ -529,6 +545,7 @@ where
         let downloads = Box::pin(Downloads::new(
             block_network,
             verifier,
+            read_state,
             latest_chain_tip.clone(),
             past_lookahead_limit_sender,
             max(
@@ -1211,33 +1228,59 @@ where
                 let _ = self.misbehavior_sender.try_send((advertiser_addr, 100));
             }
 
+            // The downloader only sets `advertiser_addr` here when the parent Zebra already holds
+            // proves the body's claimed height wrong. A peer can answer with a canonical header and
+            // a rewritten coinbase height because the initial hash check does not recompute the
+            // header's commitment to the body's authorizing data (GHSA-g95h-hw6g-pvgv). Peers that
+            // serve genuinely old blocks arrive unattributed and fall through unscored. Score a
+            // proven rewrite like the mirror-image above-lookahead drop.
+            Err(BlockDownloadVerifyError::BehindTipHeightLimit {
+                advertiser_addr: Some(advertiser_addr),
+                ..
+            }) => {
+                let _ = self.misbehavior_sender.try_send((advertiser_addr, 100));
+            }
+
             Err(_) => {}
         };
 
-        // A block whose download failed because no peer delivered it (`NotFound`)
-        // is otherwise dropped here and never re-requested, which wedges the
-        // checkpoint frontier until the verify timeout (#5709). Re-queue it for
-        // the next sync round, bounded by `MAX_BLOCK_REOBTAIN_RETRIES`. Consensus
-        // failures (`Invalid`/`ValidationRequestError`) are deliberately excluded —
+        // A hash the syncer still needs, whose download did not produce a usable block, is
+        // otherwise dropped here and only rediscovered by a later sync round. Re-queue it for the
+        // next sync round, bounded by `MAX_BLOCK_REOBTAIN_RETRIES`:
+        // - `DownloadFailed`/`NotFound`: no peer delivered the block, which wedges the checkpoint
+        //   frontier until the verify timeout (#5709).
+        // - `BehindTipHeightLimit`: the body was not a usable block for this hash, so the hash is
+        //   still missing (GHSA-g95h-hw6g-pvgv). This re-request runs whether or not the peer could
+        //   be attributed, and covers the window before a score reaches the address book, which
+        //   only applies misbehavior reports in batches.
+        // Consensus failures (`Invalid`/`ValidationRequestError`) are deliberately excluded —
         // re-downloading a block the network already rejected is pointless.
-        if let Err(BlockDownloadVerifyError::DownloadFailed { error, hash }) = &response {
-            if format!("{error:?}").contains("NotFound") {
-                let attempts = self.block_reobtain_retries.entry(*hash).or_insert(0);
-                if *attempts < MAX_BLOCK_REOBTAIN_RETRIES {
-                    *attempts += 1;
-                    self.reobtain_hashes.insert(*hash);
-                    debug!(
-                        ?hash,
-                        attempts = *attempts,
-                        "re-queueing missing block for re-download"
-                    );
-                } else {
-                    debug!(
-                        ?hash,
-                        "missing block exceeded re-download retries, dropping"
-                    );
-                    self.block_reobtain_retries.remove(hash);
-                }
+        let reobtain_hash = match &response {
+            Err(BlockDownloadVerifyError::DownloadFailed { error, hash })
+                if format!("{error:?}").contains("NotFound") =>
+            {
+                Some(*hash)
+            }
+            Err(BlockDownloadVerifyError::BehindTipHeightLimit { hash, .. }) => Some(*hash),
+            _ => None,
+        };
+
+        if let Some(hash) = reobtain_hash {
+            let attempts = self.block_reobtain_retries.entry(hash).or_insert(0);
+            if *attempts < MAX_BLOCK_REOBTAIN_RETRIES {
+                *attempts += 1;
+                self.reobtain_hashes.insert(hash);
+                debug!(
+                    ?hash,
+                    attempts = *attempts,
+                    "re-queueing missing block for re-download"
+                );
+            } else {
+                debug!(
+                    ?hash,
+                    "missing block exceeded re-download retries, dropping"
+                );
+                self.block_reobtain_retries.remove(&hash);
             }
         }
 
@@ -1321,8 +1364,8 @@ where
             BlockDownloadVerifyError::BehindTipHeightLimit { .. } => {
                 debug!(
                     error = ?e,
-                    "block height is behind the current state tip, \
-                     assuming the syncer will eventually catch up to the state, continuing"
+                    "block height is behind the current state tip: re-requesting the hash, \
+                     and scoring the peer if the body contradicts the parent we hold, continuing"
                 );
                 false
             }

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -1234,18 +1234,14 @@ where
                 let _ = self.misbehavior_sender.try_send((advertiser_addr, 100));
             }
 
-            // `AboveLookaheadHeightLimit` deliberately falls through unscored, and must stay
-            // that way (GHSA-qhr3-cvch-5fh2). GHSA-gvjc-3w7c-92jx originally scored
-            // `advertiser_addr` 100 here, but that names the peer that *served* the block,
-            // not the one that chose its height: `Response::BlockHashes` carries no address
-            // and multi-block `inv`s are never registered as inventory, so the follow-up
-            // getdata goes to an independently chosen, honest peer. Scoring it let a
-            // malicious `FindBlocks` responder evict honest peers throughout IBD.
-            //
-            // Unlike the behind-tip sibling advisory, the block here is genuine, so there is
-            // no local proof of forgery to re-attribute with. The block is still dropped in
-            // `downloads.rs` and the hash is re-requested once our tip advances. Do not
-            // restore symmetry with the arms above by adding scoring back.
+            // `AboveLookaheadHeightLimit` deliberately falls through unscored, and must
+            // stay that way (GHSA-qhr3-cvch-5fh2): `advertiser_addr` names the peer that
+            // *served* the block, not the one that chose its height — `FindBlocks`
+            // responses carry no address, so the follow-up request goes to an
+            // independently chosen, honest peer, and scoring it let a malicious
+            // `FindBlocks` responder evict honest peers throughout IBD. Unlike the
+            // behind-tip sibling advisory, the block here is genuine, so there is no
+            // local proof of forgery to re-attribute with. Do not add scoring back.
             Err(_) => {}
         };
 

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -1214,13 +1214,6 @@ where
                     .try_send((advertiser_addr, error.misbehavior_score()));
             }
 
-            Err(BlockDownloadVerifyError::AboveLookaheadHeightLimit {
-                advertiser_addr: Some(advertiser_addr),
-                ..
-            }) => {
-                let _ = self.misbehavior_sender.try_send((advertiser_addr, 100));
-            }
-
             Err(BlockDownloadVerifyError::InvalidHeight {
                 advertiser_addr: Some(advertiser_addr),
                 ..
@@ -1241,6 +1234,18 @@ where
                 let _ = self.misbehavior_sender.try_send((advertiser_addr, 100));
             }
 
+            // `AboveLookaheadHeightLimit` deliberately falls through unscored, and must stay
+            // that way (GHSA-qhr3-cvch-5fh2). GHSA-gvjc-3w7c-92jx originally scored
+            // `advertiser_addr` 100 here, but that names the peer that *served* the block,
+            // not the one that chose its height: `Response::BlockHashes` carries no address
+            // and multi-block `inv`s are never registered as inventory, so the follow-up
+            // getdata goes to an independently chosen, honest peer. Scoring it let a
+            // malicious `FindBlocks` responder evict honest peers throughout IBD.
+            //
+            // Unlike the behind-tip sibling advisory, the block here is genuine, so there is
+            // no local proof of forgery to re-attribute with. The block is still dropped in
+            // `downloads.rs` and the hash is re-requested once our tip advances. Do not
+            // restore symmetry with the arms above by adding scoring back.
             Err(_) => {}
         };
 

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -1221,12 +1221,12 @@ where
                 let _ = self.misbehavior_sender.try_send((advertiser_addr, 100));
             }
 
-            // The downloader only sets `advertiser_addr` here when the parent Zebra already holds
-            // proves the body's claimed height wrong. A peer can answer with a canonical header and
-            // a rewritten coinbase height because the initial hash check does not recompute the
-            // header's commitment to the body's authorizing data (GHSA-g95h-hw6g-pvgv). Peers that
-            // serve genuinely old blocks arrive unattributed and fall through unscored. Score a
-            // proven rewrite like the mirror-image above-lookahead drop.
+            // The downloader only sets `advertiser_addr` here when Zebra already holds the parent
+            // header and it proves the body's claimed height wrong. A peer can answer with a
+            // canonical header and a rewritten coinbase height because the initial hash check does
+            // not recompute the header's commitment to the body's authorizing data
+            // (GHSA-g95h-hw6g-pvgv). Peers that serve genuinely old blocks arrive unattributed and
+            // fall through unscored. Score only a parent-proven rewrite.
             Err(BlockDownloadVerifyError::BehindTipHeightLimit {
                 advertiser_addr: Some(advertiser_addr),
                 ..

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -1235,12 +1235,11 @@ where
             }
 
             // `AboveLookaheadHeightLimit` deliberately falls through unscored, and must
-            // stay that way (GHSA-qhr3-cvch-5fh2): `advertiser_addr` names the peer that
-            // *served* the block, not the one that chose its height — `FindBlocks`
-            // responses carry no address, so the follow-up request goes to an
-            // independently chosen, honest peer, and scoring it let a malicious
-            // `FindBlocks` responder evict honest peers throughout IBD. Unlike the
-            // behind-tip sibling advisory, the block here is genuine, so there is no
+            // stay that way (GHSA-qhr3-cvch-5fh2): `FindBlocks` responses carry no
+            // address, so the follow-up request goes to an independently chosen, honest
+            // peer that served the block but did not choose its height. Scoring it let a
+            // malicious `FindBlocks` responder evict honest peers throughout IBD. Unlike
+            // the behind-tip sibling advisory, the block here is genuine, so there is no
             // local proof of forgery to re-attribute with. Do not add scoring back.
             Err(_) => {}
         };

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -6,6 +6,7 @@ use std::{
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
+    time::Duration,
 };
 
 use futures::{
@@ -34,6 +35,9 @@ use crate::components::sync::{
     FINAL_CHECKPOINT_BLOCK_VERIFY_TIMEOUT, FINAL_CHECKPOINT_BLOCK_VERIFY_TIMEOUT_LIMIT,
 };
 
+#[cfg(test)]
+mod tests;
+
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 /// A multiplier used to calculate the extra number of blocks we allow in the
@@ -57,6 +61,13 @@ pub const VERIFICATION_PIPELINE_SCALING_MULTIPLIER: usize = 2;
 /// The maximum height difference between Zebra's state tip and a downloaded block.
 /// Blocks higher than this will get dropped and return an error.
 pub const VERIFICATION_PIPELINE_DROP_LIMIT: HeightDiff = 50_000;
+
+/// How long to wait for the parent-height lookup that decides whether a behind-tip block was
+/// forged.
+///
+/// Bounds a drop path that also fires for honest old blocks. Timing out is treated as "no proof",
+/// so a slow state read costs the peer nothing.
+const PARENT_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Copy, Clone, Debug)]
 pub(super) struct AlwaysHedge;
@@ -111,10 +122,19 @@ pub enum BlockDownloadVerifyError {
         advertiser_addr: Option<PeerSocketAddr>,
     },
 
+    /// A downloaded block claimed a height a long way behind the state chain tip.
+    ///
+    /// A peer can answer with a canonical header and a rewritten coinbase height because the
+    /// initial hash check does not recompute the header's commitment to the body's authorizing data
+    /// (GHSA-g95h-hw6g-pvgv). Peers also legitimately serve blocks that are genuinely this old, so
+    /// the block is always dropped, but `advertiser_addr` is only set when the parent Zebra already
+    /// holds proves the claimed height wrong — a block's height is one more than its parent's. An
+    /// authentic old block, or one whose parent Zebra does not hold, is dropped anonymously.
     #[error("downloaded block was too far behind the chain tip: {height:?} {hash:?}")]
     BehindTipHeightLimit {
         height: block::Height,
         hash: block::Hash,
+        advertiser_addr: Option<PeerSocketAddr>,
     },
 
     #[error("downloaded block had an invalid height: {hash:?}")]
@@ -175,7 +195,7 @@ impl From<tokio::time::error::Elapsed> for BlockDownloadVerifyError {
 /// Represents a [`Stream`] of download and verification tasks during chain sync.
 #[pin_project]
 #[derive(Debug)]
-pub struct Downloads<ZN, ZV, ZSTip>
+pub struct Downloads<ZN, ZV, ZS, ZSTip>
 where
     ZN: Service<zn::Request, Response = zn::Response, Error = BoxError> + Send + Sync + 'static,
     ZN::Future: Send,
@@ -185,6 +205,7 @@ where
         + Clone
         + 'static,
     ZV::Future: Send,
+    ZS: zs::ReadState + Sync,
     ZSTip: ChainTip + Clone + Send + 'static,
 {
     // Services
@@ -195,6 +216,12 @@ where
 
     /// A service that verifies downloaded blocks.
     verifier: ZV,
+
+    /// A read-only handle to the state, used to query the blocks Zebra already holds.
+    ///
+    /// Checks a downloaded block's claimed height against its parent's, so a rewritten coinbase
+    /// height can be told apart from a genuinely old block (GHSA-g95h-hw6g-pvgv).
+    read_state: ZS,
 
     /// Allows efficient access to the best tip of the blockchain.
     latest_chain_tip: ZSTip,
@@ -229,7 +256,7 @@ where
     cancel_handles: HashMap<block::Hash, oneshot::Sender<()>>,
 }
 
-impl<ZN, ZV, ZSTip> Stream for Downloads<ZN, ZV, ZSTip>
+impl<ZN, ZV, ZS, ZSTip> Stream for Downloads<ZN, ZV, ZS, ZSTip>
 where
     ZN: Service<zn::Request, Response = zn::Response, Error = BoxError> + Send + Sync + 'static,
     ZN::Future: Send,
@@ -239,6 +266,7 @@ where
         + Clone
         + 'static,
     ZV::Future: Send,
+    ZS: zs::ReadState + Sync,
     ZSTip: ChainTip + Clone + Send + 'static,
 {
     type Item = Result<(Height, block::Hash), BlockDownloadVerifyError>;
@@ -276,7 +304,7 @@ where
     }
 }
 
-impl<ZN, ZV, ZSTip> Downloads<ZN, ZV, ZSTip>
+impl<ZN, ZV, ZS, ZSTip> Downloads<ZN, ZV, ZS, ZSTip>
 where
     ZN: Service<zn::Request, Response = zn::Response, Error = BoxError> + Send + Sync + 'static,
     ZN::Future: Send,
@@ -286,6 +314,7 @@ where
         + Clone
         + 'static,
     ZV::Future: Send,
+    ZS: zs::ReadState + Sync,
     ZSTip: ChainTip + Clone + Send + 'static,
 {
     /// Initialize a new download stream with the provided `network` and
@@ -301,6 +330,7 @@ where
     pub fn new(
         network: ZN,
         verifier: ZV,
+        read_state: ZS,
         latest_chain_tip: ZSTip,
         past_lookahead_limit_sender: watch::Sender<bool>,
         lookahead_limit: usize,
@@ -312,6 +342,7 @@ where
         Self {
             network,
             verifier,
+            read_state,
             latest_chain_tip,
             lookahead_limit,
             max_checkpoint_height,
@@ -357,6 +388,7 @@ where
         let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
 
         let mut verifier = self.verifier.clone();
+        let read_state = self.read_state.clone();
         let latest_chain_tip = self.latest_chain_tip.clone();
 
         let lookahead_limit = self.lookahead_limit;
@@ -513,7 +545,46 @@ where
                     );
                     metrics::counter!("gossip.min.height.limit.dropped.block.count").increment(1);
 
-                    Err(BlockDownloadVerifyError::BehindTipHeightLimit { height: block_height, hash })?;
+                    // Security: only attribute the drop to the supplying peer when the block's own
+                    // parent proves the claimed height wrong.
+                    //
+                    // A peer can answer with a canonical header and a rewritten coinbase height
+                    // because the initial hash check does not recompute the header's commitment to
+                    // the body's authorizing data (GHSA-g95h-hw6g-pvgv). A block's height is one
+                    // more than its parent's, so a mismatch proves the body was rewritten.
+                    //
+                    // Peers legitimately serve genuinely old blocks: the syncer tolerates an
+                    // out-of-order first hash in `FindBlocks` responses, so a requested hash can
+                    // resolve to an old side-chain block that an honest peer still has. Those
+                    // responses are consistent with their parent, or have a parent we don't hold, so
+                    // they are dropped without scoring.
+                    let advertiser_addr = match advertiser_addr {
+                        Some(advertiser_addr) => match timeout(
+                            PARENT_LOOKUP_TIMEOUT,
+                            read_state.oneshot(zs::ReadRequest::BlockHeader(
+                                block.header.previous_block_hash.into(),
+                            )),
+                        )
+                        .await
+                        {
+                            Ok(Ok(zs::ReadResponse::BlockHeader {
+                                height: parent_height,
+                                ..
+                            })) if (parent_height + 1) != Some(block_height) => Some(advertiser_addr),
+                            // Parent unknown, height consistent with it, or the lookup failed or
+                            // timed out: there is no proof of misbehaviour, so the peer is not
+                            // scored.
+                            _ => None,
+                        },
+                        // There is no peer to score, so skip the state lookup.
+                        None => None,
+                    };
+
+                    return Err(BlockDownloadVerifyError::BehindTipHeightLimit {
+                        height: block_height,
+                        hash,
+                        advertiser_addr,
+                    });
                 }
 
                 // Wait for the verifier service to be ready.

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -119,7 +119,6 @@ pub enum BlockDownloadVerifyError {
     AboveLookaheadHeightLimit {
         height: block::Height,
         hash: block::Hash,
-        advertiser_addr: Option<PeerSocketAddr>,
     },
 
     /// A downloaded block claimed a height a long way behind the state chain tip.
@@ -488,7 +487,10 @@ where
                 };
 
                 if block_height > lookahead_drop_height {
-                    Err(BlockDownloadVerifyError::AboveLookaheadHeightLimit { height: block_height, hash, advertiser_addr })?;
+                    Err(BlockDownloadVerifyError::AboveLookaheadHeightLimit {
+                        height: block_height,
+                        hash,
+                    })?;
                 } else if block_height > lookahead_pause_height {
                     // This log can be very verbose, usually hundreds of blocks are dropped.
                     // So we only log at info level for the first above-height block.

--- a/zebrad/src/components/sync/downloads/tests.rs
+++ b/zebrad/src/components/sync/downloads/tests.rs
@@ -1,0 +1,409 @@
+//! Fixed test vectors for the syncer's block download stream.
+
+use std::{iter, sync::Arc, time::Duration};
+
+use futures::stream::StreamExt;
+use tokio::sync::watch;
+
+use zebra_chain::{
+    block::{self, Block, Height},
+    chain_tip::mock::MockChainTip,
+    serialization::ZcashDeserializeInto,
+};
+use zebra_network::{InventoryResponse, PeerSocketAddr};
+use zebra_state::MAX_BLOCK_REORG_HEIGHT;
+use zebra_test::mock_service::{MockService, PanicAssertion};
+
+use zebra_network as zn;
+use zebra_state as zs;
+
+use crate::components::sync::MIN_CHECKPOINT_CONCURRENCY_LIMIT;
+
+use super::{BlockDownloadVerifyError, Downloads};
+
+use InventoryResponse::*;
+
+/// Maximum time to wait for a request to any test service.
+///
+/// These tests run the download task in parallel with the test, so machines under heavy load need a
+/// longer delay.
+const MAX_SERVICE_REQUEST_DELAY: Duration = Duration::from_millis(1000);
+
+/// A peer address used to check whether the supplying peer can be scored.
+const ADVERTISER: &str = "127.0.0.1:8233";
+
+type MockNetwork = MockService<zn::Request, zn::Response, PanicAssertion>;
+type MockVerifier = MockService<zebra_consensus::Request, block::Hash, PanicAssertion>;
+type MockState = MockService<zs::ReadRequest, zs::ReadResponse, PanicAssertion>;
+
+/// Build a downloader whose state tip is at `tip_height`, returning the mock network, verifier, and
+/// state services so a test can drive and assert on them.
+#[allow(clippy::type_complexity)]
+fn mock_downloads(
+    tip_height: Height,
+) -> (
+    Downloads<MockNetwork, MockVerifier, MockState, MockChainTip>,
+    MockNetwork,
+    MockVerifier,
+    MockState,
+) {
+    let network: MockNetwork = MockService::build()
+        .with_max_request_delay(MAX_SERVICE_REQUEST_DELAY)
+        .for_unit_tests();
+
+    let verifier: MockVerifier = MockService::build()
+        .with_max_request_delay(MAX_SERVICE_REQUEST_DELAY)
+        .for_unit_tests();
+
+    let state: MockState = MockService::build()
+        .with_max_request_delay(MAX_SERVICE_REQUEST_DELAY)
+        .for_unit_tests();
+
+    let (latest_chain_tip, chain_tip_sender) = MockChainTip::new();
+    chain_tip_sender.send_best_tip_height(tip_height);
+    // Dropping the sender is fine: `watch::Receiver::borrow` keeps returning the height we just
+    // sent, and no test changes the tip mid-run.
+
+    let (past_lookahead_limit_sender, _past_lookahead_limit_receiver) = watch::channel(false);
+
+    // `max_checkpoint_height` is far above the test blocks, so the final-checkpoint verify timeout
+    // workaround does not apply.
+    let downloads = Downloads::new(
+        network.clone(),
+        verifier.clone(),
+        state.clone(),
+        latest_chain_tip,
+        past_lookahead_limit_sender,
+        MIN_CHECKPOINT_CONCURRENCY_LIMIT,
+        Height(1_000_000),
+    );
+
+    (downloads, network, verifier, state)
+}
+
+/// Load the mainnet block 1 vector, which these tests use as a low-height block body.
+fn block_1() -> Arc<Block> {
+    zebra_test::vectors::BLOCK_MAINNET_1_BYTES
+        .zcash_deserialize_into()
+        .expect("hard-coded block vector deserializes")
+}
+
+/// Load the mainnet block 2 vector.
+fn block_2() -> Arc<Block> {
+    zebra_test::vectors::BLOCK_MAINNET_2_BYTES
+        .zcash_deserialize_into()
+        .expect("hard-coded block vector deserializes")
+}
+
+/// Load the mainnet genesis block vector.
+fn genesis() -> Arc<Block> {
+    zebra_test::vectors::BLOCK_MAINNET_GENESIS_BYTES
+        .zcash_deserialize_into()
+        .expect("hard-coded block vector deserializes")
+}
+
+/// Regression test for GHSA-g95h-hw6g-pvgv: a body whose claimed height contradicts the parent we
+/// already hold is attributed to the peer that supplied it, and never reaches consensus.
+///
+/// A peer can answer with a canonical header and rewritten coinbase height because the initial hash
+/// check does not recompute the header's commitment to the body's authorizing data. The parent is
+/// the proof: a block's height is one more than its parent's.
+#[tokio::test]
+async fn contradicted_behind_tip_height_is_attributed_and_never_verified() {
+    let _init_guard = zebra_test::init();
+
+    // The tip is far enough ahead that a claimed height of 1 is behind the reorg limit.
+    let (mut downloads, mut network, mut verifier, mut state) =
+        mock_downloads(Height(2 * MAX_BLOCK_REORG_HEIGHT));
+
+    // Block 2's header with block 1's body: the hash and parent are block 2's, because the hash
+    // covers only the header, but the coinbase now claims height 1 instead of 2. This is the shape
+    // of the reported attack, without reproducing the hash-preserving rewrite itself.
+    let block_1 = block_1();
+    let block_2 = block_2();
+    let block = Arc::new(Block {
+        header: block_2.header.clone(),
+        transactions: block_1.transactions.clone(),
+    });
+    let hash = block.hash();
+    assert_eq!(
+        hash,
+        block_2.hash(),
+        "the block hash covers only the header"
+    );
+    assert_eq!(
+        block.coinbase_height(),
+        Some(Height(1)),
+        "the body must claim the height the downloader reads"
+    );
+
+    let advertiser: PeerSocketAddr = ADVERTISER.parse().expect("hard-coded address is valid");
+
+    downloads
+        .download_and_verify(hash)
+        .await
+        .expect("download is queued");
+
+    network
+        .expect_request(zn::Request::BlocksByHash(iter::once(hash).collect()))
+        .await
+        .respond(zn::Response::Blocks(vec![Available((
+            block.clone(),
+            Some(advertiser),
+        ))]));
+
+    // We hold the real parent, block 1, so the body's real height is 2, not the 1 it claims.
+    state
+        .expect_request(zs::ReadRequest::BlockHeader(
+            block.header.previous_block_hash.into(),
+        ))
+        .await
+        .respond(zs::ReadResponse::BlockHeader {
+            header: block_1.header.clone(),
+            hash: block_1.hash(),
+            height: Height(1),
+            next_block_hash: Some(hash),
+        });
+
+    let error = downloads
+        .next()
+        .await
+        .expect("downloads is non-empty")
+        .expect_err("block behind the reorg limit is dropped");
+
+    assert!(
+        matches!(
+            error,
+            BlockDownloadVerifyError::BehindTipHeightLimit {
+                height: Height(1),
+                hash: error_hash,
+                advertiser_addr: Some(error_advertiser),
+            } if error_hash == hash && error_advertiser == advertiser
+        ),
+        "a contradicted behind-tip height must report the height, hash, and supplying peer, \
+         but was: {error:?}"
+    );
+
+    // The rewritten body is dropped before consensus validation, which is why the peer must be
+    // scored on this path instead.
+    verifier.expect_no_requests().await;
+}
+
+/// A peer that serves a genuinely old block is not attributed, so it cannot be scored.
+///
+/// The syncer tolerates an out-of-order first hash in `FindBlocks` responses, so a requested hash
+/// can resolve to an old block that an honest peer still holds. Its height agrees with its parent's,
+/// so there is no proof of misbehaviour and the drop must stay anonymous.
+#[tokio::test]
+async fn genuinely_old_block_is_dropped_without_attribution() {
+    let _init_guard = zebra_test::init();
+
+    let (mut downloads, mut network, mut verifier, mut state) =
+        mock_downloads(Height(2 * MAX_BLOCK_REORG_HEIGHT));
+
+    let block = block_1();
+    let hash = block.hash();
+    let advertiser: PeerSocketAddr = ADVERTISER.parse().expect("hard-coded address is valid");
+
+    downloads
+        .download_and_verify(hash)
+        .await
+        .expect("download is queued");
+
+    network
+        .expect_request(zn::Request::BlocksByHash(iter::once(hash).collect()))
+        .await
+        .respond(zn::Response::Blocks(vec![Available((
+            block.clone(),
+            Some(advertiser),
+        ))]));
+
+    // The parent is genesis, one below the height the body claims: the body is authentic.
+    let genesis = genesis();
+    assert_eq!(
+        block.header.previous_block_hash,
+        genesis.hash(),
+        "block 1's parent is genesis"
+    );
+    state
+        .expect_request(zs::ReadRequest::BlockHeader(
+            block.header.previous_block_hash.into(),
+        ))
+        .await
+        .respond(zs::ReadResponse::BlockHeader {
+            header: genesis.header.clone(),
+            hash: genesis.hash(),
+            height: Height(0),
+            next_block_hash: Some(hash),
+        });
+
+    let error = downloads
+        .next()
+        .await
+        .expect("downloads is non-empty")
+        .expect_err("block behind the reorg limit is dropped");
+
+    assert!(
+        matches!(
+            error,
+            BlockDownloadVerifyError::BehindTipHeightLimit {
+                advertiser_addr: None,
+                ..
+            }
+        ),
+        "an authentic old block must not be attributed to its peer, but was: {error:?}"
+    );
+
+    verifier.expect_no_requests().await;
+}
+
+/// A peer whose old block has a parent we do not hold is not attributed either: without the parent
+/// there is no proof the height was rewritten.
+#[tokio::test]
+async fn behind_tip_block_with_unknown_parent_is_not_attributed() {
+    let _init_guard = zebra_test::init();
+
+    let (mut downloads, mut network, mut verifier, mut state) =
+        mock_downloads(Height(2 * MAX_BLOCK_REORG_HEIGHT));
+
+    let block = block_1();
+    let hash = block.hash();
+    let advertiser: PeerSocketAddr = ADVERTISER.parse().expect("hard-coded address is valid");
+
+    downloads
+        .download_and_verify(hash)
+        .await
+        .expect("download is queued");
+
+    network
+        .expect_request(zn::Request::BlocksByHash(iter::once(hash).collect()))
+        .await
+        .respond(zn::Response::Blocks(vec![Available((
+            block.clone(),
+            Some(advertiser),
+        ))]));
+
+    state
+        .expect_request(zs::ReadRequest::BlockHeader(
+            block.header.previous_block_hash.into(),
+        ))
+        .await
+        .respond(Err(zn::BoxError::from("block not found in any chain")));
+
+    let error = downloads
+        .next()
+        .await
+        .expect("downloads is non-empty")
+        .expect_err("block behind the reorg limit is dropped");
+
+    assert!(
+        matches!(
+            error,
+            BlockDownloadVerifyError::BehindTipHeightLimit {
+                advertiser_addr: None,
+                ..
+            }
+        ),
+        "a block whose parent we do not hold must not be attributed, but was: {error:?}"
+    );
+
+    verifier.expect_no_requests().await;
+}
+
+/// The parent lookup is bounded: when the state does not answer, the block is still dropped and
+/// the peer is still not attributed.
+///
+/// Paused time lets the runtime advance past `PARENT_LOOKUP_TIMEOUT` as soon as the download task
+/// is the only thing waiting, so the test does not sleep for real.
+#[tokio::test(start_paused = true)]
+async fn behind_tip_parent_lookup_timeout_is_not_attributed() {
+    let _init_guard = zebra_test::init();
+
+    let (mut downloads, mut network, mut verifier, _state) =
+        mock_downloads(Height(2 * MAX_BLOCK_REORG_HEIGHT));
+
+    let block = block_1();
+    let hash = block.hash();
+    let advertiser: PeerSocketAddr = ADVERTISER.parse().expect("hard-coded address is valid");
+
+    downloads
+        .download_and_verify(hash)
+        .await
+        .expect("download is queued");
+
+    network
+        .expect_request(zn::Request::BlocksByHash(iter::once(hash).collect()))
+        .await
+        .respond(zn::Response::Blocks(vec![Available((
+            block.clone(),
+            Some(advertiser),
+        ))]));
+
+    // The state service is deliberately never answered, so the lookup can only end by timing out.
+    let error = downloads
+        .next()
+        .await
+        .expect("downloads is non-empty")
+        .expect_err("block behind the reorg limit is dropped");
+
+    assert!(
+        matches!(
+            error,
+            BlockDownloadVerifyError::BehindTipHeightLimit {
+                advertiser_addr: None,
+                ..
+            }
+        ),
+        "a timed-out parent lookup must not attribute the drop, but was: {error:?}"
+    );
+
+    verifier.expect_no_requests().await;
+}
+
+/// A block at the oldest height the syncer can legitimately be served is verified, not dropped.
+///
+/// This is the guard against dropping and attributing honest near-boundary blocks:
+/// `min_accepted_height` is the boundary, and the behind-tip comparison is strict, so a block
+/// exactly on it is a normal download and the state is never consulted.
+#[tokio::test]
+async fn block_at_reorg_boundary_is_verified_not_dropped() {
+    let _init_guard = zebra_test::init();
+
+    // `min_accepted_height` is `Height(1)`, so the height-1 block sits exactly on the boundary.
+    let (mut downloads, mut network, mut verifier, mut state) =
+        mock_downloads(Height(MAX_BLOCK_REORG_HEIGHT + 1));
+
+    let block = block_1();
+    let hash = block.hash();
+    let advertiser: PeerSocketAddr = ADVERTISER.parse().expect("hard-coded address is valid");
+
+    downloads
+        .download_and_verify(hash)
+        .await
+        .expect("download is queued");
+
+    network
+        .expect_request(zn::Request::BlocksByHash(iter::once(hash).collect()))
+        .await
+        .respond(zn::Response::Blocks(vec![Available((
+            block.clone(),
+            Some(advertiser),
+        ))]));
+
+    verifier
+        .expect_request(zebra_consensus::Request::Commit(block))
+        .await
+        .respond(hash);
+
+    assert_eq!(
+        downloads
+            .next()
+            .await
+            .expect("downloads is non-empty")
+            .expect("block on the reorg boundary is verified"),
+        (Height(1), hash),
+        "a block at min_accepted_height must be verified, not dropped as behind the tip"
+    );
+
+    state.expect_no_requests().await;
+}

--- a/zebrad/src/components/sync/tests/timing.rs
+++ b/zebrad/src/components/sync/tests/timing.rs
@@ -150,6 +150,12 @@ fn request_genesis_is_rate_limited() {
         }
     });
 
+    // create a read-only state service that is never called: the genesis download fails before any
+    // block body is available to check
+    let read_state_service = tower::service_fn(move |_request| async move {
+        unreachable!("no request to this service is allowed")
+    });
+
     // create an empty latest chain tip
     let (_sender, latest_chain_tip, _change) = ChainTipSender::new(None, &Network::Mainnet);
 
@@ -167,6 +173,7 @@ fn request_genesis_is_rate_limited() {
         peer_service,
         verifier_service,
         state_service,
+        read_state_service,
         latest_chain_tip,
         misbehavior_tx,
     );

--- a/zebrad/src/components/sync/tests/vectors.rs
+++ b/zebrad/src/components/sync/tests/vectors.rs
@@ -10,6 +10,7 @@ use futures::{Future, FutureExt};
 use zebra_chain::{
     block::{self, Block, Height},
     chain_tip::mock::{MockChainTip, MockChainTipSender},
+    parameters::subsidy::SubsidyError,
     serialization::ZcashDeserializeInto,
 };
 use zebra_consensus::{Config as ConsensusConfig, RouterError, VerifyBlockError};
@@ -1573,6 +1574,81 @@ async fn download_failed_is_only_requeued_for_not_found() {
             Err(tokio::sync::mpsc::error::TryRecvError::Empty)
         ),
         "a failed download must not score any peer"
+    );
+}
+
+/// Verifies fix for GHSA-qhr3-cvch-5fh2: a block that lands above the lookahead
+/// height limit must NOT score the peer that served it.
+///
+/// A malicious peer can answer `FindBlocks` with real but far-ahead block hashes.
+/// Those hashes carry no peer attribution, and `FindBlocks` suppliers are never
+/// registered in the inventory registry, so the follow-up `BlocksByHash` getdata is
+/// routed to an independently chosen, honest peer. That honest peer returns exactly
+/// the block we asked for, the download fails with `AboveLookaheadHeightLimit`, and
+/// `advertiser_addr` names the *serving* peer, not the peer that supplied the hash.
+/// Scoring on this path therefore bans an honest peer at the attacker's direction.
+///
+/// This drives the real [`ChainSync::handle_block_response`] method and asserts that
+/// nothing at all reaches the misbehavior channel.
+#[tokio::test]
+async fn far_ahead_block_does_not_score_serving_peer() {
+    let (mut chain_sync, mut misbehavior_rx) = new_chain_sync_with_misbehavior();
+
+    let serving_peer: PeerSocketAddr = "127.0.0.1:8233".parse().unwrap();
+
+    let _ = chain_sync.handle_block_response(Err(
+        BlockDownloadVerifyError::AboveLookaheadHeightLimit {
+            height: block::Height(60_000),
+            hash: block::Hash::from([0xBB; 32]),
+            advertiser_addr: Some(serving_peer),
+        },
+    ));
+
+    let received = misbehavior_rx.try_recv();
+
+    assert_eq!(
+        received,
+        Err(tokio::sync::mpsc::error::TryRecvError::Empty),
+        "GHSA-qhr3-cvch-5fh2: an above-lookahead block must not produce any misbehavior \
+         score. `advertiser_addr` here is the peer that *served* the block we explicitly \
+         requested, not the peer that supplied the far-ahead hash, so scoring it lets a \
+         malicious peer get arbitrary honest peers banned. Got: {received:?}"
+    );
+}
+
+/// Positive control for the GHSA-qhr3-cvch-5fh2 fix: removing the above-lookahead
+/// scoring must not disable misbehavior scoring in general.
+///
+/// A `BlockDownloadVerifyError::Invalid` with a non-zero `misbehavior_score()` and a
+/// known advertiser still has to reach the misbehavior channel. This test passes both
+/// before and after the fix.
+#[tokio::test]
+async fn invalid_block_still_scores_advertising_peer() {
+    let (mut chain_sync, mut misbehavior_rx) = new_chain_sync_with_misbehavior();
+
+    let advertiser: PeerSocketAddr = "127.0.0.1:8233".parse().unwrap();
+
+    let router_error = RouterError::Block {
+        source: Box::new(VerifyBlockError::Subsidy(SubsidyError::NoCoinbase)),
+    };
+    let expected_score = router_error.misbehavior_score();
+    assert_ne!(
+        expected_score, 0,
+        "this control needs an error with a non-zero misbehavior score"
+    );
+
+    let _ = chain_sync.handle_block_response(Err(BlockDownloadVerifyError::Invalid {
+        error: router_error,
+        height: block::Height(60_000),
+        hash: block::Hash::from([0xAB; 32]),
+        advertiser_addr: Some(advertiser),
+    }));
+
+    assert_eq!(
+        misbehavior_rx.try_recv(),
+        Ok((advertiser, expected_score)),
+        "consensus-invalid blocks must still score the advertising peer — the \
+         GHSA-qhr3-cvch-5fh2 fix only removes the above-lookahead attribution"
     );
 }
 

--- a/zebrad/src/components/sync/tests/vectors.rs
+++ b/zebrad/src/components/sync/tests/vectors.rs
@@ -1289,6 +1289,7 @@ async fn should_restart_sync_returns_false() {
     let restart = ChainSync::<
         MockService<zn::Request, zn::Response, PanicAssertion>,
         MockService<zs::Request, zs::Response, PanicAssertion>,
+        MockService<zs::ReadRequest, zs::ReadResponse, PanicAssertion>,
         MockService<zebra_consensus::Request, block::Hash, PanicAssertion>,
         MockChainTip,
     >::should_restart_sync(&err);
@@ -1311,6 +1312,7 @@ async fn above_lookahead_does_not_restart_sync() {
     let restart = ChainSync::<
         MockService<zn::Request, zn::Response, PanicAssertion>,
         MockService<zs::Request, zs::Response, PanicAssertion>,
+        MockService<zs::ReadRequest, zs::ReadResponse, PanicAssertion>,
         MockService<zebra_consensus::Request, block::Hash, PanicAssertion>,
         MockChainTip,
     >::should_restart_sync(&err);
@@ -1353,6 +1355,7 @@ async fn both_height_limits_do_not_restart_sync() {
     let below = BlockDownloadVerifyError::BehindTipHeightLimit {
         height: block::Height(1),
         hash: block::Hash::from([0xDD; 32]),
+        advertiser_addr: None,
     };
 
     let above = BlockDownloadVerifyError::AboveLookaheadHeightLimit {
@@ -1364,6 +1367,7 @@ async fn both_height_limits_do_not_restart_sync() {
     let restart_below = ChainSync::<
         MockService<zn::Request, zn::Response, PanicAssertion>,
         MockService<zs::Request, zs::Response, PanicAssertion>,
+        MockService<zs::ReadRequest, zs::ReadResponse, PanicAssertion>,
         MockService<zebra_consensus::Request, block::Hash, PanicAssertion>,
         MockChainTip,
     >::should_restart_sync(&below);
@@ -1371,6 +1375,7 @@ async fn both_height_limits_do_not_restart_sync() {
     let restart_above = ChainSync::<
         MockService<zn::Request, zn::Response, PanicAssertion>,
         MockService<zs::Request, zs::Response, PanicAssertion>,
+        MockService<zs::ReadRequest, zs::ReadResponse, PanicAssertion>,
         MockService<zebra_consensus::Request, block::Hash, PanicAssertion>,
         MockChainTip,
     >::should_restart_sync(&above);
@@ -1398,6 +1403,7 @@ async fn invalid_height_does_not_restart_sync() {
     let restart = ChainSync::<
         MockService<zn::Request, zn::Response, PanicAssertion>,
         MockService<zs::Request, zs::Response, PanicAssertion>,
+        MockService<zs::ReadRequest, zs::ReadResponse, PanicAssertion>,
         MockService<zebra_consensus::Request, block::Hash, PanicAssertion>,
         MockChainTip,
     >::should_restart_sync(&err);
@@ -1417,6 +1423,198 @@ async fn invalid_height_does_not_restart_sync() {
         has_addr,
         "InvalidHeight should carry advertiser_addr for peer scoring"
     );
+}
+
+/// Regression test for GHSA-g95h-hw6g-pvgv: a behind-tip drop scores the supplying peer and
+/// re-queues the hash the syncer still needs.
+///
+/// Before this fix the drop was free for the peer: it satisfied the download request without
+/// delivering a usable block, was never scored, and the hash waited for the next sync round.
+#[tokio::test]
+async fn behind_tip_height_limit_scores_peer_and_requeues_hash() {
+    let (mut chain_sync, mut misbehavior_rx) = new_chain_sync_with_misbehavior();
+
+    let advertiser: PeerSocketAddr = "127.0.0.1:8233".parse().unwrap();
+    let hash = block::Hash::from([0xAB; 32]);
+
+    chain_sync
+        .handle_block_response(Err(BlockDownloadVerifyError::BehindTipHeightLimit {
+            height: block::Height(1),
+            hash,
+            advertiser_addr: Some(advertiser),
+        }))
+        .expect("behind-tip drop is non-fatal and must not restart the syncer");
+
+    assert_eq!(
+        misbehavior_rx.try_recv().ok(),
+        Some((advertiser, 100)),
+        "BehindTipHeightLimit must score the supplying peer at the ban threshold"
+    );
+    assert!(
+        chain_sync.reobtain_hashes.contains(&hash),
+        "BehindTipHeightLimit must re-queue the hash the syncer still needs"
+    );
+}
+
+/// A behind-tip drop with no peer attribution still re-queues the hash.
+///
+/// Responses from isolated connections have no transient address, so there is nothing to score, but
+/// the hash is still missing.
+#[tokio::test]
+async fn behind_tip_height_limit_without_advertiser_is_still_requeued() {
+    let (mut chain_sync, mut misbehavior_rx) = new_chain_sync_with_misbehavior();
+
+    let hash = block::Hash::from([0xBC; 32]);
+
+    chain_sync
+        .handle_block_response(Err(BlockDownloadVerifyError::BehindTipHeightLimit {
+            height: block::Height(1),
+            hash,
+            advertiser_addr: None,
+        }))
+        .expect("behind-tip drop is non-fatal and must not restart the syncer");
+
+    assert!(
+        matches!(
+            misbehavior_rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ),
+        "an unattributed behind-tip drop must not score any peer"
+    );
+    assert!(
+        chain_sync.reobtain_hashes.contains(&hash),
+        "an unattributed behind-tip drop must still re-queue the hash"
+    );
+}
+
+/// The behind-tip re-request is bounded, so a peer cannot turn it into an unbounded download loop.
+#[tokio::test]
+async fn behind_tip_height_limit_requeue_is_bounded() {
+    let (mut chain_sync, _misbehavior_rx) = new_chain_sync_with_misbehavior();
+
+    let advertiser: PeerSocketAddr = "127.0.0.1:8233".parse().unwrap();
+    let hash = block::Hash::from([0xCD; 32]);
+
+    for attempt in 1..=sync::MAX_BLOCK_REOBTAIN_RETRIES + 1 {
+        chain_sync
+            .handle_block_response(Err(BlockDownloadVerifyError::BehindTipHeightLimit {
+                height: block::Height(1),
+                hash,
+                advertiser_addr: Some(advertiser),
+            }))
+            .expect("behind-tip drop is non-fatal and must not restart the syncer");
+
+        if attempt <= sync::MAX_BLOCK_REOBTAIN_RETRIES {
+            assert!(
+                chain_sync.reobtain_hashes.contains(&hash),
+                "attempt {attempt} of {} must re-queue the hash",
+                sync::MAX_BLOCK_REOBTAIN_RETRIES
+            );
+        } else {
+            assert!(
+                chain_sync.reobtain_hashes.is_empty(),
+                "the hash must not be re-queued after {} retries",
+                sync::MAX_BLOCK_REOBTAIN_RETRIES
+            );
+            assert!(
+                !chain_sync.block_reobtain_retries.contains_key(&hash),
+                "exhausted retry bookkeeping must be dropped"
+            );
+        }
+
+        // Stand in for `reobtain_missing_blocks()`, which drains the set each sync round.
+        chain_sync.reobtain_hashes.clear();
+    }
+}
+
+/// The pre-existing `NotFound` re-request (#5709) still works, and only fires for `NotFound`.
+///
+/// Both cases now share one bounded re-queue, so this pins the behavior the behind-tip fix reuses.
+#[tokio::test]
+async fn download_failed_is_only_requeued_for_not_found() {
+    let (mut chain_sync, mut misbehavior_rx) = new_chain_sync_with_misbehavior();
+
+    let missing_hash = block::Hash::from([0xDE; 32]);
+    chain_sync
+        .handle_block_response(Err(BlockDownloadVerifyError::DownloadFailed {
+            error: std::io::Error::new(std::io::ErrorKind::NotFound, "NotFoundResponse").into(),
+            hash: missing_hash,
+        }))
+        .expect("a missing block is non-fatal and must not restart the syncer");
+
+    assert!(
+        chain_sync.reobtain_hashes.contains(&missing_hash),
+        "a block no peer delivered must be re-queued (#5709)"
+    );
+
+    // A download that failed for any other reason is a syncer restart, and is not re-queued.
+    let failed_hash = block::Hash::from([0xEF; 32]);
+    let restart = chain_sync
+        .handle_block_response(Err(BlockDownloadVerifyError::DownloadFailed {
+            error: std::io::Error::new(std::io::ErrorKind::ConnectionReset, "connection reset")
+                .into(),
+            hash: failed_hash,
+        }))
+        .is_err();
+    assert!(
+        restart,
+        "a download that failed for another reason must restart the syncer"
+    );
+
+    assert!(
+        !chain_sync.reobtain_hashes.contains(&failed_hash),
+        "a download that failed for another reason must not be re-queued"
+    );
+
+    // Neither case attributes misbehavior: the download never produced a block to judge.
+    assert!(
+        matches!(
+            misbehavior_rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ),
+        "a failed download must not score any peer"
+    );
+}
+
+/// Build a [`ChainSync`] wired to mock services, returning the receiver end of the misbehavior
+/// channel so a test can assert whether a peer was scored.
+///
+/// Unlike [`setup`], this returns the `ChainSync` value itself rather than its `sync` future, so a
+/// test can call response-handling methods directly.
+#[allow(clippy::type_complexity)]
+fn new_chain_sync_with_misbehavior() -> (
+    ChainSync<
+        MockService<zn::Request, zn::Response, PanicAssertion>,
+        MockService<zs::Request, zs::Response, PanicAssertion>,
+        MockService<zs::ReadRequest, zs::ReadResponse, PanicAssertion>,
+        MockService<zebra_consensus::Request, block::Hash, PanicAssertion>,
+        MockChainTip,
+    >,
+    tokio::sync::mpsc::Receiver<(PeerSocketAddr, u32)>,
+) {
+    let _init_guard = zebra_test::init();
+
+    let config = ZebradConfig {
+        consensus: ConsensusConfig::default(),
+        state: StateConfig::ephemeral(),
+        ..Default::default()
+    };
+
+    let (mock_chain_tip, _mock_chain_tip_sender) = MockChainTip::new();
+
+    let (misbehavior_tx, misbehavior_rx) = tokio::sync::mpsc::channel(4);
+    let (chain_sync, _sync_status) = ChainSync::new(
+        &config,
+        Height(0),
+        MockService::build().for_unit_tests(),
+        MockService::build().for_unit_tests(),
+        MockService::build().for_unit_tests(),
+        MockService::build().for_unit_tests(),
+        mock_chain_tip,
+        misbehavior_tx,
+    );
+
+    (chain_sync, misbehavior_rx)
 }
 
 fn setup() -> (
@@ -1456,6 +1654,11 @@ fn setup() -> (
         .with_max_request_delay(MAX_SERVICE_REQUEST_DELAY)
         .for_unit_tests();
 
+    let read_state_service: MockService<zs::ReadRequest, zs::ReadResponse, PanicAssertion> =
+        MockService::build()
+            .with_max_request_delay(MAX_SERVICE_REQUEST_DELAY)
+            .for_unit_tests();
+
     let (mock_chain_tip, mock_chain_tip_sender) = MockChainTip::new();
 
     let (misbehavior_tx, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
@@ -1465,6 +1668,7 @@ fn setup() -> (
         peer_set.clone(),
         block_verifier_router.clone(),
         state_service.clone(),
+        read_state_service,
         mock_chain_tip,
         misbehavior_tx,
     );

--- a/zebrad/src/components/sync/tests/vectors.rs
+++ b/zebrad/src/components/sync/tests/vectors.rs
@@ -1324,31 +1324,6 @@ async fn above_lookahead_does_not_restart_sync() {
     );
 }
 
-/// Verifies fix for GHSA-gvjc-3w7c-92jx: `AboveLookaheadHeightLimit` now
-/// carries `advertiser_addr` so the offending peer can be scored.
-#[tokio::test]
-async fn above_lookahead_has_peer_attribution() {
-    let addr: PeerSocketAddr = "127.0.0.1:8233".parse().unwrap();
-    let err = BlockDownloadVerifyError::AboveLookaheadHeightLimit {
-        height: block::Height(60_000),
-        hash: block::Hash::from([0xCC; 32]),
-        advertiser_addr: Some(addr),
-    };
-
-    let has_addr = match &err {
-        BlockDownloadVerifyError::AboveLookaheadHeightLimit {
-            advertiser_addr, ..
-        } => advertiser_addr.is_some(),
-        _ => false,
-    };
-
-    assert!(
-        has_addr,
-        "AboveLookaheadHeightLimit should carry advertiser_addr for peer scoring \
-         (GHSA-gvjc-3w7c-92jx fix)"
-    );
-}
-
 /// Verifies fix for GHSA-gvjc-3w7c-92jx: both height-limit errors now
 /// return `false` from `should_restart_sync` — symmetric handling.
 #[tokio::test]
@@ -1578,56 +1553,21 @@ async fn download_failed_is_only_requeued_for_not_found() {
 }
 
 /// Verifies fix for GHSA-qhr3-cvch-5fh2: a block that lands above the lookahead
-/// height limit must NOT score the peer that served it.
+/// height limit must NOT score the peer that served it, while consensus-invalid
+/// blocks still must.
 ///
-/// A malicious peer can answer `FindBlocks` with real but far-ahead block hashes.
-/// Those hashes carry no peer attribution, and `FindBlocks` suppliers are never
-/// registered in the inventory registry, so the follow-up `BlocksByHash` getdata is
-/// routed to an independently chosen, honest peer. That honest peer returns exactly
-/// the block we asked for, the download fails with `AboveLookaheadHeightLimit`, and
-/// `advertiser_addr` names the *serving* peer, not the peer that supplied the hash.
-/// Scoring on this path therefore bans an honest peer at the attacker's direction.
-///
-/// This drives the real [`ChainSync::handle_block_response`] method and asserts that
-/// nothing at all reaches the misbehavior channel.
+/// Far-ahead hashes from a malicious `FindBlocks` response carry no peer attribution,
+/// so the follow-up `BlocksByHash` request is routed to an independently chosen,
+/// honest peer — `advertiser_addr` names the *serving* peer, not the peer that chose
+/// the height. Scoring this path bans honest peers at the attacker's direction.
 #[tokio::test]
 async fn far_ahead_block_does_not_score_serving_peer() {
     let (mut chain_sync, mut misbehavior_rx) = new_chain_sync_with_misbehavior();
 
-    let serving_peer: PeerSocketAddr = "127.0.0.1:8233".parse().unwrap();
+    let peer: PeerSocketAddr = "127.0.0.1:8233".parse().unwrap();
 
-    let _ = chain_sync.handle_block_response(Err(
-        BlockDownloadVerifyError::AboveLookaheadHeightLimit {
-            height: block::Height(60_000),
-            hash: block::Hash::from([0xBB; 32]),
-            advertiser_addr: Some(serving_peer),
-        },
-    ));
-
-    let received = misbehavior_rx.try_recv();
-
-    assert_eq!(
-        received,
-        Err(tokio::sync::mpsc::error::TryRecvError::Empty),
-        "GHSA-qhr3-cvch-5fh2: an above-lookahead block must not produce any misbehavior \
-         score. `advertiser_addr` here is the peer that *served* the block we explicitly \
-         requested, not the peer that supplied the far-ahead hash, so scoring it lets a \
-         malicious peer get arbitrary honest peers banned. Got: {received:?}"
-    );
-}
-
-/// Positive control for the GHSA-qhr3-cvch-5fh2 fix: removing the above-lookahead
-/// scoring must not disable misbehavior scoring in general.
-///
-/// A `BlockDownloadVerifyError::Invalid` with a non-zero `misbehavior_score()` and a
-/// known advertiser still has to reach the misbehavior channel. This test passes both
-/// before and after the fix.
-#[tokio::test]
-async fn invalid_block_still_scores_advertising_peer() {
-    let (mut chain_sync, mut misbehavior_rx) = new_chain_sync_with_misbehavior();
-
-    let advertiser: PeerSocketAddr = "127.0.0.1:8233".parse().unwrap();
-
+    // Positive control, and proof the channel plumbing works: a consensus-invalid
+    // block with a non-zero score must still be reported.
     let router_error = RouterError::Block {
         source: Box::new(VerifyBlockError::Subsidy(SubsidyError::NoCoinbase)),
     };
@@ -1641,14 +1581,26 @@ async fn invalid_block_still_scores_advertising_peer() {
         error: router_error,
         height: block::Height(60_000),
         hash: block::Hash::from([0xAB; 32]),
-        advertiser_addr: Some(advertiser),
+        advertiser_addr: Some(peer),
     }));
-
     assert_eq!(
         misbehavior_rx.try_recv(),
-        Ok((advertiser, expected_score)),
-        "consensus-invalid blocks must still score the advertising peer — the \
-         GHSA-qhr3-cvch-5fh2 fix only removes the above-lookahead attribution"
+        Ok((peer, expected_score)),
+        "consensus-invalid blocks must still score the serving peer"
+    );
+
+    // The fix: an above-lookahead block must not produce any misbehavior score.
+    let _ = chain_sync.handle_block_response(Err(
+        BlockDownloadVerifyError::AboveLookaheadHeightLimit {
+            height: block::Height(60_000),
+            hash: block::Hash::from([0xBB; 32]),
+            advertiser_addr: Some(peer),
+        },
+    ));
+    assert_eq!(
+        misbehavior_rx.try_recv(),
+        Err(tokio::sync::mpsc::error::TryRecvError::Empty),
+        "GHSA-qhr3-cvch-5fh2: an above-lookahead block must not score the serving peer"
     );
 }
 

--- a/zebrad/src/components/sync/tests/vectors.rs
+++ b/zebrad/src/components/sync/tests/vectors.rs
@@ -1307,7 +1307,6 @@ async fn above_lookahead_does_not_restart_sync() {
     let err = BlockDownloadVerifyError::AboveLookaheadHeightLimit {
         height: block::Height(60_000),
         hash: block::Hash::from([0xBB; 32]),
-        advertiser_addr: None,
     };
 
     let restart = ChainSync::<
@@ -1337,7 +1336,6 @@ async fn both_height_limits_do_not_restart_sync() {
     let above = BlockDownloadVerifyError::AboveLookaheadHeightLimit {
         height: block::Height(60_000),
         hash: block::Hash::from([0xEE; 32]),
-        advertiser_addr: None,
     };
 
     let restart_below = ChainSync::<
@@ -1558,10 +1556,10 @@ async fn download_failed_is_only_requeued_for_not_found() {
 ///
 /// Far-ahead hashes from a malicious `FindBlocks` response carry no peer attribution,
 /// so the follow-up `BlocksByHash` request is routed to an independently chosen,
-/// honest peer — `advertiser_addr` names the *serving* peer, not the peer that chose
-/// the height. Scoring this path bans honest peers at the attacker's direction.
+/// honest peer. That serving peer did not choose the height, so scoring this path bans
+/// honest peers at the attacker's direction.
 #[tokio::test]
-async fn far_ahead_block_does_not_score_serving_peer() {
+async fn far_ahead_block_does_not_produce_misbehavior_score() {
     let (mut chain_sync, mut misbehavior_rx) = new_chain_sync_with_misbehavior();
 
     let peer: PeerSocketAddr = "127.0.0.1:8233".parse().unwrap();
@@ -1594,7 +1592,6 @@ async fn far_ahead_block_does_not_score_serving_peer() {
         BlockDownloadVerifyError::AboveLookaheadHeightLimit {
             height: block::Height(60_000),
             hash: block::Hash::from([0xBB; 32]),
-            advertiser_addr: Some(peer),
         },
     ));
     assert_eq!(


### PR DESCRIPTION
## Motivation

This PR batches three coordinated security fixes for Zebra 6.3.0:

- [GHSA-g95h-hw6g-pvgv](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-g95h-hw6g-pvgv): a peer could serve a block with a canonical header and rewritten coinbase height, causing the syncer to drop it without scoring the peer or promptly re-requesting the hash.
- [GHSA-qhr3-cvch-5fh2](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-qhr3-cvch-5fh2): a malicious `FindBlocks` responder could cause Zebra to score and ban an unrelated honest peer that served a genuine far-ahead block.
- [GHSA-8hh2-hrf2-cqf4](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-8hh2-hrf2-cqf4): peers serving consensus-invalid gossiped blocks were not scored because the inbound cleanup expected `VerifyBlockError`, while the production verifier returns `RouterError`.

The fixes are submitted together so they can be reviewed, tested, and released as one security update. Their histories remain separated by merge commits so each advisory and its integration decisions can be inspected independently.

## Solution

### Behind-tip block downloads

- Add peer attribution to `BlockDownloadVerifyError::BehindTipHeightLimit` only when a lookup of the parent header proves that the block body's claimed height is false.
- Score an attributed peer at the ban threshold while leaving genuine old blocks and blocks with unknown parents unattributed.
- Immediately re-request the missing hash through the existing bounded retry machinery, whether or not the serving peer can be attributed.
- Add a read-state service to `Downloads` so parent-header queries use the appropriate `ReadRequest` boundary.

### Far-ahead block downloads

- Stop scoring `AboveLookaheadHeightLimit` responses. The address identifies the peer that served the requested block, not the peer that supplied the far-ahead hash.
- Continue dropping the block without restarting synchronization and retry the hash after the local tip advances.
- Retain scoring for consensus-invalid blocks, with a regression test serving as a positive control.

### Invalid gossiped blocks

- Extract misbehavior scores from the `RouterError` returned by `BlockVerifierRouter`.
- Retain the `VerifyBlockError` fallback so scoring remains correct if the verifier stack is rewired.
- Attribute the score to the peer that actually served the block, even when it differs from the peer that advertised it.
- Leave zero-score verification failures, timeouts, and transport errors unscored.

### Integration

The overlapping sync tests use a shared `ChainSync` fixture with the newer separate read-state service. The combined behavior deliberately distinguishes the two height-limit cases: a parent-contradicted behind-tip block can be narrowly attributed and scored, while a genuine above-lookahead block cannot be attributed to the peer that selected its height and remains unscored.

### Tests

The included regression coverage exercises:

- Parent-contradicted, genuinely old, unknown-parent, and reorg-boundary block downloads.
- Behind-tip scoring, attributed and unattributed re-requests, retry bounds, and the existing `NotFound` retry path.
- Far-ahead no-scoring behavior with consensus-invalid scoring as a positive control.
- Invalid gossiped-block scoring, serving-peer attribution, zero-score router errors, and verifier timeouts.

The source branches reported these focused results:

- `components::sync::` — 21 passed.
- `components::inbound` — 16 passed.

During integration, the affected sync and inbound nextest filters were also run after conflict resolution and passed.

### Specifications & References

- [GHSA-g95h-hw6g-pvgv](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-g95h-hw6g-pvgv)
- [GHSA-qhr3-cvch-5fh2](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-qhr3-cvch-5fh2)
- [GHSA-8hh2-hrf2-cqf4](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-8hh2-hrf2-cqf4)

### Follow-up Work

Update the security release process so independently developed fixes can be integrated without rewriting or adapting their individual commit series.

### AI Disclosure

- [x] AI tools were used: Claude Code assisted with analysis, regression tests, and fixes in the GHSA-qhr3-cvch-5fh2 and GHSA-8hh2-hrf2-cqf4 branches. OpenAI Codex assisted with integration conflict resolution, focused test execution, and preparation of this combined PR description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed with the Zebra team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.