### PR TITLE
feat(network): v2 peer connection, handshake, and handshaker service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 
 ### Added
 
+- Implementation of the draft version 2 Zcash P2P network protocol
+  ([zcash/zips#1344](https://github.com/zcash/zips/pull/1344)): a QUIC transport with
+  per-network ALPN identifiers, a stream-typed request/announcement layer, a single
+  `init`-record handshake, addrv2-only address relay, compact block relay, mempool
+  subscriptions, and serving-side synchronization primitives. Disabled by default:
+  enable the listener with `network.v2_listen`, and dial v2 peers with
+  `network.initial_v2_peers`. Version 2 peers join the peer set alongside legacy peers.
 - The state database format is bumped to 28.1.0 for a per-block synchronization
   metadata index, which serves the version 2 `get-hashes` and `get-tree-roots`
   requests. Existing databases backfill the index on the next start, which reads

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4418,6 +4418,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "reddsa"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7124,6 +7136,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
+
+[[package]]
 name = "yoke"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7486,9 +7507,12 @@ dependencies = [
  "pin-project",
  "proptest",
  "proptest-derive",
+ "quinn",
  "rand 0.8.6",
  "rayon",
+ "rcgen",
  "regex",
+ "rustls",
  "schemars 1.2.1",
  "serde",
  "sha2 0.10.9",

--- a/zebra-network/CHANGELOG.md
+++ b/zebra-network/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   `AddressBookPeers` and reports the bound local listener address) and a
   `PeerBookHandle` tower service for requests that need an answer from the book
   (sanitized addresses, cache snapshots, candidate selection, gossip intake).
+- `RemoteHandshake` replaces the legacy `VersionMessage` in `ConnectionInfo`: it
+  stores the remote peer's actual handshake data per transport protocol, with
+  accessors for the shared fields.
 - Misbehavior scores and bans are keyed by the new `BanKey` type (an IPv4
   address, or an IPv6 /64 prefix), persist across connections for about the
   ban duration, and are owned by the peer book actor instead of the address

--- a/zebra-network/Cargo.toml
+++ b/zebra-network/Cargo.toml
@@ -57,8 +57,11 @@ lazy_static = { workspace = true }
 num-integer = { workspace = true }
 ordered-map = { workspace = true }
 pin-project = { workspace = true }
+quinn = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
+rcgen = { workspace = true }
+rustls = { workspace = true }
 regex = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["serde_derive"] }

--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -193,6 +193,20 @@ pub struct Config {
     /// after the handshake, but before adding them to the peer set. The total numbers of inbound and
     /// outbound connections are also limited to a multiple of `peerset_initial_target_size`.
     pub max_connections_per_ip: usize,
+
+    /// Listen for version 2 protocol (QUIC) peer connections on the UDP
+    /// port of `listen_addr`, alongside the legacy TCP listener.
+    ///
+    /// The version 2 protocol is specified by a draft ZIP, and is disabled
+    /// by default until the ZIP is assigned a network upgrade.
+    pub v2_listen: bool,
+
+    /// A list of peer addresses to connect to over the version 2 protocol
+    /// (QUIC) transport at startup, in `address:port` format.
+    ///
+    /// Version 2 peers are used alongside legacy peers; this list is empty by
+    /// default.
+    pub initial_v2_peers: IndexSet<String>,
 }
 
 impl Config {
@@ -271,6 +285,20 @@ impl Config {
 
             dns_peers.into_iter().chain(disk_peers).collect()
         }
+    }
+
+    /// Resolves the configured initial version 2 protocol peers into IP
+    /// addresses.
+    ///
+    /// Unlike [`initial_peers`](Self::initial_peers), version 2 peers have no
+    /// peer cache on disk, and an empty list is normal when only version 2
+    /// listening is enabled.
+    pub(crate) async fn initial_v2_peers(&self) -> HashSet<PeerSocketAddr> {
+        if self.initial_v2_peers.is_empty() {
+            return HashSet::new();
+        }
+
+        Config::resolve_peers(&self.initial_v2_peers.iter().cloned().collect()).await
     }
 
     /// Concurrently resolves `peers` into zero or more IP addresses, with a
@@ -585,6 +613,8 @@ impl Default for Config {
             // so that idle peers don't use too many connection slots.
             peerset_initial_target_size: DEFAULT_PEERSET_INITIAL_TARGET_SIZE,
             max_connections_per_ip: DEFAULT_MAX_CONNS_PER_IP,
+            v2_listen: false,
+            initial_v2_peers: IndexSet::new(),
         }
     }
 }
@@ -656,6 +686,10 @@ struct DConfig {
     #[serde(alias = "new_peer_interval", with = "humantime_serde")]
     crawl_new_peer_interval: Duration,
     max_connections_per_ip: Option<usize>,
+    #[serde(default)]
+    v2_listen: bool,
+    #[serde(default)]
+    initial_v2_peers: IndexSet<String>,
 }
 
 impl Default for DConfig {
@@ -672,6 +706,8 @@ impl Default for DConfig {
             peerset_initial_target_size: config.peerset_initial_target_size,
             crawl_new_peer_interval: config.crawl_new_peer_interval,
             max_connections_per_ip: Some(config.max_connections_per_ip),
+            v2_listen: config.v2_listen,
+            initial_v2_peers: config.initial_v2_peers,
         }
     }
 }
@@ -730,6 +766,8 @@ impl From<Config> for DConfig {
             peerset_initial_target_size,
             crawl_new_peer_interval,
             max_connections_per_ip,
+            v2_listen,
+            initial_v2_peers,
         }: Config,
     ) -> Self {
         let dnetwork = match network.kind() {
@@ -764,6 +802,8 @@ impl From<Config> for DConfig {
             peerset_initial_target_size,
             crawl_new_peer_interval,
             max_connections_per_ip: Some(max_connections_per_ip),
+            v2_listen,
+            initial_v2_peers,
         }
     }
 }
@@ -784,6 +824,8 @@ impl<'de> Deserialize<'de> for Config {
             peerset_initial_target_size,
             crawl_new_peer_interval,
             max_connections_per_ip,
+            v2_listen,
+            initial_v2_peers,
         } = DConfig::deserialize(deserializer)?;
 
         let network = match (dnetwork, testnet_parameters) {
@@ -859,6 +901,8 @@ impl<'de> Deserialize<'de> for Config {
             peerset_initial_target_size,
             crawl_new_peer_interval,
             max_connections_per_ip,
+            v2_listen,
+            initial_v2_peers,
         })
     }
 }

--- a/zebra-network/src/config/cache_dir.rs
+++ b/zebra-network/src/config/cache_dir.rs
@@ -56,6 +56,23 @@ impl CacheDir {
         }
     }
 
