### PR TITLE
feat(network): run the experimental v2 (QUIC) transport in the peer set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Zebra 6.3.0](https://github.com/ZcashFoundation/zebra/releases/tag/v6.3.0) - 2026-08-10
+## [Unreleased]
 
 ### Added
 
@@ -13,13 +13,27 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   ([zcash/zips#1344](https://github.com/zcash/zips/pull/1344)): a QUIC transport with
   per-network ALPN identifiers, a stream-typed request/announcement layer, a single
   `init`-record handshake, addrv2-only address relay, compact block relay, mempool
-  subscriptions, and serving-side synchronization primitives. Disabled by default:
-  enable the listener with `network.v2_listen`, and dial v2 peers with
-  `network.initial_v2_peers`. Version 2 peers join the peer set alongside legacy peers.
+  subscriptions, and serving-side synchronization primitives backed by a new state
+  index. Disabled by default: enable the listener with `network.v2_listen`, and dial
+  v2 peers with `network.initial_v2_peers`. Version 2 peers join the peer set alongside
+  legacy peers, and the crawler dials whichever transport a peer accepts.
 - The state database format is bumped to 28.1.0 for a per-block synchronization
   metadata index, which serves the version 2 `get-hashes` and `get-tree-roots`
   requests. Existing databases backfill the index on the next start, which reads
   the chain once; the node stays usable while it runs.
+
+### Changed
+
+- The peer address book is now owned by a single peer book actor instead of being
+  shared behind a mutex ([#1976](https://github.com/ZcashFoundation/zebra/issues/1976)).
+  Gossiped addresses are bucketed by a secret-keyed address group and rate-limited per
+  connection, and misbehaviour bans are keyed by IPv4 address or IPv6 /64 prefix and
+  expire after 24 hours.
+
+## [Zebra 6.3.0](https://github.com/ZcashFoundation/zebra/releases/tag/v6.3.0) - 2026-08-10
+
+### Added
+
 - Added `seeder.zec.rocks` and `seeder.testnet.zec.rocks` as default DNS seeders
   ([#11096](https://github.com/ZcashFoundation/zebra/pull/11096)).
 - Prometheus metrics now separate peer connection attempts and terminal outcomes by network,
@@ -36,11 +50,6 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - Chain synchronization now downloads a peer's only unknown block hash from a short
   `FindBlocks` response, allowing nodes near the chain tip to continue advancing
   ([#11165](https://github.com/ZcashFoundation/zebra/pull/11165)).
-- The peer address book is now owned by a single peer book actor instead of being
-  shared behind a mutex ([#1976](https://github.com/ZcashFoundation/zebra/issues/1976)).
-  Gossiped addresses are bucketed by a secret-keyed address group and rate-limited per
-  connection, and misbehaviour bans are keyed by IPv4 address or IPv6 /64 prefix and
-  expire after 24 hours.
 - Peer-set, crawler-handshake, and address-book gauges now include a `network` label, so Mainnet
   and Testnet values no longer overwrite each other in processes that run both networks
   ([#11135](https://github.com/ZcashFoundation/zebra/pull/11135)).

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -27,6 +27,7 @@
   - [Contribution Guide](CONTRIBUTING.md)
   - [Design Overview](dev/overview.md)
   - [Mempool Specification](dev/mempool-specification.md)
+  - [Dual-Protocol Networking](dev/dual-protocol-networking.md)
   - [Diagrams](dev/diagrams.md)
     - [Network Architecture](dev/diagrams/zebra-network.md)
     - [Mempool Architecture](dev/diagrams/mempool-architecture.md)

--- a/book/src/dev/dual-protocol-networking.md
+++ b/book/src/dev/dual-protocol-networking.md
@@ -1,0 +1,82 @@
+# Dual-Protocol Networking: Running v2 on the Legacy Network
+
+Zebra speaks two peer protocols: the legacy protocol over TCP, and the draft
+version 2 protocol over QUIC ([zcash/zips#1344], [zcash/zips#1346]). This
+describes how they coexist, and what is left to do.
+
+The version 2 draft has **no compatibility bridge** by design: it is a
+distinct protocol deployed through the network upgrade mechanism, with epoch
+enforcement retiring legacy peers at activation. Until then both run
+together — QUIC uses UDP where the legacy protocol uses TCP, so both are
+served on the same address and port.
+
+[zcash/zips#1344]: https://github.com/zcash/zips/pull/1344
+[zcash/zips#1346]: https://github.com/zcash/zips/pull/1346
+
+## How they share one node
+
+Almost everything is shared, by construction:
+
+| Concern | Shared mechanism |
+| --- | --- |
+| Peer set membership | Both transports produce a `peer::Client`, delivered over one channel |
+| Outbound dialing | Both are `Service<OutboundConnectorRequest>`: `peer::Connector` and `peer::V2Connector` |
+| Inbound admission | One screening path, one connection counter, one per-IP limit |
+| Address book | One peer book actor; legacy `addr` messages and v2 address announcements use the same intake |
+| Bans | One store, keyed by IP — transport is not an identity, so a peer banned over one cannot return over the other |
+| Inventory | One registry, so gossip routing already mixes transports |
+| Block sync | The syncer's `FindBlocks`/`BlocksByHash` work unchanged: v2 bridges `FindBlocks` onto `get-headers` |
+
+Two things are transport-specific. `peer_book::transports` records which
+transports each address is known to accept, since relayed addresses carry no
+transport hint; and `Request::peer_capability` marks requests that only
+version 2 peers can answer, so the peer set does not route them to a legacy
+peer. Both are documented at their definitions.
+
+## What is left
+
+**Learned reachability is not persisted, and is learned only from outbound
+dials.** It lives in a side table beside the address book rather than on
+`MetaAddr`, so an inbound v2 handshake teaches the node nothing, a restart
+discards everything probing learned, and reachability cannot influence which
+candidates the address book selects — only decorate them afterwards. Moving
+it onto the address record fixes all three, and is what Tor addressing will
+need anyway.
+
+**Probing is how version 2 peers are discovered at all.** Because addresses
+carry no transport hint, a peer not known to accept QUIC is probed at a small
+rate before its legacy dial. A per-address transport hint in the draft — a
+service bit, or an addrv2 network ID — would replace probing with direct
+dialing; this is filed as feedback item 3 in the conformance doc.
+
+**No preference target.** The dial policy uses version 2 wherever a peer is
+known to accept it, but does not aim for a minimum number of version 2
+connections. That becomes worth adding once the version 2 population is
+non-trivial.
+
+**The peer set filters capabilities on one routing path.** `route_p2c`
+consults `peer_capability`; the inventory and broadcast paths do not. No
+capability-bearing request reaches them today, but nothing enforces that.
+
+At the network upgrade, epoch enforcement retires legacy peers and the dial
+policy becomes version 2 only. Until then, version 2 is used opportunistically
+wherever it is found.
+
+## Two properties to preserve
+
+**Transport is not an identity.** Bans are keyed by IP, so a peer cannot evade
+one by switching transports. For the same reason, learned reachability belongs
+on the address record rather than in a second address book: a peer that could
+occupy two entries by being reachable two ways would weaken the address book's
+eclipse resistance.
+
+**Probes are not an amplifier.** A probe is one QUIC initial packet to an
+address that already passed the book's filters — routable, correct port, not
+banned — in place of the TCP SYN the node would have sent anyway.
+
+## Configuration
+
+`network.v2_listen` serves version 2 on the UDP port of `listen_addr`;
+`network.initial_v2_peers` names version 2 peers to dial at startup, which
+are seeded as QUIC-reachable so the crawler maintains them like any other
+peer. Both default off, and with them off nothing about the node changes.

--- a/zebra-network/CHANGELOG.md
+++ b/zebra-network/CHANGELOG.md
@@ -20,9 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org).
   `AddressBookPeers` and reports the bound local listener address) and a
   `PeerBookHandle` tower service for requests that need an answer from the book
   (sanitized addresses, cache snapshots, candidate selection, gossip intake).
-- `RemoteHandshake` replaces the legacy `VersionMessage` in `ConnectionInfo`: it
-  stores the remote peer's actual handshake data per transport protocol, with
-  accessors for the shared fields.
+- `RemoteHandshake` replaces the synthesized legacy `VersionMessage` in
+  `ConnectionInfo`: it stores the remote peer's actual handshake data per
+  transport protocol, with accessors for the shared fields.
 - Misbehavior scores and bans are keyed by the new `BanKey` type (an IPv4
   address, or an IPv6 /64 prefix), persist across connections for about the
   ban duration, and are owned by the peer book actor instead of the address

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -524,6 +524,54 @@ impl AddressBook {
         updated
     }
 
+    /// Removes the entry with `addr`, returning it if it exists
+    ///
+    /// # Note
+    ///
+    /// All address removals should go through `take`, so that the address
+    /// book metrics are accurate.
+    #[allow(dead_code)]
+    fn take(&mut self, removed_addr: PeerSocketAddr) -> Option<MetaAddr> {
+        let _guard = self.span.enter();
+
+        let instant_now = Instant::now();
+        let chrono_now = Utc::now();
+
+        trace!(
+            ?removed_addr,
+            total_peers = self.by_addr.len(),
+            recent_peers = self.recently_live_peers(chrono_now).len(),
+        );
+
+        if let Some(entry) = self.by_addr.remove(&removed_addr) {
+            // Check if this surplus peer's addr matches that in `most_recent_by_ip`
+            // for this the surplus peer's ip to remove it there as well.
+            if self.should_remove_most_recent_by_ip(entry.addr) {
+                if let Some(most_recent_by_ip) = self.most_recent_by_ip.as_mut() {
+                    most_recent_by_ip.remove(&entry.addr.ip());
+                }
+            }
+
+            std::mem::drop(_guard);
+            self.update_metrics(instant_now, chrono_now);
+            Some(entry)
+        } else {
+            None
+        }
+    }
+
+    /// Returns true if the given [`PeerSocketAddr`] is pending a reconnection
+    /// attempt.
+    pub fn pending_reconnection_addr(&mut self, addr: PeerSocketAddr) -> bool {
+        let meta_addr = self.get(addr);
+
+        let _guard = self.span.enter();
+        match meta_addr {
+            None => false,
+            Some(peer) => peer.last_connection_state == PeerAddrState::AttemptPending,
+        }
+    }
+
     /// Return an iterator over all peers.
     ///
     /// Returns peers in reconnection attempt order, including recently connected peers.
@@ -589,30 +637,29 @@ impl AddressBook {
             .cloned()
     }
 
+    /// Return an iterator over peers that might be connected,
+    /// in reconnection attempt order.
+    pub fn maybe_connected_peers(
+        &'_ self,
+        instant_now: Instant,
+        chrono_now: chrono::DateTime<Utc>,
+    ) -> impl DoubleEndedIterator<Item = MetaAddr> + '_ {
+        let _guard = self.span.enter();
+
+        self.by_addr
+            .descending_values()
+            .filter(move |peer| {
+                !peer.is_ready_for_connection_attempt(instant_now, chrono_now, &self.network)
+            })
+            .cloned()
+    }
+
     /// Removes the entry for `addr`, and its per-IP bookkeeping.
     ///
     /// Used by the peer book actor when a gossiped entry is evicted by
     /// bucket replacement.
     pub(crate) fn remove(&mut self, addr: PeerSocketAddr) {
-        if self.remove_without_metrics(addr) {
-            self.update_metrics(Instant::now(), Utc::now());
-        }
-    }
-
-    /// Removes the entry for `addr`, returning whether it was present.
-    ///
-    /// The caller must refresh the metrics watch once it has finished
-    /// removing, so a bulk removal does not walk the book per entry.
-    fn remove_without_metrics(&mut self, addr: PeerSocketAddr) -> bool {
-        // Only clear the per-IP cache when this entry is the one it holds:
-        // another entry with the same IP may have replaced it.
-        let clear_most_recent = self.should_remove_most_recent_by_ip(addr);
-
-        if self.by_addr.remove(&addr).is_none() {
-            return false;
-        }
-
-        if clear_most_recent {
+        if self.by_addr.remove(&addr).is_some() {
             // `most_recent_by_ip` is only populated when
             // `max_connections_per_ip == 1`, so the optional cache must be
             // guarded, not unwrapped.
@@ -620,8 +667,6 @@ impl AddressBook {
                 most_recent_by_ip.remove(&addr.ip());
             }
         }
-
-        true
     }
 
     /// Removes every entry whose IP address matches `predicate`, along with
@@ -638,12 +683,10 @@ impl AddressBook {
             .collect();
 
         for addr in &matching {
-            self.remove_without_metrics(*addr);
+            self.remove(*addr);
         }
 
         if !matching.is_empty() {
-            self.update_metrics(Instant::now(), Utc::now());
-
             warn!(
                 removed = matching.len(),
                 total_peers = self.by_addr.len(),

--- a/zebra-network/src/address_book.rs
+++ b/zebra-network/src/address_book.rs
@@ -426,7 +426,7 @@ impl AddressBook {
     /// changes, and only once: a refresh walks the address book several times, so
     /// refreshing per change makes a batch quadratic.
     #[allow(clippy::unwrap_in_result)]
-    fn update_without_metrics(&mut self, change: MetaAddrChange) -> Option<MetaAddr> {
+    pub(crate) fn update_without_metrics(&mut self, change: MetaAddrChange) -> Option<MetaAddr> {
         // Banned addresses are filtered out by the peer book actor before
         // they reach the address book, so changes here are never banned.
         let previous = self.get(change.addr());
@@ -654,17 +654,26 @@ impl AddressBook {
             .cloned()
     }
 
+    /// Refreshes the address metrics, after a batch of
+    /// [`update_without_metrics`](Self::update_without_metrics) calls.
+    pub(crate) fn refresh_metrics(&mut self) {
+        self.update_metrics(Instant::now(), Utc::now());
+    }
+
     /// Removes the entry for `addr`, and its per-IP bookkeeping.
     ///
     /// Used by the peer book actor when a gossiped entry is evicted by
     /// bucket replacement.
     pub(crate) fn remove(&mut self, addr: PeerSocketAddr) {
         if self.by_addr.remove(&addr).is_some() {
-            // `most_recent_by_ip` is only populated when
-            // `max_connections_per_ip == 1`, so the optional cache must be
-            // guarded, not unwrapped.
-            if let Some(most_recent_by_ip) = self.most_recent_by_ip.as_mut() {
-                most_recent_by_ip.remove(&addr.ip());
+            // Only clear the per-IP most-recent cache when the removed
+            // entry is the cached one: another peer on the same IP may
+            // still be the most recent responder.
+            if self.should_remove_most_recent_by_ip(addr) {
+                self.most_recent_by_ip
+                    .as_mut()
+                    .expect("should be some when should_remove_most_recent_by_ip is true")
+                    .remove(&addr.ip());
             }
         }
     }

--- a/zebra-network/src/address_book/tests/vectors.rs
+++ b/zebra-network/src/address_book/tests/vectors.rs
@@ -248,3 +248,67 @@ fn test_reconnection_peers_skips_recently_updated_ip<
         assert_ne!(next_reconnection_peer, None,);
     }
 }
+
+/// Regression test for <https://github.com/ZcashFoundation/zebra/issues/11134>.
+///
+/// `by_addr` is ordered by reconnection order, not grouped by IP, so a contiguous
+/// `skip_while(ip != banned).take_while(ip == banned)` scan stopped at the first entry for a
+/// different IP, and any later entry on the banned IP survived. That survivor then stayed at the
+/// front of the reconnection order for the lifetime of the process: it was selected as a candidate
+/// on every crawl.
+///
+/// Ban decisions live in the peer book actor's misbehavior store; this test covers the removal
+/// the actor performs when a ban fires.
+#[test]
+fn ban_removes_every_entry_for_the_banned_ip() {
+    let banned_addr: crate::PeerSocketAddr = "127.0.0.1:8233".parse().unwrap();
+    let unrelated_addr: crate::PeerSocketAddr = "127.0.0.2:8233".parse().unwrap();
+    // An ephemeral-port entry for the same IP, like the one in #11134.
+    let zombie_addr: crate::PeerSocketAddr = "127.0.0.1:43562".parse().unwrap();
+
+    // `max_connections_per_ip` is above one, so `reconnection_peers` does not skip the second
+    // entry on the banned IP for being a duplicate IP.
+    let mut address_book =
+        AddressBook::new("0.0.0.0:0".parse().unwrap(), &Mainnet, 2, Span::current());
+
+    // `MetaAddr`'s `Ord` sorts more recently gossiped addresses first, so these last seen times
+    // place the unrelated IP between the two entries for the banned IP.
+    for (addr, last_seen) in [(banned_addr, 2), (unrelated_addr, 1), (zombie_addr, 0)] {
+        address_book.update(gossiped_change(
+            addr,
+            PeerServices::NODE_NETWORK,
+            DateTime32::MIN.saturating_add(Duration32::from_seconds(last_seen)),
+        ));
+    }
+
+    // Without this ordering the test would also pass before the fix, because a contiguous scan
+    // removes contiguous entries correctly.
+    assert_eq!(
+        address_book.by_addr.descending_keys().collect::<Vec<_>>(),
+        vec![&banned_addr, &unrelated_addr, &zombie_addr],
+        "test setup: the unrelated IP must sort between the two entries for the banned IP",
+    );
+
+    // Remove the banned IP's entries, like the peer book actor does when a
+    // misbehavior score reaches the ban threshold.
+    let banned_ip = banned_addr.ip();
+    address_book.remove_if_key_matches(|ip| ip == banned_ip);
+
+    assert_eq!(
+        address_book.by_addr.descending_keys().collect::<Vec<_>>(),
+        vec![&unrelated_addr],
+        "the ban should remove every entry for the banned IP, including the one that does not \
+         sort next to the banned address",
+    );
+
+    let candidates: Vec<_> = address_book
+        .reconnection_peers(Instant::now(), Utc::now())
+        .map(|peer| peer.addr)
+        .collect();
+
+    assert_eq!(
+        candidates,
+        vec![unrelated_addr],
+        "a banned IP must never be a reconnection candidate",
+    );
+}

--- a/zebra-network/src/address_book_updater/tests.rs
+++ b/zebra-network/src/address_book_updater/tests.rs
@@ -121,26 +121,29 @@ async fn peer_book_actor_serves_all_request_variants() {
         "gossiped peers should not be recently live",
     );
 
-    // A `SelectCandidate` request returns one of the gossiped peers.
+    // A `SelectCandidates` request returns one of the gossiped peers.
     let response = handles
         .handle
         .clone()
-        .oneshot(PeerBookRequest::SelectCandidate)
+        .oneshot(PeerBookRequest::SelectCandidates { max: 1 })
         .await
         .expect("actor should be running");
     match response {
-        PeerBookResponse::Candidate(Some((peer, _transports))) => {
+        PeerBookResponse::Candidates(candidates) => {
+            let (peer, _transports) = candidates
+                .first()
+                .expect("gossiped peers should be available for reconnection");
             let gossiped: Vec<_> = (0..3).map(|number| gossiped_addr(number).into()).collect();
             assert!(
                 gossiped.contains(&peer.addr),
                 "the reconnection candidate should be one of the gossiped peers: {peer:?}",
             );
         }
-        other => panic!("gossiped peers should be available for reconnection: {other:?}"),
+        other => panic!("unexpected response variant: {other:?}"),
     }
 }
 
-/// Test that concurrent `SelectCandidate` requests never return the same peer.
+/// Test that concurrent `SelectCandidates` requests never return the same peer.
 ///
 /// The actor picks the candidate and marks it as `AttemptPending` in the same
 /// actor turn, so each request marks its candidate before the next request
@@ -181,7 +184,7 @@ async fn concurrent_select_candidate_requests_return_distinct_peers() {
         handles
             .handle
             .clone()
-            .oneshot(PeerBookRequest::SelectCandidate)
+            .oneshot(PeerBookRequest::SelectCandidates { max: 1 })
     });
 
     let responses = future::join_all(requests).await;
@@ -190,9 +193,11 @@ async fn concurrent_select_candidate_requests_return_distinct_peers() {
         .into_iter()
         .map(|response| {
             match response.expect("the peer book actor should serve concurrent requests") {
-                PeerBookResponse::Candidate(Some((peer, _transports))) => peer.addr,
-                PeerBookResponse::Candidate(None) => {
-                    panic!("every request should return a candidate peer")
+                PeerBookResponse::Candidates(candidates) => {
+                    let (peer, _transports) = candidates
+                        .first()
+                        .expect("every request should return a candidate peer");
+                    peer.addr
                 }
                 other => panic!("unexpected response variant: {other:?}"),
             }
@@ -202,6 +207,6 @@ async fn concurrent_select_candidate_requests_return_distinct_peers() {
     assert_eq!(
         unique_peers.len(),
         TEST_PEER_COUNT,
-        "concurrent SelectCandidate requests must never return the same peer",
+        "concurrent SelectCandidates requests must never return the same peer",
     );
 }

--- a/zebra-network/src/address_book_updater/tests.rs
+++ b/zebra-network/src/address_book_updater/tests.rs
@@ -129,7 +129,7 @@ async fn peer_book_actor_serves_all_request_variants() {
         .await
         .expect("actor should be running");
     match response {
-        PeerBookResponse::Candidate(Some(peer)) => {
+        PeerBookResponse::Candidate(Some((peer, _transports))) => {
             let gossiped: Vec<_> = (0..3).map(|number| gossiped_addr(number).into()).collect();
             assert!(
                 gossiped.contains(&peer.addr),
@@ -190,7 +190,7 @@ async fn concurrent_select_candidate_requests_return_distinct_peers() {
         .into_iter()
         .map(|response| {
             match response.expect("the peer book actor should serve concurrent requests") {
-                PeerBookResponse::Candidate(Some(peer)) => peer.addr,
+                PeerBookResponse::Candidate(Some((peer, _transports))) => peer.addr,
                 PeerBookResponse::Candidate(None) => {
                     panic!("every request should return a candidate peer")
                 }

--- a/zebra-network/src/meta_addr.rs
+++ b/zebra-network/src/meta_addr.rs
@@ -917,6 +917,14 @@ impl MetaAddrChange {
         }
     }
 
+    /// Return the timestamp when a ping was last sent, if available.
+    pub fn ping_sent(&self) -> Option<Instant> {
+        match self {
+            UpdatePingSent { ping_sent_at, .. } => Some(*ping_sent_at),
+            _ => None,
+        }
+    }
+
     /// Return the RTT for this change, if available
     pub fn rtt(&self) -> Option<Duration> {
         match self {

--- a/zebra-network/src/meta_addr/tests/prop.rs
+++ b/zebra-network/src/meta_addr/tests/prop.rs
@@ -357,7 +357,9 @@ proptest! {
             let mut attempt_count: usize = 0;
 
             for (i, change) in changes.into_iter().enumerate() {
-                while let Some(candidate_addr) = next_reconnect_peer(&mut next_peer_service).await {
+                while let Some((candidate_addr, _transports)) =
+                    next_reconnect_peer(&mut next_peer_service).await
+                {
                     prop_assert_eq!(candidate_addr.addr, addr.addr);
 
                     attempt_count += 1;

--- a/zebra-network/src/peer/handshake.rs
+++ b/zebra-network/src/peer/handshake.rs
@@ -17,7 +17,7 @@ use futures::{channel::oneshot, future, pin_mut, FutureExt, SinkExt, StreamExt};
 use indexmap::IndexSet;
 use tokio::{
     io::{AsyncRead, AsyncWrite},
-    sync::broadcast,
+    sync::{broadcast, watch},
     task::JoinError,
     time::{error, timeout, Instant},
 };
@@ -129,8 +129,18 @@ where
 ///
 /// Each transport keeps its own set: a nonce is only ever echoed back on the
 /// protocol that sent it.
-#[derive(Clone, Debug, Default)]
-pub struct HandshakeNonces(Arc<futures::lock::Mutex<IndexSet<Nonce>>>);
+///
+/// The set is a [`watch`] channel used as a shared cell: updates run
+/// atomically in [`watch::Sender::send_modify`], and reads take a
+/// [`watch::Sender::borrow`] snapshot, so handshakes never hold a lock.
+#[derive(Clone, Debug)]
+pub struct HandshakeNonces(watch::Sender<IndexSet<Nonce>>);
+
+impl Default for HandshakeNonces {
+    fn default() -> Self {
+        Self(watch::channel(IndexSet::new()).0)
+    }
+}
 
 impl HandshakeNonces {
     /// Inserts a newly generated local `nonce` into the set, bounding the
@@ -141,11 +151,6 @@ impl HandshakeNonces {
     /// progress. Duplicate nonces are very rare, because they require a
     /// 64-bit random number collision, and the nonce set is limited to a few
     /// hundred entries.
-    ///
-    /// # Correctness
-    ///
-    /// It is ok to wait for the lock here, because handshakes have a short
-    /// timeout, and the async mutex will be released when the task times out.
     ///
     /// # Security
     ///
@@ -160,28 +165,24 @@ impl HandshakeNonces {
     /// - memory usage: 16 bytes per [`Nonce`], 3.2 kB for 200 nonces
     /// - collision probability: two hundred 64-bit nonces have a very low collision probability
     ///   <https://en.wikipedia.org/wiki/Birthday_problem#Probability_of_a_shared_birthday_(collision)>
-    pub async fn register(&self, nonce: Nonce, limit: usize) -> bool {
-        let mut nonces = self.0.lock().await;
+    pub fn register(&self, nonce: Nonce, limit: usize) -> bool {
+        let mut inserted = false;
 
-        if !nonces.insert(nonce) {
-            return false;
-        }
+        self.0.send_modify(|nonces| {
+            inserted = nonces.insert(nonce);
 
-        while nonces.len() > limit {
-            nonces.shift_remove_index(0);
-        }
+            if inserted {
+                while nonces.len() > limit {
+                    nonces.shift_remove_index(0);
+                }
+            }
+        });
 
-        true
+        inserted
     }
 
     /// Returns true if `nonce` was recently sent in one of this node's own
     /// handshake messages: the peer that echoed it is this node itself.
-    ///
-    /// # Correctness
-    ///
-    /// The caller must wait for the lock before continuing with the
-    /// connection, to avoid self-connection. If the connection times out, the
-    /// async lock will be released.
     ///
     /// # Security
     ///
@@ -189,14 +190,14 @@ impl HandshakeNonces {
     /// that observe this node's network traffic could maliciously fail
     /// handshakes to evict nonces, and force it to make self-connections.
     /// The set is bounded by [`register`](Self::register) instead.
-    pub async fn contains(&self, nonce: &Nonce) -> bool {
-        self.0.lock().await.contains(nonce)
+    pub fn contains(&self, nonce: &Nonce) -> bool {
+        self.0.borrow().contains(nonce)
     }
 
     /// Returns the number of nonces in the set.
     #[cfg(test)]
-    pub async fn len(&self) -> usize {
-        self.0.lock().await.len()
+    pub fn len(&self) -> usize {
+        self.0.borrow().len()
     }
 }
 
@@ -757,10 +758,7 @@ where
 
     // Insert the nonce for this handshake into the shared nonce set.
     // Each connection has its own connection state, and handshakes execute concurrently.
-    if !nonces
-        .register(local_nonce, config.peerset_total_connection_limit())
-        .await
-    {
+    if !nonces.register(local_nonce, config.peerset_total_connection_limit()) {
         return Err(HandshakeError::LocalDuplicateNonce);
     }
 
@@ -876,7 +874,7 @@ where
     }
 
     // Check for nonce reuse, indicating self-connection
-    let nonce_reuse = nonces.contains(&remote.nonce).await;
+    let nonce_reuse = nonces.contains(&remote.nonce);
     if nonce_reuse {
         info!(?connected_addr, "rejecting self-connection attempt");
         return Err(remote_version_outcome.record_error(HandshakeError::RemoteNonceReuse));

--- a/zebra-network/src/peer/handshake/tests.rs
+++ b/zebra-network/src/peer/handshake/tests.rs
@@ -14,6 +14,6 @@ where
 {
     /// Returns a count of how many connection nonces are stored in this [`Handshake`]
     pub async fn nonce_count(&self) -> usize {
-        self.nonces.len().await
+        self.nonces.len()
     }
 }

--- a/zebra-network/src/peer/load_tracked_client.rs
+++ b/zebra-network/src/peer/load_tracked_client.rs
@@ -14,7 +14,7 @@ use tower::{
 
 use crate::{
     constants::{EWMA_DECAY_TIME_NANOS, EWMA_DEFAULT_RTT},
-    peer::{Client, ConnectedAddr, ConnectionInfo},
+    peer::{Client, ConnectedAddr, ConnectionInfo, RemoteHandshake},
     protocol::external::{canonical_socket_addr, types::Version},
 };
 
@@ -53,6 +53,14 @@ impl LoadTrackedClient {
     /// Retrieve the peer's reported protocol version.
     pub fn remote_version(&self) -> Version {
         self.connection_info.remote.version()
+    }
+
+    /// Returns true if this peer speaks the version 2 protocol.
+    ///
+    /// The handshake record is the transport: legacy peers send a `version`
+    /// message, version 2 peers send an `init` record.
+    pub fn is_v2(&self) -> bool {
+        matches!(self.connection_info.remote, RemoteHandshake::Init(_))
     }
 
     /// Returns true if this peer connected directly to us from `ip`.

--- a/zebra-network/src/peer/v2/connection.rs
+++ b/zebra-network/src/peer/v2/connection.rs
@@ -60,9 +60,8 @@ use crate::{
             record,
             request::Request as WireRequest,
             response::{
-                encode_result_entry, read_result_entry, AddrResponse, HashesResponse,
-                HeadersResponse, MempoolResponse, TreeRootsResponse, RESULT_NOT_FOUND,
-                RESULT_OBJECT,
+                AddrResponse, BlockResponseEntry, HashesResponse, HeadersResponse, MempoolResponse,
+                TreeRootsResponse, TxResponseEntry, RESULT_NOT_FOUND, RESULT_OBJECT,
             },
             txref::TransactionReference,
             types::{ErrorCode, StreamType, WireError},
@@ -128,13 +127,19 @@ const RECONSTRUCTED_BLOCK_CACHE_LIMIT: usize = 4;
 /// a QUIC stream locks shared transport state.
 const RESPONSE_STREAM_READ_BUFFER_SIZE: usize = 64 * 1024;
 
-/// The read buffer size for record streams: inbound requests, and the
-/// long-lived handshake and announcement streams.
+/// The read buffer size for inbound request streams.
 ///
-/// Their records are small and infrequent, and the remote peer can hold
-/// many of these streams open at once, each keeping its buffer for as long
-/// as the stream lives. A large per-stream buffer would let it pin
-/// megabytes of allocations per connection.
+/// Inbound requests are small (only `get-tx` exceeds a few KiB), and the
+/// remote peer can hold many request streams open concurrently, so a large
+/// per-stream buffer would let it pin megabytes of allocations per
+/// connection.
+const INBOUND_REQUEST_STREAM_READ_BUFFER_SIZE: usize = 8 * 1024;
+
+/// The read buffer size for the long-lived handshake and announcement
+/// streams.
+///
+/// Their records are small and infrequent, and each open stream keeps its
+/// buffer for the life of the connection.
 const RECORD_STREAM_READ_BUFFER_SIZE: usize = 8 * 1024;
 
 /// An announcement record queued for the announcement writer task.
@@ -866,13 +871,18 @@ where
         .oneshot(Request::BlocksByHash(std::iter::once(hash).collect()))
         .await;
 
-    let block = response
-        .ok()
-        .and_then(|response| available_blocks(response).swap_remove(&hash));
-
-    let Some(block) = block else {
-        debug!(?hash, "skipping announcement of block not found locally");
-        return;
+    let block = match response {
+        Ok(Response::Blocks(mut blocks)) => match blocks.pop() {
+            Some(InventoryResponse::Available((block, _))) => block,
+            _ => {
+                debug!(?hash, "skipping announcement of block not found locally");
+                return;
+            }
+        },
+        other => {
+            debug!(?hash, ?other, "skipping block announcement");
+            return;
+        }
     };
 
     match build_block_announcement(&block, &shared.remote_init, rand::random()) {
@@ -1138,9 +1148,9 @@ where
             .await
             .ok()?;
         for position in wire_positions {
-            match read_result_entry(&mut recv, "get-tx").await.ok()? {
-                Some(tx) => slots[position] = Some(tx),
-                None => return None,
+            match TxResponseEntry::read(&mut recv).await.ok()? {
+                TxResponseEntry::Found(tx) => slots[position] = Some(tx),
+                TxResponseEntry::NotFound => return None,
             }
         }
         record::expect_end_of_stream(&mut recv).await.ok()?;
@@ -1268,12 +1278,13 @@ async fn fetch_announced_block(shared: &SharedConnection, hash: block::Hash) -> 
     let mut recv = send_wire_request(shared, WireRequest::GetBlocks { hashes: vec![hash] })
         .await
         .ok()?;
-    let entry = read_result_entry::<Block, _>(&mut recv, "get-blocks")
-        .await
-        .ok()?;
+    let entry = BlockResponseEntry::read(&mut recv).await.ok()?;
     record::expect_end_of_stream(&mut recv).await.ok()?;
 
-    entry.filter(|block| block.hash() == hash)
+    match entry {
+        BlockResponseEntry::Full(block) if block.hash() == hash => Some(block),
+        _ => None,
+    }
 }
 
 /// Builds the short transaction ID table of a block, using the nonce of the
@@ -1530,10 +1541,9 @@ async fn drive_outbound_request(
                 transient_addr,
                 "get-blocks",
                 "block",
-                async |recv| {
-                    Ok(read_result_entry::<Block, _>(recv, "get-blocks")
-                        .await?
-                        .map(|block| (block.hash(), block)))
+                async |recv| match BlockResponseEntry::read(recv).await? {
+                    BlockResponseEntry::Full(block) => Ok(Some((block.hash(), block))),
+                    BlockResponseEntry::NotFound => Ok(None),
                 },
             )
             .await?;
@@ -1556,12 +1566,12 @@ async fn drive_outbound_request(
                 transient_addr,
                 "get-tx",
                 "transaction",
-                async |recv| {
-                    Ok(read_result_entry(recv, "get-tx").await?.map(|transaction| {
+                async |recv| match TxResponseEntry::read(recv).await? {
+                    TxResponseEntry::Found(transaction) => {
                         let transaction = UnminedTx::from(transaction);
-
-                        (transaction.id, transaction)
-                    }))
+                        Ok(Some((transaction.id, transaction)))
+                    }
+                    TxResponseEntry::NotFound => Ok(None),
                 },
             )
             .await?;
@@ -1871,7 +1881,8 @@ async fn read_inbound_request(
         }
     };
 
-    let mut recv = tokio::io::BufReader::with_capacity(RECORD_STREAM_READ_BUFFER_SIZE, recv);
+    let mut recv =
+        tokio::io::BufReader::with_capacity(INBOUND_REQUEST_STREAM_READ_BUFFER_SIZE, recv);
     let request = match WireRequest::read(stream_type, &mut recv).await {
         Ok(request) => request,
         Err(error) => {
@@ -2147,8 +2158,13 @@ where
             // not grow a fresh buffer from empty.
             let mut bytes = Vec::new();
             for hash in hashes {
+                let entry = match available.get(&hash) {
+                    Some(block) => BlockResponseEntry::Full(block.clone()),
+                    None => BlockResponseEntry::NotFound,
+                };
+
                 bytes.clear();
-                encode_result_entry(&mut bytes, available.get(&hash).map(Arc::as_ref))?;
+                entry.encode(&mut bytes)?;
                 write_response_bytes(send, &bytes).await?;
             }
 
@@ -2290,17 +2306,22 @@ where
             // not grow a fresh buffer from empty.
             let mut bytes = Vec::new();
             for source in ids {
-                let entry: Option<&Transaction> = match &source {
-                    TxSource::ById(id) => available
-                        .get(id)
-                        .map(|transaction| transaction.transaction.as_ref())
-                        .or_else(|| direct.get(id).map(Arc::as_ref)),
-                    TxSource::Direct(transaction) => Some(transaction),
-                    TxSource::NotFound => None,
+                let entry = match source {
+                    TxSource::ById(id) => match available.get(&id) {
+                        Some(transaction) => {
+                            TxResponseEntry::Found(transaction.transaction.clone())
+                        }
+                        None => match direct.get(&id) {
+                            Some(transaction) => TxResponseEntry::Found(transaction.clone()),
+                            None => TxResponseEntry::NotFound,
+                        },
+                    },
+                    TxSource::Direct(transaction) => TxResponseEntry::Found(transaction),
+                    TxSource::NotFound => TxResponseEntry::NotFound,
                 };
 
                 bytes.clear();
-                encode_result_entry(&mut bytes, entry)?;
+                entry.encode(&mut bytes)?;
                 write_response_bytes(send, &bytes).await?;
             }
 
@@ -2352,7 +2373,13 @@ where
                 )
                 .await?;
 
-                let block = available_blocks(response).swap_remove(&next_hash);
+                let block = match response {
+                    Response::Blocks(mut blocks) => match blocks.pop() {
+                        Some(InventoryResponse::Available((block, _))) => Some(block),
+                        _ => None,
+                    },
+                    _ => None,
+                };
 
                 let Some(block) = block else {
                     if delivered_count == 0 {

--- a/zebra-network/src/peer/v2/connection.rs
+++ b/zebra-network/src/peer/v2/connection.rs
@@ -17,7 +17,7 @@ use std::{
     collections::{HashMap, HashSet},
     sync::{
         atomic::{AtomicU32, Ordering},
-        Arc, Mutex,
+        Arc,
     },
 };
 
@@ -177,6 +177,37 @@ fn insert_bounded<K: std::hash::Hash + Eq, V>(
 }
 
 /// State shared between the connection task and the per-stream tasks it
+/// A mutable value shared between the connection task and the per-stream
+/// tasks it spawns.
+///
+/// Backed by a [`watch`](tokio::sync::watch) channel used as a cell: updates
+/// run atomically inside [`send_modify`](tokio::sync::watch::Sender::send_modify),
+/// and reads take a short borrow snapshot.
+pub(super) struct SharedCell<T>(tokio::sync::watch::Sender<T>);
+
+impl<T: Default> Default for SharedCell<T> {
+    fn default() -> Self {
+        Self(tokio::sync::watch::channel(T::default()).0)
+    }
+}
+
+impl<T> SharedCell<T> {
+    /// Runs `f` on the shared value, atomically with other updates.
+    fn with<R>(&self, f: impl FnOnce(&mut T) -> R) -> R {
+        let mut result = None;
+        self.0.send_modify(|value| result = Some(f(value)));
+        result.expect("send_modify runs the closure exactly once")
+    }
+
+    /// Returns a read snapshot of the shared value.
+    ///
+    /// The snapshot must be dropped before any await point, like a lock
+    /// guard.
+    fn read(&self) -> tokio::sync::watch::Ref<'_, T> {
+        self.0.borrow()
+    }
+}
+
 /// spawns.
 pub(super) struct SharedConnection {
     /// The QUIC connection.
@@ -220,18 +251,18 @@ pub(super) struct SharedConnection {
     pub(super) announcement_tx: tokio::sync::mpsc::Sender<AnnouncementRecord>,
 
     /// Recently pushed transactions, served to the peer's `get-tx` requests.
-    pub(super) pushed_transactions: Mutex<IndexMap<UnminedTxId, UnminedTx>>,
+    pub(super) pushed_transactions: SharedCell<IndexMap<UnminedTxId, UnminedTx>>,
 
     /// Blocks recently sent to this peer with their transactions identified
     /// rather than included — as compact block announcements or `get-headers`
     /// entries with transaction IDs — retained to serve the peer's
     /// reconstruction `get-tx` requests, including by `SHORTID` reference.
-    pub(super) sent_blocks: Mutex<IndexMap<block::Hash, SentBlock>>,
+    pub(super) sent_blocks: SharedCell<IndexMap<block::Hash, SentBlock>>,
 
     /// Blocks reconstructed from this peer's compact block announcements,
     /// serving the local gossip downloader's follow-up block requests
     /// without a wire round-trip.
-    pub(super) reconstructed_blocks: Mutex<IndexMap<block::Hash, Arc<Block>>>,
+    pub(super) reconstructed_blocks: SharedCell<IndexMap<block::Hash, Arc<Block>>>,
 
     /// Broadcasts transactions newly accepted into the local mempool to the
     /// peer's `get-mempool` subscription, if one is active.
@@ -242,7 +273,7 @@ pub(super) struct SharedConnection {
 
     /// Transactions queued for announcement to this peer at the next
     /// trickle flush.
-    pub(super) pending_tx_announcements: Mutex<IndexSet<UnminedTxId>>,
+    pub(super) pending_tx_announcements: SharedCell<IndexSet<UnminedTxId>>,
 
     /// Whether the peer currently has a `get-mempool` subscription open;
     /// a second concurrent subscription is a connection error.
@@ -256,20 +287,20 @@ pub(super) struct SharedConnection {
     /// oldest half beyond the bound: removals from the remote mempool are
     /// never communicated, so old entries only expire by eviction or
     /// disconnection.
-    pub(super) remote_mempool: Mutex<IndexSet<UnminedTxId>>,
+    pub(super) remote_mempool: SharedCell<IndexSet<UnminedTxId>>,
 
     /// Peer addresses announced by the remote peer, served to internal
     /// [`Request::Peers`] requests, mirroring the legacy connection's
     /// address cache.
-    pub(super) cached_addrs: Mutex<Vec<MetaAddr>>,
+    pub(super) cached_addrs: SharedCell<Vec<MetaAddr>>,
 
     /// Rate-limits the relayed addresses accepted from this peer's address
     /// announcement stream.
-    pub(super) addr_tokens: Mutex<AddrTokenBucket>,
+    pub(super) addr_tokens: SharedCell<AddrTokenBucket>,
 
     /// The announcement stream types the remote peer currently has open
     /// towards this node, to enforce the one-stream-per-type rule.
-    pub(super) open_inbound_announcements: Mutex<HashSet<u8>>,
+    pub(super) open_inbound_announcements: SharedCell<HashSet<u8>>,
 
     /// Whether this node has already sent a `get-addr` request on this
     /// connection.
@@ -364,17 +395,17 @@ impl SharedConnection {
     /// request it.
     pub(super) fn record_sent_block(&self, block: Arc<Block>, nonce: Option<u64>) {
         let hash = block.hash();
-        let mut sent = self.sent_blocks.lock().expect("mutex is not poisoned");
-
         // Re-recording moves the block to the most recent slot, and a
         // compact block's nonce replaces a `get-headers` entry's absent
         // nonce.
-        insert_bounded(
-            &mut sent,
-            hash,
-            SentBlock { block, nonce },
-            SENT_BLOCK_CACHE_LIMIT,
-        );
+        self.sent_blocks.with(|sent| {
+            insert_bounded(
+                sent,
+                hash,
+                SentBlock { block, nonce },
+                SENT_BLOCK_CACHE_LIMIT,
+            )
+        });
     }
 
     /// Fails the connection: records `error` in the error slot and closes
@@ -720,12 +751,11 @@ fn dispatch_client_request<S>(
         // address requests without a wire round-trip, mirroring the legacy
         // connection's address cache.
         Request::Peers => {
-            let cached: Vec<MetaAddr> = {
-                let mut cached_addrs = shared.cached_addrs.lock().expect("mutex is not poisoned");
-                // Security: this method performs security-sensitive operations, see its comments
-                // for details.
-                update_addr_cache(&mut cached_addrs, None, constants::PEER_ADDR_RESPONSE_LIMIT)
-            };
+            // Security: this method performs security-sensitive operations, see its comments
+            // for details.
+            let cached: Vec<MetaAddr> = shared.cached_addrs.with(|cached_addrs| {
+                update_addr_cache(cached_addrs, None, constants::PEER_ADDR_RESPONSE_LIMIT)
+            });
 
             // To impede fingerprinting, a node only answers address requests
             // on connections the remote peer initiated, and sends `get-addr`
@@ -751,18 +781,14 @@ fn dispatch_client_request<S>(
         // v2 has no unsolicited transaction push: cache the transaction for
         // the peer's `get-tx`, and announce it.
         Request::PushTransaction(transaction, _) => {
-            {
-                let mut pushed = shared
-                    .pushed_transactions
-                    .lock()
-                    .expect("mutex is not poisoned");
+            shared.pushed_transactions.with(|pushed| {
                 insert_bounded(
-                    &mut pushed,
+                    pushed,
                     transaction.id,
                     transaction.clone(),
                     PUSHED_TRANSACTION_CACHE_LIMIT,
-                );
-            }
+                )
+            });
 
             queue_transaction_announcements(shared, [transaction.id]);
             let _ = tx.send(Ok(Response::Nil));
@@ -789,18 +815,16 @@ fn queue_transaction_announcements(
     shared: &SharedConnection,
     ids: impl IntoIterator<Item = UnminedTxId>,
 ) {
-    let mut pending = shared
-        .pending_tx_announcements
-        .lock()
-        .expect("mutex is not poisoned");
-    for id in ids {
-        // Announcements are best-effort and unordered, so the bound evicts
-        // an arbitrary old entry.
-        if pending.len() >= PENDING_TX_ANNOUNCEMENT_LIMIT {
-            pending.swap_remove_index(0);
+    shared.pending_tx_announcements.with(|pending| {
+        for id in ids {
+            // Announcements are best-effort and unordered, so the bound evicts
+            // an arbitrary old entry.
+            if pending.len() >= PENDING_TX_ANNOUNCEMENT_LIMIT {
+                pending.swap_remove_index(0);
+            }
+            pending.insert(id);
         }
-        pending.insert(id);
-    }
+    });
 }
 
 /// Trickles this connection's transaction announcements: queued
@@ -817,13 +841,9 @@ pub(super) async fn trickle_transaction_announcements(shared: Arc<SharedConnecti
             _ = shared.quic.closed() => return,
         }
 
-        let batch: Vec<UnminedTxId> = {
-            let mut pending = shared
-                .pending_tx_announcements
-                .lock()
-                .expect("mutex is not poisoned");
-            pending.drain(..).collect()
-        };
+        let batch: Vec<UnminedTxId> = shared
+            .pending_tx_announcements
+            .with(|pending| pending.drain(..).collect());
         if batch.is_empty() {
             continue;
         }
@@ -1009,11 +1029,9 @@ async fn reconstruct_compact_block<S>(
 
     match block {
         Some(block) => {
-            let mut cache = shared
+            shared
                 .reconstructed_blocks
-                .lock()
-                .expect("mutex is not poisoned");
-            insert_bounded(&mut cache, hash, block, RECONSTRUCTED_BLOCK_CACHE_LIMIT);
+                .with(|cache| insert_bounded(cache, hash, block, RECONSTRUCTED_BLOCK_CACHE_LIMIT));
         }
         None => debug!(?hash, "an announced compact block could not be obtained"),
     }
@@ -1247,15 +1265,14 @@ pub(super) async fn maintain_mempool_subscription<S>(
 
         // Mirror the references into the cache, evicting the oldest half
         // beyond the bound.
-        {
-            let mut cache = shared.remote_mempool.lock().expect("mutex is not poisoned");
+        shared.remote_mempool.with(|cache| {
             cache.extend(ids.iter().copied());
             let len = cache.len();
             if len > MAX_MEMPOOL_RESPONSE_REFS {
                 let recent = cache.split_off(len / 2);
                 *cache = recent;
             }
-        }
+        });
 
         // Forward the references as an advertisement: the mempool dedups
         // known transactions and downloads the rest with `get-tx`.
@@ -1469,14 +1486,9 @@ async fn drive_outbound_request(
             // bounded random sample, so a single peer cannot control the
             // address book by the size or order of its response, like the
             // legacy connection.
-            let response_addrs = {
-                let mut cached_addrs = shared.cached_addrs.lock().expect("mutex is not poisoned");
-                update_addr_cache(
-                    &mut cached_addrs,
-                    &addrs.0,
-                    constants::PEER_ADDR_RESPONSE_LIMIT,
-                )
-            };
+            let response_addrs = shared.cached_addrs.with(|cached_addrs| {
+                update_addr_cache(cached_addrs, &addrs.0, constants::PEER_ADDR_RESPONSE_LIMIT)
+            });
 
             Ok(Response::Peers(response_addrs))
         }
@@ -1485,10 +1497,7 @@ async fn drive_outbound_request(
             // Answered from the mempool subscription's mirror: only one
             // concurrent `get-mempool` stream per peer is allowed, and the
             // connection's subscription task holds it.
-            let ids: Vec<UnminedTxId> = {
-                let cache = shared.remote_mempool.lock().expect("mutex is not poisoned");
-                cache.iter().copied().collect()
-            };
+            let ids: Vec<UnminedTxId> = shared.remote_mempool.read().iter().copied().collect();
             Ok(Response::TransactionIds(ids))
         }
 
@@ -1512,10 +1521,7 @@ async fn drive_outbound_request(
             // downloader fetches an announced block right back from the
             // announcing connection.
             let reconstructed: Option<Vec<Arc<Block>>> = {
-                let cache = shared
-                    .reconstructed_blocks
-                    .lock()
-                    .expect("mutex is not poisoned");
+                let cache = shared.reconstructed_blocks.read();
                 hashes.iter().map(|hash| cache.get(hash).cloned()).collect()
             };
             if let Some(blocks) = reconstructed {
@@ -2209,14 +2215,13 @@ where
                     } => {
                         let table = short_id_tables.entry(*block_hash).or_insert_with(|| {
                             // Take a handle to the block, then build the
-                            // table outside the lock: hashing every
+                            // table outside the borrow: hashing every
                             // transaction of a block must not block the
                             // announcement and reconstruction paths that
-                            // share this mutex.
+                            // share this cell.
                             let sent = shared
                                 .sent_blocks
-                                .lock()
-                                .expect("mutex is not poisoned")
+                                .read()
                                 .get(block_hash)
                                 .map(|sent| (sent.block.clone(), sent.nonce));
 
@@ -2244,10 +2249,7 @@ where
             let mut direct: IndexMap<UnminedTxId, Arc<Transaction>> = IndexMap::new();
 
             let mut available: IndexMap<UnminedTxId, UnminedTx> = {
-                let pushed = shared
-                    .pushed_transactions
-                    .lock()
-                    .expect("mutex is not poisoned");
+                let pushed = shared.pushed_transactions.read();
                 lookup_ids
                     .iter()
                     .filter_map(|id| pushed.get(id).map(|tx| (*id, tx.clone())))
@@ -2285,7 +2287,7 @@ where
             if !unresolved.is_empty() {
                 // Take handles to the blocks, then search outside the lock.
                 let sent: Vec<Arc<Block>> = {
-                    let sent = shared.sent_blocks.lock().expect("mutex is not poisoned");
+                    let sent = shared.sent_blocks.read();
                     sent.values().map(|entry| entry.block.clone()).collect()
                 };
 
@@ -2659,17 +2661,14 @@ async fn read_inbound_announcement_stream<S>(
     }
 
     // Enforce at most one open announcement stream per type and direction.
-    {
-        let mut open = shared
-            .open_inbound_announcements
-            .lock()
-            .expect("mutex is not poisoned");
-        if !open.insert(type_byte) {
-            shared.fail_protocol(format!(
-                "peer opened a second concurrent announcement stream of type {type_byte:#04x}",
-            ));
-            return;
-        }
+    let newly_opened = shared
+        .open_inbound_announcements
+        .with(|open| open.insert(type_byte));
+    if !newly_opened {
+        shared.fail_protocol(format!(
+            "peer opened a second concurrent announcement stream of type {type_byte:#04x}",
+        ));
+        return;
     }
 
     let mut recv = tokio::io::BufReader::with_capacity(RECORD_STREAM_READ_BUFFER_SIZE, recv);
@@ -2697,9 +2696,7 @@ async fn read_inbound_announcement_stream<S>(
     // The stream ended: the peer may open a replacement.
     shared
         .open_inbound_announcements
-        .lock()
-        .expect("mutex is not poisoned")
-        .remove(&type_byte);
+        .with(|open| open.remove(&type_byte));
 }
 
 /// Handles one inbound announcement record.
@@ -2816,15 +2813,14 @@ where
                 // incur no penalty.
                 let admitted = shared
                     .addr_tokens
-                    .lock()
-                    .expect("mutex is not poisoned")
-                    .try_take(std::time::Instant::now());
+                    .with(|tokens| tokens.try_take(std::time::Instant::now()));
                 if admitted {
-                    let mut cached = shared.cached_addrs.lock().expect("mutex is not poisoned");
                     // Adds the address to the cache and bounds the cache
                     // size, like the legacy connection's unsolicited `addr`
                     // handling.
-                    let no_response = update_addr_cache(&mut cached, &[addr], None);
+                    let no_response = shared
+                        .cached_addrs
+                        .with(|cached| update_addr_cache(cached, &[addr], None));
                     debug_assert!(no_response.is_empty(), "no response was requested");
                 }
             }

--- a/zebra-network/src/peer/v2/connection.rs
+++ b/zebra-network/src/peer/v2/connection.rs
@@ -16,7 +16,7 @@
 use std::{
     collections::{HashMap, HashSet},
     sync::{
-        atomic::{AtomicU32, Ordering},
+        atomic::{AtomicU32, AtomicU64, Ordering},
         Arc,
     },
 };
@@ -314,6 +314,12 @@ pub(super) struct SharedConnection {
     /// response from this peer.
     pub(super) consecutive_timeouts: AtomicU32,
 
+    /// The number of responses received from this peer, used to ignore
+    /// request timeouts that overlapped a response: requests run
+    /// concurrently, and only a peer that answers nothing at all is
+    /// unresponsive.
+    pub(super) responses_received: AtomicU64,
+
     /// The bulk block streams (`get-block-range`) this node is currently
     /// serving to the peer.
     pub(super) active_bulk_streams: SlotCounter,
@@ -438,12 +444,25 @@ impl SharedConnection {
     /// Records that this peer answered a request, clearing the consecutive
     /// timeout count.
     pub(super) fn record_response(&self) {
+        self.responses_received.fetch_add(1, Ordering::Relaxed);
         self.consecutive_timeouts.store(0, Ordering::Relaxed);
     }
 
     /// Records that a request to this peer timed out, and fails the
-    /// connection once [`MAX_CONSECUTIVE_REQUEST_TIMEOUTS`] are reached.
-    pub(super) fn record_request_timeout(&self) {
+    /// connection once [`MAX_CONSECUTIVE_REQUEST_TIMEOUTS`] unanswered
+    /// windows are reached.
+    ///
+    /// `responses_at_request_start` is the caller's snapshot of
+    /// [`responses_received`](Self::responses_received) from when it sent the
+    /// request. A timeout only counts if the peer answered nothing at all
+    /// while the request was outstanding: requests run concurrently, so a
+    /// batch of requests timing out together must not each count towards the
+    /// disconnect threshold when the peer is merely slow.
+    pub(super) fn record_request_timeout(&self, responses_at_request_start: u64) {
+        if self.responses_received.load(Ordering::Relaxed) != responses_at_request_start {
+            return;
+        }
+
         let timeouts = self.consecutive_timeouts.fetch_add(1, Ordering::Relaxed) + 1;
 
         if timeouts >= MAX_CONSECUTIVE_REQUEST_TIMEOUTS {
@@ -1337,6 +1356,7 @@ fn spawn_outbound_request(
     tokio::spawn(
         async move {
             let command = request.command();
+            let responses_at_request_start = shared.responses_received.load(Ordering::Relaxed);
             let result = tokio::time::timeout(
                 constants::REQUEST_TIMEOUT,
                 drive_outbound_request(&shared, request),
@@ -1349,7 +1369,9 @@ fn spawn_outbound_request(
                     shared.record_response();
                     Ok(response)
                 }
-                Err(error) => Err(error.into_shared_error(&shared, command)),
+                Err(error) => {
+                    Err(error.into_shared_error(&shared, command, responses_at_request_start))
+                }
             };
 
             let _ = tx.send(result);
@@ -1383,15 +1405,19 @@ impl OutboundError {
     /// Converts this error to the [`SharedPeerError`] reported to the
     /// caller, failing the connection for connection-level errors.
     ///
-    /// `command` is the command name of the failed request, for logging.
+    /// `command` is the command name of the failed request, for logging, and
+    /// `responses_at_request_start` is the caller's
+    /// [`responses_received`](SharedConnection::responses_received) snapshot
+    /// from when it sent the request.
     fn into_shared_error(
         self,
         shared: &SharedConnection,
         command: &'static str,
+        responses_at_request_start: u64,
     ) -> SharedPeerError {
         match self {
             OutboundError::Timeout => {
-                shared.record_request_timeout();
+                shared.record_request_timeout(responses_at_request_start);
                 PeerError::ConnectionReceiveTimeout.into()
             }
             // A local error: the peer is not at fault, so the connection

--- a/zebra-network/src/peer/v2/handshake.rs
+++ b/zebra-network/src/peer/v2/handshake.rs
@@ -96,7 +96,6 @@ pub struct HandshakeParams {
 ///
 /// The handshake stream halves are kept open for the life of the connection:
 /// finishing or resetting the handshake stream signals intent to disconnect.
-#[derive(Debug)]
 pub struct V2Handshake {
     /// The remote peer's `init` record.
     pub remote_init: InitRecord,
@@ -110,6 +109,15 @@ pub struct V2Handshake {
 
     /// The receiving half of the handshake stream.
     pub handshake_recv: quinn::RecvStream,
+}
+
+impl std::fmt::Debug for V2Handshake {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("V2Handshake")
+            .field("remote_init", &self.remote_init)
+            .field("negotiated_version", &self.negotiated_version)
+            .finish()
+    }
 }
 
 /// Performs the version 2 handshake as the connection initiator:

--- a/zebra-network/src/peer/v2/handshake.rs
+++ b/zebra-network/src/peer/v2/handshake.rs
@@ -206,7 +206,7 @@ async fn read_and_validate_remote_init(
     // Check the remote nonce against every nonce this node recently sent:
     // any match means the connection is to the node itself, possibly via a
     // simultaneous connection in each direction.
-    if params.nonces.contains(&remote_init.nonce).await {
+    if params.nonces.contains(&remote_init.nonce) {
         return Err(V2HandshakeError::SelfConnection);
     }
 
@@ -226,7 +226,6 @@ async fn register_local_nonce(params: &HandshakeParams) -> Result<(), V2Handshak
     if !params
         .nonces
         .register(params.local_init.nonce, params.nonce_limit)
-        .await
     {
         return Err(V2HandshakeError::LocalDuplicateNonce);
     }

--- a/zebra-network/src/peer/v2/service.rs
+++ b/zebra-network/src/peer/v2/service.rs
@@ -288,6 +288,7 @@ where
                 open_inbound_announcements: Default::default(),
                 sent_get_addr: Default::default(),
                 consecutive_timeouts: Default::default(),
+                responses_received: Default::default(),
                 active_bulk_streams: Default::default(),
                 artifact_dir,
             });

--- a/zebra-network/src/peer/v2/service.rs
+++ b/zebra-network/src/peer/v2/service.rs
@@ -9,7 +9,7 @@
 use std::{
     future::Future,
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::Arc,
     task::{Context, Poll},
 };
 
@@ -273,19 +273,19 @@ where
                 inv_collector: inv_collector.clone(),
                 misbehavior_tx,
                 announcement_tx,
-                pushed_transactions: Mutex::new(Default::default()),
-                sent_blocks: Mutex::new(Default::default()),
-                reconstructed_blocks: Mutex::new(Default::default()),
+                pushed_transactions: Default::default(),
+                sent_blocks: Default::default(),
+                reconstructed_blocks: Default::default(),
                 mempool_updates: tokio::sync::broadcast::channel(
                     connection::MEMPOOL_UPDATES_CHANNEL_CAPACITY,
                 )
                 .0,
                 mempool_subscribed: Default::default(),
-                remote_mempool: Mutex::new(Default::default()),
-                pending_tx_announcements: Mutex::new(Default::default()),
-                cached_addrs: Mutex::new(Vec::new()),
-                addr_tokens: Mutex::new(Default::default()),
-                open_inbound_announcements: Mutex::new(Default::default()),
+                remote_mempool: Default::default(),
+                pending_tx_announcements: Default::default(),
+                cached_addrs: Default::default(),
+                addr_tokens: Default::default(),
+                open_inbound_announcements: Default::default(),
                 sent_get_addr: Default::default(),
                 consecutive_timeouts: Default::default(),
                 active_bulk_streams: Default::default(),

--- a/zebra-network/src/peer/v2/service/tests/vectors.rs
+++ b/zebra-network/src/peer/v2/service/tests/vectors.rs
@@ -604,7 +604,7 @@ async fn v2_oversized_get_headers_response_is_scored() {
     // connection error.
     let mut data = TestData::new();
     let header = data.headers[0].clone();
-    data.headers = vec![header; MAX_HEADERS_RESULTS as usize + 1];
+    data.headers = vec![header; MAX_HEADERS_RESULTS + 1];
 
     let mut peers = connect_peers(Arc::new(data)).await;
 
@@ -979,8 +979,12 @@ async fn v2_get_blocks_is_hash_only_and_unservable_tx_refs_answer_not_found() {
     use zebra_chain::transaction::{AuthDigest, UnminedTxId, WtxId};
 
     use crate::protocol::v2::{
-        compact_block::ShortTxId, record, request::Request as V2WireRequest,
-        response::read_result_entry, txref::TransactionReference,
+        compact_block::ShortTxId,
+        record,
+        request::Request as V2WireRequest,
+        response::{BlockResponseEntry, TxResponseEntry},
+        txref::TransactionReference,
+        types::StreamType,
     };
 
     let _init_guard = zebra_test::init();
@@ -992,23 +996,22 @@ async fn v2_get_blocks_is_hash_only_and_unservable_tx_refs_answer_not_found() {
 
     // Request the block by hash on a raw request stream: `get-blocks`
     // requests carry only hashes, and are served with full blocks.
-    let mut recv = send_request(
-        &connection,
-        V2WireRequest::GetBlocks {
-            hashes: vec![block.hash()],
-        },
-    )
-    .await;
+    let (mut send, mut recv) = connection.open_bi().await.expect("stream opens");
+    let mut bytes = vec![StreamType::GetBlocks.byte()];
+    V2WireRequest::GetBlocks {
+        hashes: vec![block.hash()],
+    }
+    .encode(&mut bytes)
+    .expect("request encodes");
+    send.write_all(&bytes).await.expect("request writes");
+    send.finish().expect("stream finishes");
 
-    let entry = tokio::time::timeout(
-        TEST_TIMEOUT,
-        read_result_entry::<zebra_chain::block::Block, _>(&mut recv, "get-blocks"),
-    )
-    .await
-    .expect("response arrives in time")
-    .expect("response entry parses");
+    let entry = tokio::time::timeout(TEST_TIMEOUT, BlockResponseEntry::read(&mut recv))
+        .await
+        .expect("response arrives in time")
+        .expect("response entry parses");
     match entry {
-        Some(served) => assert_eq!(served.hash(), block.hash()),
+        BlockResponseEntry::Full(served) => assert_eq!(served.hash(), block.hash()),
         other => panic!("expected a full block response, got: {other:?}"),
     }
     record::expect_end_of_stream(&mut recv)
@@ -1019,33 +1022,32 @@ async fn v2_get_blocks_is_hash_only_and_unservable_tx_refs_answer_not_found() {
     // sent to the requesting peer for the block. No compact block has been
     // sent on this connection, so they are answered not-found, without an
     // error or a penalty.
-    let mut recv = send_request(
-        &connection,
-        V2WireRequest::GetTx {
-            refs: vec![
-                TransactionReference::ShortId {
-                    block_hash: block.hash(),
-                    short_id: ShortTxId([0x0F; 6]),
-                },
-                TransactionReference::ShortId {
-                    block_hash: zebra_chain::block::Hash([0xAB; 32]),
-                    short_id: ShortTxId([0x0F; 6]),
-                },
-            ],
-        },
-    )
-    .await;
+    let (mut send, mut recv) = connection.open_bi().await.expect("stream opens");
+    let mut bytes = vec![StreamType::GetTx.byte()];
+    V2WireRequest::GetTx {
+        refs: vec![
+            TransactionReference::ShortId {
+                block_hash: block.hash(),
+                short_id: ShortTxId([0x0F; 6]),
+            },
+            TransactionReference::ShortId {
+                block_hash: zebra_chain::block::Hash([0xAB; 32]),
+                short_id: ShortTxId([0x0F; 6]),
+            },
+        ],
+    }
+    .encode(&mut bytes)
+    .expect("request encodes");
+    send.write_all(&bytes).await.expect("request writes");
+    send.finish().expect("stream finishes");
 
     for _ in 0..2 {
-        let missing = tokio::time::timeout(
-            TEST_TIMEOUT,
-            read_result_entry::<zebra_chain::transaction::Transaction, _>(&mut recv, "get-tx"),
-        )
-        .await
-        .expect("response arrives in time")
-        .expect("response entry parses");
+        let missing = tokio::time::timeout(TEST_TIMEOUT, TxResponseEntry::read(&mut recv))
+            .await
+            .expect("response arrives in time")
+            .expect("response entry parses");
         assert!(
-            missing.is_none(),
+            matches!(missing, TxResponseEntry::NotFound),
             "a SHORTID without a sent compact block is answered not-found",
         );
     }
@@ -1067,33 +1069,32 @@ async fn v2_get_blocks_is_hash_only_and_unservable_tx_refs_answer_not_found() {
         auth_digest: AuthDigest([0xFF; 32]),
     });
 
-    let mut recv = send_request(
-        &connection,
-        V2WireRequest::GetTx {
-            refs: vec![
-                wrong_typed,
-                TransactionReference::from(raw.data.transaction.id),
-            ],
-        },
-    )
-    .await;
+    let (mut send, mut recv) = connection.open_bi().await.expect("stream opens");
+    let mut bytes = vec![StreamType::GetTx.byte()];
+    V2WireRequest::GetTx {
+        refs: vec![
+            wrong_typed,
+            TransactionReference::from(raw.data.transaction.id),
+        ],
+    }
+    .encode(&mut bytes)
+    .expect("request encodes");
+    send.write_all(&bytes).await.expect("request writes");
+    send.finish().expect("stream finishes");
 
-    let missing = tokio::time::timeout(
-        TEST_TIMEOUT,
-        read_result_entry::<zebra_chain::transaction::Transaction, _>(&mut recv, "get-tx"),
-    )
-    .await
-    .expect("response arrives in time")
-    .expect("response entry parses");
+    let missing = tokio::time::timeout(TEST_TIMEOUT, TxResponseEntry::read(&mut recv))
+        .await
+        .expect("response arrives in time")
+        .expect("response entry parses");
     assert!(
-        missing.is_none(),
+        matches!(missing, TxResponseEntry::NotFound),
         "a wrong-typed reference is answered not-found",
     );
-    let found = read_result_entry::<zebra_chain::transaction::Transaction, _>(&mut recv, "get-tx")
+    let found = TxResponseEntry::read(&mut recv)
         .await
         .expect("response entry parses");
     match found {
-        Some(transaction) => {
+        TxResponseEntry::Found(transaction) => {
             assert_eq!(transaction, raw.data.transaction.transaction);
         }
         other => panic!("expected the referenced transaction, got: {other:?}"),
@@ -1231,7 +1232,7 @@ async fn v2_compact_announcement_is_reconstructed_and_served_from_cache() {
         compact_block::{CompactBlock, CompactBlockIds},
         record,
         request::Request as V2WireRequest,
-        response::encode_result_entry,
+        response::TxResponseEntry,
         txref::TransactionReference,
         types::StreamType,
     };
@@ -1296,7 +1297,9 @@ async fn v2_compact_announcement_is_reconstructed_and_served_from_cache() {
 
     let mut bytes = Vec::new();
     for tx in block.transactions.iter().skip(1) {
-        encode_result_entry(&mut bytes, Some(tx.as_ref())).expect("entry encodes");
+        TxResponseEntry::Found(tx.clone())
+            .encode(&mut bytes)
+            .expect("entry encodes");
     }
     req_send.write_all(&bytes).await.expect("response writes");
     req_send.finish().expect("stream finishes");
@@ -1836,7 +1839,7 @@ async fn v2_hb_compact_block_announcement_and_reconstruction_serving() {
         compact_block::{short_id_keys, short_transaction_id, CompactBlock, CompactBlockIds},
         record,
         request::Request as V2WireRequest,
-        response::read_result_entry,
+        response::TxResponseEntry,
         txref::TransactionReference,
         types::StreamType,
     };
@@ -1906,37 +1909,36 @@ async fn v2_hb_compact_block_announcement_and_reconstruction_serving() {
     // IDs of the announcement, and by ordinary references, even though the
     // responder's mempool does not hold them. Unknown short IDs and other
     // blocks' short IDs are answered not-found.
-    let mut recv = send_request(
-        &connection,
-        V2WireRequest::GetTx {
-            refs: vec![
-                TransactionReference::ShortId {
-                    block_hash: block.hash(),
-                    short_id: expected_ids[0],
-                },
-                TransactionReference::from(UnminedTxId::from(block.transactions[2].as_ref())),
-                TransactionReference::ShortId {
-                    block_hash: block.hash(),
-                    short_id: crate::protocol::v2::compact_block::ShortTxId([0x0F; 6]),
-                },
-                TransactionReference::ShortId {
-                    block_hash: zebra_chain::block::Hash([0xAB; 32]),
-                    short_id: expected_ids[0],
-                },
-            ],
-        },
-    )
-    .await;
+    let (mut send, mut recv) = connection.open_bi().await.expect("stream opens");
+    let mut bytes = vec![StreamType::GetTx.byte()];
+    V2WireRequest::GetTx {
+        refs: vec![
+            TransactionReference::ShortId {
+                block_hash: block.hash(),
+                short_id: expected_ids[0],
+            },
+            TransactionReference::from(UnminedTxId::from(block.transactions[2].as_ref())),
+            TransactionReference::ShortId {
+                block_hash: block.hash(),
+                short_id: crate::protocol::v2::compact_block::ShortTxId([0x0F; 6]),
+            },
+            TransactionReference::ShortId {
+                block_hash: zebra_chain::block::Hash([0xAB; 32]),
+                short_id: expected_ids[0],
+            },
+        ],
+    }
+    .encode(&mut bytes)
+    .expect("request encodes");
+    send.write_all(&bytes).await.expect("request writes");
+    send.finish().expect("stream finishes");
 
     let mut entries = Vec::new();
     for _ in 0..4 {
-        let entry = tokio::time::timeout(
-            TEST_TIMEOUT,
-            read_result_entry::<zebra_chain::transaction::Transaction, _>(&mut recv, "get-tx"),
-        )
-        .await
-        .expect("response arrives in time")
-        .expect("response entry parses");
+        let entry = tokio::time::timeout(TEST_TIMEOUT, TxResponseEntry::read(&mut recv))
+            .await
+            .expect("response arrives in time")
+            .expect("response entry parses");
         entries.push(entry);
     }
     record::expect_end_of_stream(&mut recv)
@@ -1944,19 +1946,19 @@ async fn v2_hb_compact_block_announcement_and_reconstruction_serving() {
         .expect("response is complete");
 
     match &entries[0] {
-        Some(tx) => assert_eq!(tx, &block.transactions[1]),
+        TxResponseEntry::Found(tx) => assert_eq!(tx, &block.transactions[1]),
         other => panic!("expected the short ID's transaction, got: {other:?}"),
     }
     match &entries[1] {
-        Some(tx) => assert_eq!(tx, &block.transactions[2]),
+        TxResponseEntry::Found(tx) => assert_eq!(tx, &block.transactions[2]),
         other => panic!("expected the sent block's transaction, got: {other:?}"),
     }
     assert!(
-        entries[2].is_none(),
+        matches!(entries[2], TxResponseEntry::NotFound),
         "an unknown short ID is answered not-found",
     );
     assert!(
-        entries[3].is_none(),
+        matches!(entries[3], TxResponseEntry::NotFound),
         "a short ID for a block without a sent compact block is answered not-found",
     );
 
@@ -2100,7 +2102,11 @@ async fn v2_get_headers_with_tx_ids_serves_coinbase_and_full_ids() {
 
     use zebra_chain::{block::Header, transaction::Transaction};
 
-    use crate::protocol::v2::{record, request::Request as V2WireRequest, types::WireError};
+    use crate::protocol::v2::{
+        record,
+        request::Request as V2WireRequest,
+        types::{StreamType, WireError},
+    };
 
     let _init_guard = zebra_test::init();
 
@@ -2111,15 +2117,17 @@ async fn v2_get_headers_with_tx_ids_serves_coinbase_and_full_ids() {
     let raw = raw_initiator(Arc::new(data)).await;
     let block_1 = raw.data.block_1.clone();
 
-    let mut recv = send_request(
-        &raw.connection,
-        V2WireRequest::GetHeaders {
-            known_blocks: vec![],
-            stop: None,
-            tx_ids: true,
-        },
-    )
-    .await;
+    let (mut send, mut recv) = raw.connection.open_bi().await.expect("stream opens");
+    let mut bytes = vec![StreamType::GetHeaders.byte()];
+    V2WireRequest::GetHeaders {
+        known_blocks: vec![],
+        stop: None,
+        tx_ids: true,
+    }
+    .encode(&mut bytes)
+    .expect("request encodes");
+    send.write_all(&bytes).await.expect("request writes");
+    send.finish().expect("stream finishes");
 
     let response = tokio::time::timeout(TEST_TIMEOUT, async {
         let count = record::read_compact_size(&mut recv).await?;
@@ -2191,42 +2199,40 @@ async fn v2_get_headers_with_tx_ids_serves_coinbase_and_full_ids() {
     // transactions to this peer, even though they are not in its mempool —
     // but not by `SHORTID`, which only a compact block establishes.
     use crate::protocol::v2::{
-        compact_block::ShortTxId, response::read_result_entry, txref::TransactionReference,
+        compact_block::ShortTxId, response::TxResponseEntry, txref::TransactionReference,
     };
     use zebra_chain::transaction::UnminedTxId;
 
     let coinbase_id = UnminedTxId::from(block_1.transactions[0].as_ref());
-    let mut recv = send_request(
-        &raw.connection,
-        V2WireRequest::GetTx {
-            refs: vec![
-                TransactionReference::from(coinbase_id),
-                TransactionReference::ShortId {
-                    block_hash: block_1.hash(),
-                    short_id: ShortTxId([0x0F; 6]),
-                },
-            ],
-        },
-    )
-    .await;
+    let (mut send, mut recv) = raw.connection.open_bi().await.expect("stream opens");
+    let mut bytes = vec![StreamType::GetTx.byte()];
+    V2WireRequest::GetTx {
+        refs: vec![
+            TransactionReference::from(coinbase_id),
+            TransactionReference::ShortId {
+                block_hash: block_1.hash(),
+                short_id: ShortTxId([0x0F; 6]),
+            },
+        ],
+    }
+    .encode(&mut bytes)
+    .expect("request encodes");
+    send.write_all(&bytes).await.expect("request writes");
+    send.finish().expect("stream finishes");
 
-    let found = tokio::time::timeout(
-        TEST_TIMEOUT,
-        read_result_entry::<zebra_chain::transaction::Transaction, _>(&mut recv, "get-tx"),
-    )
-    .await
-    .expect("response arrives in time")
-    .expect("response entry parses");
+    let found = tokio::time::timeout(TEST_TIMEOUT, TxResponseEntry::read(&mut recv))
+        .await
+        .expect("response arrives in time")
+        .expect("response entry parses");
     match found {
-        Some(tx) => assert_eq!(&tx, &block_1.transactions[0]),
+        TxResponseEntry::Found(tx) => assert_eq!(&tx, &block_1.transactions[0]),
         other => panic!("expected the sent block's coinbase, got: {other:?}"),
     }
-    let missing =
-        read_result_entry::<zebra_chain::transaction::Transaction, _>(&mut recv, "get-tx")
-            .await
-            .expect("response entry parses");
+    let missing = TxResponseEntry::read(&mut recv)
+        .await
+        .expect("response entry parses");
     assert!(
-        missing.is_none(),
+        matches!(missing, TxResponseEntry::NotFound),
         "a SHORTID reference to a block sent without a compact block is not-found",
     );
 }
@@ -2333,62 +2339,78 @@ async fn v2_sync_primitives_are_served() {
         }
     }
 
-    // Each case is (name, anchor, count, max_bytes, expected result,
-    // expected block hashes).
-    let cases: [(&str, zebra_chain::block::Hash, u64, u64, u8, Vec<_>); 4] = [
-        (
-            "blocks stream in descending order from the anchor",
-            raw.data.block_2.hash(),
-            5,
-            8_000_000,
-            0x00,
-            vec![raw.data.block_2.hash(), raw.data.block_1.hash()],
-        ),
-        (
-            "the count bound is exact",
-            raw.data.block_2.hash(),
-            1,
-            8_000_000,
-            0x00,
-            vec![raw.data.block_2.hash()],
-        ),
-        (
-            "the first block is delivered regardless of max_bytes",
-            raw.data.block_2.hash(),
-            5,
-            1,
-            0x00,
-            vec![raw.data.block_2.hash()],
-        ),
-        (
-            "an unknown anchor answers not-found",
-            zebra_chain::block::Hash([0xAB; 32]),
-            5,
-            8_000_000,
-            0x02,
-            vec![],
-        ),
-    ];
+    let mut recv = send_request(
+        &connection,
+        V2WireRequest::GetBlockRange {
+            final_hash: raw.data.block_2.hash(),
+            count: 5,
+            max_bytes: 8_000_000,
+        },
+    )
+    .await;
+    let (result, blocks) = tokio::time::timeout(TEST_TIMEOUT, read_block_range(&mut recv))
+        .await
+        .expect("response arrives in time");
+    assert_eq!(result, 0x00);
+    let hashes: Vec<_> = blocks.iter().map(|block| block.hash()).collect();
+    assert_eq!(
+        hashes,
+        vec![raw.data.block_2.hash(), raw.data.block_1.hash()],
+        "blocks stream in descending order from the anchor",
+    );
 
-    for (name, final_hash, count, max_bytes, expected_result, expected_hashes) in cases {
-        let mut recv = send_request(
-            &connection,
-            V2WireRequest::GetBlockRange {
-                final_hash,
-                count,
-                max_bytes,
-            },
-        )
-        .await;
+    // The count bound is exact.
+    let mut recv = send_request(
+        &connection,
+        V2WireRequest::GetBlockRange {
+            final_hash: raw.data.block_2.hash(),
+            count: 1,
+            max_bytes: 8_000_000,
+        },
+    )
+    .await;
+    let (result, blocks) = tokio::time::timeout(TEST_TIMEOUT, read_block_range(&mut recv))
+        .await
+        .expect("response arrives in time");
+    assert_eq!(result, 0x00);
+    assert_eq!(blocks.len(), 1, "the count bound is exact");
 
-        let (result, blocks) = tokio::time::timeout(TEST_TIMEOUT, read_block_range(&mut recv))
-            .await
-            .unwrap_or_else(|_| panic!("{name}: response arrives in time"));
+    // The first block is delivered regardless of max_bytes; the second
+    // would exceed it.
+    let mut recv = send_request(
+        &connection,
+        V2WireRequest::GetBlockRange {
+            final_hash: raw.data.block_2.hash(),
+            count: 5,
+            max_bytes: 1,
+        },
+    )
+    .await;
+    let (result, blocks) = tokio::time::timeout(TEST_TIMEOUT, read_block_range(&mut recv))
+        .await
+        .expect("response arrives in time");
+    assert_eq!(result, 0x00);
+    assert_eq!(
+        blocks.len(),
+        1,
+        "the first block is delivered regardless of max_bytes",
+    );
 
-        assert_eq!(result, expected_result, "{name}");
-        let hashes: Vec<_> = blocks.iter().map(|block| block.hash()).collect();
-        assert_eq!(hashes, expected_hashes, "{name}");
-    }
+    // An unknown anchor answers not-found.
+    let mut recv = send_request(
+        &connection,
+        V2WireRequest::GetBlockRange {
+            final_hash: zebra_chain::block::Hash([0xAB; 32]),
+            count: 5,
+            max_bytes: 8_000_000,
+        },
+    )
+    .await;
+    let (result, blocks) = tokio::time::timeout(TEST_TIMEOUT, read_block_range(&mut recv))
+        .await
+        .expect("response arrives in time");
+    assert_eq!(result, 0x02, "an unknown anchor answers not-found");
+    assert!(blocks.is_empty());
 }
 
 /// `get-object` serves ranged reads of content-addressed artifacts from
@@ -2399,7 +2421,11 @@ async fn v2_sync_primitives_are_served() {
 async fn v2_get_object_serves_ranged_artifact_reads() {
     use sha2::{Digest, Sha256};
 
-    use crate::protocol::v2::{record, request::Request as V2WireRequest, types::ObjectHash};
+    use crate::protocol::v2::{
+        record,
+        request::Request as V2WireRequest,
+        types::{ObjectHash, StreamType},
+    };
 
     let _init_guard = zebra_test::init();
 
@@ -2428,7 +2454,11 @@ async fn v2_get_object_serves_ranged_artifact_reads() {
         connection: &quinn::Connection,
         request: V2WireRequest,
     ) -> (u8, u64, Vec<u8>) {
-        let mut recv = send_request(connection, request).await;
+        let (mut send, mut recv) = connection.open_bi().await.expect("stream opens");
+        let mut bytes = vec![StreamType::GetObject.byte()];
+        request.encode(&mut bytes).expect("request encodes");
+        send.write_all(&bytes).await.expect("request writes");
+        send.finish().expect("stream finishes");
 
         let result = record::read_u8(&mut recv)
             .await
@@ -2449,67 +2479,93 @@ async fn v2_get_object_serves_ranged_artifact_reads() {
         (result, size, data)
     }
 
-    // Each case is (name, hash, offset, length, expected result, expected data).
-    let cases: [(&str, [u8; 32], u64, u64, u8, &[u8]); 5] = [
-        ("the whole object", hash, 0, 200_000, 0x00, &object),
-        (
-            "a middle range delivers exactly the requested bytes",
-            hash,
-            40_000,
-            10_000,
-            0x00,
-            &object[40_000..50_000],
+    // The whole object.
+    let (result, size, data) = tokio::time::timeout(
+        TEST_TIMEOUT,
+        get_object(
+            &connection,
+            V2WireRequest::GetObject {
+                hash: ObjectHash(hash),
+                offset: 0,
+                length: 200_000,
+            },
         ),
-        (
-            "a range past the end is truncated at the object's size",
-            hash,
-            90_000,
-            50_000,
-            0x00,
-            &object[90_000..],
-        ),
-        (
-            "an offset at the size answers the size and no data",
-            hash,
-            100_000,
-            1_000,
-            0x00,
-            &[],
-        ),
-        (
-            "an unknown hash answers not-found",
-            [0xEE; 32],
-            0,
-            16,
-            0x02,
-            &[],
-        ),
-    ];
+    )
+    .await
+    .expect("response arrives in time");
+    assert_eq!(result, 0x00);
+    assert_eq!(size, object.len() as u64);
+    assert_eq!(data, object);
 
-    for (name, object_hash, offset, length, expected_result, expected_data) in cases {
-        let (result, size, data) = tokio::time::timeout(
-            TEST_TIMEOUT,
-            get_object(
-                &connection,
-                V2WireRequest::GetObject {
-                    hash: ObjectHash(object_hash),
-                    offset,
-                    length,
-                },
-            ),
-        )
-        .await
-        .unwrap_or_else(|_| panic!("{name}: response arrives in time"));
+    // A middle range delivers exactly the requested bytes.
+    let (result, size, data) = tokio::time::timeout(
+        TEST_TIMEOUT,
+        get_object(
+            &connection,
+            V2WireRequest::GetObject {
+                hash: ObjectHash(hash),
+                offset: 40_000,
+                length: 10_000,
+            },
+        ),
+    )
+    .await
+    .expect("response arrives in time");
+    assert_eq!(result, 0x00);
+    assert_eq!(size, object.len() as u64);
+    assert_eq!(data, object[40_000..50_000]);
 
-        assert_eq!(result, expected_result, "{name}");
-        assert_eq!(data, expected_data, "{name}");
+    // A range past the end is truncated at the object's size.
+    let (result, _size, data) = tokio::time::timeout(
+        TEST_TIMEOUT,
+        get_object(
+            &connection,
+            V2WireRequest::GetObject {
+                hash: ObjectHash(hash),
+                offset: 90_000,
+                length: 50_000,
+            },
+        ),
+    )
+    .await
+    .expect("response arrives in time");
+    assert_eq!(result, 0x00);
+    assert_eq!(data, object[90_000..]);
 
-        // A found result always reports the object's full size, whatever
-        // range of it was asked for.
-        if result == 0x00 && offset + length <= object.len() as u64 {
-            assert_eq!(size, object.len() as u64, "{name}");
-        }
-    }
+    // An offset at the size answers the size and no data.
+    let (result, size, data) = tokio::time::timeout(
+        TEST_TIMEOUT,
+        get_object(
+            &connection,
+            V2WireRequest::GetObject {
+                hash: ObjectHash(hash),
+                offset: 100_000,
+                length: 1_000,
+            },
+        ),
+    )
+    .await
+    .expect("response arrives in time");
+    assert_eq!(result, 0x00);
+    assert_eq!(size, object.len() as u64);
+    assert!(data.is_empty());
+
+    // An unknown hash answers not-found.
+    let (result, _size, data) = tokio::time::timeout(
+        TEST_TIMEOUT,
+        get_object(
+            &connection,
+            V2WireRequest::GetObject {
+                hash: ObjectHash([0xEE; 32]),
+                offset: 0,
+                length: 16,
+            },
+        ),
+    )
+    .await
+    .expect("response arrives in time");
+    assert_eq!(result, 0x02);
+    assert!(data.is_empty());
 }
 
 /// `get-object` requests are refused while the artifact store does not
@@ -2577,7 +2633,10 @@ async fn v2_get_object_is_refused_and_malformed_sync_requests_are_rejected() {
 #[tokio::test]
 async fn v2_unknown_stream_types_are_refused_without_penalty() {
     use crate::protocol::v2::{
-        record, request::Request as V2WireRequest, response::read_result_entry, types::ErrorCode,
+        record,
+        request::Request as V2WireRequest,
+        response::BlockResponseEntry,
+        types::{ErrorCode, StreamType},
     };
 
     let _init_guard = zebra_test::init();
@@ -2615,23 +2674,22 @@ async fn v2_unknown_stream_types_are_refused_without_penalty() {
 
     // The connection survives, requests are still served, and no penalty
     // was assigned.
-    let mut recv = send_request(
-        &connection,
-        V2WireRequest::GetBlocks {
-            hashes: vec![raw.data.block.hash()],
-        },
-    )
-    .await;
+    let (mut send, mut recv) = connection.open_bi().await.expect("stream opens");
+    let mut bytes = vec![StreamType::GetBlocks.byte()];
+    V2WireRequest::GetBlocks {
+        hashes: vec![raw.data.block.hash()],
+    }
+    .encode(&mut bytes)
+    .expect("request encodes");
+    send.write_all(&bytes).await.expect("request writes");
+    send.finish().expect("stream finishes");
 
-    let entry = tokio::time::timeout(
-        TEST_TIMEOUT,
-        read_result_entry::<zebra_chain::block::Block, _>(&mut recv, "get-blocks"),
-    )
-    .await
-    .expect("response arrives in time")
-    .expect("response entry parses");
+    let entry = tokio::time::timeout(TEST_TIMEOUT, BlockResponseEntry::read(&mut recv))
+        .await
+        .expect("response arrives in time")
+        .expect("response entry parses");
     assert!(
-        entry.is_some(),
+        matches!(entry, BlockResponseEntry::Full(_)),
         "the connection still serves requests after refused streams",
     );
     record::expect_end_of_stream(&mut recv)
@@ -2761,7 +2819,7 @@ async fn v2_stalled_inbound_request_stream_is_abandoned() {
         constants::INBOUND_STREAM_TIMEOUT,
         record,
         request::Request as V2WireRequest,
-        response::read_result_entry,
+        response::BlockResponseEntry,
         types::{ErrorCode, StreamType},
     };
 
@@ -2800,23 +2858,22 @@ async fn v2_stalled_inbound_request_stream_is_abandoned() {
 
     // The connection survives, requests are still served, and no penalty
     // was assigned: a stall is indistinguishable from a slow peer.
-    let mut recv = send_request(
-        &connection,
-        V2WireRequest::GetBlocks {
-            hashes: vec![raw.data.block.hash()],
-        },
-    )
-    .await;
+    let (mut send, mut recv) = connection.open_bi().await.expect("stream opens");
+    let mut bytes = vec![StreamType::GetBlocks.byte()];
+    V2WireRequest::GetBlocks {
+        hashes: vec![raw.data.block.hash()],
+    }
+    .encode(&mut bytes)
+    .expect("request encodes");
+    send.write_all(&bytes).await.expect("request writes");
+    send.finish().expect("stream finishes");
 
-    let entry = tokio::time::timeout(
-        TEST_TIMEOUT,
-        read_result_entry::<zebra_chain::block::Block, _>(&mut recv, "get-blocks"),
-    )
-    .await
-    .expect("response arrives in time")
-    .expect("response entry parses");
+    let entry = tokio::time::timeout(TEST_TIMEOUT, BlockResponseEntry::read(&mut recv))
+        .await
+        .expect("response arrives in time")
+        .expect("response entry parses");
     assert!(
-        entry.is_some(),
+        matches!(entry, BlockResponseEntry::Full(_)),
         "the connection still serves requests after an abandoned stream",
     );
     record::expect_end_of_stream(&mut recv)

--- a/zebra-network/src/peer_book.rs
+++ b/zebra-network/src/peer_book.rs
@@ -20,6 +20,7 @@ mod handle;
 pub(crate) mod intake;
 pub(crate) mod misbehavior;
 mod reader;
+pub(crate) mod transports;
 
 #[cfg(test)]
 mod tests;

--- a/zebra-network/src/peer_book/actor.rs
+++ b/zebra-network/src/peer_book/actor.rs
@@ -101,7 +101,7 @@ pub(crate) fn spawn_actor(
 
                             continue;
                         }
-                    } else if misbehavior.is_banned(ban_key) {
+                    } else if misbehavior.is_banned(&ban_key) {
                         // Ignore changes for banned peers, so they cannot
                         // re-enter the book while the ban lasts.
                         continue;
@@ -263,26 +263,32 @@ fn answer_call(
         PeerBookRequest::CacheSnapshot => {
             PeerBookResponse::Addrs(address_book.cacheable(Utc::now()))
         }
-        PeerBookRequest::SelectCandidate => {
+        PeerBookRequest::SelectCandidates { max } => {
             // The pick and the attempt mark happen in the same actor turn,
             // so concurrent selections cannot return the same peer.
             let instant_now = Instant::now();
-            let next_peer = address_book
-                .reconnection_peers(instant_now, Utc::now())
-                .next();
+            let chrono_now = Utc::now();
 
-            let candidate = next_peer
-                .and_then(|peer| address_book.update(MetaAddr::new_reconnect(peer.addr)))
-                .map(|marked| {
+            let mut candidates = Vec::new();
+            for _ in 0..max {
+                let Some(next_peer) = address_book
+                    .reconnection_peers(instant_now, chrono_now)
+                    .next()
+                else {
+                    break;
+                };
+
+                let change = MetaAddr::new_reconnect(next_peer.addr);
+                if let Some(marked) = address_book.update(change) {
                     // The dialer needs to know which transports this peer
                     // accepts, so it can reach version 2 peers it learned
                     // about over the legacy network.
                     let transports = transports.dialable(&marked.addr, instant_now);
+                    candidates.push((marked, transports));
+                }
+            }
 
-                    (marked, transports)
-                });
-
-            PeerBookResponse::Candidate(candidate)
+            PeerBookResponse::Candidates(candidates)
         }
         PeerBookRequest::ReadyCandidateCount => {
             let instant_now = Instant::now();
@@ -304,7 +310,7 @@ fn answer_call(
                 super::intake::validate_addrs(addrs, zebra_chain::serialization::DateTime32::now());
 
             let changes: Vec<MetaAddrChange> = addrs
-                .filter(|addr| !misbehavior.is_banned(BanKey::from(addr.addr.ip())))
+                .filter(|addr| !misbehavior.is_banned(&BanKey::from(addr.addr.ip())))
                 .map(MetaAddr::new_gossiped_change)
                 .map(|change| change.expect("gossiped peers always have services set"))
                 .collect();

--- a/zebra-network/src/peer_book/actor.rs
+++ b/zebra-network/src/peer_book/actor.rs
@@ -1,9 +1,9 @@
-//! The peer book actor: a single blocking thread that owns the address book.
+//! The peer book actor: an async task that owns the address book.
 //!
 //! The actor is the address book's only owner. It applies
 //! [`MetaAddrChange`]s and answers [`PeerBookHandle`](super::PeerBookHandle)
-//! calls in channel order on one dedicated blocking thread, so book access
-//! needs no locks at all, and it maintains the bans and recently-live watch
+//! calls in channel order on one dedicated task, so book access needs no
+//! locks at all, and it maintains the bans and recently-live watch
 //! snapshots for lock-free readers.
 
 use std::{
@@ -17,7 +17,7 @@ use tokio::{
     sync::{mpsc, watch},
     task::JoinHandle,
 };
-use tracing::Span;
+use tracing::{Instrument, Span};
 
 use crate::{
     address_book_updater::AllAddressBookUpdaterSendersClosed,
@@ -54,7 +54,7 @@ pub(crate) fn spawn_actor(
         crate::address_book::AddressMetrics,
     >,
 ) -> JoinHandle<Result<(), BoxError>> {
-    let actor = move || {
+    let actor = async move {
         info!("starting the peer book actor");
 
         #[cfg(feature = "progress-bar")]
@@ -74,14 +74,21 @@ pub(crate) fn spawn_actor(
         let mut last_live_refresh = Instant::now();
         let mut live_changed = false;
 
-        while let Some(message) = messages_rx.blocking_recv() {
+        while let Some(message) = messages_rx.recv().await {
+            // Expired bans must leave the published snapshot too, or the
+            // peer set and inbound admission would enforce them forever
+            // while the actor already re-admits the peer.
+            if misbehavior.prune_due(Instant::now()) {
+                let _ = bans_sender.send(misbehavior.bans_snapshot());
+            }
+
             match message {
                 Message::Change(change) => {
                     trace!(?change, "got address book change");
 
                     let ban_key = BanKey::from(change.addr().ip());
 
-                    if let MetaAddrChange::UpdateMisbehavior {
+                    let apply = if let MetaAddrChange::UpdateMisbehavior {
                         score_increment, ..
                     } = &change
                     {
@@ -99,37 +106,37 @@ pub(crate) fn spawn_actor(
                             transports.remove_if(|addr| BanKey::from(addr.ip()) == ban_key);
                             let _ = bans_sender.send(misbehavior.bans_snapshot());
 
-                            continue;
+                            // The removed entries were typically recently
+                            // live, so the snapshot must be refreshed.
+                            live_changed = true;
+                            false
+                        } else {
+                            // A sub-threshold report for a still-banned key
+                            // must not re-create the peer's book entry: the
+                            // ban reset its score, so later reports start
+                            // from zero and fall through the threshold.
+                            !misbehavior.is_banned(&ban_key)
                         }
-                    } else if misbehavior.is_banned(&ban_key) {
+                    } else {
                         // Ignore changes for banned peers, so they cannot
                         // re-enter the book while the ban lasts.
-                        continue;
-                    }
+                        !misbehavior.is_banned(&ban_key)
+                    };
 
-                    // # Security
-                    //
-                    // Gossiped addresses are unauthenticated relay data:
-                    // new ones are admitted through the secret-keyed
-                    // buckets, which bound the book share of any address
-                    // group and of gossip as a whole (eclipse resistance).
-                    if let MetaAddrChange::NewGossiped { addr, .. } = &change {
-                        let addr = *addr;
-                        if address_book.get(addr).is_none() {
-                            let victim = gossip_buckets.admit(addr, |entry| {
-                                address_book.get(entry).is_some_and(|meta| {
-                                    meta.last_connection_state
-                                        == crate::PeerAddrState::NeverAttemptedGossiped
-                                })
-                            });
-                            if let Some(victim) = victim {
-                                address_book.remove(victim);
-                            }
+                    if apply {
+                        // # Security
+                        //
+                        // Gossiped addresses are unauthenticated relay data:
+                        // new ones are admitted through the secret-keyed
+                        // buckets, which bound the book share of any address
+                        // group and of gossip as a whole (eclipse resistance).
+                        if let MetaAddrChange::NewGossiped { addr, .. } = &change {
+                            admit_gossiped(&mut address_book, &mut gossip_buckets, *addr);
                         }
-                    }
 
-                    address_book.update(change);
-                    live_changed = true;
+                        address_book.update(change);
+                        live_changed = true;
+                    }
                 }
 
                 Message::Transport {
@@ -148,6 +155,7 @@ pub(crate) fn spawn_actor(
                     let response = answer_call(
                         &mut address_book,
                         &mut misbehavior,
+                        &mut gossip_buckets,
                         &mut transports,
                         &mut get_addr_cache,
                         request,
@@ -210,10 +218,38 @@ pub(crate) fn spawn_actor(
         error
     };
 
-    // The actor accesses the address book on its own dedicated blocking
-    // thread, so async tasks never block on book operations (#1976).
+    // # Correctness
+    //
+    // The actor is an async task, not a blocking thread:
+    // - each message is handled without awaiting while the book is
+    //   borrowed, so the task never blocks the runtime for long, and no
+    //   other task can observe the book mid-change (#1976), and
+    // - a long-lived blocking thread would inhibit auto-advance in tests
+    //   that pause the tokio clock.
     let span = Span::current();
-    tokio::task::spawn_blocking(move || span.in_scope(actor))
+    tokio::spawn(actor.instrument(span))
+}
+
+/// Admits a newly gossiped `addr` through the secret-keyed buckets,
+/// removing the bucket's eviction victim from the book, if any.
+///
+/// Addresses already in the book only refresh their entry, so repeated
+/// gossip cannot evict other peers.
+fn admit_gossiped(
+    address_book: &mut AddressBook,
+    gossip_buckets: &mut super::buckets::GossipBuckets,
+    addr: crate::PeerSocketAddr,
+) {
+    if address_book.get(addr).is_none() {
+        let victim = gossip_buckets.admit(addr, |entry| {
+            address_book.get(entry).is_some_and(|meta| {
+                meta.last_connection_state == crate::PeerAddrState::NeverAttemptedGossiped
+            })
+        });
+        if let Some(victim) = victim {
+            address_book.remove(victim);
+        }
+    }
 }
 
 /// How long one sanitized `get-addr` response snapshot is served before a
@@ -234,6 +270,7 @@ const GET_ADDR_CACHE_JITTER: Duration = Duration::from_secs(6 * 60 * 60);
 fn answer_call(
     address_book: &mut AddressBook,
     misbehavior: &mut MisbehaviorStore,
+    gossip_buckets: &mut super::buckets::GossipBuckets,
     transports: &mut TransportTable,
     get_addr_cache: &mut Option<(Instant, Vec<MetaAddr>)>,
     request: PeerBookRequest,
@@ -315,7 +352,22 @@ fn answer_call(
                 .map(|change| change.expect("gossiped peers always have services set"))
                 .collect();
 
-            address_book.extend(changes);
+            // # Security
+            //
+            // New gossiped addresses are admitted through the secret-keyed
+            // buckets before entering the book, which bound the book share
+            // of any address group and of gossip as a whole (eclipse
+            // resistance). Admission is interleaved with the writes,
+            // because each bucket decision depends on the book state left
+            // by the changes before it.
+            let mut applied = false;
+            for change in changes {
+                admit_gossiped(address_book, gossip_buckets, change.addr());
+                applied |= address_book.update_without_metrics(change).is_some();
+            }
+            if applied {
+                address_book.refresh_metrics();
+            }
 
             PeerBookResponse::Done
         }

--- a/zebra-network/src/peer_book/actor.rs
+++ b/zebra-network/src/peer_book/actor.rs
@@ -25,6 +25,7 @@ use crate::{
     peer_book::{
         handle::{Call, Message},
         misbehavior::{BanKey, MisbehaviorStore},
+        transports::TransportTable,
         PeerBookRequest, PeerBookResponse,
     },
     AddressBook, AddressBookPeers, BoxError,
@@ -68,6 +69,7 @@ pub(crate) fn spawn_actor(
 
         let mut misbehavior = MisbehaviorStore::default();
         let mut gossip_buckets = super::buckets::GossipBuckets::new();
+        let mut transports = super::transports::TransportTable::default();
         let mut get_addr_cache: Option<(Instant, Vec<MetaAddr>)> = None;
         let mut last_live_refresh = Instant::now();
         let mut live_changed = false;
@@ -94,6 +96,7 @@ pub(crate) fn spawn_actor(
 
                             address_book.remove_if_key_matches(|ip| BanKey::from(ip) == ban_key);
                             gossip_buckets.remove_if(|addr| BanKey::from(addr.ip()) == ban_key);
+                            transports.remove_if(|addr| BanKey::from(addr.ip()) == ban_key);
                             let _ = bans_sender.send(misbehavior.bans_snapshot());
 
                             continue;
@@ -129,10 +132,23 @@ pub(crate) fn spawn_actor(
                     live_changed = true;
                 }
 
+                Message::Transport {
+                    addr,
+                    transport,
+                    reachable,
+                } => {
+                    if reachable {
+                        transports.record_reachable(addr, transport);
+                    } else {
+                        transports.record_unreachable(addr, transport, Instant::now());
+                    }
+                }
+
                 Message::Call(Call { request, reply }) => {
                     let response = answer_call(
                         &mut address_book,
                         &mut misbehavior,
+                        &mut transports,
                         &mut get_addr_cache,
                         request,
                     );
@@ -218,6 +234,7 @@ const GET_ADDR_CACHE_JITTER: Duration = Duration::from_secs(6 * 60 * 60);
 fn answer_call(
     address_book: &mut AddressBook,
     misbehavior: &mut MisbehaviorStore,
+    transports: &mut TransportTable,
     get_addr_cache: &mut Option<(Instant, Vec<MetaAddr>)>,
     request: PeerBookRequest,
 ) -> PeerBookResponse {
@@ -249,12 +266,21 @@ fn answer_call(
         PeerBookRequest::SelectCandidate => {
             // The pick and the attempt mark happen in the same actor turn,
             // so concurrent selections cannot return the same peer.
+            let instant_now = Instant::now();
             let next_peer = address_book
-                .reconnection_peers(Instant::now(), Utc::now())
+                .reconnection_peers(instant_now, Utc::now())
                 .next();
 
-            let candidate =
-                next_peer.and_then(|peer| address_book.update(MetaAddr::new_reconnect(peer.addr)));
+            let candidate = next_peer
+                .and_then(|peer| address_book.update(MetaAddr::new_reconnect(peer.addr)))
+                .map(|marked| {
+                    // The dialer needs to know which transports this peer
+                    // accepts, so it can reach version 2 peers it learned
+                    // about over the legacy network.
+                    let transports = transports.dialable(&marked.addr, instant_now);
+
+                    (marked, transports)
+                });
 
             PeerBookResponse::Candidate(candidate)
         }

--- a/zebra-network/src/peer_book/handle.rs
+++ b/zebra-network/src/peer_book/handle.rs
@@ -10,6 +10,7 @@ use tower::Service;
 
 use crate::{
     meta_addr::{MetaAddr, MetaAddrChange},
+    peer_book::transports::AddrTransports,
     BoxError,
 };
 
@@ -25,6 +26,18 @@ pub(crate) enum Message {
 
     /// A request that needs an answer from the book.
     Call(Call),
+
+    /// A learned transport reachability report, applied in channel order.
+    Transport {
+        /// The peer's address.
+        addr: crate::PeerSocketAddr,
+
+        /// The transport the dial used.
+        transport: AddrTransports,
+
+        /// Whether the handshake completed.
+        reachable: bool,
+    },
 }
 
 /// Sends peer status changes to the peer book actor.
@@ -55,6 +68,25 @@ impl ChangeSender {
                 Message::Change(change) => SendError(change),
                 _ => unreachable!("this method only sends changes"),
             })
+    }
+
+    /// Reports that a dial to `addr` over `transport` completed its
+    /// handshake, or was refused.
+    ///
+    /// Reports are best-effort: a full channel means the actor is busy
+    /// applying connection events, and reachability is re-learned on the
+    /// next dial.
+    pub fn record_transport(
+        &self,
+        addr: crate::PeerSocketAddr,
+        transport: AddrTransports,
+        reachable: bool,
+    ) {
+        let _ = self.tx.try_send(Message::Transport {
+            addr,
+            transport,
+            reachable,
+        });
     }
 
     /// Sends `change` to the actor without waiting.
@@ -119,8 +151,9 @@ pub enum PeerBookResponse {
     /// The requested addresses.
     Addrs(Vec<MetaAddr>),
 
-    /// The selected outbound connection candidate, marked as attempted.
-    Candidate(Option<MetaAddr>),
+    /// The selected outbound connection candidate, marked as attempted,
+    /// with the transports it is known to accept.
+    Candidate(Option<(MetaAddr, AddrTransports)>),
 
     /// The number of peers ready for an outbound connection attempt.
     ReadyCandidateCount(usize),

--- a/zebra-network/src/peer_book/handle.rs
+++ b/zebra-network/src/peer_book/handle.rs
@@ -115,10 +115,13 @@ pub enum PeerBookRequest {
     /// Requests the addresses worth writing to the peer cache on disk.
     CacheSnapshot,
 
-    /// Selects a peer for an outbound connection attempt, marking it as
-    /// attempted in the same actor turn, so concurrent selections cannot
-    /// return the same peer.
-    SelectCandidate,
+    /// Selects up to `max` peers for outbound connection attempts, marking
+    /// them as attempted in the same actor turn, so concurrent selections
+    /// cannot return the same peer.
+    SelectCandidates {
+        /// The maximum number of candidates to select.
+        max: usize,
+    },
 
     /// Requests the number of peers currently ready for an outbound
     /// connection attempt.
@@ -151,9 +154,9 @@ pub enum PeerBookResponse {
     /// The requested addresses.
     Addrs(Vec<MetaAddr>),
 
-    /// The selected outbound connection candidate, marked as attempted,
-    /// with the transports it is known to accept.
-    Candidate(Option<(MetaAddr, AddrTransports)>),
+    /// The selected outbound connection candidates, marked as attempted,
+    /// each with the transports it is known to accept.
+    Candidates(Vec<(MetaAddr, AddrTransports)>),
 
     /// The number of peers ready for an outbound connection attempt.
     ReadyCandidateCount(usize),

--- a/zebra-network/src/peer_book/misbehavior.rs
+++ b/zebra-network/src/peer_book/misbehavior.rs
@@ -109,12 +109,7 @@ impl MisbehaviorStore {
 
         if entry.score >= MAX_PEER_MISBEHAVIOR_SCORE {
             self.scores.shift_remove(&key);
-            self.bans.insert(key, now);
-
-            // Bound the number of banned keys, dropping the oldest bans.
-            while self.bans.len() > MAX_BANNED_IPS {
-                self.bans.shift_remove_index(0);
-            }
+            self.ban(key, now);
 
             return true;
         }
@@ -127,10 +122,20 @@ impl MisbehaviorStore {
         false
     }
 
+    /// Bans `key` at `now`.
+    pub(crate) fn ban(&mut self, key: BanKey, now: Instant) {
+        self.bans.insert(key, now);
+
+        // Bound the number of banned keys, dropping the oldest bans.
+        while self.bans.len() > MAX_BANNED_IPS {
+            self.bans.shift_remove_index(0);
+        }
+    }
+
     /// Returns true if `key` is currently banned.
-    pub(crate) fn is_banned(&self, key: BanKey) -> bool {
+    pub(crate) fn is_banned(&self, key: &BanKey) -> bool {
         self.bans
-            .get(&key)
+            .get(key)
             .is_some_and(|banned_at| banned_at.elapsed() < DEFAULT_BAN_DURATION)
     }
 

--- a/zebra-network/src/peer_book/misbehavior.rs
+++ b/zebra-network/src/peer_book/misbehavior.rs
@@ -78,7 +78,8 @@ pub(crate) struct MisbehaviorStore {
 
 /// The interval between sweeps of expired scores and bans.
 ///
-/// Expiry is enforced per lookup, so sweeping only reclaims memory.
+/// Expiry is enforced per lookup inside the store, so sweeping reclaims
+/// memory and tells the actor when the published bans snapshot went stale.
 const PRUNE_INTERVAL: Duration = Duration::from_secs(60);
 
 impl MisbehaviorStore {
@@ -89,17 +90,6 @@ impl MisbehaviorStore {
     /// Reaching the threshold resets the score: the ban itself carries the
     /// state forward.
     pub(crate) fn record(&mut self, key: BanKey, points: u32, now: Instant) -> bool {
-        // Expired entries are ignored by every lookup, so pruning them is
-        // only about memory: a periodic sweep bounds it without making each
-        // report scan both maps.
-        let due = self
-            .last_prune
-            .is_none_or(|last| now.saturating_duration_since(last) >= PRUNE_INTERVAL);
-        if due {
-            self.prune(now);
-            self.last_prune = Some(now);
-        }
-
         let entry = self.scores.entry(key).or_insert(ScoreEntry {
             score: 0,
             last_penalty: now,
@@ -142,6 +132,27 @@ impl MisbehaviorStore {
     /// Returns a snapshot of the current bans, for the bans watch channel.
     pub(crate) fn bans_snapshot(&self) -> Arc<IndexMap<BanKey, Instant>> {
         Arc::new(self.bans.clone())
+    }
+
+    /// Prunes expired scores and bans, at most once per [`PRUNE_INTERVAL`].
+    ///
+    /// Returns `true` if any ban expired. Expiry is enforced per lookup
+    /// inside the store, but the bans watch consumers only see the
+    /// published snapshot, so the caller must republish it when this
+    /// returns `true` — otherwise the peer set and inbound admission would
+    /// enforce expired bans forever.
+    pub(crate) fn prune_due(&mut self, now: Instant) -> bool {
+        let due = self
+            .last_prune
+            .is_none_or(|last| now.saturating_duration_since(last) >= PRUNE_INTERVAL);
+        if !due {
+            return false;
+        }
+        self.last_prune = Some(now);
+
+        let bans_before = self.bans.len();
+        self.prune(now);
+        bans_before != self.bans.len()
     }
 
     /// Drops scores that have not been updated for about the ban duration,

--- a/zebra-network/src/peer_book/reader.rs
+++ b/zebra-network/src/peer_book/reader.rs
@@ -78,6 +78,16 @@ impl PeerBookReader {
     pub(crate) fn change_sender(&self) -> &ChangeSender {
         &self.changes
     }
+
+    /// Returns the local listener as a [`MetaAddr`].
+    ///
+    /// This address contains minimal state, but it is not sanitized.
+    pub fn local_listener_meta_addr(&self, now: chrono::DateTime<Utc>) -> MetaAddr {
+        let now = now.try_into().expect("will succeed until 2038");
+
+        MetaAddr::new_local_listener_change(self.local_listener)
+            .local_listener_into_new_meta_addr(now)
+    }
 }
 
 impl AddressBookPeers for PeerBookReader {

--- a/zebra-network/src/peer_book/tests/vectors.rs
+++ b/zebra-network/src/peer_book/tests/vectors.rs
@@ -237,14 +237,19 @@ async fn ban_removes_every_entry_for_the_banned_ip() {
     let response = handles
         .handle
         .clone()
-        .oneshot(PeerBookRequest::SelectCandidate)
+        .oneshot(PeerBookRequest::SelectCandidates { max: 1 })
         .await
         .expect("the actor is running");
     match response {
-        PeerBookResponse::Candidate(Some((peer, _transports))) => assert_eq!(
-            peer.addr, unrelated_addr,
-            "a banned IP must never be a reconnection candidate",
-        ),
-        other => panic!("the unrelated peer should be a candidate: {other:?}"),
+        PeerBookResponse::Candidates(candidates) => {
+            let (peer, _transports) = candidates
+                .first()
+                .expect("the unrelated peer should be a candidate");
+            assert_eq!(
+                peer.addr, unrelated_addr,
+                "a banned IP must never be a reconnection candidate",
+            );
+        }
+        other => panic!("unexpected response variant: {other:?}"),
     }
 }

--- a/zebra-network/src/peer_book/tests/vectors.rs
+++ b/zebra-network/src/peer_book/tests/vectors.rs
@@ -253,3 +253,113 @@ async fn ban_removes_every_entry_for_the_banned_ip() {
         other => panic!("unexpected response variant: {other:?}"),
     }
 }
+
+/// A sub-threshold misbehavior report for an already-banned peer must not
+/// re-create its book entry: the ban reset the peer's score, so later
+/// reports fall through the ban threshold and used to reach the book.
+#[tokio::test]
+async fn banned_peer_cannot_reenter_via_further_misbehavior() {
+    let _init_guard = zebra_test::init();
+
+    let config = Config {
+        network: Network::Mainnet,
+        ..Config::default()
+    };
+
+    let handles =
+        AddressBookUpdater::spawn(&config, "127.0.0.1:8233".parse().expect("valid address"));
+    let mut bans_receiver = handles.bans_receiver.clone();
+
+    let addr: PeerSocketAddr = "203.0.113.10:8233".parse().expect("valid address");
+    handles
+        .change_sender
+        .send(MetaAddrChange::UpdateMisbehavior {
+            addr,
+            score_increment: MAX_PEER_MISBEHAVIOR_SCORE,
+        })
+        .await
+        .expect("the actor is running");
+
+    tokio::time::timeout(TEST_TIMEOUT, bans_receiver.changed())
+        .await
+        .expect("the bans watch updates in time")
+        .expect("the actor is running");
+
+    // A follow-up report, like one from the misbehavior batcher flushing
+    // after the ban fired.
+    handles
+        .change_sender
+        .send(MetaAddrChange::UpdateMisbehavior {
+            addr,
+            score_increment: 1,
+        })
+        .await
+        .expect("the actor is running");
+
+    let response = handles
+        .handle
+        .clone()
+        .oneshot(crate::peer_book::PeerBookRequest::TestPeerEntry(addr))
+        .await
+        .expect("the actor is running");
+    assert!(
+        matches!(response, PeerBookResponse::PeerEntry(None)),
+        "a banned peer must not re-enter the book through further misbehavior reports: \
+         {response:?}",
+    );
+}
+
+/// Gossiped addresses from one address group are bounded by the group's
+/// secret-keyed bucket, on the production intake path (`GossipedAddrs`).
+#[tokio::test]
+async fn gossiped_addrs_are_bounded_by_group_buckets() {
+    use zebra_chain::serialization::DateTime32;
+
+    use crate::peer_book::buckets::GOSSIP_BUCKET_SIZE;
+
+    let _init_guard = zebra_test::init();
+
+    let config = Config {
+        network: Network::Mainnet,
+        ..Config::default()
+    };
+
+    let handles =
+        AddressBookUpdater::spawn(&config, "127.0.0.1:8233".parse().expect("valid address"));
+
+    // Three buckets' worth of addresses, all in one IPv4 /16 group.
+    let addrs: Vec<MetaAddr> = (0..3 * GOSSIP_BUCKET_SIZE)
+        .map(|index| {
+            // Safety: the index is bounded far below u8::MAX * 250.
+            let addr = format!("198.51.{}.{}:8233", index / 250, 1 + (index % 250));
+            MetaAddr::new_gossiped_meta_addr(
+                addr.parse().expect("valid address"),
+                crate::protocol::types::PeerServices::NODE_NETWORK,
+                DateTime32::now(),
+            )
+        })
+        .collect();
+
+    let response = handles
+        .handle
+        .clone()
+        .oneshot(crate::peer_book::PeerBookRequest::GossipedAddrs { addrs })
+        .await
+        .expect("the actor is running");
+    assert!(matches!(response, PeerBookResponse::Done));
+
+    let response = handles
+        .handle
+        .clone()
+        .oneshot(crate::peer_book::PeerBookRequest::CacheSnapshot)
+        .await
+        .expect("the actor is running");
+    match response {
+        PeerBookResponse::Addrs(peers) => assert_eq!(
+            peers.len(),
+            GOSSIP_BUCKET_SIZE,
+            "one address group must be bounded by one bucket's capacity",
+        ),
+        other => panic!("unexpected response variant: {other:?}"),
+    }
+}

--- a/zebra-network/src/peer_book/tests/vectors.rs
+++ b/zebra-network/src/peer_book/tests/vectors.rs
@@ -241,7 +241,7 @@ async fn ban_removes_every_entry_for_the_banned_ip() {
         .await
         .expect("the actor is running");
     match response {
-        PeerBookResponse::Candidate(Some(peer)) => assert_eq!(
+        PeerBookResponse::Candidate(Some((peer, _transports))) => assert_eq!(
             peer.addr, unrelated_addr,
             "a banned IP must never be a reconnection candidate",
         ),

--- a/zebra-network/src/peer_book/transports.rs
+++ b/zebra-network/src/peer_book/transports.rs
@@ -1,0 +1,144 @@
+//! Which transports each peer address is reachable on.
+//!
+//! Zebra speaks two peer protocols: the legacy protocol over TCP, and the
+//! version 2 protocol over QUIC. Relayed addresses carry no indication of
+//! which transports a peer accepts — the draft ZIP has no transport hint,
+//! and the QUIC transport deliberately uses the UDP port of the same address
+//! — so reachability is *learned*, never trusted:
+//!
+//! - a completed handshake proves the transport it used,
+//! - a refused dial is remembered for a while, so the crawler stops
+//!   retrying a transport that a peer does not accept, and
+//! - gossip contributes nothing.
+//!
+//! Learned reachability is what lets a version 2 node dial version 2 peers
+//! it discovered over the legacy network, instead of only the peers in its
+//! configuration.
+//!
+//! # Interim design
+//!
+//! This is a side table beside the address book, not a field on
+//! [`MetaAddr`](crate::meta_addr::MetaAddr), so reachability is learned
+//! only from outbound dials, is not persisted across restarts, and cannot
+//! influence candidate selection. Moving it onto the address record — as
+//! `book/src/dev/dual-protocol-networking.md` specifies — is the next step,
+//! and is what inbound handshakes, the disk peer cache, and Tor addressing
+//! all need.
+
+use std::time::{Duration, Instant};
+
+use bitflags::bitflags;
+use indexmap::IndexMap;
+
+use crate::PeerSocketAddr;
+
+#[cfg(test)]
+mod tests;
+
+bitflags! {
+    /// The peer transports an address is known to accept.
+    #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash)]
+    pub struct AddrTransports: u8 {
+        /// The legacy protocol over TCP.
+        const TCP = 0b0000_0001;
+
+        /// The version 2 protocol over QUIC.
+        const QUIC = 0b0000_0010;
+    }
+}
+
+/// How long a refused transport is remembered before it is retried.
+///
+/// Peers upgrade, so a refusal must expire; until it does, the crawler
+/// spends its dials on transports the peer actually accepts.
+const TRANSPORT_FAILURE_RETRY_INTERVAL: Duration = Duration::from_secs(4 * 60 * 60);
+
+/// The maximum number of addresses with learned transport reachability.
+///
+/// Bounded like the address book itself: entries are attacker-suppliable
+/// addresses, and the oldest are dropped when the table is full.
+const MAX_TRANSPORT_ENTRIES: usize = crate::constants::MAX_ADDRS_IN_ADDRESS_BOOK;
+
+/// What is known about one address's transport reachability.
+#[derive(Copy, Clone, Debug, Default)]
+struct TransportRecord {
+    /// The transports that completed a handshake, or were configured.
+    known: AddrTransports,
+
+    /// The transports whose most recent dial was refused, and when.
+    ///
+    /// The two are one fact, so they are stored as one: a refusal always
+    /// has a time, and clearing it clears both.
+    refused: Option<(AddrTransports, Instant)>,
+}
+
+/// The learned transport reachability of peer addresses, in insertion
+/// order so the oldest can be evicted.
+#[derive(Debug, Default)]
+pub(crate) struct TransportTable {
+    entries: IndexMap<PeerSocketAddr, TransportRecord>,
+}
+
+impl TransportTable {
+    /// Records that `addr` completed a handshake over `transport`, or is
+    /// configured to be reached over it.
+    pub(crate) fn record_reachable(&mut self, addr: PeerSocketAddr, transport: AddrTransports) {
+        let record = self.entry(addr);
+        record.known |= transport;
+        record.refused = record
+            .refused
+            .map(|(refused, at)| (refused - transport, at))
+            .filter(|(refused, _at)| !refused.is_empty());
+    }
+
+    /// Records that a dial to `addr` over `transport` was refused at `now`.
+    ///
+    /// A transport that previously completed a handshake stays known: a
+    /// single refusal is more likely to be a restart than a downgrade, and
+    /// the failure is retried after [`TRANSPORT_FAILURE_RETRY_INTERVAL`].
+    pub(crate) fn record_unreachable(
+        &mut self,
+        addr: PeerSocketAddr,
+        transport: AddrTransports,
+        now: Instant,
+    ) {
+        let record = self.entry(addr);
+        let refused = record
+            .refused
+            .map_or(transport, |(refused, _at)| refused | transport);
+        record.refused = Some((refused, now));
+    }
+
+    /// Returns the transports `addr` is worth dialing at `now`: those it is
+    /// known to accept, minus those it recently refused.
+    pub(crate) fn dialable(&self, addr: &PeerSocketAddr, now: Instant) -> AddrTransports {
+        let Some(record) = self.entries.get(addr) else {
+            return AddrTransports::empty();
+        };
+
+        match record.refused {
+            Some((refused, at))
+                if now.saturating_duration_since(at) < TRANSPORT_FAILURE_RETRY_INTERVAL =>
+            {
+                record.known - refused
+            }
+            _ => record.known,
+        }
+    }
+
+    /// Removes every entry matching `predicate`, after a ban.
+    pub(crate) fn remove_if(&mut self, predicate: impl Fn(PeerSocketAddr) -> bool) {
+        self.entries.retain(|addr, _record| !predicate(*addr));
+    }
+
+    /// Returns `addr`'s record, bounding the table first.
+    fn entry(&mut self, addr: PeerSocketAddr) -> &mut TransportRecord {
+        while self.entries.len() >= MAX_TRANSPORT_ENTRIES && !self.entries.contains_key(&addr) {
+            // Dropping the oldest entry only costs a re-probe, and the bound
+            // must hold against gossiped addresses.
+            self.entries.shift_remove_index(0);
+        }
+
+        self.entries.entry(addr).or_default()
+    }
+}

--- a/zebra-network/src/peer_book/transports/tests.rs
+++ b/zebra-network/src/peer_book/transports/tests.rs
@@ -1,0 +1,81 @@
+//! Tests for learned transport reachability.
+
+use std::time::{Duration, Instant};
+
+use crate::PeerSocketAddr;
+
+use super::{AddrTransports, TransportTable, TRANSPORT_FAILURE_RETRY_INTERVAL};
+
+fn addr(host: u8) -> PeerSocketAddr {
+    format!("10.0.0.{host}:8233")
+        .parse()
+        .expect("valid address")
+}
+
+#[test]
+fn handshakes_establish_reachability_per_transport() {
+    let _init_guard = zebra_test::init();
+
+    let mut table = TransportTable::default();
+    let now = Instant::now();
+
+    table.record_reachable(addr(1), AddrTransports::TCP);
+    assert_eq!(table.dialable(&addr(1), now), AddrTransports::TCP);
+
+    table.record_reachable(addr(1), AddrTransports::QUIC);
+    assert_eq!(
+        table.dialable(&addr(1), now),
+        AddrTransports::TCP | AddrTransports::QUIC,
+        "a peer can be reachable on both transports",
+    );
+
+    // Other addresses are unaffected.
+    assert_eq!(table.dialable(&addr(2), now), AddrTransports::empty());
+}
+
+#[test]
+fn refusals_are_remembered_then_retried() {
+    let _init_guard = zebra_test::init();
+
+    let mut table = TransportTable::default();
+    let now = Instant::now();
+
+    table.record_reachable(addr(1), AddrTransports::TCP | AddrTransports::QUIC);
+    table.record_unreachable(addr(1), AddrTransports::QUIC, now);
+
+    assert_eq!(
+        table.dialable(&addr(1), now),
+        AddrTransports::TCP,
+        "a refused transport is not dialed again immediately",
+    );
+
+    let later = now + TRANSPORT_FAILURE_RETRY_INTERVAL + Duration::from_secs(1);
+    assert_eq!(
+        table.dialable(&addr(1), later),
+        AddrTransports::TCP | AddrTransports::QUIC,
+        "peers upgrade, so refusals expire",
+    );
+
+    // A later handshake clears the refusal immediately.
+    table.record_unreachable(addr(1), AddrTransports::QUIC, later);
+    table.record_reachable(addr(1), AddrTransports::QUIC);
+    assert_eq!(
+        table.dialable(&addr(1), later),
+        AddrTransports::TCP | AddrTransports::QUIC,
+    );
+}
+
+#[test]
+fn bans_remove_learned_reachability() {
+    let _init_guard = zebra_test::init();
+
+    let mut table = TransportTable::default();
+    let now = Instant::now();
+    table.record_reachable(addr(1), AddrTransports::QUIC);
+    table.record_reachable(addr(2), AddrTransports::QUIC);
+
+    table.remove_if(|entry| entry == addr(1));
+
+    assert_eq!(table.dialable(&addr(1), now), AddrTransports::empty());
+    assert_eq!(table.dialable(&addr(2), now), AddrTransports::QUIC);
+}

--- a/zebra-network/src/peer_cache_updater.rs
+++ b/zebra-network/src/peer_cache_updater.rs
@@ -3,7 +3,7 @@
 use std::io;
 
 use tokio::time::sleep;
-use tower::ServiceExt;
+use tower::{Service, ServiceExt};
 
 use crate::{
     constants::{DNS_LOOKUP_TIMEOUT, PEER_DISK_CACHE_UPDATE_INTERVAL},
@@ -29,7 +29,7 @@ pub async fn peer_cache_updater(
     loop {
         // Ignore errors because updating the cache is optional.
         // Errors are already logged by the functions we're calling.
-        wrote_cache |= update_peer_cache_once(&config, peer_book_handle.clone())
+        wrote_cache |= update_peer_cache_once(&config, &mut peer_book_handle.clone())
             .await
             .unwrap_or(false);
 
@@ -52,10 +52,13 @@ pub async fn peer_cache_updater(
 /// keeping any previous cache.
 pub async fn update_peer_cache_once(
     config: &Config,
-    peer_book_handle: PeerBookHandle,
+    peer_book_handle: &mut PeerBookHandle,
 ) -> io::Result<bool> {
     let response = peer_book_handle
-        .oneshot(PeerBookRequest::CacheSnapshot)
+        .ready()
+        .await
+        .map_err(io::Error::other)?
+        .call(PeerBookRequest::CacheSnapshot)
         .await
         .map_err(io::Error::other)?;
     let PeerBookResponse::Addrs(cacheable) = response else {

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -109,7 +109,7 @@ use tower::{Service, ServiceExt};
 
 use crate::{
     constants,
-    peer_book::{PeerBookHandle, PeerBookRequest, PeerBookResponse},
+    peer_book::{transports::AddrTransports, PeerBookHandle, PeerBookRequest, PeerBookResponse},
     types::MetaAddr,
     BoxError, Request, Response,
 };
@@ -187,14 +187,14 @@ where
 /// apart. If a peer was recently provided, then this future will sleep
 /// until the rate-limit has passed.
 ///
-/// The returned candidate records which transports the peer is known to
+/// The candidate is returned with the transports it is known to
 /// accept, so the dialer can reach version 2 peers over QUIC and
 /// everything else over TCP.
 ///
 /// [`Responded`]: crate::PeerAddrState::Responded
 pub(crate) async fn next_reconnect_peer(
     next_peer_service: &mut NextPeerService,
-) -> Option<MetaAddr> {
+) -> Option<(MetaAddr, AddrTransports)> {
     // Security: new outbound peer connections are rate-limited by the
     // [`RateLimitOnYield`] middleware, which only sleeps before yielding
     // an address: when there is no peer, `None` is returned immediately.

--- a/zebra-network/src/peer_set/candidate_set.rs
+++ b/zebra-network/src/peer_set/candidate_set.rs
@@ -152,7 +152,7 @@ where
     let next_peer_service = RateLimitOnYield::new(
         peer_book_handle.clone(),
         constants::MIN_OUTBOUND_PEER_CONNECTION_INTERVAL,
-        |response| matches!(response, PeerBookResponse::Candidate(Some(_))),
+        |response| matches!(response, PeerBookResponse::Candidates(candidates) if !candidates.is_empty()),
     );
 
     let crawl_service = CrawlFanout::service(peer_service, peer_book_handle);
@@ -201,15 +201,15 @@ pub(crate) async fn next_reconnect_peer(
     let response = match next_peer_service.ready().await {
         Ok(next_peer_service) => {
             next_peer_service
-                .call(PeerBookRequest::SelectCandidate)
+                .call(PeerBookRequest::SelectCandidates { max: 1 })
                 .await
         }
         Err(error) => Err(error),
     };
 
     match response {
-        Ok(PeerBookResponse::Candidate(next_peer)) => next_peer,
-        Ok(_) => unreachable!("SelectCandidate requests always return Candidate"),
+        Ok(PeerBookResponse::Candidates(candidates)) => candidates.into_iter().next(),
+        Ok(_) => unreachable!("SelectCandidates requests always return Candidates"),
         Err(error) => {
             debug!(
                 ?error,

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -50,7 +50,7 @@ use crate::{
         self, address_is_valid_for_inbound_listeners, HandshakeRequest, MinimumPeerVersion,
         OutboundConnectorRequest, PeerPreference,
     },
-    peer_book::{ChangeSender, PeerBookHandle, PeerBookReader},
+    peer_book::{transports::AddrTransports, ChangeSender, PeerBookHandle, PeerBookReader},
     peer_cache_updater::peer_cache_updater,
     peer_set::{
         crawl_once, crawler_services, next_reconnect_peer, ready_peer_count, set::MorePeers,
@@ -67,6 +67,24 @@ mod tests;
 mod inbound_admission;
 mod recent_by_ip;
 mod v2_transport;
+
+/// The share of candidates with unknown transport reachability that are
+/// probed for version 2 support before the legacy dial.
+///
+/// Probing is how a node discovers version 2 peers it learned about over the
+/// legacy network, before the draft ZIP grows a per-address transport hint.
+/// The share is small, and probes are rate-limited along with every other
+/// dial, so the cost is a few UDP packets per minute.
+const V2_PROBE_RATIO: f32 = 0.05;
+
+/// The timeout for a version 2 probe of a peer whose version 2
+/// reachability is unknown.
+///
+/// Deliberately well under [`HANDSHAKE_TIMEOUT`](constants::HANDSHAKE_TIMEOUT):
+/// a probe of a peer that does not speak version 2 must barely delay the
+/// legacy dial that follows it. A QUIC handshake to a listening peer takes
+/// one round trip, so this is generous for a peer that answers at all.
+const V2_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// The version 2 outbound connector, type-erased so the crawler does not
 /// carry the inbound service and chain tip types.
@@ -244,7 +262,6 @@ where
     {
         advertised_services |= crate::protocol::external::types::PeerServices::NODE_SYNC_ARTIFACTS;
     }
-    let want_transactions = true;
 
     // The v2 (QUIC) transport, if enabled: it shares the
     // inbound service, address book, and inventory collector with the
@@ -255,7 +272,8 @@ where
             config.clone(),
             user_agent.clone(),
             advertised_services,
-            want_transactions,
+            // Zebra always wants transaction announcements.
+            true,
             inbound_service.clone(),
             address_book_updater.clone(),
             misbehavior_tx.clone(),
@@ -280,7 +298,7 @@ where
             .with_advertised_services(advertised_services)
             .with_user_agent(user_agent)
             .with_latest_chain_tip(latest_chain_tip.clone())
-            .want_transactions(want_transactions)
+            .want_transactions(true)
             .finish()
             .expect("configured all required parameters");
         (
@@ -391,17 +409,17 @@ where
         None => (None, None),
     };
 
-    // Dial the configured version 2 peers, and add them to the book so the
-    // legacy crawler redials them if the version 2 connection drops.
-    if let Some(connector) = v2_connector.clone() {
-        let dial_fut = add_initial_v2_peers(
-            config.clone(),
-            connector,
-            peerset_tx.clone(),
-            address_book_updater.clone(),
-            active_outbound_connections.clone(),
-        );
-        tokio::spawn(dial_fut.in_current_span());
+    // Seed the configured version 2 peers as QUIC-reachable, and add them
+    // to the book: the crawler then dials and redials them over version 2
+    // like any other peer whose reachability this node has learned.
+    if v2_connector.is_some() {
+        for peer_addr in config.initial_v2_peers().await {
+            address_book_updater.record_transport(peer_addr, AddrTransports::QUIC, true);
+
+            let _ = address_book_updater
+                .send(MetaAddr::new_initial_peer(peer_addr))
+                .await;
+        }
     }
 
     // 2. Initial peers, specified in the config and cached on disk.
@@ -456,6 +474,7 @@ where
         crawl_service,
         peer_book_handle.clone(),
         outbound_connector,
+        v2_connector,
         peerset_tx,
         active_outbound_connections,
         address_book_updater,
@@ -1061,6 +1080,7 @@ enum CrawlerAction {
         crawl_service,
         peer_book_handle,
         outbound_connector,
+        v2_connector,
         peerset_tx,
         active_outbound_connections,
         address_book_updater,
@@ -1077,6 +1097,7 @@ async fn crawl_and_dial<C, S>(
     crawl_service: CrawlService<S>,
     peer_book_handle: PeerBookHandle,
     outbound_connector: C,
+    v2_connector: Option<V2OutboundConnector>,
     peerset_tx: futures::channel::mpsc::Sender<DiscoveredPeer>,
     active_outbound_connections: SharedConnectionCounter,
     address_book_updater: ChangeSender,
@@ -1177,6 +1198,7 @@ where
                 let mut next_peer_service = next_peer_service.clone();
                 let crawl_service = crawl_service.clone();
                 let outbound_connector = outbound_connector.clone();
+                let v2_connector = v2_connector.clone();
                 let active_outbound_connections = active_outbound_connections.clone();
                 let peerset_tx = peerset_tx.clone();
                 let address_book_updater = address_book_updater.clone();
@@ -1203,13 +1225,16 @@ where
                         // task, so it shouldn't hang.
                         let candidate = next_reconnect_peer(&mut next_peer_service).await;
 
-                        if let Some(candidate) = candidate {
+                        if let Some((candidate, transports)) = candidate {
                             // we don't need to spawn here, because there's nothing running concurrently
                             dial(
                                 network,
                                 candidate,
+                                transports,
                                 outbound_connector,
+                                v2_connector,
                                 outbound_connection_tracker,
+                                active_outbound_connections,
                                 outbound_connections,
                                 peerset_tx,
                                 address_book_updater,
@@ -1359,7 +1384,9 @@ where
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip(
     outbound_connector,
+    v2_connector,
     outbound_connection_tracker,
+    active_outbound_connections,
     outbound_connections,
     peerset_tx,
     address_book_updater,
@@ -1368,8 +1395,11 @@ where
 async fn dial<C>(
     network: Network,
     candidate: MetaAddr,
+    transports: AddrTransports,
     mut outbound_connector: C,
-    outbound_connection_tracker: ConnectionTracker,
+    v2_connector: Option<V2OutboundConnector>,
+    mut outbound_connection_tracker: ConnectionTracker,
+    active_outbound_connections: SharedConnectionCounter,
     outbound_connections: usize,
     mut peerset_tx: futures::channel::mpsc::Sender<DiscoveredPeer>,
     address_book_updater: ChangeSender,
@@ -1396,6 +1426,35 @@ where
     // - functions that have a reasonable timeout
 
     debug!(?candidate.addr, "attempting outbound connection in response to demand");
+
+    // The version 2 attempt comes first for peers known to accept QUIC, so
+    // the node uses version 2 wherever it is available. Every failure falls
+    // back to the legacy transport immediately, so a node is never worse
+    // off than a legacy-only node.
+    if let Some(connector) = v2_connector {
+        match dial_v2(
+            &candidate,
+            transports,
+            connector,
+            outbound_connection_tracker,
+            &active_outbound_connections,
+            &address_book_updater,
+        )
+        .await
+        {
+            Ok(client) => {
+                debug!(?candidate.addr, "successfully dialed new v2 peer");
+                address_book_updater.record_transport(candidate.addr, AddrTransports::QUIC, true);
+
+                peerset_tx.send((candidate.addr, client)).await?;
+                return Ok(());
+            }
+            // The legacy dial below continues with the tracker the attempt
+            // returned, so one logical dial holds one outbound slot however
+            // many transports it tries.
+            Err(tracker) => outbound_connection_tracker = tracker,
+        }
+    }
 
     // the connector is always ready, so this can't hang
     let outbound_connector = outbound_connector.ready().await?;
@@ -1452,53 +1511,70 @@ where
     Ok(())
 }
 
-/// Dials the configured version 2 peers, and adds them to the address book.
+/// Attempts a version 2 dial to `candidate`, if the dial policy calls for
+/// one, and records what the attempt taught about the peer's reachability.
 ///
-/// The configured peers are the only ones dialed over version 2: a relayed
-/// address carries no indication of the transports its peer accepts, so
-/// this node cannot tell which of them would answer a QUIC dial.
-#[instrument(skip(
-    connector,
-    peerset_tx,
-    address_book_updater,
-    active_outbound_connections
-))]
-async fn add_initial_v2_peers(
-    config: Config,
-    mut connector: V2OutboundConnector,
-    mut peerset_tx: futures::channel::mpsc::Sender<DiscoveredPeer>,
-    address_book_updater: crate::peer_book::ChangeSender,
-    active_outbound_connections: SharedConnectionCounter,
-) {
-    for addr in config.initial_v2_peers().await {
-        // The book keeps the peer as a reconnection candidate for the
-        // legacy crawler if the version 2 connection drops.
-        let _ = address_book_updater
-            .send(MetaAddr::new_initial_peer(addr))
-            .await;
+/// A peer known to accept QUIC is always tried. A peer not known to accept
+/// it is probed at [`V2_PROBE_RATIO`], which is how a node discovers the
+/// version 2 peers it learned about over the legacy network: relayed
+/// addresses carry no transport hint, so reachability can only be learned
+/// by trying.
+///
+/// Returns the connected client, or the outbound connection tracker for the
+/// caller's legacy dial.
+async fn dial_v2(
+    candidate: &MetaAddr,
+    transports: AddrTransports,
+    connector: V2OutboundConnector,
+    connection_tracker: ConnectionTracker,
+    active_outbound_connections: &SharedConnectionCounter,
+    address_book_updater: &crate::peer_book::ChangeSender,
+) -> Result<peer::Client, ConnectionTracker> {
+    let known_v2 = transports.contains(AddrTransports::QUIC);
 
-        let request = OutboundConnectorRequest {
-            addr,
-            connection_tracker: active_outbound_connections.track_connection(),
-        };
+    // A peer that speaks the legacy protocol may also speak version 2, so
+    // the probe is gated on version 2 reachability alone: gating on "no
+    // known transports" would stop probing every peer as soon as it
+    // completed one legacy handshake.
+    let probe = !known_v2 && rand::random::<f32>() < V2_PROBE_RATIO;
+    if !known_v2 && !probe {
+        return Err(connection_tracker);
+    }
 
-        let Ok(connector) = connector.ready().await else {
-            return;
-        };
+    // A probe of a peer that does not answer must barely delay the legacy
+    // dial that follows it.
+    let timeout = if known_v2 {
+        constants::HANDSHAKE_TIMEOUT
+    } else {
+        V2_PROBE_TIMEOUT
+    };
 
-        match connector.call(request).await {
-            Ok((addr, client)) => {
-                debug!(?addr, "connected to configured v2 peer");
+    let request = OutboundConnectorRequest {
+        addr: candidate.addr,
+        connection_tracker,
+    };
 
-                if peerset_tx.send((addr, client)).await.is_err() {
-                    return;
-                }
-            }
-            Err(error) => {
-                info!(?error, ?addr, "failed to connect to configured v2 peer");
-            }
+    // The attempt owns the tracker from here: the handshake takes it on
+    // success, and it is dropped with the future otherwise. Timing out
+    // drops the future, which cancels the dial and releases the slot, so an
+    // abandoned attempt cannot hold one until the transport's idle timeout.
+    match tokio::time::timeout(timeout, connector.oneshot(request)).await {
+        Ok(Ok((_addr, client))) => return Ok(client),
+        Ok(Err(error)) => {
+            debug!(?error, ?candidate.addr, "v2 dial failed, trying the legacy transport");
+
+            // A refused dial is what teaches the peer book that this peer
+            // does not accept QUIC.
+            address_book_updater.record_transport(candidate.addr, AddrTransports::QUIC, false);
+        }
+        // A timeout does not prove the peer refuses QUIC, so it teaches the
+        // peer book nothing.
+        Err(_elapsed) => {
+            debug!(?candidate.addr, "v2 dial timed out, trying the legacy transport");
         }
     }
+
+    Err(active_outbound_connections.track_connection())
 }
 
 /// Mark `addr` as a failed peer to `address_book_updater`.

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -262,6 +262,7 @@ where
     {
         advertised_services |= crate::protocol::external::types::PeerServices::NODE_SYNC_ARTIFACTS;
     }
+    let want_transactions = true;
 
     // The v2 (QUIC) transport, if enabled: it shares the
     // inbound service, address book, and inventory collector with the
@@ -272,8 +273,7 @@ where
             config.clone(),
             user_agent.clone(),
             advertised_services,
-            // Zebra always wants transaction announcements.
-            true,
+            want_transactions,
             inbound_service.clone(),
             address_book_updater.clone(),
             misbehavior_tx.clone(),
@@ -298,7 +298,7 @@ where
             .with_advertised_services(advertised_services)
             .with_user_agent(user_agent)
             .with_latest_chain_tip(latest_chain_tip.clone())
-            .want_transactions(true)
+            .want_transactions(want_transactions)
             .finish()
             .expect("configured all required parameters");
         (
@@ -1442,7 +1442,7 @@ where
         )
         .await
         {
-            Ok(client) => {
+            V2Dial::Connected(client) => {
                 debug!(?candidate.addr, "successfully dialed new v2 peer");
                 address_book_updater.record_transport(candidate.addr, AddrTransports::QUIC, true);
 
@@ -1450,9 +1450,8 @@ where
                 return Ok(());
             }
             // The legacy dial below continues with the tracker the attempt
-            // returned, so one logical dial holds one outbound slot however
-            // many transports it tries.
-            Err(tracker) => outbound_connection_tracker = tracker,
+            // returned.
+            V2Dial::Fallback(tracker) => outbound_connection_tracker = tracker,
         }
     }
 
@@ -1478,6 +1477,7 @@ where
     match handshake_result {
         Ok((address, client)) => {
             debug!(?candidate.addr, "successfully dialed new peer");
+            address_book_updater.record_transport(candidate.addr, AddrTransports::TCP, true);
 
             // The connection limit makes sure this send doesn't block.
             peerset_tx.send((address, client)).await?;
@@ -1511,6 +1511,18 @@ where
     Ok(())
 }
 
+/// The outcome of a version 2 dial attempt.
+enum V2Dial {
+    /// The peer connected over version 2.
+    Connected(peer::Client),
+
+    /// Version 2 was not attempted, or the attempt failed. The caller
+    /// falls back to the legacy transport with the returned tracker, so one
+    /// logical dial holds one outbound slot however many transports it
+    /// tries.
+    Fallback(ConnectionTracker),
+}
+
 /// Attempts a version 2 dial to `candidate`, if the dial policy calls for
 /// one, and records what the attempt taught about the peer's reachability.
 ///
@@ -1519,9 +1531,6 @@ where
 /// version 2 peers it learned about over the legacy network: relayed
 /// addresses carry no transport hint, so reachability can only be learned
 /// by trying.
-///
-/// Returns the connected client, or the outbound connection tracker for the
-/// caller's legacy dial.
 async fn dial_v2(
     candidate: &MetaAddr,
     transports: AddrTransports,
@@ -1529,7 +1538,7 @@ async fn dial_v2(
     connection_tracker: ConnectionTracker,
     active_outbound_connections: &SharedConnectionCounter,
     address_book_updater: &crate::peer_book::ChangeSender,
-) -> Result<peer::Client, ConnectionTracker> {
+) -> V2Dial {
     let known_v2 = transports.contains(AddrTransports::QUIC);
 
     // A peer that speaks the legacy protocol may also speak version 2, so
@@ -1538,7 +1547,7 @@ async fn dial_v2(
     // completed one legacy handshake.
     let probe = !known_v2 && rand::random::<f32>() < V2_PROBE_RATIO;
     if !known_v2 && !probe {
-        return Err(connection_tracker);
+        return V2Dial::Fallback(connection_tracker);
     }
 
     // A probe of a peer that does not answer must barely delay the legacy
@@ -1559,7 +1568,7 @@ async fn dial_v2(
     // drops the future, which cancels the dial and releases the slot, so an
     // abandoned attempt cannot hold one until the transport's idle timeout.
     match tokio::time::timeout(timeout, connector.oneshot(request)).await {
-        Ok(Ok((_addr, client))) => return Ok(client),
+        Ok(Ok((_addr, client))) => return V2Dial::Connected(client),
         Ok(Err(error)) => {
             debug!(?error, ?candidate.addr, "v2 dial failed, trying the legacy transport");
 
@@ -1574,7 +1583,7 @@ async fn dial_v2(
         }
     }
 
-    Err(active_outbound_connections.track_connection())
+    V2Dial::Fallback(active_outbound_connections.track_connection())
 }
 
 /// Mark `addr` as a failed peer to `address_book_updater`.

--- a/zebra-network/src/peer_set/initialize.rs
+++ b/zebra-network/src/peer_set/initialize.rs
@@ -344,7 +344,8 @@ where
 
     // The legacy and v2 transports open connections from separate tasks, but
     // their connections share the configured limits, so they share these
-    // counters.
+    // counters, and one per-IP inbound limiter: separate limiters would let
+    // one IP hold `max_connections_per_ip` connections on each transport.
     let active_inbound_connections = SharedConnectionCounter::new_counter_with(
         config.peerset_inbound_connection_limit(),
         "Inbound Connections",
@@ -353,6 +354,11 @@ where
         config.peerset_outbound_connection_limit(),
         "Outbound Connections",
     );
+    let recent_inbound_connections = watch::channel(recent_by_ip::RecentByIp::new(
+        None,
+        Some(config.max_connections_per_ip),
+    ))
+    .0;
 
     // Connect peerset_tx to the 3 peer sources:
     //
@@ -366,6 +372,7 @@ where
         bans_receiver.clone(),
         block_gossip_peer_ips,
         active_inbound_connections.clone(),
+        recent_inbound_connections.clone(),
     );
     let listen_guard = tokio::spawn(listen_fut.in_current_span());
 
@@ -399,6 +406,7 @@ where
                 peerset_tx.clone(),
                 bans_receiver,
                 active_inbound_connections,
+                recent_inbound_connections,
             );
 
             (
@@ -810,15 +818,13 @@ async fn accept_inbound_connections<S>(
     bans_receiver: watch::Receiver<Arc<IndexMap<crate::peer_book::BanKey, std::time::Instant>>>,
     zcashd_compat_peer_ips: Vec<IpAddr>,
     active_inbound_connections: SharedConnectionCounter,
+    recent_inbound_connections: watch::Sender<recent_by_ip::RecentByIp>,
 ) -> Result<(), BoxError>
 where
     S: Service<peer::HandshakeRequest<TcpStream>, Response = peer::Client, Error = BoxError>
         + Clone,
     S::Future: Send + 'static,
 {
-    let mut recent_inbound_connections =
-        recent_by_ip::RecentByIp::new(None, Some(config.max_connections_per_ip));
-
     let zcashd_compat_peer_ips: HashSet<_> = zcashd_compat_peer_ips
         .into_iter()
         .map(|ip| canonical_socket_addr(SocketAddr::new(ip, 0)).ip())
@@ -900,10 +906,9 @@ where
                 match inbound_admission::try_reserve_public_inbound_slot(
                     &config.network,
                     addr,
-                    active_public_inbound_connections,
                     public_limit,
                     &active_inbound_connections,
-                    &mut recent_inbound_connections,
+                    &recent_inbound_connections,
                 ) {
                     Some(tracker) => tracker,
                     None => {

--- a/zebra-network/src/peer_set/initialize/inbound_admission.rs
+++ b/zebra-network/src/peer_set/initialize/inbound_admission.rs
@@ -69,10 +69,7 @@ pub(super) fn screen_inbound_addr(
 /// Checks an inbound connection against the public inbound connection limit
 /// and the per-IP rate limit, and reserves a public inbound slot if allowed.
 ///
-/// `active_count` is the caller's snapshot of `active_inbound_connections`,
-/// taken before any transport-specific slot decisions, so one snapshot backs
-/// all of them. `limit` is the public inbound connection limit for this
-/// transport.
+/// `limit` is the public inbound connection limit for this transport.
 ///
 /// Returns a tracker holding the slot, or `None` after recording the
 /// "capacity_or_rate_limited" rejection metric. On `None`, the caller must
@@ -81,16 +78,34 @@ pub(super) fn screen_inbound_addr(
 pub(super) fn try_reserve_public_inbound_slot(
     network: &Network,
     addr: PeerSocketAddr,
-    active_count: usize,
     limit: usize,
     active_inbound_connections: &SharedConnectionCounter,
-    recent_inbound_connections: &mut RecentByIp,
+    recent_inbound_connections: &watch::Sender<RecentByIp>,
 ) -> Option<ConnectionTracker> {
-    if active_count >= limit || recent_inbound_connections.is_past_limit_or_add(addr.ip()) {
+    // # Security
+    //
+    // The capacity check and the slot reservation are one atomic update, so
+    // the transports' accept loops cannot both take the last free slot and
+    // overshoot the shared limit.
+    let Some(tracker) = active_inbound_connections.try_track_connection(limit) else {
         // Too many open inbound connections or pending handshakes already.
+        record_inbound_connection_rejected(network, addr, "capacity_or_rate_limited");
+        return None;
+    };
+
+    // # Security
+    //
+    // The per-IP limiter is shared between the transports' accept loops, so
+    // one IP cannot hold `max_connections_per_ip` connections on each
+    // transport. The check-and-record runs atomically inside the watch cell.
+    let mut past_limit = false;
+    recent_inbound_connections
+        .send_modify(|recent| past_limit = recent.is_past_limit_or_add(addr.ip()));
+    if past_limit {
+        // Dropping the tracker releases the reserved slot.
         record_inbound_connection_rejected(network, addr, "capacity_or_rate_limited");
         return None;
     }
 
-    Some(active_inbound_connections.track_connection())
+    Some(tracker)
 }

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -874,6 +874,8 @@ async fn crawler_refills_spare_outbound_capacity_on_timer() {
         crawl_service,
         peer_book_handle.clone(),
         success_stay_open_outbound_connector,
+        // The version 2 transport is disabled in this test.
+        None,
         peerset_tx,
         active_outbound_connections,
         address_book_updater,
@@ -2414,6 +2416,8 @@ where
         crawl_service,
         peer_book_handle.clone(),
         outbound_connector,
+        // The version 2 transport is disabled in this test.
+        None,
         peerset_tx,
         active_outbound_connections,
         address_book_updater,

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -55,6 +55,18 @@ use Network::*;
 
 /// Returns the inbound connection counter the listener under test shares with
 /// the v2 transport in production.
+/// Returns the shared per-IP inbound limiter the listener under test shares
+/// with the v2 transport in production.
+fn test_recent_by_ip(
+    config: &Config,
+) -> tokio::sync::watch::Sender<super::super::recent_by_ip::RecentByIp> {
+    tokio::sync::watch::channel(super::super::recent_by_ip::RecentByIp::new(
+        None,
+        Some(config.max_connections_per_ip),
+    ))
+    .0
+}
+
 fn test_inbound_counter(config: &Config) -> SharedConnectionCounter {
     SharedConnectionCounter::new_counter_with(
         config.peerset_inbound_connection_limit(),
@@ -1182,6 +1194,7 @@ async fn listener_reserves_one_zcashd_compat_inbound_slot() {
     let (_bans_tx, bans_rx) = tokio::sync::watch::channel(Default::default());
 
     let active_inbound_connections = test_inbound_counter(&config);
+    let recent_inbound_connections = test_recent_by_ip(&config);
     let listen_fut = accept_inbound_connections(
         config.clone(),
         tcp_listener,
@@ -1191,6 +1204,7 @@ async fn listener_reserves_one_zcashd_compat_inbound_slot() {
         bans_rx,
         vec![IpAddr::V6(zcashd_compat_ip.to_ipv6_mapped())],
         active_inbound_connections,
+        recent_inbound_connections,
     );
     let listen_task_handle = tokio::spawn(listen_fut);
 
@@ -1276,6 +1290,7 @@ async fn listener_zcashd_compat_reconnect_bypasses_recent_ip_limit() {
     let (_bans_tx, bans_rx) = tokio::sync::watch::channel(Default::default());
 
     let active_inbound_connections = test_inbound_counter(&config);
+    let recent_inbound_connections = test_recent_by_ip(&config);
     let listen_fut = accept_inbound_connections(
         config,
         tcp_listener,
@@ -1285,6 +1300,7 @@ async fn listener_zcashd_compat_reconnect_bypasses_recent_ip_limit() {
         bans_rx,
         vec![zcashd_compat_ip.into()],
         active_inbound_connections,
+        recent_inbound_connections,
     );
     let listen_task_handle = tokio::spawn(listen_fut);
 
@@ -1343,6 +1359,7 @@ async fn listener_bans_zcashd_compat_peer_before_reserved_slot() {
     );
 
     let active_inbound_connections = test_inbound_counter(&config);
+    let recent_inbound_connections = test_recent_by_ip(&config);
     let listen_fut = accept_inbound_connections(
         config,
         tcp_listener,
@@ -1352,6 +1369,7 @@ async fn listener_bans_zcashd_compat_peer_before_reserved_slot() {
         bans_rx,
         vec![zcashd_compat_ip.into()],
         active_inbound_connections,
+        recent_inbound_connections,
     );
     let listen_task_handle = tokio::spawn(listen_fut);
 
@@ -1432,6 +1450,7 @@ async fn listener_canonicalizes_ipv4_mapped_inbound_addrs() {
     let (_bans_tx, bans_rx) = tokio::sync::watch::channel(Default::default());
 
     let active_inbound_connections = test_inbound_counter(&config);
+    let recent_inbound_connections = test_recent_by_ip(&config);
     let listen_fut = accept_inbound_connections(
         config,
         tcp_listener,
@@ -1441,6 +1460,7 @@ async fn listener_canonicalizes_ipv4_mapped_inbound_addrs() {
         bans_rx,
         Vec::new(),
         active_inbound_connections,
+        recent_inbound_connections,
     );
     let listen_task_handle = tokio::spawn(listen_fut);
 
@@ -1524,6 +1544,7 @@ async fn listener_bans_ipv4_mapped_inbound_connection() {
     );
 
     let active_inbound_connections = test_inbound_counter(&config);
+    let recent_inbound_connections = test_recent_by_ip(&config);
     let listen_fut = accept_inbound_connections(
         config,
         tcp_listener,
@@ -1533,6 +1554,7 @@ async fn listener_bans_ipv4_mapped_inbound_connection() {
         bans_rx,
         Vec::new(),
         active_inbound_connections,
+        recent_inbound_connections,
     );
     let listen_task_handle = tokio::spawn(listen_fut);
 
@@ -2544,6 +2566,7 @@ where
 
     // Start listening for connections.
     let active_inbound_connections = test_inbound_counter(&config);
+    let recent_inbound_connections = test_recent_by_ip(&config);
     let listen_fut = accept_inbound_connections(
         config.clone(),
         tcp_listener,
@@ -2553,6 +2576,7 @@ where
         bans_rx,
         Vec::new(),
         active_inbound_connections,
+        recent_inbound_connections,
     );
     let listen_task_handle = tokio::spawn(listen_fut);
 
@@ -2867,6 +2891,7 @@ async fn v2_listener_rejects_banned_peers() {
         peerset_tx,
         bans_rx,
         test_inbound_counter(&config),
+        test_recent_by_ip(&config),
     );
     let v2_task_handle = tokio::spawn(v2_fut);
 

--- a/zebra-network/src/peer_set/initialize/tests/vectors.rs
+++ b/zebra-network/src/peer_set/initialize/tests/vectors.rs
@@ -1977,9 +1977,7 @@ async fn self_connections_should_fail() {
     .await;
 
     // Insert our own address into the address book, and make sure it works
-    let real_self_listener =
-        MetaAddr::new_local_listener_change(address_book.local_listener_socket_addr())
-            .local_listener_into_new_meta_addr(Utc::now().try_into().expect("in range"));
+    let real_self_listener = address_book.local_listener_meta_addr(Utc::now());
 
     // Set a fake listener on the book to get past the check for adding our
     // own address. The change below travels the same channel, so it is
@@ -2245,24 +2243,24 @@ async fn local_listener_port_with(listen_addr: SocketAddr, network: Network) {
         "Test user agent".to_string(),
     )
     .await;
-    let local_listener = peer_book_reader.local_listener_socket_addr();
+    let local_listener = peer_book_reader.local_listener_meta_addr(Utc::now());
 
     if listen_addr.port() == 0 {
         assert_ne!(
-            local_listener.port(),
+            local_listener.addr.port(),
             0,
             "dynamic ports are replaced with OS-assigned ports"
         );
     } else {
         assert_eq!(
-            local_listener.port(),
+            local_listener.addr.port(),
             listen_addr.port(),
             "fixed ports are correctly propagated"
         );
     }
 
     assert_eq!(
-        local_listener.ip(),
+        local_listener.addr.ip(),
         listen_addr.ip(),
         "IP addresses are correctly propagated"
     );

--- a/zebra-network/src/peer_set/initialize/v2_transport.rs
+++ b/zebra-network/src/peer_set/initialize/v2_transport.rs
@@ -6,17 +6,18 @@
 //! ordinary peer [`Client`](crate::peer::Client)s, which join the peer set
 //! alongside legacy peers.
 
-use std::{net::IpAddr, sync::Arc};
+use std::{net::IpAddr, pin::Pin, sync::Arc};
 
-use futures::SinkExt;
+use futures::{future::FutureExt, stream::FuturesUnordered, Future, SinkExt, StreamExt};
 use indexmap::IndexMap;
 use tokio::sync::watch;
 use tower::{Service, ServiceExt};
 use tracing::{debug, info, warn, Instrument};
 
-use zebra_chain::chain_tip::ChainTip;
+use zebra_chain::{chain_tip::ChainTip, diagnostic::task::WaitForPanics};
 
 use crate::{
+    connection_metrics::{record_connection_attempt_finished, ConnectionDirection},
     constants,
     peer::{
         v2::{V2HandshakeRequest, V2Handshaker},
@@ -85,11 +86,37 @@ where
     C: ChainTip + Clone + Send + Sync + 'static,
 {
     // Accept inbound v2 connections.
+    //
     // The inbound handshakes currently in progress; above the threshold,
     // unvalidated addresses are asked to retry with a token.
     let pending_handshakes = crate::peer_set::SlotCounter::default();
 
-    while let Some(incoming) = endpoint.accept().await {
+    // The per-connection handshake tasks are supervised, so a panic in any
+    // of them stops the node instead of silently reducing the transport's
+    // connectivity.
+    let mut handshake_tasks: FuturesUnordered<Pin<Box<dyn Future<Output = ()> + Send>>> =
+        FuturesUnordered::new();
+    // Keeping an unresolved future in the pool means the stream never terminates.
+    handshake_tasks.push(futures::future::pending().boxed());
+
+    loop {
+        // Check for panics in finished tasks, before accepting new connections.
+        let incoming = tokio::select! {
+            biased;
+            joined = handshake_tasks.next() => match joined {
+                Some(()) => continue,
+                None => unreachable!(
+                    "handshake_tasks never terminates, because it contains a future that never resolves"
+                ),
+            },
+
+            // This future must wait until new connections are available: it can't have a timeout.
+            incoming = endpoint.accept() => match incoming {
+                Some(incoming) => incoming,
+                // The endpoint was closed: this node is shutting down.
+                None => return Ok(()),
+            },
+        };
         // # Security
         //
         // Above a threshold of concurrently pending handshakes — as under a
@@ -139,11 +166,17 @@ where
         // Counts this attempt as a pending handshake until it completes.
         let pending_slot = pending_handshakes.claim();
 
-        tokio::spawn(
+        let handshake_task = tokio::spawn(
             async move {
                 let connection = match quic::accept(incoming, &network).await {
                     Ok(connection) => connection,
                     Err(error) => {
+                        record_connection_attempt_finished(
+                            &network,
+                            ConnectionDirection::Inbound,
+                            addr,
+                            Some(&error),
+                        );
                         debug!(%error, ?addr, "inbound v2 connection failed");
                         return;
                     }
@@ -160,6 +193,13 @@ where
                     .await;
                 drop(pending_slot);
 
+                record_connection_attempt_finished(
+                    &network,
+                    ConnectionDirection::Inbound,
+                    addr,
+                    client.as_ref().err(),
+                );
+
                 match client {
                     Ok(client) => {
                         let _ = peerset_tx.send((addr, client)).await;
@@ -169,10 +209,14 @@ where
             }
             .in_current_span(),
         );
+        handshake_tasks.push(handshake_task.wait_for_panics().boxed());
 
         // Rate-limit inbound connections, like the legacy listener.
         tokio::time::sleep(constants::MIN_INBOUND_PEER_CONNECTION_INTERVAL).await;
-    }
 
-    Ok(())
+        // Security: Let other tasks run after each connection is processed,
+        // so remote peers cannot starve other Zebra tasks using inbound
+        // connections. (Sleeps are not guaranteed to schedule other tasks.)
+        tokio::task::yield_now().await;
+    }
 }

--- a/zebra-network/src/peer_set/initialize/v2_transport.rs
+++ b/zebra-network/src/peer_set/initialize/v2_transport.rs
@@ -77,6 +77,7 @@ pub(super) async fn run_v2_endpoint<S, C>(
     peerset_tx: futures::channel::mpsc::Sender<DiscoveredPeer>,
     bans_receiver: watch::Receiver<Arc<IndexMap<crate::peer_book::BanKey, std::time::Instant>>>,
     active_inbound_connections: SharedConnectionCounter,
+    recent_inbound_connections: watch::Sender<recent_by_ip::RecentByIp>,
 ) -> Result<(), BoxError>
 where
     S: Service<Request, Response = Response, Error = BoxError> + Clone + Send + 'static,
@@ -84,9 +85,6 @@ where
     C: ChainTip + Clone + Send + Sync + 'static,
 {
     // Accept inbound v2 connections.
-    let mut recent_inbound_connections =
-        recent_by_ip::RecentByIp::new(None, Some(config.max_connections_per_ip));
-
     // The inbound handshakes currently in progress; above the threshold,
     // unvalidated addresses are asked to retry with a token.
     let pending_handshakes = crate::peer_set::SlotCounter::default();
@@ -124,10 +122,9 @@ where
         let Some(connection_tracker) = inbound_admission::try_reserve_public_inbound_slot(
             &config.network,
             addr,
-            active_inbound_connections.update_count(),
             config.peerset_inbound_connection_limit(),
             &active_inbound_connections,
-            &mut recent_inbound_connections,
+            &recent_inbound_connections,
         ) else {
             incoming.refuse();
             // Allow invalid connections to be cleared quickly, but still put a

--- a/zebra-network/src/peer_set/limit.rs
+++ b/zebra-network/src/peer_set/limit.rs
@@ -200,62 +200,154 @@ impl Drop for ActiveConnectionCounter {
     }
 }
 
-/// An [`ActiveConnectionCounter`] shared by the tasks that open connections
-/// of the same kind.
+/// A connection counter shared by the tasks that open connections of the
+/// same kind, counting with atomic slots instead of a single owner.
 ///
 /// The legacy and version 2 transports accept and dial connections from
 /// separate tasks, but their connections share one limit, so they must share
 /// one counter: separate counters would let each transport fill the limit on
 /// its own, doubling the connections an operator configured.
 #[derive(Clone, Debug)]
-pub struct SharedConnectionCounter(Arc<std::sync::Mutex<ActiveConnectionCounter>>);
+pub struct SharedConnectionCounter {
+    /// The reserved and open connection slots currently held.
+    slots: SlotCounter,
+
+    /// The number of slots whose trackers have been marked open, for
+    /// diagnostics.
+    open: Arc<AtomicUsize>,
+
+    /// The limit for this type of connection, for diagnostics only.
+    /// The caller must enforce the limit by ignoring, delaying, or dropping
+    /// connections, or by reserving slots with
+    /// [`try_track_connection`](Self::try_track_connection).
+    limit: usize,
+
+    /// The label for this connection counter, typically its type.
+    label: Arc<str>,
+
+    /// Active connection count progress bar, closed when the last clone of
+    /// this counter is dropped.
+    #[cfg(feature = "progress-bar")]
+    connection_bar: Arc<ConnectionBar>,
+}
+
+/// Closes the progress bar of a [`SharedConnectionCounter`] when its last
+/// clone is dropped.
+#[cfg(feature = "progress-bar")]
+struct ConnectionBar(howudoin::Tx);
+
+// `howudoin::Tx` does not implement `Debug`, so it cannot be derived.
+#[cfg(feature = "progress-bar")]
+impl fmt::Debug for ConnectionBar {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("ConnectionBar").finish()
+    }
+}
+
+#[cfg(feature = "progress-bar")]
+impl Drop for ConnectionBar {
+    fn drop(&mut self) {
+        self.0.close();
+    }
+}
 
 impl SharedConnectionCounter {
     /// Create and return a new shared connection counter with `limit` and
     /// `label`. The caller must check and enforce limits using
-    /// [`update_count()`](Self::update_count).
+    /// [`update_count()`](Self::update_count), or reserve slots atomically
+    /// with [`try_track_connection`](Self::try_track_connection).
     pub fn new_counter_with<S: ToString>(limit: usize, label: S) -> Self {
-        Self(Arc::new(std::sync::Mutex::new(
-            ActiveConnectionCounter::new_counter_with(limit, label),
-        )))
+        let label = label.to_string();
+
+        #[cfg(feature = "progress-bar")]
+        let connection_bar = Arc::new(ConnectionBar(howudoin::new_root().label(label.clone())));
+
+        Self {
+            slots: SlotCounter::default(),
+            open: Arc::new(AtomicUsize::new(0)),
+            limit,
+            label: label.into(),
+            #[cfg(feature = "progress-bar")]
+            connection_bar,
+        }
     }
 
-    /// Check for closed connection notifications, and return the current connection count.
+    /// Returns the current connection count, including reserved slots for
+    /// connection attempts.
     pub fn update_count(&self) -> usize {
-        self.lock().update_count()
+        let count = self.slots.count();
+
+        trace!(
+            open_connections = ?count,
+            limit = ?self.limit,
+            label = ?self.label,
+            "updated active connection count",
+        );
+
+        #[cfg(feature = "progress-bar")]
+        self.connection_bar
+            .0
+            .set_pos(u64::try_from(self.open.load(Ordering::Acquire)).expect("fits in u64"));
+
+        count
     }
 
     /// Create and return a new [`ConnectionTracker`], and add 1 to this counter.
     ///
-    /// When the returned tracker is dropped, this counter will be notified, and decreased by 1.
+    /// When the returned tracker is dropped, this counter is decreased by 1.
     pub fn track_connection(&self) -> ConnectionTracker {
-        self.lock().track_connection()
+        ConnectionTracker::new_shared(self, self.slots.claim())
     }
 
-    /// Locks the counter.
+    /// Atomically checks the current connection count against `limit`, and
+    /// creates and returns a new [`ConnectionTracker`] if the count is below
+    /// the limit.
     ///
-    /// The lock is only held for the duration of a counter update, and is
-    /// never held across an await point.
-    fn lock(&self) -> std::sync::MutexGuard<'_, ActiveConnectionCounter> {
-        self.0.lock().expect("mutex is not poisoned")
+    /// # Security
+    ///
+    /// The check and the reservation are one atomic update, so tasks sharing
+    /// this counter cannot both pass the check at the last free slot and
+    /// overshoot the limit.
+    pub fn try_track_connection(&self, limit: usize) -> Option<ConnectionTracker> {
+        let slot = self.slots.try_claim(limit)?;
+        Some(ConnectionTracker::new_shared(self, slot))
     }
 }
 
 /// A per-connection tracker.
 ///
-/// [`ActiveConnectionCounter`] creates a tracker instance for each active connection.
-/// When these trackers are dropped, the counter gets notified.
+/// [`ActiveConnectionCounter`] and [`SharedConnectionCounter`] create a
+/// tracker instance for each active connection. When these trackers are
+/// dropped, the counter is notified or decreased.
 pub struct ConnectionTracker {
-    /// The channel used to send open connection status notifications on first response or
-    /// closed connection notifications on drop.
-    status_notification_tx: mpsc::UnboundedSender<ConnectionStatus>,
+    /// The counter this tracker reports to.
+    counter: TrackerCounter,
 
-    /// A flag indicating whether this connection tracker has sent a notification that the
-    /// connection has been opened and that another notification should not be sent on drop.
+    /// A flag indicating whether this connection tracker has already counted the
+    /// connection as opened, so it is not double-counted.
     has_marked_open: bool,
 
     /// The label for this connection counter, typically its type.
     label: Arc<str>,
+}
+
+/// The counter a [`ConnectionTracker`] reports to.
+enum TrackerCounter {
+    /// A single-owner [`ActiveConnectionCounter`], notified over its channel.
+    Channel {
+        /// The channel used to send open connection status notifications on first response or
+        /// closed connection notifications on drop.
+        status_notification_tx: mpsc::UnboundedSender<ConnectionStatus>,
+    },
+
+    /// A [`SharedConnectionCounter`], holding one of its atomic slots.
+    Shared {
+        /// The held slot; dropping it decreases the shared count.
+        _slot: SlotGuard,
+
+        /// The shared counter's open-connection diagnostic count.
+        open: Arc<AtomicUsize>,
+    },
 }
 
 impl fmt::Debug for ConnectionTracker {
@@ -267,12 +359,23 @@ impl fmt::Debug for ConnectionTracker {
 }
 
 impl ConnectionTracker {
-    /// Sends a notification to the status notification channel to count the connection as open, and
-    /// marks this [`ConnectionTracker`] as having sent that open notification to avoid double-counting.
+    /// Counts the connection as open, exactly once: later calls and the
+    /// implicit call on drop are ignored.
     pub fn mark_open(&mut self) {
         if !self.has_marked_open {
-            let _ = self.status_notification_tx.send(ConnectionStatus::Opened);
             self.has_marked_open = true;
+
+            match &self.counter {
+                TrackerCounter::Channel {
+                    status_notification_tx,
+                } => {
+                    let _ = status_notification_tx.send(ConnectionStatus::Opened);
+                }
+                TrackerCounter::Shared { open, .. } => {
+                    open.fetch_add(1, Ordering::AcqRel);
+                    debug!(label = ?self.label, "a peer connection was opened");
+                }
+            }
         }
     }
 
@@ -291,7 +394,32 @@ impl ConnectionTracker {
         );
 
         Self {
-            status_notification_tx: counter.status_notification_tx.clone(),
+            counter: TrackerCounter::Channel {
+                status_notification_tx: counter.status_notification_tx.clone(),
+            },
+            has_marked_open: false,
+            label: counter.label.clone(),
+        }
+    }
+
+    /// Create and return a new active connection tracker holding `slot` of
+    /// `counter`'s slots.
+    ///
+    /// When the returned tracker is dropped, the slot is released, and the
+    /// shared count decreases by 1.
+    fn new_shared(counter: &SharedConnectionCounter, slot: SlotGuard) -> Self {
+        debug!(
+            open_connections = ?counter.slots.count(),
+            limit = ?counter.limit,
+            label = ?counter.label,
+            "opening a new peer connection",
+        );
+
+        Self {
+            counter: TrackerCounter::Shared {
+                _slot: slot,
+                open: counter.open.clone(),
+            },
             has_marked_open: false,
             label: counter.label.clone(),
         }
@@ -303,19 +431,28 @@ impl Drop for ConnectionTracker {
     fn drop(&mut self) {
         debug!(label = ?self.label, "closing a peer connection");
 
-        // We ignore disconnected errors, because the receiver can be dropped
-        // before some connections are dropped.
-        //
-        // # Security
-        //
-        // This channel is actually bounded by the inbound and outbound connection limit.
-        //
         // # Correctness
         //
-        // Unopened connections should be opened just before being closed to decrement both
-        // the count for pending connection attempts and the count for open connections in
-        // the active connection tracker.
+        // Unopened connections are opened just before being closed, so both
+        // the pending-attempt count and the open count are balanced.
         self.mark_open();
-        let _ = self.status_notification_tx.send(ConnectionStatus::Closed);
+
+        match &self.counter {
+            // We ignore disconnected errors, because the receiver can be dropped
+            // before some connections are dropped.
+            //
+            // # Security
+            //
+            // This channel is actually bounded by the inbound and outbound connection limit.
+            TrackerCounter::Channel {
+                status_notification_tx,
+            } => {
+                let _ = status_notification_tx.send(ConnectionStatus::Closed);
+            }
+            // The held slot is released when this tracker drops.
+            TrackerCounter::Shared { open, .. } => {
+                open.fetch_sub(1, Ordering::AcqRel);
+            }
+        }
     }
 }

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -139,7 +139,7 @@ use crate::{
     },
     protocol::{
         external::InventoryHash,
-        internal::{Request, Response},
+        internal::{PeerCapability, Request, Response},
     },
     BoxError, Config, PeerError, PeerSocketAddr, SharedPeerError,
 };
@@ -913,15 +913,17 @@ where
         }
     }
 
-    /// Performs P2C over the ready peers that can answer the request.
+    /// Performs P2C on `self.ready_services` to randomly select a less-loaded ready service.
+    /// Performs P2C over the ready peers that can answer `capability`.
     ///
-    /// Returns `None` when no ready peer can, so the caller reports no ready
-    /// peers instead of spending the request on one that will refuse it.
-    fn select_ready_p2c_peer(&self, requires_v2: bool) -> Option<D::Key> {
+    /// Returns `None` when no ready peer supports it, so the caller can fall
+    /// back to a request every peer understands, instead of spending the
+    /// request on a peer that will refuse it.
+    fn select_ready_p2c_peer(&self, capability: PeerCapability) -> Option<D::Key> {
         let capable: HashSet<D::Key> = self
             .ready_services
             .iter()
-            .filter(|(_key, svc)| !requires_v2 || svc.is_v2())
+            .filter(|(_key, svc)| capability == PeerCapability::Any || svc.is_v2())
             .map(|(key, _svc)| *key)
             .collect();
 
@@ -1053,7 +1055,7 @@ where
 
     /// Routes a request using P2C load-balancing.
     fn route_p2c(&mut self, req: Request) -> <Self as tower::Service<Request>>::Future {
-        if let Some(p2c_key) = self.select_ready_p2c_peer(req.requires_v2_peer()) {
+        if let Some(p2c_key) = self.select_ready_p2c_peer(req.peer_capability()) {
             tracing::trace!(?p2c_key, "routing based on p2c");
 
             let mut svc = self

--- a/zebra-network/src/peer_set/set.rs
+++ b/zebra-network/src/peer_set/set.rs
@@ -913,9 +913,19 @@ where
         }
     }
 
-    /// Performs P2C on `self.ready_services` to randomly select a less-loaded ready service.
-    fn select_p2c_peer(&self) -> Option<D::Key> {
-        self.select_p2c_peer_from_list(&self.ready_services.keys().copied().collect())
+    /// Performs P2C over the ready peers that can answer the request.
+    ///
+    /// Returns `None` when no ready peer can, so the caller reports no ready
+    /// peers instead of spending the request on one that will refuse it.
+    fn select_ready_p2c_peer(&self, requires_v2: bool) -> Option<D::Key> {
+        let capable: HashSet<D::Key> = self
+            .ready_services
+            .iter()
+            .filter(|(_key, svc)| !requires_v2 || svc.is_v2())
+            .map(|(key, _svc)| *key)
+            .collect();
+
+        self.select_p2c_peer_from_list(&capable)
     }
 
     /// Performs P2C on `ready_service_list` to randomly select a less-loaded ready service.
@@ -1043,7 +1053,7 @@ where
 
     /// Routes a request using P2C load-balancing.
     fn route_p2c(&mut self, req: Request) -> <Self as tower::Service<Request>>::Future {
-        if let Some(p2c_key) = self.select_p2c_peer() {
+        if let Some(p2c_key) = self.select_ready_p2c_peer(req.requires_v2_peer()) {
             tracing::trace!(?p2c_key, "routing based on p2c");
 
             let mut svc = self

--- a/zebra-network/src/protocol/internal.rs
+++ b/zebra-network/src/protocol/internal.rs
@@ -2,6 +2,6 @@ mod request;
 mod response;
 mod response_status;
 
-pub use request::Request;
+pub use request::{PeerCapability, Request};
 pub use response::Response;
 pub use response_status::InventoryResponse;

--- a/zebra-network/src/protocol/internal/request.rs
+++ b/zebra-network/src/protocol/internal/request.rs
@@ -292,6 +292,35 @@ pub enum Request {
     },
 }
 
+/// What a peer must support to answer a [`Request`].
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum PeerCapability {
+    /// Any connected peer can answer.
+    Any,
+
+    /// Only version 2 peers can answer: the request has no legacy protocol
+    /// encoding.
+    V2,
+}
+
+impl Request {
+    /// Returns what a peer must support to answer this request.
+    pub fn peer_capability(&self) -> PeerCapability {
+        match self {
+            // Bulk block streaming is a version 2 request stream, with no
+            // legacy equivalent: the legacy locator walk is used instead.
+            Request::BlockRange { .. } => PeerCapability::V2,
+
+            // Answered by the local inbound service, never routed to a
+            // peer; the peer set treats them as unroutable rather than
+            // sending them anywhere.
+            Request::SyncHashes { .. } | Request::TreeRoots { .. } => PeerCapability::V2,
+
+            _ => PeerCapability::Any,
+        }
+    }
+}
+
 impl fmt::Display for Request {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(&match self {
@@ -330,20 +359,6 @@ impl fmt::Display for Request {
 }
 
 impl Request {
-    /// Returns true if only version 2 peers can answer this request.
-    ///
-    /// Bulk block streaming is a version 2 request stream, with no legacy
-    /// equivalent: the legacy locator walk is used instead. The
-    /// synchronization primitives are answered by the local inbound
-    /// service, so the peer set treats them as unroutable rather than
-    /// sending them to a legacy peer that would refuse them.
-    pub fn requires_v2_peer(&self) -> bool {
-        matches!(
-            self,
-            Request::BlockRange { .. } | Request::SyncHashes { .. } | Request::TreeRoots { .. }
-        )
-    }
-
     /// Returns the Zebra internal request type as a string.
     pub fn command(&self) -> &'static str {
         match self {

--- a/zebra-network/src/protocol/internal/request.rs
+++ b/zebra-network/src/protocol/internal/request.rs
@@ -330,6 +330,20 @@ impl fmt::Display for Request {
 }
 
 impl Request {
+    /// Returns true if only version 2 peers can answer this request.
+    ///
+    /// Bulk block streaming is a version 2 request stream, with no legacy
+    /// equivalent: the legacy locator walk is used instead. The
+    /// synchronization primitives are answered by the local inbound
+    /// service, so the peer set treats them as unroutable rather than
+    /// sending them to a legacy peer that would refuse them.
+    pub fn requires_v2_peer(&self) -> bool {
+        matches!(
+            self,
+            Request::BlockRange { .. } | Request::SyncHashes { .. } | Request::TreeRoots { .. }
+        )
+    }
+
     /// Returns the Zebra internal request type as a string.
     pub fn command(&self) -> &'static str {
         match self {

--- a/zebra-network/src/protocol/v2/SPEC-CONFORMANCE.md
+++ b/zebra-network/src/protocol/v2/SPEC-CONFORMANCE.md
@@ -1,0 +1,101 @@
+# v2 P2P Protocol — Spec Conformance Tracking
+
+Implemented against the draft ZIPs in zcash/zips PR [#1346] at revision
+**`a3f4fa2a`** ("Harden misbehavior tracking against induced-ban and
+misattribution attacks", 2026-08-06), which includes the PR [#1344] transport
+draft. The drafts are unreviewed past daira's 2026-08-04 pass on #1344, so
+sections added after that pass are expected to move; on every draft change,
+update the pinned revision here and re-check the affected rows.
+
+[#1344]: https://github.com/zcash/zips/pull/1344
+[#1346]: https://github.com/zcash/zips/pull/1346
+
+Status legend: ✓/● implemented · ◐ partial · ✗ absent. Gap numbers (G1–G23)
+and phase numbers refer to the implementation plan.
+
+The remaining ◐ and ✗ entries are deferred for recorded reasons:
+client-side synchronization scheduling converges with the ibd-engine work;
+the Tor transport is blocked on an `arti` dependency conflict; per-address
+transport hints need a draft change (feedback item 3); and
+`MIN_V2_PROTOCOL_VERSION` needs a network upgrade assignment.
+
+| Draft section | Implementing module | Tests | Status |
+|---|---|---|---|
+| Network Parameters / Networks (ALPN) | `protocol/v2/quic.rs`, `protocol/v2/constants.rs` | `protocol/v2/quic/tests/vectors.rs` | ◐ custom-testnet ALPN unresolved (G15, spec feedback) |
+| DNS Seeds | — (external seeder work) | — | ✗ deployment (Phase 7) |
+| Peer Discovery | `peer_set/initialize.rs`, `peer_book/transports.rs` | `peer_book/transports/tests.rs` | ◐ the crawler dials whichever transport a peer is known to accept, and probes unknown peers, because addresses carry no transport hint (feedback item 3); learned reachability is not persisted across restarts (G12) |
+| Transports / Connection Management | `peer_set/initialize/{v2_transport,inbound_admission}.rs`, `peer/v2/connector.rs`, `peer_set/limit.rs` | `peer_set/initialize/tests/vectors.rs` | ◐ both transports share one admission path, one connection counter and one connector interface; the shared limits are tested through the v1 listener, the v2 dial policy is not yet tested |
+| QUIC Transport | `protocol/v2/quic.rs`, `peer_set/initialize/v2_transport.rs` | `protocol/v2/quic/tests/vectors.rs` | ● retry-token address validation required above 32 concurrently pending inbound handshakes (G7; stateless retry path is quinn-provided, not separately tested); UDP buffer/GSO tuning left to quinn defaults |
+| QUIC / Certificates | `protocol/v2/quic.rs` | `protocol/v2/quic/tests/vectors.rs` | ◐ presents X.509/Ed25519; accepts X.509 with Ed25519 + P-256; RFC 7250 raw public keys blocked on rustls (G6, spec feedback item 2) |
+| QUIC / Bulk Transfer Performance | `protocol/v2/quic.rs` | — | ✗ bulk flow-control profile (G16, Phase 5) |
+| QUIC / Stream Layer Mapping | `protocol/v2/quic.rs` | `peer/v2/service/tests/vectors.rs` | ✓ |
+| Tor Transport | — | — | ✗ blocked on the `arti` x25519-dalek version conflict. A sans-IO framing layer was written and then removed as unreachable code; recover it from git history when `arti` unblocks |
+| Stream Layer / Transport Requirements | `protocol/v2/quic.rs` | `protocol/v2/quic/tests/vectors.rs` | ✓ stream limits, no datagrams, 0-RTT never negotiable (G20) |
+| Stream Types | `protocol/v2/types.rs` | `protocol/v2/tests/vectors.rs`, `peer/v2/service/tests/vectors.rs` | ✓ `0x00`–`0x09`, `0x10`–`0x12`; unknown types refused without penalty, both directions |
+| Request Streams | `peer/v2/connection.rs` | `peer/v2/service/tests/vectors.rs` | ✓ incl. stalled-stream abandonment after `INBOUND_STREAM_TIMEOUT` |
+| Announcement Streams | `peer/v2/connection.rs` | `peer/v2/service/tests/vectors.rs` | ✓ singleton rule + reopen-after-reset tested; own-listener announcements sent on every connection (G9) |
+| Records | `protocol/v2/record.rs` | `protocol/v2/tests/vectors.rs` | ✓ |
+| Application Error Codes | `protocol/v2/types.rs` | `protocol/v2/tests/vectors.rs` | ✓ |
+| CompactSize | `protocol/v2/record.rs` (via `zebra-chain` `CompactSize64`) | `protocol/v2/tests/vectors.rs` | ✓ canonical both directions |
+| Strings | `protocol/v2/init.rs` | `protocol/v2/tests/vectors.rs` | ✓ |
+| Serialized Blocks | `zebra-chain` serialization | `protocol/v2/tests/vectors.rs` | ✓ |
+| Network Address Record | `protocol/external/addr/v2.rs` | `protocol/external/addr` tests | ✓ |
+| Transaction References | `protocol/v2/txref.rs` | `protocol/v2/tests/vectors.rs`, `peer/v2/service/tests/vectors.rs` | ✓ incl. wrong-typed `get-tx` refs answered not-found, no penalty |
+| Service Flags | `protocol/external/types.rs`, `peer_set/initialize.rs` | — | ● bits 3/4/10 defined; `NODE_TREE_ROOTS` advertised (index backfilled by the state upgrade; pre-backfill requests refused); `NODE_SYNC_ARTIFACTS` advertised when the artifact directory exists; `NODE_NETWORK_LIMITED` unused (full nodes advertise `NODE_NETWORK`) |
+| Connection Handshake | `protocol/v2/init.rs`, `peer/v2/handshake.rs` | `peer/v2/handshake/tests/vectors.rs` | ✓ |
+| Protocol Versioning | `protocol/v2/constants.rs` (`MIN_V2_PROTOCOL_VERSION` placeholder), `peer_set/set.rs` | — | ◐ NU assignment pending; mid-connection epoch enforcement shared with v1 (G14): `disconnect_from_outdated_peers` reads the v2 init version via `RemoteHandshake`, and handshakes enforce `max(MIN_V2, MinimumPeerVersion)` |
+| `get-headers` | `protocol/v2/{request,response}.rs`, `peer/v2/connection.rs` | `protocol/v2/tests/vectors.rs`, `peer/v2/service/tests/vectors.rs` | ● served incl. `tx_ids` (coinbase + full IDs; unavailable blocks answer `has_txs = 0`); requester side sends `tx_ids = 0` until Phase 5 |
+| `get-blocks` | `protocol/v2/{request,response}.rs`, `peer/v2/connection.rs` | `protocol/v2/tests/vectors.rs`, `peer/v2/service/tests/vectors.rs` | ✓ hash-only requests, full-block results (G1) |
+| `get-tx` | `protocol/v2/{request,response,txref}.rs`, `peer/v2/connection.rs` | `protocol/v2/tests/vectors.rs`, `peer/v2/service/tests/vectors.rs` | ✓ |
+| `get-addr` | `protocol/v2/{request,response}.rs`, `peer/v2/connection.rs` | `protocol/v2/tests/vectors.rs`, `peer/v2/service/tests/vectors.rs` | ✓ direction policy + at most one request per connection (G8) |
+| `get-mempool` | `protocol/v2/{request,response}.rs`, `peer/v2/connection.rs` | `protocol/v2/tests/vectors.rs`, `peer/v2/service/tests/vectors.rs` | ● subscription: snapshot records then per-batch updates (lag → re-snapshot; duplicates allowed, not deduped); single-concurrent enforced (PROTOCOL_ERROR), sequential re-subscribe served, prompt cancel detection; requester keeps one subscription per connection, mirrors into a 50k-bounded cache answering internal mempool requests |
+| `get-hashes` | `protocol/v2/{request,response}.rs`, `peer/v2/connection.rs`, `zebra-state` | `protocol/v2/tests/vectors.rs`, `peer/v2/service/tests/vectors.rs` | ● served from the state sync-metadata index: best-chain hashes + span sums, tip margin of `MAX_BLOCK_REORG_HEIGHT` (stricter than the draft's 100), prefix truncation (also at the backfill frontier); client Phase 5 |
+| `get-block-range` | `protocol/v2/request.rs`, `peer/v2/connection.rs` | `protocol/v2/tests/vectors.rs`, `peer/v2/service/tests/vectors.rs` | ● serve: descending parent-walk streaming, exact `count`/`max_bytes` bounds with the first-block rule, not-found result, early-finish truncation, ≤2 concurrent bulk streams per peer (REFUSED beyond); request (internal `Request::BlockRange`): on-arrival anchor/parent-link/merkle verification (violations → PROTOCOL_ERROR), bound overruns → FLOOD, truncation-resumable; scheduler integration converges with ibd-engine |
+| `get-tree-roots` | `protocol/v2/{request,response}.rs`, `peer/v2/connection.rs`, `zebra-state` | `protocol/v2/tests/vectors.rs`, `peer/v2/service/tests/vectors.rs` | ● served: anchor-at-height membership check (REFUSED on mismatch or missing index), per-height sapling/orchard/ironwood roots (zeros pre-activation), ZIP 221 counts + `auth_data_root` from the index; client verification Phase 5 |
+| `get-object` | `protocol/v2/request.rs`, `peer/v2/connection.rs`, `config/cache_dir.rs` | `protocol/v2/tests/vectors.rs`, `peer/v2/service/tests/vectors.rs` | ● served from the cache-dir artifact directory (hex-named content-addressed files): exact `offset`/`length`/size bounds, size-only answers past the end, not-found for unheld objects, `REFUSED` + no `NODE_SYNC_ARTIFACTS` without the directory; artifact population (known-hash chunks) is operator/ibd-engine work; client Phase 5 |
+| Block Announcements | `peer/v2/connection.rs` | `peer/v2/service/tests/vectors.rs` | ● send: compact to `announce = 1` peers (`full_ids` honored), header otherwise + oversize substitute; receive: both kinds, kind 0x01 only when locally requested, context-free header PoW checked (invalid → +100); announced-block limit is 1 (no intermediate-header backfill) |
+| Transaction Announcements | `peer/v2/connection.rs` | `peer/v2/service/tests/vectors.rs` | ✓ send + receive (trickling G11, Phase 3) |
+| Address Announcements | `peer/v2/connection.rs` | `peer/v2/service/tests/vectors.rs` | ✓ send (own listener, daily) + receive (G9) |
+| Divided Block Relay | `peer/v2/connection.rs` | `peer/v2/service/tests/vectors.rs` | ◐ `tx_ids` serving done; requester-side reconstruction with Phase 5 (G19) |
+| Compact Block Relay | `protocol/v2/compact_block.rs`, `peer/v2/connection.rs`, `peer/v2/service.rs` | `protocol/v2/tests/vectors.rs`, `peer/v2/service/tests/vectors.rs` | ● HB send + sent-block obligations (SHORTID / full-ref `get-tx`, 8-block/peer bound); HB request on ≤3 self-initiated connections (slot claim, reconnect-only rotation — most-recent-announcer preference simplified); reconstruction: mempool match → `SHORTID`/full-ref `get-tx` → merkle check → `get-blocks` fallback, no penalty; reconstructed blocks answer `BlocksByHash` from a 4-block cache; HB exemption via withheld advertiser (header kind included); LB fetches full blocks (`tx_ids` reconstruction near tip is a MAY, not used) |
+| Headers-First Synchronization | `peer/v2/connection.rs` (`FindBlocks` bridge) | `peer/v2/service/tests/vectors.rs` | ◐ bridged onto `get-headers` (conforming: v2 wire is headers-first); syncer swap + bridge retirement converge with the ibd-engine scheduler (G19) |
+| Checkpointed Synchronization | — | — | ✗ Phase 5 (converges with ibd-engine) |
+| Block Download Parameters | — | — | ✗ Phase 5 |
+| Transaction Relay / Trickling | `peer/v2/connection.rs` | `peer/v2/service/tests/vectors.rs` | ◐ per-connection exponential trickle (mean 5s, 4× cap) batching announcements + subscription updates; blocks untrickled per spec; expiring-soon (TX_EXPIRING_SOON_THRESHOLD) filter not implemented (matches v1 zebrad) |
+| Transaction Expiry / Mempool Policy (penalty exemptions) | `zebrad` syncer/mempool misbehavior senders | — | ◐ audited under G21 (P1.3) |
+| Address Relay / Rate Limiting / Address Book Management / Broadcasting | `peer_book/{actor,buckets,misbehavior}.rs`, `peer/v2/connection.rs` | `peer_book/buckets/tests.rs`, `peer/v2/service/tests/vectors.rs` | ◐ single-owner peer book actor (G8); own-listener announcements (G9); gossiped intake bucketed by secret-keyed /16 (v4) / /32 (v6) group, 256×32, keyed replacement (Address Book Management); per-connection token bucket 0.1/s burst 1000 on v2 announcements (Rate Limiting); misbehavior/ban store keyed by addr / v6-64 (G22/G23); remaining: multi-transport `PeerAddr` keying, persisted reachability, tried-table test-before-evict (G10/G12) |
+| Misbehavior and Banning | `protocol/v2/types.rs` (`WireError::Misbehavior`), `peer/v2/connection.rs`, shared ban mechanism | `peer/v2/service/tests/vectors.rs` | ◐ provable penalties (G21) + address-keyed persistent scores with IPv6 /64 keying and bounded bans (G22, G23); whitelist exemption pending a whitelist config |
+| Deployment | `config.rs` (`v2_listen`, `initial_v2_peers`) | `zebrad` config tests | ◐ config-gated; rollout Phase 7 |
+
+## Spec feedback found during implementation
+
+Items to file against the drafts, discovered while implementing (beyond the
+feedback list already prepared with the implementation plan):
+
+1. `get-hashes` has an explicit MUST that the greatest requested height not
+   exceed `0xFFFFFFFF`, but `get-tree-roots` — whose highest requested
+   height `start_height + count − 1` can also overflow — has no matching
+   rule. An overflowing anchor height cannot exist, so this implementation
+   accepts the request and lets the `final_hash` membership check refuse it,
+   but an explicit rule (or a note that refusal is expected) would make
+   implementations agree.
+
+2. "A node MUST be prepared to accept both certificate encodings (X.509 and
+   raw public key)" is not implementable with rustls (0.23): its RFC 7250
+   support is all-or-nothing per endpoint — a client either offers only
+   `RawPublicKey` in `server_certificate_type` (and stops interoperating
+   with X.509-only peers) or does not offer the extension at all. Offering
+   both types and accepting the peer's choice has no API. Consider
+   downgrading RPK acceptance to SHOULD, or adding a transition note
+   ("X.509 required, raw public keys optional") until TLS implementations
+   can offer both.
+
+3. Network address records carry no indication of which transports a peer
+   is reachable on: `ADDRV2` IPv4/IPv6 entries cover TCP (legacy) and QUIC
+   (v2) implicitly, and the Deployment section's shared-port note means a
+   crawler can only *probe* UDP to discover v2 reachability before
+   activation. A per-address transport hint (a service bit, or an addrv2
+   network ID) would let crawlers dial v2 endpoints directly instead of
+   probing; until then, this implementation probes a small fraction of
+   outbound dials, and relies on DNS seeders probing QUIC as the draft
+   anticipates.

--- a/zebra-network/src/protocol/v2/constants.rs
+++ b/zebra-network/src/protocol/v2/constants.rs
@@ -29,27 +29,27 @@ pub const ALPN_REGTEST: &[u8] = b"zcash/regtest";
 pub const MAX_RECORD_PAYLOAD_LEN: usize = MAX_PROTOCOL_MESSAGE_LEN;
 
 /// The maximum number of block locator hashes in a `get-headers` request.
-pub const MAX_LOCATOR_HASHES: u64 = 101;
+pub const MAX_LOCATOR_HASHES: usize = 101;
 
 /// The maximum number of headers in a `get-headers` response
 /// (`MAX_HEADERS_RESULTS`): the same limit as legacy `headers` messages.
 ///
 /// A response with more headers incurs a misbehavior penalty of
 /// [`MISBEHAVIOR_PENALTY_LIMIT_EXCEEDED`] points.
-pub const MAX_HEADERS_RESULTS: u64 = MAX_HEADERS_PER_MESSAGE as u64;
+pub const MAX_HEADERS_RESULTS: usize = MAX_HEADERS_PER_MESSAGE;
 
 /// The maximum number of block hashes in a `get-blocks` request.
-pub const MAX_GET_BLOCKS_HASHES: u64 = 128;
+pub const MAX_GET_BLOCKS_HASHES: usize = 128;
 
 /// The maximum number of transaction references in a `get-tx` request.
-pub const MAX_GET_TX_REFS: u64 = 50_000;
+pub const MAX_GET_TX_REFS: usize = 50_000;
 
 /// The maximum number of address records in a `get-addr` response: the same
 /// limit as legacy `addr` messages.
 ///
 /// A response with more address records incurs a misbehavior penalty of
 /// [`MISBEHAVIOR_PENALTY_LIMIT_EXCEEDED`] points.
-pub const MAX_ADDRS_IN_RESPONSE: u64 = crate::constants::MAX_ADDRS_IN_MESSAGE as u64;
+pub const MAX_ADDRS_IN_RESPONSE: usize = crate::constants::MAX_ADDRS_IN_MESSAGE;
 
 /// The maximum number of transaction references in a `get-mempool` response.
 ///
@@ -71,10 +71,10 @@ pub const MAX_MEMPOOL_RESPONSE_REFS: usize = MAX_INV_IN_RECEIVED_MESSAGE as usiz
 pub const MAX_MEMPOOL_RECORD_REFS: usize = 25_000;
 
 /// The maximum number of block hashes requested by a `get-hashes` request.
-pub const MAX_GET_HASHES_COUNT: u64 = 50_000;
+pub const MAX_GET_HASHES_COUNT: usize = 50_000;
 
 /// The maximum number of blocks requested by a `get-block-range` request.
-pub const MAX_GET_BLOCK_RANGE_COUNT: u64 = 65_536;
+pub const MAX_GET_BLOCK_RANGE_COUNT: usize = 65_536;
 
 /// The maximum total serialized size of the blocks requested by a
 /// `get-block-range` request, in bytes (64 MiB).
@@ -100,7 +100,7 @@ pub const MAX_PENDING_INBOUND_HANDSHAKES: usize = 32;
 pub const MAX_CONCURRENT_BULK_STREAMS: usize = 2;
 
 /// The maximum number of entries requested by a `get-tree-roots` request.
-pub const MAX_GET_TREE_ROOTS_COUNT: u64 = 4_000;
+pub const MAX_GET_TREE_ROOTS_COUNT: usize = 4_000;
 
 /// The maximum number of bytes requested by a `get-object` request (32 MiB).
 ///

--- a/zebra-network/src/protocol/v2/quic.rs
+++ b/zebra-network/src/protocol/v2/quic.rs
@@ -127,6 +127,11 @@ fn transport_config() -> Result<TransportConfig, BoxError> {
     Ok(transport)
 }
 
+/// Returns the ring [`CryptoProvider`] used for v2 protocol TLS.
+fn crypto_provider() -> Arc<CryptoProvider> {
+    Arc::new(rustls::crypto::ring::default_provider())
+}
+
 /// Builds the QUIC server configuration for `network`.
 ///
 /// The server presents `cert` and `key`, offers the network's ALPN
@@ -136,7 +141,7 @@ pub fn server_config(
     cert: CertificateDer<'static>,
     key: PrivatePkcs8KeyDer<'static>,
 ) -> Result<quinn::ServerConfig, BoxError> {
-    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let provider = crypto_provider();
 
     let mut crypto = rustls::ServerConfig::builder_with_provider(provider)
         .with_protocol_versions(&[&rustls::version::TLS13])?
@@ -156,7 +161,7 @@ pub fn server_config(
 /// The client accepts any server certificate (see
 /// [`AcceptAnyServerCert`]), and offers the network's ALPN identifier.
 pub fn client_config(network: &Network) -> Result<quinn::ClientConfig, BoxError> {
-    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let provider = crypto_provider();
 
     let mut crypto = rustls::ClientConfig::builder_with_provider(provider.clone())
         .with_protocol_versions(&[&rustls::version::TLS13])?

--- a/zebra-network/src/protocol/v2/record.rs
+++ b/zebra-network/src/protocol/v2/record.rs
@@ -48,8 +48,8 @@ pub fn write_compact_size<W: io::Write>(mut writer: W, value: u64) -> Result<(),
 ///
 /// Exceeding the limit is a scored violation rather than a connection
 /// error: the response is discarded, and the peer is penalized.
-pub fn check_recv_limit_scored(count: u64, limit: u64, what: &str) -> Result<(), WireError> {
-    if count > limit {
+pub fn check_recv_limit_scored(count: u64, limit: usize, what: &str) -> Result<(), WireError> {
+    if count > limit as u64 {
         return Err(WireError::Misbehavior {
             points: super::constants::MISBEHAVIOR_PENALTY_LIMIT_EXCEEDED,
             reason: format!("{what} response with {count} entries exceeds the limit {limit}"),
@@ -59,12 +59,41 @@ pub fn check_recv_limit_scored(count: u64, limit: u64, what: &str) -> Result<(),
     Ok(())
 }
 
-/// Checks an outbound count or length against a protocol limit.
+/// Checks an outbound collection length against a protocol limit.
 ///
 /// Exceeding the limit is a [`WireError::Local`] error: this node built the
 /// over-limit message, so the peer is never blamed for it, and the
 /// connection stays open.
-pub fn check_send_limit(value: u64, limit: u64, what: &str) -> Result<(), WireError> {
+pub fn check_send_limit(len: usize, limit: usize, what: &str) -> Result<(), WireError> {
+    if len > limit {
+        return Err(WireError::Local(format!(
+            "attempted to send {len} {what}; the limit is {limit}",
+        )));
+    }
+
+    Ok(())
+}
+
+/// Checks an untrusted collection count from the peer against a protocol
+/// limit.
+///
+/// Exceeding the limit is a connection error of type `PROTOCOL_ERROR`.
+pub fn check_recv_limit(count: u64, limit: usize, what: &str) -> Result<(), WireError> {
+    if count > limit as u64 {
+        return Err(WireError::Protocol(format!(
+            "{what} count {count} exceeds the limit {limit}",
+        )));
+    }
+
+    Ok(())
+}
+
+/// Checks an outbound numeric request field against a protocol limit.
+///
+/// Exceeding the limit is a [`WireError::Local`] error: this node built the
+/// over-limit request, so the peer is never blamed for it, and the
+/// connection stays open.
+pub fn check_send_value(value: u64, limit: u64, what: &str) -> Result<(), WireError> {
     if value > limit {
         return Err(WireError::Local(format!(
             "attempted to send a {what} of {value}; the limit is {limit}",
@@ -74,11 +103,11 @@ pub fn check_send_limit(value: u64, limit: u64, what: &str) -> Result<(), WireEr
     Ok(())
 }
 
-/// Checks an untrusted count or length from the peer against a protocol
+/// Checks an untrusted numeric field from the peer against a protocol
 /// limit.
 ///
 /// Exceeding the limit is a connection error of type `PROTOCOL_ERROR`.
-pub fn check_recv_limit(value: u64, limit: u64, what: &str) -> Result<(), WireError> {
+pub fn check_recv_value(value: u64, limit: u64, what: &str) -> Result<(), WireError> {
     if value > limit {
         return Err(WireError::Protocol(format!(
             "{what} {value} exceeds the limit {limit}",

--- a/zebra-network/src/protocol/v2/request.rs
+++ b/zebra-network/src/protocol/v2/request.rs
@@ -167,11 +167,7 @@ impl Request {
                 stop,
                 tx_ids,
             } => {
-                record::check_send_limit(
-                    known_blocks.len() as u64,
-                    MAX_LOCATOR_HASHES,
-                    "locator hashes",
-                )?;
+                record::check_send_limit(known_blocks.len(), MAX_LOCATOR_HASHES, "locator hashes")?;
 
                 record::write_compact_size(&mut writer, known_blocks.len() as u64)?;
                 for hash in known_blocks {
@@ -181,11 +177,7 @@ impl Request {
                 writer.write_all(&[u8::from(*tx_ids)])?;
             }
             Request::GetBlocks { hashes } => {
-                record::check_send_limit(
-                    hashes.len() as u64,
-                    MAX_GET_BLOCKS_HASHES,
-                    "block requests",
-                )?;
+                record::check_send_limit(hashes.len(), MAX_GET_BLOCKS_HASHES, "block requests")?;
 
                 record::write_compact_size(&mut writer, hashes.len() as u64)?;
                 for hash in hashes {
@@ -193,11 +185,7 @@ impl Request {
                 }
             }
             Request::GetTx { refs } => {
-                record::check_send_limit(
-                    refs.len() as u64,
-                    MAX_GET_TX_REFS,
-                    "transaction references",
-                )?;
+                record::check_send_limit(refs.len(), MAX_GET_TX_REFS, "transaction references")?;
 
                 record::write_compact_size(&mut writer, refs.len() as u64)?;
                 for txref in refs {
@@ -222,12 +210,12 @@ impl Request {
                 count,
                 max_bytes,
             } => {
-                record::check_send_limit(
+                record::check_send_value(
                     *count,
-                    MAX_GET_BLOCK_RANGE_COUNT,
+                    MAX_GET_BLOCK_RANGE_COUNT as u64,
                     "get-block-range count",
                 )?;
-                record::check_send_limit(
+                record::check_send_value(
                     *max_bytes,
                     MAX_GET_BLOCK_RANGE_BYTES,
                     "get-block-range max_bytes",
@@ -242,7 +230,11 @@ impl Request {
                 final_hash,
                 count,
             } => {
-                record::check_send_limit(*count, MAX_GET_TREE_ROOTS_COUNT, "get-tree-roots count")?;
+                record::check_send_value(
+                    *count,
+                    MAX_GET_TREE_ROOTS_COUNT as u64,
+                    "get-tree-roots count",
+                )?;
 
                 writer.write_all(&start_height.to_le_bytes())?;
                 writer.write_all(&final_hash.0)?;
@@ -253,7 +245,7 @@ impl Request {
                 offset,
                 length,
             } => {
-                record::check_send_limit(*length, MAX_GET_OBJECT_LENGTH, "get-object length")?;
+                record::check_send_value(*length, MAX_GET_OBJECT_LENGTH, "get-object length")?;
 
                 writer.write_all(&hash.0)?;
                 record::write_compact_size(&mut writer, *offset)?;
@@ -346,13 +338,13 @@ impl Request {
             StreamType::GetBlockRange => {
                 let final_hash = record::read_block_hash(reader).await?;
                 let count = record::read_compact_size(reader).await?;
-                record::check_recv_limit(
+                record::check_recv_value(
                     count,
-                    MAX_GET_BLOCK_RANGE_COUNT,
+                    MAX_GET_BLOCK_RANGE_COUNT as u64,
                     "get-block-range count",
                 )?;
                 let max_bytes = record::read_compact_size(reader).await?;
-                record::check_recv_limit(
+                record::check_recv_value(
                     max_bytes,
                     MAX_GET_BLOCK_RANGE_BYTES,
                     "get-block-range max_bytes",
@@ -368,7 +360,11 @@ impl Request {
                 let start_height = record::read_exact_u32_le(reader).await?;
                 let final_hash = record::read_block_hash(reader).await?;
                 let count = record::read_compact_size(reader).await?;
-                record::check_recv_limit(count, MAX_GET_TREE_ROOTS_COUNT, "get-tree-roots count")?;
+                record::check_recv_value(
+                    count,
+                    MAX_GET_TREE_ROOTS_COUNT as u64,
+                    "get-tree-roots count",
+                )?;
 
                 Ok(Request::GetTreeRoots {
                     start_height,
@@ -381,7 +377,7 @@ impl Request {
                 record::read_exact_or_incomplete(reader, &mut hash).await?;
                 let offset = record::read_compact_size(reader).await?;
                 let length = record::read_compact_size(reader).await?;
-                record::check_recv_limit(length, MAX_GET_OBJECT_LENGTH, "get-object length")?;
+                record::check_recv_value(length, MAX_GET_OBJECT_LENGTH, "get-object length")?;
 
                 Ok(Request::GetObject {
                     hash: ObjectHash(hash),
@@ -411,7 +407,7 @@ fn check_get_hashes_bounds(start_height: u32, stride: u32, count: u64) -> Result
         return Err("get-hashes stride must not be 0".to_string());
     }
 
-    if count > MAX_GET_HASHES_COUNT {
+    if count > MAX_GET_HASHES_COUNT as u64 {
         return Err(format!(
             "get-hashes count {count} exceeds the limit {MAX_GET_HASHES_COUNT}",
         ));

--- a/zebra-network/src/protocol/v2/response.rs
+++ b/zebra-network/src/protocol/v2/response.rs
@@ -5,13 +5,14 @@
 //! requested item, in request order, so their entries are encoded and read
 //! individually. The other responses are single structures.
 
-use std::{any::type_name, io, sync::Arc};
+use std::{io, sync::Arc};
 
 use tokio::io::AsyncRead;
 
 use zebra_chain::{
-    block::{self, CountedHeader, Header, SyncHashEntry, TreeRootsEntry},
+    block::{self, Block, CountedHeader, Header, SyncHashEntry, TreeRootsEntry},
     serialization::{ZcashDeserialize, ZcashSerialize},
+    transaction::Transaction,
 };
 
 use super::{
@@ -105,47 +106,104 @@ impl HeadersResponse {
     }
 }
 
-/// Encodes one entry of a `get-blocks` or `get-tx` response to `writer`.
-///
-/// `None` encodes the not-found result. Compact blocks occur only as
-/// announcements, so there is no compact block result.
-pub fn encode_result_entry<T: ZcashSerialize, W: io::Write>(
-    mut writer: W,
-    entry: Option<&T>,
-) -> Result<(), WireError> {
-    let Some(object) = entry else {
-        writer.write_all(&[RESULT_NOT_FOUND])?;
+/// One entry of a `get-blocks` response.
+#[derive(Clone, Debug)]
+pub enum BlockResponseEntry {
+    /// A full block.
+    Full(Arc<Block>),
 
-        return Ok(());
-    };
-
-    writer.write_all(&[RESULT_OBJECT])?;
-    let bytes = object
-        .zcash_serialize_to_vec()
-        .map_err(|err| WireError::Local(format!("unserializable {}: {err}", type_name::<T>())))?;
-    record::write_record(&mut writer, &bytes)?;
-
-    Ok(())
+    /// The block was not found.
+    NotFound,
 }
 
-/// Reads one entry of a `get-blocks` or `get-tx` response from `reader`.
-///
-/// Returns `None` for the not-found result. An unrecognized `result` value
-/// is a connection error of type `PROTOCOL_ERROR`.
-pub async fn read_result_entry<T: ZcashDeserialize, R: AsyncRead + Unpin>(
-    reader: &mut R,
-    what: &str,
-) -> Result<Option<Arc<T>>, WireError> {
-    match record::read_u8(reader).await? {
-        RESULT_OBJECT => {
-            let bytes = record::read_length_prefixed_bytes(reader, MAX_RECORD_PAYLOAD_LEN).await?;
-
-            Ok(Some(Arc::new(T::zcash_deserialize(bytes.as_slice())?)))
+impl BlockResponseEntry {
+    /// Encodes this entry to `writer`.
+    pub fn encode<W: io::Write>(&self, mut writer: W) -> Result<(), WireError> {
+        match self {
+            BlockResponseEntry::Full(block) => {
+                writer.write_all(&[RESULT_OBJECT])?;
+                let block_bytes = block
+                    .zcash_serialize_to_vec()
+                    .map_err(|err| WireError::Local(format!("unserializable block: {err}")))?;
+                record::write_record(&mut writer, &block_bytes)?;
+            }
+            BlockResponseEntry::NotFound => {
+                writer.write_all(&[RESULT_NOT_FOUND])?;
+            }
         }
-        RESULT_NOT_FOUND => Ok(None),
-        unknown => Err(WireError::Protocol(format!(
-            "unrecognized {what} result value {unknown:#04x}",
-        ))),
+
+        Ok(())
+    }
+
+    /// Reads one entry of a `get-blocks` response from `reader`.
+    ///
+    /// An unrecognized `result` value is a connection error of type
+    /// `PROTOCOL_ERROR`. Compact blocks occur only as announcements, so
+    /// there is no compact block result.
+    pub async fn read<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Self, WireError> {
+        match record::read_u8(reader).await? {
+            RESULT_OBJECT => {
+                let block_bytes =
+                    record::read_length_prefixed_bytes(reader, MAX_RECORD_PAYLOAD_LEN).await?;
+                let block = Arc::new(Block::zcash_deserialize(block_bytes.as_slice())?);
+                Ok(BlockResponseEntry::Full(block))
+            }
+            RESULT_NOT_FOUND => Ok(BlockResponseEntry::NotFound),
+            unknown => Err(WireError::Protocol(format!(
+                "unrecognized get-blocks result value {unknown:#04x}",
+            ))),
+        }
+    }
+}
+
+/// One entry of a `get-tx` response.
+#[derive(Clone, Debug)]
+pub enum TxResponseEntry {
+    /// The requested transaction.
+    Found(Arc<Transaction>),
+
+    /// The transaction was not found.
+    NotFound,
+}
+
+impl TxResponseEntry {
+    /// Encodes this entry to `writer`.
+    #[allow(clippy::unwrap_in_result)]
+    pub fn encode<W: io::Write>(&self, mut writer: W) -> Result<(), WireError> {
+        match self {
+            TxResponseEntry::Found(tx) => {
+                writer.write_all(&[RESULT_OBJECT])?;
+                let tx_bytes = tx
+                    .zcash_serialize_to_vec()
+                    .expect("serializing a transaction to a Vec never fails");
+                record::write_record(&mut writer, &tx_bytes)?;
+            }
+            TxResponseEntry::NotFound => {
+                writer.write_all(&[RESULT_NOT_FOUND])?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Reads one entry of a `get-tx` response from `reader`.
+    ///
+    /// An unrecognized `result` value is a connection error of type
+    /// `PROTOCOL_ERROR`. A compact block result is only defined for
+    /// `get-blocks` responses, so it is unrecognized here.
+    pub async fn read<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Self, WireError> {
+        match record::read_u8(reader).await? {
+            RESULT_OBJECT => {
+                let tx_bytes =
+                    record::read_length_prefixed_bytes(reader, MAX_RECORD_PAYLOAD_LEN).await?;
+                let tx = Arc::new(Transaction::zcash_deserialize(tx_bytes.as_slice())?);
+                Ok(TxResponseEntry::Found(tx))
+            }
+            RESULT_NOT_FOUND => Ok(TxResponseEntry::NotFound),
+            unknown => Err(WireError::Protocol(format!(
+                "unrecognized get-tx result value {unknown:#04x}",
+            ))),
+        }
     }
 }
 
@@ -157,11 +215,7 @@ pub struct AddrResponse(pub Vec<MetaAddr>);
 impl AddrResponse {
     /// Encodes this response to `writer`.
     pub fn encode<W: io::Write>(&self, mut writer: W) -> Result<(), WireError> {
-        record::check_send_limit(
-            self.0.len() as u64,
-            MAX_ADDRS_IN_RESPONSE,
-            "address records",
-        )?;
+        record::check_send_limit(self.0.len(), MAX_ADDRS_IN_RESPONSE, "address records")?;
 
         record::write_compact_size(&mut writer, self.0.len() as u64)?;
         for addr in &self.0 {

--- a/zebra-network/src/protocol/v2/tests/vectors.rs
+++ b/zebra-network/src/protocol/v2/tests/vectors.rs
@@ -5,7 +5,7 @@ use std::{sync::Arc, time::Duration};
 use zebra_chain::{
     block::{self, Block},
     serialization::{DateTime32, ZcashDeserializeInto, ZcashSerialize},
-    transaction::{AuthDigest, Transaction, UnminedTxId, WtxId},
+    transaction::{AuthDigest, UnminedTxId, WtxId},
 };
 
 use crate::{
@@ -29,7 +29,7 @@ use super::super::{
     record,
     request::Request,
     response::{
-        encode_result_entry, read_result_entry, AddrResponse, HeadersResponse, MempoolResponse,
+        AddrResponse, BlockResponseEntry, HeadersResponse, MempoolResponse, TxResponseEntry,
     },
     txref::TransactionReference,
     types::{ErrorCode, ObjectHash, StreamType, WireError},
@@ -173,7 +173,7 @@ async fn record_stream_end_and_errors() {
 
     // A length prefix over the payload limit is a FLOOD error.
     let mut over_limit = Vec::new();
-    record::write_compact_size(&mut over_limit, MAX_RECORD_PAYLOAD_LEN as u64 + 1)
+    record::write_compact_size(&mut over_limit, (MAX_RECORD_PAYLOAD_LEN + 1) as u64)
         .expect("write to Vec succeeds");
     let mut reader = over_limit.as_slice();
     let result = record::read_record(&mut reader).await;
@@ -615,7 +615,7 @@ async fn request_rejects_over_limit() {
     // A locator with more than the maximum hashes is rejected on encode
     // and on decode.
     let over_limit = Request::GetHeaders {
-        known_blocks: vec![block::Hash([0; 32]); MAX_LOCATOR_HASHES as usize + 1],
+        known_blocks: vec![block::Hash([0; 32]); MAX_LOCATOR_HASHES + 1],
         stop: None,
         tx_ids: false,
     };
@@ -629,13 +629,15 @@ async fn request_rejects_over_limit() {
     );
 
     let mut buf = Vec::new();
-    record::write_compact_size(&mut buf, MAX_LOCATOR_HASHES + 1).expect("write to Vec succeeds");
+    record::write_compact_size(&mut buf, (MAX_LOCATOR_HASHES + 1) as u64)
+        .expect("write to Vec succeeds");
     let mut reader = buf.as_slice();
     let result = Request::read(StreamType::GetHeaders, &mut reader).await;
     assert_protocol_error(&result, "the encoding");
 
     let mut buf = Vec::new();
-    record::write_compact_size(&mut buf, MAX_GET_BLOCKS_HASHES + 1).expect("write to Vec succeeds");
+    record::write_compact_size(&mut buf, (MAX_GET_BLOCKS_HASHES + 1) as u64)
+        .expect("write to Vec succeeds");
     let mut reader = buf.as_slice();
     let result = Request::read(StreamType::GetBlocks, &mut reader).await;
     assert_protocol_error(&result, "the encoding");
@@ -730,7 +732,7 @@ async fn sync_request_bounds_are_enforced() {
         Request::GetHashes {
             start_height: 0,
             stride: 1,
-            count: MAX_GET_HASHES_COUNT + 1,
+            count: MAX_GET_HASHES_COUNT as u64 + 1,
         },
         // The greatest requested height must not exceed `u32::MAX`:
         // this request's second hash would be above it.
@@ -741,7 +743,7 @@ async fn sync_request_bounds_are_enforced() {
         },
         Request::GetBlockRange {
             final_hash: block::Hash([0; 32]),
-            count: MAX_GET_BLOCK_RANGE_COUNT + 1,
+            count: MAX_GET_BLOCK_RANGE_COUNT as u64 + 1,
             max_bytes: 0,
         },
         Request::GetBlockRange {
@@ -752,7 +754,7 @@ async fn sync_request_bounds_are_enforced() {
         Request::GetTreeRoots {
             start_height: 0,
             final_hash: block::Hash([0; 32]),
-            count: MAX_GET_TREE_ROOTS_COUNT + 1,
+            count: MAX_GET_TREE_ROOTS_COUNT as u64 + 1,
         },
         Request::GetObject {
             hash: ObjectHash([0; 32]),
@@ -954,13 +956,14 @@ async fn sync_response_round_trips() {
 
     // Counts over the request limits are rejected while reading.
     let mut buf = Vec::new();
-    record::write_compact_size(&mut buf, MAX_GET_HASHES_COUNT + 1).expect("write to Vec succeeds");
+    record::write_compact_size(&mut buf, (MAX_GET_HASHES_COUNT + 1) as u64)
+        .expect("write to Vec succeeds");
     let mut reader = buf.as_slice();
     let result = HashesResponse::read(&mut reader).await;
     assert_protocol_error(&result, "the encoding");
 
     let mut buf = Vec::new();
-    record::write_compact_size(&mut buf, MAX_GET_TREE_ROOTS_COUNT + 1)
+    record::write_compact_size(&mut buf, (MAX_GET_TREE_ROOTS_COUNT + 1) as u64)
         .expect("write to Vec succeeds");
     let mut reader = buf.as_slice();
     let result = TreeRootsResponse::read(&mut reader).await;
@@ -973,30 +976,36 @@ async fn block_response_entries_round_trip() {
 
     let block = test_block();
 
+    let entries = vec![
+        BlockResponseEntry::Full(block.clone()),
+        BlockResponseEntry::NotFound,
+    ];
+
     let mut buf = Vec::new();
-    encode_result_entry(&mut buf, Some(block.as_ref())).expect("write to Vec succeeds");
-    encode_result_entry::<Block, _>(&mut buf, None).expect("write to Vec succeeds");
+    for entry in &entries {
+        entry.encode(&mut buf).expect("write to Vec succeeds");
+    }
 
     let mut reader = buf.as_slice();
-    let read_full = read_result_entry::<Block, _>(&mut reader, "get-blocks")
+    let read_full = BlockResponseEntry::read(&mut reader)
         .await
         .expect("entry parses");
-    assert_eq!(read_full.as_deref(), Some(block.as_ref()));
-    let read_missing = read_result_entry::<Block, _>(&mut reader, "get-blocks")
+    assert!(matches!(&read_full, BlockResponseEntry::Full(b) if *b == block));
+    let read_missing = BlockResponseEntry::read(&mut reader)
         .await
         .expect("entry parses");
-    assert!(read_missing.is_none());
+    assert!(matches!(read_missing, BlockResponseEntry::NotFound));
     assert!(reader.is_empty());
 
     // The compact block result byte of earlier draft revisions was removed:
     // compact blocks occur only as announcements, so `0x01` is unrecognized.
     let mut reader = &[0x01][..];
-    let result = read_result_entry::<Block, _>(&mut reader, "get-blocks").await;
+    let result = BlockResponseEntry::read(&mut reader).await;
     assert_protocol_error(&result, "the encoding");
 
     // An unrecognized result byte is rejected.
     let mut reader = &[0x03][..];
-    let result = read_result_entry::<Block, _>(&mut reader, "get-blocks").await;
+    let result = BlockResponseEntry::read(&mut reader).await;
     assert_protocol_error(&result, "the encoding");
 }
 
@@ -1007,24 +1016,30 @@ async fn tx_response_entries_round_trip() {
     let block = test_block();
     let tx = block.transactions[1].clone();
 
+    let entries = vec![
+        TxResponseEntry::Found(tx.clone()),
+        TxResponseEntry::NotFound,
+    ];
+
     let mut buf = Vec::new();
-    encode_result_entry(&mut buf, Some(tx.as_ref())).expect("write to Vec succeeds");
-    encode_result_entry::<Transaction, _>(&mut buf, None).expect("write to Vec succeeds");
+    for entry in &entries {
+        entry.encode(&mut buf).expect("write to Vec succeeds");
+    }
 
     let mut reader = buf.as_slice();
-    let read_found = read_result_entry::<Transaction, _>(&mut reader, "get-tx")
+    let read_found = TxResponseEntry::read(&mut reader)
         .await
         .expect("entry parses");
-    assert_eq!(read_found.as_deref(), Some(tx.as_ref()));
-    let read_missing = read_result_entry::<Transaction, _>(&mut reader, "get-tx")
+    assert!(matches!(&read_found, TxResponseEntry::Found(t) if *t == tx));
+    let read_missing = TxResponseEntry::read(&mut reader)
         .await
         .expect("entry parses");
-    assert!(read_missing.is_none());
+    assert!(matches!(read_missing, TxResponseEntry::NotFound));
     assert!(reader.is_empty());
 
     // A compact block result byte is not valid in a get-tx response.
     let mut reader = &[0x01][..];
-    let result = read_result_entry::<Transaction, _>(&mut reader, "get-tx").await;
+    let result = TxResponseEntry::read(&mut reader).await;
     assert_protocol_error(&result, "the encoding");
 }
 

--- a/zebra-network/src/protocol/v2/types.rs
+++ b/zebra-network/src/protocol/v2/types.rs
@@ -58,23 +58,6 @@ pub enum StreamType {
 }
 
 impl StreamType {
-    /// Every stream type the draft defines, in wire byte order.
-    pub const ALL: [StreamType; 13] = [
-        StreamType::Handshake,
-        StreamType::GetHeaders,
-        StreamType::GetBlocks,
-        StreamType::GetTx,
-        StreamType::GetAddr,
-        StreamType::GetMempool,
-        StreamType::GetHashes,
-        StreamType::GetBlockRange,
-        StreamType::GetTreeRoots,
-        StreamType::GetObject,
-        StreamType::BlockAnnouncements,
-        StreamType::TransactionAnnouncements,
-        StreamType::AddressAnnouncements,
-    ];
-
     /// Returns the stream type for `byte`, or `None` if the byte is not a
     /// recognized stream type.
     ///
@@ -82,7 +65,22 @@ impl StreamType {
     /// [`ErrorCode::UnsupportedStreamType`], without treating it as a
     /// connection error or assigning a misbehavior penalty.
     pub fn from_byte(byte: u8) -> Option<Self> {
-        Self::ALL.into_iter().find(|kind| kind.byte() == byte)
+        match byte {
+            0x00 => Some(StreamType::Handshake),
+            0x01 => Some(StreamType::GetHeaders),
+            0x02 => Some(StreamType::GetBlocks),
+            0x03 => Some(StreamType::GetTx),
+            0x04 => Some(StreamType::GetAddr),
+            0x05 => Some(StreamType::GetMempool),
+            0x06 => Some(StreamType::GetHashes),
+            0x07 => Some(StreamType::GetBlockRange),
+            0x08 => Some(StreamType::GetTreeRoots),
+            0x09 => Some(StreamType::GetObject),
+            0x10 => Some(StreamType::BlockAnnouncements),
+            0x11 => Some(StreamType::TransactionAnnouncements),
+            0x12 => Some(StreamType::AddressAnnouncements),
+            _ => None,
+        }
     }
 
     /// Returns the wire byte for this stream type.
@@ -91,16 +89,29 @@ impl StreamType {
     }
 
     /// Returns true if this is a request stream type.
-    ///
-    /// The draft assigns request streams the byte range `0x01`-`0x0F`, and
-    /// announcement streams `0x10`-`0x1F`.
     pub fn is_request(self) -> bool {
-        (0x01..=0x0F).contains(&self.byte())
+        matches!(
+            self,
+            StreamType::GetHeaders
+                | StreamType::GetBlocks
+                | StreamType::GetTx
+                | StreamType::GetAddr
+                | StreamType::GetMempool
+                | StreamType::GetHashes
+                | StreamType::GetBlockRange
+                | StreamType::GetTreeRoots
+                | StreamType::GetObject
+        )
     }
 
     /// Returns true if this is an announcement stream type.
     pub fn is_announcement(self) -> bool {
-        (0x10..=0x1F).contains(&self.byte())
+        matches!(
+            self,
+            StreamType::BlockAnnouncements
+                | StreamType::TransactionAnnouncements
+                | StreamType::AddressAnnouncements
+        )
     }
 }
 

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -1227,10 +1227,9 @@ async fn setup_gossiped_block_misbehavior(
         DEFAULT_MAX_CONNS_PER_IP,
         Span::none(),
     );
-
     // An empty state, so gossiped blocks are always unknown, and the lookahead limit is
     // measured from the genesis height.
-    let (state, _read_only_state_service, latest_chain_tip, _chain_tip_change) =
+    let (state, read_only_state_service, latest_chain_tip, _chain_tip_change) =
         zebra_state::init(state_config, &network, Height::MAX, 0).await;
     let state_service = ServiceBuilder::new().buffer(1).service(state);
 
@@ -1258,6 +1257,7 @@ async fn setup_gossiped_block_misbehavior(
         block_verifier,
         mempool: buffered_mempool,
         state: state_service,
+        read_state: read_only_state_service,
         latest_chain_tip,
         misbehavior_sender,
     };


### PR DESCRIPTION
## Motivation

Final PR of the five-PR stack implementing the draft version 2 Zcash P2P network protocol ([zcash/zips#1344](https://github.com/zcash/zips/pull/1344)). This PR wires the v2 transport into the peer set behind experimental config options, and removes the stack's `#[allow(dead_code)]` scaffolding.

## Solution

- Adds `peer_set/initialize/v2_transport.rs`: a QUIC endpoint that accepts inbound v2 connections on the UDP port of the listen address (when `network.experimental_v2_listen` is enabled) and maintains connections to `network.initial_v2_peers`, redialling them when they fail or disconnect.
- Inbound v2 connections go through the same shared admission policy as the TCP listener (canonicalization, dual-representation ban check, shared connection counter with atomic slot reservation, and one shared per-IP limiter), so the two transports cannot drift and together stay within the configured limits.
- Initial v2 peers are resolved and dialed from a supervised task, so slow or failing DNS cannot delay the listener; the dialer and per-connection handshake tasks are supervised from the accept loop like the legacy listener, so panics stop the node instead of silently reducing connectivity.
- v2 peers produce ordinary peer `Client`s and join the peer set alongside legacy peers; connection attempt metrics are recorded for both stages of inbound v2 connections.
- New config options (both default off / empty): `network.experimental_v2_listen` and `network.initial_v2_peers`.

### Tests

- Integration tests over real QUIC connections: the listener accepts a v2 connection and serves a request through the inbound service, and refuses connections from banned peers.
- Full `zebra-network` suite passes (260 tests); `cargo clippy -p zebra-network --all-targets` warning-free; `zebrad` builds; config compatibility test updated.
- Not yet tested: a live two-node sync session between separate zebrad instances on a public network.

### Specifications & References

- Draft version 2 Zcash P2P network protocol: [zcash/zips#1344](https://github.com/zcash/zips/pull/1344)

### Follow-up Work

- Add v2 peers to the crawler once address gossip indicates which transports a peer is reachable on.
- Live two-node test evidence on Regtest/Testnet.
- Structured v2 peer error enum replacing the stringly `V2Protocol`/`V2Internal` variants.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude Code was used to implement the integration and tests, run the test/lint verification, and draft the commit messages and this description; the changes were reviewed by the author.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
