### PR TITLE
fix(zebra-state): use candidate block height for testnet min-difficulty spacing

### DIFF
--- a/.changes/unreleased/zebra-state-Fixed-20260819-000000.yaml
+++ b/.changes/unreleased/zebra-state-Fixed-20260819-000000.yaml
@@ -1,0 +1,4 @@
+project: zebra-state
+kind: Fixed
+body: 'The `getblocktemplate` RPC now looks up the Testnet minimum-difficulty block spacing at the candidate (next) block''s height instead of the previous block''s. At a network-upgrade activation boundary that changes the target spacing (such as Blossom), the template''s difficulty and `mintime` were previously computed from the pre-upgrade spacing ([#10621](https://github.com/ZcashFoundation/zebra/issues/10621)).'
+time: 2026-08-19T00:00:00.000000000Z

--- a/zebra-state/src/service/read/difficulty.rs
+++ b/zebra-state/src/service/read/difficulty.rs
@@ -308,8 +308,15 @@ fn adjust_difficulty_and_time_for_testnet(
         .try_into()
         .expect("valid blocks have in-range times");
 
+    // Use the candidate (next) block's height, not the previous block's. At a network
+    // upgrade activation boundary that changes the target spacing, the candidate block
+    // is governed by the new upgrade's rules, so the spacing must be looked up at its
+    // height. See #10621.
+    let candidate_block_height =
+        (previous_block_height + 1).expect("candidate block height is in range");
+
     let Some(minimum_difficulty_spacing) =
-        NetworkUpgrade::minimum_difficulty_spacing_for_height(network, previous_block_height)
+        NetworkUpgrade::minimum_difficulty_spacing_for_height(network, candidate_block_height)
     else {
         // Returns early if the testnet minimum difficulty consensus rule is not active
         return;
@@ -548,5 +555,71 @@ mod tests {
             result.max_time,
             DateTime32::from(PREV + BLOCK_MAX_TIME_SINCE_MEDIAN)
         );
+    }
+
+    /// Regression test for #10621: at a network-upgrade boundary that changes the target
+    /// spacing, the minimum-difficulty gap must be looked up at the candidate (next) block's
+    /// height, not the previous block's.
+    ///
+    /// Blossom activates exactly at the candidate height, so the previous block is pre-Blossom
+    /// (150 s spacing, `6 * 150 = 900` s gap) while the candidate is Blossom (75 s spacing,
+    /// `6 * 75 = 450` s gap). With `cur_time` at `PREV + 500` — past the candidate's 450 s gap
+    /// but well within the previous block's stale 900 s gap — the candidate is a
+    /// minimum-difficulty template. The old code looked the gap up at the previous height and so
+    /// wrongly left it at standard difficulty.
+    #[test]
+    fn spacing_uses_candidate_height_across_nu_boundary() {
+        use zebra_chain::parameters::testnet::{ConfiguredActivationHeights, Parameters};
+
+        // A candidate height well above the minimum-difficulty start height (299188).
+        let previous_block_height = Height(1_000_000);
+        let candidate_block_height = Height(1_000_001);
+
+        let network = Parameters::build()
+            .with_activation_heights(ConfiguredActivationHeights {
+                before_overwinter: Some(1),
+                sapling: Some(2),
+                blossom: Some(candidate_block_height.0),
+                // Canopy must be set for `to_network` (it defines the mandatory checkpoint); put
+                // it just above the boundary so it doesn't affect the two heights under test.
+                heartwood: Some(candidate_block_height.0 + 1),
+                canopy: Some(candidate_block_height.0 + 2),
+                ..Default::default()
+            })
+            .expect("activation heights are valid")
+            .clear_funding_streams()
+            .to_network()
+            .expect("configured testnet is valid");
+
+        // The boundary this test depends on: the spacing changes between the two heights.
+        assert_eq!(
+            NetworkUpgrade::current(&network, previous_block_height),
+            NetworkUpgrade::Sapling
+        );
+        assert_eq!(
+            NetworkUpgrade::current(&network, candidate_block_height),
+            NetworkUpgrade::Blossom
+        );
+
+        // Past the candidate's 450 s gap, but within the previous block's stale 900 s gap.
+        let cur = PREV + 500;
+        let mut result = chain_info(cur);
+
+        adjust_difficulty_and_time_for_testnet(
+            &mut result,
+            &network,
+            previous_block_height,
+            recent_block_data(&network),
+        );
+
+        // The candidate is a minimum-difficulty template: difficulty recomputed to the PoWLimit
+        // and min_time raised past the candidate's 450 s gap (PREV + 451). The buggy code, using
+        // the previous block's 900 s gap, left this at standard difficulty with the sentinel
+        // difficulty unchanged.
+        assert_eq!(
+            result.expected_difficulty,
+            network.target_difficulty_limit().to_compact()
+        );
+        assert_eq!(result.min_time, DateTime32::from(PREV + 6 * 75 + 1));
     }
 }


### PR DESCRIPTION
## Motivation

Closes #10621.

On Testnet the minimum-difficulty consensus rule (ZIP-208) makes a block a minimum-difficulty block when its time is more than `6 * PoWTargetSpacing(height)` after the previous block. The `getblocktemplate` RPC's testnet adjustment (`adjust_difficulty_and_time_for_testnet`) uses this gap to decide whether the template is standard- or minimum-difficulty and to clamp its `mintime`/`maxtime`.

It was looking the gap up at the **previous** block's height. At a network-upgrade activation boundary that changes the target spacing — Blossom halves it from 150s to 75s — the candidate block is governed by the new upgrade's rules, so the gap must be computed at the candidate (next) block's height. Using the previous height applied the stale spacing across the boundary, mis-selecting standard vs. minimum difficulty and producing the wrong template difficulty and `mintime`.

## Solution

Compute `candidate_block_height = previous_block_height + 1` and pass it to `NetworkUpgrade::minimum_difficulty_spacing_for_height`.

This matches the consensus-validation path: `AdjustedDifficulty::expected_difficulty_threshold` already evaluates `is_testnet_min_difficulty_block` at the candidate height, so the template now agrees with the block it will later validate. The unrelated `AdjustedDifficulty::new_from_header_time` call is unchanged — it takes the *previous* height by contract and derives the candidate height itself.

## Tests

Added `spacing_uses_candidate_height_across_nu_boundary`, a unit test that configures a Testnet where Blossom activates exactly at the candidate height (previous block pre-Blossom, 150s → 900s gap; candidate Blossom, 75s → 450s gap). With `cur_time` past the candidate's 450s gap but within the previous block's stale 900s gap, it asserts the template switches to minimum difficulty (`expected_difficulty` recomputed to the PoWLimit, `min_time` raised to `PREV + 451`). The test fails against the pre-fix code on both assertions and passes with the fix.

`cargo test -p zebra-state --lib service::read::difficulty::tests`, `cargo fmt --all -- --check`, and `cargo clippy -p zebra-state --lib --all-features` are clean.

## Specifications & References

- ZIP-208, minimum-difficulty blocks on the test network: <https://zips.z.cash/zip-0208#minimum-difficulty-blocks-on-the-test-network>

## Follow-up Work

None.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude (Claude Code) — wrote the fix and regression test.

## PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