+    /// Returns the synchronization artifact directory for `network`, if the
+    /// directory exists.
+    ///
+    /// Artifacts are content-addressed files named by the lowercase hex
+    /// SHA-256 hash of their contents, served by the v2 protocol's
+    /// `get-object` requests. The directory is only used when it already
+    /// exists, so nodes without artifacts refuse `get-object` instead.
+    pub fn artifact_dir_path(&self, network: &Network) -> Option<PathBuf> {
+        let dir = self
+            .cache_dir()?
+            .join("network")
+            .join("artifacts")
+            .join(network.lowercase_name());
+
+        dir.is_dir().then_some(dir)
+    }
+
     /// Returns the peer cache file path for `network`, if enabled.
     pub fn peer_cache_file_path(&self, network: &Network) -> Option<PathBuf> {
         Some(

--- a/zebra-network/src/lib.rs
+++ b/zebra-network/src/lib.rs
@@ -193,7 +193,10 @@ pub use crate::{
     config::{CacheDir, Config},
     isolated::{connect_isolated, connect_isolated_tcp_direct},
     meta_addr::{PeerAddrState, PeerSocketAddr},
-    peer::{Client, ConnectedAddr, ConnectionInfo, HandshakeError, PeerError, SharedPeerError},
+    peer::{
+        Client, ConnectedAddr, ConnectionInfo, HandshakeError, PeerError, RemoteHandshake,
+        SharedPeerError,
+    },
     peer_book::{PeerBookHandle, PeerBookReader, PeerBookRequest, PeerBookResponse},
     peer_set::{init, init_with_block_gossip_peer_ips},
     policies::RetryLimit,

--- a/zebra-network/src/peer.rs
+++ b/zebra-network/src/peer.rs
@@ -8,6 +8,8 @@ mod handshake;
 mod load_tracked_client;
 mod minimum_peer_version;
 mod priority;
+pub mod v2;
+
 #[cfg(any(test, feature = "proptest-impl"))]
 #[allow(unused_imports)]
 pub use client::tests::ClientTestHarness;
@@ -25,7 +27,7 @@ pub use client::Client;
 pub use connection::Connection;
 pub use connector::{Connector, OutboundConnectorRequest};
 pub use error::{ErrorSlot, HandshakeError, PeerError, SharedPeerError};
-pub use handshake::{ConnectedAddr, ConnectionInfo, Handshake, HandshakeRequest};
+pub use handshake::{ConnectedAddr, ConnectionInfo, Handshake, HandshakeRequest, RemoteHandshake};
 pub use load_tracked_client::LoadTrackedClient;
 pub use minimum_peer_version::MinimumPeerVersion;
 #[allow(unused_imports)]
@@ -33,3 +35,4 @@ pub use priority::{
     address_is_valid_for_inbound_listeners, address_is_valid_for_outbound_connections,
     AttributePreference, PeerPreference,
 };
+pub use v2::V2Connector;

--- a/zebra-network/src/peer/client/tests.rs
+++ b/zebra-network/src/peer/client/tests.rs
@@ -335,7 +335,7 @@ where
 
         let connection_info = Arc::new(ConnectionInfo {
             connected_addr: self.connected_addr.unwrap_or(ConnectedAddr::Isolated),
-            remote,
+            remote: crate::peer::RemoteHandshake::Version(remote),
             negotiated_version,
         });
 

--- a/zebra-network/src/peer/connection.rs
+++ b/zebra-network/src/peer/connection.rs
@@ -1637,12 +1637,12 @@ where
 
             tracing::info!(
                 drop_connection_probability = format!("{drop_connection_probability:.3}"),
-                remote_user_agent = ?self.connection_info.remote.user_agent,
+                remote_user_agent = ?self.connection_info.remote.user_agent(),
                 negotiated_version = ?self.connection_info.negotiated_version,
                 peer = ?self.metrics_label,
                 last_peer_state = ?self.last_metrics_state,
                 // TODO: remove this detailed debug info once #6506 is fixed
-                remote_height = ?self.connection_info.remote.start_height,
+                remote_height = ?self.connection_info.remote.start_height(),
                 cached_addrs = ?self.cached_addrs.len(),
                 connection_state = ?self.state,
                 "inbound service {error} error, closing connection",

--- a/zebra-network/src/peer/connection/tests.rs
+++ b/zebra-network/src/peer/connection/tests.rs
@@ -74,7 +74,7 @@ fn new_test_connection<A>() -> (
 
     let connection_info = ConnectionInfo {
         connected_addr: ConnectedAddr::Isolated,
-        remote,
+        remote: crate::peer::RemoteHandshake::Version(remote),
         negotiated_version: fake_version,
     };
 

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -46,6 +46,7 @@ use crate::{
     protocol::{
         external::{types::*, AddrInVersion, Codec, InventoryHash, Message},
         internal::{Request, Response},
+        v2::init::InitRecord,
     },
     types::MetaAddr,
     BoxError, Config, PeerSocketAddr, VersionMessage,
@@ -237,14 +238,78 @@ pub struct ConnectionInfo {
     /// which will appear as the connected address to the OS and Zebra.
     pub connected_addr: ConnectedAddr,
 
-    /// The network protocol [`VersionMessage`] sent by the remote peer.
-    pub remote: VersionMessage,
+    /// The handshake data sent by the remote peer, by transport protocol.
+    pub remote: RemoteHandshake,
 
     /// The network protocol version negotiated with the remote peer.
     ///
-    /// Derived from `remote.version` and the
+    /// Derived from the remote peer's version and the
     /// [current `zebra_network` protocol version](constants::CURRENT_NETWORK_PROTOCOL_VERSION).
     pub negotiated_version: Version,
+}
+
+/// The handshake data the remote peer sent, by transport protocol.
+///
+/// The two protocols advertise the same core peer metadata in different
+/// wire structures; the accessors expose the shared fields, so consumers do
+/// not depend on the transport. Fields that exist in only one protocol (the
+/// legacy timestamp and addresses, the v2 announcement preferences) are
+/// available by matching on the variant.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RemoteHandshake {
+    /// The `version` message from a legacy protocol peer.
+    Version(VersionMessage),
+
+    /// The `init` record from a version 2 protocol peer.
+    Init(Arc<InitRecord>),
+}
+
+impl RemoteHandshake {
+    /// Returns the network protocol version the remote peer advertised.
+    pub fn version(&self) -> Version {
+        match self {
+            RemoteHandshake::Version(remote) => remote.version,
+            RemoteHandshake::Init(init) => init.version,
+        }
+    }
+
+    /// Returns the services the remote peer advertised.
+    pub fn services(&self) -> PeerServices {
+        match self {
+            RemoteHandshake::Version(remote) => remote.services,
+            RemoteHandshake::Init(init) => init.services,
+        }
+    }
+
+    /// Returns the user agent the remote peer advertised.
+    pub fn user_agent(&self) -> &str {
+        match self {
+            RemoteHandshake::Version(remote) => &remote.user_agent,
+            RemoteHandshake::Init(init) => &init.user_agent,
+        }
+    }
+
+    /// Returns the chain tip height the remote peer advertised during the
+    /// handshake.
+    pub fn start_height(&self) -> block::Height {
+        match self {
+            RemoteHandshake::Version(remote) => remote.start_height,
+            RemoteHandshake::Init(init) => init.start_height,
+        }
+    }
+
+    /// Returns the canonical address the remote peer advertised for itself,
+    /// if the handshake carried one.
+    ///
+    /// Only the legacy `version` message advertises an address; version 2
+    /// peers announce their addresses on address announcement streams
+    /// instead.
+    pub fn canonical_addr(&self) -> Option<PeerSocketAddr> {
+        match self {
+            RemoteHandshake::Version(remote) => Some(remote.address_from.addr()),
+            RemoteHandshake::Init(_) => None,
+        }
+    }
 }
 
 /// The peer address that we are handshaking with.
@@ -899,16 +964,16 @@ where
     // Limit containing struct size, and avoid multiple duplicates of 300+ bytes of data.
     let connection_info = Arc::new(ConnectionInfo {
         connected_addr: *connected_addr,
-        remote,
+        remote: RemoteHandshake::Version(remote),
         negotiated_version,
     });
 
     debug!(
         remote_ip = ?their_addr,
-        remote_version = ?connection_info.remote.version,
+        remote_version = ?connection_info.remote.version(),
         ?negotiated_version,
         ?min_version,
-        user_agent = ?connection_info.remote.user_agent,
+        user_agent = ?connection_info.remote.user_agent(),
         "negotiated network protocol version with peer",
     );
 
@@ -916,10 +981,10 @@ where
     metrics::counter!(
         "zcash.net.peers.connected",
         "remote_ip" => their_addr.to_string(),
-        "remote_version" => connection_info.remote.version.to_string(),
+        "remote_version" => connection_info.remote.version().to_string(),
         "negotiated_version" => negotiated_version.to_string(),
         "min_version" => min_version.to_string(),
-        "user_agent" => connection_info.remote.user_agent.to_string(),
+        "user_agent" => connection_info.remote.user_agent().to_string(),
     )
     .increment(1);
 
@@ -928,7 +993,7 @@ where
         "zcash.net.peers.version.connected",
         "remote_ip" => their_addr.to_string(),
     )
-    .set(connection_info.remote.version.0 as f64);
+    .set(connection_info.remote.version().0 as f64);
 
     if let Err(error) = peer_conn.send(Message::Verack).await {
         return Err(remote_version_outcome.record_error(HandshakeError::from(error)));
@@ -1112,7 +1177,7 @@ where
                 }
             };
 
-            let remote_services = connection_info.remote.services;
+            let remote_services = connection_info.remote.services();
 
             // The handshake succeeded: update the peer status from AttemptPending to Responded,
             // send initial connection info, and update the active connection counter.
@@ -1120,7 +1185,7 @@ where
                 &mut connection_tracker,
                 &connected_addr,
                 remote_services,
-                connection_info.remote.user_agent.to_string(),
+                connection_info.remote.user_agent().to_string(),
                 connection_info.negotiated_version,
                 &address_book_updater,
             )
@@ -1249,7 +1314,10 @@ where
             // - opening connections is rate-limited
             // - these addresses are put in the peer address cache
             // - the peer address cache is only used when Zebra requests addresses from that peer
-            let remote_canonical_addr = connection_info.remote.address_from.addr();
+            let remote_canonical_addr = connection_info
+                .remote
+                .canonical_addr()
+                .expect("legacy handshakes always carry a version message");
             let alternate_addrs = connected_addr
                 .get_alternate_addrs(remote_canonical_addr)
                 .map(|addr| {

--- a/zebra-network/src/peer/handshake/tests/vectors.rs
+++ b/zebra-network/src/peer/handshake/tests/vectors.rs
@@ -171,7 +171,7 @@ async fn inbound_direct_accepts_non_serving_peer() {
         negotiate_with_remote_services(connected_addr, PeerServices::empty(), NoChainTip).await;
 
     let connection_info = result.expect("inbound handshake with a non-serving peer succeeds");
-    assert_eq!(connection_info.remote.services, PeerServices::empty());
+    assert_eq!(connection_info.remote.services(), PeerServices::empty());
 }
 
 /// Isolated handshakes must accept peers that don't advertise `NODE_NETWORK`.
@@ -199,7 +199,7 @@ async fn outbound_direct_accepts_non_serving_peer_at_tip() {
 
     let connection_info =
         result.expect("outbound handshake with a non-serving peer at the network tip succeeds");
-    assert_eq!(connection_info.remote.services, PeerServices::empty());
+    assert_eq!(connection_info.remote.services(), PeerServices::empty());
 }
 
 /// Outbound handshakes must accept peers that advertise `NODE_NETWORK`.
@@ -213,7 +213,10 @@ async fn outbound_direct_accepts_serving_peer() {
             .await;
 
     let connection_info = result.expect("outbound handshake with a serving peer succeeds");
-    assert_eq!(connection_info.remote.services, PeerServices::NODE_NETWORK);
+    assert_eq!(
+        connection_info.remote.services(),
+        PeerServices::NODE_NETWORK
+    );
 }
 
 /// A rejected non-serving outbound peer must NOT have its advertised services recorded by the

--- a/zebra-network/src/peer/load_tracked_client.rs
+++ b/zebra-network/src/peer/load_tracked_client.rs
@@ -52,7 +52,7 @@ impl From<Client> for LoadTrackedClient {
 impl LoadTrackedClient {
     /// Retrieve the peer's reported protocol version.
     pub fn remote_version(&self) -> Version {
-        self.connection_info.remote.version
+        self.connection_info.remote.version()
     }
 
     /// Returns true if this peer connected directly to us from `ip`.

--- a/zebra-network/src/peer/v2.rs
+++ b/zebra-network/src/peer/v2.rs
@@ -1,0 +1,18 @@
+//! Peer connections over the version 2 Zcash P2P network protocol.
+//!
+//! This module implements the connection lifecycle of the version 2
+//! protocol: the application handshake on the dedicated handshake stream,
+//! and the connection task that maps the internal [`Request`](crate::Request)
+//! and [`Response`](crate::Response) protocol onto v2 request and
+//! announcement streams.
+//!
+//! The wire formats and the QUIC transport itself are implemented in
+//! [`protocol::v2`](crate::protocol::v2).
+
+pub mod connection;
+pub mod connector;
+pub mod handshake;
+pub mod service;
+
+pub use connector::Connector as V2Connector;
+pub use service::{Handshake as V2Handshaker, HandshakeRequest as V2HandshakeRequest};

--- a/zebra-network/src/peer/v2/connection.rs
+++ b/zebra-network/src/peer/v2/connection.rs
@@ -1,0 +1,2829 @@
+//! The version 2 peer connection task.
+//!
+//! A [`Connection`] maps the internal [`Request`]/[`Response`] protocol onto
+//! version 2 streams:
+//!
+//! - Each outbound internal request opens its own request stream, so
+//!   requests are correlated structurally, and are cancelled and timed out
+//!   per stream. Unlike the legacy connection, requests run concurrently.
+//! - Each inbound request stream is decoded, served by the inbound service,
+//!   and answered on the same stream.
+//! - Announcements (blocks, transactions, addresses) are written to and read
+//!   from long-lived unidirectional announcement streams. Outbound
+//!   announcements are best-effort: they are dropped rather than queued
+//!   indefinitely when the transport applies backpressure.
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc, Mutex,
+    },
+};
+
+use futures::StreamExt;
+use indexmap::{IndexMap, IndexSet};
+use tower::{Service, ServiceExt};
+use tracing::{debug, warn, Instrument};
+
+use zebra_chain::{
+    block::{self, merkle, Block},
+    serialization::{ZcashDeserialize, ZcashSerialize},
+    transaction::{Transaction, UnminedTx, UnminedTxId, WtxId},
+};
+
+use crate::{
+    constants,
+    meta_addr::MetaAddr,
+    peer::{
+        client::{ClientRequestReceiver, InProgressClientRequest, MustUseClientResponseSender},
+        connection::update_addr_cache,
+        ErrorSlot, PeerError, SharedPeerError,
+    },
+    peer_set::{ConnectionTracker, InventoryChange, SlotCounter, SlotGuard},
+    protocol::{
+        external::InventoryHash,
+        internal::{InventoryResponse, Request, Response},
+        v2::{
+            compact_block::{
+                full_transaction_id, short_id_keys, short_transaction_id, CompactBlock,
+                CompactBlockIds, ShortTxId,
+            },
+            constants::{
+                BLOCK_ANNOUNCEMENT_KIND_COMPACT, BLOCK_ANNOUNCEMENT_KIND_HEADER,
+                HEADERS_ENTRY_HAS_TXS, HEADERS_ENTRY_NO_TXS, INBOUND_STREAM_TIMEOUT,
+                MAX_CONCURRENT_BULK_STREAMS, MAX_CONSECUTIVE_REQUEST_TIMEOUTS,
+                MAX_MEMPOOL_RECORD_REFS, MAX_MEMPOOL_RESPONSE_REFS, MAX_RECORD_PAYLOAD_LEN,
+                MISBEHAVIOR_PENALTY_INVALID_POW, TX_TRICKLE_MEAN_INTERVAL,
+            },
+            init::{HandshakeRecord, InitRecord},
+            record,
+            request::Request as WireRequest,
+            response::{
+                encode_result_entry, read_result_entry, AddrResponse, HashesResponse,
+                HeadersResponse, MempoolResponse, TreeRootsResponse, RESULT_NOT_FOUND,
+                RESULT_OBJECT,
+            },
+            txref::TransactionReference,
+            types::{ErrorCode, StreamType, WireError},
+        },
+    },
+    BoxError, PeerSocketAddr,
+};
+
+/// The maximum number of outbound announcement records queued for writing.
+///
+/// Announcements are best-effort: when the queue is full, new announcements
+/// are dropped rather than queued indefinitely.
+pub(super) const ANNOUNCEMENT_QUEUE_LIMIT: usize = 64;
+
+/// The capacity of the per-connection mempool update channel feeding the
+/// peer's `get-mempool` subscription.
+///
+/// When the subscription serving task falls this far behind, it recovers by
+/// re-sending a whole mempool snapshot in place of the lost updates.
+pub(super) const MEMPOOL_UPDATES_CHANNEL_CAPACITY: usize = 64;
+
+/// The maximum number of transaction announcements queued for a
+/// connection's next trickle flush.
+///
+/// Announcements are best-effort: beyond the bound, the oldest queued
+/// announcement is dropped. The peer can still learn of dropped
+/// transactions from its `get-tx` responses or a later `get-mempool`
+/// snapshot.
+const PENDING_TX_ANNOUNCEMENT_LIMIT: usize = 5_000;
+
+/// The maximum number of recently pushed transactions kept for serving
+/// `get-tx` requests.
+///
+/// The v2 protocol has no unsolicited transaction push: pushed transactions
+/// are announced, and the peer fetches them with `get-tx`. This cache serves
+/// those fetches even if the transaction has not reached the local mempool.
+const PUSHED_TRANSACTION_CACHE_LIMIT: usize = 32;
+
+/// The maximum number of recently sent blocks kept per connection for
+/// serving the peer's reconstruction `get-tx` requests.
+///
+/// A node that sends a compact block, or a `get-headers` response entry with
+/// transaction IDs, must be able to serve that block's transactions to the
+/// same peer for a reasonable time afterwards, even if they leave its
+/// mempool. This cache is that time bound: at most this many blocks are
+/// retained per peer, so the total memory bound is this limit times the peer
+/// count (blocks near the tip are also usually shared between the caches).
+const SENT_BLOCK_CACHE_LIMIT: usize = 8;
+
+/// The maximum number of blocks reconstructed from compact block
+/// announcements kept per connection, to serve the local gossip
+/// downloader's follow-up block request without a wire round-trip.
+///
+/// Only connections on which this node requested high-bandwidth
+/// announcements fill this cache, so its memory bound is this limit times
+/// [`MAX_HIGH_BANDWIDTH_PEERS`].
+const RECONSTRUCTED_BLOCK_CACHE_LIMIT: usize = 4;
+
+/// The read buffer size for outbound request streams, whose responses can
+/// carry multiple megabytes of blocks or transactions.
+///
+/// Responses are decoded with many small reads, and every unbuffered read of
+/// a QUIC stream locks shared transport state.
+const RESPONSE_STREAM_READ_BUFFER_SIZE: usize = 64 * 1024;
+
+/// The read buffer size for record streams: inbound requests, and the
+/// long-lived handshake and announcement streams.
+///
+/// Their records are small and infrequent, and the remote peer can hold
+/// many of these streams open at once, each keeping its buffer for as long
+/// as the stream lives. A large per-stream buffer would let it pin
+/// megabytes of allocations per connection.
+const RECORD_STREAM_READ_BUFFER_SIZE: usize = 8 * 1024;
+
+/// An announcement record queued for the announcement writer task.
+pub(super) type AnnouncementRecord = (StreamType, Vec<u8>);
+
+/// Collects the blocks an inventory [`Response`] made available, keyed by
+/// hash.
+fn available_blocks(response: Response) -> IndexMap<block::Hash, Arc<Block>> {
+    let Response::Blocks(blocks) = response else {
+        return IndexMap::new();
+    };
+
+    blocks
+        .into_iter()
+        .filter_map(|entry| entry.available())
+        .map(|(block, _)| (block.hash(), block))
+        .collect()
+}
+
+/// Inserts `key` into a bounded most-recently-used cache, evicting the
+/// oldest entries until `limit` is respected.
+///
+/// Re-inserting an existing key moves it to the most recent slot.
+fn insert_bounded<K: std::hash::Hash + Eq, V>(
+    cache: &mut IndexMap<K, V>,
+    key: K,
+    value: V,
+    limit: usize,
+) {
+    cache.shift_remove(&key);
+    while cache.len() >= limit {
+        cache.shift_remove_index(0);
+    }
+    cache.insert(key, value);
+}
+
+/// State shared between the connection task and the per-stream tasks it
+/// spawns.
+pub(super) struct SharedConnection {
+    /// The QUIC connection.
+    pub(super) quic: quinn::Connection,
+
+    /// The shared error slot for this connection.
+    pub(super) error_slot: ErrorSlot,
+
+    /// The remote peer's `init` record.
+    pub(super) remote_init: Arc<InitRecord>,
+
+    /// Whether this node requested transaction relay in its own `init`
+    /// record.
+    pub(super) local_relay: bool,
+
+    /// The high-bandwidth announcement slot this connection claimed, if it
+    /// requested high-bandwidth compact block announcements in its own
+    /// `init` record; dropping it releases the slot to a replacement
+    /// connection.
+    ///
+    /// Holding a slot is exactly this connection's `announce` preference,
+    /// so the two can never disagree.
+    pub(super) hb_slot: Option<SlotGuard>,
+
+    /// The remote peer's address, used to identify it in the inventory
+    /// registry and the inbound service.
+    pub(super) transient_addr: Option<PeerSocketAddr>,
+
+    /// Whether the remote peer initiated this connection.
+    pub(super) is_inbound: bool,
+
+    /// Registers inventory advertised or missing on this connection.
+    pub(super) inv_collector: tokio::sync::broadcast::Sender<InventoryChange>,
+
+    /// Sends misbehavior scores for this peer, so it is banned once it
+    /// reaches the ban threshold.
+    pub(super) misbehavior_tx: tokio::sync::mpsc::Sender<(PeerSocketAddr, u32)>,
+
+    /// Queues outbound announcement records for the announcement writer
+    /// task.
+    pub(super) announcement_tx: tokio::sync::mpsc::Sender<AnnouncementRecord>,
+
+    /// Recently pushed transactions, served to the peer's `get-tx` requests.
+    pub(super) pushed_transactions: Mutex<IndexMap<UnminedTxId, UnminedTx>>,
+
+    /// Blocks recently sent to this peer with their transactions identified
+    /// rather than included — as compact block announcements or `get-headers`
+    /// entries with transaction IDs — retained to serve the peer's
+    /// reconstruction `get-tx` requests, including by `SHORTID` reference.
+    pub(super) sent_blocks: Mutex<IndexMap<block::Hash, SentBlock>>,
+
+    /// Blocks reconstructed from this peer's compact block announcements,
+    /// serving the local gossip downloader's follow-up block requests
+    /// without a wire round-trip.
+    pub(super) reconstructed_blocks: Mutex<IndexMap<block::Hash, Arc<Block>>>,
+
+    /// Broadcasts transactions newly accepted into the local mempool to the
+    /// peer's `get-mempool` subscription, if one is active.
+    ///
+    /// Fed by the connection's trickle task, so subscription updates share
+    /// the announcement stream's trickling.
+    pub(super) mempool_updates: tokio::sync::broadcast::Sender<Vec<UnminedTxId>>,
+
+    /// Transactions queued for announcement to this peer at the next
+    /// trickle flush.
+    pub(super) pending_tx_announcements: Mutex<IndexSet<UnminedTxId>>,
+
+    /// Whether the peer currently has a `get-mempool` subscription open;
+    /// a second concurrent subscription is a connection error.
+    pub(super) mempool_subscribed: std::sync::atomic::AtomicBool,
+
+    /// The remote peer's mempool transaction IDs, mirrored by this node's
+    /// own `get-mempool` subscription to the peer, answering internal
+    /// [`Request::MempoolTransactionIds`] without a wire round-trip.
+    ///
+    /// Bounded at [`MAX_MEMPOOL_RESPONSE_REFS`] entries, evicting the
+    /// oldest half beyond the bound: removals from the remote mempool are
+    /// never communicated, so old entries only expire by eviction or
+    /// disconnection.
+    pub(super) remote_mempool: Mutex<IndexSet<UnminedTxId>>,
+
+    /// Peer addresses announced by the remote peer, served to internal
+    /// [`Request::Peers`] requests, mirroring the legacy connection's
+    /// address cache.
+    pub(super) cached_addrs: Mutex<Vec<MetaAddr>>,
+
+    /// Rate-limits the relayed addresses accepted from this peer's address
+    /// announcement stream.
+    pub(super) addr_tokens: Mutex<AddrTokenBucket>,
+
+    /// The announcement stream types the remote peer currently has open
+    /// towards this node, to enforce the one-stream-per-type rule.
+    pub(super) open_inbound_announcements: Mutex<HashSet<u8>>,
+
+    /// Whether this node has already sent a `get-addr` request on this
+    /// connection.
+    ///
+    /// To impede address-based fingerprinting, `get-addr` is sent at most
+    /// once per connection; later address requests are answered from the
+    /// address cache.
+    pub(super) sent_get_addr: std::sync::atomic::AtomicBool,
+
+    /// The number of outbound requests that have timed out since the last
+    /// response from this peer.
+    pub(super) consecutive_timeouts: AtomicU32,
+
+    /// The bulk block streams (`get-block-range`) this node is currently
+    /// serving to the peer.
+    pub(super) active_bulk_streams: SlotCounter,
+
+    /// The directory of content-addressed synchronization artifacts served
+    /// to the peer's `get-object` requests, when this node has one.
+    pub(super) artifact_dir: Option<Arc<std::path::PathBuf>>,
+}
+
+/// A token bucket rate-limiting the relayed addresses accepted from one
+/// connection.
+///
+/// Addresses beyond the sustained rate and burst capacity are silently
+/// dropped: rate limiting is not a penalty.
+#[derive(Debug)]
+pub(super) struct AddrTokenBucket {
+    /// The available tokens; one address costs one token.
+    tokens: f64,
+
+    /// When the bucket was last refilled.
+    last_refill: std::time::Instant,
+}
+
+impl Default for AddrTokenBucket {
+    fn default() -> Self {
+        AddrTokenBucket {
+            tokens: crate::protocol::v2::constants::ADDR_TOKEN_BUCKET_CAPACITY,
+            last_refill: std::time::Instant::now(),
+        }
+    }
+}
+
+impl AddrTokenBucket {
+    /// Takes one token at `now`, refilling at the reference rate first.
+    ///
+    /// Returns whether the address should be processed.
+    pub(super) fn try_take(&mut self, now: std::time::Instant) -> bool {
+        use crate::protocol::v2::constants::{ADDR_TOKEN_BUCKET_CAPACITY, ADDR_TOKEN_RATE};
+
+        let elapsed = now
+            .saturating_duration_since(self.last_refill)
+            .as_secs_f64();
+        self.last_refill = now;
+        self.tokens = (self.tokens + elapsed * ADDR_TOKEN_RATE).min(ADDR_TOKEN_BUCKET_CAPACITY);
+
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// A block recently sent to the peer with its transactions identified rather
+/// than included, retained to serve reconstruction `get-tx` requests.
+pub(super) struct SentBlock {
+    /// The block.
+    pub(super) block: Arc<Block>,
+
+    /// The short transaction ID nonce of the compact block sent for this
+    /// block, if one was sent.
+    ///
+    /// `SHORTID` references are resolved with the nonce of the compact block
+    /// most recently sent to the requesting peer for the block. Blocks sent
+    /// only as `get-headers` entries carry full transaction IDs, so they
+    /// have no nonce, and `SHORTID` references to them are answered
+    /// not-found.
+    pub(super) nonce: Option<u64>,
+}
+
+impl SharedConnection {
+    /// Records that a block was sent to this peer with its transactions
+    /// identified rather than included, so its transactions can be served to
+    /// the peer's reconstruction `get-tx` requests.
+    ///
+    /// Callers record the block before the announcement or response entry is
+    /// written, so the obligation is servable as soon as the peer can
+    /// request it.
+    pub(super) fn record_sent_block(&self, block: Arc<Block>, nonce: Option<u64>) {
+        let hash = block.hash();
+        let mut sent = self.sent_blocks.lock().expect("mutex is not poisoned");
+
+        // Re-recording moves the block to the most recent slot, and a
+        // compact block's nonce replaces a `get-headers` entry's absent
+        // nonce.
+        insert_bounded(
+            &mut sent,
+            hash,
+            SentBlock { block, nonce },
+            SENT_BLOCK_CACHE_LIMIT,
+        );
+    }
+
+    /// Fails the connection: records `error` in the error slot and closes
+    /// the connection with `code`.
+    pub(super) fn fail(&self, code: ErrorCode, error: PeerError) {
+        let message = error.to_string();
+        // Ignore errors updating the slot: the earliest error wins.
+        let _ = self.error_slot.try_update_error(error.into());
+        self.quic.close(code.into(), message.as_bytes());
+    }
+
+    /// Fails the connection with a `PROTOCOL_ERROR`: the peer violated the
+    /// v2 protocol.
+    pub(super) fn fail_protocol(&self, reason: impl Into<String>) {
+        self.fail(
+            ErrorCode::ProtocolError,
+            PeerError::V2Protocol(reason.into()),
+        );
+    }
+
+    /// Fails the connection for a violation reported as a [`WireError`],
+    /// closing it with the error's connection error code.
+    pub(super) fn fail_wire_error(&self, error: &WireError) {
+        let code = error
+            .connection_error_code()
+            .unwrap_or(ErrorCode::ProtocolError);
+        self.fail(code, PeerError::V2Protocol(error.to_string()));
+    }
+
+    /// Records that this peer answered a request, clearing the consecutive
+    /// timeout count.
+    pub(super) fn record_response(&self) {
+        self.consecutive_timeouts.store(0, Ordering::Relaxed);
+    }
+
+    /// Records that a request to this peer timed out, and fails the
+    /// connection once [`MAX_CONSECUTIVE_REQUEST_TIMEOUTS`] are reached.
+    pub(super) fn record_request_timeout(&self) {
+        let timeouts = self.consecutive_timeouts.fetch_add(1, Ordering::Relaxed) + 1;
+
+        if timeouts >= MAX_CONSECUTIVE_REQUEST_TIMEOUTS {
+            // A responder must answer a request stream it accepted, or reset
+            // it, so a peer that does neither is not following the protocol.
+            self.fail_protocol(format!(
+                "peer did not answer {timeouts} consecutive requests"
+            ));
+        }
+    }
+
+    /// Assigns a misbehavior score to this peer.
+    ///
+    /// Unlike [`fail`](Self::fail), this leaves the connection open: the peer
+    /// is disconnected and banned by the address book once its accumulated
+    /// score reaches
+    /// [`MAX_PEER_MISBEHAVIOR_SCORE`](crate::constants::MAX_PEER_MISBEHAVIOR_SCORE).
+    pub(super) fn report_misbehavior(&self, points: u32, reason: &str) {
+        let Some(addr) = self.transient_addr else {
+            return;
+        };
+
+        debug!(?addr, points, reason, "v2 peer misbehaved");
+
+        // The channel has room for one update per peer connection, so a full
+        // channel means the updates are already being batched.
+        if self.misbehavior_tx.try_send((addr, points)).is_err() {
+            debug!(?addr, "dropping a v2 misbehavior update: channel is full");
+        }
+    }
+
+    /// Queues an announcement record for the writer task, dropping it if the
+    /// queue is full.
+    pub(super) fn enqueue_announcement(&self, stream_type: StreamType, payload: Vec<u8>) {
+        if self
+            .announcement_tx
+            .try_send((stream_type, payload))
+            .is_err()
+        {
+            debug!(?stream_type, "dropping queued announcement");
+        }
+    }
+}
+
+/// The version 2 peer connection task state.
+pub struct Connection<S> {
+    /// State shared with the per-stream tasks.
+    pub(super) shared: Arc<SharedConnection>,
+
+    /// The service that handles requests from the remote peer.
+    pub(super) inbound_service: S,
+
+    /// Receives internal requests from the [`Client`](crate::peer::Client)
+    /// half of the connection.
+    pub(super) client_rx: ClientRequestReceiver,
+
+    /// The receiving half of the handshake stream, monitored for control
+    /// records and disconnection for the life of the connection.
+    pub(super) handshake_recv: quinn::RecvStream,
+
+    /// The sending half of the handshake stream, held open for the life of
+    /// the connection: finishing it would signal intent to disconnect.
+    pub(super) handshake_send: quinn::SendStream,
+
+    /// The receiving half of the announcement queue.
+    pub(super) announcement_rx: tokio::sync::mpsc::Receiver<AnnouncementRecord>,
+
+    /// Keeps the connection counted while this connection is open.
+    pub(super) connection_tracker: ConnectionTracker,
+}
+
+impl<S> Connection<S>
+where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    /// Runs the connection until it fails, the peer disconnects, or the
+    /// [`Client`](crate::peer::Client) is dropped.
+    pub async fn run(self) {
+        let Connection {
+            shared,
+            inbound_service,
+            mut client_rx,
+            handshake_recv,
+            handshake_send,
+            announcement_rx,
+            connection_tracker,
+        } = self;
+
+        // The handshake send half is held open for the life of the
+        // connection: finishing it would signal intent to disconnect.
+        let _handshake_send = handshake_send;
+
+        // The handshake stream monitor and announcement writer run as
+        // separate tasks, because their reads and writes are not
+        // cancellation-safe inside a select loop.
+        let handshake_monitor = tokio::spawn(
+            monitor_handshake_stream(shared.clone(), handshake_recv).in_current_span(),
+        );
+        let announcement_writer = tokio::spawn(
+            write_announcements(shared.quic.clone(), announcement_rx).in_current_span(),
+        );
+
+        let quic = shared.quic.clone();
+
+        let exit_error: PeerError = loop {
+            tokio::select! {
+                client_request = client_rx.next() => match client_request {
+                    Some(request) => {
+                        dispatch_client_request(&shared, &inbound_service, request)
+                    }
+                    // The Client was dropped: this node is disconnecting.
+                    None => break PeerError::ClientDropped,
+                },
+
+                bi_stream = quic.accept_bi() => match bi_stream {
+                    Ok((send, recv)) => {
+                        let shared = shared.clone();
+                        let inbound_service = inbound_service.clone();
+                        tokio::spawn(
+                            serve_inbound_request_stream(shared, inbound_service, send, recv)
+                                .in_current_span(),
+                        );
+                    }
+                    Err(error) => break connection_error_to_peer_error(error),
+                },
+
+                uni_stream = quic.accept_uni() => match uni_stream {
+                    Ok(recv) => {
+                        let shared = shared.clone();
+                        let inbound_service = inbound_service.clone();
+                        tokio::spawn(
+                            read_inbound_announcement_stream(shared, inbound_service, recv)
+                                .in_current_span(),
+                        );
+                    }
+                    Err(error) => break connection_error_to_peer_error(error),
+                },
+            }
+        };
+
+        debug!(?exit_error, "closing v2 peer connection");
+
+        // Record the exit error for the Client, and close the connection.
+        // The earliest recorded error wins, so a specific failure recorded
+        // by a stream task is not overwritten.
+        let _ = shared.error_slot.try_update_error(exit_error.into());
+        quic.close(ErrorCode::NoError.into(), b"disconnecting");
+
+        handshake_monitor.abort();
+        announcement_writer.abort();
+
+        // Fail any queued client requests.
+        while let Some(InProgressClientRequest { tx, span, .. }) = client_rx.close_and_flush_next()
+        {
+            let _entered = span.enter();
+            let error = shared
+                .error_slot
+                .try_get_error()
+                .expect("the error slot was just set");
+            let _ = tx.send(Err(error));
+        }
+
+        // The connection is closed: release its connection count.
+        std::mem::drop(connection_tracker);
+    }
+}
+
+/// Converts a QUIC connection error into the [`PeerError`] reported to the
+/// [`Client`](crate::peer::Client).
+fn connection_error_to_peer_error(error: quinn::ConnectionError) -> PeerError {
+    match error {
+        quinn::ConnectionError::ApplicationClosed(closed) => {
+            let code = ErrorCode::from_wire(closed.error_code.into());
+            PeerError::V2Protocol(format!(
+                "connection closed by peer with {code:?}: {}",
+                String::from_utf8_lossy(&closed.reason),
+            ))
+        }
+        quinn::ConnectionError::LocallyClosed => PeerError::ConnectionClosed,
+        quinn::ConnectionError::TimedOut => PeerError::ConnectionReceiveTimeout,
+        other => PeerError::V2Protocol(format!("connection error: {other}")),
+    }
+}
+
+/// Monitors the handshake stream for the life of the connection.
+///
+/// Records of unrecognized kinds are ignored, so future revisions can define
+/// new control records. A second `init` record is a connection error of type
+/// `PROTOCOL_ERROR`. Finishing the handshake stream signals intent to
+/// disconnect, and the connection is closed with `NO_ERROR`.
+async fn monitor_handshake_stream(
+    shared: Arc<SharedConnection>,
+    handshake_recv: quinn::RecvStream,
+) {
+    let mut handshake_recv =
+        tokio::io::BufReader::with_capacity(RECORD_STREAM_READ_BUFFER_SIZE, handshake_recv);
+
+    loop {
+        let record = record::read_record_timeout(&mut handshake_recv, INBOUND_STREAM_TIMEOUT)
+            .await
+            .and_then(|payload| payload.as_deref().map(HandshakeRecord::parse).transpose());
+
+        match record {
+            Ok(Some(HandshakeRecord::Init(_))) => {
+                shared.fail_protocol("peer sent more than one init record");
+                break;
+            }
+            Ok(Some(HandshakeRecord::Unknown(kind))) => {
+                debug!(kind, "ignoring unrecognized handshake stream record");
+            }
+            // The peer finished the handshake stream: it is disconnecting.
+            Ok(None) => {
+                let _ = shared
+                    .error_slot
+                    .try_update_error(PeerError::ConnectionClosed.into());
+                shared
+                    .quic
+                    .close(ErrorCode::NoError.into(), b"peer disconnected");
+                break;
+            }
+            // The connection failed or was closed; the connection task
+            // reports the error.
+            Err(WireError::Io(_)) => break,
+            Err(error) => {
+                shared.fail_wire_error(&error);
+                break;
+            }
+        }
+    }
+}
+
+/// Writes queued announcement records to their announcement streams, opening
+/// each stream lazily on first use.
+///
+/// A single writer task per connection enforces the rule that a node opens
+/// at most one announcement stream of a given type in each direction.
+async fn write_announcements(
+    quic: quinn::Connection,
+    mut announcement_rx: tokio::sync::mpsc::Receiver<AnnouncementRecord>,
+) {
+    let mut streams: IndexMap<u8, quinn::SendStream> = IndexMap::new();
+
+    while let Some((stream_type, payload)) = announcement_rx.recv().await {
+        let send = match streams.entry(stream_type.byte()) {
+            indexmap::map::Entry::Occupied(entry) => entry.into_mut(),
+            indexmap::map::Entry::Vacant(entry) => {
+                let mut send = match quic.open_uni().await {
+                    Ok(send) => send,
+                    // The connection is closing.
+                    Err(_) => break,
+                };
+                if send.write_all(&[stream_type.byte()]).await.is_err() {
+                    continue;
+                }
+                entry.insert(send)
+            }
+        };
+
+        let mut framed = Vec::with_capacity(payload.len() + 5);
+        if record::write_record(&mut framed, &payload).is_err() {
+            continue;
+        }
+
+        if send.write_all(&framed).await.is_err() {
+            // The stream was reset or stopped; a replacement stream may be
+            // opened for the next announcement.
+            streams.shift_remove(&stream_type.byte());
+        }
+    }
+}
+
+/// Dispatches an internal request from the [`Client`](crate::peer::Client).
+///
+/// Announcements and locally-answerable requests are handled inline;
+/// requests that need a response from the peer spawn a request stream task.
+fn dispatch_client_request<S>(
+    shared: &Arc<SharedConnection>,
+    inbound_service: &S,
+    request: InProgressClientRequest,
+) where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    let InProgressClientRequest { request, tx, span } = request;
+    let _entered = span.enter();
+
+    if tx.is_canceled() {
+        return;
+    }
+
+    match request {
+        // The v2 protocol has no ping: the transport provides keep-alives and
+        // round-trip time measurement, so heartbeats are answered locally.
+        //
+        // This means heartbeats cannot detect a peer whose QUIC stack answers
+        // keep-alives but whose application never answers a request stream.
+        // Consecutive request timeouts disconnect that peer instead, see
+        // [`SharedConnection::record_request_timeout`].
+        Request::Ping(_) => {
+            let _ = tx.send(Ok(Response::Pong(shared.quic.rtt())));
+        }
+
+        // Cached addresses from the peer's address announcements answer
+        // address requests without a wire round-trip, mirroring the legacy
+        // connection's address cache.
+        Request::Peers => {
+            let cached: Vec<MetaAddr> = {
+                let mut cached_addrs = shared.cached_addrs.lock().expect("mutex is not poisoned");
+                // Security: this method performs security-sensitive operations, see its comments
+                // for details.
+                update_addr_cache(&mut cached_addrs, None, constants::PEER_ADDR_RESPONSE_LIMIT)
+            };
+
+            // To impede fingerprinting, a node only answers address requests
+            // on connections the remote peer initiated, and sends `get-addr`
+            // at most once per connection. So only ask peers this node
+            // connected to and has not asked before: asking the others
+            // always fails, or repeats a request the peer may refuse.
+            //
+            // The short-circuit matters: the sent flag is only set when this
+            // request is actually sent to the peer.
+            let should_request = cached.is_empty()
+                && !shared.is_inbound
+                && !shared
+                    .sent_get_addr
+                    .swap(true, std::sync::atomic::Ordering::Relaxed);
+
+            if should_request {
+                spawn_outbound_request(shared, Request::Peers, tx, span.clone());
+            } else {
+                let _ = tx.send(Ok(Response::Peers(cached)));
+            }
+        }
+
+        // v2 has no unsolicited transaction push: cache the transaction for
+        // the peer's `get-tx`, and announce it.
+        Request::PushTransaction(transaction, _) => {
+            {
+                let mut pushed = shared
+                    .pushed_transactions
+                    .lock()
+                    .expect("mutex is not poisoned");
+                insert_bounded(
+                    &mut pushed,
+                    transaction.id,
+                    transaction.clone(),
+                    PUSHED_TRANSACTION_CACHE_LIMIT,
+                );
+            }
+
+            queue_transaction_announcements(shared, [transaction.id]);
+            let _ = tx.send(Ok(Response::Nil));
+        }
+
+        Request::AdvertiseTransactionIds(ids, _) => {
+            queue_transaction_announcements(shared, ids);
+            let _ = tx.send(Ok(Response::Nil));
+        }
+
+        Request::AdvertiseBlock(hash, _) | Request::AdvertiseBlockToAll(hash) => {
+            let shared = shared.clone();
+            let inbound_service = inbound_service.clone();
+            tokio::spawn(announce_block(shared, inbound_service, hash).in_current_span());
+            let _ = tx.send(Ok(Response::Nil));
+        }
+
+        request => spawn_outbound_request(shared, request, tx, span.clone()),
+    }
+}
+
+/// Queues `ids` for the connection's next transaction trickle flush.
+fn queue_transaction_announcements(
+    shared: &SharedConnection,
+    ids: impl IntoIterator<Item = UnminedTxId>,
+) {
+    let mut pending = shared
+        .pending_tx_announcements
+        .lock()
+        .expect("mutex is not poisoned");
+    for id in ids {
+        // Announcements are best-effort and unordered, so the bound evicts
+        // an arbitrary old entry.
+        if pending.len() >= PENDING_TX_ANNOUNCEMENT_LIMIT {
+            pending.swap_remove_index(0);
+        }
+        pending.insert(id);
+    }
+}
+
+/// Trickles this connection's transaction announcements: queued
+/// announcements are flushed in one batch after a random delay, to impede
+/// network topology inference.
+///
+/// Each flush feeds the transaction announcement stream — unless the peer
+/// declined transaction relay — and the peer's `get-mempool` subscription.
+/// The task ends when the connection closes.
+pub(super) async fn trickle_transaction_announcements(shared: Arc<SharedConnection>) {
+    loop {
+        tokio::select! {
+            _ = tokio::time::sleep(trickle_delay()) => {}
+            _ = shared.quic.closed() => return,
+        }
+
+        let batch: Vec<UnminedTxId> = {
+            let mut pending = shared
+                .pending_tx_announcements
+                .lock()
+                .expect("mutex is not poisoned");
+            pending.drain(..).collect()
+        };
+        if batch.is_empty() {
+            continue;
+        }
+
+        // The clone is only paid for when a `get-mempool` subscription is
+        // actually listening.
+        if shared.mempool_updates.receiver_count() > 0 {
+            let _ = shared.mempool_updates.send(batch.clone());
+        }
+
+        // A node must not open a transaction announcement stream to a peer
+        // whose init record had relay = 0.
+        if shared.remote_init.relay {
+            for id in batch {
+                let mut payload = Vec::with_capacity(65);
+                if TransactionReference::from(id).encode(&mut payload).is_ok() {
+                    shared.enqueue_announcement(StreamType::TransactionAnnouncements, payload);
+                }
+            }
+        }
+    }
+}
+
+/// Samples the random trickle delay: exponentially distributed with mean
+/// [`TX_TRICKLE_MEAN_INTERVAL`], capped at four times the mean.
+fn trickle_delay() -> std::time::Duration {
+    let uniform: f64 = rand::random();
+    // ln(0) is -inf; the epsilon makes it hit the cap instead.
+    let exponential = -(uniform.max(f64::EPSILON)).ln();
+    TX_TRICKLE_MEAN_INTERVAL.mul_f64(exponential.min(4.0))
+}
+
+/// Fetches `hash` from the local inbound service and queues a block
+/// announcement for it.
+///
+/// Block announcements carry the block header (or a compact block), so the
+/// header is fetched from the local node; the internal advertise requests
+/// only carry the hash.
+async fn announce_block<S>(shared: Arc<SharedConnection>, inbound_service: S, hash: block::Hash)
+where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    let response = inbound_service
+        .oneshot(Request::BlocksByHash(std::iter::once(hash).collect()))
+        .await;
+
+    let block = response
+        .ok()
+        .and_then(|response| available_blocks(response).swap_remove(&hash));
+
+    let Some(block) = block else {
+        debug!(?hash, "skipping announcement of block not found locally");
+        return;
+    };
+
+    match build_block_announcement(&block, &shared.remote_init, rand::random()) {
+        BlockAnnouncementRecord::Compact { payload, nonce } => {
+            shared.record_sent_block(block, Some(nonce));
+            shared.enqueue_announcement(StreamType::BlockAnnouncements, payload);
+        }
+        BlockAnnouncementRecord::Header { payload } => {
+            shared.enqueue_announcement(StreamType::BlockAnnouncements, payload);
+        }
+    }
+}
+
+/// A block announcement record payload, built for one remote peer.
+pub(super) enum BlockAnnouncementRecord {
+    /// A compact block announcement (`kind = 0x01`), with the nonce its
+    /// short transaction IDs were computed with.
+    Compact { payload: Vec<u8>, nonce: u64 },
+
+    /// A header announcement (`kind = 0x00`).
+    Header { payload: Vec<u8> },
+}
+
+/// Builds the block announcement record for `block`: a compact block if the
+/// peer requested high-bandwidth announcements in its `init` record, and a
+/// header announcement otherwise.
+///
+/// A header announcement is also substituted when the block cannot be
+/// encoded as a compact block, or its compact block encoding would exceed
+/// the record payload limit.
+pub(super) fn build_block_announcement(
+    block: &Block,
+    remote_init: &InitRecord,
+    nonce: u64,
+) -> BlockAnnouncementRecord {
+    if remote_init.announce {
+        // The coinbase transaction must be prefilled, and is; predicting
+        // other transactions the peer is missing is left to the peer's
+        // `get-tx` follow-up.
+        if let Ok(compact) = CompactBlock::from_block(block, nonce, remote_init.full_ids, &[]) {
+            let mut payload = Vec::with_capacity(2048);
+            payload.push(BLOCK_ANNOUNCEMENT_KIND_COMPACT);
+            if compact.encode(&mut payload).is_ok() && payload.len() <= MAX_RECORD_PAYLOAD_LEN {
+                return BlockAnnouncementRecord::Compact {
+                    payload,
+                    nonce: compact.nonce,
+                };
+            }
+        }
+    }
+
+    let mut payload = Vec::with_capacity(2048);
+    payload.push(BLOCK_ANNOUNCEMENT_KIND_HEADER);
+    block
+        .header
+        .zcash_serialize(&mut payload)
+        .expect("serializing a header to a Vec never fails");
+    BlockAnnouncementRecord::Header { payload }
+}
+
+/// The short transaction IDs of one sent block: each ID that identifies
+/// exactly one transaction maps to it, and IDs on which the block's
+/// transactions collide map to `None`, since an ambiguous match is answered
+/// not-found.
+type SentBlockShortIds = std::collections::HashMap<ShortTxId, Option<Arc<Transaction>>>;
+
+/// Returns whether `block`'s transactions match its header's merkle root.
+///
+/// Checkable by hashing alone, so a mismatch is provable misbehavior or a
+/// failed reconstruction, never a chain view difference.
+fn block_matches_merkle_root(block: &Block) -> bool {
+    let merkle_root: merkle::Root = block.transactions.iter().map(|tx| tx.hash()).collect();
+
+    merkle_root == block.header.merkle_root
+}
+
+/// Checks `header`'s context-free proof of work: its Equihash solution, and
+/// its hash against its own difficulty threshold.
+///
+/// Whether the threshold itself is correct is contextual, and is checked
+/// when the block is verified; this check bounds the work a forged
+/// announcement can demand, and provably attributes an invalid announcement
+/// to its sender.
+fn header_pow_is_valid(header: &block::Header) -> bool {
+    let Some(threshold) = header.difficulty_threshold.to_expanded() else {
+        return false;
+    };
+
+    header.hash() <= threshold && header.solution.check(header).is_ok()
+}
+
+/// Reconstructs the block of a compact block announcement, and hands it to
+/// the inbound service as an advertised block.
+///
+/// The reconstructed block is cached on the connection, so the local gossip
+/// downloader's follow-up [`Request::BlocksByHash`] is answered without a
+/// wire round-trip. When reconstruction fails, the full block is requested
+/// from the announcing peer instead. Either way, the advertiser is withheld
+/// from the gossip pipeline: a high-bandwidth announcement may precede the
+/// announcer's own full validation, so a block that fails validation is not
+/// penalized.
+async fn reconstruct_compact_block<S>(
+    shared: Arc<SharedConnection>,
+    inbound_service: S,
+    compact: CompactBlock,
+) where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    let hash = compact.header.hash();
+
+    let match_service = inbound_service.clone();
+    let block = tokio::time::timeout(constants::REQUEST_TIMEOUT, async {
+        match match_compact_block(&shared, match_service, &compact).await {
+            Some(block) => Some(block),
+            // Reconstruction failed: fall back to requesting the full
+            // block, without penalizing the peer.
+            None => fetch_announced_block(&shared, hash).await,
+        }
+    })
+    .await
+    .ok()
+    .flatten();
+
+    match block {
+        Some(block) => {
+            let mut cache = shared
+                .reconstructed_blocks
+                .lock()
+                .expect("mutex is not poisoned");
+            insert_bounded(&mut cache, hash, block, RECONSTRUCTED_BLOCK_CACHE_LIMIT);
+        }
+        None => debug!(?hash, "an announced compact block could not be obtained"),
+    }
+
+    let request = Request::AdvertiseBlock(hash, None);
+    let _ = call_inbound_service(inbound_service, request).await;
+}
+
+/// Attempts to reconstruct the block of a compact block announcement from
+/// transactions this node already holds, requesting the unmatched
+/// transactions from the announcing peer with `get-tx`.
+///
+/// Returns `None` when reconstruction fails: a prefilled index is out of
+/// range, a requested transaction was answered not-found, or the assembled
+/// transactions do not match the header's merkle root (as happens when a
+/// short ID collision matched the wrong held transaction).
+async fn match_compact_block<S>(
+    shared: &Arc<SharedConnection>,
+    inbound_service: S,
+    compact: &CompactBlock,
+) -> Option<Arc<Block>>
+where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    let block_hash = compact.header.hash();
+    let id_count = match &compact.ids {
+        CompactBlockIds::Short(ids) => ids.len(),
+        CompactBlockIds::Full(ids) => ids.len(),
+    };
+    let total = id_count + compact.prefilled.len();
+
+    // Place the prefilled transactions at their absolute indexes; the
+    // remaining positions take the identified transactions, in order.
+    let mut slots: Vec<Option<Arc<Transaction>>> = vec![None; total];
+    for prefilled in &compact.prefilled {
+        let slot = slots.get_mut(usize::try_from(prefilled.index).ok()?)?;
+        *slot = Some(prefilled.tx.clone());
+    }
+    let id_positions: Vec<usize> = (0..total).filter(|&index| slots[index].is_none()).collect();
+
+    // Match each identified transaction against the mempool, producing the
+    // held candidate to fetch locally, and the reference that requests the
+    // transaction from the peer if the candidate falls through.
+    let mempool_ids =
+        match call_inbound_service(inbound_service.clone(), Request::MempoolTransactionIds).await {
+            Ok(Response::TransactionIds(ids)) => ids,
+            _ => Vec::new(),
+        };
+
+    let id_refs: Vec<(Option<UnminedTxId>, TransactionReference)> = match &compact.ids {
+        CompactBlockIds::Short(short_ids) => {
+            let header_bytes = compact
+                .header
+                .zcash_serialize_to_vec()
+                .expect("serializing a header to a Vec never fails");
+            let (k0, k1) = short_id_keys(&header_bytes, compact.nonce);
+
+            // Held transactions colliding on a short ID map to `None`: the
+            // match is ambiguous, so the transaction is requested instead.
+            let mut held: HashMap<ShortTxId, Option<UnminedTxId>> =
+                HashMap::with_capacity(mempool_ids.len());
+            for id in &mempool_ids {
+                held.entry(short_transaction_id(k0, k1, id))
+                    .and_modify(|matched| *matched = None)
+                    .or_insert(Some(*id));
+            }
+
+            short_ids
+                .iter()
+                .map(|short_id| {
+                    (
+                        held.get(short_id).copied().flatten(),
+                        TransactionReference::ShortId {
+                            block_hash,
+                            short_id: *short_id,
+                        },
+                    )
+                })
+                .collect()
+        }
+        CompactBlockIds::Full(full_ids) => {
+            let held: HashMap<[u8; 64], UnminedTxId> = mempool_ids
+                .iter()
+                .map(|id| (full_transaction_id(id).as_bytes(), *id))
+                .collect();
+
+            full_ids
+                .iter()
+                .map(|full_id| {
+                    (
+                        held.get(&full_id.as_bytes()).copied(),
+                        txref_from_full_id(full_id),
+                    )
+                })
+                .collect()
+        }
+    };
+
+    // Fetch the held candidates from the mempool.
+    let held_ids: HashSet<UnminedTxId> = id_refs.iter().filter_map(|(id, _)| *id).collect();
+    let mut held_txs: HashMap<UnminedTxId, Arc<Transaction>> =
+        HashMap::with_capacity(held_ids.len());
+    if !held_ids.is_empty() {
+        if let Ok(Response::Transactions(transactions)) =
+            call_inbound_service(inbound_service, Request::TransactionsById(held_ids)).await
+        {
+            for entry in transactions {
+                if let InventoryResponse::Available((tx, _)) = entry {
+                    held_txs.insert(tx.id, tx.transaction);
+                }
+            }
+        }
+    }
+
+    // Fill the identified positions, and request everything unmatched — or
+    // matched but gone from the mempool since — from the peer.
+    let mut wire_refs: Vec<TransactionReference> = Vec::new();
+    let mut wire_positions: Vec<usize> = Vec::new();
+    for (&position, (held_id, txref)) in id_positions.iter().zip(&id_refs) {
+        match held_id.and_then(|id| held_txs.get(&id).cloned()) {
+            Some(tx) => slots[position] = Some(tx),
+            None => {
+                wire_refs.push(*txref);
+                wire_positions.push(position);
+            }
+        }
+    }
+
+    if !wire_refs.is_empty() {
+        let mut recv = send_wire_request(shared, WireRequest::GetTx { refs: wire_refs })
+            .await
+            .ok()?;
+        for position in wire_positions {
+            match read_result_entry(&mut recv, "get-tx").await.ok()? {
+                Some(tx) => slots[position] = Some(tx),
+                None => return None,
+            }
+        }
+        record::expect_end_of_stream(&mut recv).await.ok()?;
+    }
+
+    let transactions: Vec<Arc<Transaction>> = slots.into_iter().collect::<Option<Vec<_>>>()?;
+    let block = Block {
+        header: compact.header.clone(),
+        transactions,
+    };
+
+    // A wrong short ID match assembles the wrong block. The merkle root
+    // check detects that here, so this node falls back to the full block
+    // instead of relaying a block that fails validation.
+    if !block_matches_merkle_root(&block) {
+        return None;
+    }
+
+    Some(Arc::new(block))
+}
+
+/// Builds the `get-tx` reference requesting an unmatched full transaction
+/// ID: a `TXID` reference for pre-v5 transactions, identified by the
+/// ZIP 244 auth digest placeholder, and a `WTXID` reference otherwise.
+fn txref_from_full_id(full_id: &WtxId) -> TransactionReference {
+    if full_id.auth_digest == merkle::AUTH_DIGEST_PLACEHOLDER {
+        TransactionReference::Txid(full_id.id)
+    } else {
+        TransactionReference::Wtxid(*full_id)
+    }
+}
+
+/// Maintains this node's `get-mempool` subscription to the peer: mirrors
+/// the peer's mempool into the connection's cache, which answers internal
+/// [`Request::MempoolTransactionIds`], and forwards newly referenced
+/// transactions to the inbound service as advertisements.
+///
+/// The subscription ends when the peer finishes or refuses it, or the
+/// connection closes; the mirrored cache keeps its contents either way.
+pub(super) async fn maintain_mempool_subscription<S>(
+    shared: Arc<SharedConnection>,
+    inbound_service: S,
+) where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    let mut recv = match send_wire_request(&shared, WireRequest::GetMempool).await {
+        Ok(recv) => recv,
+        Err(_) => return,
+    };
+
+    loop {
+        // Subscription records arrive whenever the peer's mempool changes,
+        // so an idle stream is normal, and there is no read timeout.
+        let payload = match record::read_record(&mut recv).await {
+            Ok(Some(payload)) => payload,
+            // The peer finished the subscription, for example on shutdown.
+            Ok(None) => return,
+            Err(error) => {
+                // A reset carries the peer's refusal or cancellation; only
+                // malformed response data fails the connection.
+                if !is_stream_failure(&error) {
+                    shared.fail_wire_error(&error);
+                }
+                return;
+            }
+        };
+
+        let mut reader = payload.as_slice();
+        let response = match MempoolResponse::read(&mut reader).await {
+            Ok(response) if reader.is_empty() => response,
+            Ok(_) => {
+                shared.fail_protocol("trailing bytes in a get-mempool record");
+                return;
+            }
+            Err(error) => {
+                shared.fail_wire_error(&error);
+                return;
+            }
+        };
+
+        let ids: Vec<UnminedTxId> = response
+            .0
+            .into_iter()
+            .map(|txref| {
+                txref
+                    .try_into()
+                    .expect("read rejects SHORTID references in get-mempool records")
+            })
+            .collect();
+        if ids.is_empty() {
+            continue;
+        }
+
+        // Mirror the references into the cache, evicting the oldest half
+        // beyond the bound.
+        {
+            let mut cache = shared.remote_mempool.lock().expect("mutex is not poisoned");
+            cache.extend(ids.iter().copied());
+            let len = cache.len();
+            if len > MAX_MEMPOOL_RESPONSE_REFS {
+                let recent = cache.split_off(len / 2);
+                *cache = recent;
+            }
+        }
+
+        // Forward the references as an advertisement: the mempool dedups
+        // known transactions and downloads the rest with `get-tx`.
+        if let Some(addr) = shared.transient_addr {
+            let hashes: Vec<InventoryHash> =
+                ids.iter().map(|id| InventoryHash::from(*id)).collect();
+            if let Some(change) = InventoryChange::new_available_multi(hashes.iter(), addr) {
+                let _ = shared.inv_collector.send(change);
+            }
+        }
+        let request =
+            Request::AdvertiseTransactionIds(ids.into_iter().collect(), shared.transient_addr);
+        let _ = call_inbound_service(inbound_service.clone(), request).await;
+    }
+}
+
+/// Requests the full block for `hash` from the peer, after a compact block
+/// announcement that could not be reconstructed.
+async fn fetch_announced_block(shared: &SharedConnection, hash: block::Hash) -> Option<Arc<Block>> {
+    let mut recv = send_wire_request(shared, WireRequest::GetBlocks { hashes: vec![hash] })
+        .await
+        .ok()?;
+    let entry = read_result_entry::<Block, _>(&mut recv, "get-blocks")
+        .await
+        .ok()?;
+    record::expect_end_of_stream(&mut recv).await.ok()?;
+
+    entry.filter(|block| block.hash() == hash)
+}
+
+/// Builds the short transaction ID table of a block, using the nonce of the
+/// compact block sent for it.
+fn short_ids_of(block: &Block, nonce: u64) -> Option<SentBlockShortIds> {
+    let header_bytes = block
+        .header
+        .zcash_serialize_to_vec()
+        .expect("serializing a header to a Vec never fails");
+    let (k0, k1) = short_id_keys(&header_bytes, nonce);
+
+    let mut table = SentBlockShortIds::with_capacity(block.transactions.len());
+    for tx in &block.transactions {
+        let short_id = short_transaction_id(k0, k1, &UnminedTxId::from(tx.as_ref()));
+        table
+            .entry(short_id)
+            .and_modify(|matched| *matched = None)
+            .or_insert_with(|| Some(tx.clone()));
+    }
+
+    Some(table)
+}
+
+/// Spawns a task that performs `request` on its own request stream and sends
+/// the result to `tx`.
+fn spawn_outbound_request(
+    shared: &Arc<SharedConnection>,
+    request: Request,
+    tx: MustUseClientResponseSender,
+    span: tracing::Span,
+) {
+    let shared = shared.clone();
+    tokio::spawn(
+        async move {
+            let command = request.command();
+            let result = tokio::time::timeout(
+                constants::REQUEST_TIMEOUT,
+                drive_outbound_request(&shared, request),
+            )
+            .await
+            .unwrap_or(Err(OutboundError::Timeout));
+
+            let result = match result {
+                Ok(response) => {
+                    shared.record_response();
+                    Ok(response)
+                }
+                Err(error) => Err(error.into_shared_error(&shared, command)),
+            };
+
+            let _ = tx.send(result);
+        }
+        .instrument(span),
+    );
+}
+
+/// An error performing an outbound request.
+enum OutboundError {
+    /// The response did not arrive within the request timeout.
+    Timeout,
+
+    /// The peer answered every requested item with a not-found result.
+    NotFound(Vec<InventoryHash>),
+
+    /// A wire or transport error.
+    Wire(WireError),
+
+    /// A local error that leaves the connection usable.
+    Local(PeerError),
+}
+
+impl From<WireError> for OutboundError {
+    fn from(error: WireError) -> Self {
+        OutboundError::Wire(error)
+    }
+}
+
+impl OutboundError {
+    /// Converts this error to the [`SharedPeerError`] reported to the
+    /// caller, failing the connection for connection-level errors.
+    ///
+    /// `command` is the command name of the failed request, for logging.
+    fn into_shared_error(
+        self,
+        shared: &SharedConnection,
+        command: &'static str,
+    ) -> SharedPeerError {
+        match self {
+            OutboundError::Timeout => {
+                shared.record_request_timeout();
+                PeerError::ConnectionReceiveTimeout.into()
+            }
+            // A local error: the peer is not at fault, so the connection
+            // stays open.
+            OutboundError::Local(error) => error.into(),
+            // The peer answered, so it is not unresponsive: a not-found
+            // response is a valid answer.
+            OutboundError::NotFound(hashes) => {
+                shared.record_response();
+                PeerError::NotFoundResponse(hashes).into()
+            }
+            // This node could not build a valid request: the peer is not at
+            // fault, so the connection stays open.
+            OutboundError::Wire(WireError::Local(reason)) => {
+                warn!(request = %command, %reason, "could not encode a v2 request");
+                PeerError::V2Internal(reason).into()
+            }
+
+            // The peer violated a limit that is scored rather than
+            // disconnected on: the request fails, and the peer is banned once
+            // its accumulated score reaches the threshold.
+            OutboundError::Wire(WireError::Misbehavior { points, reason }) => {
+                shared.report_misbehavior(points, &reason);
+                PeerError::V2Protocol(reason).into()
+            }
+            OutboundError::Wire(error) => match stream_reset_code(&error) {
+                // The responder declined the request by resetting the
+                // stream; the connection remains usable.
+                Some(ErrorCode::Refused) => {
+                    PeerError::V2Protocol(format!("peer refused {command}")).into()
+                }
+                _ => match error.connection_error_code() {
+                    // The peer sent an invalid response: this is a
+                    // connection error of the indicated type.
+                    Some(code) if !is_stream_failure(&error) => {
+                        let message = error.to_string();
+                        shared.fail(code, PeerError::V2Protocol(message.clone()));
+                        PeerError::V2Protocol(message).into()
+                    }
+                    _ => {
+                        warn!(request = %command, %error, "outbound v2 request failed");
+                        PeerError::V2Protocol(error.to_string()).into()
+                    }
+                },
+            },
+        }
+    }
+}
+
+/// Returns the application error code if `error` is a stream reset by the
+/// peer.
+fn stream_reset_code(error: &WireError) -> Option<ErrorCode> {
+    if let WireError::Io(io_error) = error {
+        let mut source: Option<&(dyn std::error::Error + 'static)> =
+            io_error.get_ref().map(|error| error as _);
+        while let Some(error) = source {
+            if let Some(quinn::ReadError::Reset(code)) = error.downcast_ref::<quinn::ReadError>() {
+                return Some(ErrorCode::from_wire(code.into_inner()));
+            }
+            source = error.source();
+        }
+    }
+
+    None
+}
+
+/// Returns true if `error` reading a stream was caused by a stream reset, a
+/// transport failure, or a stalled peer, rather than by invalid data sent by
+/// the peer.
+///
+/// These errors abandon the stream, but leave the connection usable.
+fn is_stream_failure(error: &WireError) -> bool {
+    matches!(error, WireError::Io(_) | WireError::Timeout(_))
+}
+
+/// Performs `request` on a new request stream and decodes the response.
+async fn drive_outbound_request(
+    shared: &SharedConnection,
+    request: Request,
+) -> Result<Response, OutboundError> {
+    let transient_addr = shared.transient_addr;
+
+    match request {
+        Request::Peers => {
+            let mut recv = send_wire_request(shared, WireRequest::GetAddr).await?;
+            let addrs = AddrResponse::read(&mut recv).await?;
+            record::expect_end_of_stream(&mut recv).await?;
+
+            // # Security
+            //
+            // Merge the response into the address cache, and answer with a
+            // bounded random sample, so a single peer cannot control the
+            // address book by the size or order of its response, like the
+            // legacy connection.
+            let response_addrs = {
+                let mut cached_addrs = shared.cached_addrs.lock().expect("mutex is not poisoned");
+                update_addr_cache(
+                    &mut cached_addrs,
+                    &addrs.0,
+                    constants::PEER_ADDR_RESPONSE_LIMIT,
+                )
+            };
+
+            Ok(Response::Peers(response_addrs))
+        }
+
+        Request::MempoolTransactionIds => {
+            // Answered from the mempool subscription's mirror: only one
+            // concurrent `get-mempool` stream per peer is allowed, and the
+            // connection's subscription task holds it.
+            let ids: Vec<UnminedTxId> = {
+                let cache = shared.remote_mempool.lock().expect("mutex is not poisoned");
+                cache.iter().copied().collect()
+            };
+            Ok(Response::TransactionIds(ids))
+        }
+
+        Request::FindHeaders { known_blocks, stop } => {
+            let (headers, _hashes) = get_headers(shared, known_blocks, stop).await?;
+            Ok(Response::BlockHeaders(headers.0))
+        }
+
+        // The v2 protocol is headers-first only: the legacy inventory walk
+        // is bridged onto `get-headers` by hashing the returned headers.
+        Request::FindBlocks { known_blocks, stop } => {
+            let (_headers, hashes) = get_headers(shared, known_blocks, stop).await?;
+            Ok(Response::BlockHashes(hashes))
+        }
+
+        Request::BlocksByHash(hashes) => {
+            let hashes: Vec<block::Hash> = hashes.into_iter().collect();
+
+            // Blocks reconstructed from this peer's compact block
+            // announcements answer without a wire request: the gossip
+            // downloader fetches an announced block right back from the
+            // announcing connection.
+            let reconstructed: Option<Vec<Arc<Block>>> = {
+                let cache = shared
+                    .reconstructed_blocks
+                    .lock()
+                    .expect("mutex is not poisoned");
+                hashes.iter().map(|hash| cache.get(hash).cloned()).collect()
+            };
+            if let Some(blocks) = reconstructed {
+                return Ok(Response::Blocks(
+                    blocks
+                        .into_iter()
+                        .map(|block| InventoryResponse::Available((block, transient_addr)))
+                        .collect(),
+                ));
+            }
+
+            let recv = send_wire_request(
+                shared,
+                WireRequest::GetBlocks {
+                    hashes: hashes.clone(),
+                },
+            )
+            .await?;
+
+            let blocks = read_matched_entries(
+                recv,
+                &hashes,
+                transient_addr,
+                "get-blocks",
+                "block",
+                async |recv| {
+                    Ok(read_result_entry::<Block, _>(recv, "get-blocks")
+                        .await?
+                        .map(|block| (block.hash(), block)))
+                },
+            )
+            .await?;
+
+            Ok(Response::Blocks(blocks))
+        }
+
+        Request::TransactionsById(ids) => {
+            let ids: Vec<UnminedTxId> = ids.into_iter().collect();
+            let refs = ids
+                .iter()
+                .map(|id| TransactionReference::from(*id))
+                .collect();
+
+            let recv = send_wire_request(shared, WireRequest::GetTx { refs }).await?;
+
+            let transactions = read_matched_entries(
+                recv,
+                &ids,
+                transient_addr,
+                "get-tx",
+                "transaction",
+                async |recv| {
+                    Ok(read_result_entry(recv, "get-tx").await?.map(|transaction| {
+                        let transaction = UnminedTx::from(transaction);
+
+                        (transaction.id, transaction)
+                    }))
+                },
+            )
+            .await?;
+
+            Ok(Response::Transactions(transactions))
+        }
+
+        Request::Ping(_)
+        | Request::PushTransaction(_, _)
+        | Request::AdvertiseTransactionIds(_, _)
+        | Request::AdvertiseBlock(_, _)
+        | Request::AdvertiseBlockToAll(_) => {
+            unreachable!("locally-handled requests are dispatched before this point")
+        }
+
+        Request::BlockRange {
+            final_hash,
+            count,
+            max_bytes,
+        } => {
+            let mut recv = send_wire_request(
+                shared,
+                WireRequest::GetBlockRange {
+                    final_hash,
+                    count,
+                    max_bytes,
+                },
+            )
+            .await?;
+
+            match record::read_u8(&mut recv).await? {
+                RESULT_OBJECT => {}
+                RESULT_NOT_FOUND => {
+                    record::expect_end_of_stream(&mut recv).await?;
+                    return Ok(Response::Blocks(vec![InventoryResponse::Missing(
+                        final_hash,
+                    )]));
+                }
+                unknown => {
+                    return Err(OutboundError::Wire(WireError::Protocol(format!(
+                        "unrecognized get-block-range result value {unknown:#04x}",
+                    ))));
+                }
+            }
+
+            // Every block is verified on arrival, by hashing alone: the
+            // first block must hash to the anchor, each subsequent block
+            // must be the parent of the previous one, and each block's
+            // transactions must match its header's merkle root. A violation
+            // is a connection error of type `PROTOCOL_ERROR`, and exceeding
+            // either request bound is `FLOOD`: both are checkable without
+            // any chain state, so blame is exact.
+            let mut blocks = Vec::new();
+            let mut expected_hash = final_hash;
+            let mut delivered_bytes: u64 = 0;
+
+            while let Some(payload) = record::read_record(&mut recv).await? {
+                if blocks.len() as u64 >= count {
+                    return Err(OutboundError::Wire(WireError::Flood(
+                        "get-block-range delivered more blocks than requested".to_string(),
+                    )));
+                }
+                if !blocks.is_empty()
+                    && delivered_bytes.saturating_add(payload.len() as u64) > max_bytes
+                {
+                    return Err(OutboundError::Wire(WireError::Flood(
+                        "get-block-range delivered blocks past the requested byte bound"
+                            .to_string(),
+                    )));
+                }
+
+                let block = Arc::new(
+                    Block::zcash_deserialize(payload.as_slice()).map_err(WireError::from)?,
+                );
+                if block.hash() != expected_hash {
+                    return Err(OutboundError::Wire(WireError::Protocol(
+                        "get-block-range block does not extend the verified chain".to_string(),
+                    )));
+                }
+                if !block_matches_merkle_root(&block) {
+                    return Err(OutboundError::Wire(WireError::Protocol(
+                        "get-block-range block does not match its merkle root".to_string(),
+                    )));
+                }
+
+                delivered_bytes = delivered_bytes.saturating_add(payload.len() as u64);
+                expected_hash = block.header.previous_block_hash;
+                blocks.push(InventoryResponse::Available((block, transient_addr)));
+            }
+
+            Ok(Response::Blocks(blocks))
+        }
+
+        // These are answered by the local inbound service, never by a
+        // peer: a mis-routed request is a local wiring mistake, so the
+        // caller is told rather than the connection task panicking.
+        request @ (Request::SyncHashes { .. } | Request::TreeRoots { .. }) => Err(
+            OutboundError::Local(PeerError::LocalOnlyRequest(request.command())),
+        ),
+    }
+}
+
+/// Reads one result-tagged response entry per requested key, in request
+/// order, and checks that the stream ends after the last entry.
+///
+/// `read_entry` reads a single entry, returning the item and its identifying
+/// key, or `None` for a not-found entry.
+///
+/// # Security
+///
+/// Each returned item's key must match the requested key, so a peer cannot
+/// substitute an unrequested item for a requested one. If every entry is
+/// not-found, a retryable [`OutboundError::NotFound`] is reported, like the
+/// legacy connection.
+async fn read_matched_entries<K, T>(
+    mut recv: tokio::io::BufReader<quinn::RecvStream>,
+    keys: &[K],
+    transient_addr: Option<PeerSocketAddr>,
+    request_kind: &'static str,
+    item_kind: &'static str,
+    mut read_entry: impl AsyncFnMut(
+        &mut tokio::io::BufReader<quinn::RecvStream>,
+    ) -> Result<Option<(K, T)>, WireError>,
+) -> Result<Vec<InventoryResponse<(T, Option<PeerSocketAddr>), K>>, OutboundError>
+where
+    K: Copy + Eq + std::fmt::Display + Into<InventoryHash>,
+{
+    let mut entries = Vec::with_capacity(keys.len());
+    for key in keys {
+        match read_entry(&mut recv).await? {
+            Some((entry_key, item)) => {
+                // # Security
+                //
+                // Check that the response matches the request before using
+                // it.
+                if entry_key != *key {
+                    return Err(WireError::Protocol(format!(
+                        "peer answered a {request_kind} entry for {key} \
+                         with a different {item_kind}",
+                    ))
+                    .into());
+                }
+                entries.push(InventoryResponse::Available((item, transient_addr)));
+            }
+            None => entries.push(InventoryResponse::Missing(*key)),
+        }
+    }
+    record::expect_end_of_stream(&mut recv).await?;
+
+    // If the peer has none of the requested items, report a retryable
+    // not-found error, like the legacy connection.
+    if entries
+        .iter()
+        .all(|entry| matches!(entry, InventoryResponse::Missing(_)))
+    {
+        return Err(OutboundError::NotFound(
+            keys.iter().copied().map(Into::into).collect(),
+        ));
+    }
+
+    Ok(entries)
+}
+
+/// Sends a `get-headers` request and reads and validates the response,
+/// returning it along with the hash of each returned header.
+async fn get_headers(
+    shared: &SharedConnection,
+    known_blocks: Vec<block::Hash>,
+    stop: Option<block::Hash>,
+) -> Result<(HeadersResponse, Vec<block::Hash>), OutboundError> {
+    let mut recv = send_wire_request(
+        shared,
+        WireRequest::GetHeaders {
+            known_blocks,
+            stop,
+            // The internal protocol has no request for headers with
+            // transaction IDs: the transaction-ID form is used by the
+            // compact block reconstruction path.
+            tx_ids: false,
+        },
+    )
+    .await?;
+    let headers = HeadersResponse::read(&mut recv).await?;
+    record::expect_end_of_stream(&mut recv).await?;
+
+    let hashes = headers.check_contiguous()?;
+
+    Ok((headers, hashes))
+}
+
+/// Opens a request stream, writes `request`, and finishes the sending
+/// direction, returning the buffered receiving half.
+async fn send_wire_request(
+    shared: &SharedConnection,
+    request: WireRequest,
+) -> Result<tokio::io::BufReader<quinn::RecvStream>, WireError> {
+    let (mut send, recv) = shared
+        .quic
+        .open_bi()
+        .await
+        .map_err(|error| WireError::Io(std::io::Error::other(error)))?;
+
+    let mut bytes = vec![request.stream_type().byte()];
+    request.encode(&mut bytes)?;
+
+    send.write_all(&bytes)
+        .await
+        .map_err(|error| WireError::Io(std::io::Error::other(error)))?;
+    send.finish()
+        .map_err(|error| WireError::Io(std::io::Error::other(error)))?;
+
+    Ok(tokio::io::BufReader::with_capacity(
+        RESPONSE_STREAM_READ_BUFFER_SIZE,
+        recv,
+    ))
+}
+
+/// Serves one inbound request stream from the remote peer.
+///
+/// Reading the request, and serving any single-response request, is bounded
+/// by [`INBOUND_STREAM_TIMEOUT`]: a peer that opens a stream and then
+/// stalls, or that stops reading its response, would otherwise pin this task
+/// and its buffers for the life of the connection. A `get-mempool`
+/// subscription is exempt: its response is open-ended by design, and it is
+/// bounded instead by the requester cancelling it or the connection closing.
+async fn serve_inbound_request_stream<S>(
+    shared: Arc<SharedConnection>,
+    inbound_service: S,
+    mut send: quinn::SendStream,
+    mut recv: quinn::RecvStream,
+) where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    let read = read_inbound_request(&shared, &mut send, &mut recv);
+    let request = match tokio::time::timeout(INBOUND_STREAM_TIMEOUT, read).await {
+        Ok(Some(request)) => request,
+        Ok(None) => return,
+        Err(_elapsed) => {
+            debug!("abandoning a stalled inbound v2 request stream");
+            let _ = recv.stop(ErrorCode::Cancelled.into());
+            let _ = send.reset(ErrorCode::Cancelled.into());
+            return;
+        }
+    };
+
+    let result = if matches!(request, WireRequest::GetMempool) {
+        serve_mempool_subscription(&shared, inbound_service, &mut send).await
+    } else {
+        let serve = serve_request(&shared, inbound_service, request, &mut send);
+        match tokio::time::timeout(INBOUND_STREAM_TIMEOUT, serve).await {
+            Ok(result) => result,
+            Err(_elapsed) => {
+                debug!("abandoning a stalled inbound v2 request stream");
+                let _ = send.reset(ErrorCode::Cancelled.into());
+                return;
+            }
+        }
+    };
+
+    match result {
+        Ok(()) => {
+            let _ = send.finish();
+        }
+        Err(ServeError::Refused) => {
+            let _ = send.reset(ErrorCode::Refused.into());
+        }
+        Err(ServeError::Encode(error)) => {
+            debug!(%error, "internal error encoding a v2 response");
+            let _ = send.reset(ErrorCode::InternalError.into());
+        }
+        // The requester cancelled the request or the connection closed.
+        Err(ServeError::Write) => {}
+    }
+}
+
+/// Reads and decodes the request of one inbound request stream, through the
+/// end of its receive direction.
+///
+/// Returns `None` when the stream was refused or failed; protocol
+/// violations fail the connection.
+async fn read_inbound_request(
+    shared: &Arc<SharedConnection>,
+    send: &mut quinn::SendStream,
+    recv: &mut quinn::RecvStream,
+) -> Option<WireRequest> {
+    let type_byte = read_stream_type_or_fail(shared, recv).await?;
+
+    let stream_type = match StreamType::from_byte(type_byte) {
+        Some(stream_type) if stream_type.is_request() => stream_type,
+        Some(StreamType::Handshake) => {
+            // Only the initiator opens the handshake stream, and a
+            // connection has exactly one.
+            shared.fail_protocol("unexpected extra handshake stream");
+            return None;
+        }
+        Some(_announcement_type) => {
+            shared.fail_protocol("announcement stream type on a bidirectional stream");
+            return None;
+        }
+        // Refuse unrecognized stream types without penalizing the peer, so
+        // future stream types can be deployed without version gating.
+        None => {
+            let _ = recv.stop(ErrorCode::UnsupportedStreamType.into());
+            let _ = send.reset(ErrorCode::UnsupportedStreamType.into());
+            return None;
+        }
+    };
+
+    let mut recv = tokio::io::BufReader::with_capacity(RECORD_STREAM_READ_BUFFER_SIZE, recv);
+    let request = match WireRequest::read(stream_type, &mut recv).await {
+        Ok(request) => request,
+        Err(error) => {
+            handle_inbound_wire_error(shared, error);
+            return None;
+        }
+    };
+    if let Err(error) = record::expect_end_of_stream(&mut recv).await {
+        handle_inbound_wire_error(shared, error);
+        return None;
+    }
+
+    // To impede fingerprinting, only answer address requests on inbound
+    // connections.
+    if matches!(request, WireRequest::GetAddr) && !shared.is_inbound {
+        let _ = send.reset(ErrorCode::Refused.into());
+        return None;
+    }
+
+    Some(request)
+}
+
+/// Serves a `get-mempool` subscription: one or more records referencing the
+/// whole mempool (the snapshot), then a record per batch of transactions
+/// accepted into the mempool, until the requester cancels the subscription
+/// or the connection ends.
+async fn serve_mempool_subscription<S>(
+    shared: &Arc<SharedConnection>,
+    inbound_service: S,
+    send: &mut quinn::SendStream,
+) -> Result<(), ServeError>
+where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    // A peer must not open more than one concurrent subscription.
+    if shared.mempool_subscribed.swap(true, Ordering::AcqRel) {
+        shared.fail_protocol("second concurrent get-mempool subscription");
+        return Err(ServeError::Write);
+    }
+
+    // Clears the subscription slot when serving ends for any reason, so the
+    // peer can subscribe again sequentially.
+    struct SubscriptionGuard<'a>(&'a SharedConnection);
+    impl Drop for SubscriptionGuard<'_> {
+        fn drop(&mut self) {
+            self.0.mempool_subscribed.store(false, Ordering::Release);
+        }
+    }
+    let _guard = SubscriptionGuard(shared);
+
+    // Subscribe to updates before reading the snapshot, so transactions
+    // accepted while the snapshot is sent are not missed. The overlap can
+    // only duplicate references, which the requester tolerates.
+    let mut updates = shared.mempool_updates.subscribe();
+
+    let snapshot = mempool_transaction_ids(inbound_service.clone()).await?;
+    write_mempool_records(send, &snapshot).await?;
+
+    loop {
+        let update = tokio::select! {
+            update = updates.recv() => update,
+            // The requester cancelled the subscription. Noticing here, and
+            // not on the next write, releases the subscription slot while
+            // the mempool is quiet, so the peer can subscribe again.
+            _ = send.stopped() => return Ok(()),
+        };
+
+        let batch = match update {
+            Ok(ids) => ids,
+            // The channel lagged: some accepted transactions were lost, so
+            // re-send a whole snapshot. Duplicates are tolerated.
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                mempool_transaction_ids(inbound_service.clone()).await?
+            }
+            // The connection is shutting down.
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => return Ok(()),
+        };
+
+        if !batch.is_empty() {
+            write_mempool_records(send, &batch).await?;
+        }
+    }
+}
+
+/// Fetches the local mempool's transaction IDs for a `get-mempool`
+/// subscription record.
+async fn mempool_transaction_ids<S>(inbound_service: S) -> Result<Vec<UnminedTxId>, ServeError>
+where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    let response = call_inbound_service(inbound_service, Request::MempoolTransactionIds).await?;
+    Ok(match response {
+        Response::TransactionIds(ids) => ids,
+        _ => Vec::new(),
+    })
+}
+
+/// Writes `ids` as one or more `get-mempool` response records, splitting so
+/// that every record stays within the payload limit.
+///
+/// An empty `ids` writes a single `count = 0` record: the snapshot of an
+/// empty mempool.
+async fn write_mempool_records(
+    send: &mut quinn::SendStream,
+    ids: &[UnminedTxId],
+) -> Result<(), ServeError> {
+    let mut bytes = Vec::new();
+
+    if ids.is_empty() {
+        let mut payload = Vec::new();
+        MempoolResponse(Vec::new())
+            .encode(&mut payload)
+            .map_err(ServeError::Encode)?;
+        record::write_record(&mut bytes, &payload).map_err(ServeError::Encode)?;
+        return write_response_bytes(send, &bytes).await;
+    }
+
+    for chunk in ids.chunks(MAX_MEMPOOL_RECORD_REFS) {
+        let refs = chunk
+            .iter()
+            .map(|id| TransactionReference::from(*id))
+            .collect();
+
+        let mut payload = Vec::with_capacity(chunk.len() * 65 + 9);
+        MempoolResponse(refs)
+            .encode(&mut payload)
+            .map_err(ServeError::Encode)?;
+
+        bytes.clear();
+        record::write_record(&mut bytes, &payload).map_err(ServeError::Encode)?;
+        write_response_bytes(send, &bytes).await?;
+    }
+
+    Ok(())
+}
+
+/// An error serving an inbound request.
+enum ServeError {
+    /// The inbound service declined or failed to serve the request.
+    Refused,
+
+    /// The response could not be encoded.
+    Encode(WireError),
+
+    /// The response could not be written to the stream.
+    ///
+    /// The write error itself is not reported: the requester cancelled the
+    /// request or the connection is closing.
+    Write,
+}
+
+impl From<WireError> for ServeError {
+    fn from(error: WireError) -> Self {
+        ServeError::Encode(error)
+    }
+}
+
+/// Serves a decoded inbound request, writing the response to `send`.
+async fn serve_request<S>(
+    shared: &Arc<SharedConnection>,
+    inbound_service: S,
+    request: WireRequest,
+    send: &mut quinn::SendStream,
+) -> Result<(), ServeError>
+where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    match request {
+        WireRequest::GetHeaders {
+            known_blocks,
+            stop,
+            tx_ids,
+        } => {
+            let response = call_inbound_service(
+                inbound_service.clone(),
+                Request::FindHeaders { known_blocks, stop },
+            )
+            .await?;
+            let headers = match response {
+                Response::BlockHeaders(headers) => headers,
+                _ => Vec::new(),
+            };
+
+            if !tx_ids {
+                let mut bytes = Vec::new();
+                HeadersResponse(headers).encode(&mut bytes)?;
+                return write_response_bytes(send, &bytes).await;
+            }
+
+            // The transaction-ID form additionally identifies each block's
+            // transactions: the coinbase transaction in full (it is never
+            // otherwise relayed), and every other transaction by its full
+            // transaction ID. Headers whose blocks this node cannot supply
+            // are answered with `has_txs = 0x00`, and the requester falls
+            // back to `get-blocks`.
+            let hashes: Vec<block::Hash> =
+                headers.iter().map(|header| header.header.hash()).collect();
+            let response = call_inbound_service(
+                inbound_service,
+                Request::BlocksByHash(hashes.iter().copied().collect()),
+            )
+            .await?;
+
+            let available = available_blocks(response);
+
+            let mut bytes = Vec::new();
+            record::write_compact_size(&mut bytes, headers.len() as u64)
+                .map_err(ServeError::Encode)?;
+            write_response_bytes(send, &bytes).await?;
+
+            for (header, hash) in headers.iter().zip(hashes) {
+                bytes.clear();
+
+                let header_bytes = header
+                    .header
+                    .zcash_serialize_to_vec()
+                    .expect("serializing a header to a Vec never fails");
+                record::write_record(&mut bytes, &header_bytes).map_err(ServeError::Encode)?;
+
+                match available.get(&hash) {
+                    Some(block) => {
+                        // The peer can now request this block's transactions
+                        // from the IDs below, so they must stay servable.
+                        shared.record_sent_block(block.clone(), None);
+
+                        bytes.push(HEADERS_ENTRY_HAS_TXS);
+
+                        let coinbase_bytes = block
+                            .transactions
+                            .first()
+                            .expect("valid blocks have a coinbase transaction")
+                            .zcash_serialize_to_vec()
+                            .map_err(|err| {
+                                ServeError::Encode(WireError::Local(format!(
+                                    "unserializable coinbase transaction: {err}"
+                                )))
+                            })?;
+                        record::write_record(&mut bytes, &coinbase_bytes)
+                            .map_err(ServeError::Encode)?;
+
+                        let ids: Vec<_> = block
+                            .transactions
+                            .iter()
+                            .skip(1)
+                            .map(|tx| full_transaction_id(&UnminedTxId::from(tx.as_ref())))
+                            .collect();
+                        record::write_compact_size(&mut bytes, ids.len() as u64)
+                            .map_err(ServeError::Encode)?;
+                        for id in ids {
+                            bytes.extend_from_slice(&id.as_bytes());
+                        }
+                    }
+                    None => bytes.push(HEADERS_ENTRY_NO_TXS),
+                }
+
+                write_response_bytes(send, &bytes).await?;
+            }
+
+            Ok(())
+        }
+
+        WireRequest::GetBlocks { hashes } => {
+            let requested: HashSet<block::Hash> = hashes.iter().copied().collect();
+            let response =
+                call_inbound_service(inbound_service, Request::BlocksByHash(requested)).await?;
+
+            let available = available_blocks(response);
+
+            // Reuse one buffer across the entries, so each large entry does
+            // not grow a fresh buffer from empty.
+            let mut bytes = Vec::new();
+            for hash in hashes {
+                bytes.clear();
+                encode_result_entry(&mut bytes, available.get(&hash).map(Arc::as_ref))?;
+                write_response_bytes(send, &bytes).await?;
+            }
+
+            Ok(())
+        }
+
+        WireRequest::GetTx { refs } => {
+            // Resolve each reference to a transaction source: an ID to look
+            // up, a transaction resolved directly from a sent block, or
+            // not-found.
+            enum TxSource {
+                ById(UnminedTxId),
+                Direct(Arc<Transaction>),
+                NotFound,
+            }
+
+            // Short ID tables for the referenced blocks, built at most once
+            // per block per request. `None` records a block without a
+            // servable compact block, so repeated references to it stay
+            // cheap.
+            let mut short_id_tables: IndexMap<block::Hash, Option<SentBlockShortIds>> =
+                IndexMap::new();
+
+            let mut ids: Vec<TxSource> = Vec::with_capacity(refs.len());
+            for txref in &refs {
+                match txref {
+                    TransactionReference::Txid(_) | TransactionReference::Wtxid(_) => {
+                        let id = (*txref)
+                            .try_into()
+                            .expect("TXID and WTXID references convert to unmined ids");
+                        ids.push(TxSource::ById(id))
+                    }
+                    // Short transaction IDs identify a transaction within
+                    // the compact block most recently sent to this peer for
+                    // the referenced block. A reference to a block without a
+                    // sent compact block, or whose short ID matches no
+                    // transaction — or more than one — in the block, is
+                    // answered not-found.
+                    TransactionReference::ShortId {
+                        block_hash,
+                        short_id,
+                    } => {
+                        let table = short_id_tables.entry(*block_hash).or_insert_with(|| {
+                            // Take a handle to the block, then build the
+                            // table outside the lock: hashing every
+                            // transaction of a block must not block the
+                            // announcement and reconstruction paths that
+                            // share this mutex.
+                            let sent = shared
+                                .sent_blocks
+                                .lock()
+                                .expect("mutex is not poisoned")
+                                .get(block_hash)
+                                .map(|sent| (sent.block.clone(), sent.nonce));
+
+                            sent.and_then(|(block, nonce)| short_ids_of(&block, nonce?))
+                        });
+
+                        let source = match table.as_ref().and_then(|table| table.get(short_id)) {
+                            Some(Some(tx)) => TxSource::Direct(tx.clone()),
+                            _ => TxSource::NotFound,
+                        };
+                        ids.push(source);
+                    }
+                }
+            }
+
+            let lookup_ids: HashSet<UnminedTxId> = ids
+                .iter()
+                .filter_map(|source| match source {
+                    TxSource::ById(id) => Some(*id),
+                    _ => None,
+                })
+                .collect();
+
+            // Transactions resolved outside the mempool, served as-is.
+            let mut direct: IndexMap<UnminedTxId, Arc<Transaction>> = IndexMap::new();
+
+            let mut available: IndexMap<UnminedTxId, UnminedTx> = {
+                let pushed = shared
+                    .pushed_transactions
+                    .lock()
+                    .expect("mutex is not poisoned");
+                lookup_ids
+                    .iter()
+                    .filter_map(|id| pushed.get(id).map(|tx| (*id, tx.clone())))
+                    .collect()
+            };
+
+            let missing_ids: HashSet<UnminedTxId> = lookup_ids
+                .iter()
+                .filter(|id| !available.contains_key(*id))
+                .copied()
+                .collect();
+            if !missing_ids.is_empty() {
+                let response = call_inbound_service(
+                    inbound_service,
+                    Request::TransactionsById(missing_ids.clone()),
+                )
+                .await?;
+                if let Response::Transactions(transactions) = response {
+                    for entry in transactions {
+                        if let InventoryResponse::Available((transaction, _)) = entry {
+                            available.insert(transaction.id, transaction);
+                        }
+                    }
+                }
+            }
+
+            // Recently sent blocks fill remaining misses: their transactions
+            // must stay servable to this peer even after leaving the
+            // mempool, so reconstruction can complete.
+            let mut unresolved: HashSet<UnminedTxId> = missing_ids
+                .iter()
+                .filter(|id| !available.contains_key(*id))
+                .copied()
+                .collect();
+            if !unresolved.is_empty() {
+                // Take handles to the blocks, then search outside the lock.
+                let sent: Vec<Arc<Block>> = {
+                    let sent = shared.sent_blocks.lock().expect("mutex is not poisoned");
+                    sent.values().map(|entry| entry.block.clone()).collect()
+                };
+
+                'blocks: for block in sent {
+                    for tx in &block.transactions {
+                        let id = UnminedTxId::from(tx.as_ref());
+                        if unresolved.remove(&id) {
+                            direct.insert(id, tx.clone());
+                            if unresolved.is_empty() {
+                                break 'blocks;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Reuse one buffer across the entries, so each large entry does
+            // not grow a fresh buffer from empty.
+            let mut bytes = Vec::new();
+            for source in ids {
+                let entry: Option<&Transaction> = match &source {
+                    TxSource::ById(id) => available
+                        .get(id)
+                        .map(|transaction| transaction.transaction.as_ref())
+                        .or_else(|| direct.get(id).map(Arc::as_ref)),
+                    TxSource::Direct(transaction) => Some(transaction),
+                    TxSource::NotFound => None,
+                };
+
+                bytes.clear();
+                encode_result_entry(&mut bytes, entry)?;
+                write_response_bytes(send, &bytes).await?;
+            }
+
+            Ok(())
+        }
+
+        WireRequest::GetAddr => {
+            let response = call_inbound_service(inbound_service, Request::Peers).await?;
+            let addrs = match response {
+                Response::Peers(addrs) => addrs,
+                _ => Vec::new(),
+            };
+
+            // The inbound service bounds its address responses; if it ever
+            // returns more than the wire limit, the encoder reports a local
+            // error, and the stream is reset without blaming the peer.
+            let mut bytes = Vec::new();
+            AddrResponse(addrs).encode(&mut bytes)?;
+            write_response_bytes(send, &bytes).await
+        }
+
+        WireRequest::GetMempool => {
+            unreachable!("get-mempool subscriptions are served by serve_mempool_subscription")
+        }
+
+        WireRequest::GetBlockRange {
+            final_hash,
+            count,
+            max_bytes,
+        } => {
+            // Bound the bulk streams one peer holds open concurrently: each
+            // commits this node to up to 64 MiB of block reads and
+            // transfer. The peer sizes its work units to the bound, and a
+            // refused stream is retried on another peer.
+            let _slot = shared
+                .active_bulk_streams
+                .try_claim(MAX_CONCURRENT_BULK_STREAMS)
+                .ok_or(ServeError::Refused)?;
+
+            let mut delivered_count: u64 = 0;
+            let mut delivered_bytes: u64 = 0;
+            let mut next_hash = final_hash;
+            let mut bytes = Vec::new();
+
+            while delivered_count < count {
+                let response = call_inbound_service(
+                    inbound_service.clone(),
+                    Request::BlocksByHash(std::iter::once(next_hash).collect()),
+                )
+                .await?;
+
+                let block = available_blocks(response).swap_remove(&next_hash);
+
+                let Some(block) = block else {
+                    if delivered_count == 0 {
+                        // The anchor block is not held: a not-found result,
+                        // with nothing following.
+                        return write_response_bytes(send, &[RESULT_NOT_FOUND]).await;
+                    }
+                    // The chain ended (or the block is missing): finishing
+                    // early is allowed, and the requester can resume from
+                    // the last delivered block's parent hash.
+                    return Ok(());
+                };
+
+                let block_bytes = block.zcash_serialize_to_vec().map_err(|err| {
+                    ServeError::Encode(WireError::Local(format!("unserializable block: {err}")))
+                })?;
+
+                // Both request bounds are exact. The first block is always
+                // delivered regardless of `max_bytes`, so a maximum-size
+                // block stays retrievable; every later block must fit.
+                if delivered_count > 0
+                    && delivered_bytes.saturating_add(block_bytes.len() as u64) > max_bytes
+                {
+                    return Ok(());
+                }
+
+                bytes.clear();
+                if delivered_count == 0 {
+                    bytes.push(RESULT_OBJECT);
+                }
+                record::write_record(&mut bytes, &block_bytes).map_err(ServeError::Encode)?;
+                write_response_bytes(send, &bytes).await?;
+
+                delivered_count += 1;
+                delivered_bytes = delivered_bytes.saturating_add(block_bytes.len() as u64);
+                next_hash = block.header.previous_block_hash;
+            }
+
+            Ok(())
+        }
+
+        WireRequest::GetHashes {
+            start_height,
+            stride,
+            count,
+        } => {
+            let response = call_inbound_service(
+                inbound_service,
+                Request::SyncHashes {
+                    start_height,
+                    stride,
+                    // The wire request bounds the count at
+                    // `MAX_GET_HASHES_COUNT` (50,000), so the cast is safe.
+                    count: count as u32,
+                },
+            )
+            .await?;
+            let Response::SyncHashes(entries) = response else {
+                return Err(ServeError::Refused);
+            };
+
+            let mut bytes = Vec::new();
+            HashesResponse(entries).encode(&mut bytes)?;
+            write_response_bytes(send, &bytes).await
+        }
+
+        WireRequest::GetTreeRoots {
+            start_height,
+            final_hash,
+            count,
+        } => {
+            let response = call_inbound_service(
+                inbound_service,
+                Request::TreeRoots {
+                    start_height,
+                    final_hash,
+                    // The wire request bounds the count at
+                    // `MAX_GET_TREE_ROOTS_COUNT` (4,000), so the cast is
+                    // safe.
+                    count: count as u32,
+                },
+            )
+            .await?;
+            // Refuse when the anchor is not in the best chain, or the
+            // index is unavailable, rather than serve entries for
+            // different blocks.
+            let Response::TreeRoots(Some(entries)) = response else {
+                return Err(ServeError::Refused);
+            };
+
+            let mut bytes = Vec::new();
+            TreeRootsResponse(entries).encode(&mut bytes)?;
+            write_response_bytes(send, &bytes).await
+        }
+
+        WireRequest::GetObject {
+            hash,
+            offset,
+            length,
+        } => {
+            // A node without an artifact store refuses `get-object`; it
+            // also does not advertise `NODE_SYNC_ARTIFACTS`.
+            let Some(artifact_dir) = shared.artifact_dir.clone() else {
+                return Err(ServeError::Refused);
+            };
+
+            // Artifacts are named by the lowercase hex hash of their
+            // contents, so a lookup cannot escape the artifact directory.
+            let path = artifact_dir.join(hex::encode(hash.0));
+            let mut file = match tokio::fs::File::open(&path).await {
+                Ok(file) => file,
+                // The object is not held: a not-found result, with nothing
+                // following.
+                Err(_) => return write_response_bytes(send, &[RESULT_NOT_FOUND]).await,
+            };
+            let size = file
+                .metadata()
+                .await
+                .map_err(|err| {
+                    ServeError::Encode(WireError::Local(format!("unreadable artifact: {err}")))
+                })?
+                .len();
+
+            let mut bytes = vec![RESULT_OBJECT];
+            record::write_compact_size(&mut bytes, size).map_err(ServeError::Encode)?;
+            write_response_bytes(send, &bytes).await?;
+
+            // Deliver up to `length` bytes from `offset`, and never a byte
+            // past the object's size: both response bounds are exact. An
+            // offset at or past the size delivers no data.
+            if offset < size {
+                use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+                file.seek(std::io::SeekFrom::Start(offset))
+                    .await
+                    .map_err(|err| {
+                        ServeError::Encode(WireError::Local(format!("unseekable artifact: {err}")))
+                    })?;
+
+                let mut remaining = length.min(size - offset);
+                let mut buf = vec![0u8; 64 * 1024];
+                while remaining > 0 {
+                    // The cast is safe: `take` is at most the buffer size.
+                    let take = (buf.len() as u64).min(remaining) as usize;
+                    let read = file.read(&mut buf[..take]).await.map_err(|err| {
+                        ServeError::Encode(WireError::Local(format!("unreadable artifact: {err}")))
+                    })?;
+                    if read == 0 {
+                        // The file shrank while serving: finishing early is
+                        // allowed, and the requester re-requests the rest.
+                        break;
+                    }
+                    write_response_bytes(send, &buf[..read]).await?;
+                    remaining -= read as u64;
+                }
+            }
+
+            Ok(())
+        }
+    }
+}
+
+/// Calls the inbound service, mapping service unavailability to a stream
+/// refusal.
+async fn call_inbound_service<S>(
+    inbound_service: S,
+    request: Request,
+) -> Result<Response, ServeError>
+where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    inbound_service.oneshot(request).await.map_err(|error| {
+        // An overloaded inbound service refuses the request; the requester
+        // can retry it on another peer.
+        debug!(%error, "inbound service failed to serve v2 request");
+        ServeError::Refused
+    })
+}
+
+/// Writes response bytes to the stream, mapping errors to [`ServeError`].
+async fn write_response_bytes(
+    send: &mut quinn::SendStream,
+    bytes: &[u8],
+) -> Result<(), ServeError> {
+    send.write_all(bytes).await.map_err(|_| ServeError::Write)
+}
+
+/// Reads the stream type byte of a stream the remote peer opened, failing
+/// the connection if the peer finished the stream without one.
+///
+/// The peer must send the type byte promptly, so that a stream it opens and
+/// then leaves idle does not pin its reader task.
+///
+/// Returns `None` if the type byte did not arrive: on a stream reset,
+/// transport failure, or stall, the caller abandons the stream without
+/// penalizing the peer.
+async fn read_stream_type_or_fail(
+    shared: &SharedConnection,
+    recv: &mut quinn::RecvStream,
+) -> Option<u8> {
+    let type_byte = tokio::time::timeout(INBOUND_STREAM_TIMEOUT, record::read_u8(recv))
+        .await
+        .unwrap_or_else(|_elapsed| {
+            Err(WireError::Timeout(
+                "a stream opened without a stream type".to_string(),
+            ))
+        });
+
+    match type_byte {
+        Ok(type_byte) => Some(type_byte),
+        Err(error) => {
+            if !is_stream_failure(&error) {
+                shared.fail_protocol("peer finished a stream without a stream type");
+            }
+            None
+        }
+    }
+}
+
+/// Handles a wire error reading an inbound request: peer violations fail the
+/// connection, transport failures are ignored (the connection task reports
+/// them).
+fn handle_inbound_wire_error(shared: &SharedConnection, error: WireError) {
+    if is_stream_failure(&error) {
+        return;
+    }
+
+    // This node's own encoding failures never close the connection.
+    if let WireError::Local(reason) = &error {
+        warn!(%reason, "internal error handling an inbound v2 request");
+        return;
+    }
+
+    // Scored violations leave the connection open: the peer is banned once
+    // its accumulated score reaches the threshold.
+    if let WireError::Misbehavior { points, reason } = &error {
+        shared.report_misbehavior(*points, reason);
+        return;
+    }
+
+    shared.fail_wire_error(&error);
+}
+
+/// Reads one inbound announcement stream for the life of the stream.
+async fn read_inbound_announcement_stream<S>(
+    shared: Arc<SharedConnection>,
+    inbound_service: S,
+    mut recv: quinn::RecvStream,
+) where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    let Some(type_byte) = read_stream_type_or_fail(&shared, &mut recv).await else {
+        return;
+    };
+
+    let stream_type = match StreamType::from_byte(type_byte) {
+        Some(stream_type) if stream_type.is_announcement() => stream_type,
+        Some(_bidirectional_type) => {
+            shared.fail_protocol("bidirectional stream type on a unidirectional stream");
+            return;
+        }
+        None => {
+            let _ = recv.stop(ErrorCode::UnsupportedStreamType.into());
+            return;
+        }
+    };
+
+    // A node must not open a transaction announcement stream to a peer that
+    // declined transaction relay.
+    if stream_type == StreamType::TransactionAnnouncements && !shared.local_relay {
+        shared.fail_protocol(
+            "peer opened a transaction announcement stream after relay was declined",
+        );
+        return;
+    }
+
+    // Enforce at most one open announcement stream per type and direction.
+    {
+        let mut open = shared
+            .open_inbound_announcements
+            .lock()
+            .expect("mutex is not poisoned");
+        if !open.insert(type_byte) {
+            shared.fail_protocol(format!(
+                "peer opened a second concurrent announcement stream of type {type_byte:#04x}",
+            ));
+            return;
+        }
+    }
+
+    let mut recv = tokio::io::BufReader::with_capacity(RECORD_STREAM_READ_BUFFER_SIZE, recv);
+
+    loop {
+        // Announcement streams idle between records, so only a record the
+        // peer has started and not finished is a stall.
+        let payload = match record::read_record_timeout(&mut recv, INBOUND_STREAM_TIMEOUT).await {
+            Ok(Some(payload)) => payload,
+            Ok(None) => break,
+            Err(error) => {
+                handle_inbound_wire_error(&shared, error);
+                break;
+            }
+        };
+
+        if let Err(error) =
+            handle_announcement(&shared, inbound_service.clone(), stream_type, &payload).await
+        {
+            handle_inbound_wire_error(&shared, error);
+            break;
+        }
+    }
+
+    // The stream ended: the peer may open a replacement.
+    shared
+        .open_inbound_announcements
+        .lock()
+        .expect("mutex is not poisoned")
+        .remove(&type_byte);
+}
+
+/// Handles one inbound announcement record.
+async fn handle_announcement<S>(
+    shared: &Arc<SharedConnection>,
+    inbound_service: S,
+    stream_type: StreamType,
+    payload: &[u8],
+) -> Result<(), WireError>
+where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    match stream_type {
+        StreamType::TransactionAnnouncements => {
+            let txref = TransactionReference::parse_exact(payload).await?;
+            if txref.is_short_id() {
+                return Err(WireError::Protocol(
+                    "SHORTID reference in a transaction announcement".to_string(),
+                ));
+            }
+            let id: UnminedTxId = txref
+                .try_into()
+                .expect("non-SHORTID references convert to unmined ids");
+
+            register_advertised(shared, InventoryHash::from(id));
+
+            let request = Request::AdvertiseTransactionIds([id].into(), shared.transient_addr);
+            let _ = call_inbound_service(inbound_service, request).await;
+        }
+
+        StreamType::BlockAnnouncements => {
+            let (&kind, body) = payload.split_first().ok_or_else(|| {
+                WireError::Protocol("empty block announcement record".to_string())
+            })?;
+
+            let header_hash = match kind {
+                // A header announcement.
+                BLOCK_ANNOUNCEMENT_KIND_HEADER => {
+                    let header = block::Header::zcash_deserialize(body)?;
+                    header.hash()
+                }
+                // A compact block announcement: only conforming on
+                // connections where this node requested high-bandwidth
+                // announcements in its `init` record.
+                BLOCK_ANNOUNCEMENT_KIND_COMPACT => {
+                    if shared.hb_slot.is_none() {
+                        return Err(WireError::Protocol(
+                            "unrequested compact block announcement".to_string(),
+                        ));
+                    }
+
+                    let mut body = body;
+                    let compact = CompactBlock::read(&mut body).await?;
+                    if !body.is_empty() {
+                        return Err(WireError::Protocol(
+                            "trailing bytes in a compact block announcement".to_string(),
+                        ));
+                    }
+
+                    // The high-bandwidth penalty exemption only covers
+                    // blocks whose header is valid: an announcement whose
+                    // header fails its own proof of work is provable
+                    // misbehavior, and its block is not worth
+                    // reconstructing.
+                    if !header_pow_is_valid(&compact.header) {
+                        shared.report_misbehavior(
+                            MISBEHAVIOR_PENALTY_INVALID_POW,
+                            "compact block announcement with an invalid proof of work",
+                        );
+                        return Ok(());
+                    }
+
+                    register_advertised(shared, InventoryHash::Block(compact.header.hash()));
+                    tokio::spawn(
+                        reconstruct_compact_block(shared.clone(), inbound_service, compact)
+                            .in_current_span(),
+                    );
+                    return Ok(());
+                }
+                unknown => {
+                    return Err(WireError::Protocol(format!(
+                        "unrecognized block announcement kind {unknown:#04x}",
+                    )));
+                }
+            };
+
+            register_advertised(shared, InventoryHash::Block(header_hash));
+
+            // On connections where this node requested high-bandwidth
+            // announcements, a header announcement may be the oversize
+            // substitute for a compact block, sent before the announcer
+            // fully validated the block: the advertiser is withheld from
+            // the gossip pipeline, so a block that fails validation is not
+            // penalized. The download is still routed to announcers by the
+            // inventory registration above.
+            let advertiser = if shared.hb_slot.is_some() {
+                None
+            } else {
+                shared.transient_addr
+            };
+            let request = Request::AdvertiseBlock(header_hash, advertiser);
+            let _ = call_inbound_service(inbound_service, request).await;
+        }
+
+        StreamType::AddressAnnouncements => {
+            let addr = read_announced_addr(payload)?;
+            if let Some(addr) = addr {
+                // # Security
+                //
+                // Relayed addresses are rate-limited per connection with
+                // the reference token bucket, so an address flood cannot
+                // churn the address cache or the book. Dropped addresses
+                // incur no penalty.
+                let admitted = shared
+                    .addr_tokens
+                    .lock()
+                    .expect("mutex is not poisoned")
+                    .try_take(std::time::Instant::now());
+                if admitted {
+                    let mut cached = shared.cached_addrs.lock().expect("mutex is not poisoned");
+                    // Adds the address to the cache and bounds the cache
+                    // size, like the legacy connection's unsolicited `addr`
+                    // handling.
+                    let no_response = update_addr_cache(&mut cached, &[addr], None);
+                    debug_assert!(no_response.is_empty(), "no response was requested");
+                }
+            }
+        }
+
+        _ => unreachable!("only announcement stream types reach this function"),
+    }
+
+    Ok(())
+}
+
+/// Parses a single announced `addrv2` address record.
+fn read_announced_addr(payload: &[u8]) -> Result<Option<MetaAddr>, WireError> {
+    use crate::protocol::external::addr::v2::AddrV2;
+
+    let addr = AddrV2::zcash_deserialize(payload)?;
+
+    Ok(MetaAddr::try_from(addr).ok())
+}
+
+/// Registers advertised inventory from this peer with the inventory
+/// registry, so block and transaction downloads are routed to it.
+fn register_advertised(shared: &SharedConnection, hash: InventoryHash) {
+    if let Some(addr) = shared.transient_addr {
+        let _ = shared
+            .inv_collector
+            .send(InventoryChange::new_available(hash, addr));
+    }
+}

