### PR TITLE
feat(network): v2 P2P protocol wire formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7492,6 +7492,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "sha2 0.10.9",
+ "siphasher",
  "static_assertions",
  "tempfile",
  "thiserror 2.0.18",

--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -27,6 +27,7 @@ mod serialize;
 
 pub mod genesis;
 pub mod merkle;
+pub mod sync_metadata;
 
 #[cfg(any(test, feature = "proptest-impl"))]
 pub mod arbitrary;
@@ -41,6 +42,7 @@ pub use hash::Hash;
 pub use header::{BlockTimeError, CountedHeader, Header, ZCASH_BLOCK_VERSION};
 pub use height::{Height, HeightDiff, TryIntoHeight};
 pub use serialize::{SerializedBlock, MAX_BLOCK_BYTES};
+pub use sync_metadata::{SyncHashEntry, TreeRootsEntry};
 
 #[cfg(any(test, feature = "proptest-impl"))]
 pub use arbitrary::LedgerState;

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -63,6 +63,7 @@ regex = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["serde_derive"] }
 sha2 = { workspace = true }
+siphasher = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 

--- a/zebra-network/src/protocol.rs
+++ b/zebra-network/src/protocol.rs
@@ -6,3 +6,5 @@ pub mod external;
 pub mod internal;
 /// Newtype wrappers giving semantic meaning to primitive datatypes.
 pub mod types;
+/// The version 2 Zcash P2P network protocol.
+pub mod v2;

--- a/zebra-network/src/protocol/external.rs
+++ b/zebra-network/src/protocol/external.rs
@@ -21,6 +21,8 @@ pub use codec::Codec;
 pub use inv::{InventoryHash, MAX_TX_INV_IN_SENT_MESSAGE};
 pub use message::{Message, VersionMessage};
 
+pub(crate) use codec::zcash_deserialize_user_agent;
+pub(crate) use inv::MAX_INV_IN_RECEIVED_MESSAGE;
 pub use types::{Nonce, Version};
 
 pub use zebra_chain::serialization::MAX_PROTOCOL_MESSAGE_LEN;

--- a/zebra-network/src/protocol/v2.rs
+++ b/zebra-network/src/protocol/v2.rs
@@ -1,0 +1,39 @@
+//! The version 2 Zcash P2P network protocol.
+//!
+//! This module implements the wire formats of the draft ZIP
+//! "Version 2 Zcash P2P Network Protocol": a successor to the legacy
+//! Bitcoin-inherited message protocol, defined against a transport-neutral
+//! stream layer realized by QUIC.
+//!
+//! Implemented against the draft revision pinned in `SPEC-CONFORMANCE.md`
+//! (zcash/zips PR #1346 at `a3f4fa2a`, which includes the PR #1344 transport
+//! draft). The drafts are still moving: that file maps each draft section to
+//! its implementing module, tests, and conformance status, and must be
+//! updated whenever the implemented revision changes.
+//!
+//! All application data is carried on streams typed by their first byte:
+//! - a single bidirectional *handshake stream* (type `0x00`) carrying
+//!   length-prefixed records, starting with the [`init`] record exchange,
+//! - bidirectional *request streams* (types `0x01`–`0x09`), each carrying
+//!   exactly one request and its response, and
+//! - long-lived unidirectional *announcement streams* (types `0x10`–`0x12`)
+//!   carrying length-prefixed announcement records.
+//!
+//! This module contains the wire encodings and their limits. The QUIC
+//! transport that carries them, and the peer connection logic that uses
+//! them, are added by the commits that follow this one.
+// Every item here is reached through the transport and connection layers,
+// which land in later commits; the tests below exercise them meanwhile.
+#![allow(dead_code)]
+
+pub mod compact_block;
+pub mod constants;
+pub mod init;
+pub mod record;
+pub mod request;
+pub mod response;
+pub mod txref;
+pub mod types;
+
+#[cfg(test)]
+mod tests;

--- a/zebra-network/src/protocol/v2/compact_block.rs
+++ b/zebra-network/src/protocol/v2/compact_block.rs
@@ -1,0 +1,356 @@
+//! Compact block encoding for the version 2 Zcash P2P network protocol.
+//!
+//! Compact block relay is adapted from BIP 152: a block is relayed as its
+//! header plus identifiers of its transactions — short transaction IDs, or
+//! full transaction IDs at the receiver's option — with transactions the
+//! receiver is predicted not to have prefilled in full.
+
+use std::{io, sync::Arc};
+
+use sha2::{Digest, Sha256};
+use siphasher::sip::SipHasher24;
+use tokio::io::AsyncRead;
+
+use zebra_chain::{
+    block::{merkle::AUTH_DIGEST_PLACEHOLDER, Block, Header},
+    serialization::{ZcashDeserialize, ZcashSerialize},
+    transaction::{Transaction, UnminedTxId, WtxId},
+};
+
+use super::{
+    constants::{MAX_COMPACT_BLOCK_TX_COUNT, MAX_PREFILLED_TX_INDEX, MAX_RECORD_PAYLOAD_LEN},
+    record,
+    types::WireError,
+};
+
+/// The `ids_kind` byte of a compact block whose `ids` field contains short
+/// transaction IDs.
+pub const IDS_KIND_SHORT: u8 = 0x00;
+
+/// The `ids_kind` byte of a compact block whose `ids` field contains full
+/// transaction IDs.
+pub const IDS_KIND_FULL: u8 = 0x01;
+
+/// A short transaction ID: the least significant 6 bytes, in little-endian
+/// byte order, of a keyed SipHash-2-4 of the transaction's relay identifier.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct ShortTxId(pub [u8; 6]);
+
+/// The transaction IDs of a compact block: short or full, at the receiver's
+/// option.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CompactBlockIds {
+    /// Short transaction IDs (`ids_kind = 0`).
+    Short(Vec<ShortTxId>),
+
+    /// Full transaction IDs (`ids_kind = 1`): each is the transaction's txid
+    /// followed by its authorizing data commitment, with the ZIP 244
+    /// placeholder for transactions with version 4 or earlier.
+    Full(Vec<WtxId>),
+}
+
+/// A transaction included in full in a compact block.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PrefilledTransaction {
+    /// The absolute index of this transaction within the block.
+    ///
+    /// On the wire, indexes are differentially encoded; this is the decoded
+    /// absolute index.
+    pub index: u64,
+
+    /// The transaction.
+    pub tx: Arc<Transaction>,
+}
+
+/// A compact block: a block's header plus a compact representation of its
+/// transactions.
+///
+/// Each transaction in the block, in block order, is represented either by a
+/// transaction ID in `ids` or by a full serialized transaction in
+/// `prefilled`. The coinbase transaction must be prefilled.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompactBlock {
+    /// The block header.
+    pub header: Arc<Header>,
+
+    /// The nonce for short transaction ID computation.
+    ///
+    /// If `ids` contains full transaction IDs, this field should be 0 and
+    /// must be ignored.
+    pub nonce: u64,
+
+    /// The block's transaction IDs, in block order, excluding prefilled
+    /// transactions.
+    pub ids: CompactBlockIds,
+
+    /// The prefilled transactions, with strictly increasing absolute
+    /// indexes.
+    pub prefilled: Vec<PrefilledTransaction>,
+}
+
+impl CompactBlock {
+    /// Builds a compact block for `block`.
+    ///
+    /// The coinbase transaction is always prefilled; `extra_prefilled`
+    /// selects additional transaction indexes to prefill (transactions the
+    /// sender predicts the receiver does not have). If `full_ids` is true,
+    /// the remaining transactions are identified by full transaction IDs and
+    /// the nonce is 0; otherwise they are identified by short transaction
+    /// IDs computed with `nonce`.
+    #[allow(clippy::unwrap_in_result)]
+    pub fn from_block(
+        block: &Block,
+        nonce: u64,
+        full_ids: bool,
+        extra_prefilled: &[u64],
+    ) -> Result<Self, WireError> {
+        let header = block.header.clone();
+        let tx_count = block.transactions.len() as u64;
+
+        if tx_count > MAX_COMPACT_BLOCK_TX_COUNT
+            || tx_count.saturating_sub(1) > MAX_PREFILLED_TX_INDEX
+        {
+            return Err(WireError::Local(format!(
+                "block with {tx_count} transactions cannot be relayed as a compact block",
+            )));
+        }
+
+        let mut prefilled = Vec::new();
+        let mut id_txs = Vec::new();
+
+        for (index, tx) in block.transactions.iter().enumerate() {
+            let index = index as u64;
+            // The coinbase transaction (index 0) must be prefilled.
+            if index == 0 || extra_prefilled.contains(&index) {
+                prefilled.push(PrefilledTransaction {
+                    index,
+                    tx: tx.clone(),
+                });
+            } else {
+                id_txs.push(tx);
+            }
+        }
+
+        let ids = if full_ids {
+            CompactBlockIds::Full(
+                id_txs
+                    .into_iter()
+                    .map(|tx| full_transaction_id(&UnminedTxId::from(tx.as_ref())))
+                    .collect(),
+            )
+        } else {
+            let header_bytes = header
+                .zcash_serialize_to_vec()
+                .expect("serializing a header to a Vec never fails");
+            let (k0, k1) = short_id_keys(&header_bytes, nonce);
+
+            CompactBlockIds::Short(
+                id_txs
+                    .into_iter()
+                    .map(|tx| short_transaction_id(k0, k1, &UnminedTxId::from(tx.as_ref())))
+                    .collect(),
+            )
+        };
+
+        Ok(CompactBlock {
+            header,
+            nonce: if full_ids { 0 } else { nonce },
+            ids,
+            prefilled,
+        })
+    }
+
+    /// Encodes this compact block to `writer`.
+    #[allow(clippy::unwrap_in_result)]
+    pub fn encode<W: io::Write>(&self, mut writer: W) -> Result<(), WireError> {
+        let header_bytes = self
+            .header
+            .zcash_serialize_to_vec()
+            .expect("serializing a header to a Vec never fails");
+        record::write_record(&mut writer, &header_bytes)?;
+
+        writer.write_all(&self.nonce.to_le_bytes())?;
+
+        match &self.ids {
+            CompactBlockIds::Short(ids) => {
+                writer.write_all(&[IDS_KIND_SHORT])?;
+                record::write_compact_size(&mut writer, ids.len() as u64)?;
+                for id in ids {
+                    writer.write_all(&id.0)?;
+                }
+            }
+            CompactBlockIds::Full(ids) => {
+                writer.write_all(&[IDS_KIND_FULL])?;
+                record::write_compact_size(&mut writer, ids.len() as u64)?;
+                for id in ids {
+                    writer.write_all(&id.as_bytes())?;
+                }
+            }
+        }
+
+        record::write_compact_size(&mut writer, self.prefilled.len() as u64)?;
+        let mut previous_index: Option<u64> = None;
+        for prefilled in &self.prefilled {
+            let differential = match previous_index {
+                None => prefilled.index,
+                Some(previous) => prefilled
+                    .index
+                    .checked_sub(previous + 1)
+                    .expect("prefilled indexes are strictly increasing"),
+            };
+            previous_index = Some(prefilled.index);
+
+            record::write_compact_size(&mut writer, differential)?;
+
+            let tx_bytes = prefilled
+                .tx
+                .zcash_serialize_to_vec()
+                .expect("serializing a transaction to a Vec never fails");
+            record::write_record(&mut writer, &tx_bytes)?;
+        }
+
+        Ok(())
+    }
+
+    /// Reads a compact block from `reader`.
+    ///
+    /// A compact block in which `ids_count + prefilled_count` exceeds
+    /// [`MAX_COMPACT_BLOCK_TX_COUNT`] is a connection error of type `FLOOD`.
+    /// A compact block with an invalid `ids_kind`, or in which any prefilled
+    /// absolute index would exceed [`MAX_PREFILLED_TX_INDEX`], overflows, or
+    /// is not strictly increasing, is rejected as a `PROTOCOL_ERROR`.
+    pub async fn read<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Self, WireError> {
+        let header_bytes =
+            record::read_length_prefixed_bytes(reader, MAX_RECORD_PAYLOAD_LEN).await?;
+        let header = Arc::new(Header::zcash_deserialize(header_bytes.as_slice())?);
+
+        let nonce = record::read_exact_u64_le(reader).await?;
+
+        let ids_kind = record::read_u8(reader).await?;
+        let ids_count = record::read_compact_size(reader).await?;
+
+        if ids_count > MAX_COMPACT_BLOCK_TX_COUNT {
+            return Err(WireError::Flood(format!(
+                "compact block ids_count {ids_count} exceeds the transaction count limit",
+            )));
+        }
+
+        let ids = match ids_kind {
+            IDS_KIND_SHORT => {
+                let mut ids = Vec::with_capacity(record::preallocate_len(ids_count));
+                for _ in 0..ids_count {
+                    let mut id = [0u8; 6];
+                    record::read_exact_or_incomplete(reader, &mut id).await?;
+                    ids.push(ShortTxId(id));
+                }
+                CompactBlockIds::Short(ids)
+            }
+            IDS_KIND_FULL => {
+                let mut ids = Vec::with_capacity(record::preallocate_len(ids_count));
+                for _ in 0..ids_count {
+                    let mut id = [0u8; 64];
+                    record::read_exact_or_incomplete(reader, &mut id).await?;
+                    ids.push(WtxId::from(id));
+                }
+                CompactBlockIds::Full(ids)
+            }
+            invalid => {
+                return Err(WireError::Protocol(format!(
+                    "invalid compact block ids_kind {invalid}: must be 0 or 1",
+                )))
+            }
+        };
+
+        let prefilled_count = record::read_compact_size(reader).await?;
+        let total_count = ids_count.checked_add(prefilled_count);
+        if total_count.is_none_or(|total| total > MAX_COMPACT_BLOCK_TX_COUNT) {
+            return Err(WireError::Flood(format!(
+                "compact block transaction count {ids_count} + {prefilled_count} \
+                 exceeds the limit {MAX_COMPACT_BLOCK_TX_COUNT}",
+            )));
+        }
+
+        let mut prefilled = Vec::with_capacity(record::preallocate_len(prefilled_count));
+        let mut previous_index: Option<u64> = None;
+        for _ in 0..prefilled_count {
+            let differential = record::read_compact_size(reader).await?;
+
+            let index = match previous_index {
+                None => differential,
+                Some(previous) => previous
+                    .checked_add(1)
+                    .and_then(|next| next.checked_add(differential))
+                    .ok_or_else(|| {
+                        WireError::Protocol("prefilled transaction index overflow".to_string())
+                    })?,
+            };
+
+            if index > MAX_PREFILLED_TX_INDEX {
+                return Err(WireError::Protocol(format!(
+                    "prefilled transaction index {index} exceeds the limit",
+                )));
+            }
+            previous_index = Some(index);
+
+            let tx_bytes =
+                record::read_length_prefixed_bytes(reader, MAX_RECORD_PAYLOAD_LEN).await?;
+            let tx = Arc::new(Transaction::zcash_deserialize(tx_bytes.as_slice())?);
+
+            prefilled.push(PrefilledTransaction { index, tx });
+        }
+
+        Ok(CompactBlock {
+            header,
+            nonce,
+            ids,
+            prefilled,
+        })
+    }
+}
+
+/// Computes the SipHash keys for short transaction IDs: the single SHA-256
+/// hash of the serialized block header followed by the 8-byte little-endian
+/// nonce, interpreted as two little-endian `u64` values.
+pub fn short_id_keys(serialized_header: &[u8], nonce: u64) -> (u64, u64) {
+    let mut hasher = Sha256::new();
+    hasher.update(serialized_header);
+    hasher.update(nonce.to_le_bytes());
+    let hash = hasher.finalize();
+
+    let k0 = u64::from_le_bytes(hash[0..8].try_into().expect("slice length is 8"));
+    let k1 = u64::from_le_bytes(hash[8..16].try_into().expect("slice length is 8"));
+
+    (k0, k1)
+}
+
+/// Computes the short transaction ID of a transaction: the least significant
+/// 6 bytes, in little-endian byte order, of `SipHash-2-4(k0, k1, input)`,
+/// where the input is the transaction's relay identifier.
+pub fn short_transaction_id(k0: u64, k1: u64, id: &UnminedTxId) -> ShortTxId {
+    use std::hash::Hasher;
+
+    let mut hasher = SipHasher24::new_with_keys(k0, k1);
+    match id {
+        // For a transaction with version 4 or earlier, the input is its
+        // 32-byte txid.
+        UnminedTxId::Legacy(txid) => hasher.write(&txid.0),
+        // For a transaction with version 5 or later, the input is its
+        // 64-byte wtxid.
+        UnminedTxId::Witnessed(wtxid) => hasher.write(&wtxid.as_bytes()),
+    }
+
+    let hash = hasher.finish();
+    let bytes = hash.to_le_bytes();
+
+    ShortTxId(bytes[0..6].try_into().expect("slice length is 6"))
+}
+
+/// Returns the full transaction ID of a transaction: its txid followed by
+/// its authorizing data commitment, with the ZIP 244 placeholder for
+/// transactions with version 4 or earlier.
+pub fn full_transaction_id(id: &UnminedTxId) -> WtxId {
+    WtxId {
+        id: id.mined_id(),
+        auth_digest: id.auth_digest().unwrap_or(AUTH_DIGEST_PLACEHOLDER),
+    }
+}

