### PR TITLE
fix(zebra-consensus): flush batch verifiers with rayon::scope so drop waits for completion

### DIFF
--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The batch signature verifiers (`redjubjub`, `ed25519`, `halo2`, `redpallas`) now block until
+  verification completes when flushed on drop, using `rayon::scope` instead of `rayon::spawn_fifo`.
+  Previously `flush_blocking` returned before the spawned work ran, so pending batched verification
+  could be abandoned on shutdown; this was latent because the process exits before the abandonment
+  is observable ([#10598](https://github.com/ZcashFoundation/zebra/issues/10598)).
+
 ## [15.0.0] - 2026-08-10
 
 ### Breaking Changes

--- a/zebra-consensus/CHANGELOG.md
+++ b/zebra-consensus/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- The batch signature verifiers (`redjubjub`, `ed25519`, `halo2`, `redpallas`) now block until
+- The batch verifiers (`redjubjub`, `ed25519`, `halo2`, `redpallas`, and `sapling`) now block until
   verification completes when flushed on drop, using `rayon::scope` instead of `rayon::spawn_fifo`.
-  Previously `flush_blocking` returned before the spawned work ran, so pending batched verification
-  could be abandoned on shutdown; this was latent because the process exits before the abandonment
-  is observable ([#10598](https://github.com/ZcashFoundation/zebra/issues/10598)).
+  Previously the flush returned before the spawned work ran, so pending batched verification could
+  be abandoned on shutdown; this was latent because the process exits before the abandonment is
+  observable ([#10598](https://github.com/ZcashFoundation/zebra/issues/10598)).
 
 ## [15.0.0] - 2026-08-10
 

--- a/zebra-consensus/src/primitives/ed25519.rs
+++ b/zebra-consensus/src/primitives/ed25519.rs
@@ -135,14 +135,21 @@ impl Verifier {
     }
 
     /// Flush the batch using a thread pool, and return the result via the channel.
-    /// This returns immediately, usually before the batch is completed.
+    /// This blocks until the batch is completed.
     fn flush_blocking(&mut self) {
         let (batch, tx) = self.take();
 
         // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
         //
-        // We don't care about execution order here, because this method is only called on drop.
-        tokio::task::block_in_place(|| rayon::spawn_fifo(|| Self::verify(batch, tx)));
+        // Use `rayon::scope` rather than `spawn_fifo` so this blocks until verification
+        // finishes: `flush_blocking` is called from `Drop`, which requires the batch to be
+        // flushed (and its result sent) before the verifier is dropped. `spawn_fifo` returned
+        // before the work ran, so pending verification could be abandoned on shutdown. See #10598.
+        tokio::task::block_in_place(|| {
+            rayon::scope(|s| {
+                s.spawn(move |_| Self::verify(batch, tx));
+            });
+        });
     }
 
     /// Flush the batch using a thread pool, and return the result via the channel.
@@ -226,7 +233,7 @@ impl Service<BatchControl<Item>> for Verifier {
 impl Drop for Verifier {
     fn drop(&mut self) {
         // We need to flush the current batch in case there are still any pending futures.
-        // This returns immediately, usually before the batch is completed.
+        // This blocks until the batch is completed.
         self.flush_blocking();
     }
 }

--- a/zebra-consensus/src/primitives/halo2.rs
+++ b/zebra-consensus/src/primitives/halo2.rs
@@ -400,14 +400,21 @@ impl Verifier {
     }
 
     /// Flush the batch using a thread pool, sending the result via the channel.
-    /// This returns immediately, usually before the batch is completed.
+    /// This blocks until the batch is completed.
     fn flush_blocking(&mut self) {
         let (batch, tx) = self.take();
 
         // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
         //
-        // We don't care about execution order here, because this method is only called on drop.
-        tokio::task::block_in_place(|| rayon::spawn_fifo(move || Self::verify(batch, tx)));
+        // Use `rayon::scope` rather than `spawn_fifo` so this blocks until verification
+        // finishes: `flush_blocking` is called from `Drop`, which requires the batch to be
+        // flushed (and its result sent) before the verifier is dropped. `spawn_fifo` returned
+        // before the work ran, so pending verification could be abandoned on shutdown. See #10598.
+        tokio::task::block_in_place(|| {
+            rayon::scope(|s| {
+                s.spawn(move |_| Self::verify(batch, tx));
+            });
+        });
     }
 
     /// Flush the batch using a thread pool, returning the result via the channel. This function
@@ -523,7 +530,7 @@ impl Service<BatchControl<Item>> for Verifier {
 impl Drop for Verifier {
     fn drop(&mut self) {
         // We need to flush the current batch in case there are still any pending futures.
-        // This returns immediately, usually before the batch is completed.
+        // This blocks until the batch is completed.
         self.flush_blocking()
     }
 }

--- a/zebra-consensus/src/primitives/redjubjub.rs
+++ b/zebra-consensus/src/primitives/redjubjub.rs
@@ -130,14 +130,21 @@ impl Verifier {
     }
 
     /// Flush the batch using a thread pool, and return the result via the channel.
-    /// This returns immediately, usually before the batch is completed.
+    /// This blocks until the batch is completed.
     fn flush_blocking(&mut self) {
         let (batch, tx) = self.take();
 
         // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
         //
-        // We don't care about execution order here, because this method is only called on drop.
-        tokio::task::block_in_place(|| rayon::spawn_fifo(|| Self::verify(batch, tx)));
+        // Use `rayon::scope` rather than `spawn_fifo` so this blocks until verification
+        // finishes: `flush_blocking` is called from `Drop`, which requires the batch to be
+        // flushed (and its result sent) before the verifier is dropped. `spawn_fifo` returned
+        // before the work ran, so pending verification could be abandoned on shutdown. See #10598.
+        tokio::task::block_in_place(|| {
+            rayon::scope(|s| {
+                s.spawn(move |_| Self::verify(batch, tx));
+            });
+        });
     }
 
     /// Flush the batch using a thread pool, and return the result via the channel.
@@ -222,7 +229,7 @@ impl Service<BatchControl<Item>> for Verifier {
 impl Drop for Verifier {
     fn drop(&mut self) {
         // We need to flush the current batch in case there are still any pending futures.
-        // This returns immediately, usually before the batch is completed.
+        // This blocks until the batch is completed.
         self.flush_blocking();
     }
 }

--- a/zebra-consensus/src/primitives/redpallas.rs
+++ b/zebra-consensus/src/primitives/redpallas.rs
@@ -148,14 +148,21 @@ impl Verifier {
     }
 
     /// Flush the batch using a thread pool, and return the result via the channel.
-    /// This returns immediately, usually before the batch is completed.
+    /// This blocks until the batch is completed.
     fn flush_blocking(&mut self) {
         let (batch, tx) = self.take();
 
         // Correctness: Do CPU-intensive work on a dedicated thread, to avoid blocking other futures.
         //
-        // We don't care about execution order here, because this method is only called on drop.
-        tokio::task::block_in_place(|| rayon::spawn_fifo(|| Self::verify(batch, tx)));
+        // Use `rayon::scope` rather than `spawn_fifo` so this blocks until verification
+        // finishes: `flush_blocking` is called from `Drop`, which requires the batch to be
+        // flushed (and its result sent) before the verifier is dropped. `spawn_fifo` returned
+        // before the work ran, so pending verification could be abandoned on shutdown. See #10598.
+        tokio::task::block_in_place(|| {
+            rayon::scope(|s| {
+                s.spawn(move |_| Self::verify(batch, tx));
+            });
+        });
     }
 
     /// Flush the batch using a thread pool, and return the result via the channel.
@@ -239,7 +246,7 @@ impl Service<BatchControl<Item>> for Verifier {
 impl Drop for Verifier {
     fn drop(&mut self) {
         // We need to flush the current batch in case there are still any pending futures.
-        // This returns immediately, usually before the batch is completed.
+        // This blocks until the batch is completed.
         self.flush_blocking();
     }
 }

--- a/zebra-consensus/src/primitives/redpallas/tests.rs
+++ b/zebra-consensus/src/primitives/redpallas/tests.rs
@@ -81,3 +81,27 @@ async fn batch_flushes_on_max_latency() -> Result<()> {
 
     Ok(())
 }
+
+/// Regression test for #10598: dropping a verifier flushes its batch
+/// synchronously (via `rayon::scope`), so the result is sent before `drop`
+/// returns, rather than on a detached `spawn_fifo` task that could be abandoned
+/// on shutdown.
+#[tokio::test(flavor = "multi_thread")]
+async fn drop_flushes_batch_synchronously() {
+    let verifier = Verifier::default();
+    let mut rx = verifier.tx.subscribe();
+
+    // No batch result has been sent yet.
+    assert!(rx.borrow_and_update().is_none());
+
+    drop(verifier);
+
+    // With `rayon::scope`, `flush_blocking` blocks until the batch is verified and
+    // the result sent, so it is present synchronously without awaiting. Under the
+    // old `spawn_fifo` the send happened after `drop` returned, so this could still
+    // be `None`.
+    assert!(
+        rx.borrow().is_some(),
+        "dropping the verifier must flush the batch before returning"
+    );
+}

--- a/zebra-consensus/src/primitives/sapling.rs
+++ b/zebra-consensus/src/primitives/sapling.rs
@@ -75,19 +75,27 @@ impl fmt::Debug for Verifier {
 impl Drop for Verifier {
     // Flush the current batch in case there are still any pending futures.
     //
-    // Flushing the batch means we need to validate it. This function fires off the validation and
-    // returns immediately, usually before the validation finishes.
+    // Flushing validates the batch, blocking until validation completes so any pending futures
+    // receive their result before the verifier is dropped.
     fn drop(&mut self) {
         let batch = mem::take(&mut self.batch);
         let tx = mem::take(&mut self.tx);
 
-        // The validation is CPU-intensive; do it on a dedicated thread so it does not block.
-        rayon::spawn_fifo(move || {
-            let (spend_vk, output_vk) = SAPLING.verifying_keys();
+        // The validation is CPU-intensive; do it on a dedicated thread. Use `rayon::scope` rather
+        // than `spawn_fifo` so this blocks until validation finishes and the result is sent —
+        // otherwise pending verification could be abandoned when the verifier is dropped on
+        // shutdown. Unlike the other batch verifiers this doesn't wrap the scope in
+        // `block_in_place`: sapling's single-item fallback (`verify_single`) drops a verifier per
+        // item, and the batch is already emptied there, so the flush is a no-op that shouldn't pay
+        // `block_in_place`'s cost or require a multi-threaded runtime. See #10598.
+        rayon::scope(|s| {
+            s.spawn(move |_| {
+                let (spend_vk, output_vk) = SAPLING.verifying_keys();
 
-            // Validate the batch and send the result through the channel.
-            let res = batch.validate(&spend_vk, &output_vk, thread_rng());
-            let _ = tx.send(Some(res));
+                // Validate the batch and send the result through the channel.
+                let res = batch.validate(&spend_vk, &output_vk, thread_rng());
+                let _ = tx.send(Some(res));
+            });
         });
     }
 }


### PR DESCRIPTION
## Motivation

Closes #10598.

The batch verifiers (`zebra-consensus/src/primitives/{redjubjub,ed25519,halo2,redpallas,sapling}.rs`) flush the pending batch from `Drop` using `rayon::spawn_fifo`, which schedules the verification and returns immediately. A verifier dropped during shutdown could therefore return from `drop` before the batch ran, abandoning the pending verification and leaving the per-item futures to hit `"verifier was dropped without flushing"`. It is latent today because `ZebradApp::shutdown()` calls `process::exit()` before that is observable.

## Solution

Use `rayon::scope`, which blocks the calling thread until the spawned closure finishes, so the batch is verified and its result sent before `drop` returns — upholding the `Drop` invariant. The async path (`flush_spawning`) already awaits completion and is unchanged. Stale `Drop`-site comments ("returns immediately…") are corrected.

Two decisions beyond the issue's four named files:
- **Sapling is included** — its `Drop` had the identical bug.
- **Sapling uses a bare `rayon::scope`, not `block_in_place(|| rayon::scope(..))` like the other four.** Sapling's single-item fallback `verify_single` constructs and drops a `Verifier` per item with the batch already emptied, so the drop-flush is a no-op there; wrapping it in `block_in_place` would add that cost (and a multi-threaded-runtime requirement) to a hot path for no benefit. The other four keep `block_in_place` (their originals had it, and they only flush real batches on drop).

Consensus results are unchanged — only *when* the drop-time flush returns changes. Two behavioural notes: shutdown teardown now blocks until the final batch verifies (bounded); and a panic inside `verify` now re-raises at the `scope(..)` call site inside `Drop` rather than being detached onto a rayon worker (in practice `verify`/`validate` return `Err`, not panic). No consensus-rule, state-format, RPC, or config change.

### Tests

`drop_flushes_batch_synchronously` (redpallas) subscribes to a verifier's result channel, drops the verifier, and asserts the result is present **synchronously** (no `.await`) — which only holds if the flush blocks until completion. Confirmed it fails before the fix and passes after. `cargo test -p zebra-consensus --lib -- primitives::{redpallas,redjubjub,ed25519}` = 8 passed; `cargo fmt`/`clippy --all-targets` clean. A bespoke sapling drop test isn't added (it would load the Sapling parameters and is slow); the redpallas test covers the shared behaviour.

### Specifications & References

None.

### Follow-up Work

None.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude (Claude Code) — wrote the fix, the comment corrections, and the regression test.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
- [x] `extra-reviews` applied (touches consensus batch-verifier drop/shutdown behaviour).