--- a/zebra-network/src/peer/v2/connector.rs
+++ b/zebra-network/src/peer/v2/connector.rs
@@ -1,0 +1,108 @@
+//! Wrapper around version 2 (QUIC) peer connection handshakes.
+//!
+//! This is the version 2 analog of the legacy
+//! [`Connector`](crate::peer::Connector): both answer the same
+//! [`OutboundConnectorRequest`] with the same [`Client`], so the crawler
+//! dials either transport through one interface.
+
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::FutureExt;
+use tower::{Service, ServiceExt};
+use tracing::{info_span, Instrument};
+
+use zebra_chain::{chain_tip::ChainTip, parameters::Network};
+
+use crate::{
+    peer::{
+        v2::{V2HandshakeRequest, V2Handshaker},
+        Client, ConnectedAddr, OutboundConnectorRequest,
+    },
+    protocol::v2::quic,
+    BoxError, PeerSocketAddr, Request, Response,
+};
+
+/// A wrapper around [`peer::v2::Handshake`](crate::peer::v2::Handshake) that
+/// opens a QUIC connection before the handshake.
+#[derive(Clone)]
+pub struct Connector<S, C = zebra_chain::chain_tip::NoChainTip> {
+    /// The QUIC endpoint outbound connections are opened from.
+    ///
+    /// This is the endpoint that also accepts inbound connections, so both
+    /// directions share one UDP socket.
+    endpoint: quinn::Endpoint,
+
+    /// The configured network, which selects the ALPN identifier.
+    network: Network,
+
+    /// The version 2 handshake service.
+    handshaker: V2Handshaker<S, C>,
+}
+
+impl<S, C> Connector<S, C> {
+    /// Creates a version 2 connector over `endpoint`.
+    pub fn new(
+        endpoint: quinn::Endpoint,
+        network: Network,
+        handshaker: V2Handshaker<S, C>,
+    ) -> Self {
+        Connector {
+            endpoint,
+            network,
+            handshaker,
+        }
+    }
+}
+
+impl<S, C> Service<OutboundConnectorRequest> for Connector<S, C>
+where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    C: ChainTip + Clone + Send + Sync + 'static,
+{
+    type Response = (PeerSocketAddr, Client);
+    type Error = BoxError;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: OutboundConnectorRequest) -> Self::Future {
+        let OutboundConnectorRequest {
+            addr,
+            connection_tracker,
+        } = req;
+
+        let endpoint = self.endpoint.clone();
+        let network = self.network.clone();
+        let handshaker = self.handshaker.clone();
+        let connected_addr = ConnectedAddr::new_outbound_direct(addr);
+        let connector_span = info_span!("v2_connector", peer = ?connected_addr);
+
+        // # Security
+        //
+        // The caller times this future out. Dropping it cancels the dial and
+        // releases the connection tracker, so an abandoned attempt cannot
+        // hold an outbound slot until the transport's idle timeout.
+        async move {
+            let connection = quic::connect(&endpoint, *addr, &network).await?;
+            let client = handshaker
+                .oneshot(V2HandshakeRequest {
+                    connection,
+                    connected_addr,
+                    connection_tracker,
+                })
+                .await?;
+
+            Ok((addr, client))
+        }
+        .instrument(connector_span)
+        .boxed()
+    }
+}