--- a/zebra-network/src/protocol/v2/constants.rs
+++ b/zebra-network/src/protocol/v2/constants.rs
@@ -1,0 +1,253 @@
+//! Constants for the version 2 Zcash P2P network protocol.
+
+use std::time::Duration;
+
+use zebra_chain::serialization::{MAX_HEADERS_PER_MESSAGE, MAX_PROTOCOL_MESSAGE_LEN};
+
+use crate::protocol::external::{types::Version, MAX_INV_IN_RECEIVED_MESSAGE};
+
+/// The ALPN protocol identifier for Mainnet connections.
+pub const ALPN_MAINNET: &[u8] = b"zcash/main";
+
+/// The ALPN protocol identifier for Testnet connections.
+pub const ALPN_TESTNET: &[u8] = b"zcash/test";
+
+/// The ALPN protocol identifier for Regtest connections.
+pub const ALPN_REGTEST: &[u8] = b"zcash/regtest";
+
+/// The maximum length of a record payload, and of any individually
+/// length-prefixed element in a request or response, such as a serialized
+/// block.
+///
+/// A length prefix exceeding this limit is a connection error of type
+/// [`ErrorCode::Flood`](super::types::ErrorCode::Flood).
+///
+/// This is [`MAX_PROTOCOL_MESSAGE_LEN`] (2 MiB), so [`CompactSizeMessage`]
+/// length prefixes enforce it automatically.
+///
+/// [`CompactSizeMessage`]: zebra_chain::serialization::CompactSizeMessage
+pub const MAX_RECORD_PAYLOAD_LEN: usize = MAX_PROTOCOL_MESSAGE_LEN;
+
+/// The maximum number of block locator hashes in a `get-headers` request.
+pub const MAX_LOCATOR_HASHES: u64 = 101;
+
+/// The maximum number of headers in a `get-headers` response
+/// (`MAX_HEADERS_RESULTS`): the same limit as legacy `headers` messages.
+///
+/// A response with more headers incurs a misbehavior penalty of
+/// [`MISBEHAVIOR_PENALTY_LIMIT_EXCEEDED`] points.
+pub const MAX_HEADERS_RESULTS: u64 = MAX_HEADERS_PER_MESSAGE as u64;
+
+/// The maximum number of block hashes in a `get-blocks` request.
+pub const MAX_GET_BLOCKS_HASHES: u64 = 128;
+
+/// The maximum number of transaction references in a `get-tx` request.
+pub const MAX_GET_TX_REFS: u64 = 50_000;
+
+/// The maximum number of address records in a `get-addr` response: the same
+/// limit as legacy `addr` messages.
+///
+/// A response with more address records incurs a misbehavior penalty of
+/// [`MISBEHAVIOR_PENALTY_LIMIT_EXCEEDED`] points.
+pub const MAX_ADDRS_IN_RESPONSE: u64 = crate::constants::MAX_ADDRS_IN_MESSAGE as u64;
+
+/// The maximum number of transaction references in a `get-mempool` response.
+///
+/// The draft ZIP does not specify a limit for this response; this
+/// implementation-defined bound matches the legacy `inv` message limit, and
+/// bounds the memory allocated while reading untrusted response data.
+//
+// The legacy limit is 50,000, which fits in a `usize` on every supported
+// platform.
+pub const MAX_MEMPOOL_RESPONSE_REFS: usize = MAX_INV_IN_RECEIVED_MESSAGE as usize;
+
+/// The maximum number of transaction references sent in a single
+/// `get-mempool` response record.
+///
+/// This is an implementation-defined bound: references are 65 bytes at
+/// most, so a record of this many stays under [`MAX_RECORD_PAYLOAD_LEN`],
+/// and under the [`MAX_MEMPOOL_RESPONSE_REFS`] reading limit. A snapshot
+/// with more references spans multiple records.
+pub const MAX_MEMPOOL_RECORD_REFS: usize = 25_000;
+
+/// The maximum number of block hashes requested by a `get-hashes` request.
+pub const MAX_GET_HASHES_COUNT: u64 = 50_000;
+
+/// The maximum number of blocks requested by a `get-block-range` request.
+pub const MAX_GET_BLOCK_RANGE_COUNT: u64 = 65_536;
+
+/// The maximum total serialized size of the blocks requested by a
+/// `get-block-range` request, in bytes (64 MiB).
+pub const MAX_GET_BLOCK_RANGE_BYTES: u64 = 67_108_864;
+
+/// The number of concurrently pending inbound v2 handshakes above which new
+/// connection attempts must validate their source address with a retry
+/// token before they are accepted.
+///
+/// Below the threshold, connections accept in one round trip. Above it — as
+/// under a handshake flood — an attempt from an unvalidated address costs
+/// this node only a stateless retry packet, not a TLS handshake, and
+/// spoofed-source attempts never reach the handshake at all.
+pub const MAX_PENDING_INBOUND_HANDSHAKES: usize = 32;
+
+/// The maximum number of `get-block-range` streams served concurrently to
+/// one peer.
+///
+/// This is an implementation-defined bound: each bulk stream commits this
+/// node to up to [`MAX_GET_BLOCK_RANGE_BYTES`] of block reads and transfer,
+/// and a synchronizing peer spreads its work units across many peers, so
+/// streams beyond the bound are refused rather than queued.
+pub const MAX_CONCURRENT_BULK_STREAMS: usize = 2;
+
+/// The maximum number of entries requested by a `get-tree-roots` request.
+pub const MAX_GET_TREE_ROOTS_COUNT: u64 = 4_000;
+
+/// The maximum number of bytes requested by a `get-object` request (32 MiB).
+///
+/// Artifacts are expected to be divided into pieces no larger than this, so
+/// that each piece is independently fetchable and verifiable.
+pub const MAX_GET_OBJECT_LENGTH: u64 = 33_554_432;
+
+/// The maximum total number of transactions (`ids_count + prefilled_count`)
+/// in a compact block.
+///
+/// A compact block exceeding this limit is a connection error of type
+/// [`ErrorCode::Flood`](super::types::ErrorCode::Flood).
+pub const MAX_COMPACT_BLOCK_TX_COUNT: u64 = 65_536;
+
+/// The maximum absolute index of a prefilled transaction in a compact block.
+pub const MAX_PREFILLED_TX_INDEX: u64 = 65_535;
+
+/// The minimum number of concurrent bidirectional streams a node should allow
+/// its peer to have open.
+pub const MIN_CONCURRENT_BIDI_STREAMS: u32 = 32;
+
+/// The minimum number of concurrent unidirectional streams a node should
+/// allow its peer to have open.
+pub const MIN_CONCURRENT_UNI_STREAMS: u32 = 8;
+
+/// The minimum idle timeout for connections a node wishes to retain.
+pub const IDLE_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// The interval between transport keep-alives on connections a node wishes
+/// to retain.
+///
+/// This is an implementation-defined value, chosen to be well under
+/// [`IDLE_TIMEOUT`].
+pub const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(45);
+
+/// The maximum time an inbound stream may make no progress before it is
+/// abandoned.
+///
+/// A peer that opens a stream must send its stream type byte, a peer that
+/// opens a request stream must send its request, and a peer that starts a
+/// record must finish it, all within this time. Serving one inbound request
+/// stream is bounded by it as well, because the requester gives up after
+/// [`REQUEST_TIMEOUT`](crate::constants::REQUEST_TIMEOUT).
+///
+/// Streams are read by their own tasks, and transport keep-alives stop
+/// [`IDLE_TIMEOUT`] from firing on an otherwise live connection, so without
+/// this bound a stalled stream would pin its task and its buffers for the
+/// life of the connection.
+pub const INBOUND_STREAM_TIMEOUT: Duration =
+    Duration::from_secs(2 * crate::constants::REQUEST_TIMEOUT.as_secs());
+
+/// The number of consecutive request timeouts that disconnect a peer.
+///
+/// The transport provides keep-alives, so heartbeats are answered locally and
+/// cannot detect a peer whose QUIC stack is alive but whose application never
+/// answers a request stream. Consecutive timeouts are that peer's only
+/// signature, so they disconnect it here instead: without this, it would stay
+/// in the peer set and sink every request routed to it for the process
+/// lifetime.
+///
+/// More than one timeout is required, so that a single slow response does not
+/// disconnect an otherwise healthy peer.
+pub const MAX_CONSECUTIVE_REQUEST_TIMEOUTS: u32 = 3;
+
+/// The minimum peer protocol version of the version 2 protocol.
+///
+/// The protocol version from which the version 2 protocol is deployed has not
+/// yet been assigned; it will be assigned to a network upgrade according to
+/// the draft ZIP's assignment procedure. Until then, this placeholder is the
+/// current network protocol version.
+//
+// TODO: replace with the assigned version when the draft ZIP is assigned a
+//       network upgrade and protocol version.
+pub const MIN_V2_PROTOCOL_VERSION: Version = crate::constants::CURRENT_NETWORK_PROTOCOL_VERSION;
+
+/// The misbehavior penalty for exceeding a `SHOULD`-level response size limit:
+/// a `get-headers` response with more than [`MAX_HEADERS_RESULTS`] headers,
+/// a non-contiguous `get-headers` response, or a `get-addr` response with
+/// more than [`MAX_ADDRS_IN_RESPONSE`] address records.
+pub const MISBEHAVIOR_PENALTY_LIMIT_EXCEEDED: u32 = 20;
+
+/// The misbehavior penalty for an announcement whose block header fails its
+/// own proof of work.
+///
+/// The announcement is provable misbehavior on its own: the header is
+/// received data, and its Equihash solution and hash are checked against
+/// the header itself, independent of any chain state. The penalty reaches
+/// the disconnection threshold immediately.
+pub const MISBEHAVIOR_PENALTY_INVALID_POW: u32 = crate::constants::MAX_PEER_MISBEHAVIOR_SCORE;
+
+/// The maximum number of peers this node requests high-bandwidth compact
+/// block announcements from, by setting `announce = 1` in its `init` record
+/// on at most this many connections at a time.
+pub const MAX_HIGH_BANDWIDTH_PEERS: usize = 3;
+
+/// The mean of the random per-connection transaction trickle delay.
+///
+/// Transaction announcements, and `get-mempool` subscription updates, are
+/// not sent immediately: they are batched and flushed after a random
+/// exponentially distributed delay, to impede network topology inference.
+/// The mean matches the legacy reference behavior cited by the draft ZIP
+/// (ZIP 204).
+#[cfg(not(test))]
+pub const TX_TRICKLE_MEAN_INTERVAL: Duration = Duration::from_secs(5);
+
+/// A short trickle mean, so tests exercise the trickle path without slow
+/// flushes.
+#[cfg(test)]
+pub const TX_TRICKLE_MEAN_INTERVAL: Duration = Duration::from_millis(25);
+
+/// The `kind` byte of a header block announcement record.
+pub const BLOCK_ANNOUNCEMENT_KIND_HEADER: u8 = 0x00;
+
+/// The `kind` byte of a compact block announcement record.
+pub const BLOCK_ANNOUNCEMENT_KIND_COMPACT: u8 = 0x01;
+
+/// The `has_txs` byte of a `get-headers` entry whose block's transactions
+/// are identified.
+pub const HEADERS_ENTRY_HAS_TXS: u8 = 0x01;
+
+/// The `has_txs` byte of a `get-headers` entry without transactions: the
+/// responder does not hold the block, and the requester falls back to
+/// `get-blocks`.
+pub const HEADERS_ENTRY_NO_TXS: u8 = 0x00;
+
+/// The record kind of the `init` record on the handshake stream.
+pub const HANDSHAKE_RECORD_KIND_INIT: u8 = 0x00;
+
+/// The sustained rate at which relayed addresses are accepted from one
+/// connection, in addresses per second.
+///
+/// This is the token-bucket reference rate used by zcashd, cited by the
+/// draft ZIP via ZIP 204: address floods beyond the burst capacity are
+/// silently dropped, without a penalty.
+pub const ADDR_TOKEN_RATE: f64 = 0.1;
+
+/// The burst capacity of the relayed-address token bucket, in addresses.
+///
+/// The bucket starts full, so a new connection's initial gossip is
+/// accepted.
+pub const ADDR_TOKEN_BUCKET_CAPACITY: f64 = 1_000.0;
+
+/// The interval between announcements of this node's own listener address
+/// on each connection's address announcement stream.
+///
+/// The broadcast interval is implementation-defined; this matches the
+/// approximate daily self-advertisement of legacy implementations.
+//
+// TODO: cite the ZIP 204 reference value once the companion update lands.
+pub const SELF_ADDR_ANNOUNCEMENT_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);

--- a/zebra-network/src/protocol/v2/init.rs
+++ b/zebra-network/src/protocol/v2/init.rs
@@ -1,0 +1,195 @@
+//! The `init` record of the version 2 Zcash P2P network protocol handshake.
+
+use std::io;
+
+use byteorder::{LittleEndian, ReadBytesExt};
+
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+
+use zebra_chain::{
+    block,
+    serialization::{CompactSize64, ZcashDeserialize, ZcashSerialize},
+};
+
+use crate::protocol::external::{
+    types::{Nonce, PeerServices, Version},
+    zcash_deserialize_user_agent,
+};
+
+use super::{constants::HANDSHAKE_RECORD_KIND_INIT, record, types::WireError};
+
+/// A record on the handshake stream.
+///
+/// A node must ignore handshake-stream records whose kind it does not
+/// recognize, so that future record kinds can be introduced without version
+/// gating.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum HandshakeRecord {
+    /// The `init` record (kind `0x00`).
+    Init(InitRecord),
+
+    /// A record of an unrecognized kind, which is ignored.
+    Unknown(u8),
+}
+
+/// The `init` record exchanged on the handshake stream when a connection is
+/// established.
+///
+/// The legacy `timestamp`, `addr_recv`, and `addr_from` fields have no
+/// equivalent: they served clock sanity checks and address self-discovery
+/// functions that are out of scope for the version 2 protocol.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InitRecord {
+    /// The sender's advertised protocol version.
+    pub version: Version,
+
+    /// The services advertised by the sender.
+    pub services: PeerServices,
+
+    /// A random nonce for self-connection detection.
+    pub nonce: Nonce,
+
+    /// The sender's user agent string (at most `MAX_USER_AGENT_LENGTH`
+    /// bytes, the same limit as legacy `version` messages).
+    pub user_agent: String,
+
+    /// The best block height known to the sender.
+    pub start_height: block::Height,
+
+    /// Whether the sender wants transaction relay.
+    ///
+    /// If false, the peer must not open a transaction announcement stream to
+    /// the sender, and should not announce transactions to it by any other
+    /// means.
+    pub relay: bool,
+
+    /// Whether the sender requests high-bandwidth compact block
+    /// announcements.
+    pub announce: bool,
+
+    /// Whether the sender requests full transaction IDs in compact block
+    /// announcements.
+    pub full_ids: bool,
+}
+
+impl InitRecord {
+    /// Encodes this `init` record as a handshake-stream record payload,
+    /// including the leading record kind byte.
+    pub fn to_record_payload(&self) -> Vec<u8> {
+        let mut payload = Vec::with_capacity(32 + self.user_agent.len());
+
+        payload.push(HANDSHAKE_RECORD_KIND_INIT);
+        payload.extend_from_slice(&self.version.0.to_le_bytes());
+        CompactSize64::from(self.services.bits())
+            .zcash_serialize(&mut payload)
+            .expect("writing to a Vec never fails");
+        payload.extend_from_slice(&self.nonce.0.to_le_bytes());
+
+        // Receivers enforce `MAX_USER_AGENT_LENGTH`; senders construct their
+        // user agent from local configuration.
+        self.user_agent
+            .zcash_serialize(&mut payload)
+            .expect("writing to a Vec never fails");
+
+        payload.extend_from_slice(&self.start_height.0.to_le_bytes());
+        payload.push(self.relay.into());
+        payload.push(self.announce.into());
+        payload.push(self.full_ids.into());
+
+        payload
+    }
+
+    /// Writes this `init` record to `writer` as a length-prefixed
+    /// handshake-stream record, and flushes the writer.
+    pub async fn write<W: AsyncWrite + Unpin>(&self, writer: &mut W) -> Result<(), WireError> {
+        let mut record = Vec::new();
+        record::write_record(&mut record, &self.to_record_payload())?;
+        writer.write_all(&record).await?;
+        writer.flush().await?;
+        Ok(())
+    }
+
+    /// Reads the next record from the handshake stream, skipping records of
+    /// unrecognized kinds, until an `init` record arrives.
+    ///
+    /// Returns `Ok(None)` if the stream was finished before an `init` record
+    /// arrived: the peer is signalling intent to disconnect.
+    pub async fn read<R: AsyncRead + Unpin>(
+        reader: &mut R,
+    ) -> Result<Option<InitRecord>, WireError> {
+        loop {
+            let payload = match record::read_record(reader).await? {
+                Some(payload) => payload,
+                None => return Ok(None),
+            };
+
+            match HandshakeRecord::parse(&payload)? {
+                HandshakeRecord::Init(init) => return Ok(Some(init)),
+                HandshakeRecord::Unknown(_kind) => continue,
+            }
+        }
+    }
+}
+
+impl HandshakeRecord {
+    /// Parses a handshake-stream record payload.
+    pub fn parse(payload: &[u8]) -> Result<Self, WireError> {
+        let (&kind, fields) = payload.split_first().ok_or_else(|| {
+            WireError::Protocol("empty record on the handshake stream".to_string())
+        })?;
+
+        if kind != HANDSHAKE_RECORD_KIND_INIT {
+            return Ok(HandshakeRecord::Unknown(kind));
+        }
+
+        let mut reader = io::Cursor::new(fields);
+
+        let version = Version(reader.read_u32::<LittleEndian>()?);
+        let services = CompactSize64::zcash_deserialize(&mut reader)?;
+        let services = PeerServices::from_bits_truncate(services.into());
+        let nonce = Nonce(reader.read_u64::<LittleEndian>()?);
+
+        let user_agent = read_user_agent(&mut reader)?;
+
+        let start_height = block::Height(reader.read_u32::<LittleEndian>()?);
+        let relay = read_bool_field(&mut reader, "relay")?;
+        let announce = read_bool_field(&mut reader, "announce")?;
+        let full_ids = read_bool_field(&mut reader, "full_ids")?;
+
+        if reader.position() != fields.len() as u64 {
+            return Err(WireError::Protocol(
+                "trailing data in an init record".to_string(),
+            ));
+        }
+
+        Ok(HandshakeRecord::Init(InitRecord {
+            version,
+            services,
+            nonce,
+            user_agent,
+            start_height,
+            relay,
+            announce,
+            full_ids,
+        }))
+    }
+}
+
+/// Reads the length-prefixed `user_agent` field, checking the length against
+/// `MAX_USER_AGENT_LENGTH` before allocating, via the legacy `version`
+/// message deserializer.
+fn read_user_agent<R: io::Read>(reader: &mut R) -> Result<String, WireError> {
+    zcash_deserialize_user_agent(reader)
+        .map_err(|error| WireError::Protocol(format!("invalid user agent: {error}")))
+}
+
+/// Reads a field that must be exactly 0 or 1.
+fn read_bool_field<R: io::Read>(reader: &mut R, name: &str) -> Result<bool, WireError> {
+    match reader.read_u8()? {
+        0 => Ok(false),
+        1 => Ok(true),
+        value => Err(WireError::Protocol(format!(
+            "invalid value {value} for the {name} field: must be 0 or 1",
+        ))),
+    }
+}

