### PR TITLE
docs(book): add a guide for syncing from the ZF state snapshots

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -8,6 +8,7 @@
     - [Platform Tier Policy](user/target-tier-policies.md)
   - [Building and Installing Zebra](user/install.md)
   - [Running Zebra](user/run.md)
+    - [Syncing from a State Snapshot](user/snapshots.md)
   - [Zebra with Docker](user/docker.md)
   - [Tracing Zebra](user/tracing.md)
   - [Zebra Metrics](user/metrics.md)

--- a/book/src/user/docker.md
+++ b/book/src/user/docker.md
@@ -17,7 +17,9 @@ docker run -d \
 
 The `-p 8233:8233` flag publishes Zebra's P2P port so other Zcash nodes can
 connect to yours (use `-p 18233:18233` for Testnet), and `-v` mounts a named
-volume so the chain state survives container restarts.
+volume so the chain state survives container restarts. To skip the multi-day
+initial sync, you can seed that volume from a
+[state snapshot](./snapshots.md#docker).
 
 You can also use `docker compose`, which we recommend. First get the repo:
 

--- a/book/src/user/requirements.md
+++ b/book/src/user/requirements.md
@@ -21,7 +21,9 @@ without any issues.](https://x.com/Zerodartz/status/1811460885996798159)
 ## Disk Requirements
 
 Zebra uses around 300 GB for cached Mainnet data, and 10 GB for cached Testnet
-data. We expect disk usage to grow over time.
+data. We expect disk usage to grow over time. Syncing from a
+[state snapshot](./snapshots.md) temporarily needs about twice that while the
+archive is extracted.
 
 Zebra cleans up its database periodically, and also when you shut it down or
 restart it. Changes are committed using RocksDB database transactions. If you

--- a/book/src/user/run.md
+++ b/book/src/user/run.md
@@ -8,6 +8,9 @@ You can run Zebra as a backend for [`lightwalletd`][lwd], or a [mining][mining] 
 For Kubernetes and load balancer integrations, Zebra provides simple [HTTP
 health endpoints](./health.md).
 
+A first sync from genesis takes days on Mainnet. To start from a recent
+height instead, see [Syncing from a State Snapshot](./snapshots.md).
+
 ## Optional Configs & Features
 
 Zebra supports a variety of optional features which you can enable and configure

--- a/book/src/user/snapshots.md
+++ b/book/src/user/snapshots.md
@@ -1,0 +1,134 @@
+# Syncing from a State Snapshot
+
+A full sync from genesis takes days on Mainnet. The Zcash Foundation publishes
+snapshots of Zebra's cached state at <https://snapshots.zfnd.org/> so a new
+node can start a few blocks behind the tip instead.
+
+## Available snapshots
+
+| Network | Archive | Manifest |
+|---|---|---|
+| Mainnet | [zebrad-state-mainnet-v28-20260728-post.tar.zst](https://snapshots.zfnd.org/mainnet/20260728-post/zebrad-state-mainnet-v28-20260728-post.tar.zst) (268.7 GB) | [manifest.json](https://snapshots.zfnd.org/mainnet/20260728-post/zebrad-state-mainnet-v28-20260728-post.manifest.json) |
+| Testnet | [zebrad-state-testnet-v28-20260728.tar.zst](https://snapshots.zfnd.org/testnet/20260728/zebrad-state-testnet-v28-20260728.tar.zst) (9.1 GB) | [manifest.json](https://snapshots.zfnd.org/testnet/20260728/zebrad-state-testnet-v28-20260728.manifest.json) |
+
+Each archive has a `.sha256` checksum at the same URL with `.sha256` appended.
+
+Always read the manifest before using a snapshot: it has the exact chain
+height, the database format version, and the `zebrad` version that produced
+that specific file.
+
+## On trust
+
+A snapshot replaces the blocks Zebra would otherwise download and validate
+itself. When you load one, you are trusting that the node it was cut from
+validated the chain correctly up to the snapshot height; Zebra does not
+re-validate the blocks it finds in its cached state.
+
+The `.sha256` checksum only proves the file you downloaded is the file that was
+published. The manifests are currently **unsigned**, so it does not prove the
+file was published by the Zcash Foundation. If your node secures funds or
+serves other people's wallets, and you cannot afford to trust a third party's
+validation, sync from genesis instead.
+
+## Before you start
+
+1. **Check the database format version.** Compare `database_format_major_version`
+   in the manifest with the version your `zebrad` build expects. Zebra logs it
+   at startup as the `v<major>` directory in the cached state path
+   (`Opened Zebra state cache at .../state/v28/mainnet`), and it is defined as
+   `DATABASE_FORMAT_VERSION` in `zebra-state/src/constants.rs` at your
+   release's tag. If the major versions differ, the snapshot won't load; don't
+   use it.
+2. **Free disk space.** The Mainnet archive is ~270 GB compressed and needs about
+   that much again once extracted. Have at least 300 GB free, more if you keep
+   the compressed archive around.
+3. **Stop `zebrad`** if it is already running against the `cache_dir` you are
+   about to use.
+4. **Know your `cache_dir`.** This is `state.cache_dir` in your `zebrad.toml`
+   (`~/.cache/zebra` by default on Linux, `/home/zebra/.cache/zebra` inside the
+   Docker image). Getting this path wrong is the most common way this goes
+   silently wrong; see the warning in step 2 below.
+
+## Steps
+
+### 1. Download and verify
+
+```sh
+curl -sSO https://snapshots.zfnd.org/mainnet/20260728-post/zebrad-state-mainnet-v28-20260728-post.tar.zst
+curl -sSO https://snapshots.zfnd.org/mainnet/20260728-post/zebrad-state-mainnet-v28-20260728-post.tar.zst.sha256
+
+sha256sum -c zebrad-state-mainnet-v28-20260728-post.tar.zst.sha256
+```
+
+Swap in the Testnet URLs from the table above if that's what you need.
+
+### 2. Extract into your `cache_dir`
+
+The archive already contains the `state/v28/mainnet/` path Zebra expects, so
+extract it straight into `cache_dir`:
+
+```sh
+mkdir -p /path/to/your/cache_dir
+tar --zstd -xf zebrad-state-mainnet-v28-20260728-post.tar.zst -C /path/to/your/cache_dir
+```
+
+To avoid keeping the compressed archive on disk, you can stream the download
+straight into `tar`. This skips the checksum step, so only do it if you have
+verified the checksum some other way:
+
+```sh
+curl -sS https://snapshots.zfnd.org/mainnet/20260728-post/zebrad-state-mainnet-v28-20260728-post.tar.zst \
+  | tar --zstd -x -C /path/to/your/cache_dir
+```
+
+**This path has to match exactly.** If the directory you extract into is not
+`state.cache_dir` in your `zebrad.toml`, `zebrad` won't error; it will create an
+empty state there and start syncing from genesis, silently. Double-check the
+path before you extract.
+
+#### Docker
+
+If you run Zebra with the `zfnd/zebra` image and the named volume from the
+[Docker quick start](docker.md#quick-start), extract into the volume with a
+throwaway container. The image's entrypoint fixes file ownership on the next
+start, so extracting as root is fine:
+
+```sh
+docker run --rm \
+  -v zebrad-cache:/home/zebra/.cache/zebra \
+  -v "$PWD":/snapshots:ro \
+  alpine sh -c 'apk add --no-cache zstd tar >/dev/null && \
+    tar --zstd -xf /snapshots/zebrad-state-mainnet-v28-20260728-post.tar.zst -C /home/zebra/.cache/zebra'
+```
+
+### 3. Start `zebrad`
+
+```toml
+# zebrad.toml
+[state]
+cache_dir = "/path/to/your/cache_dir"
+```
+
+```sh
+zebrad start
+```
+
+Check the logs for the loaded tip. It should be close to `chain_tip.height`
+from the manifest, not genesis:
+
+```text
+zebra_state::service: loaded Zebra state cache chain_tip=Some((block::Hash("0000..."), Height(3428145)))
+```
+
+From there `zebrad` syncs the remaining blocks up to the current chain tip.
+
+## Troubleshooting
+
+- **Sync starts from genesis anyway.** Your `cache_dir` doesn't match where you
+  extracted the archive. Check both paths, and that the extracted tree is
+  `<cache_dir>/state/v28/<network>/`.
+- **`zebrad` won't start, or errors about the state format.** Compare
+  `database_format_major_version` in the manifest with your build's
+  `DATABASE_FORMAT_VERSION`. A mismatch won't fix itself on retry; you need a
+  snapshot cut for your version, or a `zebrad` build matching the snapshot.
+- **Checksum mismatch.** Re-download. Don't use a file that fails `sha256sum -c`.

--- a/book/src/user/snapshots.md
+++ b/book/src/user/snapshots.md
@@ -1,95 +1,143 @@
 # Syncing from a State Snapshot
 
 A full sync from genesis takes days on Mainnet. The Zcash Foundation publishes
-snapshots of Zebra's cached state at <https://snapshots.zfnd.org/> so a new
+snapshots of Zebra's cached state at <https://snapshots.zfnd.org/>, so a new
 node can start a few blocks behind the tip instead.
 
-## Available snapshots
+**Start at that site.** It lists the current archive for each network with its
+height, size, and checksum, and it has the download, verify, and extract
+commands. It is regenerated every time a snapshot is cut, so it is always
+current; this page deliberately does not repeat archive names, dates, or sizes,
+because those change with every cut and older archives are pruned.
 
-| Network | Archive | Manifest |
-|---|---|---|
-| Mainnet | [zebrad-state-mainnet-v28-20260728-post.tar.zst](https://snapshots.zfnd.org/mainnet/20260728-post/zebrad-state-mainnet-v28-20260728-post.tar.zst) (268.7 GB) | [manifest.json](https://snapshots.zfnd.org/mainnet/20260728-post/zebrad-state-mainnet-v28-20260728-post.manifest.json) |
-| Testnet | [zebrad-state-testnet-v28-20260728.tar.zst](https://snapshots.zfnd.org/testnet/20260728/zebrad-state-testnet-v28-20260728.tar.zst) (9.1 GB) | [manifest.json](https://snapshots.zfnd.org/testnet/20260728/zebrad-state-testnet-v28-20260728.manifest.json) |
+What follows is the Zebra side of the operation: how to resolve the current
+archive, what you are trusting, which snapshots your build can actually load,
+and where the archive has to land.
 
-Each archive has a `.sha256` checksum at the same URL with `.sha256` appended.
+## Resolving the current archive
 
-Always read the manifest before using a snapshot: it has the exact chain
-height, the database format version, and the `zebrad` version that produced
-that specific file.
+There is no `latest` alias URL, so don't hardcode an archive name. Each network
+publishes `https://snapshots.zfnd.org/<network>/snapshots.json`: an array of
+every archive available for that network, newest first, where the newest entry
+carries `"latest"` in its `roles`. Resolve it at download time:
+
+```sh
+url=$(curl -s https://snapshots.zfnd.org/mainnet/snapshots.json \
+  | jq -r 'map(select(.roles | index("latest")))[0].url')
+
+curl -sS -O "$url" -O "$url.sha256"
+sha256sum -c "$(basename "$url").sha256"
+```
+
+Use `testnet` in place of `mainnet` for the Testnet archive. Don't use an
+archive that fails `sha256sum -c`; re-download it.
+
+Each entry also carries `height`, `db_major`, `sha256`, `zebrad_version`, and
+`manifest_url`, so a script can check compatibility before it commits to a
+long download:
+
+```sh
+curl -s https://snapshots.zfnd.org/mainnet/snapshots.json \
+  | jq -r '.[0] | "height=\(.height) db_major=\(.db_major) zebrad=\(.zebrad_version)"'
+```
 
 ## On trust
 
 A snapshot replaces the blocks Zebra would otherwise download and validate
 itself. When you load one, you are trusting that the node it was cut from
-validated the chain correctly up to the snapshot height; Zebra does not
-re-validate the blocks it finds in its cached state.
+validated the chain correctly up to the snapshot height. Zebra does not
+re-validate the blocks it finds in its cached state, so nothing downstream will
+catch a bad snapshot for you.
 
-The `.sha256` checksum only proves the file you downloaded is the file that was
-published. The manifests are currently **unsigned**, so it does not prove the
-file was published by the Zcash Foundation. If your node secures funds or
-serves other people's wallets, and you cannot afford to trust a third party's
-validation, sync from genesis instead.
+The `.sha256` checksum is narrower than it looks. It proves the bytes you
+received are the bytes that host served — no more. It is published by the same
+host as the archive, so it cannot show the archive came from the Zcash
+Foundation: a host serving a bad archive serves a matching checksum with it. The
+manifests are currently **unsigned**, so there is no first-party way to
+authenticate a snapshot today.
 
-## Before you start
+This is true however you fetch a snapshot — downloaded and verified, streamed
+straight into `tar`, or unpacked inside a container. Verifying the checksum
+protects you against a corrupted transfer, not against a compromised or
+substituted archive. If you need more assurance than that, the expected digest
+has to reach you out of band: from an operator you trust who has verified the
+same archive, or from a digest you recorded earlier through a channel you
+trust. And if your node secures funds or serves other people's wallets, and you
+cannot afford to trust a third party's validation at all, sync from genesis
+instead.
 
-1. **Check the database format version.** Compare `database_format_major_version`
-   in the manifest with the version your `zebrad` build expects. Zebra logs it
-   at startup as the `v<major>` directory in the cached state path
-   (`Opened Zebra state cache at .../state/v28/mainnet`), and it is defined as
-   `DATABASE_FORMAT_VERSION` in `zebra-state/src/constants.rs` at your
-   release's tag. If the major versions differ, the snapshot won't load; don't
-   use it.
-2. **Free disk space.** The Mainnet archive is ~270 GB compressed and needs about
-   that much again once extracted. Have at least 300 GB free, more if you keep
-   the compressed archive around.
-3. **Stop `zebrad`** if it is already running against the `cache_dir` you are
-   about to use.
-4. **Know your `cache_dir`.** This is `state.cache_dir` in your `zebrad.toml`
-   (`~/.cache/zebra` by default on Linux, `/home/zebra/.cache/zebra` inside the
-   Docker image). Getting this path wrong is the most common way this goes
-   silently wrong; see the warning in step 2 below.
+## Check the database format version
 
-## Steps
+A snapshot only loads into a `zebrad` whose state database format _major_
+version matches the archive. If they differ, the snapshot won't load; don't use
+it. Get a snapshot cut for your version, or run a `zebrad` that matches.
 
-### 1. Download and verify
+Both sides of that comparison are easy to read:
 
-```sh
-curl -sSO https://snapshots.zfnd.org/mainnet/20260728-post/zebrad-state-mainnet-v28-20260728-post.tar.zst
-curl -sSO https://snapshots.zfnd.org/mainnet/20260728-post/zebrad-state-mainnet-v28-20260728-post.tar.zst.sha256
+- The archive: `db_major` in `snapshots.json`, the `v<major>` in its filename,
+  and `database_format_major_version` in its manifest.
+- Your build: `DATABASE_FORMAT_VERSION` in `zebra-state/src/constants.rs` at
+  your release's tag. Zebra also logs it at startup as the `v<major>` component
+  of the cached state path:
 
-sha256sum -c zebrad-state-mainnet-v28-20260728-post.tar.zst.sha256
-```
+  ```text
+  zebra_state::...::disk_db: Opened Zebra state cache at /home/user/.cache/zebra/state/v28/mainnet
+  ```
 
-Swap in the Testnet URLs from the table above if that's what you need.
+The manifest is also where you'll find the snapshot's chain height and the
+`zebrad` version that produced it.
 
-### 2. Extract into your `cache_dir`
+## Extract into your `cache_dir`
 
-The archive already contains the `state/v28/mainnet/` path Zebra expects, so
-extract it straight into `cache_dir`:
+The archive already contains the `state/v<major>/<network>/` path Zebra
+expects, so extract it straight into `cache_dir` — there is no path to
+assemble by hand:
 
 ```sh
 mkdir -p /path/to/your/cache_dir
-tar --zstd -xf zebrad-state-mainnet-v28-20260728-post.tar.zst -C /path/to/your/cache_dir
+tar --zstd -xf "$(basename "$url")" -C /path/to/your/cache_dir
 ```
 
-To avoid keeping the compressed archive on disk, you can stream the download
-straight into `tar`. This skips the checksum step, so only do it if you have
-verified the checksum some other way:
-
-```sh
-curl -sS https://snapshots.zfnd.org/mainnet/20260728-post/zebrad-state-mainnet-v28-20260728-post.tar.zst \
-  | tar --zstd -x -C /path/to/your/cache_dir
-```
+`cache_dir` is `state.cache_dir` in your `zebrad.toml`, which defaults to
+`~/.cache/zebra` on Linux. In the Docker image it is `ZEBRA_STATE__CACHE_DIR`,
+which defaults to `/home/zebra/.cache/zebra`.
 
 **This path has to match exactly.** If the directory you extract into is not
-`state.cache_dir` in your `zebrad.toml`, `zebrad` won't error; it will create an
-empty state there and start syncing from genesis, silently. Double-check the
-path before you extract.
+the `cache_dir` Zebra runs with, `zebrad` won't error; it will create an empty
+state there and start syncing from genesis, silently. Double-check both paths
+before you extract, and stop `zebrad` first if it is already running against
+that directory.
 
-#### Docker
+Once it starts, confirm from the logs that it picked the snapshot up. The tip
+should be close to the manifest's `chain_tip.height`, not genesis:
+
+```text
+zebra_state::service: loaded Zebra state cache chain_tip=Some((block::Hash("0000..."), Height(3459525)))
+```
+
+### Streaming, to avoid needing the space twice
+
+Downloading and then extracting needs the archive and the extracted state on
+disk at once, and the extracted state is larger than the archive. To avoid
+holding both, pipe the download straight into `tar`:
+
+```sh
+curl -sS "$url" | tar --zstd -x -C /path/to/your/cache_dir
+```
+
+The trade-off is that you write the archive into your state directory before
+you have checked it. A transfer that is corrupted or truncated on the way will
+still fail loudly — TLS detects a truncated stream, and `zstd` and `tar` reject
+damaged input — so this is mostly safe against accidental corruption. It gives
+up nothing against a substituted archive, because as [On trust](#on-trust)
+explains, the published checksum never covered that case either. If you have an
+expected digest from out of band, download to disk and verify it before you
+extract rather than streaming.
+
+## Docker
 
 If you run Zebra with the `zfnd/zebra` image and the named volume from the
-[Docker quick start](docker.md#quick-start), extract into the volume with a
+[Docker quick start](./docker.md#quick-start), extract into the volume with a
 throwaway container. The image's entrypoint fixes file ownership on the next
 start, so extracting as root is fine:
 
@@ -98,37 +146,30 @@ docker run --rm \
   -v zebrad-cache:/home/zebra/.cache/zebra \
   -v "$PWD":/snapshots:ro \
   alpine sh -c 'apk add --no-cache zstd tar >/dev/null && \
-    tar --zstd -xf /snapshots/zebrad-state-mainnet-v28-20260728-post.tar.zst -C /home/zebra/.cache/zebra'
+    tar --zstd -xf /snapshots/<archive>.tar.zst -C /home/zebra/.cache/zebra'
 ```
 
-### 3. Start `zebrad`
+Replace `<archive>` with the file you downloaded, and keep the volume name and
+mount point in step with whatever your `docker run` or compose file uses.
 
-```toml
-# zebrad.toml
-[state]
-cache_dir = "/path/to/your/cache_dir"
-```
+You can stream into the volume instead, with the same trade-off described in
+[Streaming](#streaming-to-avoid-needing-the-space-twice) — note the `-i` so the
+container reads stdin:
 
 ```sh
-zebrad start
+curl -sS "$url" | docker run --rm -i \
+  -v zebrad-cache:/home/zebra/.cache/zebra \
+  alpine sh -c 'apk add --no-cache zstd tar >/dev/null && \
+    tar --zstd -x -C /home/zebra/.cache/zebra'
 ```
-
-Check the logs for the loaded tip. It should be close to `chain_tip.height`
-from the manifest, not genesis:
-
-```text
-zebra_state::service: loaded Zebra state cache chain_tip=Some((block::Hash("0000..."), Height(3428145)))
-```
-
-From there `zebrad` syncs the remaining blocks up to the current chain tip.
 
 ## Troubleshooting
 
 - **Sync starts from genesis anyway.** Your `cache_dir` doesn't match where you
   extracted the archive. Check both paths, and that the extracted tree is
-  `<cache_dir>/state/v28/<network>/`.
+  `<cache_dir>/state/v<major>/<network>/`.
 - **`zebrad` won't start, or errors about the state format.** Compare
   `database_format_major_version` in the manifest with your build's
-  `DATABASE_FORMAT_VERSION`. A mismatch won't fix itself on retry; you need a
-  snapshot cut for your version, or a `zebrad` build matching the snapshot.
-- **Checksum mismatch.** Re-download. Don't use a file that fails `sha256sum -c`.
+  `DATABASE_FORMAT_VERSION`. A mismatch won't fix itself on retry.
+- **Checksum mismatch.** Re-download. Don't use a file that fails
+  `sha256sum -c`.


### PR DESCRIPTION
### Motivation

ZF publishes Zebra state snapshots at https://snapshots.zfnd.org/.

The site exposes a root page listing current archives per network, a per-network `snapshots.json`, and a per-network `SHA256SUMS`, and it carries the full download/verify/extract walkthrough. So this page stops duplicating the catalogue — archive names, dates, and sizes — and no longer names an archive at all. The first draft hardcoded the `20260728` URLs in its table, its download commands, and its Docker snippet; older archives get pruned as new ones are cut, so every one of those links would have broken on the next cut. The commands that remain here resolve the current archive from `snapshots.json` instead.

### Solution

New `user/snapshots.md`, scoped to what is a fact about Zebra rather than about the archive host:

- **Resolving the current archive** from `snapshots.json` with `jq`. There is no `latest` alias URL, so the page names no archive and nothing on it breaks when an archive is pruned.
- **On trust.** Loading a snapshot transfers validation to the node it was cut from; Zebra does not re-validate blocks already in its cached state. The `.sha256` is served by the same host as the archive, so it shows a clean transfer, not authenticity, and the manifests are unsigned. That caveat applies to every fetch path, not just streaming.
- **Database format version check**, against `DATABASE_FORMAT_VERSION` in `zebra-state/src/constants.rs` and the `state/v<major>/<network>` layout.
- **`cache_dir`**, and the footgun where a mismatched path silently syncs from genesis instead of erroring.
- **Streaming**, for operators who can't spare the archive and the extracted state at once, with the trade-off stated.
- **Docker**: extracting into the named volume, and streaming into it — neither of which the site covers.

Plus one-line pointers from Running Zebra, Docker, and System Requirements.

### Follow-ups (not this PR)

- Sign the manifests (the manifest's own `signing.todo` — Cosign keyless needs a CI OIDC token).
- Capture `block_hash` in the manifest (currently `null`).
- Optional: a `latest` alias URL per network, so simple recipes don't need `jq`. Not required — this page resolves via `snapshots.json`.

### Review

Docs only.

- `mdbook build book` is clean (mdBook 0.5.4, matching CI's `~0.5`).
- `mdbook-linkcheck -s book` reports no findings against any page this PR touches. It does report two pre-existing errors on `main` (`dev/continuous-delivery.md` and `dev/gcp-deployment-operations.md` link to `../../../docs/decisions/...`, outside the book root). Note that `book/book.toml` has no `[output.linkcheck]` section, so `book.yml`'s `use-linkcheck: true` installs linkcheck but never runs it — worth a separate issue.
- The `jq` expressions, and the `docker run -i` streaming form, were run against the live site and a scratch volume rather than written from memory.

### AI disclosure

Used Claude Code to survey the state-format and `cache_dir` code paths, verify the quoted log lines and `jq`/Docker commands against the live site, and draft this revision of the page.
