### PR TITLE
chore: fix nightly and links

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -48,7 +48,7 @@ exclude_path = [
 ]
 
 # Accept these HTTP status codes as valid
-accept = ["200", "204", "206", "301", "302", "307", "308", "429"]
+accept = ["200", "202", "204", "206", "301", "302", "307", "308", "403", "429"]
 
 # Timeout for requests (seconds)
 timeout = 30

--- a/zebra-chain/src/work/u256.rs
+++ b/zebra-chain/src/work/u256.rs
@@ -9,6 +9,7 @@
 #![allow(unknown_lints)]
 #![allow(semicolon_in_expressions_from_macros)]
 #![allow(semicolon_in_expressions_from_non_local_macros)]
+#![allow(deprecated)]
 
 use uint::construct_uint;
 


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

Closes https://github.com/ZcashFoundation/zebra/issues/11244

## Solution

I added 202 (some zfnd.org are returning it, and working) and 403 (probably rate-limiting. I think it makes sense to accept it since if link checkers are blocked, we can't really  work around it anyway).

A `uint` macro is using a deprecated method. The proper fix would be for `uint` to update and fix that, but we don't really need to block on that, so just allow deprecated in that module.

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
-->

### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [ ] No AI tools were used in this PR
- [ ] AI tools were used: <!-- tool name and what it was used for, e.g., "Claude for test boilerplate" -->

### PR Checklist

- [ ] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [ ] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [ ] The solution is tested.
- [ ] The documentation and changelogs are up to date.
