### PR TITLE
fix(state): prefer the first-received chain on equal-work ties

### DIFF
--- a/.changes/unreleased/zebra-state-Fixed-20260818-180434.yaml
+++ b/.changes/unreleased/zebra-state-Fixed-20260818-180434.yaml
@@ -1,0 +1,4 @@
+project: zebra-state
+kind: Fixed
+body: 'Equal-work chain ties now prefer the first-received chain, per the protocol specification, instead of the higher tip hash. Each block committed to the non-finalized state is stamped with a receipt sequence (like zcashd''s `nSequenceId`), `Chain::cmp` breaks work ties on the tip''s sequence, and blocks queued while their parent was missing are committed in arrival order, so an already-adopted tip is no longer displaced by a later-arriving equal-work sibling ([#11240](https://github.com/ZcashFoundation/zebra/issues/11240)).'
+time: 2026-08-18T18:04:34.000000000Z

--- a/.changes/unreleased/zebrad-Fixed-20260818-180433.yaml
+++ b/.changes/unreleased/zebrad-Fixed-20260818-180433.yaml
@@ -1,0 +1,4 @@
+project: zebrad
+kind: Fixed
+body: 'Equal-work chain ties now prefer the first-received chain, per the protocol specification, instead of the higher tip hash. Each block committed to the non-finalized state is stamped with a receipt sequence (like zcashd''s `nSequenceId`), `Chain::cmp` breaks work ties on the tip''s sequence, and blocks queued while their parent was missing are committed in arrival order, so an already-adopted tip is no longer displaced by a later-arriving equal-work sibling ([#11240](https://github.com/ZcashFoundation/zebra/issues/11240)).'
+time: 2026-08-18T18:04:33.000000000Z

--- a/book/src/dev/rfcs/0005-state-updates.md
+++ b/book/src/dev/rfcs/0005-state-updates.md
@@ -426,14 +426,18 @@ Remove the highest height block of the non-finalized portion of a chain.
 
 The `Chain` type implements `Ord` for reorganizing chains. First chains are
 compared by their `partial_cumulative_work`. Ties are then broken by
-comparing `block::Hash`es of the tips of each chain. (This tie-breaker means
-that all `Chain`s in the `NonFinalizedState` must have at least one block.)
+preferring the chain whose tip block was received first (the lowest tip
+receipt sequence, like `zcashd`'s `nSequenceId`), implementing the protocol
+rule that a node prefers the first block it received. The tip `block::Hash`
+remains as a final tie-breaker for blocks without a receipt sequence
+(test-constructed chains). (These tie-breakers mean that all `Chain`s in the
+`NonFinalizedState` must have at least one block.)
 
-**Note**: Unlike `zcashd`, Zebra does not use block arrival times as a
-tie-breaker for the best tip. Since Zebra downloads blocks in parallel,
-download times are not guaranteed to be unique. Using the `block::Hash`
-provides a consistent tip order. (As a side-effect, the tip order is also
-consistent after a node restart, and between nodes.)
+**Note**: Receipt sequences are assigned when a full block is committed to
+the non-finalized state, are node-local, and are not persisted: blocks
+restored from the non-finalized backup after a restart are re-stamped in
+replay order, like `zcashd`'s disk-loaded blocks, which all share
+`nSequenceId` 0.
 
 #### `Default`
 

--- a/zebra-state/src/arbitrary.rs
+++ b/zebra-state/src/arbitrary.rs
@@ -114,6 +114,7 @@ impl ContextuallyVerifiedBlock {
             spent_outputs: new_outputs,
             transaction_hashes,
             chain_value_pool_change: ValueBalance::zero(),
+            receipt_sequence: 0,
         }
     }
 }

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -329,6 +329,21 @@ pub struct ContextuallyVerifiedBlock {
 
     /// The sum of the chain value pool changes of all transactions in this block.
     pub(crate) chain_value_pool_change: ValueBalance<NegativeAllowed>,
+
+    /// The order in which this node received this block, relative to the other blocks in the
+    /// non-finalized state (like `zcashd`'s `nSequenceId`).
+    ///
+    /// Used by `Chain::cmp` to prefer the first-received chain when cumulative works are equal:
+    ///
+    /// > To break ties between leaf blocks, a node will prefer the block that it received first.
+    ///
+    /// <https://zips.z.cash/protocol/protocol.pdf#blockchain>
+    ///
+    /// This is node-local, in-memory metadata, not consensus data: it is assigned once when the
+    /// block is committed to the non-finalized state, is never persisted (blocks restored from
+    /// the non-finalized backup are re-stamped in replay order), and is 0 for blocks constructed
+    /// outside a commit (tests).
+    pub(crate) receipt_sequence: u64,
 }
 
 /// Wraps note commitment trees and the history tree together.
