### PR TITLE
test(zebra-rpc): assert submitblock serializes an accepted block to result: null

### DIFF
--- a/zebra-rpc/src/methods/types/submit_block.rs
+++ b/zebra-rpc/src/methods/types/submit_block.rs
@@ -108,3 +108,33 @@ impl Default for SubmitBlockChannel {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for #10571: an accepted `submitblock` response serializes
+    /// to an explicit JSON `null`, so the JSON-RPC response carries `"result":
+    /// null` rather than omitting the `result` member. (The report was not
+    /// reproducible; the serialization is correct.)
+    #[test]
+    fn accepted_serializes_to_null() {
+        assert_eq!(
+            serde_json::to_value(SubmitBlockResponse::Accepted).expect("serializes"),
+            serde_json::Value::Null,
+        );
+    }
+
+    /// A non-accepted `submitblock` response serializes to its kebab-case string
+    /// reason (not `null`), matching the Zcash RPC contract.
+    #[test]
+    fn error_response_serializes_to_string() {
+        assert_eq!(
+            serde_json::to_value(SubmitBlockResponse::ErrorResponse(
+                SubmitBlockErrorResponse::Rejected
+            ))
+            .expect("serializes"),
+            serde_json::json!("rejected"),
+        );
+    }
+}


### PR DESCRIPTION
## Motivation

Closes #10571.

A report claimed accepted `submitblock` responses omit the JSON-RPC `result` member (so a strict client sees `{"jsonrpc":"2.0","id":"submitblock"}` with no `result`). It is **not reproducible**: `SubmitBlockResponse::Accepted` is a unit variant under `#[serde(untagged)]`, which serializes to an explicit `null`, so the response carries `"result": null`. The reported omission was almost certainly on the client side (the Stratum bridge). This PR locks the correct behaviour in with tests so the issue can be closed as not-reproducible.

## Solution

Add unit tests in `zebra-rpc/src/methods/types/submit_block.rs`: an accepted response serializes to `serde_json::Value::Null`, and a non-accepted response serializes to its kebab-case string reason (`"rejected"`), matching the Zcash RPC contract. No behaviour change — tests only.

## Tests

```
cargo test -p zebra-rpc --lib -- methods::types::submit_block::tests
test result: ok. 2 passed
```

`cargo fmt` and `cargo clippy -p zebra-rpc --lib --all-features` are clean.

## Specifications & References

zcashd `submitblock` contract: acceptance is a `null` result, rejection is a string reason (<https://zcash.github.io/rpc/submitblock.html>).

## Follow-up Work

None. The issue is not-reproducible and can be closed once this merges.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude (Claude Code) — wrote the tests and this description.

## PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
