### PR TITLE
fix(zebra-node-services): validate JSON-RPC version and id in the rpc-client

### DIFF
--- a/zebra-node-services/CHANGELOG.md
+++ b/zebra-node-services/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The `rpc-client` `RpcRequestClient` now issues a distinct id per request and, in
+  `json_result_from_call`, rejects a response whose `jsonrpc` version is missing or whose `id`
+  doesn't match the request, instead of accepting any well-formed response
+  ([#10687](https://github.com/ZcashFoundation/zebra/issues/10687)).
+
 ## [10.0.0] - 2026-08-10
 
 ### Breaking Changes

--- a/zebra-node-services/src/rpc_client.rs
+++ b/zebra-node-services/src/rpc_client.rs
@@ -2,8 +2,13 @@
 //!
 //! Used in the rpc sync scanning functionality and in various tests and tools.
 
-use std::{net::SocketAddr, time::Duration};
+use std::{
+    net::SocketAddr,
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
 
+use jsonrpsee_types::Id;
 use reqwest::Client;
 
 use crate::BoxError;
@@ -13,6 +18,15 @@ use crate::BoxError;
 /// This is a safety net to prevent RPC calls from hanging indefinitely
 /// when a server is alive but unresponsive.
 const RPC_REQUEST_TIMEOUT: Duration = Duration::from_secs(180);
+
+/// A process-wide, monotonically increasing counter for JSON-RPC request ids, so
+/// each request carries a distinct id that its response can be correlated against.
+static NEXT_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Returns the next distinct JSON-RPC request id.
+fn next_request_id() -> u64 {
+    NEXT_REQUEST_ID.fetch_add(1, Ordering::Relaxed)
+}
 
 /// An HTTP client for making JSON-RPC requests.
 #[derive(Clone, Debug)]
@@ -46,13 +60,22 @@ impl RpcRequestClient {
         method: impl AsRef<str>,
         params: impl AsRef<str>,
     ) -> reqwest::Result<reqwest::Response> {
-        let method = method.as_ref();
-        let params = params.as_ref();
+        self.call_with_id(method.as_ref(), params.as_ref(), next_request_id())
+            .await
+    }
 
+    /// Builds an rpc request with the given request `id` and an `application/json`
+    /// content type.
+    async fn call_with_id(
+        &self,
+        method: &str,
+        params: &str,
+        id: u64,
+    ) -> reqwest::Result<reqwest::Response> {
         self.client
             .post(format!("http://{}", self.rpc_address))
             .body(format!(
-                r#"{{"jsonrpc": "2.0", "method": "{method}", "params": {params}, "id":123 }}"#
+                r#"{{"jsonrpc": "2.0", "method": "{method}", "params": {params}, "id":{id} }}"#
             ))
             .header("Content-Type", "application/json")
             .send()
@@ -68,11 +91,12 @@ impl RpcRequestClient {
     ) -> reqwest::Result<reqwest::Response> {
         let method = method.as_ref();
         let params = params.as_ref();
+        let id = next_request_id();
 
         self.client
             .post(format!("http://{}", self.rpc_address))
             .body(format!(
-                r#"{{"jsonrpc": "2.0", "method": "{method}", "params": {params}, "id":123 }}"#
+                r#"{{"jsonrpc": "2.0", "method": "{method}", "params": {params}, "id":{id} }}"#
             ))
             .header("Content-Type", content_type)
             .send()
@@ -87,11 +111,12 @@ impl RpcRequestClient {
     ) -> reqwest::Result<reqwest::Response> {
         let method = method.as_ref();
         let params = params.as_ref();
+        let id = next_request_id();
 
         self.client
             .post(format!("http://{}", self.rpc_address))
             .body(format!(
-                r#"{{"jsonrpc": "2.0", "method": "{method}", "params": {params}, "id":123 }}"#
+                r#"{{"jsonrpc": "2.0", "method": "{method}", "params": {params}, "id":{id} }}"#
             ))
             .send()
             .await
@@ -110,24 +135,58 @@ impl RpcRequestClient {
     /// it to the expected result type.
     ///
     /// Returns Ok with json result from response if successful.
-    /// Returns an error if the call or result deserialization fail.
+    /// Returns an error if the call fails, the response is missing the `jsonrpc`
+    /// version, a successful response's `id` doesn't match the request, or result
+    /// deserialization fails.
     pub async fn json_result_from_call<T: serde::de::DeserializeOwned>(
         &self,
         method: impl AsRef<str>,
         params: impl AsRef<str>,
     ) -> std::result::Result<T, BoxError> {
-        Self::json_result_from_response_text(&self.text_from_call(method, params).await?)
+        let id = next_request_id();
+        let response_text = self
+            .call_with_id(method.as_ref(), params.as_ref(), id)
+            .await?
+            .text()
+            .await?;
+
+        Self::json_result_from_response_text(&response_text, Id::Number(id))
     }
 
-    /// Accepts response text from an RPC call
-    /// Returns `Ok` with a deserialized `result` value in the expected type, or an error report.
+    /// Accepts response text from an RPC call and the id of the request it answers.
+    ///
+    /// Returns `Ok` with a deserialized `result` value in the expected type, or an
+    /// error report. Rejects a response whose `jsonrpc` version is absent (a
+    /// non-`"2.0"` version already fails to deserialize), and a *successful*
+    /// response whose `id` does not match `expected_id`. Error payloads are
+    /// returned as-is (a null `id` is valid on some JSON-RPC errors).
     fn json_result_from_response_text<T: serde::de::DeserializeOwned>(
         response_text: &str,
+        expected_id: Id<'_>,
     ) -> std::result::Result<T, BoxError> {
         let output: jsonrpsee_types::Response<serde_json::Value> =
             serde_json::from_str(response_text)?;
+
+        // A wrong `jsonrpc` version already fails to deserialize above (the field
+        // only accepts "2.0"), so here we only need to reject a missing version.
+        if output.jsonrpc.is_none() {
+            return Err("JSON-RPC response is missing the \"jsonrpc\" version field".into());
+        }
+
         match output.payload {
             jsonrpsee_types::ResponsePayload::Success(success) => {
+                // Correlate the result to its request. The id check is only applied
+                // to success responses: JSON-RPC allows a null `id` on errors where
+                // the request id could not be determined, so an error is returned
+                // as-is rather than masked by an id mismatch.
+                if output.id != expected_id {
+                    return Err(format!(
+                        "JSON-RPC response id {:?} does not match request id {expected_id:?}",
+                        output.id
+                    )
+                    .into());
+                }
+
                 Ok(serde_json::from_value(success.into_owned())?)
             }
             jsonrpsee_types::ResponsePayload::Error(failure) => Err(failure.to_string().into()),
@@ -179,5 +238,47 @@ mod tests {
         accept_thread
             .join()
             .expect("accept thread should exit cleanly");
+    }
+
+    /// Regression test for #10687: the client validates the `jsonrpc` version and
+    /// the response `id`, rejecting a mismatched id or a missing version.
+    #[test]
+    fn validates_version_and_id() {
+        // A matching version and id deserializes the result.
+        let matching = r#"{"jsonrpc":"2.0","result":42,"id":7}"#;
+        let value: i64 = RpcRequestClient::json_result_from_response_text(matching, Id::Number(7))
+            .expect("a matching response should deserialize");
+        assert_eq!(value, 42);
+
+        // A mismatched id is rejected.
+        let mismatched_id = r#"{"jsonrpc":"2.0","result":42,"id":8}"#;
+        assert!(
+            RpcRequestClient::json_result_from_response_text::<i64>(mismatched_id, Id::Number(7))
+                .is_err(),
+            "a response with a mismatched id should be rejected",
+        );
+
+        // A missing jsonrpc version is rejected.
+        let missing_version = r#"{"result":42,"id":7}"#;
+        assert!(
+            RpcRequestClient::json_result_from_response_text::<i64>(missing_version, Id::Number(7))
+                .is_err(),
+            "a response missing the jsonrpc version should be rejected",
+        );
+    }
+
+    /// An error response is returned as an error and surfaces the server's message,
+    /// even when its `id` is null (which JSON-RPC permits on some errors) and so
+    /// does not match the request id. See #10687.
+    #[test]
+    fn error_response_is_returned_regardless_of_id() {
+        let error =
+            r#"{"jsonrpc":"2.0","error":{"code":-32601,"message":"method not found"},"id":null}"#;
+        let err = RpcRequestClient::json_result_from_response_text::<i64>(error, Id::Number(7))
+            .expect_err("an error response should be returned as an error");
+        assert!(
+            err.to_string().contains("method not found"),
+            "the error should surface the server's message, got: {err}",
+        );
     }
 }


### PR DESCRIPTION
## Motivation

Closes #10687.

`RpcRequestClient::json_result_from_response_text` (`zebra-node-services/src/rpc_client.rs`, the feature-gated `rpc-client` used by tests and tools) returned the `result` without validating the response's `jsonrpc` version or `id`, and every request hardcoded `"id":123`. So a response with a mismatched, null, or missing `id`, or a missing `jsonrpc` version, was accepted as a valid result.

## Solution

- Issue a distinct per-request id from a process-wide `AtomicU64` counter (replacing the hardcoded `123`). The public `call*` methods now all send distinct ids; `json_result_from_call` generates the id, sends the request via a new private `call_with_id`, and threads the id into validation.
- In `json_result_from_response_text`, reject a response whose `jsonrpc` version field is absent. A *wrong* version (e.g. `"1.0"`) already fails to deserialize, because the field is `Option<TwoPointZero>` and `TwoPointZero` only accepts `"2.0"` — so only a *missing* version needs an explicit check.
- Validate the `id` only for **success** responses (correlating a result to its request). Error payloads are returned as-is, because JSON-RPC allows a null `id` on errors where the request id could not be determined — checking the id first would mask the real error.

No public API change (the `call*` signatures are unchanged; `json_result_from_response_text` is private). Feature-gated tooling only — not part of the default node build.

## Tests

- `validates_version_and_id`: a matching response deserializes; a mismatched id and a missing `jsonrpc` version are each rejected. Fails before the fix (confirmed by neutralizing each check).
- `error_response_is_returned_regardless_of_id`: an error response with `id: null` surfaces the server's error message rather than an id-mismatch error.

```
cargo test -p zebra-node-services --lib -- rpc_client::tests
test result: ok. 3 passed
```

`cargo fmt` and `cargo clippy -p zebra-node-services --all-targets --all-features` are clean.

## Specifications & References

JSON-RPC 2.0: success responses require a matching `id`; errors may carry a null `id` when the request id can't be determined.

## Follow-up Work

None.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude (Claude Code) — wrote the fix and the tests.

## PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