--- a/zebra-network/src/peer/v2/handshake.rs
+++ b/zebra-network/src/peer/v2/handshake.rs
@@ -1,0 +1,256 @@
+//! The application handshake of the version 2 Zcash P2P network protocol.
+//!
+//! Immediately after the transport connection is established, the initiator
+//! opens the dedicated handshake stream (stream type `0x00`) and the peers
+//! exchange `init` records. The handshake is complete for a peer once it has
+//! both sent and received an `init` record; the negotiated protocol version
+//! is the minimum of the two advertised versions.
+//!
+//! The handshake stream remains open for the life of the connection.
+
+use thiserror::Error;
+
+use crate::{
+    peer::handshake::HandshakeNonces,
+    protocol::{
+        external::types::Version,
+        v2::{
+            init::InitRecord,
+            record,
+            types::{ErrorCode, StreamType, WireError},
+        },
+    },
+};
+
+/// An error during the version 2 application handshake.
+#[derive(Error, Debug)]
+pub enum V2HandshakeError {
+    /// The remote peer's protocol version is below the minimum for this
+    /// protocol or the current network epoch.
+    #[error("remote peer protocol version {0:?} is obsolete")]
+    ObsoleteVersion(Version),
+
+    /// The remote peer sent a nonce that this node recently sent: the
+    /// connection is to the node itself.
+    #[error("connection to self detected")]
+    SelfConnection,
+
+    /// This node generated a nonce that collided with one already in use.
+    #[error("local nonce already used by another connection")]
+    LocalDuplicateNonce,
+
+    /// The remote peer finished the handshake stream before sending an
+    /// `init` record, signalling intent to disconnect.
+    #[error("remote peer closed the handshake stream before sending an init record")]
+    ConnectionClosed,
+
+    /// A wire-format error reading the remote peer's handshake records.
+    #[error("handshake wire error: {0}")]
+    Wire(#[from] WireError),
+
+    /// The transport connection failed during the handshake.
+    #[error("connection error during handshake: {0}")]
+    Connection(#[from] quinn::ConnectionError),
+
+    /// A stream write failed during the handshake.
+    #[error("stream write error during handshake: {0}")]
+    Write(#[from] quinn::WriteError),
+}
+
+impl V2HandshakeError {
+    /// Returns the application error code to close the connection with, if
+    /// this error requires closing the connection.
+    pub fn connection_error_code(&self) -> Option<ErrorCode> {
+        match self {
+            V2HandshakeError::ObsoleteVersion(_) => Some(ErrorCode::Obsolete),
+            V2HandshakeError::SelfConnection => Some(ErrorCode::SelfConnection),
+            V2HandshakeError::LocalDuplicateNonce => Some(ErrorCode::InternalError),
+            V2HandshakeError::ConnectionClosed => Some(ErrorCode::NoError),
+            V2HandshakeError::Wire(wire) => wire.connection_error_code(),
+            V2HandshakeError::Connection(_) | V2HandshakeError::Write(_) => None,
+        }
+    }
+}
+
+/// The shared parameters of a version 2 handshake.
+#[derive(Clone, Debug)]
+pub struct HandshakeParams {
+    /// The `init` record to send, containing a freshly generated nonce.
+    pub local_init: InitRecord,
+
+    /// The minimum acceptable remote protocol version: the maximum of the
+    /// v2 protocol's minimum version and the version required by the current
+    /// network epoch.
+    pub min_remote_version: Version,
+
+    /// The set of nonces recently sent in `init` records by this node, for
+    /// self-connection detection. Shared between all connections.
+    pub nonces: HandshakeNonces,
+
+    /// The maximum number of nonces to keep in the shared set, bounding its
+    /// memory use. Usually the configured total connection limit.
+    pub nonce_limit: usize,
+}
+
+/// A completed version 2 handshake.
+///
+/// The handshake stream halves are kept open for the life of the connection:
+/// finishing or resetting the handshake stream signals intent to disconnect.
+#[derive(Debug)]
+pub struct V2Handshake {
+    /// The remote peer's `init` record.
+    pub remote_init: InitRecord,
+
+    /// The negotiated protocol version:
+    /// `min(local_version, remote_version)`.
+    pub negotiated_version: Version,
+
+    /// The sending half of the handshake stream.
+    pub handshake_send: quinn::SendStream,
+
+    /// The receiving half of the handshake stream.
+    pub handshake_recv: quinn::RecvStream,
+}
+
+/// Performs the version 2 handshake as the connection initiator:
+/// opens the handshake stream, sends the local `init` record, and reads and
+/// validates the remote peer's `init` record.
+///
+/// On validation failure, closes the connection with the applicable error
+/// code. The caller should apply an overall handshake timeout.
+pub async fn initiate(
+    connection: &quinn::Connection,
+    params: &HandshakeParams,
+) -> Result<V2Handshake, V2HandshakeError> {
+    register_local_nonce(params).await?;
+
+    let handshake = async {
+        let (mut handshake_send, handshake_recv) = connection.open_bi().await?;
+
+        handshake_send
+            .write_all(&[StreamType::Handshake.byte()])
+            .await?;
+        params.local_init.write(&mut handshake_send).await?;
+
+        read_and_validate_remote_init(handshake_send, handshake_recv, params).await
+    }
+    .await;
+
+    finish_handshake(connection, handshake)
+}
+
+/// Performs the version 2 handshake as the connection responder:
+/// accepts streams until the handshake stream arrives (refusing any other
+/// stream opened before the handshake), sends the local `init` record, and
+/// reads and validates the remote peer's `init` record.
+///
+/// On validation failure, closes the connection with the applicable error
+/// code. The caller should apply an overall handshake timeout.
+pub async fn respond(
+    connection: &quinn::Connection,
+    params: &HandshakeParams,
+) -> Result<V2Handshake, V2HandshakeError> {
+    register_local_nonce(params).await?;
+
+    let handshake = async {
+        let (mut handshake_send, handshake_recv) = loop {
+            let (send, mut recv) = connection.accept_bi().await?;
+
+            match record::read_u8(&mut recv).await {
+                Ok(type_byte) if type_byte == StreamType::Handshake.byte() => {
+                    break (send, recv);
+                }
+                Ok(_other_stream_type) => {
+                    // A stream received before the handshake completes may
+                    // be refused; the peer can retry it afterwards.
+                    refuse_stream(send, recv);
+                }
+                // The stream was reset before its type byte arrived.
+                Err(_) => drop((send, recv)),
+            }
+        };
+
+        // Send the local init record as soon as the handshake stream's type
+        // byte has been observed, without waiting for the remote init record.
+        params.local_init.write(&mut handshake_send).await?;
+
+        read_and_validate_remote_init(handshake_send, handshake_recv, params).await
+    }
+    .await;
+
+    finish_handshake(connection, handshake)
+}
+
+/// Reads the remote `init` record and validates it against `params`.
+async fn read_and_validate_remote_init(
+    handshake_send: quinn::SendStream,
+    mut handshake_recv: quinn::RecvStream,
+    params: &HandshakeParams,
+) -> Result<V2Handshake, V2HandshakeError> {
+    let remote_init = InitRecord::read(&mut handshake_recv)
+        .await?
+        .ok_or(V2HandshakeError::ConnectionClosed)?;
+
+    if remote_init.version < params.min_remote_version {
+        return Err(V2HandshakeError::ObsoleteVersion(remote_init.version));
+    }
+
+    // Check the remote nonce against every nonce this node recently sent:
+    // any match means the connection is to the node itself, possibly via a
+    // simultaneous connection in each direction.
+    if params.nonces.contains(&remote_init.nonce).await {
+        return Err(V2HandshakeError::SelfConnection);
+    }
+
+    let negotiated_version = std::cmp::min(params.local_init.version, remote_init.version);
+
+    Ok(V2Handshake {
+        remote_init,
+        negotiated_version,
+        handshake_send,
+        handshake_recv,
+    })
+}
+
+/// Inserts the local nonce into the shared nonce set, bounding the set's
+/// size.
+async fn register_local_nonce(params: &HandshakeParams) -> Result<(), V2HandshakeError> {
+    if !params
+        .nonces
+        .register(params.local_init.nonce, params.nonce_limit)
+        .await
+    {
+        return Err(V2HandshakeError::LocalDuplicateNonce);
+    }
+
+    Ok(())
+}
+
+/// Closes the connection with the applicable error code if the handshake
+/// failed.
+fn finish_handshake(
+    connection: &quinn::Connection,
+    handshake: Result<V2Handshake, V2HandshakeError>,
+) -> Result<V2Handshake, V2HandshakeError> {
+    if let Err(error) = &handshake {
+        if let Some(code) = error.connection_error_code() {
+            connection.close(code.into(), error.to_string().as_bytes());
+        }
+
+        // The local nonce is deliberately not evicted here, even though this
+        // handshake will not use it again: see the security note on
+        // [`HandshakeNonces::contains`].
+    }
+
+    handshake
+}
+
+/// Refuses a bidirectional stream: cancels the peer's sending direction and
+/// resets the local sending direction, both with the `REFUSED` error code.
+fn refuse_stream(mut send: quinn::SendStream, mut recv: quinn::RecvStream) {
+    let _ = recv.stop(ErrorCode::Refused.into());
+    let _ = send.reset(ErrorCode::Refused.into());
+}
+
+#[cfg(test)]
+mod tests;

--- a/zebra-network/src/peer/v2/handshake/tests.rs
+++ b/zebra-network/src/peer/v2/handshake/tests.rs
@@ -1,0 +1,3 @@
+//! Tests for the version 2 application handshake.
+
+mod vectors;

--- a/zebra-network/src/peer/v2/handshake/tests/vectors.rs
+++ b/zebra-network/src/peer/v2/handshake/tests/vectors.rs
@@ -1,0 +1,263 @@
+//! Handshake tests over loopback QUIC connections.
+
+use zebra_chain::{block, parameters::Network};
+
+use crate::{
+    peer::{
+        handshake::HandshakeNonces,
+        v2::handshake::{initiate, respond, HandshakeParams, V2HandshakeError},
+    },
+    protocol::{
+        external::types::{Nonce, PeerServices, Version},
+        v2::{constants::MIN_V2_PROTOCOL_VERSION, init::InitRecord, quic, types::ErrorCode},
+    },
+};
+
+/// A handshake timeout that is generous enough for loopback tests.
+const TEST_HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+fn test_init(version: Version, nonce: Nonce) -> InitRecord {
+    InitRecord {
+        version,
+        services: PeerServices::NODE_NETWORK,
+        nonce,
+        user_agent: "/ZebraV2Test:0.0.1/".to_string(),
+        start_height: block::Height(0),
+        relay: true,
+        announce: false,
+        full_ids: false,
+    }
+}
+
+fn test_params(version: Version, nonce: Nonce) -> HandshakeParams {
+    HandshakeParams {
+        local_init: test_init(version, nonce),
+        min_remote_version: MIN_V2_PROTOCOL_VERSION,
+        nonces: HandshakeNonces::default(),
+        nonce_limit: 100,
+    }
+}
+
+/// Establishes a pair of connected loopback QUIC connections.
+async fn connected_pair() -> (quinn::Connection, quinn::Connection) {
+    let network = Network::Mainnet;
+    let server = quic::new_endpoint("127.0.0.1:0".parse().expect("valid address"), &network)
+        .expect("endpoint creation succeeds");
+    let client = quic::new_endpoint("127.0.0.1:0".parse().expect("valid address"), &network)
+        .expect("endpoint creation succeeds");
+    let server_addr = server.local_addr().expect("endpoint has a local address");
+
+    let accept_task = tokio::spawn(async move {
+        let incoming = server.accept().await.expect("endpoint accepts");
+        let connection = quic::accept(incoming, &Network::Mainnet)
+            .await
+            .expect("inbound connection completes");
+        // Keep the server endpoint alive for the life of the test connection.
+        (connection, server)
+    });
+
+    let outbound = quic::connect(&client, server_addr, &network)
+        .await
+        .expect("outbound connection completes");
+    let (inbound, server) = accept_task.await.expect("accept task succeeds");
+
+    // Leak the endpoints so they outlive the test connections.
+    std::mem::forget(server);
+    std::mem::forget(client);
+
+    (outbound, inbound)
+}
+
+#[tokio::test]
+async fn handshake_succeeds() {
+    let _init_guard = zebra_test::init();
+
+    let (outbound, inbound) = connected_pair().await;
+
+    let initiator_params = test_params(Version(MIN_V2_PROTOCOL_VERSION.0 + 10), Nonce(1111));
+    let responder_params = test_params(MIN_V2_PROTOCOL_VERSION, Nonce(2222));
+
+    let responder = tokio::spawn(async move {
+        tokio::time::timeout(TEST_HANDSHAKE_TIMEOUT, respond(&inbound, &responder_params))
+            .await
+            .expect("handshake completes in time")
+    });
+
+    let initiator_handshake = tokio::time::timeout(
+        TEST_HANDSHAKE_TIMEOUT,
+        initiate(&outbound, &initiator_params),
+    )
+    .await
+    .expect("handshake completes in time")
+    .expect("initiator handshake succeeds");
+
+    let responder_handshake = responder
+        .await
+        .expect("responder task succeeds")
+        .expect("responder handshake succeeds");
+
+    // Both peers negotiate the lower of the two advertised versions.
+    assert_eq!(
+        initiator_handshake.negotiated_version,
+        MIN_V2_PROTOCOL_VERSION,
+    );
+    assert_eq!(
+        responder_handshake.negotiated_version,
+        MIN_V2_PROTOCOL_VERSION,
+    );
+
+    assert_eq!(initiator_handshake.remote_init.nonce, Nonce(2222));
+    assert_eq!(responder_handshake.remote_init.nonce, Nonce(1111));
+    assert_eq!(
+        initiator_handshake.remote_init.user_agent,
+        "/ZebraV2Test:0.0.1/",
+    );
+}
+
+#[tokio::test]
+async fn handshake_rejects_obsolete_version() {
+    let _init_guard = zebra_test::init();
+
+    let (outbound, inbound) = connected_pair().await;
+
+    // The initiator advertises a version below the responder's minimum.
+    let initiator_params = test_params(Version(MIN_V2_PROTOCOL_VERSION.0 - 1), Nonce(1111));
+    let responder_params = test_params(MIN_V2_PROTOCOL_VERSION, Nonce(2222));
+
+    let responder = tokio::spawn(async move {
+        tokio::time::timeout(TEST_HANDSHAKE_TIMEOUT, respond(&inbound, &responder_params))
+            .await
+            .expect("handshake fails in time")
+    });
+
+    let initiator_result = tokio::time::timeout(
+        TEST_HANDSHAKE_TIMEOUT,
+        initiate(&outbound, &initiator_params),
+    )
+    .await
+    .expect("handshake fails in time");
+
+    let responder_result = responder.await.expect("responder task succeeds");
+    assert!(
+        matches!(responder_result, Err(V2HandshakeError::ObsoleteVersion(_))),
+        "got: {responder_result:?}",
+    );
+
+    // The initiator observes the connection close with the OBSOLETE code.
+    // Depending on timing, the initiator's own handshake may complete just
+    // before the close arrives: the responder sends its init record before
+    // validating the initiator's.
+    let closed = tokio::time::timeout(TEST_HANDSHAKE_TIMEOUT, outbound.closed())
+        .await
+        .expect("close arrives in time");
+    match closed {
+        quinn::ConnectionError::ApplicationClosed(closed) => {
+            assert_eq!(
+                u64::from(closed.error_code),
+                ErrorCode::Obsolete.wire_code(),
+            );
+        }
+        // The responder's close can outrace its init record: the initiator
+        // then fails its handshake read and closes its side first.
+        quinn::ConnectionError::LocallyClosed => {
+            assert!(
+                initiator_result.is_err(),
+                "a locally-closed connection implies an initiator handshake error",
+            );
+        }
+        other => panic!("expected an OBSOLETE application close, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn handshake_detects_self_connection() {
+    let _init_guard = zebra_test::init();
+
+    let (outbound, inbound) = connected_pair().await;
+
+    // Both sides share the same nonce set and use the same nonce, as when a
+    // node connects to its own listener.
+    let nonces = HandshakeNonces::default();
+    let shared_nonce = Nonce(0xAAAA_BBBB_CCCC_DDDD);
+
+    let mut initiator_params = test_params(MIN_V2_PROTOCOL_VERSION, shared_nonce);
+    initiator_params.nonces = nonces.clone();
+    let mut responder_params = test_params(MIN_V2_PROTOCOL_VERSION, shared_nonce);
+    responder_params.nonces = nonces;
+
+    let responder = tokio::spawn(async move {
+        tokio::time::timeout(TEST_HANDSHAKE_TIMEOUT, respond(&inbound, &responder_params))
+            .await
+            .expect("handshake fails in time")
+    });
+
+    let initiator_result = tokio::time::timeout(
+        TEST_HANDSHAKE_TIMEOUT,
+        initiate(&outbound, &initiator_params),
+    )
+    .await
+    .expect("handshake fails in time");
+    let responder_result = responder.await.expect("responder task succeeds");
+
+    // At least one side must detect the self-connection; the other may see
+    // either the same detection or the resulting connection close.
+    let self_connection_detected = matches!(
+        initiator_result,
+        Err(V2HandshakeError::SelfConnection) | Err(V2HandshakeError::LocalDuplicateNonce)
+    ) || matches!(
+        responder_result,
+        Err(V2HandshakeError::SelfConnection) | Err(V2HandshakeError::LocalDuplicateNonce)
+    );
+    assert!(
+        self_connection_detected,
+        "self connection must be detected: initiator: {initiator_result:?}, \
+         responder: {responder_result:?}",
+    );
+}
+
+#[tokio::test]
+async fn responder_refuses_streams_before_handshake() {
+    let _init_guard = zebra_test::init();
+
+    let (outbound, inbound) = connected_pair().await;
+
+    let initiator_params = test_params(MIN_V2_PROTOCOL_VERSION, Nonce(1111));
+    let responder_params = test_params(MIN_V2_PROTOCOL_VERSION, Nonce(2222));
+
+    let responder = tokio::spawn(async move {
+        tokio::time::timeout(TEST_HANDSHAKE_TIMEOUT, respond(&inbound, &responder_params))
+            .await
+            .expect("handshake completes in time")
+    });
+
+    // Open a request stream before the handshake stream: the responder
+    // refuses it and still completes the handshake.
+    let (mut early_send, _early_recv) = outbound.open_bi().await.expect("stream opens");
+    early_send
+        .write_all(&[crate::protocol::v2::types::StreamType::GetHeaders.byte()])
+        .await
+        .expect("stream write succeeds");
+
+    let initiator_handshake = tokio::time::timeout(
+        TEST_HANDSHAKE_TIMEOUT,
+        initiate(&outbound, &initiator_params),
+    )
+    .await
+    .expect("handshake completes in time")
+    .expect("initiator handshake succeeds");
+
+    let responder_handshake = responder
+        .await
+        .expect("responder task succeeds")
+        .expect("responder handshake succeeds");
+
+    assert_eq!(initiator_handshake.remote_init.nonce, Nonce(2222));
+    assert_eq!(responder_handshake.remote_init.nonce, Nonce(1111));
+
+    // The early stream is eventually stopped with the REFUSED error code.
+    let stopped = tokio::time::timeout(TEST_HANDSHAKE_TIMEOUT, early_send.stopped())
+        .await
+        .expect("refusal arrives in time")
+        .expect("stopped() resolves");
+    assert_eq!(stopped.map(u64::from), Some(ErrorCode::Refused.wire_code()),);
+}

--- a/zebra-network/src/peer/v2/service.rs
+++ b/zebra-network/src/peer/v2/service.rs
@@ -1,0 +1,414 @@
+//! A [`Service`] that performs version 2 handshakes on established QUIC
+//! connections and constructs peer [`Client`]s.
+//!
+//! This is the version 2 analog of the legacy
+//! [`Handshake`](crate::peer::Handshake) service: it produces the same
+//! [`Client`] type, so v2 peers plug into the peer set alongside legacy
+//! peers.
+
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task::{Context, Poll},
+};
+
+use futures::{channel::oneshot, FutureExt};
+use tokio::time::timeout;
+use tower::Service;
+use tracing_futures::Instrument;
+
+use zebra_chain::chain_tip::{ChainTip, NoChainTip};
+
+use crate::{
+    constants,
+    meta_addr::MetaAddr,
+    peer::{
+        handshake::{
+            report_handshake_success, send_periodic_heartbeats_with_shutdown_handle,
+            HandshakeNonces,
+        },
+        v2::connection,
+        v2::handshake,
+        Client, ConnectedAddr, ConnectionInfo, MinimumPeerVersion, RemoteHandshake,
+    },
+    peer_set::{ConnectionTracker, InventoryChange},
+    protocol::{
+        external::{
+            addr::v2::AddrV2,
+            types::{Nonce, PeerServices},
+        },
+        v2::{
+            constants::{
+                MAX_HIGH_BANDWIDTH_PEERS, MIN_V2_PROTOCOL_VERSION, SELF_ADDR_ANNOUNCEMENT_INTERVAL,
+            },
+            init::InitRecord,
+            types::StreamType,
+        },
+    },
+    BoxError, Config, PeerSocketAddr, Request, Response,
+};
+
+/// A request to perform a version 2 handshake on an established QUIC
+/// connection.
+pub struct HandshakeRequest {
+    /// The established QUIC connection, with ALPN already checked.
+    pub connection: quinn::Connection,
+
+    /// The address of the remote peer, and how the connection was made.
+    pub connected_addr: ConnectedAddr,
+
+    /// A connection tracker that reduces the open connection count when
+    /// dropped.
+    pub connection_tracker: ConnectionTracker,
+}
+
+/// A [`Service`] that performs version 2 handshakes and constructs peer
+/// [`Client`]s.
+#[derive(Clone)]
+pub struct Handshake<S, C = NoChainTip> {
+    /// The shared network configuration.
+    config: Config,
+
+    /// The user agent advertised in `init` records.
+    user_agent: String,
+
+    /// The services advertised in `init` records.
+    our_services: PeerServices,
+
+    /// Whether this node requests transaction relay from its peers.
+    relay: bool,
+
+    /// The service that handles requests from remote peers.
+    inbound_service: S,
+
+    /// Sends peer status updates to the address book.
+    address_book_updater: crate::peer_book::ChangeSender,
+
+    /// Sends misbehavior scores for peers that violate the protocol, so they
+    /// are banned once they reach the ban threshold.
+    misbehavior_tx: tokio::sync::mpsc::Sender<(PeerSocketAddr, u32)>,
+
+    /// Registers inventory advertised by remote peers.
+    inv_collector: tokio::sync::broadcast::Sender<InventoryChange>,
+
+    /// The minimum peer protocol version for the current network epoch.
+    minimum_peer_version: MinimumPeerVersion<C>,
+
+    /// The local listener address, announced to peers on each connection's
+    /// address announcement stream.
+    local_listener: std::net::SocketAddr,
+
+    /// The nonces recently sent in `init` records, shared between v2
+    /// connections for self-connection detection.
+    nonces: HandshakeNonces,
+
+    /// The connections currently claiming one of this node's high-bandwidth
+    /// compact block announcement slots.
+    hb_slots: crate::peer_set::SlotCounter,
+
+    /// The directory of content-addressed synchronization artifacts served
+    /// to `get-object` requests, when it exists.
+    artifact_dir: Option<Arc<std::path::PathBuf>>,
+}
+
+impl<S, C> Handshake<S, C>
+where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    C: ChainTip + Clone + Send + Sync + 'static,
+{
+    /// Creates a new version 2 handshake service.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        config: Config,
+        user_agent: String,
+        our_services: PeerServices,
+        relay: bool,
+        inbound_service: S,
+        address_book_updater: crate::peer_book::ChangeSender,
+        misbehavior_tx: tokio::sync::mpsc::Sender<(PeerSocketAddr, u32)>,
+        inv_collector: tokio::sync::broadcast::Sender<InventoryChange>,
+        minimum_peer_version: MinimumPeerVersion<C>,
+        local_listener: std::net::SocketAddr,
+    ) -> Self {
+        let artifact_dir = config
+            .cache_dir
+            .artifact_dir_path(&config.network)
+            .map(Arc::new);
+
+        Handshake {
+            config,
+            user_agent,
+            our_services,
+            relay,
+            inbound_service,
+            address_book_updater,
+            misbehavior_tx,
+            inv_collector,
+            minimum_peer_version,
+            artifact_dir,
+            local_listener,
+            nonces: HandshakeNonces::default(),
+            hb_slots: Default::default(),
+        }
+    }
+
+    /// Builds the local `init` record for a new connection.
+    fn local_init(&mut self, announce: bool) -> InitRecord {
+        let start_height = self
+            .minimum_peer_version
+            .chain_tip()
+            .best_tip_height()
+            .unwrap_or(zebra_chain::block::Height(0));
+
+        InitRecord {
+            version: constants::CURRENT_NETWORK_PROTOCOL_VERSION,
+            services: self.our_services,
+            nonce: Nonce::default(),
+            user_agent: self.user_agent.clone(),
+            start_height,
+            relay: self.relay,
+            announce,
+            // Short transaction IDs are matched against the local mempool,
+            // so the larger full-ID compact blocks are never requested.
+            full_ids: false,
+        }
+    }
+}
+
+impl<S, C> Service<HandshakeRequest> for Handshake<S, C>
+where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    C: ChainTip + Clone + Send + Sync + 'static,
+{
+    type Response = Client;
+    type Error = BoxError;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: HandshakeRequest) -> Self::Future {
+        let HandshakeRequest {
+            connection,
+            connected_addr,
+            mut connection_tracker,
+        } = request;
+
+        let negotiator_span = tracing::debug_span!("v2_handshake", peer = ?connected_addr);
+
+        // Request high-bandwidth compact block announcements on up to
+        // `MAX_HIGH_BANDWIDTH_PEERS` self-initiated connections at a time.
+        // The preference is fixed for the life of a connection, so the slot
+        // is held until the connection is dropped.
+        let hb_slot = if connected_addr.is_inbound() {
+            None
+        } else {
+            self.hb_slots.try_claim(MAX_HIGH_BANDWIDTH_PEERS)
+        };
+        let local_init = self.local_init(hb_slot.is_some());
+        let params = handshake::HandshakeParams {
+            local_init: local_init.clone(),
+            min_remote_version: std::cmp::max(
+                MIN_V2_PROTOCOL_VERSION,
+                self.minimum_peer_version.current(),
+            ),
+            nonces: self.nonces.clone(),
+            nonce_limit: self.config.peerset_total_connection_limit(),
+        };
+
+        let inbound_service = self.inbound_service.clone();
+        let artifact_dir = self.artifact_dir.clone();
+        let address_book_updater = self.address_book_updater.clone();
+        let misbehavior_tx = self.misbehavior_tx.clone();
+        let inv_collector = self.inv_collector.clone();
+        let local_listener = self.local_listener;
+        let network = self.config.network.clone();
+
+        let fut = async move {
+            let handshake_result = if connected_addr.is_inbound() {
+                handshake::respond(&connection, &params).await
+            } else {
+                handshake::initiate(&connection, &params).await
+            };
+            let handshake = handshake_result?;
+
+            let remote_init = Arc::new(handshake.remote_init);
+            let connection_info = Arc::new(ConnectionInfo {
+                connected_addr,
+                remote: RemoteHandshake::Init(remote_init.clone()),
+                negotiated_version: handshake.negotiated_version,
+            });
+
+            // The handshake succeeded: update the address book and the
+            // active connection counter.
+            report_handshake_success(
+                &mut connection_tracker,
+                &connected_addr,
+                remote_init.services,
+                remote_init.user_agent.clone(),
+                handshake.negotiated_version,
+                &address_book_updater,
+            )
+            .await;
+
+            let (server_tx, server_rx) = futures::channel::mpsc::channel(0);
+            let (shutdown_tx, shutdown_rx) = oneshot::channel();
+            let (announcement_tx, announcement_rx) =
+                tokio::sync::mpsc::channel(connection::ANNOUNCEMENT_QUEUE_LIMIT);
+            let error_slot = crate::peer::ErrorSlot::default();
+
+            let shared = Arc::new(connection::SharedConnection {
+                quic: connection.clone(),
+                error_slot: error_slot.clone(),
+                remote_init,
+                local_relay: local_init.relay,
+                hb_slot,
+                transient_addr: connected_addr.get_transient_addr(),
+                is_inbound: connected_addr.is_inbound(),
+                inv_collector: inv_collector.clone(),
+                misbehavior_tx,
+                announcement_tx,
+                pushed_transactions: Mutex::new(Default::default()),
+                sent_blocks: Mutex::new(Default::default()),
+                reconstructed_blocks: Mutex::new(Default::default()),
+                mempool_updates: tokio::sync::broadcast::channel(
+                    connection::MEMPOOL_UPDATES_CHANNEL_CAPACITY,
+                )
+                .0,
+                mempool_subscribed: Default::default(),
+                remote_mempool: Mutex::new(Default::default()),
+                pending_tx_announcements: Mutex::new(Default::default()),
+                cached_addrs: Mutex::new(Vec::new()),
+                addr_tokens: Mutex::new(Default::default()),
+                open_inbound_announcements: Mutex::new(Default::default()),
+                sent_get_addr: Default::default(),
+                consecutive_timeouts: Default::default(),
+                active_bulk_streams: Default::default(),
+                artifact_dir,
+            });
+
+            let announcer_shared = shared.clone();
+            let subscription_shared = shared.clone();
+            let subscription_service = inbound_service.clone();
+            let trickle_shared = shared.clone();
+
+            let server = connection::Connection {
+                shared,
+                inbound_service,
+                client_rx: server_rx.into(),
+                handshake_recv: handshake.handshake_recv,
+                handshake_send: handshake.handshake_send,
+                announcement_rx,
+                connection_tracker,
+            };
+
+            let connection_task = tokio::spawn(server.run().in_current_span().boxed());
+
+            // Announce this node's own listener address on the address
+            // announcement stream: peers learn dialable v2 addresses only
+            // through address announcements and `get-addr`. The task ends
+            // when the connection closes.
+            tokio::spawn(
+                announce_local_listener(announcer_shared, local_listener, network)
+                    .in_current_span(),
+            );
+
+            // Trickle queued transaction announcements and mempool
+            // subscription updates to the peer. The task ends when the
+            // connection closes.
+            tokio::spawn(
+                connection::trickle_transaction_announcements(trickle_shared).in_current_span(),
+            );
+
+            // Subscribe to the peer's mempool, unless this node declined
+            // transaction relay. The subscription mirrors the peer's
+            // mempool into the connection's cache, and ends when the peer
+            // refuses it or the connection closes.
+            if local_init.relay {
+                tokio::spawn(
+                    connection::maintain_mempool_subscription(
+                        subscription_shared,
+                        subscription_service,
+                    )
+                    .in_current_span(),
+                );
+            }
+
+            let heartbeat_task = tokio::spawn(
+                send_periodic_heartbeats_with_shutdown_handle(
+                    connected_addr,
+                    shutdown_rx,
+                    server_tx.clone(),
+                    address_book_updater.clone(),
+                )
+                .instrument(tracing::debug_span!("v2_heartbeat"))
+                .boxed(),
+            );
+
+            Ok::<Client, BoxError>(Client {
+                connection_info,
+                shutdown_tx: Some(shutdown_tx),
+                server_tx,
+                inv_collector,
+                error_slot,
+                connection_task,
+                heartbeat_task,
+            })
+        };
+
+        // Defence-in-depth against handshake hangs.
+        let fut = timeout(constants::HANDSHAKE_TIMEOUT, fut);
+
+        async move {
+            match fut.await {
+                Ok(result) => result,
+                Err(_elapsed) => Err(crate::peer::HandshakeError::Timeout.into()),
+            }
+        }
+        .instrument(negotiator_span)
+        .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests;
+
+/// Announces this node's own listener address on `shared`'s address
+/// announcement stream, once immediately and then per
+/// [`SELF_ADDR_ANNOUNCEMENT_INTERVAL`], until the connection closes.
+///
+/// Addresses that must not be gossiped (for example, an unspecified
+/// listener IP) are never announced: `sanitize` rejects them, and truncates
+/// times so announcements cannot fingerprint this node.
+async fn announce_local_listener(
+    shared: Arc<connection::SharedConnection>,
+    local_listener: std::net::SocketAddr,
+    network: zebra_chain::parameters::Network,
+) {
+    use zebra_chain::serialization::{DateTime32, ZcashSerialize};
+
+    loop {
+        let listener_entry = MetaAddr::new_local_listener_change(local_listener)
+            .local_listener_into_new_meta_addr(DateTime32::now());
+
+        if let Some(sanitized) = listener_entry.sanitize(&network) {
+            let mut payload = Vec::new();
+            if AddrV2::from(sanitized)
+                .zcash_serialize(&mut payload)
+                .is_ok()
+            {
+                shared.enqueue_announcement(StreamType::AddressAnnouncements, payload);
+            }
+        }
+
+        tokio::select! {
+            _ = shared.quic.closed() => break,
+            _ = tokio::time::sleep(SELF_ADDR_ANNOUNCEMENT_INTERVAL) => {}
+        }
+    }
+}

--- a/zebra-network/src/peer/v2/service/tests.rs
+++ b/zebra-network/src/peer/v2/service/tests.rs
@@ -1,0 +1,3 @@
+//! Tests for the version 2 handshake service and connection.
+
+mod vectors;

--- a/zebra-network/src/peer/v2/service/tests/vectors.rs
+++ b/zebra-network/src/peer/v2/service/tests/vectors.rs
@@ -1,0 +1,2830 @@
+//! End-to-end tests: two full v2 peer stacks over loopback QUIC.
+
+use std::{
+    collections::HashSet,
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use indexmap::IndexMap;
+use tower::{Service, ServiceExt};
+
+use zebra_chain::{
+    block::{Block, CountedHeader},
+    chain_tip::NoChainTip,
+    parameters::Network,
+    serialization::{DateTime32, ZcashDeserializeInto},
+    transaction::UnminedTx,
+};
+
+use crate::{
+    meta_addr::MetaAddr,
+    peer::{
+        v2::service::{Handshake as V2Handshake, HandshakeRequest as V2HandshakeRequest},
+        Client, ConnectedAddr, MinimumPeerVersion,
+    },
+    peer_set::ActiveConnectionCounter,
+    protocol::{
+        external::types::PeerServices,
+        internal::{InventoryResponse, Request, Response},
+        v2::{
+            constants::{
+                MAX_CONSECUTIVE_REQUEST_TIMEOUTS, MAX_HEADERS_RESULTS,
+                MISBEHAVIOR_PENALTY_LIMIT_EXCEEDED,
+            },
+            quic,
+        },
+    },
+    BoxError, Config, PeerSocketAddr,
+};
+
+/// A generous timeout for loopback test operations.
+const TEST_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// The test data served by a [`TestInbound`] service.
+struct TestData {
+    /// Contiguous mainnet headers (blocks 1 and 2).
+    headers: Vec<CountedHeader>,
+
+    /// Mainnet block 1: the block of `headers[0]`.
+    block_1: Arc<Block>,
+
+    /// Mainnet block 2: the block of `headers[1]`, and the child of
+    /// block 1.
+    block_2: Arc<Block>,
+
+    /// A block with several transactions.
+    block: Arc<Block>,
+
+    /// The blocks the inbound service serves by hash.
+    ///
+    /// Tests that need an unavailable block remove it from this map.
+    served_blocks: IndexMap<zebra_chain::block::Hash, Arc<Block>>,
+
+    /// A mempool transaction served by ID.
+    transaction: UnminedTx,
+
+    /// The peers returned for address requests.
+    peers: Vec<MetaAddr>,
+
+    /// If set, the inbound service never answers, simulating a peer whose
+    /// QUIC stack is alive but whose application is wedged.
+    hang_inbound: bool,
+}
+
+impl TestData {
+    fn new() -> Self {
+        let block_1: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_1_BYTES
+            .zcash_deserialize_into::<Block>()
+            .expect("block test vector parses")
+            .into();
+        let block_2: Arc<Block> = zebra_test::vectors::BLOCK_MAINNET_2_BYTES
+            .zcash_deserialize_into::<Block>()
+            .expect("block test vector parses")
+            .into();
+
+        let transaction = UnminedTx::from(block_2.transactions[0].clone());
+
+        // A block with several transactions, so compact blocks built from it
+        // have short transaction IDs.
+        let multi_tx_block: Arc<Block> = zebra_test::vectors::MAINNET_BLOCKS
+            .values()
+            .map(|bytes| {
+                bytes
+                    .zcash_deserialize_into::<Block>()
+                    .expect("block test vectors parse")
+            })
+            .find(|block| block.transactions.len() >= 3)
+            .expect("some mainnet block test vector has at least 3 transactions")
+            .into();
+
+        TestData {
+            headers: vec![
+                CountedHeader {
+                    header: block_1.header.clone(),
+                },
+                CountedHeader {
+                    header: block_2.header.clone(),
+                },
+            ],
+            served_blocks: [&block_1, &block_2, &multi_tx_block]
+                .into_iter()
+                .map(|block| (block.hash(), block.clone()))
+                .collect(),
+            block_1: block_1.clone(),
+            block_2: block_2.clone(),
+            block: multi_tx_block,
+            transaction,
+            peers: vec![MetaAddr::new_gossiped_meta_addr(
+                "203.0.113.7:8233".parse().expect("valid address"),
+                PeerServices::NODE_NETWORK,
+                DateTime32::from(1_700_000_000),
+            )],
+            hang_inbound: false,
+        }
+    }
+}
+
+/// The fixed `get-hashes` entries served by [`TestInbound`].
+fn test_sync_hash_entries(data: &TestData) -> Vec<zebra_chain::block::SyncHashEntry> {
+    vec![
+        zebra_chain::block::SyncHashEntry {
+            hash: data.block_1.hash(),
+            span_size: 1,
+            span_txs: 1,
+            span_notes: 0,
+        },
+        zebra_chain::block::SyncHashEntry {
+            hash: data.block_2.hash(),
+            span_size: 27,
+            span_txs: 420,
+            span_notes: 77,
+        },
+    ]
+}
+
+/// The fixed `get-tree-roots` entries served by [`TestInbound`].
+fn test_tree_roots_entries() -> Vec<zebra_chain::block::TreeRootsEntry> {
+    vec![zebra_chain::block::TreeRootsEntry {
+        sapling_root: [0x0A; 32],
+        orchard_root: [0; 32],
+        ironwood_root: [0; 32],
+        sapling_txs: 2,
+        orchard_txs: 0,
+        ironwood_txs: 0,
+        auth_data_root: [0xAD; 32],
+    }]
+}
+
+/// A minimal inbound service for tests, serving fixed test data and
+/// capturing gossip requests.
+#[derive(Clone)]
+struct TestInbound {
+    data: Arc<TestData>,
+    events: tokio::sync::mpsc::UnboundedSender<Request>,
+}
+
+impl Service<Request> for TestInbound {
+    type Response = Response;
+    type Error = BoxError;
+    type Future = Pin<Box<dyn Future<Output = Result<Response, BoxError>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let data = self.data.clone();
+        let events = self.events.clone();
+
+        if data.hang_inbound {
+            return Box::pin(futures::future::pending());
+        }
+
+        Box::pin(async move {
+            let response = match request {
+                Request::FindHeaders { .. } => Response::BlockHeaders(data.headers.clone()),
+                Request::BlocksByHash(hashes) => Response::Blocks(
+                    hashes
+                        .into_iter()
+                        .map(|hash| match data.served_blocks.get(&hash) {
+                            Some(block) => InventoryResponse::Available((block.clone(), None)),
+                            None => InventoryResponse::Missing(hash),
+                        })
+                        .collect(),
+                ),
+                Request::TransactionsById(ids) => Response::Transactions(
+                    ids.into_iter()
+                        .map(|id| {
+                            if id == data.transaction.id {
+                                InventoryResponse::Available((data.transaction.clone(), None))
+                            } else {
+                                InventoryResponse::Missing(id)
+                            }
+                        })
+                        .collect(),
+                ),
+                Request::MempoolTransactionIds => {
+                    Response::TransactionIds(vec![data.transaction.id])
+                }
+                Request::SyncHashes { .. } => Response::SyncHashes(test_sync_hash_entries(&data)),
+                Request::TreeRoots { final_hash, .. } => Response::TreeRoots(
+                    (final_hash == data.block.hash()).then(test_tree_roots_entries),
+                ),
+                Request::Peers => Response::Peers(data.peers.clone()),
+                request @ (Request::AdvertiseTransactionIds(_, _)
+                | Request::AdvertiseBlock(_, _)
+                | Request::PushTransaction(_, _)) => {
+                    let _ = events.send(request);
+                    Response::Nil
+                }
+                other => unreachable!("unexpected inbound request in test: {other:?}"),
+            };
+
+            Ok(response)
+        })
+    }
+}
+
+/// Builds a version 2 handshake service serving `data`, and the channel
+/// that captures the gossip requests its inbound service receives.
+fn test_handshaker(
+    network: &Network,
+    data: Arc<TestData>,
+    misbehavior_tx: tokio::sync::mpsc::Sender<(PeerSocketAddr, u32)>,
+) -> (
+    V2Handshake<TestInbound, NoChainTip>,
+    tokio::sync::mpsc::UnboundedReceiver<Request>,
+) {
+    let (events_tx, events) = tokio::sync::mpsc::unbounded_channel();
+
+    let handshaker = V2Handshake::new(
+        Config {
+            network: network.clone(),
+            ..Config::default()
+        },
+        "/ZebraV2Test:0.0.1/".to_string(),
+        PeerServices::NODE_NETWORK,
+        true,
+        TestInbound {
+            data,
+            events: events_tx,
+        },
+        crate::peer_book::ChangeSender::new(tokio::sync::mpsc::channel(100).0),
+        misbehavior_tx,
+        tokio::sync::broadcast::channel(100).0,
+        MinimumPeerVersion::new(NoChainTip, network),
+        "127.0.0.1:8233".parse().expect("valid address"),
+    );
+
+    (handshaker, events)
+}
+
+/// Opens a loopback QUIC endpoint, and returns it with its bound address.
+///
+/// The endpoint is leaked, because dropping it closes every connection it
+/// opened.
+fn test_endpoint(network: &Network) -> (quinn::Endpoint, std::net::SocketAddr) {
+    let endpoint = quic::new_endpoint("127.0.0.1:0".parse().expect("valid address"), network)
+        .expect("endpoint creation succeeds");
+    let addr = endpoint.local_addr().expect("endpoint has a local address");
+
+    (endpoint, addr)
+}
+
+/// A connected pair of v2 peers: each side's [`Client`] and captured inbound
+/// gossip events.
+///
+/// Tests must keep the whole struct alive: dropping either [`Client`]
+/// aborts that side's connection task.
+struct ConnectedPeers {
+    initiator_client: Client,
+    responder_client: Client,
+    /// Held for symmetry with `responder_events`; no test asserts on
+    /// initiator-side gossip yet.
+    #[allow(dead_code)]
+    initiator_events: tokio::sync::mpsc::UnboundedReceiver<Request>,
+    responder_events: tokio::sync::mpsc::UnboundedReceiver<Request>,
+    /// The misbehavior scores the initiator assigned to the responder.
+    initiator_misbehavior: tokio::sync::mpsc::Receiver<(PeerSocketAddr, u32)>,
+}
+
+/// Builds two full v2 peer stacks over loopback QUIC and connects them.
+async fn connect_peers(data: Arc<TestData>) -> ConnectedPeers {
+    let network = Network::Mainnet;
+
+    let initiator_endpoint =
+        quic::new_endpoint("127.0.0.1:0".parse().expect("valid address"), &network)
+            .expect("endpoint creation succeeds");
+    let (responder_endpoint, responder_addr) = test_endpoint(&network);
+
+    let (initiator_misbehavior_tx, initiator_misbehavior) = tokio::sync::mpsc::channel(100);
+
+    let (mut initiator_handshaker, initiator_events) =
+        test_handshaker(&network, data.clone(), initiator_misbehavior_tx);
+    let (mut responder_handshaker, responder_events) =
+        test_handshaker(&network, data, tokio::sync::mpsc::channel(100).0);
+
+    let mut counter = ActiveConnectionCounter::new_counter();
+
+    let responder_task = {
+        let responder_tracker = counter.track_connection();
+        tokio::spawn(async move {
+            let incoming = responder_endpoint.accept().await.expect("endpoint accepts");
+            let connection = quic::accept(incoming, &Network::Mainnet)
+                .await
+                .expect("inbound connection completes");
+            let connected_addr =
+                ConnectedAddr::new_inbound_direct(connection.remote_address().into());
+
+            let client = responder_handshaker
+                .ready()
+                .await
+                .expect("handshaker is ready")
+                .call(V2HandshakeRequest {
+                    connection,
+                    connected_addr,
+                    connection_tracker: responder_tracker,
+                })
+                .await
+                .expect("responder handshake succeeds");
+
+            // Keep the endpoint alive with the connection.
+            std::mem::forget(responder_endpoint);
+            client
+        })
+    };
+
+    let connection = quic::connect(&initiator_endpoint, responder_addr, &network)
+        .await
+        .expect("outbound connection completes");
+    std::mem::forget(initiator_endpoint);
+
+    let initiator_client = initiator_handshaker
+        .ready()
+        .await
+        .expect("handshaker is ready")
+        .call(V2HandshakeRequest {
+            connection,
+            connected_addr: ConnectedAddr::new_outbound_direct(responder_addr.into()),
+            connection_tracker: counter.track_connection(),
+        })
+        .await
+        .expect("initiator handshake succeeds");
+
+    let responder_client = responder_task.await.expect("responder task succeeds");
+
+    ConnectedPeers {
+        initiator_client,
+        responder_client,
+        initiator_events,
+        responder_events,
+        initiator_misbehavior,
+    }
+}
+
+/// Sends `request` through `client` with a timeout.
+async fn call(client: &mut Client, request: Request) -> Result<Response, BoxError> {
+    let response = tokio::time::timeout(
+        TEST_TIMEOUT,
+        client.ready().await.expect("client is ready").call(request),
+    )
+    .await
+    .expect("response arrives in time")?;
+
+    Ok(response)
+}
+
+/// A full v2 responder stack, driven by a raw wire-level initiator.
+///
+/// Tests must keep the struct alive: dropping the responder's [`Client`]
+/// aborts its connection task, and dropping the raw handshake closes the
+/// initiator's handshake stream.
+struct RawInitiator {
+    /// The test data the responder serves.
+    data: Arc<TestData>,
+
+    /// The initiator's QUIC connection, for opening raw streams.
+    connection: quinn::Connection,
+
+    /// The initiator's completed handshake, held to keep its streams open.
+    #[allow(dead_code)]
+    handshake: crate::peer::v2::handshake::V2Handshake,
+
+    /// The responder's peer client, held to keep its connection task alive.
+    #[allow(dead_code)]
+    responder_client: Client,
+
+    /// The gossip requests the responder's inbound service received.
+    responder_events: tokio::sync::mpsc::UnboundedReceiver<Request>,
+
+    /// The misbehavior scores the responder assigned to the initiator.
+    responder_misbehavior: tokio::sync::mpsc::Receiver<(PeerSocketAddr, u32)>,
+}
+
+/// Builds a full v2 responder stack serving `data` over loopback QUIC, and
+/// connects to it with a raw initiator that completes only the handshake,
+/// leaving the test in control of every stream.
+async fn raw_initiator(data: Arc<TestData>) -> RawInitiator {
+    raw_initiator_impl(data, false, false, None).await
+}
+
+/// Like [`raw_initiator`], with the initiator requesting high-bandwidth
+/// compact block announcements (`announce`) and full transaction IDs in
+/// them (`full_ids`) in its `init` record.
+async fn raw_initiator_with_init(
+    data: Arc<TestData>,
+    announce: bool,
+    full_ids: bool,
+) -> RawInitiator {
+    raw_initiator_impl(data, announce, full_ids, None).await
+}
+
+/// Like [`raw_initiator`], with a custom responder configuration; its
+/// network must be Mainnet.
+async fn raw_initiator_with_config(data: Arc<TestData>, config: Config) -> RawInitiator {
+    raw_initiator_impl(data, false, false, Some(config)).await
+}
+
+async fn raw_initiator_impl(
+    data: Arc<TestData>,
+    announce: bool,
+    full_ids: bool,
+    config: Option<Config>,
+) -> RawInitiator {
+    use crate::{
+        peer::{
+            handshake::HandshakeNonces,
+            v2::handshake::{initiate, HandshakeParams},
+        },
+        protocol::{
+            external::types::Nonce,
+            v2::{constants::MIN_V2_PROTOCOL_VERSION, init::InitRecord},
+        },
+    };
+
+    let network = Network::Mainnet;
+    let (responder_endpoint, responder_addr) = test_endpoint(&network);
+
+    let (responder_misbehavior_tx, responder_misbehavior) = tokio::sync::mpsc::channel(100);
+    let (mut responder_handshaker, responder_events) = match config {
+        // One test needs a custom cache directory, which only the full
+        // constructor takes.
+        Some(config) => {
+            let (events_tx, events) = tokio::sync::mpsc::unbounded_channel();
+            let handshaker = V2Handshake::new(
+                config,
+                "/ZebraV2Test:0.0.1/".to_string(),
+                PeerServices::NODE_NETWORK,
+                true,
+                TestInbound {
+                    data: data.clone(),
+                    events: events_tx,
+                },
+                crate::peer_book::ChangeSender::new(tokio::sync::mpsc::channel(100).0),
+                responder_misbehavior_tx,
+                tokio::sync::broadcast::channel(100).0,
+                MinimumPeerVersion::new(NoChainTip, &network),
+                "127.0.0.1:8233".parse().expect("valid address"),
+            );
+
+            (handshaker, events)
+        }
+        None => test_handshaker(&network, data.clone(), responder_misbehavior_tx),
+    };
+
+    let mut counter = ActiveConnectionCounter::new_counter();
+    let responder_tracker = counter.track_connection();
+    let responder_task = tokio::spawn(async move {
+        let incoming = responder_endpoint.accept().await.expect("endpoint accepts");
+        let connection = quic::accept(incoming, &Network::Mainnet)
+            .await
+            .expect("inbound connection completes");
+        let connected_addr = ConnectedAddr::new_inbound_direct(connection.remote_address().into());
+
+        let client = responder_handshaker
+            .ready()
+            .await
+            .expect("handshaker is ready")
+            .call(V2HandshakeRequest {
+                connection,
+                connected_addr,
+                connection_tracker: responder_tracker,
+            })
+            .await
+            .expect("responder handshake succeeds");
+
+        std::mem::forget(responder_endpoint);
+        client
+    });
+
+    let (initiator_endpoint, _initiator_addr) = test_endpoint(&network);
+    let connection = quic::connect(&initiator_endpoint, responder_addr, &network)
+        .await
+        .expect("outbound connection completes");
+    std::mem::forget(initiator_endpoint);
+
+    let params = HandshakeParams {
+        local_init: InitRecord {
+            version: MIN_V2_PROTOCOL_VERSION,
+            services: PeerServices::NODE_NETWORK,
+            nonce: Nonce::default(),
+            user_agent: "/ZebraV2RawTest:0.0.1/".to_string(),
+            start_height: zebra_chain::block::Height(0),
+            relay: true,
+            announce,
+            full_ids,
+        },
+        min_remote_version: MIN_V2_PROTOCOL_VERSION,
+        nonces: HandshakeNonces::default(),
+        nonce_limit: 100,
+    };
+    let handshake = tokio::time::timeout(TEST_TIMEOUT, initiate(&connection, &params))
+        .await
+        .expect("handshake completes in time")
+        .expect("initiator handshake succeeds");
+    let responder_client = responder_task.await.expect("responder task succeeds");
+
+    RawInitiator {
+        data,
+        connection,
+        handshake,
+        responder_client,
+        responder_events,
+        responder_misbehavior,
+    }
+}
+
+/// Test that a peer whose QUIC stack is alive but whose application never
+/// answers a request stream is disconnected, instead of sinking every request
+/// routed to it for the process lifetime.
+///
+/// This test waits for real request timeouts, so it takes about
+/// [`REQUEST_TIMEOUT`](crate::constants::REQUEST_TIMEOUT) to run: the
+/// requests are made concurrently so they time out together.
+#[tokio::test]
+async fn v2_unresponsive_peer_is_disconnected() {
+    let _init_guard = zebra_test::init();
+
+    let mut data = TestData::new();
+    data.hang_inbound = true;
+
+    let mut peers = connect_peers(Arc::new(data)).await;
+
+    // Enough concurrent requests to reach the consecutive timeout limit.
+    // The requests must need the wire: mempool requests are answered from
+    // the local subscription mirror.
+    let mut requests = Vec::new();
+    for _ in 0..MAX_CONSECUTIVE_REQUEST_TIMEOUTS {
+        let mut client = peers
+            .initiator_client
+            .ready()
+            .await
+            .expect("client is ready")
+            .call(Request::FindHeaders {
+                known_blocks: vec![],
+                stop: None,
+            });
+        requests.push(std::future::poll_fn(move |cx| {
+            Pin::new(&mut client).poll(cx)
+        }));
+    }
+
+    let results = tokio::time::timeout(
+        crate::constants::REQUEST_TIMEOUT + TEST_TIMEOUT,
+        futures::future::join_all(requests),
+    )
+    .await
+    .expect("the requests time out in time");
+
+    for result in results {
+        assert!(
+            result.is_err(),
+            "an unanswered request must fail, got: {result:?}",
+        );
+    }
+
+    // The connection was closed, so the peer leaves the peer set instead of
+    // sinking further requests.
+    let result = peers.initiator_client.ready().await;
+    assert!(
+        result.is_err(),
+        "an unresponsive peer must be disconnected, got: {result:?}",
+    );
+}
+
+#[tokio::test]
+async fn v2_oversized_get_headers_response_is_scored() {
+    let _init_guard = zebra_test::init();
+
+    // A `get-headers` response over the limit is a scored violation, not a
+    // connection error.
+    let mut data = TestData::new();
+    let header = data.headers[0].clone();
+    data.headers = vec![header; MAX_HEADERS_RESULTS as usize + 1];
+
+    let mut peers = connect_peers(Arc::new(data)).await;
+
+    let result = call(
+        &mut peers.initiator_client,
+        Request::FindHeaders {
+            known_blocks: Vec::new(),
+            stop: None,
+        },
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "an over-sized get-headers response must fail the request, got: {result:?}",
+    );
+
+    let (_addr, points) = tokio::time::timeout(TEST_TIMEOUT, peers.initiator_misbehavior.recv())
+        .await
+        .expect("a misbehavior update arrives in time")
+        .expect("the misbehavior channel is open");
+    assert_eq!(points, MISBEHAVIOR_PENALTY_LIMIT_EXCEEDED);
+
+    // Scored violations do not disconnect: the peer is banned by the address
+    // book once its accumulated score reaches the threshold.
+    let response = call(&mut peers.initiator_client, Request::MempoolTransactionIds)
+        .await
+        .expect("the connection is still usable after a scored violation");
+    assert!(
+        matches!(response, Response::TransactionIds(_)),
+        "got: {response:?}",
+    );
+}
+
+#[tokio::test]
+async fn v2_request_round_trips() {
+    let _init_guard = zebra_test::init();
+
+    let data = Arc::new(TestData::new());
+    let mut peers = connect_peers(data.clone()).await;
+    let initiator_client = &mut peers.initiator_client;
+
+    // Ping is answered locally from the transport's RTT measurement.
+    let response = call(initiator_client, Request::Ping(Default::default()))
+        .await
+        .expect("ping succeeds");
+    assert!(matches!(response, Response::Pong(_)), "got: {response:?}");
+
+    // FindHeaders maps to a get-headers request stream.
+    let response = call(
+        initiator_client,
+        Request::FindHeaders {
+            known_blocks: vec![data.headers[0].header.hash()],
+            stop: None,
+        },
+    )
+    .await
+    .expect("find headers succeeds");
+    match response {
+        Response::BlockHeaders(headers) => {
+            assert_eq!(headers.len(), 2);
+            assert_eq!(headers[0].header, data.headers[0].header);
+            assert_eq!(headers[1].header, data.headers[1].header);
+        }
+        other => panic!("expected BlockHeaders, got: {other:?}"),
+    }
+
+    // FindBlocks is bridged onto get-headers, returning header hashes.
+    let response = call(
+        initiator_client,
+        Request::FindBlocks {
+            known_blocks: vec![],
+            stop: None,
+        },
+    )
+    .await
+    .expect("find blocks succeeds");
+    match response {
+        Response::BlockHashes(hashes) => {
+            assert_eq!(
+                hashes,
+                vec![data.headers[0].header.hash(), data.headers[1].header.hash(),],
+            );
+        }
+        other => panic!("expected BlockHashes, got: {other:?}"),
+    }
+
+    // BlocksByHash maps to a get-blocks request stream, with per-entry
+    // found and not-found results.
+    let block_hash = data.block.hash();
+    let missing_hash = zebra_chain::block::Hash([0xEE; 32]);
+    let response = call(
+        initiator_client,
+        Request::BlocksByHash([block_hash, missing_hash].into()),
+    )
+    .await
+    .expect("blocks by hash succeeds");
+    match response {
+        Response::Blocks(blocks) => {
+            assert_eq!(blocks.len(), 2);
+            let available: Vec<_> = blocks
+                .iter()
+                .filter_map(|entry| entry.clone().available())
+                .collect();
+            assert_eq!(available.len(), 1);
+            assert_eq!(available[0].0.hash(), block_hash);
+            let missing: Vec<_> = blocks
+                .into_iter()
+                .filter_map(|entry| entry.missing())
+                .collect();
+            assert_eq!(missing, vec![missing_hash]);
+        }
+        other => panic!("expected Blocks, got: {other:?}"),
+    }
+
+    // TransactionsById maps to a get-tx request stream.
+    let response = call(
+        initiator_client,
+        Request::TransactionsById([data.transaction.id].into()),
+    )
+    .await
+    .expect("transactions by id succeeds");
+    match response {
+        Response::Transactions(transactions) => {
+            assert_eq!(transactions.len(), 1);
+            let (transaction, _) = transactions[0]
+                .clone()
+                .available()
+                .expect("transaction is available");
+            assert_eq!(transaction.id, data.transaction.id);
+        }
+        other => panic!("expected Transactions, got: {other:?}"),
+    }
+
+    // MempoolTransactionIds is answered from the connection's `get-mempool`
+    // subscription mirror, so the responder's snapshot arrives
+    // asynchronously after the handshake.
+    let mempool_mirrored = async {
+        loop {
+            let response = call(initiator_client, Request::MempoolTransactionIds)
+                .await
+                .expect("mempool request succeeds");
+            match response {
+                Response::TransactionIds(ids) if ids == vec![data.transaction.id] => break,
+                Response::TransactionIds(ids) => assert_eq!(ids, Vec::new()),
+                other => panic!("expected TransactionIds, got: {other:?}"),
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    };
+    tokio::time::timeout(TEST_TIMEOUT, mempool_mirrored)
+        .await
+        .expect("the mempool snapshot reaches the subscription mirror in time");
+
+    // Peers maps to a get-addr request stream. The initiator made an
+    // outbound connection, so the responder answers it. The responder's
+    // announced listener address shares the cache with the served address,
+    // and responses are random samples, so poll until the served address is
+    // answered.
+    let served_addr_answered = async {
+        loop {
+            let response = call(initiator_client, Request::Peers)
+                .await
+                .expect("peers request succeeds");
+            match response {
+                Response::Peers(peers) => {
+                    if peers.iter().any(|peer| peer.addr() == data.peers[0].addr()) {
+                        break;
+                    }
+                }
+                other => panic!("expected Peers, got: {other:?}"),
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    };
+    tokio::time::timeout(TEST_TIMEOUT, served_addr_answered)
+        .await
+        .expect("the served address is answered in time");
+}
+
+#[tokio::test]
+async fn v2_get_addr_only_sent_on_self_initiated_connections() {
+    let _init_guard = zebra_test::init();
+
+    let data = Arc::new(TestData::new());
+    let mut peers = connect_peers(data).await;
+
+    // The initiator opened the connection, so the responder answers its
+    // address requests with its served addresses. The response may also
+    // contain the responder's announced listener address, which the
+    // initiator caches as it arrives.
+    let served: PeerSocketAddr = "203.0.113.7:8233".parse().expect("valid address");
+    let served = crate::protocol::external::canonical_peer_addr(*served);
+
+    let response = call(&mut peers.initiator_client, Request::Peers)
+        .await
+        .expect("get-addr on a self-initiated connection succeeds");
+    match response {
+        Response::Peers(addrs) => assert!(
+            addrs.iter().any(|addr| addr.addr() == served),
+            "expected the served address in the response, got: {addrs:?}",
+        ),
+        other => panic!("expected Peers, got: {other:?}"),
+    }
+
+    // The responder accepted an inbound connection, so a get-addr request to
+    // the initiator would always be refused. It is not sent at all: the
+    // responder answers locally with the addresses the initiator announced.
+    // The initiator announces its own listener address after the handshake,
+    // so the responder's local answer converges on it.
+    let expected: PeerSocketAddr = "127.0.0.1:8233".parse().expect("valid address");
+    let expected = crate::protocol::external::canonical_peer_addr(*expected);
+
+    let local_answer_converges = async {
+        loop {
+            let response = call(&mut peers.responder_client, Request::Peers)
+                .await
+                .expect("get-addr on an inbound connection is answered locally");
+
+            match response {
+                Response::Peers(addrs) if addrs.iter().any(|addr| addr.addr() == expected) => {
+                    break;
+                }
+                Response::Peers(_) => tokio::time::sleep(Duration::from_millis(20)).await,
+                other => panic!("expected Peers, got: {other:?}"),
+            }
+        }
+    };
+    tokio::time::timeout(TEST_TIMEOUT, local_answer_converges)
+        .await
+        .expect("the initiator's announced listener reaches the responder's cache in time");
+}
+
+#[tokio::test]
+async fn v2_announcements_reach_the_remote_inbound_service() {
+    let _init_guard = zebra_test::init();
+
+    let data = Arc::new(TestData::new());
+    let mut peers = connect_peers(data.clone()).await;
+    let initiator_client = &mut peers.initiator_client;
+    let responder_events = &mut peers.responder_events;
+
+    // Advertising transaction IDs writes records on the transaction
+    // announcement stream; the responder forwards them to its inbound
+    // service.
+    let response = call(
+        initiator_client,
+        Request::AdvertiseTransactionIds([data.transaction.id].into(), None),
+    )
+    .await
+    .expect("advertise succeeds");
+    assert!(matches!(response, Response::Nil));
+
+    let event = tokio::time::timeout(TEST_TIMEOUT, responder_events.recv())
+        .await
+        .expect("announcement arrives in time")
+        .expect("events channel is open");
+    match event {
+        Request::AdvertiseTransactionIds(ids, from) => {
+            assert_eq!(ids, HashSet::from([data.transaction.id]));
+            assert!(from.is_some(), "the announcing peer's address is recorded");
+        }
+        other => panic!("expected AdvertiseTransactionIds, got: {other:?}"),
+    }
+
+    // Advertising a block fetches it locally and announces its header; the
+    // responder forwards the hash to its inbound service. Transaction
+    // advertisements from the responder's own mempool subscription mirror
+    // may interleave, and are skipped.
+    let block_hash = data.block.hash();
+    let response = call(initiator_client, Request::AdvertiseBlockToAll(block_hash))
+        .await
+        .expect("advertise succeeds");
+    assert!(matches!(response, Response::Nil));
+
+    let block_advertised = async {
+        loop {
+            let event = responder_events
+                .recv()
+                .await
+                .expect("events channel is open");
+            match event {
+                Request::AdvertiseBlock(hash, from) => {
+                    assert_eq!(hash, block_hash);
+                    assert!(from.is_some(), "the announcing peer's address is recorded");
+                    break;
+                }
+                Request::AdvertiseTransactionIds(_, _) => continue,
+                other => panic!("expected AdvertiseBlock, got: {other:?}"),
+            }
+        }
+    };
+    tokio::time::timeout(TEST_TIMEOUT, block_advertised)
+        .await
+        .expect("announcement arrives in time");
+}
+
+#[tokio::test]
+async fn v2_pushed_transactions_are_served_from_the_cache() {
+    let _init_guard = zebra_test::init();
+
+    let data = Arc::new(TestData::new());
+    let mut peers = connect_peers(data.clone()).await;
+    let ConnectedPeers {
+        initiator_client,
+        responder_client,
+        responder_events,
+        ..
+    } = &mut peers;
+
+    // Push a transaction the initiator's inbound service does NOT serve:
+    // block 1's coinbase transaction.
+    let pushed = UnminedTx::from(data.block.transactions[0].clone());
+    assert_ne!(pushed.id, data.transaction.id);
+
+    let response = call(
+        initiator_client,
+        Request::PushTransaction(pushed.clone(), None),
+    )
+    .await
+    .expect("push succeeds");
+    assert!(matches!(response, Response::Nil));
+
+    // The push becomes an announcement to the responder. Advertisements
+    // from the responder's mempool subscription mirror may interleave, and
+    // are skipped.
+    let push_advertised = async {
+        loop {
+            let event = responder_events
+                .recv()
+                .await
+                .expect("events channel is open");
+            match event {
+                Request::AdvertiseTransactionIds(ref ids, _) if ids.contains(&pushed.id) => break,
+                Request::AdvertiseTransactionIds(_, _) => continue,
+                other => panic!("expected AdvertiseTransactionIds, got: {other:?}"),
+            }
+        }
+    };
+    tokio::time::timeout(TEST_TIMEOUT, push_advertised)
+        .await
+        .expect("announcement arrives in time");
+
+    // The responder can fetch the pushed transaction from the initiator's
+    // pushed-transaction cache, even though the initiator's inbound service
+    // does not have it.
+    let response = call(
+        responder_client,
+        Request::TransactionsById([pushed.id].into()),
+    )
+    .await
+    .expect("fetching the pushed transaction succeeds");
+    match response {
+        Response::Transactions(transactions) => {
+            assert_eq!(transactions.len(), 1);
+            let (transaction, _) = transactions[0]
+                .clone()
+                .available()
+                .expect("transaction is available");
+            assert_eq!(transaction.id, pushed.id);
+        }
+        other => panic!("expected Transactions, got: {other:?}"),
+    }
+}
+
+/// `get-blocks` requests are hash-only and served with full blocks, and
+/// unservable `get-tx` references — `SHORTID` references without a sent
+/// compact block, and references whose type does not match the referenced
+/// transaction's version — are answered not-found, without an error or a
+/// misbehavior penalty.
+#[tokio::test]
+async fn v2_get_blocks_is_hash_only_and_unservable_tx_refs_answer_not_found() {
+    use zebra_chain::transaction::{AuthDigest, UnminedTxId, WtxId};
+
+    use crate::protocol::v2::{
+        compact_block::ShortTxId, record, request::Request as V2WireRequest,
+        response::read_result_entry, txref::TransactionReference,
+    };
+
+    let _init_guard = zebra_test::init();
+
+    let mut raw = raw_initiator(Arc::new(TestData::new())).await;
+    let connection = raw.connection.clone();
+    let block = raw.data.block.clone();
+    assert!(block.transactions.len() >= 3);
+
+    // Request the block by hash on a raw request stream: `get-blocks`
+    // requests carry only hashes, and are served with full blocks.
+    let mut recv = send_request(
+        &connection,
+        V2WireRequest::GetBlocks {
+            hashes: vec![block.hash()],
+        },
+    )
+    .await;
+
+    let entry = tokio::time::timeout(
+        TEST_TIMEOUT,
+        read_result_entry::<zebra_chain::block::Block, _>(&mut recv, "get-blocks"),
+    )
+    .await
+    .expect("response arrives in time")
+    .expect("response entry parses");
+    match entry {
+        Some(served) => assert_eq!(served.hash(), block.hash()),
+        other => panic!("expected a full block response, got: {other:?}"),
+    }
+    record::expect_end_of_stream(&mut recv)
+        .await
+        .expect("response is complete");
+
+    // `SHORTID` references resolve against the compact block most recently
+    // sent to the requesting peer for the block. No compact block has been
+    // sent on this connection, so they are answered not-found, without an
+    // error or a penalty.
+    let mut recv = send_request(
+        &connection,
+        V2WireRequest::GetTx {
+            refs: vec![
+                TransactionReference::ShortId {
+                    block_hash: block.hash(),
+                    short_id: ShortTxId([0x0F; 6]),
+                },
+                TransactionReference::ShortId {
+                    block_hash: zebra_chain::block::Hash([0xAB; 32]),
+                    short_id: ShortTxId([0x0F; 6]),
+                },
+            ],
+        },
+    )
+    .await;
+
+    for _ in 0..2 {
+        let missing = tokio::time::timeout(
+            TEST_TIMEOUT,
+            read_result_entry::<zebra_chain::transaction::Transaction, _>(&mut recv, "get-tx"),
+        )
+        .await
+        .expect("response arrives in time")
+        .expect("response entry parses");
+        assert!(
+            missing.is_none(),
+            "a SHORTID without a sent compact block is answered not-found",
+        );
+    }
+    record::expect_end_of_stream(&mut recv)
+        .await
+        .expect("response is complete");
+
+    // A `get-tx` reference whose type does not match the referenced
+    // transaction's version is answered not-found: the requester may have
+    // derived the reference type from data supplied by another peer, so it
+    // must not be penalized. A correctly typed reference to the same
+    // transaction is still served.
+    let legacy_txid = match raw.data.transaction.id {
+        UnminedTxId::Legacy(txid) => txid,
+        other => panic!("the test mempool transaction is legacy, got: {other:?}"),
+    };
+    let wrong_typed = TransactionReference::Wtxid(WtxId {
+        id: legacy_txid,
+        auth_digest: AuthDigest([0xFF; 32]),
+    });
+
+    let mut recv = send_request(
+        &connection,
+        V2WireRequest::GetTx {
+            refs: vec![
+                wrong_typed,
+                TransactionReference::from(raw.data.transaction.id),
+            ],
+        },
+    )
+    .await;
+
+    let missing = tokio::time::timeout(
+        TEST_TIMEOUT,
+        read_result_entry::<zebra_chain::transaction::Transaction, _>(&mut recv, "get-tx"),
+    )
+    .await
+    .expect("response arrives in time")
+    .expect("response entry parses");
+    assert!(
+        missing.is_none(),
+        "a wrong-typed reference is answered not-found",
+    );
+    let found = read_result_entry::<zebra_chain::transaction::Transaction, _>(&mut recv, "get-tx")
+        .await
+        .expect("response entry parses");
+    match found {
+        Some(transaction) => {
+            assert_eq!(transaction, raw.data.transaction.transaction);
+        }
+        other => panic!("expected the referenced transaction, got: {other:?}"),
+    }
+    record::expect_end_of_stream(&mut recv)
+        .await
+        .expect("response is complete");
+
+    // None of the not-found answers above assigned a misbehavior penalty.
+    assert!(
+        raw.responder_misbehavior.try_recv().is_err(),
+        "unservable get-tx references must not be penalized",
+    );
+}
+
+/// A raw responder connected to a full v2 initiator stack: the full stack
+/// initiated the connection, and the test controls the responder's streams.
+struct RawResponder {
+    /// The test data the initiator stack's inbound service serves.
+    data: Arc<TestData>,
+
+    /// The raw responder's QUIC connection, for raw streams.
+    connection: quinn::Connection,
+
+    /// The raw responder's completed handshake, carrying the initiator
+    /// stack's `init` record.
+    handshake: crate::peer::v2::handshake::V2Handshake,
+
+    /// The initiator stack's peer client for this connection.
+    initiator_client: Client,
+
+    /// The gossip requests the initiator stack's inbound service received.
+    initiator_events: tokio::sync::mpsc::UnboundedReceiver<Request>,
+
+    /// The misbehavior scores the initiator stack assigned to the raw
+    /// responder.
+    initiator_misbehavior: tokio::sync::mpsc::Receiver<(PeerSocketAddr, u32)>,
+}
+
+/// Builds a full v2 stack and connects it *outbound*, to a raw responder
+/// that completes only the handshake, leaving the test in control of the
+/// responder side of every stream.
+async fn raw_responder(data: Arc<TestData>) -> RawResponder {
+    use crate::{
+        peer::{
+            handshake::HandshakeNonces,
+            v2::handshake::{respond, HandshakeParams},
+        },
+        protocol::{
+            external::types::Nonce,
+            v2::{constants::MIN_V2_PROTOCOL_VERSION, init::InitRecord},
+        },
+    };
+
+    let network = Network::Mainnet;
+    let (responder_endpoint, responder_addr) = test_endpoint(&network);
+
+    let (initiator_misbehavior_tx, initiator_misbehavior) = tokio::sync::mpsc::channel(100);
+    let (mut initiator_handshaker, initiator_events) =
+        test_handshaker(&network, data.clone(), initiator_misbehavior_tx);
+
+    let mut counter = ActiveConnectionCounter::new_counter();
+    let initiator_tracker = counter.track_connection();
+    let initiator_endpoint =
+        quic::new_endpoint("127.0.0.1:0".parse().expect("valid address"), &network)
+            .expect("endpoint creation succeeds");
+    let initiator_task = tokio::spawn(async move {
+        let connection = quic::connect(&initiator_endpoint, responder_addr, &network)
+            .await
+            .expect("outbound connection completes");
+        let connected_addr = crate::peer::ConnectedAddr::new_outbound_direct(responder_addr.into());
+
+        let client = initiator_handshaker
+            .ready()
+            .await
+            .expect("handshaker is ready")
+            .call(V2HandshakeRequest {
+                connection,
+                connected_addr,
+                connection_tracker: initiator_tracker,
+            })
+            .await
+            .expect("initiator handshake succeeds");
+
+        std::mem::forget(initiator_endpoint);
+        client
+    });
+
+    let incoming = responder_endpoint.accept().await.expect("endpoint accepts");
+    let connection = quic::accept(incoming, &Network::Mainnet)
+        .await
+        .expect("inbound connection completes");
+    std::mem::forget(responder_endpoint);
+
+    let params = HandshakeParams {
+        local_init: InitRecord {
+            version: MIN_V2_PROTOCOL_VERSION,
+            services: PeerServices::NODE_NETWORK,
+            nonce: Nonce::default(),
+            user_agent: "/ZebraV2RawTest:0.0.1/".to_string(),
+            start_height: zebra_chain::block::Height(0),
+            relay: true,
+            announce: false,
+            full_ids: false,
+        },
+        min_remote_version: MIN_V2_PROTOCOL_VERSION,
+        nonces: HandshakeNonces::default(),
+        nonce_limit: 100,
+    };
+    let handshake = tokio::time::timeout(TEST_TIMEOUT, respond(&connection, &params))
+        .await
+        .expect("handshake completes in time")
+        .expect("responder handshake succeeds");
+    let initiator_client = initiator_task.await.expect("initiator task succeeds");
+
+    RawResponder {
+        data,
+        connection,
+        handshake,
+        initiator_client,
+        initiator_events,
+        initiator_misbehavior,
+    }
+}
+
+/// A compact block announcement is reconstructed by the receiving node: it
+/// requests the transactions it is missing with `SHORTID` `get-tx`
+/// references, assembles and merkle-checks the block, hands it to its
+/// gossip pipeline with the advertiser withheld (the high-bandwidth penalty
+/// exemption), and serves the follow-up block request from the connection's
+/// cache without a wire request.
+#[tokio::test]
+async fn v2_compact_announcement_is_reconstructed_and_served_from_cache() {
+    use crate::protocol::v2::{
+        compact_block::{CompactBlock, CompactBlockIds},
+        record,
+        request::Request as V2WireRequest,
+        response::encode_result_entry,
+        txref::TransactionReference,
+        types::StreamType,
+    };
+
+    let _init_guard = zebra_test::init();
+
+    let mut raw = raw_responder(Arc::new(TestData::new())).await;
+    let connection = raw.connection.clone();
+    let block = raw.data.block.clone();
+
+    // The full stack initiated this connection, so it claimed a
+    // high-bandwidth slot and requested compact block announcements with
+    // short transaction IDs.
+    assert!(
+        raw.handshake.remote_init.announce,
+        "self-initiated connections request high-bandwidth announcements",
+    );
+    assert!(!raw.handshake.remote_init.full_ids);
+
+    // Announce the multi-transaction block as a compact block. The stack's
+    // mempool does not hold its transactions, so it must request every
+    // non-coinbase transaction (the coinbase is prefilled).
+    let compact = CompactBlock::from_block(&block, 7, false, &[]).expect("compact block builds");
+    let mut payload = vec![0x01];
+    compact.encode(&mut payload).expect("compact block encodes");
+    let mut announcement = Vec::new();
+    record::write_record(&mut announcement, &payload).expect("record writes");
+
+    let mut send = connection.open_uni().await.expect("stream opens");
+    send.write_all(&[StreamType::BlockAnnouncements.byte()])
+        .await
+        .expect("stream type writes");
+    send.write_all(&announcement).await.expect("record writes");
+
+    // Serve the reconstruction `get-tx`: one `SHORTID` reference per
+    // non-coinbase transaction, in block order. The stack's standing
+    // `get-mempool` subscription stream is skipped unanswered.
+    let (mut req_send, mut req_recv) = tokio::time::timeout(
+        TEST_TIMEOUT,
+        accept_request_stream(&connection, StreamType::GetTx),
+    )
+    .await
+    .expect("get-tx stream opens in time");
+
+    let request = V2WireRequest::read(StreamType::GetTx, &mut req_recv)
+        .await
+        .expect("get-tx request parses");
+    let V2WireRequest::GetTx { refs } = request else {
+        panic!("expected a get-tx request, got: {request:?}");
+    };
+    let CompactBlockIds::Short(short_ids) = &compact.ids else {
+        panic!("the announced compact block has short IDs");
+    };
+    let expected_refs: Vec<TransactionReference> = short_ids
+        .iter()
+        .map(|short_id| TransactionReference::ShortId {
+            block_hash: block.hash(),
+            short_id: *short_id,
+        })
+        .collect();
+    assert_eq!(refs, expected_refs);
+
+    let mut bytes = Vec::new();
+    for tx in block.transactions.iter().skip(1) {
+        encode_result_entry(&mut bytes, Some(tx.as_ref())).expect("entry encodes");
+    }
+    req_send.write_all(&bytes).await.expect("response writes");
+    req_send.finish().expect("stream finishes");
+
+    // The stack reconstructs the block and forwards the announcement with
+    // the advertiser withheld: a high-bandwidth announcement of a block
+    // that fails validation must not be penalized.
+    let event = tokio::time::timeout(TEST_TIMEOUT, raw.initiator_events.recv())
+        .await
+        .expect("announcement forwarded in time")
+        .expect("events channel is open");
+    match event {
+        Request::AdvertiseBlock(hash, advertiser) => {
+            assert_eq!(hash, block.hash());
+            assert!(
+                advertiser.is_none(),
+                "high-bandwidth announcements withhold the advertiser",
+            );
+        }
+        other => panic!("expected AdvertiseBlock, got: {other:?}"),
+    }
+
+    // The reconstructed block serves the follow-up block request from the
+    // connection's cache. This test never serves `get-blocks`, so a wire
+    // request would hang past this timeout.
+    let response = tokio::time::timeout(
+        Duration::from_secs(5),
+        call(
+            &mut raw.initiator_client,
+            Request::BlocksByHash([block.hash()].into()),
+        ),
+    )
+    .await
+    .expect("the cached block answers immediately")
+    .expect("block request succeeds");
+    match response {
+        Response::Blocks(blocks) => {
+            assert_eq!(blocks.len(), 1);
+            let (served, _) = blocks[0].clone().available().expect("block is available");
+            assert_eq!(served, block);
+        }
+        other => panic!("expected Blocks, got: {other:?}"),
+    }
+
+    // Reconstruction assigned no misbehavior penalty.
+    assert!(raw.initiator_misbehavior.try_recv().is_err());
+}
+
+/// Serves one `get-block-range` request on `connection` with `result` and
+/// the given blocks, and asserts the request's anchor hash.
+async fn serve_block_range(
+    connection: &quinn::Connection,
+    expected_final_hash: zebra_chain::block::Hash,
+    result: u8,
+    blocks: Vec<Arc<Block>>,
+) {
+    use zebra_chain::serialization::ZcashSerialize;
+
+    use crate::protocol::v2::{record, request::Request as V2WireRequest, types::StreamType};
+
+    let (mut send, mut recv) = accept_request_stream(connection, StreamType::GetBlockRange).await;
+    let request = V2WireRequest::read(StreamType::GetBlockRange, &mut recv)
+        .await
+        .expect("request parses");
+    let V2WireRequest::GetBlockRange { final_hash, .. } = request else {
+        panic!("expected a get-block-range request, got: {request:?}");
+    };
+    assert_eq!(final_hash, expected_final_hash);
+
+    let mut bytes = vec![result];
+    for block in &blocks {
+        let block_bytes = block
+            .zcash_serialize_to_vec()
+            .expect("serializing a block succeeds");
+        record::write_record(&mut bytes, &block_bytes).expect("record writes");
+    }
+    send.write_all(&bytes).await.expect("response writes");
+    send.finish().expect("stream finishes");
+}
+
+/// The block-range requester verifies every delivered block on arrival and
+/// returns them in descending order; a peer without the anchor answers a
+/// missing entry.
+#[tokio::test]
+async fn v2_block_range_requester_returns_verified_blocks() {
+    let _init_guard = zebra_test::init();
+
+    let mut raw = raw_responder(Arc::new(TestData::new())).await;
+    let connection = raw.connection.clone();
+    let block_1 = raw.data.block_1.clone();
+    let block_2 = raw.data.block_2.clone();
+
+    let serve = serve_block_range(
+        &connection,
+        block_2.hash(),
+        0x00,
+        vec![block_2.clone(), block_1.clone()],
+    );
+    let request = call(
+        &mut raw.initiator_client,
+        Request::BlockRange {
+            final_hash: block_2.hash(),
+            count: 5,
+            max_bytes: 8_000_000,
+        },
+    );
+    let (_, response) = tokio::join!(serve, tokio::time::timeout(TEST_TIMEOUT, request));
+    let response = response
+        .expect("response arrives in time")
+        .expect("block range request succeeds");
+    match response {
+        Response::Blocks(blocks) => {
+            let hashes: Vec<_> = blocks
+                .into_iter()
+                .map(|entry| entry.available().expect("blocks are available").0.hash())
+                .collect();
+            assert_eq!(hashes, vec![block_2.hash(), block_1.hash()]);
+        }
+        other => panic!("expected Blocks, got: {other:?}"),
+    }
+
+    // A peer without the anchor block answers a missing entry.
+    let missing_hash = zebra_chain::block::Hash([0xEE; 32]);
+    let serve = serve_block_range(&connection, missing_hash, 0x02, Vec::new());
+    let request = call(
+        &mut raw.initiator_client,
+        Request::BlockRange {
+            final_hash: missing_hash,
+            count: 5,
+            max_bytes: 8_000_000,
+        },
+    );
+    let (_, response) = tokio::join!(serve, tokio::time::timeout(TEST_TIMEOUT, request));
+    let response = response
+        .expect("response arrives in time")
+        .expect("block range request succeeds");
+    match response {
+        Response::Blocks(blocks) => {
+            assert_eq!(blocks.len(), 1);
+            assert_eq!(blocks[0].clone().missing(), Some(missing_hash));
+        }
+        other => panic!("expected Blocks, got: {other:?}"),
+    }
+}
+
+/// A response that breaks a `get-block-range` rule fails the request and
+/// the connection.
+///
+/// The rules are checkable by hashing alone, so a violation is never
+/// attributable to a different chain view: verification failures are
+/// `PROTOCOL_ERROR`, and exceeding a request bound is `FLOOD`.
+#[tokio::test]
+async fn v2_block_range_requester_rejects_invalid_responses() {
+    use crate::protocol::v2::types::ErrorCode;
+
+    let _init_guard = zebra_test::init();
+
+    let data = TestData::new();
+    let block_1 = data.block_1.clone();
+    let block_2 = data.block_2.clone();
+
+    // Block 2's header with block 1's transactions: it hashes to the
+    // anchor, but its transactions do not match its merkle root.
+    let wrong_merkle_root = Arc::new(Block {
+        header: block_2.header.clone(),
+        transactions: block_1.transactions.clone(),
+    });
+
+    let cases = [
+        (
+            "a block that does not hash to the anchor",
+            vec![block_1.clone()],
+            5,
+            ErrorCode::ProtocolError,
+        ),
+        (
+            "a block that does not match its merkle root",
+            vec![wrong_merkle_root],
+            5,
+            ErrorCode::ProtocolError,
+        ),
+        (
+            "more blocks than the request asked for",
+            vec![block_2.clone(), block_1],
+            1,
+            ErrorCode::Flood,
+        ),
+    ];
+
+    for (rule, blocks, count, expected) in cases {
+        let mut raw = raw_responder(Arc::new(TestData::new())).await;
+        let connection = raw.connection.clone();
+
+        let serve = serve_block_range(&connection, block_2.hash(), 0x00, blocks);
+        let request = call(
+            &mut raw.initiator_client,
+            Request::BlockRange {
+                final_hash: block_2.hash(),
+                count,
+                max_bytes: 8_000_000,
+            },
+        );
+
+        let (_, response) = tokio::join!(serve, tokio::time::timeout(TEST_TIMEOUT, request));
+        assert!(
+            response.expect("response arrives in time").is_err(),
+            "{rule} must fail the request",
+        );
+
+        assert_closed_with(&connection, expected, rule).await;
+    }
+}
+
+/// The relayed-address token bucket admits a full burst, then throttles to
+/// the reference rate.
+#[test]
+fn v2_addr_token_bucket_bounds_the_rate() {
+    use std::time::{Duration, Instant};
+
+    use crate::{
+        peer::v2::connection::AddrTokenBucket,
+        protocol::v2::constants::{ADDR_TOKEN_BUCKET_CAPACITY, ADDR_TOKEN_RATE},
+    };
+
+    let _init_guard = zebra_test::init();
+
+    let mut bucket = AddrTokenBucket::default();
+    let start = Instant::now();
+
+    // The full burst is admitted, and the next address is not.
+    for _ in 0..ADDR_TOKEN_BUCKET_CAPACITY as usize {
+        assert!(bucket.try_take(start));
+    }
+    assert!(!bucket.try_take(start));
+
+    // One token refills after 1/rate seconds.
+    let refill = start + Duration::from_secs_f64(1.0 / ADDR_TOKEN_RATE);
+    assert!(bucket.try_take(refill));
+    assert!(!bucket.try_take(refill));
+
+    // Refill never exceeds the capacity.
+    let much_later = start + Duration::from_secs(60 * 60 * 24 * 365);
+    for _ in 0..ADDR_TOKEN_BUCKET_CAPACITY as usize {
+        assert!(bucket.try_take(much_later));
+    }
+    assert!(!bucket.try_take(much_later));
+}
+
+/// Sends `request` on a new request stream, and returns the response
+/// stream.
+async fn send_request(
+    connection: &quinn::Connection,
+    request: crate::protocol::v2::request::Request,
+) -> quinn::RecvStream {
+    let (mut send, recv) = connection.open_bi().await.expect("stream opens");
+    let mut bytes = vec![request.stream_type().byte()];
+    request.encode(&mut bytes).expect("request encodes");
+    send.write_all(&bytes).await.expect("request writes");
+    send.finish().expect("stream finishes");
+    recv
+}
+
+/// Reads one `get-mempool` subscription record from `recv`.
+async fn read_mempool_record(
+    recv: &mut quinn::RecvStream,
+) -> Vec<crate::protocol::v2::txref::TransactionReference> {
+    use crate::protocol::v2::{record, response::MempoolResponse};
+
+    let payload = tokio::time::timeout(TEST_TIMEOUT, record::read_record(recv))
+        .await
+        .expect("record arrives in time")
+        .expect("record parses")
+        .expect("record is present");
+    let mut reader = payload.as_slice();
+    let response = MempoolResponse::read(&mut reader)
+        .await
+        .expect("record payload parses");
+    assert!(reader.is_empty(), "no trailing bytes in the record");
+    response.0
+}
+
+/// Asserts that `connection` was closed with the application error `code`.
+async fn assert_closed_with(
+    connection: &quinn::Connection,
+    code: crate::protocol::v2::types::ErrorCode,
+    message: &str,
+) {
+    use crate::protocol::v2::types::ErrorCode;
+
+    let closed = tokio::time::timeout(TEST_TIMEOUT, connection.closed())
+        .await
+        .expect("connection closes in time");
+    match closed {
+        quinn::ConnectionError::ApplicationClosed(closed) => assert_eq!(
+            ErrorCode::from_wire(closed.error_code.into()),
+            code,
+            "{message}",
+        ),
+        other => panic!("expected an application close, got: {other:?}"),
+    }
+}
+
+/// Asserts that the peer reset `recv` with the application error `code`.
+async fn assert_reset_with(
+    recv: &mut quinn::RecvStream,
+    code: crate::protocol::v2::types::ErrorCode,
+    message: &str,
+) {
+    use crate::protocol::v2::types::ErrorCode;
+
+    let mut buf = [0u8; 1];
+    let result = tokio::time::timeout(TEST_TIMEOUT, recv.read(&mut buf))
+        .await
+        .expect("the reset arrives in time");
+    match result {
+        Err(quinn::ReadError::Reset(reset_code)) => assert_eq!(
+            ErrorCode::from_wire(reset_code.into_inner()),
+            code,
+            "{message}",
+        ),
+        other => panic!("expected a stream reset, got: {other:?}"),
+    }
+}
+
+/// Accepts bidirectional streams on `connection` until the peer opens one
+/// of `stream_type`, and returns it with the stream type byte consumed.
+///
+/// Streams of other types — like the peer's standing `get-mempool`
+/// subscription — are dropped unanswered.
+async fn accept_request_stream(
+    connection: &quinn::Connection,
+    stream_type: crate::protocol::v2::types::StreamType,
+) -> (quinn::SendStream, quinn::RecvStream) {
+    loop {
+        let (send, mut recv) = connection.accept_bi().await.expect("bi stream accepted");
+        let mut type_byte = [0u8; 1];
+        recv.read_exact(&mut type_byte)
+            .await
+            .expect("stream type byte is present");
+        if type_byte[0] == stream_type.byte() {
+            return (send, recv);
+        }
+    }
+}
+
+/// `get-mempool` opens a subscription: the responder sends its mempool
+/// snapshot, keeps its sending direction open, references transactions as
+/// they are accepted into its mempool, and serves a fresh snapshot to a
+/// sequential re-subscription after the first is cancelled.
+#[tokio::test]
+async fn v2_get_mempool_subscription_streams_snapshot_and_updates() {
+    use zebra_chain::transaction::UnminedTx;
+
+    use crate::protocol::v2::{
+        request::Request as V2WireRequest, txref::TransactionReference, types::ErrorCode,
+    };
+
+    let _init_guard = zebra_test::init();
+
+    let mut raw = raw_initiator(Arc::new(TestData::new())).await;
+    let connection = raw.connection.clone();
+
+    // Subscribe: the snapshot references the responder's whole mempool.
+    let mut recv = send_request(&connection, V2WireRequest::GetMempool).await;
+
+    let snapshot = read_mempool_record(&mut recv).await;
+    assert_eq!(
+        snapshot,
+        vec![TransactionReference::from(raw.data.transaction.id)],
+    );
+
+    // A transaction accepted into the responder's mempool afterwards is
+    // referenced in a further record on the same stream.
+    let accepted = UnminedTx::from(raw.data.block.transactions[1].clone());
+    call(
+        &mut raw.responder_client,
+        Request::AdvertiseTransactionIds([accepted.id].into(), None),
+    )
+    .await
+    .expect("advertise succeeds");
+
+    let update = read_mempool_record(&mut recv).await;
+    assert_eq!(update, vec![TransactionReference::from(accepted.id)]);
+
+    // Cancelling the subscription releases its slot: a sequential
+    // re-subscription is served a fresh snapshot.
+    recv.stop(ErrorCode::Cancelled.into())
+        .expect("stop succeeds");
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let mut recv = send_request(&connection, V2WireRequest::GetMempool).await;
+
+    let snapshot = read_mempool_record(&mut recv).await;
+    assert_eq!(
+        snapshot,
+        vec![TransactionReference::from(raw.data.transaction.id)],
+        "a sequential re-subscription is served again",
+    );
+
+    // Subscription serving assigns no misbehavior penalty.
+    assert!(raw.responder_misbehavior.try_recv().is_err());
+}
+
+/// Transaction announcements are trickled: identifiers advertised together
+/// are flushed as one batch — a single `get-mempool` update record — and
+/// each is also announced on the transaction announcement stream.
+#[tokio::test]
+async fn v2_transaction_announcements_are_trickled_in_batches() {
+    use std::collections::HashSet;
+
+    use zebra_chain::transaction::UnminedTx;
+
+    use crate::protocol::v2::{
+        record, request::Request as V2WireRequest, txref::TransactionReference, types::StreamType,
+    };
+
+    let _init_guard = zebra_test::init();
+
+    let mut raw = raw_initiator(Arc::new(TestData::new())).await;
+    let connection = raw.connection.clone();
+
+    // Subscribe first, so the trickled update record can be observed.
+    let mut recv = send_request(&connection, V2WireRequest::GetMempool).await;
+    let snapshot = read_mempool_record(&mut recv).await;
+    assert_eq!(
+        snapshot,
+        vec![TransactionReference::from(raw.data.transaction.id)],
+    );
+
+    // Two transactions advertised together share a trickle batch.
+    let tx_a = UnminedTx::from(raw.data.block.transactions[1].clone());
+    let tx_b = UnminedTx::from(raw.data.block.transactions[2].clone());
+    call(
+        &mut raw.responder_client,
+        Request::AdvertiseTransactionIds([tx_a.id, tx_b.id].into(), None),
+    )
+    .await
+    .expect("advertise succeeds");
+
+    let update: HashSet<TransactionReference> =
+        read_mempool_record(&mut recv).await.into_iter().collect();
+    let expected: HashSet<TransactionReference> = [
+        TransactionReference::from(tx_a.id),
+        TransactionReference::from(tx_b.id),
+    ]
+    .into();
+    assert_eq!(
+        update, expected,
+        "a batch advertised together is flushed as one update record",
+    );
+
+    // Each identifier is also announced on the announcement stream.
+    let mut announcements = tokio::time::timeout(
+        TEST_TIMEOUT,
+        accept_announcement_stream(&connection, StreamType::TransactionAnnouncements),
+    )
+    .await
+    .expect("transaction announcement stream opens in time");
+
+    let mut announced = HashSet::new();
+    for _ in 0..2 {
+        let payload = tokio::time::timeout(TEST_TIMEOUT, record::read_record(&mut announcements))
+            .await
+            .expect("announcement arrives in time")
+            .expect("announcement record parses")
+            .expect("announcement record is present");
+        announced.insert(
+            TransactionReference::parse_exact(&payload)
+                .await
+                .expect("announcement reference parses"),
+        );
+    }
+    assert_eq!(announced, expected);
+}
+
+/// A second concurrent `get-mempool` subscription from the same peer is a
+/// connection error of type `PROTOCOL_ERROR`.
+#[tokio::test]
+async fn v2_second_concurrent_mempool_subscription_is_a_connection_error() {
+    use crate::protocol::v2::types::{ErrorCode, StreamType};
+
+    let _init_guard = zebra_test::init();
+
+    let raw = raw_initiator(Arc::new(TestData::new())).await;
+    let connection = raw.connection.clone();
+
+    // Both receive halves stay open: dropping one would cancel that
+    // subscription, making the second one sequential instead of concurrent.
+    let (mut first, _first_recv) = connection.open_bi().await.expect("stream opens");
+    first
+        .write_all(&[StreamType::GetMempool.byte()])
+        .await
+        .expect("stream type writes");
+    first.finish().expect("stream finishes");
+
+    let (mut second, _second_recv) = connection.open_bi().await.expect("stream opens");
+    second
+        .write_all(&[StreamType::GetMempool.byte()])
+        .await
+        .expect("stream type writes");
+    second.finish().expect("stream finishes");
+
+    assert_closed_with(
+        &connection,
+        ErrorCode::ProtocolError,
+        "a second concurrent get-mempool subscription is a connection error",
+    )
+    .await;
+}
+
+/// Accepts unidirectional streams on `connection` until the peer opens one
+/// of `stream_type`, and returns it with the stream type byte consumed.
+async fn accept_announcement_stream(
+    connection: &quinn::Connection,
+    stream_type: crate::protocol::v2::types::StreamType,
+) -> quinn::RecvStream {
+    loop {
+        let mut recv = connection.accept_uni().await.expect("uni stream accepted");
+        let mut type_byte = [0u8; 1];
+        recv.read_exact(&mut type_byte)
+            .await
+            .expect("stream type byte is present");
+        if type_byte[0] == stream_type.byte() {
+            return recv;
+        }
+    }
+}
+
+/// A block advertised to a peer that requested high-bandwidth announcements
+/// is announced as a compact block, and the announcing node then serves the
+/// block's transactions to that peer's reconstruction `get-tx` requests: by
+/// `SHORTID` reference, and by ordinary reference even for transactions
+/// that are not in its mempool.
+#[tokio::test]
+async fn v2_hb_compact_block_announcement_and_reconstruction_serving() {
+    use crate::protocol::v2::{
+        compact_block::{short_id_keys, short_transaction_id, CompactBlock, CompactBlockIds},
+        record,
+        request::Request as V2WireRequest,
+        response::read_result_entry,
+        txref::TransactionReference,
+        types::StreamType,
+    };
+    use zebra_chain::{serialization::ZcashSerialize, transaction::UnminedTxId};
+
+    let _init_guard = zebra_test::init();
+
+    let mut raw = raw_initiator_with_init(Arc::new(TestData::new()), true, false).await;
+    let connection = raw.connection.clone();
+    let block = raw.data.block.clone();
+    assert!(block.transactions.len() >= 3);
+
+    // The responder node advertises the multi-transaction block: it fetches
+    // the block locally and announces it to this high-bandwidth peer.
+    call(
+        &mut raw.responder_client,
+        Request::AdvertiseBlockToAll(block.hash()),
+    )
+    .await
+    .expect("advertise request succeeds");
+
+    let mut announcements = tokio::time::timeout(
+        TEST_TIMEOUT,
+        accept_announcement_stream(&connection, StreamType::BlockAnnouncements),
+    )
+    .await
+    .expect("block announcement stream opens in time");
+
+    let payload = tokio::time::timeout(TEST_TIMEOUT, record::read_record(&mut announcements))
+        .await
+        .expect("announcement arrives in time")
+        .expect("announcement record parses")
+        .expect("announcement record is present");
+    let (&kind, mut body) = payload
+        .split_first()
+        .expect("announcement record is not empty");
+    assert_eq!(kind, 0x01, "high-bandwidth peers get compact blocks");
+
+    let compact = CompactBlock::read(&mut body)
+        .await
+        .expect("compact block parses");
+    assert_eq!(compact.header.hash(), block.hash());
+
+    // The coinbase transaction is prefilled, and every other transaction is
+    // identified by a short ID computed with the announcement's nonce.
+    assert_eq!(compact.prefilled.len(), 1);
+    assert_eq!(compact.prefilled[0].index, 0);
+    assert_eq!(compact.prefilled[0].tx, block.transactions[0]);
+
+    let header_bytes = block
+        .header
+        .zcash_serialize_to_vec()
+        .expect("serializing a header succeeds");
+    let (k0, k1) = short_id_keys(&header_bytes, compact.nonce);
+    let expected_ids: Vec<_> = block
+        .transactions
+        .iter()
+        .skip(1)
+        .map(|tx| short_transaction_id(k0, k1, &UnminedTxId::from(tx.as_ref())))
+        .collect();
+    let CompactBlockIds::Short(ids) = &compact.ids else {
+        panic!("a peer that did not request full IDs gets short IDs");
+    };
+    assert_eq!(ids, &expected_ids);
+
+    // The block's transactions are now servable to this peer: by the short
+    // IDs of the announcement, and by ordinary references, even though the
+    // responder's mempool does not hold them. Unknown short IDs and other
+    // blocks' short IDs are answered not-found.
+    let mut recv = send_request(
+        &connection,
+        V2WireRequest::GetTx {
+            refs: vec![
+                TransactionReference::ShortId {
+                    block_hash: block.hash(),
+                    short_id: expected_ids[0],
+                },
+                TransactionReference::from(UnminedTxId::from(block.transactions[2].as_ref())),
+                TransactionReference::ShortId {
+                    block_hash: block.hash(),
+                    short_id: crate::protocol::v2::compact_block::ShortTxId([0x0F; 6]),
+                },
+                TransactionReference::ShortId {
+                    block_hash: zebra_chain::block::Hash([0xAB; 32]),
+                    short_id: expected_ids[0],
+                },
+            ],
+        },
+    )
+    .await;
+
+    let mut entries = Vec::new();
+    for _ in 0..4 {
+        let entry = tokio::time::timeout(
+            TEST_TIMEOUT,
+            read_result_entry::<zebra_chain::transaction::Transaction, _>(&mut recv, "get-tx"),
+        )
+        .await
+        .expect("response arrives in time")
+        .expect("response entry parses");
+        entries.push(entry);
+    }
+    record::expect_end_of_stream(&mut recv)
+        .await
+        .expect("response is complete");
+
+    match &entries[0] {
+        Some(tx) => assert_eq!(tx, &block.transactions[1]),
+        other => panic!("expected the short ID's transaction, got: {other:?}"),
+    }
+    match &entries[1] {
+        Some(tx) => assert_eq!(tx, &block.transactions[2]),
+        other => panic!("expected the sent block's transaction, got: {other:?}"),
+    }
+    assert!(
+        entries[2].is_none(),
+        "an unknown short ID is answered not-found",
+    );
+    assert!(
+        entries[3].is_none(),
+        "a short ID for a block without a sent compact block is answered not-found",
+    );
+
+    // High-bandwidth serving assigns no misbehavior penalty.
+    assert!(raw.responder_misbehavior.try_recv().is_err());
+}
+
+/// A high-bandwidth peer that also requested full transaction IDs receives
+/// compact blocks whose transactions are identified by 64-byte full IDs,
+/// with a zero nonce.
+#[tokio::test]
+async fn v2_hb_compact_block_uses_full_ids_on_request() {
+    use crate::protocol::v2::{
+        compact_block::{full_transaction_id, CompactBlock, CompactBlockIds},
+        record,
+        types::StreamType,
+    };
+    use zebra_chain::transaction::UnminedTxId;
+
+    let _init_guard = zebra_test::init();
+
+    let mut raw = raw_initiator_with_init(Arc::new(TestData::new()), true, true).await;
+    let connection = raw.connection.clone();
+    let block = raw.data.block.clone();
+
+    call(
+        &mut raw.responder_client,
+        Request::AdvertiseBlockToAll(block.hash()),
+    )
+    .await
+    .expect("advertise request succeeds");
+
+    let mut announcements = tokio::time::timeout(
+        TEST_TIMEOUT,
+        accept_announcement_stream(&connection, StreamType::BlockAnnouncements),
+    )
+    .await
+    .expect("block announcement stream opens in time");
+
+    let payload = tokio::time::timeout(TEST_TIMEOUT, record::read_record(&mut announcements))
+        .await
+        .expect("announcement arrives in time")
+        .expect("announcement record parses")
+        .expect("announcement record is present");
+    let (&kind, mut body) = payload
+        .split_first()
+        .expect("announcement record is not empty");
+    assert_eq!(kind, 0x01);
+
+    let compact = CompactBlock::read(&mut body)
+        .await
+        .expect("compact block parses");
+    assert_eq!(compact.header.hash(), block.hash());
+    assert_eq!(compact.nonce, 0, "full ID compact blocks have a zero nonce");
+
+    let expected_ids: Vec<_> = block
+        .transactions
+        .iter()
+        .skip(1)
+        .map(|tx| full_transaction_id(&UnminedTxId::from(tx.as_ref())))
+        .collect();
+    let CompactBlockIds::Full(ids) = &compact.ids else {
+        panic!("a peer that requested full IDs gets full IDs");
+    };
+    assert_eq!(ids, &expected_ids);
+}
+
+/// Block announcements are built as headers for peers that did not request
+/// compact blocks, and as the header substitute when a block's compact
+/// encoding would exceed the record payload limit.
+#[test]
+fn v2_block_announcements_fall_back_to_headers() {
+    use crate::{
+        peer::v2::connection::{build_block_announcement, BlockAnnouncementRecord},
+        protocol::{
+            external::types::{Nonce, Version},
+            v2::init::InitRecord,
+        },
+    };
+    use zebra_chain::{block::Header, serialization::ZcashDeserialize};
+
+    let _init_guard = zebra_test::init();
+
+    let data = TestData::new();
+    let init = |announce, full_ids| InitRecord {
+        version: Version(170_160),
+        services: PeerServices::NODE_NETWORK,
+        nonce: Nonce(1),
+        user_agent: "/ZebraV2Test:0.0.1/".to_string(),
+        start_height: zebra_chain::block::Height(0),
+        relay: true,
+        announce,
+        full_ids,
+    };
+
+    // A low-bandwidth peer gets a header announcement.
+    match build_block_announcement(&data.block, &init(false, false), 42) {
+        BlockAnnouncementRecord::Header { payload } => {
+            assert_eq!(payload[0], 0x00);
+            let header = Header::zcash_deserialize(&payload[1..]).expect("header parses");
+            assert_eq!(header.hash(), data.block.hash());
+        }
+        BlockAnnouncementRecord::Compact { .. } => {
+            panic!("low-bandwidth peers must not get compact blocks")
+        }
+    }
+
+    // A high-bandwidth peer gets a compact block, carrying the nonce.
+    match build_block_announcement(&data.block, &init(true, false), 42) {
+        BlockAnnouncementRecord::Compact { payload, nonce } => {
+            assert_eq!(payload[0], 0x01);
+            assert_eq!(nonce, 42);
+        }
+        BlockAnnouncementRecord::Header { .. } => {
+            panic!("high-bandwidth peers get compact blocks")
+        }
+    }
+
+    // A block whose compact encoding exceeds the record payload limit is
+    // announced with the header substitute: 35,000 transactions at 64 bytes
+    // of full ID each overflow the 2 MiB record limit.
+    let huge_block = Block {
+        header: data.block.header.clone(),
+        transactions: vec![data.block.transactions[1].clone(); 35_000],
+    };
+    match build_block_announcement(&huge_block, &init(true, true), 42) {
+        BlockAnnouncementRecord::Header { payload } => assert_eq!(payload[0], 0x00),
+        BlockAnnouncementRecord::Compact { .. } => {
+            panic!("an oversized compact block must fall back to a header announcement")
+        }
+    }
+}
+
+/// `get-headers` with `tx_ids = 1` identifies each served block's
+/// transactions: the coinbase in full, and the rest by their full
+/// transaction IDs. Blocks the responder cannot supply are answered with
+/// `has_txs = 0x00`.
+#[tokio::test]
+async fn v2_get_headers_with_tx_ids_serves_coinbase_and_full_ids() {
+    use tokio::io::AsyncReadExt;
+
+    use zebra_chain::{block::Header, transaction::Transaction};
+
+    use crate::protocol::v2::{record, request::Request as V2WireRequest, types::WireError};
+
+    let _init_guard = zebra_test::init();
+
+    // Header 2's block is unavailable, so the has_txs = 0 fallback is
+    // exercised.
+    let mut data = TestData::new();
+    data.served_blocks.shift_remove(&data.block_2.hash());
+    let raw = raw_initiator(Arc::new(data)).await;
+    let block_1 = raw.data.block_1.clone();
+
+    let mut recv = send_request(
+        &raw.connection,
+        V2WireRequest::GetHeaders {
+            known_blocks: vec![],
+            stop: None,
+            tx_ids: true,
+        },
+    )
+    .await;
+
+    let response = tokio::time::timeout(TEST_TIMEOUT, async {
+        let count = record::read_compact_size(&mut recv).await?;
+
+        let mut entries = Vec::new();
+        for _ in 0..count {
+            let header_bytes = record::read_record(&mut recv)
+                .await?
+                .expect("header record is present");
+            let header: Header = header_bytes
+                .as_slice()
+                .zcash_deserialize_into()
+                .expect("served header parses");
+
+            let txs = match recv.read_u8().await.expect("has_txs byte is present") {
+                0x00 => None,
+                0x01 => {
+                    let coinbase_bytes = record::read_record(&mut recv)
+                        .await?
+                        .expect("coinbase record is present");
+                    let coinbase: Transaction = coinbase_bytes
+                        .as_slice()
+                        .zcash_deserialize_into()
+                        .expect("served coinbase parses");
+
+                    let id_count = record::read_compact_size(&mut recv).await?;
+                    let mut ids = Vec::new();
+                    for _ in 0..id_count {
+                        let mut id = [0u8; 64];
+                        recv.read_exact(&mut id).await.expect("full ID is present");
+                        ids.push(id);
+                    }
+
+                    Some((coinbase, ids))
+                }
+                other => panic!("invalid has_txs byte: {other:#04X}"),
+            };
+
+            entries.push((header, txs));
+        }
+
+        record::expect_end_of_stream(&mut recv).await?;
+        Ok::<_, WireError>(entries)
+    })
+    .await
+    .expect("response arrives in time")
+    .expect("response parses");
+
+    assert_eq!(response.len(), raw.data.headers.len());
+
+    // Block 1 is served: its entry carries the coinbase transaction and the
+    // (empty) list of the remaining transactions' full IDs.
+    let (header, txs) = &response[0];
+    assert_eq!(header.hash(), block_1.hash());
+    let (coinbase, ids) = txs.as_ref().expect("block 1 is served with transactions");
+    assert_eq!(coinbase, block_1.transactions[0].as_ref());
+    assert!(ids.is_empty(), "block 1 has only a coinbase transaction");
+
+    // Block 2 is not available from the responder's inbound service, so its
+    // transactions are omitted: the requester falls back to `get-blocks`.
+    let (header, txs) = &response[1];
+    assert_eq!(header.hash(), raw.data.headers[1].header.hash());
+    assert!(
+        txs.is_none(),
+        "an unavailable block is answered has_txs = 0"
+    );
+
+    // Sending the entry obligates the responder to serve the block's
+    // transactions to this peer, even though they are not in its mempool —
+    // but not by `SHORTID`, which only a compact block establishes.
+    use crate::protocol::v2::{
+        compact_block::ShortTxId, response::read_result_entry, txref::TransactionReference,
+    };
+    use zebra_chain::transaction::UnminedTxId;
+
+    let coinbase_id = UnminedTxId::from(block_1.transactions[0].as_ref());
+    let mut recv = send_request(
+        &raw.connection,
+        V2WireRequest::GetTx {
+            refs: vec![
+                TransactionReference::from(coinbase_id),
+                TransactionReference::ShortId {
+                    block_hash: block_1.hash(),
+                    short_id: ShortTxId([0x0F; 6]),
+                },
+            ],
+        },
+    )
+    .await;
+
+    let found = tokio::time::timeout(
+        TEST_TIMEOUT,
+        read_result_entry::<zebra_chain::transaction::Transaction, _>(&mut recv, "get-tx"),
+    )
+    .await
+    .expect("response arrives in time")
+    .expect("response entry parses");
+    match found {
+        Some(tx) => assert_eq!(&tx, &block_1.transactions[0]),
+        other => panic!("expected the sent block's coinbase, got: {other:?}"),
+    }
+    let missing =
+        read_result_entry::<zebra_chain::transaction::Transaction, _>(&mut recv, "get-tx")
+            .await
+            .expect("response entry parses");
+    assert!(
+        missing.is_none(),
+        "a SHORTID reference to a block sent without a compact block is not-found",
+    );
+}
+
+/// `get-hashes` and `get-tree-roots` are served from the inbound service's
+/// synchronization reads, a `get-tree-roots` request whose anchor is not in
+/// the best chain is refused, and `get-block-range` streams the anchor's
+/// ancestor chain in descending order with exact bounds.
+#[tokio::test]
+async fn v2_sync_primitives_are_served() {
+    use zebra_chain::serialization::ZcashDeserialize;
+
+    use crate::protocol::v2::{
+        record,
+        request::Request as V2WireRequest,
+        response::{HashesResponse, TreeRootsResponse},
+        types::ErrorCode,
+    };
+
+    let _init_guard = zebra_test::init();
+
+    let raw = raw_initiator(Arc::new(TestData::new())).await;
+    let connection = raw.connection.clone();
+
+    // get-hashes answers with the inbound service's entries.
+    let mut recv = send_request(
+        &connection,
+        V2WireRequest::GetHashes {
+            start_height: 0,
+            stride: 400,
+            count: 100,
+        },
+    )
+    .await;
+    let response = tokio::time::timeout(TEST_TIMEOUT, HashesResponse::read(&mut recv))
+        .await
+        .expect("response arrives in time")
+        .expect("response parses");
+    assert_eq!(response.0, test_sync_hash_entries(&raw.data));
+    record::expect_end_of_stream(&mut recv)
+        .await
+        .expect("response is complete");
+
+    // get-tree-roots answers with the inbound service's entries when the
+    // anchor matches.
+    let mut recv = send_request(
+        &connection,
+        V2WireRequest::GetTreeRoots {
+            start_height: 0,
+            final_hash: raw.data.block.hash(),
+            count: 1,
+        },
+    )
+    .await;
+    let response = tokio::time::timeout(TEST_TIMEOUT, TreeRootsResponse::read(&mut recv))
+        .await
+        .expect("response arrives in time")
+        .expect("response parses");
+    assert_eq!(response.0, test_tree_roots_entries());
+    record::expect_end_of_stream(&mut recv)
+        .await
+        .expect("response is complete");
+
+    // A get-tree-roots request whose anchor is not in the best chain is
+    // refused rather than answered with entries for different blocks.
+    let mut recv = send_request(
+        &connection,
+        V2WireRequest::GetTreeRoots {
+            start_height: 0,
+            final_hash: zebra_chain::block::Hash([0xAB; 32]),
+            count: 1,
+        },
+    )
+    .await;
+    assert_reset_with(
+        &mut recv,
+        ErrorCode::Refused,
+        "an unknown anchor is refused",
+    )
+    .await;
+
+    // get-block-range streams the anchor's ancestor chain in descending
+    // order: block 2, then block 1, then the (unserved) genesis parent
+    // truncates the stream.
+    async fn read_block_range(
+        recv: &mut quinn::RecvStream,
+    ) -> (u8, Vec<Arc<zebra_chain::block::Block>>) {
+        let result = record::read_u8(recv).await.expect("result byte parses");
+        let mut blocks = Vec::new();
+        if result != 0x00 {
+            record::expect_end_of_stream(recv)
+                .await
+                .expect("nothing follows a not-found result");
+            return (result, blocks);
+        }
+        loop {
+            match record::read_record(recv).await.expect("record parses") {
+                Some(payload) => blocks.push(Arc::new(
+                    zebra_chain::block::Block::zcash_deserialize(payload.as_slice())
+                        .expect("served block parses"),
+                )),
+                None => return (result, blocks),
+            }
+        }
+    }
+
+    // Each case is (name, anchor, count, max_bytes, expected result,
+    // expected block hashes).
+    let cases: [(&str, zebra_chain::block::Hash, u64, u64, u8, Vec<_>); 4] = [
+        (
+            "blocks stream in descending order from the anchor",
+            raw.data.block_2.hash(),
+            5,
+            8_000_000,
+            0x00,
+            vec![raw.data.block_2.hash(), raw.data.block_1.hash()],
+        ),
+        (
+            "the count bound is exact",
+            raw.data.block_2.hash(),
+            1,
+            8_000_000,
+            0x00,
+            vec![raw.data.block_2.hash()],
+        ),
+        (
+            "the first block is delivered regardless of max_bytes",
+            raw.data.block_2.hash(),
+            5,
+            1,
+            0x00,
+            vec![raw.data.block_2.hash()],
+        ),
+        (
+            "an unknown anchor answers not-found",
+            zebra_chain::block::Hash([0xAB; 32]),
+            5,
+            8_000_000,
+            0x02,
+            vec![],
+        ),
+    ];
+
+    for (name, final_hash, count, max_bytes, expected_result, expected_hashes) in cases {
+        let mut recv = send_request(
+            &connection,
+            V2WireRequest::GetBlockRange {
+                final_hash,
+                count,
+                max_bytes,
+            },
+        )
+        .await;
+
+        let (result, blocks) = tokio::time::timeout(TEST_TIMEOUT, read_block_range(&mut recv))
+            .await
+            .unwrap_or_else(|_| panic!("{name}: response arrives in time"));
+
+        assert_eq!(result, expected_result, "{name}");
+        let hashes: Vec<_> = blocks.iter().map(|block| block.hash()).collect();
+        assert_eq!(hashes, expected_hashes, "{name}");
+    }
+}
+
+/// `get-object` serves ranged reads of content-addressed artifacts from
+/// the artifact directory: the object's size always answers, data never
+/// extends past `length` bytes or the object's end, and unknown hashes
+/// answer not-found.
+#[tokio::test]
+async fn v2_get_object_serves_ranged_artifact_reads() {
+    use sha2::{Digest, Sha256};
+
+    use crate::protocol::v2::{record, request::Request as V2WireRequest, types::ObjectHash};
+
+    let _init_guard = zebra_test::init();
+
+    // An artifact directory holding one 100,000-byte object named by the
+    // hex hash of its contents.
+    let temp = tempfile::tempdir().expect("temp dir creates");
+    let artifact_dir = temp
+        .path()
+        .join("network")
+        .join("artifacts")
+        .join("mainnet");
+    std::fs::create_dir_all(&artifact_dir).expect("artifact dir creates");
+    let object: Vec<u8> = (0..100_000u32).map(|i| i as u8).collect();
+    let hash: [u8; 32] = Sha256::digest(&object).into();
+    std::fs::write(artifact_dir.join(hex::encode(hash)), &object).expect("artifact writes");
+
+    let config = Config {
+        network: Network::Mainnet,
+        cache_dir: crate::config::CacheDir::custom_path(temp.path()),
+        ..Config::default()
+    };
+    let raw = raw_initiator_with_config(Arc::new(TestData::new()), config).await;
+    let connection = raw.connection.clone();
+
+    async fn get_object(
+        connection: &quinn::Connection,
+        request: V2WireRequest,
+    ) -> (u8, u64, Vec<u8>) {
+        let mut recv = send_request(connection, request).await;
+
+        let result = record::read_u8(&mut recv)
+            .await
+            .expect("result byte parses");
+        if result != 0x00 {
+            record::expect_end_of_stream(&mut recv)
+                .await
+                .expect("nothing follows a not-found result");
+            return (result, 0, Vec::new());
+        }
+        let size = record::read_compact_size(&mut recv)
+            .await
+            .expect("size parses");
+        let mut data = Vec::new();
+        tokio::io::AsyncReadExt::read_to_end(&mut recv, &mut data)
+            .await
+            .expect("data reads");
+        (result, size, data)
+    }
+
+    // Each case is (name, hash, offset, length, expected result, expected data).
+    let cases: [(&str, [u8; 32], u64, u64, u8, &[u8]); 5] = [
+        ("the whole object", hash, 0, 200_000, 0x00, &object),
+        (
+            "a middle range delivers exactly the requested bytes",
+            hash,
+            40_000,
+            10_000,
+            0x00,
+            &object[40_000..50_000],
+        ),
+        (
+            "a range past the end is truncated at the object's size",
+            hash,
+            90_000,
+            50_000,
+            0x00,
+            &object[90_000..],
+        ),
+        (
+            "an offset at the size answers the size and no data",
+            hash,
+            100_000,
+            1_000,
+            0x00,
+            &[],
+        ),
+        (
+            "an unknown hash answers not-found",
+            [0xEE; 32],
+            0,
+            16,
+            0x02,
+            &[],
+        ),
+    ];
+
+    for (name, object_hash, offset, length, expected_result, expected_data) in cases {
+        let (result, size, data) = tokio::time::timeout(
+            TEST_TIMEOUT,
+            get_object(
+                &connection,
+                V2WireRequest::GetObject {
+                    hash: ObjectHash(object_hash),
+                    offset,
+                    length,
+                },
+            ),
+        )
+        .await
+        .unwrap_or_else(|_| panic!("{name}: response arrives in time"));
+
+        assert_eq!(result, expected_result, "{name}");
+        assert_eq!(data, expected_data, "{name}");
+
+        // A found result always reports the object's full size, whatever
+        // range of it was asked for.
+        if result == 0x00 && offset + length <= object.len() as u64 {
+            assert_eq!(size, object.len() as u64, "{name}");
+        }
+    }
+}
+
+/// `get-object` requests are refused while the artifact store does not
+/// exist, and malformed sync requests are still connection errors: requests
+/// are read and validated before refusal.
+#[tokio::test]
+async fn v2_get_object_is_refused_and_malformed_sync_requests_are_rejected() {
+    use crate::protocol::v2::{
+        request::Request as V2WireRequest,
+        types::{ErrorCode, ObjectHash, StreamType},
+    };
+
+    let _init_guard = zebra_test::init();
+
+    // The responder has no cache directory, so it has no artifact store.
+    let config = Config {
+        network: Network::Mainnet,
+        cache_dir: crate::config::CacheDir::disabled(),
+        ..Config::default()
+    };
+    let raw = raw_initiator_with_config(Arc::new(TestData::new()), config).await;
+    let connection = raw.connection.clone();
+
+    let request = V2WireRequest::GetObject {
+        hash: ObjectHash([0x5A; 32]),
+        offset: 0,
+        length: 1_024,
+    };
+    let (mut send, mut recv) = connection.open_bi().await.expect("stream opens");
+    let mut bytes = vec![request.stream_type().byte()];
+    request.encode(&mut bytes).expect("request encodes");
+    send.write_all(&bytes).await.expect("request writes");
+    send.finish().expect("stream finishes");
+
+    assert_reset_with(
+        &mut recv,
+        ErrorCode::Refused,
+        "get-object requests are refused with REFUSED",
+    )
+    .await;
+
+    // A malformed sync request (stride 0) is not refused but rejected:
+    // requests are validated before the refusal, and a violation is a
+    // connection error of type `PROTOCOL_ERROR`.
+    let (mut send, _recv) = connection.open_bi().await.expect("stream opens");
+    let mut bytes = vec![StreamType::GetHashes.byte()];
+    bytes.extend_from_slice(&0u32.to_le_bytes());
+    bytes.extend_from_slice(&0u32.to_le_bytes());
+    bytes.push(0x01);
+    send.write_all(&bytes).await.expect("request writes");
+    send.finish().expect("stream finishes");
+
+    assert_closed_with(
+        &connection,
+        ErrorCode::ProtocolError,
+        "a malformed sync request is a connection error",
+    )
+    .await;
+}
+
+/// Streams with unrecognized type bytes are refused with
+/// `UNSUPPORTED_STREAM_TYPE` — bidirectional and unidirectional alike —
+/// without a connection error or a misbehavior penalty, so future stream
+/// types can be deployed without version gating.
+#[tokio::test]
+async fn v2_unknown_stream_types_are_refused_without_penalty() {
+    use crate::protocol::v2::{
+        record, request::Request as V2WireRequest, response::read_result_entry, types::ErrorCode,
+    };
+
+    let _init_guard = zebra_test::init();
+
+    let mut raw = raw_initiator(Arc::new(TestData::new())).await;
+    let connection = raw.connection.clone();
+
+    // An unrecognized bidirectional stream type: the first unassigned
+    // request-range byte.
+    let (mut send, mut recv) = connection.open_bi().await.expect("stream opens");
+    send.write_all(&[0x0A]).await.expect("type byte writes");
+    send.finish().expect("stream finishes");
+
+    assert_reset_with(
+        &mut recv,
+        ErrorCode::UnsupportedStreamType,
+        "unknown bidirectional stream types are refused",
+    )
+    .await;
+
+    // An unrecognized unidirectional stream type: the first unassigned
+    // announcement-range byte. Refusing a unidirectional stream involves
+    // only cancelling the sender's direction.
+    let mut send = connection.open_uni().await.expect("stream opens");
+    send.write_all(&[0x13]).await.expect("type byte writes");
+    let stopped = tokio::time::timeout(TEST_TIMEOUT, send.stopped())
+        .await
+        .expect("cancellation arrives in time")
+        .expect("stream is stopped, not lost");
+    assert_eq!(
+        stopped.map(|code| ErrorCode::from_wire(code.into_inner())),
+        Some(ErrorCode::UnsupportedStreamType),
+        "unknown unidirectional stream types are refused",
+    );
+
+    // The connection survives, requests are still served, and no penalty
+    // was assigned.
+    let mut recv = send_request(
+        &connection,
+        V2WireRequest::GetBlocks {
+            hashes: vec![raw.data.block.hash()],
+        },
+    )
+    .await;
+
+    let entry = tokio::time::timeout(
+        TEST_TIMEOUT,
+        read_result_entry::<zebra_chain::block::Block, _>(&mut recv, "get-blocks"),
+    )
+    .await
+    .expect("response arrives in time")
+    .expect("response entry parses");
+    assert!(
+        entry.is_some(),
+        "the connection still serves requests after refused streams",
+    );
+    record::expect_end_of_stream(&mut recv)
+        .await
+        .expect("response is complete");
+
+    assert!(
+        raw.responder_misbehavior.try_recv().is_err(),
+        "unknown stream types must not be penalized",
+    );
+}
+
+/// A second concurrent announcement stream of the same type is a connection
+/// error of type `PROTOCOL_ERROR`.
+#[tokio::test]
+async fn v2_second_announcement_stream_of_a_type_is_a_connection_error() {
+    use crate::protocol::v2::types::{ErrorCode, StreamType};
+
+    let _init_guard = zebra_test::init();
+
+    let raw = raw_initiator(Arc::new(TestData::new())).await;
+    let connection = raw.connection.clone();
+
+    // Open two concurrent transaction announcement streams, sending only
+    // the type bytes: the second registration must fail the connection.
+    let mut first = connection.open_uni().await.expect("stream opens");
+    first
+        .write_all(&[StreamType::TransactionAnnouncements.byte()])
+        .await
+        .expect("type byte writes");
+
+    let mut second = connection.open_uni().await.expect("stream opens");
+    second
+        .write_all(&[StreamType::TransactionAnnouncements.byte()])
+        .await
+        .expect("type byte writes");
+
+    assert_closed_with(
+        &connection,
+        ErrorCode::ProtocolError,
+        "a second concurrent announcement stream of a type is a connection error",
+    )
+    .await;
+}
+
+/// After an announcement stream is reset, its sender may open a replacement
+/// of the same type, and records on the replacement are processed.
+#[tokio::test]
+async fn v2_announcement_stream_reopens_after_reset() {
+    use crate::protocol::v2::{
+        record,
+        txref::TransactionReference,
+        types::{ErrorCode, StreamType},
+    };
+
+    let _init_guard = zebra_test::init();
+
+    let mut raw = raw_initiator(Arc::new(TestData::new())).await;
+    let connection = raw.connection.clone();
+
+    let announce = |txid_byte: u8| {
+        let mut payload = Vec::new();
+        TransactionReference::Txid(zebra_chain::transaction::Hash([txid_byte; 32]))
+            .encode(&mut payload)
+            .expect("write to Vec succeeds");
+        let mut framed = vec![StreamType::TransactionAnnouncements.byte()];
+        record::write_record(&mut framed, &payload).expect("write to Vec succeeds");
+        framed
+    };
+
+    // Announce a transaction, and wait for it to reach the responder's
+    // inbound service, so the reset cannot race the record.
+    let mut first = connection.open_uni().await.expect("stream opens");
+    first
+        .write_all(&announce(0x01))
+        .await
+        .expect("record writes");
+
+    let event = tokio::time::timeout(TEST_TIMEOUT, raw.responder_events.recv())
+        .await
+        .expect("announcement arrives in time")
+        .expect("responder events channel is open");
+    assert!(
+        matches!(event, Request::AdvertiseTransactionIds(_, _)),
+        "got: {event:?}",
+    );
+
+    // Reset the announcement stream, then open a replacement of the same
+    // type: the replacement must be accepted and its records processed.
+    first
+        .reset(ErrorCode::InternalError.into())
+        .expect("stream resets");
+
+    // The responder deregisters the stream when it observes the reset, and
+    // a replacement opened before that is a second concurrent stream, so
+    // give the reset time to arrive: this wait makes the test reliable, and
+    // a lost race fails it (the connection would close with a
+    // `PROTOCOL_ERROR`).
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let mut second = connection.open_uni().await.expect("stream opens");
+    second
+        .write_all(&announce(0x02))
+        .await
+        .expect("record writes");
+
+    let event = tokio::time::timeout(TEST_TIMEOUT, raw.responder_events.recv())
+        .await
+        .expect("replacement announcement arrives in time")
+        .expect("responder events channel is open");
+    assert!(
+        matches!(event, Request::AdvertiseTransactionIds(_, _)),
+        "got: {event:?}",
+    );
+}
+
+/// A peer that opens a request stream and stalls without completing its
+/// request is abandoned after `INBOUND_STREAM_TIMEOUT`: both stream
+/// directions are cancelled with `CANCELLED`, the connection stays open,
+/// and no penalty is assigned.
+///
+/// This test waits for a real inbound stream timeout, so it takes about
+/// 40 seconds.
+#[tokio::test]
+async fn v2_stalled_inbound_request_stream_is_abandoned() {
+    use crate::protocol::v2::{
+        constants::INBOUND_STREAM_TIMEOUT,
+        record,
+        request::Request as V2WireRequest,
+        response::read_result_entry,
+        types::{ErrorCode, StreamType},
+    };
+
+    let _init_guard = zebra_test::init();
+
+    let mut raw = raw_initiator(Arc::new(TestData::new())).await;
+    let connection = raw.connection.clone();
+
+    // A `get-tx` request that promises one reference and never sends it,
+    // with the stream left open: the responder must not let the stalled
+    // stream pin its task and buffers forever.
+    let (mut send, mut recv) = connection.open_bi().await.expect("stream opens");
+    send.write_all(&[StreamType::GetTx.byte(), 0x01])
+        .await
+        .expect("partial request writes");
+
+    let stopped = tokio::time::timeout(INBOUND_STREAM_TIMEOUT + TEST_TIMEOUT, send.stopped())
+        .await
+        .expect("cancellation arrives in time")
+        .expect("stream is stopped, not lost");
+    assert_eq!(
+        stopped.map(|code| ErrorCode::from_wire(code.into_inner())),
+        Some(ErrorCode::Cancelled),
+        "a stalled request stream is cancelled",
+    );
+
+    let mut buf = [0u8; 1];
+    let result = tokio::time::timeout(TEST_TIMEOUT, recv.read(&mut buf))
+        .await
+        .expect("reset arrives in time");
+    assert!(
+        matches!(result, Err(quinn::ReadError::Reset(code))
+            if ErrorCode::from_wire(code.into_inner()) == ErrorCode::Cancelled),
+        "a stalled request stream's response direction is reset, got: {result:?}",
+    );
+
+    // The connection survives, requests are still served, and no penalty
+    // was assigned: a stall is indistinguishable from a slow peer.
+    let mut recv = send_request(
+        &connection,
+        V2WireRequest::GetBlocks {
+            hashes: vec![raw.data.block.hash()],
+        },
+    )
+    .await;
+
+    let entry = tokio::time::timeout(
+        TEST_TIMEOUT,
+        read_result_entry::<zebra_chain::block::Block, _>(&mut recv, "get-blocks"),
+    )
+    .await
+    .expect("response arrives in time")
+    .expect("response entry parses");
+    assert!(
+        entry.is_some(),
+        "the connection still serves requests after an abandoned stream",
+    );
+    record::expect_end_of_stream(&mut recv)
+        .await
+        .expect("response is complete");
+
+    assert!(
+        raw.responder_misbehavior.try_recv().is_err(),
+        "a stalled stream must not be penalized",
+    );
+}

--- a/zebra-network/src/peer_set.rs
+++ b/zebra-network/src/peer_set.rs
@@ -11,7 +11,9 @@ pub(crate) use candidate_set::{
     NextPeerService,
 };
 pub(crate) use inventory_registry::InventoryChange;
-pub(crate) use limit::{ActiveConnectionCounter, ConnectionTracker, SharedConnectionCounter};
+pub(crate) use limit::{
+    ActiveConnectionCounter, ConnectionTracker, SharedConnectionCounter, SlotCounter, SlotGuard,
+};
 
 use inventory_registry::InventoryRegistry;
 pub(crate) use set::PeerSet;

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -187,6 +187,10 @@ where
 /// apart. If a peer was recently provided, then this future will sleep
 /// until the rate-limit has passed.
 ///
+/// The returned candidate records which transports the peer is known to
+/// accept, so the dialer can reach version 2 peers over QUIC and
+/// everything else over TCP.
+///
 /// [`Responded`]: crate::PeerAddrState::Responded
 pub(crate) async fn next_reconnect_peer(
     next_peer_service: &mut NextPeerService,

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -28,7 +28,11 @@ use tokio::{
 };
 use tokio_stream::wrappers::IntervalStream;
 use tower::{
-    buffer::Buffer, discover::Change, layer::Layer, util::BoxService, Service, ServiceExt,
+    buffer::Buffer,
+    discover::Change,
+    layer::Layer,
+    util::{BoxCloneService, BoxService},
+    Service, ServiceExt,
 };
 use tracing_futures::Instrument;
 
@@ -62,6 +66,12 @@ mod tests;
 
 mod inbound_admission;
 mod recent_by_ip;
+mod v2_transport;
+
+/// The version 2 outbound connector, type-erased so the crawler does not
+/// carry the inbound service and chain tip types.
+type V2OutboundConnector =
+    BoxCloneService<OutboundConnectorRequest, (PeerSocketAddr, peer::Client), BoxError>;
 
 /// A successful outbound peer connection attempt or inbound connection handshake.
 ///
@@ -217,8 +227,43 @@ where
     // (The block syncer and mempool crawler handle bulk fetches of blocks and transactions.)
     let (inv_sender, inv_receiver) = broadcast::channel(config.peerset_total_connection_limit());
 
-    let advertised_services = crate::protocol::external::types::PeerServices::NODE_NETWORK;
+    // The identity this node advertises to its peers, shared by the legacy
+    // and v2 handshakes.
+    // NODE_TREE_ROOTS: this Zebra version maintains the per-block sync
+    // metadata index (backfilled by a state format upgrade), and serves
+    // `get-tree-roots` requests; requests that arrive before the backfill
+    // completes are refused.
+    let mut advertised_services = crate::protocol::external::types::PeerServices::NODE_NETWORK
+        | crate::protocol::external::types::PeerServices::NODE_TREE_ROOTS;
+    // NODE_SYNC_ARTIFACTS: advertised when the node has an artifact
+    // directory to serve `get-object` requests from.
+    if config
+        .cache_dir
+        .artifact_dir_path(&config.network)
+        .is_some()
+    {
+        advertised_services |= crate::protocol::external::types::PeerServices::NODE_SYNC_ARTIFACTS;
+    }
     let want_transactions = true;
+
+    // The v2 (QUIC) transport, if enabled: it shares the
+    // inbound service, address book, and inventory collector with the
+    // legacy transport, and delivers ordinary peer clients to the peer set.
+    let v2_enabled = config.v2_listen || !config.initial_v2_peers.is_empty();
+    let v2_handshaker = v2_enabled.then(|| {
+        peer::v2::V2Handshaker::new(
+            config.clone(),
+            user_agent.clone(),
+            advertised_services,
+            want_transactions,
+            inbound_service.clone(),
+            address_book_updater.clone(),
+            misbehavior_tx.clone(),
+            inv_sender.clone(),
+            MinimumPeerVersion::new(latest_chain_tip.clone(), &config.network),
+            listen_addr,
+        )
+    });
 
     // Construct services that handle inbound handshakes and perform outbound
     // handshakes. These use the same handshake service internally to detect
@@ -279,6 +324,9 @@ where
     );
     let peer_set = Buffer::new(BoxService::new(peer_set), constants::PEERSET_BUFFER_SIZE);
 
+    // The legacy and v2 transports open connections from separate tasks, but
+    // their connections share the configured limits, so they share these
+    // counters.
     let active_inbound_connections = SharedConnectionCounter::new_counter_with(
         config.peerset_inbound_connection_limit(),
         "Inbound Connections",
@@ -302,6 +350,59 @@ where
         active_inbound_connections.clone(),
     );
     let listen_guard = tokio::spawn(listen_fut.in_current_span());
+
+    // 1b. Version 2 protocol (QUIC) connections, if enabled: inbound
+    // connections on the UDP port of the listen address, the configured
+    // initial v2 peers, and crawler dials to peers known to accept QUIC.
+    // The endpoint is shared: the task below accepts on it, and the
+    // crawler dials outbound connections through it. A failure to open it
+    // is logged by the endpoint, and the node continues on the legacy
+    // transport alone.
+    let v2 = v2_handshaker.and_then(|handshaker| {
+        let endpoint = v2_transport::new_v2_endpoint(&config, listen_addr).ok()?;
+
+        Some((handshaker, endpoint))
+    });
+
+    let (v2_connector, v2_guard) = match v2 {
+        Some((v2_handshaker, endpoint)) => {
+            // Boxed so the crawler carries neither the inbound service type
+            // nor a `Sync` bound on it.
+            let connector: V2OutboundConnector = BoxCloneService::new(peer::V2Connector::new(
+                endpoint.clone(),
+                config.network.clone(),
+                v2_handshaker.clone(),
+            ));
+
+            let v2_fut = v2_transport::run_v2_endpoint(
+                config.clone(),
+                endpoint,
+                v2_handshaker,
+                peerset_tx.clone(),
+                bans_receiver,
+                active_inbound_connections,
+            );
+
+            (
+                Some(connector),
+                Some(tokio::spawn(v2_fut.in_current_span())),
+            )
+        }
+        None => (None, None),
+    };
+
+    // Dial the configured version 2 peers, and add them to the book so the
+    // legacy crawler redials them if the version 2 connection drops.
+    if let Some(connector) = v2_connector.clone() {
+        let dial_fut = add_initial_v2_peers(
+            config.clone(),
+            connector,
+            peerset_tx.clone(),
+            address_book_updater.clone(),
+            active_outbound_connections.clone(),
+        );
+        tokio::spawn(dial_fut.in_current_span());
+    }
 
     // 2. Initial peers, specified in the config and cached on disk.
     let initial_peers_fut = add_initial_peers(
@@ -365,12 +466,17 @@ where
     let peer_cache_updater_fut = peer_cache_updater(config, peer_book_handle.clone());
     let peer_cache_updater_guard = tokio::spawn(peer_cache_updater_fut.in_current_span());
 
-    let guards = vec![
+    let mut guards = vec![
         listen_guard,
         crawl_guard,
         address_book_updater_guard,
         peer_cache_updater_guard,
     ];
+    // The v2 endpoint is only spawned when the v2 transport is
+    // configured. Its guard is sent with the others, so a bind failure or
+    // panic surfaces instead of silently disabling the transport.
+    guards.extend(v2_guard);
+
     handle_tx.send(guards).unwrap();
 
     (peer_set, peer_book_reader, misbehavior_tx, peer_book_handle)
@@ -1344,6 +1450,55 @@ where
     }
 
     Ok(())
+}
+
+/// Dials the configured version 2 peers, and adds them to the address book.
+///
+/// The configured peers are the only ones dialed over version 2: a relayed
+/// address carries no indication of the transports its peer accepts, so
+/// this node cannot tell which of them would answer a QUIC dial.
+#[instrument(skip(
+    connector,
+    peerset_tx,
+    address_book_updater,
+    active_outbound_connections
+))]
+async fn add_initial_v2_peers(
+    config: Config,
+    mut connector: V2OutboundConnector,
+    mut peerset_tx: futures::channel::mpsc::Sender<DiscoveredPeer>,
+    address_book_updater: crate::peer_book::ChangeSender,
+    active_outbound_connections: SharedConnectionCounter,
+) {
+    for addr in config.initial_v2_peers().await {
+        // The book keeps the peer as a reconnection candidate for the
+        // legacy crawler if the version 2 connection drops.
+        let _ = address_book_updater
+            .send(MetaAddr::new_initial_peer(addr))
+            .await;
+
+        let request = OutboundConnectorRequest {
+            addr,
+            connection_tracker: active_outbound_connections.track_connection(),
+        };
+
+        let Ok(connector) = connector.ready().await else {
+            return;
+        };
+
+        match connector.call(request).await {
+            Ok((addr, client)) => {
+                debug!(?addr, "connected to configured v2 peer");
+
+                if peerset_tx.send((addr, client)).await.is_err() {
+                    return;
+                }
+            }
+            Err(error) => {
+                info!(?error, ?addr, "failed to connect to configured v2 peer");
+            }
+        }
+    }
 }
 
 /// Mark `addr` as a failed peer to `address_book_updater`.

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -53,7 +53,8 @@ use crate::{
 
 use Network::*;
 
-/// Returns the inbound connection counter for the listener under test.
+/// Returns the inbound connection counter the listener under test shares with
+/// the v2 transport in production.
 fn test_inbound_counter(config: &Config) -> SharedConnectionCounter {
     SharedConnectionCounter::new_counter_with(
         config.peerset_inbound_connection_limit(),
@@ -2677,4 +2678,215 @@ where
     let add_task_handle = tokio::spawn(add_fut);
 
     (add_task_handle, peerset_rx, address_book_updater_guard)
+}
+
+/// Test that the experimental v2 (QUIC) listener accepts connections, and
+/// serves requests from the inbound service through a v2 request stream.
+#[tokio::test]
+async fn v2_listener_accepts_connections_and_serves_requests() {
+    use crate::{
+        peer::{
+            v2::{V2HandshakeRequest, V2Handshaker},
+            MinimumPeerVersion,
+        },
+        peer_set::ActiveConnectionCounter,
+        protocol::{external::types::PeerServices, v2::quic},
+    };
+
+    let _init_guard = zebra_test::init();
+
+    if zebra_test::net::zebra_skip_network_tests() {
+        return;
+    }
+
+    let listen_addr = SocketAddr::new(
+        "127.0.0.1".parse().unwrap(),
+        zebra_test::net::random_known_port(),
+    );
+    let network = Network::Mainnet;
+
+    let config = Config {
+        listen_addr,
+        network: network.clone(),
+
+        // Stop Zebra making outbound connections.
+        initial_mainnet_peers: IndexSet::new(),
+        initial_testnet_peers: IndexSet::new(),
+        cache_dir: CacheDir::disabled(),
+
+        v2_listen: true,
+
+        ..Config::default()
+    };
+
+    let inbound_service = service_fn(|request| async move {
+        match request {
+            Request::FindHeaders { .. } => Ok(Response::BlockHeaders(Vec::new())),
+            _ => Ok(Response::Nil),
+        }
+    });
+
+    let (_peer_service, _peer_book_reader, _misbehavior_tx, _peer_book_handle) = init(
+        config.clone(),
+        inbound_service,
+        NoChainTip,
+        "Test user agent".to_string(),
+    )
+    .await;
+
+    // Connect a raw v2 client stack to the node's QUIC listener.
+    let client_inbound = service_fn(|_request| async { Ok(Response::Nil) });
+    let mut client_handshaker = V2Handshaker::new(
+        Config {
+            listen_addr: "127.0.0.1:0".parse().unwrap(),
+            ..config
+        },
+        "Test v2 client".to_string(),
+        PeerServices::NODE_NETWORK,
+        true,
+        client_inbound,
+        crate::peer_book::ChangeSender::new(tokio::sync::mpsc::channel(10).0),
+        tokio::sync::mpsc::channel(10).0,
+        tokio::sync::broadcast::channel(10).0,
+        MinimumPeerVersion::new(NoChainTip, &network),
+        "127.0.0.1:0".parse().unwrap(),
+    );
+
+    let client_endpoint = quic::new_endpoint("127.0.0.1:0".parse().unwrap(), &network)
+        .expect("endpoint creation succeeds");
+    let connection = tokio::time::timeout(
+        Duration::from_secs(10),
+        quic::connect(&client_endpoint, listen_addr, &network),
+    )
+    .await
+    .expect("connection completes in time")
+    .expect("connection to the v2 listener succeeds");
+
+    let mut counter = ActiveConnectionCounter::new_counter();
+    let mut client = client_handshaker
+        .ready()
+        .await
+        .expect("handshaker is ready")
+        .call(V2HandshakeRequest {
+            connection,
+            connected_addr: ConnectedAddr::new_outbound_direct(listen_addr.into()),
+            connection_tracker: counter.track_connection(),
+        })
+        .await
+        .expect("v2 handshake with the listener succeeds");
+
+    // The node's inbound service answers a v2 get-headers request stream.
+    let response = tokio::time::timeout(
+        Duration::from_secs(10),
+        client
+            .ready()
+            .await
+            .expect("client is ready")
+            .call(Request::FindHeaders {
+                known_blocks: Vec::new(),
+                stop: None,
+            }),
+    )
+    .await
+    .expect("response arrives in time")
+    .expect("request succeeds");
+
+    assert!(
+        matches!(response, Response::BlockHeaders(ref headers) if headers.is_empty()),
+        "expected an empty BlockHeaders response, got: {response:?}",
+    );
+}
+
+/// Test that the experimental v2 (QUIC) listener refuses connections from
+/// banned peers, like the legacy listener.
+#[tokio::test]
+async fn v2_listener_rejects_banned_peers() {
+    use crate::{
+        peer::{v2::V2Handshaker, MinimumPeerVersion},
+        peer_set::initialize::v2_transport::run_v2_endpoint,
+        protocol::{external::types::PeerServices, v2::quic},
+    };
+
+    let _init_guard = zebra_test::init();
+
+    if zebra_test::net::zebra_skip_network_tests() {
+        return;
+    }
+
+    let banned_ip: IpAddr = "127.0.0.1".parse().unwrap();
+    let listen_addr = SocketAddr::new(banned_ip, zebra_test::net::random_known_port());
+    let network = Network::Mainnet;
+
+    let config = Config {
+        listen_addr,
+        network: network.clone(),
+
+        initial_mainnet_peers: IndexSet::new(),
+        initial_testnet_peers: IndexSet::new(),
+        cache_dir: CacheDir::disabled(),
+
+        v2_listen: true,
+
+        ..Config::default()
+    };
+
+    // Ban the address the test client connects from.
+    let (_bans_tx, bans_rx) = tokio::sync::watch::channel(
+        [(crate::peer_book::BanKey::from(banned_ip), Instant::now())]
+            .into_iter()
+            .collect::<IndexMap<_, _>>()
+            .into(),
+    );
+
+    let unreachable_inbound = service_fn(|_request| async {
+        unreachable!("banned peers never reach the inbound service");
+    });
+    let handshaker = V2Handshaker::new(
+        config.clone(),
+        "Test user agent".to_string(),
+        PeerServices::NODE_NETWORK,
+        true,
+        unreachable_inbound,
+        crate::peer_book::ChangeSender::new(tokio::sync::mpsc::channel(10).0),
+        tokio::sync::mpsc::channel(10).0,
+        tokio::sync::broadcast::channel(10).0,
+        MinimumPeerVersion::new(NoChainTip, &network),
+        "127.0.0.1:0".parse().unwrap(),
+    );
+
+    let (peerset_tx, mut peerset_rx) = mpsc::channel::<DiscoveredPeer>(2);
+
+    let endpoint = crate::peer_set::initialize::v2_transport::new_v2_endpoint(&config, listen_addr)
+        .expect("endpoint opens");
+    let v2_fut = run_v2_endpoint(
+        config.clone(),
+        endpoint,
+        handshaker,
+        peerset_tx,
+        bans_rx,
+        test_inbound_counter(&config),
+    );
+    let v2_task_handle = tokio::spawn(v2_fut);
+
+    let client_endpoint = quic::new_endpoint("127.0.0.1:0".parse().unwrap(), &network)
+        .expect("endpoint creation succeeds");
+    let connect_result = tokio::time::timeout(
+        Duration::from_secs(10),
+        quic::connect(&client_endpoint, listen_addr, &network),
+    )
+    .await
+    .expect("the listener answers in time");
+
+    assert!(
+        connect_result.is_err(),
+        "a banned peer's v2 connection must be refused, got: {connect_result:?}",
+    );
+
+    // The banned peer must not reach the peer set.
+    assert!(
+        peerset_rx.try_recv().is_err(),
+        "a banned peer must not be added to the peer set",
+    );
+
+    v2_task_handle.abort();
 }

--- a/zebra-network/src/peer_set/initialize/v2_transport.rs
+++ b/zebra-network/src/peer_set/initialize/v2_transport.rs
@@ -1,0 +1,181 @@
+//! The version 2 protocol (QUIC) peer source.
+//!
+//! When enabled by the [`Config`], a QUIC endpoint runs alongside the legacy
+//! TCP listener: it accepts inbound v2 connections on the UDP port of the
+//! listen address, and dials the configured initial v2 peers. Both produce
+//! ordinary peer [`Client`](crate::peer::Client)s, which join the peer set
+//! alongside legacy peers.
+
+use std::{net::IpAddr, sync::Arc};
+
+use futures::SinkExt;
+use indexmap::IndexMap;
+use tokio::sync::watch;
+use tower::{Service, ServiceExt};
+use tracing::{debug, info, warn, Instrument};
+
+use zebra_chain::chain_tip::ChainTip;
+
+use crate::{
+    constants,
+    peer::{
+        v2::{V2HandshakeRequest, V2Handshaker},
+        ConnectedAddr,
+    },
+    peer_set::{
+        initialize::{inbound_admission, recent_by_ip, DiscoveredPeer},
+        limit::SharedConnectionCounter,
+    },
+    protocol::v2::quic,
+    BoxError, Config, Request, Response,
+};
+
+/// Opens the version 2 QUIC endpoint.
+///
+/// When listening is enabled, the endpoint uses the UDP port of the TCP
+/// listen address, as anticipated by the draft ZIP's deployment plan.
+/// Otherwise, an unspecified port is used for outbound connections only.
+pub(super) fn new_v2_endpoint(
+    config: &Config,
+    listen_addr: std::net::SocketAddr,
+) -> Result<quinn::Endpoint, BoxError> {
+    let bind_addr = if config.v2_listen {
+        listen_addr
+    } else {
+        use std::net::{Ipv4Addr, Ipv6Addr};
+        let unspecified: IpAddr = if listen_addr.is_ipv4() {
+            Ipv4Addr::UNSPECIFIED.into()
+        } else {
+            Ipv6Addr::UNSPECIFIED.into()
+        };
+        std::net::SocketAddr::new(unspecified, 0)
+    };
+
+    let endpoint = quic::new_endpoint(bind_addr, &config.network).map_err(|error| {
+        warn!(%error, ?bind_addr, "failed to open the v2 protocol QUIC endpoint");
+        error
+    })?;
+
+    if config.v2_listen {
+        info!(addr = ?bind_addr, "opened QUIC endpoint for v2 protocol connections");
+    }
+
+    Ok(endpoint)
+}
+
+/// Runs the version 2 QUIC endpoint: dials the configured initial v2 peers,
+/// and accepts inbound v2 connections if listening is enabled.
+///
+/// The inbound and outbound connection counters are shared with the legacy
+/// transport, so both transports together stay within the configured limits.
+///
+/// Returns an error if the endpoint cannot be created.
+pub(super) async fn run_v2_endpoint<S, C>(
+    config: Config,
+    endpoint: quinn::Endpoint,
+    handshaker: V2Handshaker<S, C>,
+    peerset_tx: futures::channel::mpsc::Sender<DiscoveredPeer>,
+    bans_receiver: watch::Receiver<Arc<IndexMap<crate::peer_book::BanKey, std::time::Instant>>>,
+    active_inbound_connections: SharedConnectionCounter,
+) -> Result<(), BoxError>
+where
+    S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    C: ChainTip + Clone + Send + Sync + 'static,
+{
+    // Accept inbound v2 connections.
+    let mut recent_inbound_connections =
+        recent_by_ip::RecentByIp::new(None, Some(config.max_connections_per_ip));
+
+    // The inbound handshakes currently in progress; above the threshold,
+    // unvalidated addresses are asked to retry with a token.
+    let pending_handshakes = crate::peer_set::SlotCounter::default();
+
+    while let Some(incoming) = endpoint.accept().await {
+        // # Security
+        //
+        // Above a threshold of concurrently pending handshakes — as under a
+        // handshake flood — require source address validation with a retry
+        // token before accepting: a spoofed-source attempt then costs this
+        // node only a stateless retry packet, not a TLS handshake.
+        if !incoming.remote_address_validated()
+            && pending_handshakes.count()
+                >= crate::protocol::v2::constants::MAX_PENDING_INBOUND_HANDSHAKES
+        {
+            // An error means the connection attempt was already unusable.
+            let _ = incoming.retry();
+            continue;
+        }
+
+        let Some((addr, _canonical_ip)) = inbound_admission::screen_inbound_addr(
+            &config.network,
+            incoming.remote_address(),
+            &bans_receiver,
+        ) else {
+            incoming.refuse();
+            continue;
+        };
+
+        // # Security
+        //
+        // The inbound counter is shared with the legacy transport, so both
+        // transports together stay within the configured limit, and the
+        // per-IP limit stops one peer from occupying the v2 connections.
+        let Some(connection_tracker) = inbound_admission::try_reserve_public_inbound_slot(
+            &config.network,
+            addr,
+            active_inbound_connections.update_count(),
+            config.peerset_inbound_connection_limit(),
+            &active_inbound_connections,
+            &mut recent_inbound_connections,
+        ) else {
+            incoming.refuse();
+            // Allow invalid connections to be cleared quickly, but still put a
+            // limit on our CPU and network usage from failed connections.
+            tokio::time::sleep(constants::MIN_INBOUND_PEER_FAILED_CONNECTION_INTERVAL).await;
+            continue;
+        };
+        let network = config.network.clone();
+        let handshaker = handshaker.clone();
+        let mut peerset_tx = peerset_tx.clone();
+
+        // Counts this attempt as a pending handshake until it completes.
+        let pending_slot = pending_handshakes.claim();
+
+        tokio::spawn(
+            async move {
+                let connection = match quic::accept(incoming, &network).await {
+                    Ok(connection) => connection,
+                    Err(error) => {
+                        debug!(%error, ?addr, "inbound v2 connection failed");
+                        return;
+                    }
+                };
+
+                let connected_addr = ConnectedAddr::new_inbound_direct(addr);
+
+                let client = handshaker
+                    .oneshot(V2HandshakeRequest {
+                        connection,
+                        connected_addr,
+                        connection_tracker,
+                    })
+                    .await;
+                drop(pending_slot);
+
+                match client {
+                    Ok(client) => {
+                        let _ = peerset_tx.send((addr, client)).await;
+                    }
+                    Err(error) => debug!(%error, ?addr, "inbound v2 handshake failed"),
+                }
+            }
+            .in_current_span(),
+        );
+
+        // Rate-limit inbound connections, like the legacy listener.
+        tokio::time::sleep(constants::MIN_INBOUND_PEER_CONNECTION_INTERVAL).await;
+    }
+
+    Ok(())
+}

--- a/zebra-network/src/peer_set/limit.rs
+++ b/zebra-network/src/peer_set/limit.rs
@@ -3,9 +3,56 @@
 //! These types can be used to count any kind of active resource.
 //! But they are currently used to track the number of open connections.
 
-use std::{fmt, sync::Arc};
+use std::{
+    fmt,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
 
 use tokio::sync::mpsc;
+
+/// A counter of the slots of a bounded resource that are currently held.
+///
+/// Slots are claimed with [`claim`](Self::claim) or
+/// [`try_claim`](Self::try_claim), and released when the returned
+/// [`SlotGuard`] is dropped, on every exit path.
+#[derive(Clone, Debug, Default)]
+pub struct SlotCounter(Arc<AtomicUsize>);
+
+impl SlotCounter {
+    /// Returns the number of slots currently held.
+    pub fn count(&self) -> usize {
+        self.0.load(Ordering::Acquire)
+    }
+
+    /// Claims a slot unconditionally.
+    pub fn claim(&self) -> SlotGuard {
+        self.0.fetch_add(1, Ordering::AcqRel);
+        SlotGuard(self.0.clone())
+    }
+
+    /// Claims a slot, unless `limit` slots are already held.
+    pub fn try_claim(&self, limit: usize) -> Option<SlotGuard> {
+        self.0
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |held| {
+                (held < limit).then_some(held + 1)
+            })
+            .ok()
+            .map(|_| SlotGuard(self.0.clone()))
+    }
+}
+
+/// A claimed slot of a [`SlotCounter`], released when it is dropped.
+#[derive(Debug)]
+pub struct SlotGuard(Arc<AtomicUsize>);
+
+impl Drop for SlotGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::AcqRel);
+    }
+}
 
 /// A signal sent by a [`Connection`][1] when it opens or closes.
 ///

--- a/zebra-network/src/protocol/v2.rs
+++ b/zebra-network/src/protocol/v2.rs
@@ -19,16 +19,13 @@
 //! - long-lived unidirectional *announcement streams* (types `0x10`–`0x12`)
 //!   carrying length-prefixed announcement records.
 //!
-//! This module contains the wire encodings and their limits. The QUIC
-//! transport that carries them, and the peer connection logic that uses
-//! them, are added by the commits that follow this one.
-// Every item here is reached through the transport and connection layers,
-// which land in later commits; the tests below exercise them meanwhile.
-#![allow(dead_code)]
+//! This module contains the wire encodings and their limits, and the QUIC
+//! transport that carries them; the peer connection logic lives elsewhere.
 
 pub mod compact_block;
 pub mod constants;
 pub mod init;
+pub mod quic;
 pub mod record;
 pub mod request;
 pub mod response;

--- a/zebra-network/src/protocol/v2/quic.rs
+++ b/zebra-network/src/protocol/v2/quic.rs
@@ -1,0 +1,309 @@
+//! The QUIC transport for the version 2 Zcash P2P network protocol.
+//!
+//! The QUIC transport uses QUIC version 1 over UDP, secured with TLS 1.3.
+//! Connections are encrypted but endpoints are not authenticated: the goal
+//! is protection against passive network observers, not endpoint identity.
+//!
+//! - The network of a connection is identified by an ALPN protocol
+//!   identifier, negotiated in the QUIC-TLS handshake; a connection between
+//!   peers on different networks fails before any application data is
+//!   exchanged.
+//! - Each node presents a self-signed X.509 certificate for an ephemeral
+//!   Ed25519 key, and accepts any certificate from its peer — for both
+//!   Ed25519 and ECDSA P-256 keys: certificates are not required to chain to
+//!   a certification authority, and connections are never rejected on the
+//!   basis of certificate contents.
+//! - RFC 7250 raw public keys are not accepted yet: rustls can only offer a
+//!   single certificate type per endpoint (a client that requires raw public
+//!   keys stops interoperating with X.509 peers), so accepting both
+//!   encodings, as the draft requires, is blocked on the TLS ecosystem. See
+//!   the spec feedback section of `SPEC-CONFORMANCE.md`.
+//! - 0-RTT early data is never used: requests carried in 0-RTT data would be
+//!   replayable by an attacker. Neither side enables TLS early data, so a
+//!   peer cannot negotiate 0-RTT at all — an attempt is rejected in the TLS
+//!   handshake, below the application layer.
+//! - QUIC datagrams are not used: support is not advertised, and DATAGRAM
+//!   frames are never sent.
+
+use std::sync::Arc;
+
+use quinn::{
+    crypto::rustls::{HandshakeData, QuicClientConfig, QuicServerConfig},
+    IdleTimeout, TransportConfig, VarInt,
+};
+use rustls::{
+    client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+    crypto::{verify_tls12_signature, verify_tls13_signature, CryptoProvider},
+    pki_types::{CertificateDer, PrivatePkcs8KeyDer, ServerName, UnixTime},
+    DigitallySignedStruct, SignatureScheme,
+};
+
+use zebra_chain::parameters::Network;
+
+use crate::BoxError;
+
+use super::{
+    constants::{
+        ALPN_MAINNET, ALPN_REGTEST, ALPN_TESTNET, IDLE_TIMEOUT, KEEP_ALIVE_INTERVAL,
+        MAX_RECORD_PAYLOAD_LEN, MIN_CONCURRENT_BIDI_STREAMS, MIN_CONCURRENT_UNI_STREAMS,
+    },
+    types::ErrorCode,
+};
+
+/// The maximum number of concurrent bidirectional streams the remote peer may
+/// open: request streams, bounded well above the specified minimum.
+pub const MAX_CONCURRENT_REMOTE_BIDI_STREAMS: u32 = 4 * MIN_CONCURRENT_BIDI_STREAMS;
+
+/// The maximum number of concurrent unidirectional streams the remote peer
+/// may open: the three announcement stream types, plus headroom for future
+/// types, bounded above the specified minimum.
+pub const MAX_CONCURRENT_REMOTE_UNI_STREAMS: u32 = 2 * MIN_CONCURRENT_UNI_STREAMS;
+
+/// The TLS server name offered when dialing peers.
+///
+/// Peer certificates are not validated against any name (peers use ephemeral
+/// self-signed certificates), so this value carries no meaning; rustls
+/// requires one to be present.
+pub const DUMMY_SERVER_NAME: &str = "zcash";
+
+impl From<ErrorCode> for VarInt {
+    fn from(code: ErrorCode) -> VarInt {
+        VarInt::from_u64(code.wire_code())
+            .expect("v2 protocol error codes are single bytes, which fit in a QUIC varint")
+    }
+}
+
+/// Returns the ALPN protocol identifier for `network`.
+//
+// TODO: the draft ZIP only defines ALPN identifiers for Mainnet, Testnet,
+//       and Regtest. Custom testnets currently share the Testnet identifier,
+//       and rely on the genesis hash mismatch being detected after the
+//       handshake, like the legacy protocol's shared Testnet network magic.
+pub fn alpn_protocol(network: &Network) -> &'static [u8] {
+    if network.is_regtest() {
+        ALPN_REGTEST
+    } else if matches!(network, Network::Testnet(_)) {
+        ALPN_TESTNET
+    } else {
+        ALPN_MAINNET
+    }
+}
+
+/// Generates an ephemeral Ed25519 key and a self-signed certificate for it.
+///
+/// A fresh key is generated for each endpoint, so nodes cannot be linked
+/// across restarts by their TLS keys.
+pub fn generate_ephemeral_identity(
+) -> Result<(CertificateDer<'static>, PrivatePkcs8KeyDer<'static>), BoxError> {
+    let key_pair = rcgen::KeyPair::generate_for(&rcgen::PKCS_ED25519)?;
+
+    // The certificate contents are irrelevant: peers must not reject a
+    // connection on the basis of certificate contents.
+    let params = rcgen::CertificateParams::new(Vec::<String>::new())?;
+    let cert = params.self_signed(&key_pair)?;
+
+    Ok((
+        cert.der().clone(),
+        PrivatePkcs8KeyDer::from(key_pair.serialize_der()),
+    ))
+}
+
+/// Returns the QUIC transport parameters for v2 protocol connections.
+fn transport_config() -> Result<TransportConfig, BoxError> {
+    let mut transport = TransportConfig::default();
+
+    transport
+        .max_idle_timeout(Some(IdleTimeout::try_from(IDLE_TIMEOUT)?))
+        .keep_alive_interval(Some(KEEP_ALIVE_INTERVAL))
+        .max_concurrent_bidi_streams(MAX_CONCURRENT_REMOTE_BIDI_STREAMS.into())
+        .max_concurrent_uni_streams(MAX_CONCURRENT_REMOTE_UNI_STREAMS.into())
+        // Never advertise QUIC datagram support.
+        .datagram_receive_buffer_size(None)
+        // Allow a maximum-size element (a 2 MiB block) plus framing to be in
+        // flight on a single stream without flow control stalls.
+        .stream_receive_window(VarInt::from_u32(2 * MAX_RECORD_PAYLOAD_LEN as u32))
+        .receive_window(VarInt::from_u32(8 * MAX_RECORD_PAYLOAD_LEN as u32));
+
+    Ok(transport)
+}
+
+/// Builds the QUIC server configuration for `network`.
+///
+/// The server presents `cert` and `key`, offers the network's ALPN
+/// identifier, and does not request TLS client authentication.
+pub fn server_config(
+    network: &Network,
+    cert: CertificateDer<'static>,
+    key: PrivatePkcs8KeyDer<'static>,
+) -> Result<quinn::ServerConfig, BoxError> {
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+
+    let mut crypto = rustls::ServerConfig::builder_with_provider(provider)
+        .with_protocol_versions(&[&rustls::version::TLS13])?
+        .with_no_client_auth()
+        .with_single_cert(vec![cert], key.into())?;
+    crypto.alpn_protocols = vec![alpn_protocol(network).to_vec()];
+
+    let mut config =
+        quinn::ServerConfig::with_crypto(Arc::new(QuicServerConfig::try_from(crypto)?));
+    config.transport_config(Arc::new(transport_config()?));
+
+    Ok(config)
+}
+
+/// Builds the QUIC client configuration for `network`.
+///
+/// The client accepts any server certificate (see
+/// [`AcceptAnyServerCert`]), and offers the network's ALPN identifier.
+pub fn client_config(network: &Network) -> Result<quinn::ClientConfig, BoxError> {
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+
+    let mut crypto = rustls::ClientConfig::builder_with_provider(provider.clone())
+        .with_protocol_versions(&[&rustls::version::TLS13])?
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(AcceptAnyServerCert::new(&provider)))
+        .with_no_client_auth();
+    crypto.alpn_protocols = vec![alpn_protocol(network).to_vec()];
+
+    let mut config = quinn::ClientConfig::new(Arc::new(QuicClientConfig::try_from(crypto)?));
+    config.transport_config(Arc::new(transport_config()?));
+
+    Ok(config)
+}
+
+/// Creates a QUIC endpoint for `network`, bound to `listen_addr`, that can
+/// both accept inbound connections and dial outbound connections.
+///
+/// A fresh ephemeral TLS identity is generated for the endpoint.
+pub fn new_endpoint(
+    listen_addr: std::net::SocketAddr,
+    network: &Network,
+) -> Result<quinn::Endpoint, BoxError> {
+    let (cert, key) = generate_ephemeral_identity()?;
+
+    let mut endpoint = quinn::Endpoint::server(server_config(network, cert, key)?, listen_addr)?;
+    endpoint.set_default_client_config(client_config(network)?);
+
+    Ok(endpoint)
+}
+
+/// Dials a v2 protocol connection to `addr` from `endpoint`, and checks that
+/// ALPN negotiation selected the identifier of `network`.
+pub async fn connect(
+    endpoint: &quinn::Endpoint,
+    addr: std::net::SocketAddr,
+    network: &Network,
+) -> Result<quinn::Connection, BoxError> {
+    let connection = endpoint.connect(addr, DUMMY_SERVER_NAME)?.await?;
+
+    check_negotiated_alpn(&connection, network)?;
+
+    Ok(connection)
+}
+
+/// Accepts a v2 protocol connection from `incoming`, and checks that ALPN
+/// negotiation selected the identifier of `network`.
+pub async fn accept(
+    incoming: quinn::Incoming,
+    network: &Network,
+) -> Result<quinn::Connection, BoxError> {
+    let connection = incoming.await?;
+
+    check_negotiated_alpn(&connection, network)?;
+
+    Ok(connection)
+}
+
+/// Checks that ALPN negotiation on `connection` selected the identifier of
+/// `network`, closing the connection if it did not.
+///
+/// The TLS handshake fails on its own when the ALPN identifiers offered by
+/// the two endpoints do not overlap; this check enforces the requirement
+/// that a node must not complete a connection on which ALPN negotiation did
+/// not select its network's identifier, even against a peer that skipped
+/// ALPN altogether.
+fn check_negotiated_alpn(
+    connection: &quinn::Connection,
+    network: &Network,
+) -> Result<(), BoxError> {
+    let negotiated = connection
+        .handshake_data()
+        .and_then(|data| data.downcast::<HandshakeData>().ok())
+        .and_then(|data| data.protocol);
+
+    if negotiated.as_deref() != Some(alpn_protocol(network)) {
+        connection.close(ErrorCode::ProtocolError.into(), b"ALPN mismatch");
+        return Err(format!(
+            "connection to {} did not negotiate the {} ALPN identifier",
+            connection.remote_address(),
+            String::from_utf8_lossy(alpn_protocol(network)),
+        )
+        .into());
+    }
+
+    Ok(())
+}
+
+/// A TLS certificate verifier that accepts any certificate, verifying only
+/// the TLS 1.3 handshake signature.
+///
+/// The v2 protocol encrypts connections but deliberately does not
+/// authenticate endpoints: a node must not require the peer's certificate to
+/// chain to any certification authority, and must not reject a connection on
+/// the basis of certificate contents. The handshake signature is still
+/// verified against the presented certificate's public key, which binds the
+/// TLS channel keys to the certificate.
+#[derive(Debug)]
+pub struct AcceptAnyServerCert {
+    /// The signature verification algorithms of the TLS crypto provider.
+    algorithms: rustls::crypto::WebPkiSupportedAlgorithms,
+}
+
+impl AcceptAnyServerCert {
+    /// Creates a verifier using `provider`'s signature verification
+    /// algorithms.
+    pub fn new(provider: &CryptoProvider) -> Self {
+        AcceptAnyServerCert {
+            algorithms: provider.signature_verification_algorithms,
+        }
+    }
+}
+
+impl ServerCertVerifier for AcceptAnyServerCert {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        // QUIC only uses TLS 1.3, so this method is never called.
+        verify_tls12_signature(message, cert, dss, &self.algorithms)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        verify_tls13_signature(message, cert, dss, &self.algorithms)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.algorithms.supported_schemes()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/zebra-network/src/protocol/v2/quic/tests.rs
+++ b/zebra-network/src/protocol/v2/quic/tests.rs
@@ -1,0 +1,3 @@
+//! Tests for the QUIC transport of the version 2 protocol.
+
+mod vectors;

--- a/zebra-network/src/protocol/v2/quic/tests/vectors.rs
+++ b/zebra-network/src/protocol/v2/quic/tests/vectors.rs
@@ -1,0 +1,228 @@
+//! QUIC transport tests: local endpoint pairs over loopback UDP.
+
+use zebra_chain::parameters::Network;
+
+use crate::protocol::v2::{
+    constants::{ALPN_MAINNET, ALPN_REGTEST, ALPN_TESTNET},
+    quic::{alpn_protocol, connect, generate_ephemeral_identity, new_endpoint, DUMMY_SERVER_NAME},
+    types::ErrorCode,
+};
+
+/// The localhost address with an OS-allocated port.
+const LOCALHOST_UNSPECIFIED_PORT: &str = "127.0.0.1:0";
+
+fn local_endpoint(network: &Network) -> quinn::Endpoint {
+    new_endpoint(
+        LOCALHOST_UNSPECIFIED_PORT.parse().expect("valid address"),
+        network,
+    )
+    .expect("endpoint creation succeeds")
+}
+
+#[test]
+fn alpn_identifiers_match_networks() {
+    let _init_guard = zebra_test::init();
+
+    assert_eq!(alpn_protocol(&Network::Mainnet), ALPN_MAINNET);
+    assert_eq!(alpn_protocol(&Network::new_default_testnet()), ALPN_TESTNET,);
+    assert_eq!(
+        alpn_protocol(&Network::new_regtest(Default::default())),
+        ALPN_REGTEST
+    );
+}
+
+#[test]
+fn ephemeral_identities_are_unique() {
+    let _init_guard = zebra_test::init();
+
+    let (cert_a, key_a) = generate_ephemeral_identity().expect("identity generation succeeds");
+    let (cert_b, key_b) = generate_ephemeral_identity().expect("identity generation succeeds");
+
+    assert_ne!(cert_a, cert_b, "ephemeral certificates must be unique");
+    assert_ne!(
+        key_a.secret_pkcs8_der(),
+        key_b.secret_pkcs8_der(),
+        "ephemeral keys must be unique",
+    );
+}
+
+/// Two endpoints on the same network connect, negotiate the network's ALPN
+/// identifier, accept each other's self-signed certificates, and can
+/// exchange stream data in both directions.
+#[tokio::test]
+async fn connect_same_network() {
+    let _init_guard = zebra_test::init();
+
+    let network = Network::Mainnet;
+    let server = local_endpoint(&network);
+    let client = local_endpoint(&network);
+    let server_addr = server.local_addr().expect("endpoint has a local address");
+
+    let server_task = tokio::spawn(async move {
+        let incoming = server.accept().await.expect("endpoint accepts");
+        let connection = crate::protocol::v2::quic::accept(incoming, &Network::Mainnet)
+            .await
+            .expect("inbound connection completes");
+
+        let (mut send, mut recv) = connection.accept_bi().await.expect("stream accepted");
+        let mut buf = [0u8; 5];
+        tokio::io::AsyncReadExt::read_exact(&mut recv, &mut buf)
+            .await
+            .expect("stream data arrives");
+        assert_eq!(&buf, b"hello");
+
+        send.write_all(b"world")
+            .await
+            .expect("stream write succeeds");
+        send.finish().expect("stream finishes");
+        // Keep the connection alive until the client has read the response.
+        connection.closed().await;
+    });
+
+    let connection = connect(&client, server_addr, &network)
+        .await
+        .expect("outbound connection completes");
+
+    let (mut send, mut recv) = connection.open_bi().await.expect("stream opens");
+    send.write_all(b"hello")
+        .await
+        .expect("stream write succeeds");
+    send.finish().expect("stream finishes");
+
+    let response = recv.read_to_end(1024).await.expect("response arrives");
+    assert_eq!(response, b"world");
+
+    connection.close(ErrorCode::NoError.into(), b"");
+    server_task.await.expect("server task succeeds");
+}
+
+/// A peer presenting an ECDSA P-256 certificate is accepted: a node must be
+/// prepared to accept both Ed25519 and ECDSA P-256 keys from its peers.
+///
+/// (Ed25519 acceptance is covered by `connect_same_network`: this node's own
+/// certificates use Ed25519 keys.)
+#[tokio::test]
+async fn p256_certificates_are_accepted() {
+    let _init_guard = zebra_test::init();
+
+    let network = Network::Mainnet;
+
+    // A server whose TLS identity is an ECDSA P-256 key.
+    let key_pair = rcgen::KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256)
+        .expect("P-256 key generation succeeds");
+    let params =
+        rcgen::CertificateParams::new(Vec::<String>::new()).expect("empty params are valid");
+    let cert = params
+        .self_signed(&key_pair)
+        .expect("self-signing succeeds");
+
+    let server_config = crate::protocol::v2::quic::server_config(
+        &network,
+        cert.der().clone(),
+        rustls::pki_types::PrivatePkcs8KeyDer::from(key_pair.serialize_der()),
+    )
+    .expect("server config builds with a P-256 identity");
+    let server = quinn::Endpoint::server(
+        server_config,
+        LOCALHOST_UNSPECIFIED_PORT.parse().expect("valid address"),
+    )
+    .expect("endpoint creation succeeds");
+    let server_addr = server.local_addr().expect("endpoint has a local address");
+
+    let client = local_endpoint(&network);
+
+    let server_task = tokio::spawn(async move {
+        let incoming = server.accept().await.expect("endpoint accepts");
+        let connection = crate::protocol::v2::quic::accept(incoming, &Network::Mainnet)
+            .await
+            .expect("inbound connection completes");
+
+        let (mut send, _recv) = connection.accept_bi().await.expect("stream accepted");
+        send.write_all(b"ack").await.expect("stream write succeeds");
+        send.finish().expect("stream finishes");
+        connection.closed().await;
+    });
+
+    let connection = connect(&client, server_addr, &network)
+        .await
+        .expect("a P-256 server certificate is accepted");
+
+    let (mut send, mut recv) = connection.open_bi().await.expect("stream opens");
+    send.finish().expect("stream finishes");
+    let response = recv.read_to_end(16).await.expect("response arrives");
+    assert_eq!(response, b"ack");
+
+    connection.close(ErrorCode::NoError.into(), b"");
+    server_task.await.expect("server task succeeds");
+}
+
+/// 0-RTT is never available on v2 endpoints: neither side enables TLS early
+/// data, so even a client resuming a cached session cannot enter 0-RTT, and
+/// requests are never carried in replayable early data.
+#[tokio::test]
+async fn zero_rtt_is_never_available() {
+    let _init_guard = zebra_test::init();
+
+    let network = Network::Mainnet;
+    let server = local_endpoint(&network);
+    let client = local_endpoint(&network);
+    let server_addr = server.local_addr().expect("endpoint has a local address");
+
+    let server_task = tokio::spawn(async move {
+        for _ in 0..2 {
+            let incoming = server.accept().await.expect("endpoint accepts");
+            let _connection = crate::protocol::v2::quic::accept(incoming, &Network::Mainnet)
+                .await
+                .expect("inbound connection completes");
+        }
+    });
+
+    // Complete a first handshake, and give the client time to cache any
+    // session tickets the server sends after it.
+    let first = connect(&client, server_addr, &network)
+        .await
+        .expect("outbound connection completes");
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // A second connection must not offer 0-RTT, with or without a cached
+    // session: early data is disabled on both sides.
+    let connecting = client
+        .connect(server_addr, DUMMY_SERVER_NAME)
+        .expect("connect starts");
+    let connecting = match connecting.into_0rtt() {
+        Err(connecting) => connecting,
+        Ok(_) => panic!("0-RTT must never be available on v2 endpoints"),
+    };
+    let second = connecting.await.expect("handshake completes");
+
+    first.close(ErrorCode::NoError.into(), b"");
+    second.close(ErrorCode::NoError.into(), b"");
+    server_task.await.expect("server task succeeds");
+}
+
+/// Endpoints on different networks fail to connect: ALPN negotiation fails
+/// in the TLS handshake, before any application data is exchanged.
+#[tokio::test]
+async fn connect_different_networks_fails() {
+    let _init_guard = zebra_test::init();
+
+    let server = local_endpoint(&Network::Mainnet);
+    let client = local_endpoint(&Network::new_default_testnet());
+    let server_addr = server.local_addr().expect("endpoint has a local address");
+
+    // The server driving its accept loop lets the TLS handshake proceed far
+    // enough to fail; it never yields a completed connection.
+    let server_task = tokio::spawn(async move {
+        while let Some(incoming) = server.accept().await {
+            let _ = crate::protocol::v2::quic::accept(incoming, &Network::Mainnet).await;
+        }
+    });
+
+    let result = connect(&client, server_addr, &Network::new_default_testnet()).await;
+    assert!(
+        result.is_err(),
+        "connections between different networks must fail: {result:?}",
+    );
+
+    server_task.abort();
+}

--- a/zebra-network/tests/acceptance.rs
+++ b/zebra-network/tests/acceptance.rs
@@ -10,7 +10,7 @@ use chrono::Utc;
 use zebra_chain::block::Height;
 use zebra_network::{
     types::{AddrInVersion, Nonce, PeerServices},
-    ConnectedAddr, ConnectionInfo, PeerSocketAddr, Version, VersionMessage,
+    ConnectedAddr, ConnectionInfo, PeerSocketAddr, RemoteHandshake, Version, VersionMessage,
 };
 
 /// Test that the types used in [`ConnectionInfo`] are public,
@@ -39,7 +39,7 @@ fn connection_info_types_are_public() {
 
     let _connection_info = Arc::new(ConnectionInfo {
         connected_addr,
-        remote,
+        remote: RemoteHandshake::Version(remote),
         negotiated_version,
     });
 }

--- a/zebrad/tests/common/configs/v6.3.0.toml
+++ b/zebrad/tests/common/configs/v6.3.0.toml
@@ -74,10 +74,12 @@ initial_testnet_peers = [
     "seeder.testnet.zec.rocks:18233",
     "testnet.seeder.zfnd.org:18233",
 ]
+initial_v2_peers = []
 listen_addr = "[::]:8233"
 max_connections_per_ip = 1
 network = "Mainnet"
 peerset_initial_target_size = 25
+v2_listen = false
 
 [notify]
 

--- a/zebrad/tests/integration/network.rs
+++ b/zebrad/tests/integration/network.rs
@@ -326,15 +326,15 @@ async fn disconnects_from_misbehaving_peers_impl() -> Result<()> {
     rpc_client_1.submit_block(genesis_block.clone()).await?;
     rpc_client_2.submit_block(genesis_block).await?;
 
-    // Call the `generate` method to mine blocks in the zebrad instance where PoW is disabled
+    // Mine blocks with invalid PoW in the zebrad instance where PoW is
+    // disabled, one at a time. Node 2 only downloads gossiped blocks within
+    // its verification lookahead of its own tip — which stays at genesis —
+    // so the invalid blocks must arrive near-tip for its inbound service to
+    // download, verify, and penalize their announcer. (The syncer assigns
+    // no penalties for blocks it requested itself: an *announced* block
+    // that provably fails proof of work is the penalizable case.)
     tracing::info!("committed genesis block, mining blocks with invalid PoW");
     tokio::time::sleep(Duration::from_secs(2)).await;
-
-    rpc_client_1.call("generate", "[500]").await?;
-
-    tracing::info!("wait for misbehavior messages to flush into address updater channel");
-
-    tokio::time::sleep(Duration::from_secs(30)).await;
 
     tracing::info!("calling getpeerinfo to confirm Zebra has dropped the peer connection");
 


### PR DESCRIPTION
## Motivation

Fourth PR of the five-PR stack implementing the draft version 2 Zcash P2P network protocol ([zcash/zips#1344](https://github.com/zcash/zips/pull/1344)). This PR adds the peer connection layer: the application handshake and the connection task that map Zebra's internal request/response protocol onto v2 streams.

## Solution

Adds `zebra-network/src/peer/v2/`:

- **Handshake** (`handshake.rs`): the initiator opens the dedicated handshake stream and the peers exchange `init` records; version negotiation takes the minimum of the advertised versions, gated on the epoch minimum. Self-connection detection uses the shared `HandshakeNonces` policy from the first PR of the stack (per-transport nonce set, never evicted on failed handshakes).
- **Connection task** (`connection.rs`): each outbound internal request opens its own request stream, so requests run concurrently and are cancelled and timed out per stream, with the response-to-request echo check single-sourced for blocks and transactions. Inbound request streams are decoded with bounded buffers, served by the inbound service, and answered on the same stream. Announcements use long-lived unidirectional streams, with outbound announcements dropped rather than queued when the transport applies backpressure.
- **Compact block serving**: short transaction ID tables are precomputed when a compact block is sent, so `SHORTID` follow-ups are pure lookups; tables are skipped for peers that requested full transaction IDs.
- **Address handling**: address requests are answered through the shared bounded-random-sampling cache policy (#1869), and `get-addr` is only answered on inbound connections to impede fingerprinting.
- **Unresponsive peer detection**: the transport answers keep-alives locally, so heartbeats cannot detect a peer whose application never answers. The connection disconnects after three request timeouts during which the peer sent no response at all — concurrent timeouts overlapping a response do not count.
- **Handshaker service** (`service.rs`): produces the same peer `Client` type as the legacy transport, so v2 peers plug into the peer set unchanged.

The modules are `#[allow(dead_code)]`-scaffolded until the peer set integration PR consumes them; the attribute is removed in the final PR of the stack.

### Tests

- Loopback QUIC pair tests for the handshake (version negotiation, obsolete version rejection, self-connection detection, duplicate nonce handling) and for the full service (request round trips over real QUIC connections, pushed transaction serving, compact block and `SHORTID` serving, oversized response scoring, unresponsive-peer disconnection).
- `cargo clippy -p zebra-network --all-targets` warning-free; full `zebra-network` suite passes.

### Specifications & References

- Draft version 2 Zcash P2P network protocol: [zcash/zips#1344](https://github.com/zcash/zips/pull/1344)

### Follow-up Work

- Final PR of the stack: `p2p-v2-5-peer-set-integration`.
- High-bandwidth compact block announcements (`announce = 1`) and full-ID mode are not requested yet.
- The stringly `PeerError::V2Protocol`/`V2Internal` variants should become a structured error enum in a follow-up.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude Code was used to implement the connection layer and tests, run the test/lint verification, and draft the commit messages and this description; the changes were reviewed by the author.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
