### PR TITLE
perf(zebra-rpc): avoid an unconditional request-body copy in the JSON-RPC compatibility middleware

### DIFF
--- a/zebra-rpc/CHANGELOG.md
+++ b/zebra-rpc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The JSON-RPC version compatibility middleware no longer copies the request body an extra time when
+  building the rewritten request; the buffer is reclaimed in place when uniquely owned
+  ([#10574](https://github.com/ZcashFoundation/zebra/issues/10574)).
+
 ## [16.0.0] - 2026-08-10
 
 ### Breaking Changes

--- a/zebra-rpc/src/server/http_request_compatibility.rs
+++ b/zebra-rpc/src/server/http_request_compatibility.rs
@@ -150,7 +150,11 @@ impl<S> HttpRequestMiddleware<S> {
             };
         Ok((
             version,
-            HttpRequest::from_parts(parts, HttpBody::from(bytes.as_ref().to_vec())),
+            // `HttpBody` is built from a `Vec<u8>`. Convert the `Bytes` with
+            // `Vec::from`, which reclaims the buffer in place when it is uniquely
+            // owned (the common case here, e.g. the re-serialized request) rather
+            // than always allocating and copying like `bytes.as_ref().to_vec()`.
+            HttpRequest::from_parts(parts, HttpBody::from(Vec::from(bytes))),
         ))
     }
     /// Maps JSON-2.0 to whatever JSON-RPC version the client is using.


### PR DESCRIPTION
## Motivation

Closes #10574.

`HttpRequestMiddleware::request_to_json_rpc_2` (`zebra-rpc/src/server/http_request_compatibility.rs`) fed the request body into `HttpBody::from` via `bytes.as_ref().to_vec()`, which always allocates and copies the whole body.

## Solution

The issue suggested `HttpBody::from(bytes)`, but `HttpBody` (jsonrpsee 0.24) has no `From<Bytes>` — only `From<Vec<u8>>`/`From<String>` — so the `Bytes` still has to become a `Vec<u8>`. Use `Vec::from(bytes)` instead of `bytes.as_ref().to_vec()`: `impl From<Bytes> for Vec<u8>` reclaims the buffer in place when the `Bytes` is uniquely owned, so the common paths (the re-serialized request, and the JSON-RPC-2.0/`Unknown` pass-through) are now zero-copy rather than an unconditional allocation + copy per request. Behaviour is unchanged — the resulting bytes are identical.

No public API, consensus, state-format, or config change.

### Tests

Behaviour-preserving, so no new test — the existing middleware tests still pass:

```
cargo test -p zebra-rpc --lib -- server::tests::http_request_compatibility
test result: ok. 2 passed
```

`cargo fmt` and `cargo clippy -p zebra-rpc --lib --all-features` are clean.

### Specifications & References

`bytes` crate `impl From<Bytes> for Vec<u8>` (in-place reclaim when uniquely owned).

### Follow-up Work

The re-serialized branch still round-trips `Vec → Bytes → Vec`; the intermediate `Bytes` is avoidable but predates this change and is out of scope here.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude (Claude Code) — wrote the fix and this description.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