@@ -526,6 +541,8 @@ impl ContextuallyVerifiedBlock {
                 &utxos_from_ordered_utxos(spent_outputs),
                 deferred_pool_balance_change,
             )?,
+            // Stamped by the non-finalized state when the block is committed.
+            receipt_sequence: 0,
         })
     }
 }

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -62,6 +62,15 @@ pub struct NonFinalizedState {
     /// state.
     invalidated_blocks: IndexMap<Height, Arc<Vec<ContextuallyVerifiedBlock>>>,
 
+    /// The receipt sequence number assigned to the next block committed to this
+    /// non-finalized state (like `zcashd`'s `nBlockSequenceId` counter).
+    ///
+    /// `Chain::cmp` breaks equal-work ties by preferring the chain whose tip block has the
+    /// lowest receipt sequence, implementing the consensus rule that a node prefers the
+    /// block it received first. Node-local and in-memory only; starts at 1 so that 0 marks
+    /// blocks constructed outside a commit (tests).
+    next_receipt_sequence: u64,
+
     // Configuration
     //
     /// The configured Zcash network.
@@ -96,6 +105,8 @@ impl std::fmt::Debug for NonFinalizedState {
         f.field("chain_set", &self.chain_set)
             .field("network", &self.network);
 
+        f.field("next_receipt_sequence", &self.next_receipt_sequence);
+
         f.field("should_count_metrics", &self.should_count_metrics);
 
         f.finish()
@@ -108,6 +119,7 @@ impl Clone for NonFinalizedState {
             chain_set: self.chain_set.clone(),
             network: self.network.clone(),
             invalidated_blocks: self.invalidated_blocks.clone(),
+            next_receipt_sequence: self.next_receipt_sequence,
             should_count_metrics: self.should_count_metrics,
             // Don't track progress in clones.
             #[cfg(feature = "progress-bar")]
@@ -125,6 +137,7 @@ impl NonFinalizedState {
             chain_set: Default::default(),
             network: network.clone(),
             invalidated_blocks: Default::default(),
+            next_receipt_sequence: 1,
             should_count_metrics: true,
             #[cfg(feature = "progress-bar")]
             chain_count_bar: None,
@@ -250,6 +263,9 @@ impl NonFinalizedState {
     pub fn eq_internal_state(&self, other: &NonFinalizedState) -> bool {
         // this method must be updated every time a consensus-critical field is added to NonFinalizedState
         // (diagnostic fields can be ignored)
+        //
+        // `next_receipt_sequence` is deliberately excluded: it is node-local receipt-order
+        // metadata, and a failed commit advances it without changing any chain.
 
         self.chain_set.len() == other.chain_set.len()
             && self
@@ -273,7 +289,18 @@ impl NonFinalizedState {
     where
         F: FnOnce(&mut BTreeSet<Arc<Chain>>),
     {
-        self.chain_set.insert(chain);
+        // If a chain with this tip is already tracked, keep the incumbent: it was received
+        // first. Before receipt sequences, such chains compared `Equal` and this insert was
+        // a silent `BTreeSet` no-op (see the `Chain::cmp` docs and the tests for #10586);
+        // with sequences, a re-committed duplicate tip could otherwise carry a fresh
+        // sequence and add a second chain for the same tip.
+        let duplicate_tip = self
+            .chain_set
+            .iter()
+            .any(|tracked| tracked.non_finalized_tip_hash() == chain.non_finalized_tip_hash());
+        if !duplicate_tip {
+            self.chain_set.insert(chain);
+        }
 
         chain_filter(&mut self.chain_set);
 
@@ -293,8 +320,8 @@ impl NonFinalizedState {
     /// Finalize the lowest height block in the non-finalized portion of the best
     /// chain and update all side-chains to match.
     pub fn finalize(&mut self) -> FinalizableBlock {
-        // Chain::cmp uses the partial cumulative work, and the hash of the tip block.
-        // Neither of these fields has interior mutability.
+        // Chain::cmp uses the partial cumulative work, the tip block's receipt sequence,
+        // and the hash of the tip block. None of these fields has interior mutability.
         // (And when the tip block is dropped for a chain, the chain is also dropped.)
         #[allow(clippy::mutable_key_type)]
         let chains = mem::take(&mut self.chain_set);
@@ -560,7 +587,7 @@ impl NonFinalizedState {
     /// or the finalized tip.
     #[tracing::instrument(level = "debug", skip(self, finalized_state, new_chain))]
     fn validate_and_commit(
-        &self,
+        &mut self,
         new_chain: Arc<Chain>,
         prepared: SemanticallyVerifiedBlock,
         finalized_state: &ZebraDb,
@@ -600,7 +627,7 @@ impl NonFinalizedState {
         );
 
         // Quick check that doesn't read from disk
-        let contextual = ContextuallyVerifiedBlock::with_block_and_spent_utxos(
+        let mut contextual = ContextuallyVerifiedBlock::with_block_and_spent_utxos(
             prepared.clone(),
             spent_utxos.clone(),
             calculate_deferred_pool_balance_change(prepared.height, &self.network),
@@ -614,6 +641,14 @@ impl NonFinalizedState {
                 spent_utxo_count: spent_utxos.len(),
             }
         })?;
+
+        // Stamp the block's receipt order (like zcashd's `nSequenceId`), used by `Chain::cmp`
+        // to prefer the first-received chain on equal-work ties. `reconsider_block` re-pushes
+        // stored blocks without passing through here, which preserves their original stamp.
+        // If validation fails below, the consumed sequence leaves a gap, which is harmless:
+        // only the relative order of accepted blocks matters.
+        contextual.receipt_sequence = self.next_receipt_sequence;
+        self.next_receipt_sequence += 1;
 
         Self::validate_and_update_parallel(new_chain, contextual, sprout_final_treestates)
     }
@@ -707,7 +742,7 @@ impl NonFinalizedState {
     /// Returns the first chain satisfying the given predicate.
     ///
     /// If multiple chains satisfy the predicate, returns the chain with the highest difficulty.
-    /// (Using the tip block hash tie-breaker.)
+    /// (Breaking ties by preferring the first-received tip block, then the tip block hash.)
     pub fn find_chain<P>(&self, mut predicate: P) -> Option<Arc<Chain>>
     where
         P: FnMut(&Chain) -> bool,

--- a/zebra-state/src/service/non_finalized_state/backup.rs
+++ b/zebra-state/src/service/non_finalized_state/backup.rs
@@ -30,6 +30,11 @@ pub(crate) const MIN_DURATION_BETWEEN_BACKUP_UPDATES: Duration = Duration::from_
 /// Looks for blocks above the finalized tip height in the backup directory (if a path was provided) and
 /// attempts to commit them to the non-finalized state.
 ///
+/// Restored blocks are re-stamped with fresh receipt sequences in replay order (ascending
+/// height, arbitrary order within a height), so equal-work sibling preference from before
+/// the restart is not preserved. This matches `zcashd`, where blocks loaded from disk all
+/// share `nSequenceId` 0.
+///
 /// Returns the resulting non-finalized state.
 pub(super) fn restore_backup(
     mut non_finalized_state: NonFinalizedState,

--- a/zebra-state/src/service/non_finalized_state/chain.rs
+++ b/zebra-state/src/service/non_finalized_state/chain.rs
@@ -2623,17 +2623,14 @@ impl UpdateWith<(ValueBalance<NegativeAllowed>, Height, usize)> for Chain {
 impl Ord for Chain {
     /// Chain order for the [`NonFinalizedState`][1]'s `chain_set`.
     ///
-    /// Chains with higher cumulative Proof of Work are [`Ordering::Greater`],
-    /// breaking ties using the tip block hash.
-    ///
-    /// Despite the consensus rules, Zebra uses the tip block hash as a
-    /// tie-breaker. Zebra blocks are downloaded in parallel, so download
-    /// timestamps may not be unique. (And Zebra currently doesn't track
-    /// download times, because [`Block`](block::Block)s are immutable.)
-    ///
-    /// This departure from the consensus rules may delay network convergence,
-    /// for as long as the greater hash belongs to the later mined block.
-    /// But Zebra nodes should converge as soon as the tied work is broken.
+    /// Chains with higher cumulative Proof of Work are [`Ordering::Greater`].
+    /// Ties are broken by preferring the chain whose tip block was received
+    /// first (its tip has the lower receipt sequence), implementing the
+    /// consensus rule below, like `zcashd`'s `nSequenceId`. Sibling blocks on
+    /// Zcash always have equal work (`nBits` is fully determined by their
+    /// ancestors), so without first-received preference, an already-adopted
+    /// tip could be displaced by an equal-work sibling arriving arbitrarily
+    /// later.
     ///
     /// "At a given point in time, each full validator is aware of a set of candidate blocks.
     /// These form a tree rooted at the genesis block, where each node in the tree
@@ -2655,17 +2652,23 @@ impl Ord for Chain {
     ///
     /// <https://zips.z.cash/protocol/protocol.pdf#blockchain>
     ///
+    /// The tip block hash remains as a final tie-breaker, so that the order is
+    /// total for blocks that were never stamped with a receipt sequence
+    /// (test-constructed blocks, which all use sequence 0).
+    ///
     /// # Correctness
     ///
     /// `Chain::cmp` is used in a `BTreeSet`, so the fields accessed by `cmp` must not have
-    /// interior mutability.
+    /// interior mutability. The receipt sequence is stamped on each block once, before it
+    /// is pushed onto a chain, and never modified afterwards.
     ///
-    /// `cmp` returns [`Ordering::Equal`] only when both the cumulative work and
-    /// the tip hash match. The [`NonFinalizedState::chain_set`][2] is a
-    /// `BTreeSet<Arc<Chain>>`, so an attempt to insert a chain that compares
-    /// equal to an existing entry is a no-op rather than a process-fatal panic.
-    /// Callers that need to replace such a chain must remove the existing entry
-    /// first.
+    /// `cmp` returns [`Ordering::Equal`] only when the cumulative work, the tip receipt
+    /// sequence, and the tip hash all match. Two chains with the same tip hash share the
+    /// same stored tip block (and therefore the same sequence), so same-tip chains still
+    /// compare [`Ordering::Equal`]: the [`NonFinalizedState::chain_set`][2] is a
+    /// `BTreeSet<Arc<Chain>>`, so an attempt to insert a chain that compares equal to an
+    /// existing entry is a no-op rather than a process-fatal panic. Callers that need to
+    /// replace such a chain must remove the existing entry first.
     ///
     /// [1]: super::NonFinalizedState
     /// [2]: super::NonFinalizedState::chain_set
@@ -2674,23 +2677,33 @@ impl Ord for Chain {
             self.partial_cumulative_work
                 .cmp(&other.partial_cumulative_work)
         } else {
-            let self_hash = self
+            let self_tip = self
                 .blocks
                 .values()
                 .last()
-                .expect("always at least 1 element")
-                .hash;
+                .expect("always at least 1 element");
 
-            let other_hash = other
+            let other_tip = other
                 .blocks
                 .values()
                 .last()
-                .expect("always at least 1 element")
-                .hash;
+                .expect("always at least 1 element");
 
-            // This comparison is a tie-breaker within the local node, so it does not need to
-            // be consistent with the ordering on `ExpandedDifficulty` and `block::Hash`.
-            self_hash.0.cmp(&other_hash.0)
+            // Prefer the first-received tip: a LOWER receipt sequence is a BETTER chain,
+            // so it must compare `Greater` (the best chain is the greatest in the set).
+            match self_tip
+                .receipt_sequence
+                .cmp(&other_tip.receipt_sequence)
+                .reverse()
+            {
+                // Distinct stamped tips always have distinct sequences, so this branch is
+                // reached only for identical tips or unstamped (sequence 0, test-built)
+                // blocks. The comparison is a tie-breaker within the local node, so it
+                // does not need to be consistent with the ordering on
+                // `ExpandedDifficulty` and `block::Hash`.
+                Ordering::Equal => self_tip.hash.0.cmp(&other_tip.hash.0),
+                ordering => ordering,
+            }
         }
     }
 }
@@ -2703,10 +2716,13 @@ impl PartialOrd for Chain {
 
 impl PartialEq for Chain {
     /// Chain equality for [`NonFinalizedState::chain_set`][1], using proof of
-    /// work, then the tip block hash as a tie-breaker.
+    /// work, then the tip block's receipt sequence, then the tip block hash.
     ///
-    /// Two chains with the same cumulative work and tip hash are equal; the
-    /// `chain_set` uses this to keep tip hashes unique.
+    /// Two chains with the same cumulative work, tip receipt sequence, and tip
+    /// hash are equal. Same-tip chains share the stored tip block (and its
+    /// sequence), so they always compare equal; `NonFinalizedState::insert_with`
+    /// additionally skips inserting a chain whose tip is already tracked, which
+    /// keeps tip hashes unique in the `chain_set`.
     ///
     /// [1]: super::NonFinalizedState::chain_set
     fn eq(&self, other: &Self) -> bool {

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -371,7 +371,9 @@ fn invalidating_non_finalized_root_does_not_panic() {
 /// parent previously panicked. The second invalidation produced a shortened
 /// parent chain whose tip hash matched an existing entry, and `BTreeSet::insert`
 /// reached `Chain::cmp`'s `unreachable!()`. After the fix, `Chain::cmp` returns
-/// `Equal` for matching tip hashes, so the duplicate insert is a no-op and the
+/// `Equal` for matching tip hashes (same-tip chains share the stored tip block,
+/// including its receipt sequence), and `insert_with` skips inserting a chain
+/// whose tip is already tracked, so the duplicate insert is a no-op and the
 /// pre-existing parent chain is retained.
 #[test]
 fn invalidating_same_height_fork_tips_is_idempotent() {
@@ -1178,4 +1180,127 @@ fn commit_new_chain_sets_chain_value_pools_deferred_amount() -> Result<()> {
     assert_eq!(chain.chain_value_pools.deferred_amount(), expected);
 
     Ok(())
+}
+
+/// Regression test for <https://github.com/ZcashFoundation/zebra/issues/11240>.
+///
+/// Sibling blocks always have equal work on Zcash (`nBits` is fully determined by their
+/// ancestors), and the spec breaks equal-work ties by preferring the block received first.
+/// The old `Chain::cmp` compared tip hashes instead, so whichever sibling's hash sorted
+/// higher displaced an already-adopted tip, regardless of arrival order.
+///
+/// Commits two equal-work siblings in both arrival orders and checks that the
+/// first-received sibling stays best both times; one of the two orders fails under hash
+/// tie-breaking by construction. Then extends the losing sibling and checks that strictly
+/// more cumulative work still overrides receipt order.
+#[test]
+fn equal_work_ties_prefer_first_seen() -> Result<()> {
+    let _init_guard = zebra_test::init();
+
+    let network = Network::Mainnet;
+    let block1: Arc<Block> = Arc::new(network.test_block(653599, 583999).unwrap());
+
+    // Same parent and work, different commitment bytes: the siblings tie on cumulative
+    // work with distinct hashes.
+    let sibling_a = block1
+        .make_fake_child()
+        .set_work(10)
+        .set_block_commitment([0x01; 32]);
+    let sibling_b = block1
+        .make_fake_child()
+        .set_work(10)
+        .set_block_commitment([0x02; 32]);
+    assert_ne!(
+        sibling_a.hash(),
+        sibling_b.hash(),
+        "siblings must have distinct hashes"
+    );
+
+    for (first, second) in [(&sibling_a, &sibling_b), (&sibling_b, &sibling_a)] {
+        let (mut state, finalized_state) = new_invalidate_test_state(&network);
+
+        state.commit_new_chain(block1.clone().prepare(), &finalized_state)?;
+
+        state.commit_block((*first).clone().prepare(), &finalized_state)?;
+        assert_eq!(
+            state.best_chain().unwrap().non_finalized_tip_hash(),
+            first.hash(),
+            "the first sibling is adopted as the best tip"
+        );
+
+        state.commit_block((*second).clone().prepare(), &finalized_state)?;
+        assert_eq!(2, state.chain_set.len(), "both sibling chains are tracked");
+        assert_eq!(
+            state.best_chain().unwrap().non_finalized_tip_hash(),
+            first.hash(),
+            "a later equal-work sibling must not displace the adopted tip"
+        );
+
+        // Strictly more cumulative work still overrides receipt order.
+        let second_child = second.make_fake_child().set_work(10);
+        state.commit_block(second_child.clone().prepare(), &finalized_state)?;
+        assert_eq!(
+            state.best_chain().unwrap().non_finalized_tip_hash(),
+            second_child.hash(),
+            "more cumulative work must override receipt order"
+        );
+    }
+
+    Ok(())
+}
+
+/// Regression test for <https://github.com/ZcashFoundation/zebra/issues/11240>.
+///
+/// Receipt order must survive invalidate/reconsider: `reconsider_block` replays the
+/// stored blocks, so a reconsidered block keeps its original receipt sequence and
+/// resumes winning the equal-work tie it won on first receipt.
+#[test]
+fn reconsidered_block_keeps_original_receipt_order() {
+    let _init_guard = zebra_test::init();
+
+    let network = Network::Mainnet;
+    let block1: Arc<Block> = Arc::new(network.test_block(653599, 583999).unwrap());
+    let sibling_a = block1
+        .make_fake_child()
+        .set_work(10)
+        .set_block_commitment([0x01; 32]);
+    let sibling_b = block1
+        .make_fake_child()
+        .set_work(10)
+        .set_block_commitment([0x02; 32]);
+
+    let (mut state, finalized_state) = new_invalidate_test_state(&network);
+
+    state
+        .commit_new_chain(block1.prepare(), &finalized_state)
+        .expect("fake root block should commit");
+    state
+        .commit_block(sibling_a.clone().prepare(), &finalized_state)
+        .expect("first sibling should commit");
+    state
+        .commit_block(sibling_b.clone().prepare(), &finalized_state)
+        .expect("second sibling should commit");
+    assert_eq!(
+        state.best_chain().unwrap().non_finalized_tip_hash(),
+        sibling_a.hash(),
+        "the first-received sibling starts as the best tip"
+    );
+
+    state
+        .invalidate_block(sibling_a.hash())
+        .expect("invalidating the first sibling should succeed");
+    assert_eq!(
+        state.best_chain().unwrap().non_finalized_tip_hash(),
+        sibling_b.hash(),
+        "the remaining sibling is best while the first is invalidated"
+    );
+
+    state
+        .reconsider_block(sibling_a.hash(), &finalized_state.db)
+        .expect("reconsidering the first sibling should succeed");
+    assert_eq!(
+        state.best_chain().unwrap().non_finalized_tip_hash(),
+        sibling_a.hash(),
+        "the reconsidered sibling keeps its original receipt sequence and wins the tie again"
+    );
 }

--- a/zebra-state/src/service/queued_blocks.rs
+++ b/zebra-state/src/service/queued_blocks.rs
@@ -5,6 +5,7 @@ use std::{
     iter, mem,
 };
 
+use indexmap::IndexSet;
 use tokio::sync::oneshot;
 use tracing::instrument;
 
@@ -37,7 +38,12 @@ pub struct QueuedBlocks {
     /// Blocks awaiting their parent blocks for contextual verification.
     blocks: HashMap<block::Hash, QueuedSemanticallyVerified>,
     /// Hashes from `queued_blocks`, indexed by parent hash.
-    by_parent: HashMap<block::Hash, HashSet<block::Hash>>,
+    ///
+    /// The per-parent set preserves insertion order, so children of the same parent are
+    /// dequeued in the order they arrived: the non-finalized state stamps receipt
+    /// sequences at commit, and this keeps commit order equal to arrival order for
+    /// equal-work siblings that were queued while their parent was missing.
+    by_parent: HashMap<block::Hash, IndexSet<block::Hash>>,
     /// Hashes from `queued_blocks`, indexed by block height.
     by_height: BTreeMap<block::Height, HashSet<block::Hash>>,
     /// Known UTXOs.
@@ -88,7 +94,11 @@ impl QueuedBlocks {
     }
 
     /// Dequeue and return all blocks that were waiting for the arrival of
-    /// `parent`.
+    /// `parent`, in the order they arrived.
+    ///
+    /// The arrival order matters: these blocks are committed in the returned order, and
+    /// the non-finalized state breaks equal-work chain ties by preferring the block
+    /// committed first (see `receipt_sequence` in `ContextuallyVerifiedBlock`).
     #[instrument(skip(self), fields(%parent_hash))]
     pub fn dequeue_children(
         &mut self,
@@ -181,7 +191,8 @@ impl QueuedBlocks {
                 );
             } else {
                 assert!(
-                    parent_list.remove(&hash),
+                    // `shift_remove` keeps the remaining children in arrival order.
+                    parent_list.shift_remove(&hash),
                     "hash must be present in parent hash list"
                 );
             }

--- a/zebra-state/src/service/queued_blocks/tests/vectors.rs
+++ b/zebra-state/src/service/queued_blocks/tests/vectors.rs
@@ -245,3 +245,44 @@ fn dequeue_children_preserves_same_height_siblings() -> Result<()> {
 
     Ok(())
 }
+
+/// Children of the same parent must dequeue in arrival order: the non-finalized state
+/// stamps receipt sequences at commit, and equal-work chain ties are broken by
+/// preferring the first-received block, so the queue must not reorder siblings that
+/// were waiting for a missing parent (the receipt-order half of
+/// <https://github.com/ZcashFoundation/zebra/issues/11240>).
+#[test]
+fn dequeue_children_returns_siblings_in_arrival_order() -> Result<()> {
+    let _init_guard = zebra_test::init();
+
+    let parent_block: Arc<Block> =
+        zebra_test::vectors::BLOCK_MAINNET_419200_BYTES.zcash_deserialize_into()?;
+
+    // Five siblings of the same parent with distinct hashes, queued in a known order.
+    let siblings: Vec<Arc<Block>> = (1u8..=5)
+        .map(|index| {
+            parent_block
+                .make_fake_child()
+                .set_block_commitment([index; 32])
+        })
+        .collect();
+
+    let mut queue = QueuedBlocks::default();
+    for sibling in &siblings {
+        queue.queue(sibling.clone().into_queued());
+    }
+
+    let dequeued: Vec<_> = queue
+        .dequeue_children(parent_block.hash())
+        .into_iter()
+        .map(|(block, _)| block.hash)
+        .collect();
+    let expected: Vec<_> = siblings.iter().map(|sibling| sibling.hash()).collect();
+
+    assert_eq!(
+        dequeued, expected,
+        "siblings of the same parent must dequeue in the order they were queued"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

Closes #11240.

The protocol spec, quoted in `Chain::cmp`'s own docs: "To break ties between leaf blocks, a node will prefer the block that it received first." Zebra instead compares raw tip-hash bytes, and `best_chain()` is re-evaluated on every commit, so an already-validated, already-announced tip is displaced whenever an equal-work sibling with a higher-sorting hash arrives, no matter how much later. On Zcash, sibling blocks always tie on work (nBits is fully determined by ancestors) and equal-length fork subtrees stay tied, so this fires on every sibling race. #11240 documents mainnet blocks orphaned this way despite winning propagation by ~0.4s; the hash rule also removes the race penalty for block withholding, since a sibling released only after seeing a competitor's block still wins about half of ties, deterministically across all zebra nodes.

On the documented rationale for the current behavior (parallel downloads make receipt timestamps non-unique, and Zebra doesn't track download times): this change uses no timestamps. It stamps a monotonic sequence at the moment a block is committed to the non-finalized state, which is unique by construction, and makes commit order match arrival order in the one place they could diverge (children queued behind a missing parent). The "consistent across restarts and between nodes" side-effect of hash ordering is deliberately given up: that property is exactly what makes every zebra node prefer the same later-arriving sibling.

## Solution

The zcashd `nSequenceId` analogue, adapted to zebra-state:

- `ContextuallyVerifiedBlock` gains `receipt_sequence: u64`, stamped once in `NonFinalizedState::validate_and_commit` from a per-instance counter (the analogue of `ReceivedBlockTransactions`). Node-local, in-memory, never persisted; backup-restored blocks re-stamp in replay order, matching zcashd's disk-loaded blocks all sharing id 0. The stamp rides through fork/push/pop/invalidate, and `reconsider_block` replays stored blocks, so receipt order survives invalidate/reconsider.
- `Chain::cmp` orders by cumulative work (unchanged), then the tip's receipt sequence (lower preferred), then the existing tip-hash comparison last. The hash fallback keeps the order total for unstamped (test-built, sequence-0) chains and keeps same-tip chains comparing `Equal`, preserving the #10586 invariants.
- `NonFinalizedState::insert_with` skips inserting a chain whose tip is already tracked: keeping the incumbent is first-received, and it preserves the duplicate-tip no-op that same-tip `Equal` used to provide on paths without a duplicate filter (the `zebra-rpc` sync mirror).
- `QueuedBlocks::by_parent` becomes an `IndexSet` (with `shift_remove` on the prune path), so siblings queued while their parent was missing are dequeued, committed, and stamped in arrival order.
- `eq_internal_state` excludes the counter, since a failed commit advances it without changing any chain.
- Docs updated: `Chain::cmp`/`PartialEq`, `find_chain`, `finalize`, backup restore, the #10586 test comments, and the state RFC's `Ord` section.

Strictly more cumulative work always still wins; the sequence only decides exact work ties, which is local policy (both blocks are valid), now aligned with the spec and zcashd.

## Tests

- `equal_work_ties_prefer_first_seen`: two equal-work siblings committed in both arrival orders keep the first-received tip best in both (one order fails under hash tie-breaking by construction); a strictly higher-work extension still overrides receipt order.
- `reconsidered_block_keeps_original_receipt_order`: invalidate/reconsider preserves the original tie win.
- `dequeue_children_returns_siblings_in_arrival_order`: queued siblings dequeue in insertion order.
- Existing #10586 regression tests and the fork/finalize property tests pass unchanged.
- `cargo fmt --all -- --check`, `cargo clippy -p zebra-state -p zebra-rpc --all-targets -- -D warnings`, and `cargo nextest run -p zebra-state -p zebra-rpc` pass on this branch.

## AI Disclosure

This change was developed with Claude (Claude Code): code, tests, and this description, under human direction and review. It ships in Shielded Labs' Zero v26 (a zebra downstream). The contributor is the responsible author.