--- a/zebra-network/src/protocol/v2/record.rs
+++ b/zebra-network/src/protocol/v2/record.rs
@@ -1,0 +1,312 @@
+//! Record framing for the version 2 Zcash P2P network protocol.
+//!
+//! Each record on an announcement or handshake stream is encoded as a
+//! CompactSize length prefix followed by that many bytes of payload. The same
+//! length-prefixed encoding is used for individually length-prefixed elements
+//! in requests and responses, such as serialized blocks.
+//!
+//! CompactSize encodings must be canonical: the shortest possible encoding
+//! must be used for any given value, and non-canonical encodings are
+//! rejected.
+
+use std::io;
+
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+use zebra_chain::{
+    block,
+    serialization::{CompactSize64, ZcashDeserialize, ZcashSerialize},
+};
+
+use super::{constants::MAX_RECORD_PAYLOAD_LEN, types::WireError};
+
+/// Writes a CompactSize length prefix followed by `payload` to `writer`.
+///
+/// Returns an error if `payload` is longer than [`MAX_RECORD_PAYLOAD_LEN`]:
+/// a conforming sender never produces such a record.
+pub fn write_record<W: io::Write>(mut writer: W, payload: &[u8]) -> Result<(), WireError> {
+    if payload.len() > MAX_RECORD_PAYLOAD_LEN {
+        return Err(WireError::Local(format!(
+            "attempted to write an over-sized record: {} bytes",
+            payload.len(),
+        )));
+    }
+
+    write_compact_size(&mut writer, payload.len() as u64)?;
+    writer.write_all(payload)?;
+
+    Ok(())
+}
+
+/// Writes `value` to `writer` in the canonical CompactSize encoding.
+pub fn write_compact_size<W: io::Write>(mut writer: W, value: u64) -> Result<(), WireError> {
+    CompactSize64::from(value).zcash_serialize(&mut writer)?;
+    Ok(())
+}
+
+/// Checks a response count against a `SHOULD`-level protocol limit.
+///
+/// Exceeding the limit is a scored violation rather than a connection
+/// error: the response is discarded, and the peer is penalized.
+pub fn check_recv_limit_scored(count: u64, limit: u64, what: &str) -> Result<(), WireError> {
+    if count > limit {
+        return Err(WireError::Misbehavior {
+            points: super::constants::MISBEHAVIOR_PENALTY_LIMIT_EXCEEDED,
+            reason: format!("{what} response with {count} entries exceeds the limit {limit}"),
+        });
+    }
+
+    Ok(())
+}
+
+/// Checks an outbound count or length against a protocol limit.
+///
+/// Exceeding the limit is a [`WireError::Local`] error: this node built the
+/// over-limit message, so the peer is never blamed for it, and the
+/// connection stays open.
+pub fn check_send_limit(value: u64, limit: u64, what: &str) -> Result<(), WireError> {
+    if value > limit {
+        return Err(WireError::Local(format!(
+            "attempted to send a {what} of {value}; the limit is {limit}",
+        )));
+    }
+
+    Ok(())
+}
+
+/// Checks an untrusted count or length from the peer against a protocol
+/// limit.
+///
+/// Exceeding the limit is a connection error of type `PROTOCOL_ERROR`.
+pub fn check_recv_limit(value: u64, limit: u64, what: &str) -> Result<(), WireError> {
+    if value > limit {
+        return Err(WireError::Protocol(format!(
+            "{what} {value} exceeds the limit {limit}",
+        )));
+    }
+
+    Ok(())
+}
+
+/// Reads a complete record from `reader`.
+///
+/// Returns `Ok(None)` if the stream was finished at a record boundary.
+/// A stream that is finished in the middle of a record is a connection error
+/// of type `PROTOCOL_ERROR`, and a length prefix exceeding
+/// [`MAX_RECORD_PAYLOAD_LEN`] is a connection error of type `FLOOD`.
+pub async fn read_record<R: AsyncRead + Unpin>(
+    reader: &mut R,
+) -> Result<Option<Vec<u8>>, WireError> {
+    let first = match read_first_byte(reader).await? {
+        Some(first) => first,
+        None => return Ok(None),
+    };
+
+    Ok(Some(read_record_body(reader, first).await?))
+}
+
+/// Reads a complete record from `reader`, waiting indefinitely for the record
+/// to start, but requiring the rest of it within `timeout`.
+///
+/// Announcement and handshake streams are long-lived and idle between
+/// records, so only a record the peer has started and not finished is a
+/// stall.
+pub async fn read_record_timeout<R: AsyncRead + Unpin>(
+    reader: &mut R,
+    timeout: std::time::Duration,
+) -> Result<Option<Vec<u8>>, WireError> {
+    let first = match read_first_byte(reader).await? {
+        Some(first) => first,
+        None => return Ok(None),
+    };
+
+    let payload = tokio::time::timeout(timeout, read_record_body(reader, first))
+        .await
+        .map_err(|_elapsed| WireError::Timeout("a partially sent record".to_string()))??;
+
+    Ok(Some(payload))
+}
+
+/// Reads the first byte of a record, or `Ok(None)` if the stream was finished
+/// at a record boundary.
+async fn read_first_byte<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Option<u8>, WireError> {
+    let mut first = [0u8; 1];
+    let n = reader.read(&mut first).await?;
+    if n == 0 {
+        return Ok(None);
+    }
+
+    Ok(Some(first[0]))
+}
+
+/// Reads the remainder of a record whose length prefix starts with `first`.
+async fn read_record_body<R: AsyncRead + Unpin>(
+    reader: &mut R,
+    first: u8,
+) -> Result<Vec<u8>, WireError> {
+    let len = read_compact_size_body(reader, first).await?;
+
+    if len > MAX_RECORD_PAYLOAD_LEN as u64 {
+        return Err(WireError::Flood(format!(
+            "record length {len} exceeds the maximum record payload length",
+        )));
+    }
+
+    read_exact_payload(reader, len as usize).await
+}
+
+/// Reads a CompactSize length prefix followed by that many bytes from
+/// `reader`.
+///
+/// A length exceeding [`MAX_RECORD_PAYLOAD_LEN`] is a connection error of
+/// type `FLOOD`; a length exceeding the tighter `max_len` is a connection
+/// error of type `PROTOCOL_ERROR`.
+pub async fn read_length_prefixed_bytes<R: AsyncRead + Unpin>(
+    reader: &mut R,
+    max_len: usize,
+) -> Result<Vec<u8>, WireError> {
+    let len = read_compact_size(reader).await?;
+
+    if len > MAX_RECORD_PAYLOAD_LEN as u64 {
+        return Err(WireError::Flood(format!(
+            "length prefix {len} exceeds the maximum record payload length",
+        )));
+    }
+    if len > max_len as u64 {
+        return Err(WireError::Protocol(format!(
+            "length prefix {len} exceeds the limit {max_len} for this element",
+        )));
+    }
+
+    read_exact_payload(reader, len as usize).await
+}
+
+/// The maximum number of elements to preallocate for a collection whose
+/// element count comes from an untrusted peer.
+///
+/// A peer can inflate an element count in a few bytes, so collections are
+/// preallocated up to this many elements, and grow as their elements actually
+/// arrive.
+pub const MAX_PREALLOCATED_ELEMENTS: u64 = 1024;
+
+/// Returns the capacity to preallocate for an untrusted collection of `count`
+/// elements.
+pub fn preallocate_len(count: u64) -> usize {
+    // The result is at most `MAX_PREALLOCATED_ELEMENTS`, so it fits in a
+    // `usize` on every supported platform.
+    count.min(MAX_PREALLOCATED_ELEMENTS) as usize
+}
+
+/// Reads a canonical CompactSize value from `reader`.
+///
+/// An end of stream before the first byte is a connection error of type
+/// `PROTOCOL_ERROR`. Rejects non-canonical encodings with a
+/// `PROTOCOL_ERROR`.
+pub async fn read_compact_size<R: AsyncRead + Unpin>(reader: &mut R) -> Result<u64, WireError> {
+    match read_first_byte(reader).await? {
+        Some(first) => read_compact_size_body(reader, first).await,
+        None => Err(WireError::Protocol(
+            "stream finished where a CompactSize value was required".to_string(),
+        )),
+    }
+}
+
+/// Reads the remainder of a canonical CompactSize value whose first byte is
+/// `first`.
+///
+/// Parsing and canonicality validation are delegated to [`CompactSize64`],
+/// so the canonical-encoding rules live in one place.
+async fn read_compact_size_body<R: AsyncRead + Unpin>(
+    reader: &mut R,
+    first: u8,
+) -> Result<u64, WireError> {
+    // The number of trailing bytes indicated by each flag byte.
+    let trailing: usize = match first {
+        0x00..=0xFC => 0,
+        0xFD => 2,
+        0xFE => 4,
+        0xFF => 8,
+    };
+
+    let mut buf = [0u8; 9];
+    buf[0] = first;
+    read_exact_or_incomplete(reader, &mut buf[1..=trailing]).await?;
+
+    let value = CompactSize64::zcash_deserialize(&buf[..=trailing])
+        .map_err(|error| WireError::Protocol(format!("invalid CompactSize encoding: {error}")))?;
+
+    Ok(value.into())
+}
+
+/// Reads `N` bytes from `reader`.
+pub async fn read_array<const N: usize, R: AsyncRead + Unpin>(
+    reader: &mut R,
+) -> Result<[u8; N], WireError> {
+    let mut bytes = [0u8; N];
+    read_exact_or_incomplete(reader, &mut bytes).await?;
+
+    Ok(bytes)
+}
+
+/// Reads a single `u8` from `reader`.
+pub async fn read_u8<R: AsyncRead + Unpin>(reader: &mut R) -> Result<u8, WireError> {
+    Ok(read_array::<1, _>(reader).await?[0])
+}
+
+/// Reads exactly `buf.len()` bytes from `reader`.
+///
+/// An end of stream mid-element is a connection error of type
+/// `PROTOCOL_ERROR`.
+pub async fn read_exact_or_incomplete<R: AsyncRead + Unpin>(
+    reader: &mut R,
+    buf: &mut [u8],
+) -> Result<(), WireError> {
+    match reader.read_exact(buf).await {
+        Ok(_) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => Err(WireError::Protocol(
+            "stream finished in the middle of a record or element".to_string(),
+        )),
+        Err(err) => Err(err.into()),
+    }
+}
+
+/// Checks that the stream is finished: any further data is a connection error
+/// of type `PROTOCOL_ERROR`.
+pub async fn expect_end_of_stream<R: AsyncRead + Unpin>(reader: &mut R) -> Result<(), WireError> {
+    let mut buf = [0u8; 1];
+    let n = reader.read(&mut buf).await?;
+    if n != 0 {
+        return Err(WireError::Protocol(
+            "unexpected data after a complete request or response".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Reads a little-endian `u64` from `reader`.
+pub async fn read_exact_u64_le<R: AsyncRead + Unpin>(reader: &mut R) -> Result<u64, WireError> {
+    Ok(u64::from_le_bytes(read_array(reader).await?))
+}
+
+/// Reads a little-endian `u32` from `reader`.
+pub async fn read_exact_u32_le<R: AsyncRead + Unpin>(reader: &mut R) -> Result<u32, WireError> {
+    Ok(u32::from_le_bytes(read_array(reader).await?))
+}
+
+/// Reads a 32-byte block hash from `reader`.
+pub async fn read_block_hash<R: AsyncRead + Unpin>(
+    reader: &mut R,
+) -> Result<block::Hash, WireError> {
+    Ok(block::Hash(read_array(reader).await?))
+}
+
+async fn read_exact_payload<R: AsyncRead + Unpin>(
+    reader: &mut R,
+    len: usize,
+) -> Result<Vec<u8>, WireError> {
+    // `len` is already bounded by `MAX_RECORD_PAYLOAD_LEN` at every call
+    // site, so this allocation is bounded.
+    let mut payload = vec![0u8; len];
+    read_exact_or_incomplete(reader, &mut payload).await?;
+    Ok(payload)
+}

--- a/zebra-network/src/protocol/v2/request.rs
+++ b/zebra-network/src/protocol/v2/request.rs
@@ -1,0 +1,437 @@
+//! Request stream encodings for the version 2 Zcash P2P network protocol.
+//!
+//! A request stream is a bidirectional stream carrying exactly one request
+//! and its response: the requester writes the stream type byte followed by
+//! the request and finishes its sending direction, and the responder writes
+//! the response and finishes its sending direction.
+
+use std::io;
+
+use tokio::io::AsyncRead;
+
+use zebra_chain::block;
+
+use super::{
+    constants::{
+        MAX_GET_BLOCKS_HASHES, MAX_GET_BLOCK_RANGE_BYTES, MAX_GET_BLOCK_RANGE_COUNT,
+        MAX_GET_HASHES_COUNT, MAX_GET_OBJECT_LENGTH, MAX_GET_TREE_ROOTS_COUNT, MAX_GET_TX_REFS,
+        MAX_LOCATOR_HASHES,
+    },
+    record,
+    txref::TransactionReference,
+    types::{ObjectHash, StreamType, WireError},
+};
+
+/// A request on a version 2 request stream.
+//
+// The variant names mirror the draft ZIP's request stream type names
+// (`get-headers`, `get-blocks`, ...), so they intentionally share a prefix.
+#[allow(clippy::enum_variant_names)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Request {
+    /// Requests block headers starting after the first locator hash found in
+    /// the responder's best chain, up to and including `stop` or 160
+    /// headers, whichever comes first.
+    GetHeaders {
+        /// Block locator hashes, from highest to lowest height
+        /// (at most [`MAX_LOCATOR_HASHES`]).
+        known_blocks: Vec<block::Hash>,
+
+        /// The hash of the last desired header, or `None` to request as many
+        /// headers as possible.
+        stop: Option<block::Hash>,
+
+        /// Whether each returned header should be accompanied by the block's
+        /// coinbase transaction and full transaction IDs, letting the
+        /// requester fetch only the transactions it is missing via `get-tx`.
+        tx_ids: bool,
+    },
+
+    /// Requests full blocks by hash
+    /// (at most [`MAX_GET_BLOCKS_HASHES`] hashes).
+    ///
+    /// Compact blocks cannot be requested: they occur only as announcements.
+    GetBlocks {
+        /// The hashes of the requested blocks.
+        hashes: Vec<block::Hash>,
+    },
+
+    /// Requests transactions by reference
+    /// (at most [`MAX_GET_TX_REFS`] references).
+    GetTx {
+        /// The requested transaction references. All three reference types
+        /// are permitted.
+        refs: Vec<TransactionReference>,
+    },
+
+    /// Requests peer addresses. The request is empty.
+    GetAddr,
+
+    /// Requests references to the contents of the peer's transaction memory
+    /// pool. The request is empty.
+    GetMempool,
+
+    /// Requests the hashes of the blocks at heights
+    /// `start_height + k × stride` of the responder's best chain, for `k`
+    /// from 0 to `count − 1`, with sync-cost metadata for each entry's span.
+    GetHashes {
+        /// The height of the first requested block hash.
+        ///
+        /// Wire heights are raw `u32` values: the whole range is encodable,
+        /// and heights above the responder's chain tip are simply absent
+        /// from the response.
+        start_height: u32,
+
+        /// The spacing between requested heights. Must not be 0.
+        stride: u32,
+
+        /// The maximum number of block hashes requested
+        /// (at most [`MAX_GET_HASHES_COUNT`]). The greatest requested
+        /// height must not exceed `u32::MAX`.
+        count: u64,
+    },
+
+    /// Requests a contiguous chain of up to `count` blocks ending at
+    /// `final_hash`, streamed in descending height order.
+    GetBlockRange {
+        /// The hash of the highest block in the requested range.
+        final_hash: block::Hash,
+
+        /// The maximum number of blocks requested
+        /// (at most [`MAX_GET_BLOCK_RANGE_COUNT`]).
+        count: u64,
+
+        /// The maximum total serialized size of the delivered blocks, in
+        /// bytes (at most [`MAX_GET_BLOCK_RANGE_BYTES`]). The responder
+        /// delivers the first block regardless of this bound.
+        max_bytes: u64,
+    },
+
+    /// Requests per-block note commitment tree roots, transaction counts,
+    /// and authorizing data commitments for the blocks at heights
+    /// `start_height` through `start_height + count − 1` of the chain
+    /// identified by `final_hash`.
+    GetTreeRoots {
+        /// The height of the first requested entry.
+        start_height: u32,
+
+        /// The hash of the block at the highest requested height,
+        /// `start_height + count − 1`, anchoring the request to a specific
+        /// chain. A responder whose best chain does not contain this block
+        /// at that height refuses the stream rather than serving entries
+        /// for different blocks.
+        final_hash: block::Hash,
+
+        /// The maximum number of entries requested
+        /// (at most [`MAX_GET_TREE_ROOTS_COUNT`]).
+        count: u64,
+    },
+
+    /// Requests a byte range of a content-addressed synchronization
+    /// artifact.
+    GetObject {
+        /// The SHA-256 hash of the requested object.
+        hash: ObjectHash,
+
+        /// The byte offset into the object at which to start.
+        offset: u64,
+
+        /// The maximum number of bytes requested
+        /// (at most [`MAX_GET_OBJECT_LENGTH`]).
+        length: u64,
+    },
+}
+
+impl Request {
+    /// Returns the stream type that carries this request.
+    pub fn stream_type(&self) -> StreamType {
+        match self {
+            Request::GetHeaders { .. } => StreamType::GetHeaders,
+            Request::GetBlocks { .. } => StreamType::GetBlocks,
+            Request::GetTx { .. } => StreamType::GetTx,
+            Request::GetAddr => StreamType::GetAddr,
+            Request::GetMempool => StreamType::GetMempool,
+            Request::GetHashes { .. } => StreamType::GetHashes,
+            Request::GetBlockRange { .. } => StreamType::GetBlockRange,
+            Request::GetTreeRoots { .. } => StreamType::GetTreeRoots,
+            Request::GetObject { .. } => StreamType::GetObject,
+        }
+    }
+
+    /// Encodes this request to `writer`, without the leading stream type
+    /// byte.
+    pub fn encode<W: io::Write>(&self, mut writer: W) -> Result<(), WireError> {
+        match self {
+            Request::GetHeaders {
+                known_blocks,
+                stop,
+                tx_ids,
+            } => {
+                record::check_send_limit(
+                    known_blocks.len() as u64,
+                    MAX_LOCATOR_HASHES,
+                    "locator hashes",
+                )?;
+
+                record::write_compact_size(&mut writer, known_blocks.len() as u64)?;
+                for hash in known_blocks {
+                    writer.write_all(&hash.0)?;
+                }
+                writer.write_all(&stop.unwrap_or(block::Hash([0; 32])).0)?;
+                writer.write_all(&[u8::from(*tx_ids)])?;
+            }
+            Request::GetBlocks { hashes } => {
+                record::check_send_limit(
+                    hashes.len() as u64,
+                    MAX_GET_BLOCKS_HASHES,
+                    "block requests",
+                )?;
+
+                record::write_compact_size(&mut writer, hashes.len() as u64)?;
+                for hash in hashes {
+                    writer.write_all(&hash.0)?;
+                }
+            }
+            Request::GetTx { refs } => {
+                record::check_send_limit(
+                    refs.len() as u64,
+                    MAX_GET_TX_REFS,
+                    "transaction references",
+                )?;
+
+                record::write_compact_size(&mut writer, refs.len() as u64)?;
+                for txref in refs {
+                    txref.encode(&mut writer)?;
+                }
+            }
+            Request::GetAddr | Request::GetMempool => {}
+            Request::GetHashes {
+                start_height,
+                stride,
+                count,
+            } => {
+                check_get_hashes_bounds(*start_height, *stride, *count)
+                    .map_err(WireError::Local)?;
+
+                writer.write_all(&start_height.to_le_bytes())?;
+                writer.write_all(&stride.to_le_bytes())?;
+                record::write_compact_size(&mut writer, *count)?;
+            }
+            Request::GetBlockRange {
+                final_hash,
+                count,
+                max_bytes,
+            } => {
+                record::check_send_limit(
+                    *count,
+                    MAX_GET_BLOCK_RANGE_COUNT,
+                    "get-block-range count",
+                )?;
+                record::check_send_limit(
+                    *max_bytes,
+                    MAX_GET_BLOCK_RANGE_BYTES,
+                    "get-block-range max_bytes",
+                )?;
+
+                writer.write_all(&final_hash.0)?;
+                record::write_compact_size(&mut writer, *count)?;
+                record::write_compact_size(&mut writer, *max_bytes)?;
+            }
+            Request::GetTreeRoots {
+                start_height,
+                final_hash,
+                count,
+            } => {
+                record::check_send_limit(*count, MAX_GET_TREE_ROOTS_COUNT, "get-tree-roots count")?;
+
+                writer.write_all(&start_height.to_le_bytes())?;
+                writer.write_all(&final_hash.0)?;
+                record::write_compact_size(&mut writer, *count)?;
+            }
+            Request::GetObject {
+                hash,
+                offset,
+                length,
+            } => {
+                record::check_send_limit(*length, MAX_GET_OBJECT_LENGTH, "get-object length")?;
+
+                writer.write_all(&hash.0)?;
+                record::write_compact_size(&mut writer, *offset)?;
+                record::write_compact_size(&mut writer, *length)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Reads a request of the given stream type from `reader`.
+    ///
+    /// The stream type byte has already been read to dispatch the stream.
+    /// The caller checks that the stream ends after the request.
+    ///
+    /// # Panics
+    ///
+    /// If `stream_type` is not a request stream type.
+    pub async fn read<R: AsyncRead + Unpin>(
+        stream_type: StreamType,
+        reader: &mut R,
+    ) -> Result<Self, WireError> {
+        match stream_type {
+            StreamType::GetHeaders => {
+                let locator_count = record::read_compact_size(reader).await?;
+                record::check_recv_limit(locator_count, MAX_LOCATOR_HASHES, "locator")?;
+
+                let mut known_blocks = Vec::with_capacity(record::preallocate_len(locator_count));
+                for _ in 0..locator_count {
+                    known_blocks.push(record::read_block_hash(reader).await?);
+                }
+
+                let stop = record::read_block_hash(reader).await?;
+                let stop = (stop != block::Hash([0; 32])).then_some(stop);
+
+                let tx_ids = match record::read_u8(reader).await? {
+                    0 => false,
+                    1 => true,
+                    other => {
+                        return Err(WireError::Protocol(format!(
+                            "get-headers tx_ids must be 0 or 1, got {other:#04x}",
+                        )))
+                    }
+                };
+
+                Ok(Request::GetHeaders {
+                    known_blocks,
+                    stop,
+                    tx_ids,
+                })
+            }
+            StreamType::GetBlocks => {
+                let count = record::read_compact_size(reader).await?;
+                record::check_recv_limit(count, MAX_GET_BLOCKS_HASHES, "get-blocks")?;
+
+                let mut hashes = Vec::with_capacity(record::preallocate_len(count));
+                for _ in 0..count {
+                    hashes.push(record::read_block_hash(reader).await?);
+                }
+
+                Ok(Request::GetBlocks { hashes })
+            }
+            StreamType::GetTx => {
+                let count = record::read_compact_size(reader).await?;
+                record::check_recv_limit(count, MAX_GET_TX_REFS, "get-tx")?;
+
+                let mut refs = Vec::with_capacity(record::preallocate_len(count));
+                for _ in 0..count {
+                    refs.push(TransactionReference::read(reader).await?);
+                }
+
+                Ok(Request::GetTx { refs })
+            }
+            StreamType::GetAddr => Ok(Request::GetAddr),
+            StreamType::GetMempool => Ok(Request::GetMempool),
+            StreamType::GetHashes => {
+                let start_height = record::read_exact_u32_le(reader).await?;
+                let stride = record::read_exact_u32_le(reader).await?;
+                let count = record::read_compact_size(reader).await?;
+
+                check_get_hashes_bounds(start_height, stride, count)
+                    .map_err(WireError::Protocol)?;
+
+                Ok(Request::GetHashes {
+                    start_height,
+                    stride,
+                    count,
+                })
+            }
+            StreamType::GetBlockRange => {
+                let final_hash = record::read_block_hash(reader).await?;
+                let count = record::read_compact_size(reader).await?;
+                record::check_recv_limit(
+                    count,
+                    MAX_GET_BLOCK_RANGE_COUNT,
+                    "get-block-range count",
+                )?;
+                let max_bytes = record::read_compact_size(reader).await?;
+                record::check_recv_limit(
+                    max_bytes,
+                    MAX_GET_BLOCK_RANGE_BYTES,
+                    "get-block-range max_bytes",
+                )?;
+
+                Ok(Request::GetBlockRange {
+                    final_hash,
+                    count,
+                    max_bytes,
+                })
+            }
+            StreamType::GetTreeRoots => {
+                let start_height = record::read_exact_u32_le(reader).await?;
+                let final_hash = record::read_block_hash(reader).await?;
+                let count = record::read_compact_size(reader).await?;
+                record::check_recv_limit(count, MAX_GET_TREE_ROOTS_COUNT, "get-tree-roots count")?;
+
+                Ok(Request::GetTreeRoots {
+                    start_height,
+                    final_hash,
+                    count,
+                })
+            }
+            StreamType::GetObject => {
+                let mut hash = [0u8; 32];
+                record::read_exact_or_incomplete(reader, &mut hash).await?;
+                let offset = record::read_compact_size(reader).await?;
+                let length = record::read_compact_size(reader).await?;
+                record::check_recv_limit(length, MAX_GET_OBJECT_LENGTH, "get-object length")?;
+
+                Ok(Request::GetObject {
+                    hash: ObjectHash(hash),
+                    offset,
+                    length,
+                })
+            }
+            StreamType::Handshake
+            | StreamType::BlockAnnouncements
+            | StreamType::TransactionAnnouncements
+            | StreamType::AddressAnnouncements => {
+                unreachable!("Request::read is only called for request stream types")
+            }
+        }
+    }
+}
+
+/// Checks the bounds of a `get-hashes` request: `stride` must not be 0,
+/// `count` must not exceed [`MAX_GET_HASHES_COUNT`], and the greatest
+/// requested height (`start_height + (count − 1) × stride`) must not exceed
+/// `u32::MAX`.
+///
+/// Returns a description of the violated bound: a local error when checked
+/// by the encoder, and a protocol error when checked by the reader.
+fn check_get_hashes_bounds(start_height: u32, stride: u32, count: u64) -> Result<(), String> {
+    if stride == 0 {
+        return Err("get-hashes stride must not be 0".to_string());
+    }
+
+    if count > MAX_GET_HASHES_COUNT {
+        return Err(format!(
+            "get-hashes count {count} exceeds the limit {MAX_GET_HASHES_COUNT}",
+        ));
+    }
+
+    // The checks above bound this arithmetic well within `u64`: `count - 1`
+    // is at most 49,999 and `stride` at most `u32::MAX`. A request for no
+    // hashes has no greatest height to check.
+    if let Some(last_index) = count.checked_sub(1) {
+        let greatest_height = u64::from(start_height)
+            .checked_add(last_index.saturating_mul(u64::from(stride)))
+            .expect("bounded by 2^32 + 50,000 * 2^32, which fits in a u64");
+
+        if greatest_height > u64::from(u32::MAX) {
+            return Err(format!(
+                "the greatest requested get-hashes height {greatest_height} exceeds the \
+                 maximum encodable height",
+            ));
+        }
+    }
+
+    Ok(())
+}

--- a/zebra-network/src/protocol/v2/response.rs
+++ b/zebra-network/src/protocol/v2/response.rs
@@ -1,0 +1,361 @@
+//! Response encodings for the version 2 Zcash P2P network protocol request
+//! streams.
+//!
+//! `get-blocks` and `get-tx` responses carry one result-tagged entry per
+//! requested item, in request order, so their entries are encoded and read
+//! individually. The other responses are single structures.
+
+use std::{any::type_name, io, sync::Arc};
+
+use tokio::io::AsyncRead;
+
+use zebra_chain::{
+    block::{self, CountedHeader, Header, SyncHashEntry, TreeRootsEntry},
+    serialization::{ZcashDeserialize, ZcashSerialize},
+};
+
+use super::{
+    constants::{
+        MAX_ADDRS_IN_RESPONSE, MAX_GET_HASHES_COUNT, MAX_GET_TREE_ROOTS_COUNT, MAX_HEADERS_RESULTS,
+        MAX_MEMPOOL_RESPONSE_REFS, MAX_RECORD_PAYLOAD_LEN, MISBEHAVIOR_PENALTY_LIMIT_EXCEEDED,
+    },
+    record,
+    txref::TransactionReference,
+    types::WireError,
+};
+
+use crate::{
+    meta_addr::MetaAddr,
+    protocol::external::addr::v2::{AddrV2, MAX_ADDR_V2_ADDR_SIZE},
+};
+
+/// The result byte indicating that a full object follows.
+pub const RESULT_OBJECT: u8 = 0x00;
+
+/// The result byte indicating that the requested item was not found.
+/// Nothing follows for the entry.
+pub const RESULT_NOT_FOUND: u8 = 0x02;
+
+/// A `get-headers` response: up to [`MAX_HEADERS_RESULTS`] block headers,
+/// each length-prefixed.
+///
+/// The legacy always-zero transaction count that followed each header in
+/// `headers` messages is removed; [`CountedHeader`] is used here only
+/// because it is the header type of the internal protocol.
+#[derive(Clone, Debug)]
+pub struct HeadersResponse(pub Vec<CountedHeader>);
+
+impl HeadersResponse {
+    /// Encodes this response to `writer`.
+    #[allow(clippy::unwrap_in_result)]
+    pub fn encode<W: io::Write>(&self, mut writer: W) -> Result<(), WireError> {
+        record::write_compact_size(&mut writer, self.0.len() as u64)?;
+
+        for header in &self.0 {
+            let header_bytes = header
+                .header
+                .zcash_serialize_to_vec()
+                .expect("serializing a header to a Vec never fails");
+            record::write_record(&mut writer, &header_bytes)?;
+        }
+
+        Ok(())
+    }
+
+    /// Reads a `get-headers` response from `reader`.
+    ///
+    /// A response with more than [`MAX_HEADERS_RESULTS`] headers incurs a
+    /// misbehavior penalty instead of being read.
+    pub async fn read<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Self, WireError> {
+        let count = record::read_compact_size(reader).await?;
+        record::check_recv_limit_scored(count, MAX_HEADERS_RESULTS, "get-headers")?;
+
+        let mut headers = Vec::with_capacity(record::preallocate_len(count));
+        for _ in 0..count {
+            let header_bytes =
+                record::read_length_prefixed_bytes(reader, MAX_RECORD_PAYLOAD_LEN).await?;
+            let header = Arc::new(Header::zcash_deserialize(header_bytes.as_slice())?);
+            headers.push(CountedHeader { header });
+        }
+
+        Ok(HeadersResponse(headers))
+    }
+
+    /// Checks that the headers form a contiguous chain: each header's
+    /// previous block hash must match the hash of the preceding header.
+    /// Returns the hash of each header, in response order.
+    ///
+    /// Non-contiguous headers incur a misbehavior penalty.
+    pub fn check_contiguous(&self) -> Result<Vec<block::Hash>, WireError> {
+        let mut hashes: Vec<block::Hash> = Vec::with_capacity(self.0.len());
+
+        for header in &self.0 {
+            if let Some(previous) = hashes.last() {
+                if header.header.previous_block_hash != *previous {
+                    return Err(WireError::Misbehavior {
+                        points: MISBEHAVIOR_PENALTY_LIMIT_EXCEEDED,
+                        reason: "non-contiguous headers in a get-headers response".to_string(),
+                    });
+                }
+            }
+            hashes.push(header.header.hash());
+        }
+
+        Ok(hashes)
+    }
+}
+
+/// Encodes one entry of a `get-blocks` or `get-tx` response to `writer`.
+///
+/// `None` encodes the not-found result. Compact blocks occur only as
+/// announcements, so there is no compact block result.
+pub fn encode_result_entry<T: ZcashSerialize, W: io::Write>(
+    mut writer: W,
+    entry: Option<&T>,
+) -> Result<(), WireError> {
+    let Some(object) = entry else {
+        writer.write_all(&[RESULT_NOT_FOUND])?;
+
+        return Ok(());
+    };
+
+    writer.write_all(&[RESULT_OBJECT])?;
+    let bytes = object
+        .zcash_serialize_to_vec()
+        .map_err(|err| WireError::Local(format!("unserializable {}: {err}", type_name::<T>())))?;
+    record::write_record(&mut writer, &bytes)?;
+
+    Ok(())
+}
+
+/// Reads one entry of a `get-blocks` or `get-tx` response from `reader`.
+///
+/// Returns `None` for the not-found result. An unrecognized `result` value
+/// is a connection error of type `PROTOCOL_ERROR`.
+pub async fn read_result_entry<T: ZcashDeserialize, R: AsyncRead + Unpin>(
+    reader: &mut R,
+    what: &str,
+) -> Result<Option<Arc<T>>, WireError> {
+    match record::read_u8(reader).await? {
+        RESULT_OBJECT => {
+            let bytes = record::read_length_prefixed_bytes(reader, MAX_RECORD_PAYLOAD_LEN).await?;
+
+            Ok(Some(Arc::new(T::zcash_deserialize(bytes.as_slice())?)))
+        }
+        RESULT_NOT_FOUND => Ok(None),
+        unknown => Err(WireError::Protocol(format!(
+            "unrecognized {what} result value {unknown:#04x}",
+        ))),
+    }
+}
+
+/// A `get-addr` response: up to [`MAX_ADDRS_IN_RESPONSE`] network address
+/// records in the `addrv2` encoding of ZIP 155.
+#[derive(Clone, Debug)]
+pub struct AddrResponse(pub Vec<MetaAddr>);
+
+impl AddrResponse {
+    /// Encodes this response to `writer`.
+    pub fn encode<W: io::Write>(&self, mut writer: W) -> Result<(), WireError> {
+        record::check_send_limit(
+            self.0.len() as u64,
+            MAX_ADDRS_IN_RESPONSE,
+            "address records",
+        )?;
+
+        record::write_compact_size(&mut writer, self.0.len() as u64)?;
+        for addr in &self.0 {
+            AddrV2::from(addr.clone()).zcash_serialize(&mut writer)?;
+        }
+
+        Ok(())
+    }
+
+    /// Reads a `get-addr` response from `reader`.
+    ///
+    /// A response with more than [`MAX_ADDRS_IN_RESPONSE`] records incurs a
+    /// misbehavior penalty instead of being read. Address records with
+    /// unrecognized network IDs are ignored.
+    pub async fn read<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Self, WireError> {
+        let count = record::read_compact_size(reader).await?;
+        record::check_recv_limit_scored(count, MAX_ADDRS_IN_RESPONSE, "get-addr")?;
+
+        let mut addrs = Vec::with_capacity(record::preallocate_len(count));
+        for _ in 0..count {
+            let addr = read_addr_v2(reader).await?;
+            if let Ok(addr) = MetaAddr::try_from(addr) {
+                addrs.push(addr);
+            }
+        }
+
+        Ok(AddrResponse(addrs))
+    }
+}
+
+/// A `get-mempool` response: references to the contents of the peer's
+/// transaction memory pool.
+#[derive(Clone, Debug)]
+pub struct MempoolResponse(pub Vec<TransactionReference>);
+
+impl MempoolResponse {
+    /// Encodes this response to `writer`.
+    pub fn encode<W: io::Write>(&self, mut writer: W) -> Result<(), WireError> {
+        record::write_compact_size(&mut writer, self.0.len() as u64)?;
+        for txref in &self.0 {
+            assert!(
+                !txref.is_short_id(),
+                "SHORTID references must not be used in get-mempool responses",
+            );
+            txref.encode(&mut writer)?;
+        }
+
+        Ok(())
+    }
+
+    /// Reads a `get-mempool` response from `reader`.
+    ///
+    /// `SHORTID` references are a connection error of type `PROTOCOL_ERROR`:
+    /// they must not be used in `get-mempool` responses.
+    pub async fn read<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Self, WireError> {
+        let count = record::read_compact_size(reader).await?;
+        if count > MAX_MEMPOOL_RESPONSE_REFS as u64 {
+            return Err(WireError::Flood(format!(
+                "get-mempool response count {count} exceeds the limit \
+                 {MAX_MEMPOOL_RESPONSE_REFS}",
+            )));
+        }
+
+        let mut refs = Vec::with_capacity(record::preallocate_len(count));
+        for _ in 0..count {
+            let txref = TransactionReference::read(reader).await?;
+            if txref.is_short_id() {
+                return Err(WireError::Protocol(
+                    "SHORTID reference in a get-mempool response".to_string(),
+                ));
+            }
+            refs.push(txref);
+        }
+
+        Ok(MempoolResponse(refs))
+    }
+}
+
+/// A `get-hashes` response: up to the requested number of entries, one per
+/// requested height, truncated to a prefix.
+#[derive(Clone, Debug)]
+pub struct HashesResponse(pub Vec<SyncHashEntry>);
+
+impl HashesResponse {
+    /// Encodes this response to `writer`.
+    pub fn encode<W: io::Write>(&self, mut writer: W) -> Result<(), WireError> {
+        record::write_compact_size(&mut writer, self.0.len() as u64)?;
+        for entry in &self.0 {
+            writer.write_all(&entry.hash.0)?;
+            record::write_compact_size(&mut writer, entry.span_size)?;
+            record::write_compact_size(&mut writer, entry.span_txs)?;
+            record::write_compact_size(&mut writer, entry.span_notes)?;
+        }
+
+        Ok(())
+    }
+
+    /// Reads a `get-hashes` response from `reader`.
+    //
+    // Used by round-trip tests; the v2 synchronization requester (Phase 5)
+    // will use it outside tests.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub async fn read<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Self, WireError> {
+        let count = record::read_compact_size(reader).await?;
+        record::check_recv_limit(count, MAX_GET_HASHES_COUNT, "get-hashes response")?;
+
+        let mut entries = Vec::with_capacity(record::preallocate_len(count));
+        for _ in 0..count {
+            entries.push(SyncHashEntry {
+                hash: record::read_block_hash(reader).await?,
+                span_size: record::read_compact_size(reader).await?,
+                span_txs: record::read_compact_size(reader).await?,
+                span_notes: record::read_compact_size(reader).await?,
+            });
+        }
+
+        Ok(HashesResponse(entries))
+    }
+}
+
+/// A `get-tree-roots` response: up to the requested number of entries, one
+/// per requested height, truncated to a prefix.
+#[derive(Clone, Debug)]
+pub struct TreeRootsResponse(pub Vec<TreeRootsEntry>);
+
+impl TreeRootsResponse {
+    /// Encodes this response to `writer`.
+    pub fn encode<W: io::Write>(&self, mut writer: W) -> Result<(), WireError> {
+        record::write_compact_size(&mut writer, self.0.len() as u64)?;
+        for entry in &self.0 {
+            writer.write_all(&entry.sapling_root)?;
+            writer.write_all(&entry.orchard_root)?;
+            writer.write_all(&entry.ironwood_root)?;
+            record::write_compact_size(&mut writer, entry.sapling_txs)?;
+            record::write_compact_size(&mut writer, entry.orchard_txs)?;
+            record::write_compact_size(&mut writer, entry.ironwood_txs)?;
+            writer.write_all(&entry.auth_data_root)?;
+        }
+
+        Ok(())
+    }
+
+    /// Reads a `get-tree-roots` response from `reader`.
+    //
+    // Used by round-trip tests; the v2 synchronization requester (Phase 5)
+    // will use it outside tests.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub async fn read<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Self, WireError> {
+        let count = record::read_compact_size(reader).await?;
+        record::check_recv_limit(count, MAX_GET_TREE_ROOTS_COUNT, "get-tree-roots response")?;
+
+        let mut entries = Vec::with_capacity(record::preallocate_len(count));
+        for _ in 0..count {
+            entries.push(TreeRootsEntry {
+                sapling_root: record::read_array(reader).await?,
+                orchard_root: record::read_array(reader).await?,
+                ironwood_root: record::read_array(reader).await?,
+                sapling_txs: record::read_compact_size(reader).await?,
+                orchard_txs: record::read_compact_size(reader).await?,
+                ironwood_txs: record::read_compact_size(reader).await?,
+                auth_data_root: record::read_array(reader).await?,
+            });
+        }
+
+        Ok(TreeRootsResponse(entries))
+    }
+}
+
+/// Reads a single `addrv2` network address record from `reader`.
+///
+/// The `addrv2` encoding is variable-length, so the record is deserialized
+/// incrementally: the fixed-size prefix through the `sizeAddr` length, then
+/// the address bytes and port.
+async fn read_addr_v2<R: AsyncRead + Unpin>(reader: &mut R) -> Result<AddrV2, WireError> {
+    // time (4) || services (CompactSize) || networkID (1)
+    let mut time = [0u8; 4];
+    record::read_exact_or_incomplete(reader, &mut time).await?;
+    let services = record::read_compact_size(reader).await?;
+    let network_id = record::read_u8(reader).await?;
+
+    // sizeAddr (CompactSize) || addr || port (2)
+    let addr_bytes = record::read_length_prefixed_bytes(reader, MAX_ADDR_V2_ADDR_SIZE).await?;
+    let mut port = [0u8; 2];
+    record::read_exact_or_incomplete(reader, &mut port).await?;
+
+    // Re-encode the complete record and reuse the strict `addrv2`
+    // deserializer, so length and network ID validation stay in one place.
+    let mut buf = Vec::with_capacity(16 + addr_bytes.len());
+    buf.extend_from_slice(&time);
+    record::write_compact_size(&mut buf, services)?;
+    buf.push(network_id);
+    record::write_compact_size(&mut buf, addr_bytes.len() as u64)?;
+    buf.extend_from_slice(&addr_bytes);
+    buf.extend_from_slice(&port);
+
+    Ok(AddrV2::zcash_deserialize(buf.as_slice())?)
+}

--- a/zebra-network/src/protocol/v2/tests.rs
+++ b/zebra-network/src/protocol/v2/tests.rs
@@ -1,0 +1,24 @@
+//! Tests for the version 2 Zcash P2P network protocol wire formats.
+
+mod vectors;
+
+/// Asserts that reading rejected the data as a `PROTOCOL_ERROR`.
+#[track_caller]
+fn assert_protocol_error<T: std::fmt::Debug>(
+    result: &Result<T, super::types::WireError>,
+    what: &str,
+) {
+    assert!(
+        matches!(result, Err(super::types::WireError::Protocol(_))),
+        "{what} must be a protocol error, got: {result:?}",
+    );
+}
+
+/// Asserts that reading rejected the data as a `FLOOD` error.
+#[track_caller]
+fn assert_flood_error<T: std::fmt::Debug>(result: &Result<T, super::types::WireError>, what: &str) {
+    assert!(
+        matches!(result, Err(super::types::WireError::Flood(_))),
+        "{what} must be a flood error, got: {result:?}",
+    );
+}

--- a/zebra-network/src/protocol/v2/tests/vectors.rs
+++ b/zebra-network/src/protocol/v2/tests/vectors.rs
@@ -1,0 +1,1107 @@
+//! Fixed test vectors for the version 2 protocol wire formats.
+
+use std::{sync::Arc, time::Duration};
+
+use zebra_chain::{
+    block::{self, Block},
+    serialization::{DateTime32, ZcashDeserializeInto, ZcashSerialize},
+    transaction::{AuthDigest, Transaction, UnminedTxId, WtxId},
+};
+
+use crate::{
+    meta_addr::MetaAddr,
+    protocol::external::types::{Nonce, PeerServices, Version},
+};
+
+use super::{assert_flood_error, assert_protocol_error};
+
+use super::super::{
+    compact_block::{
+        self, full_transaction_id, short_id_keys, short_transaction_id, CompactBlock,
+        CompactBlockIds, ShortTxId,
+    },
+    constants::{
+        MAX_GET_BLOCKS_HASHES, MAX_GET_BLOCK_RANGE_BYTES, MAX_GET_BLOCK_RANGE_COUNT,
+        MAX_GET_HASHES_COUNT, MAX_GET_OBJECT_LENGTH, MAX_GET_TREE_ROOTS_COUNT, MAX_LOCATOR_HASHES,
+        MAX_MEMPOOL_RESPONSE_REFS, MAX_PREFILLED_TX_INDEX, MAX_RECORD_PAYLOAD_LEN,
+    },
+    init::{HandshakeRecord, InitRecord},
+    record,
+    request::Request,
+    response::{
+        encode_result_entry, read_result_entry, AddrResponse, HeadersResponse, MempoolResponse,
+    },
+    txref::TransactionReference,
+    types::{ErrorCode, ObjectHash, StreamType, WireError},
+};
+
+#[test]
+fn stream_type_round_trip() {
+    let _init_guard = zebra_test::init();
+
+    for byte in 0..=u8::MAX {
+        if let Some(stream_type) = StreamType::from_byte(byte) {
+            assert_eq!(stream_type.byte(), byte);
+            let is_bidirectional = stream_type == StreamType::Handshake || stream_type.is_request();
+            assert_eq!(is_bidirectional, !stream_type.is_announcement());
+        }
+    }
+
+    assert_eq!(StreamType::from_byte(0x0A), None);
+    assert_eq!(StreamType::from_byte(0x13), None);
+    assert_eq!(StreamType::from_byte(0xFF), None);
+}
+
+#[test]
+fn error_code_unknown_is_internal_error() {
+    let _init_guard = zebra_test::init();
+
+    for code in 0x00..=0x09u64 {
+        assert_eq!(ErrorCode::from_wire(code).wire_code(), code);
+    }
+
+    assert_eq!(ErrorCode::from_wire(0x0A), ErrorCode::InternalError);
+    assert_eq!(ErrorCode::from_wire(u64::MAX), ErrorCode::InternalError);
+}
+
+#[tokio::test]
+async fn compact_size_round_trip() {
+    let _init_guard = zebra_test::init();
+
+    for value in [
+        0u64,
+        1,
+        0xFC,
+        0xFD,
+        0xFFFF,
+        0x1_0000,
+        0xFFFF_FFFF,
+        0x1_0000_0000,
+        u64::MAX,
+    ] {
+        let mut buf = Vec::new();
+        record::write_compact_size(&mut buf, value).expect("write to Vec succeeds");
+
+        let mut reader = buf.as_slice();
+        let read = record::read_compact_size(&mut reader)
+            .await
+            .expect("canonical encoding parses");
+        assert_eq!(read, value);
+        assert!(reader.is_empty(), "no trailing bytes for {value}");
+    }
+}
+
+#[tokio::test]
+async fn compact_size_rejects_non_canonical() {
+    let _init_guard = zebra_test::init();
+
+    // 0xFC encoded with a 0xFD prefix, 0xFFFF with a 0xFE prefix,
+    // and 0xFFFF_FFFF with a 0xFF prefix.
+    for bytes in [
+        &[0xFDu8, 0xFC, 0x00][..],
+        &[0xFE, 0xFF, 0xFF, 0x00, 0x00][..],
+        &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00][..],
+    ] {
+        let mut reader = bytes;
+        let result = record::read_compact_size(&mut reader).await;
+        assert_protocol_error(&result, "non-canonical encoding {bytes:?} must be rejected");
+    }
+}
+
+#[tokio::test]
+async fn record_round_trip() {
+    let _init_guard = zebra_test::init();
+
+    for payload in [&[][..], &[0x42][..], &[0xAB; 300][..]] {
+        let mut buf = Vec::new();
+        record::write_record(&mut buf, payload).expect("write to Vec succeeds");
+
+        let mut reader = buf.as_slice();
+        let read = record::read_record(&mut reader)
+            .await
+            .expect("record parses")
+            .expect("record is present");
+        assert_eq!(read, payload);
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn record_read_times_out_on_a_partial_record() {
+    use tokio::io::AsyncWriteExt;
+
+    let _init_guard = zebra_test::init();
+
+    let (mut peer, mut reader) = tokio::io::duplex(64);
+
+    // A length prefix with no payload: the peer started a record, then
+    // stalled. The stream stays open, as it would with transport keep-alives.
+    peer.write_all(&[0x04, 0x00]).await.expect("write succeeds");
+
+    let result = record::read_record_timeout(&mut reader, Duration::from_secs(30)).await;
+    assert!(
+        matches!(result, Err(WireError::Timeout(_))),
+        "got: {result:?}",
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn record_read_waits_for_an_idle_stream() {
+    let _init_guard = zebra_test::init();
+
+    // Announcement and handshake streams idle between records, so a stream
+    // that has not started a record must not time out.
+    let (_peer, mut reader) = tokio::io::duplex(64);
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(3600),
+        record::read_record_timeout(&mut reader, Duration::from_secs(30)),
+    )
+    .await;
+    assert!(result.is_err(), "an idle stream must not time out");
+}
+
+#[tokio::test]
+async fn record_stream_end_and_errors() {
+    let _init_guard = zebra_test::init();
+
+    // A finished stream at a record boundary is a clean end.
+    let mut reader = &[][..];
+    assert!(record::read_record(&mut reader)
+        .await
+        .expect("clean end of stream")
+        .is_none());
+
+    // A length prefix over the payload limit is a FLOOD error.
+    let mut over_limit = Vec::new();
+    record::write_compact_size(&mut over_limit, MAX_RECORD_PAYLOAD_LEN as u64 + 1)
+        .expect("write to Vec succeeds");
+    let mut reader = over_limit.as_slice();
+    let result = record::read_record(&mut reader).await;
+    assert_flood_error(&result, "the encoding");
+    assert_eq!(
+        result.unwrap_err().connection_error_code(),
+        Some(ErrorCode::Flood),
+    );
+
+    // A stream finished in the middle of a record is a PROTOCOL_ERROR.
+    let mut truncated = Vec::new();
+    record::write_record(&mut truncated, &[0xAB; 100]).expect("write to Vec succeeds");
+    truncated.truncate(50);
+    let mut reader = truncated.as_slice();
+    let result = record::read_record(&mut reader).await;
+    assert_protocol_error(&result, "the encoding");
+
+    // Trailing data after a complete element is rejected by the
+    // end-of-stream check.
+    let mut reader = &[0x00][..];
+    let result = record::expect_end_of_stream(&mut reader).await;
+    assert_protocol_error(&result, "the encoding");
+    let mut reader = &[][..];
+    record::expect_end_of_stream(&mut reader)
+        .await
+        .expect("empty stream passes the end-of-stream check");
+}
+
+fn test_init_record() -> InitRecord {
+    InitRecord {
+        version: Version(170_160),
+        services: PeerServices::NODE_NETWORK,
+        nonce: Nonce(0x0123_4567_89AB_CDEF),
+        user_agent: "/ZebraV2:1.0.0/".to_string(),
+        start_height: block::Height(2_000_000),
+        relay: true,
+        announce: false,
+        full_ids: false,
+    }
+}
+
+#[tokio::test]
+async fn init_record_round_trip() {
+    let _init_guard = zebra_test::init();
+
+    let init = test_init_record();
+
+    let mut buf = Vec::new();
+    init.write(&mut buf).await.expect("write to Vec succeeds");
+
+    let mut reader = buf.as_slice();
+    let read = InitRecord::read(&mut reader)
+        .await
+        .expect("record parses")
+        .expect("record is present");
+    assert_eq!(read, init);
+}
+
+#[tokio::test]
+async fn init_record_skips_unknown_kinds() {
+    let _init_guard = zebra_test::init();
+
+    let init = test_init_record();
+
+    // An unknown record kind before the init record is ignored.
+    let mut buf = Vec::new();
+    record::write_record(&mut buf, &[0x7F, 0xAA, 0xBB]).expect("write to Vec succeeds");
+    init.write(&mut buf).await.expect("write to Vec succeeds");
+
+    let mut reader = buf.as_slice();
+    let read = InitRecord::read(&mut reader)
+        .await
+        .expect("record parses")
+        .expect("record is present");
+    assert_eq!(read, init);
+
+    // A stream finished before any init record is a clean end.
+    let mut buf = Vec::new();
+    record::write_record(&mut buf, &[0x7F]).expect("write to Vec succeeds");
+    let mut reader = buf.as_slice();
+    assert!(InitRecord::read(&mut reader)
+        .await
+        .expect("records parse")
+        .is_none());
+}
+
+#[test]
+fn init_record_rejects_invalid_fields() {
+    let _init_guard = zebra_test::init();
+
+    let init = test_init_record();
+
+    // A flag field that is not 0 or 1 is rejected.
+    let mut payload = init.to_record_payload();
+    *payload.last_mut().expect("payload is not empty") = 2;
+    let result = HandshakeRecord::parse(&payload);
+    assert_protocol_error(&result, "the encoding");
+
+    // Trailing data after the init fields is rejected.
+    let mut payload = init.to_record_payload();
+    payload.push(0x00);
+    let result = HandshakeRecord::parse(&payload);
+    assert_protocol_error(&result, "the encoding");
+
+    // An empty handshake record is rejected.
+    let result = HandshakeRecord::parse(&[]);
+    assert_protocol_error(&result, "the encoding");
+
+    // An over-long user agent is rejected.
+    let long_agent = InitRecord {
+        user_agent: "x".repeat(257),
+        ..init
+    };
+    let result = HandshakeRecord::parse(&long_agent.to_record_payload());
+    assert_protocol_error(&result, "the encoding");
+}
+
+fn test_txrefs() -> Vec<TransactionReference> {
+    vec![
+        TransactionReference::Txid(zebra_chain::transaction::Hash([0x11; 32])),
+        TransactionReference::Wtxid(WtxId {
+            id: zebra_chain::transaction::Hash([0x22; 32]),
+            auth_digest: AuthDigest([0x33; 32]),
+        }),
+        TransactionReference::ShortId {
+            block_hash: block::Hash([0x44; 32]),
+            short_id: ShortTxId([1, 2, 3, 4, 5, 6]),
+        },
+    ]
+}
+
+#[tokio::test]
+async fn transaction_reference_round_trip() {
+    let _init_guard = zebra_test::init();
+
+    for txref in test_txrefs() {
+        let mut buf = Vec::new();
+        txref.encode(&mut buf).expect("write to Vec succeeds");
+
+        let read = TransactionReference::parse_exact(&buf)
+            .await
+            .expect("reference parses");
+        assert_eq!(read, txref);
+    }
+
+    // An unrecognized reference type is rejected.
+    let result = TransactionReference::parse_exact(&[0x04; 33]).await;
+    assert_protocol_error(&result, "the encoding");
+
+    // Trailing data is rejected.
+    let mut buf = Vec::new();
+    test_txrefs()[0]
+        .encode(&mut buf)
+        .expect("write to Vec succeeds");
+    buf.push(0x00);
+    let result = TransactionReference::parse_exact(&buf).await;
+    assert_protocol_error(&result, "the encoding");
+}
+
+#[test]
+fn full_transaction_id_construction() {
+    let _init_guard = zebra_test::init();
+
+    let txid = zebra_chain::transaction::Hash([0xAA; 32]);
+    let legacy = UnminedTxId::Legacy(txid);
+    let full = full_transaction_id(&legacy);
+    assert_eq!(full.id, txid);
+    assert_eq!(
+        full.auth_digest,
+        zebra_chain::block::merkle::AUTH_DIGEST_PLACEHOLDER,
+    );
+
+    let wtxid = WtxId {
+        id: zebra_chain::transaction::Hash([0xBB; 32]),
+        auth_digest: AuthDigest([0xCC; 32]),
+    };
+    let full = full_transaction_id(&UnminedTxId::Witnessed(wtxid));
+    assert_eq!(full, wtxid);
+}
+
+/// Checks the short transaction ID computation against a manual
+/// reimplementation of the specified steps.
+#[test]
+fn short_transaction_id_computation() {
+    let _init_guard = zebra_test::init();
+
+    use sha2::{Digest, Sha256};
+    use std::hash::Hasher;
+
+    let header_bytes = [0x5A; 100];
+    let nonce = 0xDEAD_BEEF_0BAD_F00Du64;
+
+    // SHA-256 of the header bytes followed by the little-endian nonce.
+    let mut hasher = Sha256::new();
+    hasher.update(header_bytes);
+    hasher.update(nonce.to_le_bytes());
+    let digest = hasher.finalize();
+    let expected_k0 = u64::from_le_bytes(digest[0..8].try_into().unwrap());
+    let expected_k1 = u64::from_le_bytes(digest[8..16].try_into().unwrap());
+
+    let (k0, k1) = short_id_keys(&header_bytes, nonce);
+    assert_eq!((k0, k1), (expected_k0, expected_k1));
+
+    // SipHash-2-4 of the wtxid, truncated to the low 6 bytes, little-endian.
+    let wtxid = WtxId {
+        id: zebra_chain::transaction::Hash([0x77; 32]),
+        auth_digest: AuthDigest([0x88; 32]),
+    };
+    let mut hasher = siphasher::sip::SipHasher24::new_with_keys(k0, k1);
+    hasher.write(&wtxid.as_bytes());
+    let expected = hasher.finish().to_le_bytes();
+
+    let short_id = short_transaction_id(k0, k1, &UnminedTxId::Witnessed(wtxid));
+    assert_eq!(short_id.0, expected[0..6]);
+
+    // A legacy transaction hashes its 32-byte txid instead.
+    let txid = zebra_chain::transaction::Hash([0x99; 32]);
+    let mut hasher = siphasher::sip::SipHasher24::new_with_keys(k0, k1);
+    hasher.write(&txid.0);
+    let expected = hasher.finish().to_le_bytes();
+
+    let short_id = short_transaction_id(k0, k1, &UnminedTxId::Legacy(txid));
+    assert_eq!(short_id.0, expected[0..6]);
+}
+
+/// Returns a parsed mainnet block test vector with at least 3 transactions.
+fn test_block() -> Arc<Block> {
+    zebra_test::vectors::MAINNET_BLOCKS
+        .values()
+        .map(|bytes| {
+            bytes
+                .zcash_deserialize_into::<Block>()
+                .expect("block test vectors parse")
+        })
+        .find(|block| block.transactions.len() >= 3)
+        .expect("some mainnet block test vector has at least 3 transactions")
+        .into()
+}
+
+#[tokio::test]
+async fn compact_block_round_trip_short_ids() {
+    let _init_guard = zebra_test::init();
+
+    let block = test_block();
+    let compact = CompactBlock::from_block(&block, 0x1122_3344_5566_7788, false, &[])
+        .expect("compact block builds");
+
+    // Only the coinbase is prefilled.
+    assert_eq!(compact.prefilled.len(), 1);
+    assert_eq!(compact.prefilled[0].index, 0);
+    let expected_ids = block.transactions.len() - 1;
+    assert!(matches!(&compact.ids, CompactBlockIds::Short(ids) if ids.len() == expected_ids));
+
+    let mut buf = Vec::new();
+    compact.encode(&mut buf).expect("write to Vec succeeds");
+
+    let mut reader = buf.as_slice();
+    let read = CompactBlock::read(&mut reader)
+        .await
+        .expect("compact block parses");
+    assert_eq!(read, compact);
+    assert!(reader.is_empty());
+}
+
+#[tokio::test]
+async fn compact_block_round_trip_full_ids() {
+    let _init_guard = zebra_test::init();
+
+    let block = test_block();
+    // Prefill the second transaction as well as the coinbase.
+    let compact = CompactBlock::from_block(&block, 0, true, &[1]).expect("compact block builds");
+
+    assert_eq!(compact.prefilled.len(), 2);
+    assert_eq!(compact.nonce, 0);
+    let expected_ids = block.transactions.len() - 2;
+    assert!(matches!(&compact.ids, CompactBlockIds::Full(ids) if ids.len() == expected_ids));
+
+    let mut buf = Vec::new();
+    compact.encode(&mut buf).expect("write to Vec succeeds");
+
+    let mut reader = buf.as_slice();
+    let read = CompactBlock::read(&mut reader)
+        .await
+        .expect("compact block parses");
+    assert_eq!(read, compact);
+}
+
+#[tokio::test]
+async fn compact_block_rejects_invalid() {
+    let _init_guard = zebra_test::init();
+
+    let block = test_block();
+    let compact = CompactBlock::from_block(&block, 1, false, &[]).expect("compact block builds");
+
+    let mut buf = Vec::new();
+    compact.encode(&mut buf).expect("write to Vec succeeds");
+
+    // Corrupt the ids_kind byte: header record || nonce (8) || ids_kind.
+    let header_len = {
+        let header_bytes = compact
+            .header
+            .zcash_serialize_to_vec()
+            .expect("serializing a header to a Vec never fails");
+        // 3-byte CompactSize prefix for a header-sized record.
+        3 + header_bytes.len()
+    };
+    let ids_kind_offset = header_len + 8;
+
+    let mut bad_kind = buf.clone();
+    bad_kind[ids_kind_offset] = 0x02;
+    let mut reader = bad_kind.as_slice();
+    let result = CompactBlock::read(&mut reader).await;
+    assert_protocol_error(&result, "the encoding");
+}
+
+#[tokio::test]
+async fn compact_block_rejects_bad_prefilled_indexes() {
+    let _init_guard = zebra_test::init();
+
+    let block = test_block();
+
+    // Duplicate prefilled indexes cannot be encoded, and are rejected when
+    // decoding: encode a compact block, then check that decoding validates
+    // the differential encoding by constructing one with an index over the
+    // limit.
+    let mut compact =
+        CompactBlock::from_block(&block, 1, false, &[1]).expect("compact block builds");
+    compact.prefilled[1].index = MAX_PREFILLED_TX_INDEX + 1;
+
+    let mut buf = Vec::new();
+    compact.encode(&mut buf).expect("write to Vec succeeds");
+    let mut reader = buf.as_slice();
+    let result = CompactBlock::read(&mut reader).await;
+    assert_protocol_error(&result, "the encoding");
+}
+
+#[tokio::test]
+async fn compact_block_rejects_overflowing_transaction_counts() {
+    let _init_guard = zebra_test::init();
+
+    let block = test_block();
+    let compact = CompactBlock::from_block(&block, 1, false, &[]).expect("compact block builds");
+    let header_bytes = compact
+        .header
+        .zcash_serialize_to_vec()
+        .expect("serializing a header to a Vec never fails");
+
+    // A `prefilled_count` that overflows `ids_count + prefilled_count` must be
+    // rejected as a flood, rather than wrapping past the limit check and
+    // reaching the prefilled transaction preallocation.
+    let mut buf = Vec::new();
+    record::write_record(&mut buf, &header_bytes).expect("write to Vec succeeds");
+    buf.extend_from_slice(&0u64.to_le_bytes());
+    buf.push(compact_block::IDS_KIND_SHORT);
+    record::write_compact_size(&mut buf, 1).expect("write to Vec succeeds");
+    buf.extend_from_slice(&[0u8; 6]);
+    record::write_compact_size(&mut buf, u64::MAX).expect("write to Vec succeeds");
+
+    let mut reader = buf.as_slice();
+    let result = CompactBlock::read(&mut reader).await;
+    assert_flood_error(&result, "the encoding");
+}
+
+#[tokio::test]
+async fn request_round_trips() {
+    let _init_guard = zebra_test::init();
+
+    let requests = vec![
+        Request::GetHeaders {
+            known_blocks: vec![block::Hash([0x01; 32]), block::Hash([0x02; 32])],
+            stop: Some(block::Hash([0x03; 32])),
+            tx_ids: false,
+        },
+        Request::GetHeaders {
+            known_blocks: vec![],
+            stop: None,
+            tx_ids: true,
+        },
+        Request::GetBlocks {
+            hashes: vec![block::Hash([0x04; 32]), block::Hash([0x05; 32])],
+        },
+        Request::GetTx {
+            refs: test_txrefs(),
+        },
+        Request::GetAddr,
+        Request::GetMempool,
+        Request::GetHashes {
+            start_height: 0,
+            stride: 1,
+            count: 50_000,
+        },
+        Request::GetHashes {
+            start_height: u32::MAX,
+            stride: u32::MAX,
+            count: 1,
+        },
+        Request::GetHashes {
+            start_height: 419_200,
+            stride: 400,
+            count: 0,
+        },
+        Request::GetBlockRange {
+            final_hash: block::Hash([0x06; 32]),
+            count: 65_536,
+            max_bytes: 67_108_864,
+        },
+        Request::GetTreeRoots {
+            start_height: 1_046_400,
+            final_hash: block::Hash([0x07; 32]),
+            count: 4_000,
+        },
+        Request::GetObject {
+            hash: ObjectHash([0x08; 32]),
+            offset: u64::MAX,
+            length: 33_554_432,
+        },
+    ];
+
+    for request in requests {
+        let mut buf = Vec::new();
+        request.encode(&mut buf).expect("write to Vec succeeds");
+
+        let mut reader = buf.as_slice();
+        let read = Request::read(request.stream_type(), &mut reader)
+            .await
+            .expect("request parses");
+        assert_eq!(read, request);
+
+        record::expect_end_of_stream(&mut reader)
+            .await
+            .expect("request reads consume the whole request");
+    }
+}
+
+#[tokio::test]
+async fn request_rejects_over_limit() {
+    let _init_guard = zebra_test::init();
+
+    // A locator with more than the maximum hashes is rejected on encode
+    // and on decode.
+    let over_limit = Request::GetHeaders {
+        known_blocks: vec![block::Hash([0; 32]); MAX_LOCATOR_HASHES as usize + 1],
+        stop: None,
+        tx_ids: false,
+    };
+    // Encoding fails locally, so it must not be classified as a peer
+    // violation: it would close a healthy connection.
+    let mut buf = Vec::new();
+    let result = over_limit.encode(&mut buf);
+    assert!(
+        matches!(result, Err(WireError::Local(_))),
+        "got: {result:?}"
+    );
+
+    let mut buf = Vec::new();
+    record::write_compact_size(&mut buf, MAX_LOCATOR_HASHES + 1).expect("write to Vec succeeds");
+    let mut reader = buf.as_slice();
+    let result = Request::read(StreamType::GetHeaders, &mut reader).await;
+    assert_protocol_error(&result, "the encoding");
+
+    let mut buf = Vec::new();
+    record::write_compact_size(&mut buf, MAX_GET_BLOCKS_HASHES + 1).expect("write to Vec succeeds");
+    let mut reader = buf.as_slice();
+    let result = Request::read(StreamType::GetBlocks, &mut reader).await;
+    assert_protocol_error(&result, "the encoding");
+}
+
+/// The synchronization request encodings are pinned to the draft's field
+/// tables: heights and strides are little-endian `u32`s, hashes are raw
+/// 32-byte values, and counts and sizes are CompactSizes.
+#[tokio::test]
+async fn sync_request_encodings_match_the_draft() {
+    let _init_guard = zebra_test::init();
+
+    let cases: Vec<(Request, Vec<u8>)> = vec![
+        (
+            Request::GetHashes {
+                start_height: 419_200,
+                stride: 400,
+                count: 3,
+            },
+            [
+                &419_200u32.to_le_bytes()[..],
+                &400u32.to_le_bytes()[..],
+                &[0x03][..],
+            ]
+            .concat(),
+        ),
+        (
+            Request::GetBlockRange {
+                final_hash: block::Hash([0xCD; 32]),
+                count: 300,
+                max_bytes: 16_777_216,
+            },
+            [
+                &[0xCD; 32][..],
+                &[0xFD, 0x2C, 0x01][..],
+                &[0xFE, 0x00, 0x00, 0x00, 0x01][..],
+            ]
+            .concat(),
+        ),
+        (
+            Request::GetTreeRoots {
+                start_height: 500_000,
+                final_hash: block::Hash([0xAB; 32]),
+                count: 2,
+            },
+            [&500_000u32.to_le_bytes()[..], &[0xAB; 32][..], &[0x02][..]].concat(),
+        ),
+        (
+            Request::GetObject {
+                hash: ObjectHash([0xEF; 32]),
+                offset: 253,
+                length: 1_000,
+            },
+            [
+                &[0xEF; 32][..],
+                &[0xFD, 0xFD, 0x00][..],
+                &[0xFD, 0xE8, 0x03][..],
+            ]
+            .concat(),
+        ),
+    ];
+
+    for (request, expected) in cases {
+        let mut buf = Vec::new();
+        request.encode(&mut buf).expect("write to Vec succeeds");
+        assert_eq!(buf, expected, "encoding of {request:?}");
+
+        let mut reader = buf.as_slice();
+        let read = Request::read(request.stream_type(), &mut reader)
+            .await
+            .expect("request parses");
+        assert_eq!(read, request);
+        record::expect_end_of_stream(&mut reader)
+            .await
+            .expect("request reads consume the whole request");
+    }
+}
+
+/// Requests violating the synchronization stream types' bounds are local
+/// errors on the send side and connection errors on the receive side.
+#[tokio::test]
+async fn sync_request_bounds_are_enforced() {
+    let _init_guard = zebra_test::init();
+
+    let over_limit = vec![
+        // A stride of 0 is invalid.
+        Request::GetHashes {
+            start_height: 0,
+            stride: 0,
+            count: 1,
+        },
+        Request::GetHashes {
+            start_height: 0,
+            stride: 1,
+            count: MAX_GET_HASHES_COUNT + 1,
+        },
+        // The greatest requested height must not exceed `u32::MAX`:
+        // this request's second hash would be above it.
+        Request::GetHashes {
+            start_height: u32::MAX,
+            stride: 1,
+            count: 2,
+        },
+        Request::GetBlockRange {
+            final_hash: block::Hash([0; 32]),
+            count: MAX_GET_BLOCK_RANGE_COUNT + 1,
+            max_bytes: 0,
+        },
+        Request::GetBlockRange {
+            final_hash: block::Hash([0; 32]),
+            count: 0,
+            max_bytes: MAX_GET_BLOCK_RANGE_BYTES + 1,
+        },
+        Request::GetTreeRoots {
+            start_height: 0,
+            final_hash: block::Hash([0; 32]),
+            count: MAX_GET_TREE_ROOTS_COUNT + 1,
+        },
+        Request::GetObject {
+            hash: ObjectHash([0; 32]),
+            offset: 0,
+            length: MAX_GET_OBJECT_LENGTH + 1,
+        },
+    ];
+
+    for request in over_limit {
+        // Encoding fails locally, so it must not be classified as a peer
+        // violation: it would close a healthy connection.
+        let mut buf = Vec::new();
+        let result = request.encode(&mut buf);
+        assert!(
+            matches!(result, Err(WireError::Local(_))),
+            "encoding {request:?} got: {result:?}",
+        );
+
+        // Reading the same request from a peer is a connection error of
+        // type `PROTOCOL_ERROR`. The invalid fields must be encoded
+        // directly, since `encode` refuses to build them.
+        let mut buf = Vec::new();
+        match &request {
+            Request::GetHashes {
+                start_height,
+                stride,
+                count,
+            } => {
+                buf.extend_from_slice(&start_height.to_le_bytes());
+                buf.extend_from_slice(&stride.to_le_bytes());
+                record::write_compact_size(&mut buf, *count).expect("write to Vec succeeds");
+            }
+            Request::GetBlockRange {
+                final_hash,
+                count,
+                max_bytes,
+            } => {
+                buf.extend_from_slice(&final_hash.0);
+                record::write_compact_size(&mut buf, *count).expect("write to Vec succeeds");
+                record::write_compact_size(&mut buf, *max_bytes).expect("write to Vec succeeds");
+            }
+            Request::GetTreeRoots {
+                start_height,
+                final_hash,
+                count,
+            } => {
+                buf.extend_from_slice(&start_height.to_le_bytes());
+                buf.extend_from_slice(&final_hash.0);
+                record::write_compact_size(&mut buf, *count).expect("write to Vec succeeds");
+            }
+            Request::GetObject {
+                hash,
+                offset,
+                length,
+            } => {
+                buf.extend_from_slice(&hash.0);
+                record::write_compact_size(&mut buf, *offset).expect("write to Vec succeeds");
+                record::write_compact_size(&mut buf, *length).expect("write to Vec succeeds");
+            }
+            other => unreachable!("only sync requests are tested here, got: {other:?}"),
+        }
+
+        let mut reader = buf.as_slice();
+        let result = Request::read(request.stream_type(), &mut reader).await;
+        assert_protocol_error(&result, "reading {request:?} got:");
+    }
+
+    // A request truncated mid-element is a connection error of type
+    // `PROTOCOL_ERROR`.
+    let mut reader = &500_000u32.to_le_bytes()[..2];
+    let result = Request::read(StreamType::GetHashes, &mut reader).await;
+    assert_protocol_error(&result, "the encoding");
+}
+
+#[tokio::test]
+async fn headers_response_round_trip_and_contiguity() {
+    let _init_guard = zebra_test::init();
+
+    let block_1: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_1_BYTES
+        .zcash_deserialize_into::<Block>()
+        .expect("block test vector parses")
+        .into();
+    let block_2: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_2_BYTES
+        .zcash_deserialize_into::<Block>()
+        .expect("block test vector parses")
+        .into();
+
+    let headers = HeadersResponse(vec![
+        block::CountedHeader {
+            header: block_1.header.clone(),
+        },
+        block::CountedHeader {
+            header: block_2.header.clone(),
+        },
+    ]);
+
+    let mut buf = Vec::new();
+    headers.encode(&mut buf).expect("write to Vec succeeds");
+
+    let mut reader = buf.as_slice();
+    let read = HeadersResponse::read(&mut reader)
+        .await
+        .expect("headers parse");
+    assert_eq!(read.0.len(), 2);
+    assert_eq!(read.0[0].header, block_1.header);
+    assert_eq!(read.0[1].header, block_2.header);
+
+    let hashes = read
+        .check_contiguous()
+        .expect("blocks 1 and 2 are contiguous");
+    assert_eq!(hashes, vec![block_1.hash(), block_2.hash()]);
+
+    // Reversed headers are not contiguous.
+    let reversed = HeadersResponse(vec![
+        block::CountedHeader {
+            header: block_2.header.clone(),
+        },
+        block::CountedHeader {
+            header: block_1.header.clone(),
+        },
+    ]);
+    let result = reversed.check_contiguous();
+    assert!(
+        matches!(result, Err(WireError::Misbehavior { .. })),
+        "got: {result:?}",
+    );
+}
+
+#[tokio::test]
+async fn sync_response_round_trips() {
+    use zebra_chain::block::{SyncHashEntry, TreeRootsEntry};
+
+    use super::super::response::{HashesResponse, TreeRootsResponse};
+
+    let _init_guard = zebra_test::init();
+
+    let hashes = HashesResponse(vec![
+        SyncHashEntry {
+            hash: block::Hash([0x11; 32]),
+            span_size: 1,
+            span_txs: 1,
+            span_notes: 0,
+        },
+        SyncHashEntry {
+            hash: block::Hash([0x22; 32]),
+            span_size: 400,
+            span_txs: 12_345,
+            span_notes: 0xFFFF_FFFF,
+        },
+    ]);
+    let mut buf = Vec::new();
+    hashes.encode(&mut buf).expect("write to Vec succeeds");
+    let mut reader = buf.as_slice();
+    let read = HashesResponse::read(&mut reader)
+        .await
+        .expect("entries parse");
+    assert_eq!(read.0, hashes.0);
+    assert!(reader.is_empty());
+
+    // An empty response is valid: a peer without matching heights.
+    let mut buf = Vec::new();
+    HashesResponse(Vec::new())
+        .encode(&mut buf)
+        .expect("write to Vec succeeds");
+    let mut reader = buf.as_slice();
+    let read = HashesResponse::read(&mut reader)
+        .await
+        .expect("empty response parses");
+    assert!(read.0.is_empty());
+
+    let roots = TreeRootsResponse(vec![
+        TreeRootsEntry {
+            sapling_root: [0x0A; 32],
+            orchard_root: [0; 32],
+            ironwood_root: [0; 32],
+            sapling_txs: 3,
+            orchard_txs: 0,
+            ironwood_txs: 0,
+            auth_data_root: [0xFF; 32],
+        },
+        TreeRootsEntry {
+            sapling_root: [0x0B; 32],
+            orchard_root: [0x0C; 32],
+            ironwood_root: [0x0D; 32],
+            sapling_txs: 1,
+            orchard_txs: 2,
+            ironwood_txs: 3,
+            auth_data_root: [0xEE; 32],
+        },
+    ]);
+    let mut buf = Vec::new();
+    roots.encode(&mut buf).expect("write to Vec succeeds");
+    let mut reader = buf.as_slice();
+    let read = TreeRootsResponse::read(&mut reader)
+        .await
+        .expect("entries parse");
+    assert_eq!(read.0, roots.0);
+    assert!(reader.is_empty());
+
+    // Counts over the request limits are rejected while reading.
+    let mut buf = Vec::new();
+    record::write_compact_size(&mut buf, MAX_GET_HASHES_COUNT + 1).expect("write to Vec succeeds");
+    let mut reader = buf.as_slice();
+    let result = HashesResponse::read(&mut reader).await;
+    assert_protocol_error(&result, "the encoding");
+
+    let mut buf = Vec::new();
+    record::write_compact_size(&mut buf, MAX_GET_TREE_ROOTS_COUNT + 1)
+        .expect("write to Vec succeeds");
+    let mut reader = buf.as_slice();
+    let result = TreeRootsResponse::read(&mut reader).await;
+    assert_protocol_error(&result, "the encoding");
+}
+
+#[tokio::test]
+async fn block_response_entries_round_trip() {
+    let _init_guard = zebra_test::init();
+
+    let block = test_block();
+
+    let mut buf = Vec::new();
+    encode_result_entry(&mut buf, Some(block.as_ref())).expect("write to Vec succeeds");
+    encode_result_entry::<Block, _>(&mut buf, None).expect("write to Vec succeeds");
+
+    let mut reader = buf.as_slice();
+    let read_full = read_result_entry::<Block, _>(&mut reader, "get-blocks")
+        .await
+        .expect("entry parses");
+    assert_eq!(read_full.as_deref(), Some(block.as_ref()));
+    let read_missing = read_result_entry::<Block, _>(&mut reader, "get-blocks")
+        .await
+        .expect("entry parses");
+    assert!(read_missing.is_none());
+    assert!(reader.is_empty());
+
+    // The compact block result byte of earlier draft revisions was removed:
+    // compact blocks occur only as announcements, so `0x01` is unrecognized.
+    let mut reader = &[0x01][..];
+    let result = read_result_entry::<Block, _>(&mut reader, "get-blocks").await;
+    assert_protocol_error(&result, "the encoding");
+
+    // An unrecognized result byte is rejected.
+    let mut reader = &[0x03][..];
+    let result = read_result_entry::<Block, _>(&mut reader, "get-blocks").await;
+    assert_protocol_error(&result, "the encoding");
+}
+
+#[tokio::test]
+async fn tx_response_entries_round_trip() {
+    let _init_guard = zebra_test::init();
+
+    let block = test_block();
+    let tx = block.transactions[1].clone();
+
+    let mut buf = Vec::new();
+    encode_result_entry(&mut buf, Some(tx.as_ref())).expect("write to Vec succeeds");
+    encode_result_entry::<Transaction, _>(&mut buf, None).expect("write to Vec succeeds");
+
+    let mut reader = buf.as_slice();
+    let read_found = read_result_entry::<Transaction, _>(&mut reader, "get-tx")
+        .await
+        .expect("entry parses");
+    assert_eq!(read_found.as_deref(), Some(tx.as_ref()));
+    let read_missing = read_result_entry::<Transaction, _>(&mut reader, "get-tx")
+        .await
+        .expect("entry parses");
+    assert!(read_missing.is_none());
+    assert!(reader.is_empty());
+
+    // A compact block result byte is not valid in a get-tx response.
+    let mut reader = &[0x01][..];
+    let result = read_result_entry::<Transaction, _>(&mut reader, "get-tx").await;
+    assert_protocol_error(&result, "the encoding");
+}
+
+#[tokio::test]
+async fn addr_response_round_trip() {
+    let _init_guard = zebra_test::init();
+
+    let addrs = vec![
+        MetaAddr::new_gossiped_meta_addr(
+            "192.0.2.1:8233".parse().expect("valid address"),
+            PeerServices::NODE_NETWORK,
+            DateTime32::from(1_700_000_000),
+        ),
+        MetaAddr::new_gossiped_meta_addr(
+            "[2001:db8::1]:8233".parse().expect("valid address"),
+            PeerServices::NODE_NETWORK,
+            DateTime32::from(1_700_000_100),
+        ),
+    ];
+
+    let response = AddrResponse(addrs.clone());
+
+    let mut buf = Vec::new();
+    response.encode(&mut buf).expect("write to Vec succeeds");
+
+    let mut reader = buf.as_slice();
+    let read = AddrResponse::read(&mut reader)
+        .await
+        .expect("addresses parse");
+    assert_eq!(read.0.len(), addrs.len());
+    for (read, sent) in read.0.iter().zip(&addrs) {
+        assert_eq!(read.addr(), sent.addr());
+    }
+    assert!(reader.is_empty());
+}
+
+#[tokio::test]
+async fn mempool_response_round_trip() {
+    let _init_guard = zebra_test::init();
+
+    let refs: Vec<TransactionReference> = test_txrefs()
+        .into_iter()
+        .filter(|txref| !txref.is_short_id())
+        .collect();
+
+    let response = MempoolResponse(refs.clone());
+
+    let mut buf = Vec::new();
+    response.encode(&mut buf).expect("write to Vec succeeds");
+
+    let mut reader = buf.as_slice();
+    let read = MempoolResponse::read(&mut reader)
+        .await
+        .expect("references parse");
+    assert_eq!(read.0, refs);
+
+    // A SHORTID reference in a get-mempool response is rejected.
+    let mut buf = Vec::new();
+    record::write_compact_size(&mut buf, 1).expect("write to Vec succeeds");
+    TransactionReference::ShortId {
+        block_hash: block::Hash([0; 32]),
+        short_id: ShortTxId([0; 6]),
+    }
+    .encode(&mut buf)
+    .expect("write to Vec succeeds");
+
+    let mut reader = buf.as_slice();
+    let result = MempoolResponse::read(&mut reader).await;
+    assert_protocol_error(&result, "the encoding");
+
+    // A reference count over the response limit is a FLOOD connection
+    // error, before any references are read.
+    let mut buf = Vec::new();
+    record::write_compact_size(&mut buf, MAX_MEMPOOL_RESPONSE_REFS as u64 + 1)
+        .expect("write to Vec succeeds");
+
+    let mut reader = buf.as_slice();
+    let result = MempoolResponse::read(&mut reader).await;
+    assert_flood_error(&result, "the encoding");
+}

--- a/zebra-network/src/protocol/v2/txref.rs
+++ b/zebra-network/src/protocol/v2/txref.rs
@@ -1,0 +1,164 @@
+//! Transaction references for the version 2 Zcash P2P network protocol.
+//!
+//! Transactions are identified in announcements and requests by *transaction
+//! references*. Per ZIP 239, transactions with version 5 or later are relayed
+//! by wtxid, and transactions with version 4 or earlier by txid.
+
+use std::io;
+
+use tokio::io::AsyncRead;
+
+use zebra_chain::{
+    block,
+    transaction::{self, UnminedTxId, WtxId},
+};
+
+use super::{compact_block::ShortTxId, record, types::WireError};
+
+/// The wire type byte of a `TXID` transaction reference.
+pub const TXREF_TYPE_TXID: u8 = 0x01;
+
+/// The wire type byte of a `WTXID` transaction reference.
+pub const TXREF_TYPE_WTXID: u8 = 0x02;
+
+/// The wire type byte of a `SHORTID` transaction reference.
+pub const TXREF_TYPE_SHORTID: u8 = 0x03;
+
+/// A reference to a transaction, in an announcement or request.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum TransactionReference {
+    /// A transaction with version 4 or earlier, identified by its txid.
+    Txid(transaction::Hash),
+
+    /// A transaction with version 5 or later, identified by its wtxid
+    /// (the txid followed by the authorizing data commitment).
+    Wtxid(WtxId),
+
+    /// A transaction within a specific block, identified by the block hash
+    /// and a short transaction ID.
+    ///
+    /// Only valid in `get-tx` requests.
+    ShortId {
+        /// The hash of the block containing the transaction.
+        block_hash: block::Hash,
+
+        /// The short transaction ID, relative to the compact block most
+        /// recently sent by the responder for this block.
+        short_id: ShortTxId,
+    },
+}
+
+impl TransactionReference {
+    /// Encodes this transaction reference to `writer`.
+    pub fn encode<W: io::Write>(&self, mut writer: W) -> Result<(), WireError> {
+        match self {
+            TransactionReference::Txid(txid) => {
+                writer.write_all(&[TXREF_TYPE_TXID])?;
+                writer.write_all(&txid.0)?;
+            }
+            TransactionReference::Wtxid(wtxid) => {
+                writer.write_all(&[TXREF_TYPE_WTXID])?;
+                writer.write_all(&wtxid.as_bytes())?;
+            }
+            TransactionReference::ShortId {
+                block_hash,
+                short_id,
+            } => {
+                writer.write_all(&[TXREF_TYPE_SHORTID])?;
+                writer.write_all(&block_hash.0)?;
+                writer.write_all(&short_id.0)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Reads a transaction reference from `reader`.
+    ///
+    /// A transaction reference with an unrecognized type is a connection
+    /// error of type `PROTOCOL_ERROR`.
+    pub async fn read<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Self, WireError> {
+        let ref_type = record::read_u8(reader).await?;
+
+        match ref_type {
+            TXREF_TYPE_TXID => {
+                let mut txid = [0u8; 32];
+                record::read_exact_or_incomplete(reader, &mut txid).await?;
+                Ok(TransactionReference::Txid(txid.into()))
+            }
+            TXREF_TYPE_WTXID => {
+                let mut wtxid = [0u8; 64];
+                record::read_exact_or_incomplete(reader, &mut wtxid).await?;
+                Ok(TransactionReference::Wtxid(wtxid.into()))
+            }
+            TXREF_TYPE_SHORTID => {
+                let block_hash = record::read_block_hash(reader).await?;
+                let mut short_id = [0u8; 6];
+                record::read_exact_or_incomplete(reader, &mut short_id).await?;
+                Ok(TransactionReference::ShortId {
+                    block_hash,
+                    short_id: ShortTxId(short_id),
+                })
+            }
+            unknown => Err(WireError::Protocol(format!(
+                "unrecognized transaction reference type {unknown:#04x}",
+            ))),
+        }
+    }
+
+    /// Parses a transaction reference from a complete buffer, rejecting
+    /// trailing data.
+    ///
+    /// Used for transaction announcement records, which each contain exactly
+    /// one reference.
+    pub async fn parse_exact(payload: &[u8]) -> Result<Self, WireError> {
+        let mut reader = payload;
+        let reference = Self::read(&mut reader).await?;
+
+        if !reader.is_empty() {
+            return Err(WireError::Protocol(
+                "trailing data after a transaction reference".to_string(),
+            ));
+        }
+
+        Ok(reference)
+    }
+
+    /// Returns true if this is a `SHORTID` reference.
+    ///
+    /// `SHORTID` references are only valid in `get-tx` requests: they must
+    /// not be used in announcements or `get-mempool` responses.
+    pub fn is_short_id(&self) -> bool {
+        matches!(self, TransactionReference::ShortId { .. })
+    }
+}
+
+impl From<UnminedTxId> for TransactionReference {
+    /// Converts a mempool transaction ID to the reference used to relay it,
+    /// following ZIP 239: legacy IDs identify transactions with version 4 or
+    /// earlier, witnessed IDs identify transactions with version 5 or later.
+    fn from(id: UnminedTxId) -> Self {
+        match id {
+            UnminedTxId::Legacy(txid) => TransactionReference::Txid(txid),
+            UnminedTxId::Witnessed(wtxid) => TransactionReference::Wtxid(wtxid),
+        }
+    }
+}
+
+impl TryFrom<TransactionReference> for UnminedTxId {
+    type Error = WireError;
+
+    /// Converts a `TXID` or `WTXID` reference to a mempool transaction ID.
+    ///
+    /// `SHORTID` references do not identify a transaction on their own, so
+    /// they have no [`UnminedTxId`] equivalent.
+    fn try_from(reference: TransactionReference) -> Result<Self, Self::Error> {
+        match reference {
+            TransactionReference::Txid(txid) => Ok(UnminedTxId::Legacy(txid)),
+            TransactionReference::Wtxid(wtxid) => Ok(UnminedTxId::Witnessed(wtxid)),
+            TransactionReference::ShortId { .. } => Err(WireError::Protocol(
+                "a SHORTID reference is not valid here".to_string(),
+            )),
+        }
+    }
+}

--- a/zebra-network/src/protocol/v2/types.rs
+++ b/zebra-network/src/protocol/v2/types.rs
@@ -1,0 +1,252 @@
+//! Core types for the version 2 Zcash P2P network protocol:
+//! stream types, application error codes, and wire errors.
+
+use thiserror::Error;
+
+use zebra_chain::serialization::SerializationError;
+
+/// The type of a stream, identified by the first byte of the stream.
+///
+/// Stream type `0x00` and the ranges `0x01`–`0x0F` and `0x10`–`0x1F` are
+/// reserved for the handshake, request stream types, and announcement stream
+/// types respectively.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[repr(u8)]
+pub enum StreamType {
+    /// Connection handshake and control (bidirectional, initiator only).
+    Handshake = 0x00,
+
+    /// Request block headers (bidirectional).
+    GetHeaders = 0x01,
+
+    /// Request blocks, full or compact (bidirectional).
+    GetBlocks = 0x02,
+
+    /// Request transactions (bidirectional).
+    GetTx = 0x03,
+
+    /// Request peer addresses (bidirectional).
+    GetAddr = 0x04,
+
+    /// Subscribe to mempool contents (bidirectional).
+    GetMempool = 0x05,
+
+    /// Request best-chain block hashes and sync-cost metadata at a height
+    /// stride (bidirectional).
+    GetHashes = 0x06,
+
+    /// Stream a contiguous range of blocks, verified against an anchor hash
+    /// (bidirectional).
+    GetBlockRange = 0x07,
+
+    /// Request per-block note commitment tree roots for a height range
+    /// (bidirectional).
+    GetTreeRoots = 0x08,
+
+    /// Request a range of a content-addressed synchronization artifact
+    /// (bidirectional).
+    GetObject = 0x09,
+
+    /// Announce new blocks (unidirectional).
+    BlockAnnouncements = 0x10,
+
+    /// Announce new transactions (unidirectional).
+    TransactionAnnouncements = 0x11,
+
+    /// Gossip peer addresses (unidirectional).
+    AddressAnnouncements = 0x12,
+}
+
+impl StreamType {
+    /// Every stream type the draft defines, in wire byte order.
+    pub const ALL: [StreamType; 13] = [
+        StreamType::Handshake,
+        StreamType::GetHeaders,
+        StreamType::GetBlocks,
+        StreamType::GetTx,
+        StreamType::GetAddr,
+        StreamType::GetMempool,
+        StreamType::GetHashes,
+        StreamType::GetBlockRange,
+        StreamType::GetTreeRoots,
+        StreamType::GetObject,
+        StreamType::BlockAnnouncements,
+        StreamType::TransactionAnnouncements,
+        StreamType::AddressAnnouncements,
+    ];
+
+    /// Returns the stream type for `byte`, or `None` if the byte is not a
+    /// recognized stream type.
+    ///
+    /// A stream with an unrecognized type byte must be refused with
+    /// [`ErrorCode::UnsupportedStreamType`], without treating it as a
+    /// connection error or assigning a misbehavior penalty.
+    pub fn from_byte(byte: u8) -> Option<Self> {
+        Self::ALL.into_iter().find(|kind| kind.byte() == byte)
+    }
+
+    /// Returns the wire byte for this stream type.
+    pub fn byte(self) -> u8 {
+        self as u8
+    }
+
+    /// Returns true if this is a request stream type.
+    ///
+    /// The draft assigns request streams the byte range `0x01`-`0x0F`, and
+    /// announcement streams `0x10`-`0x1F`.
+    pub fn is_request(self) -> bool {
+        (0x01..=0x0F).contains(&self.byte())
+    }
+
+    /// Returns true if this is an announcement stream type.
+    pub fn is_announcement(self) -> bool {
+        (0x10..=0x1F).contains(&self.byte())
+    }
+}
+
+/// The SHA-256 content hash identifying a synchronization artifact in
+/// `get-object` requests.
+///
+/// Artifacts are immutable, content-addressed objects (for example,
+/// known-hash chunk files and state snapshot pieces); the protocol does not
+/// interpret their contents.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct ObjectHash(pub [u8; 32]);
+
+/// Application error codes, used when closing a connection, resetting a
+/// stream, or cancelling a peer's sending direction.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[repr(u64)]
+pub enum ErrorCode {
+    /// Graceful connection close.
+    NoError = 0x00,
+
+    /// The peer violated the protocol specification.
+    ProtocolError = 0x01,
+
+    /// Stream refusal: unrecognized stream type.
+    UnsupportedStreamType = 0x02,
+
+    /// The peer's protocol version is below the minimum for the current
+    /// network epoch.
+    Obsolete = 0x03,
+
+    /// The connection is to the node itself.
+    SelfConnection = 0x04,
+
+    /// The peer exceeded a size or rate limit.
+    Flood = 0x05,
+
+    /// The peer's misbehavior score reached the ban threshold.
+    Misbehavior = 0x06,
+
+    /// Stop-sending/reset: the request is no longer wanted.
+    Cancelled = 0x07,
+
+    /// Stream reset: the responder declines to serve this request.
+    Refused = 0x08,
+
+    /// The sender encountered an internal error.
+    InternalError = 0x09,
+}
+
+impl ErrorCode {
+    /// Returns the error code for a wire code.
+    ///
+    /// An unrecognized code is treated as [`ErrorCode::InternalError`],
+    /// as required by the specification.
+    pub fn from_wire(code: u64) -> Self {
+        match code {
+            0x00 => ErrorCode::NoError,
+            0x01 => ErrorCode::ProtocolError,
+            0x02 => ErrorCode::UnsupportedStreamType,
+            0x03 => ErrorCode::Obsolete,
+            0x04 => ErrorCode::SelfConnection,
+            0x05 => ErrorCode::Flood,
+            0x06 => ErrorCode::Misbehavior,
+            0x07 => ErrorCode::Cancelled,
+            0x08 => ErrorCode::Refused,
+            0x09 => ErrorCode::InternalError,
+            _ => ErrorCode::InternalError,
+        }
+    }
+
+    /// Returns the wire code for this error code.
+    pub fn wire_code(self) -> u64 {
+        self as u64
+    }
+}
+
+/// An error reading or validating version 2 protocol data.
+///
+/// Each variant maps to the action the node must take:
+/// connection errors carry the [`ErrorCode`] to close the connection with,
+/// [`WireError::Misbehavior`] assigns a score without disconnecting, and
+/// [`WireError::Local`] is this node's own fault, so it never closes the
+/// connection.
+#[derive(Error, Debug)]
+pub enum WireError {
+    /// The peer violated the specification: a connection error of type
+    /// [`ErrorCode::ProtocolError`].
+    #[error("protocol error: {0}")]
+    Protocol(String),
+
+    /// The peer exceeded a size limit: a connection error of type
+    /// [`ErrorCode::Flood`].
+    #[error("flood: {0}")]
+    Flood(String),
+
+    /// The peer violated a limit that incurs a misbehavior score instead of
+    /// immediate disconnection.
+    #[error("misbehavior ({points} points): {reason}")]
+    Misbehavior {
+        /// The misbehavior score to assign.
+        points: u32,
+        /// The reason for the penalty.
+        reason: String,
+    },
+
+    /// The peer stopped making progress part-way through a stream or record:
+    /// a connection error of type [`ErrorCode::ProtocolError`].
+    #[error("timed out waiting for the peer to finish {0}")]
+    Timeout(String),
+
+    /// This node could not encode a valid request or response.
+    ///
+    /// The remote peer is not at fault: the connection is left open, and only
+    /// the request or the stream fails.
+    #[error("local error: {0}")]
+    Local(String),
+
+    /// An inner Zcash structure failed to parse: a connection error of type
+    /// [`ErrorCode::ProtocolError`].
+    #[error("parse error: {0}")]
+    Serialization(#[from] SerializationError),
+
+    /// An I/O error reading from or writing to the transport.
+    ///
+    /// An unexpected end of stream is a connection error of type
+    /// [`ErrorCode::ProtocolError`]; other I/O errors are local transport
+    /// failures.
+    #[error("i/o error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+impl WireError {
+    /// Returns the application error code a node closing the connection due
+    /// to this error should use, or `None` if this error does not close the
+    /// connection.
+    pub fn connection_error_code(&self) -> Option<ErrorCode> {
+        match self {
+            WireError::Protocol(_) | WireError::Timeout(_) | WireError::Serialization(_) => {
+                Some(ErrorCode::ProtocolError)
+            }
+            WireError::Flood(_) => Some(ErrorCode::Flood),
+            WireError::Misbehavior { .. } | WireError::Local(_) => None,
+            WireError::Io(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => {
+                Some(ErrorCode::ProtocolError)
+            }
+            WireError::Io(_) => Some(ErrorCode::InternalError),
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

Second PR of the five-PR stack implementing the draft version 2 Zcash P2P network protocol ([zcash/zips#1344](https://github.com/zcash/zips/pull/1344)). This PR adds the transport-independent wire formats; the QUIC transport, peer connection, and peer set integration follow in the next PRs.

## Solution

Adds `zebra-network/src/protocol/v2/`, the wire encodings of the draft ZIP and their limits:

- CompactSize record framing for handshake and announcement streams, with canonical-encoding validation delegated to zebra-chain's `CompactSize64`, and shared length/count limit checks that classify over-limit *sends* as local errors (never blamed on the peer) and over-limit *reads* per the draft's severity (protocol error, flood, or misbehavior score).
- The `init` handshake record, reusing the legacy codec's count-first user agent deserializer.
- Stream-typed requests (`get-headers`, `get-blocks`, `get-tx`, `get-addr`, `get-mempool`) and their result-tagged responses, with transaction references per ZIP 239.
- Compact blocks adapted from BIP 152, with SipHash short transaction IDs and the ZIP 244 auth digest placeholder reused from zebra-chain.
- Wire error classification (`WireError`/`ErrorCode`) mapping violations to the draft's connection error codes.
- `addrv2`-only address relay, reusing the legacy `AddrV2` serialization (promoted from test-only to production).

All size and count limits are defined in terms of the existing legacy protocol constants, so the two protocols cannot drift apart.

The modules are `#[allow(dead_code)]`-scaffolded until the peer connection and peer set integration PRs consume them; the attribute is removed in the final PR of the stack.

### Tests

- 26 wire format unit tests: round trips, limit rejection, non-canonical CompactSize rejection, invalid field rejection, truncation, trailing-data rejection, and short transaction ID computation checked against a manual reimplementation of the specified steps.
- `cargo clippy -p zebra-network --all-targets` warning-free; full `zebra-network` suite passes.

### Specifications & References

- Draft version 2 Zcash P2P network protocol: [zcash/zips#1344](https://github.com/zcash/zips/pull/1344)
- ZIP 239 (wtxid relay), ZIP 244 (auth digest), ZIP 155 (addrv2), BIP 152 (compact blocks)

### Follow-up Work

- The rest of the stack: `p2p-v2-3-quic-transport` → `p2p-v2-4-peer-connection` → `p2p-v2-5-peer-set-integration`.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude Code was used to implement the wire formats and tests, run the test/lint verification, and draft the commit messages and this description; the changes were reviewed by the author.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
