### PR TITLE
docs(zebra-state): drop stale error-propagation docs on infallible batch methods

### DIFF
--- a/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/shielded.rs
@@ -598,9 +598,6 @@ impl ZebraDb {
 impl DiskWriteBatch {
     /// Prepare a database batch containing `finalized.block`'s shielded transaction indexes,
     /// and return it (without actually writing anything).
-    ///
-    /// If this method returns an error, it will be propagated,
-    /// and the batch should not be written to the database.
     pub fn prepare_shielded_transaction_batch(
         &mut self,
         zebra_db: &ZebraDb,
@@ -663,10 +660,6 @@ impl DiskWriteBatch {
 
     /// Prepare a database batch containing the note commitment and history tree updates
     /// from `finalized.block`, and return it (without actually writing anything).
-    ///
-    /// If this method returns an error, it will be propagated,
-    /// and the batch should not be written to the database.
-    #[allow(clippy::unwrap_in_result)]
     pub fn prepare_trees_batch(
         &mut self,
         zebra_db: &ZebraDb,

--- a/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
+++ b/zebra-state/src/service/finalized_state/zebra_db/transparent.rs
@@ -413,9 +413,6 @@ impl ZebraDb {
 impl DiskWriteBatch {
     /// Prepare a database batch containing `finalized.block`'s transparent transaction indexes,
     /// and return it (without actually writing anything).
-    ///
-    /// If this method returns an error, it will be propagated,
-    /// and the batch should not be written to the database.
     #[allow(clippy::too_many_arguments)]
     pub fn prepare_transparent_transaction_batch(
         &mut self,


### PR DESCRIPTION
## Motivation

Closes #9998.

The infallible `DiskWriteBatch` block-write `prepare_*` methods were already changed to return `()` instead of a `Result`, but their docs still described error propagation. The issue's remaining ask is to update those docs to match.

## Solution

Remove the stale "If this method returns an error, it will be propagated, and the batch should not be written to the database." lines from the three now-infallible methods — `prepare_transparent_transaction_batch`, `prepare_shielded_transaction_batch`, and `prepare_trees_batch` — and drop the now-inert `#[allow(clippy::unwrap_in_result)]` on `prepare_trees_batch` (the lint only applies to `Result`/`Option`-returning fns).

`prepare_chain_value_pools_batch` and `prepare_block_batch` are left unchanged: they still return a `Result` and are genuinely fallible (they `?`/`map_err` real errors), so their "# Errors" docs are accurate.

Documentation/attribute only — no behaviour change.

## Tests

No behaviour to test. `cargo fmt` and `cargo clippy -p zebra-state --lib --all-features` are clean (confirming the removed `unwrap_in_result` attr doesn't trip clippy).

## Specifications & References

None.

## Follow-up Work

There are other now-inert `#[allow(clippy::unwrap_in_result)]` attributes on `()`-returning batch helpers in these files; they're harmless (the lint doesn't fire on non-`Result` fns) and left out of scope here.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude (Claude Code) — made these documentation changes.

## PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
