### PR TITLE
docs(network): fix unresolved intra-doc link

### DIFF
--- a/zebra-network/src/peer_set/candidate_set/crawl.rs
+++ b/zebra-network/src/peer_set/candidate_set/crawl.rs
@@ -79,6 +79,7 @@ pub(crate) type CrawlService<S> = RateLimitBySkipping<CrawlFanout<S>>;
 /// [`NeverAttemptedGossiped`]: crate::PeerAddrState::NeverAttemptedGossiped
 /// [`Failed`]: crate::PeerAddrState::Failed
 /// [`AttemptPending`]: crate::PeerAddrState::AttemptPending
+/// [`next_reconnect_peer`]: super::next_reconnect_peer
 pub(crate) async fn crawl_once<S>(
     crawl_service: &mut CrawlService<S>,
     fanout_limit: Option<usize>,


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

<!--
- Describe the goals of the PR.
- If it closes any issues, enumerate them here.
-->

The post-merge "Book" workflow (which runs `cargo doc` with `-D warnings` to
build Zebra's internal docs) has been failing on `main` since #11321 merged:

https://github.com/ZcashFoundation/zebra/actions/runs/32825589745/job/97732758515

```
error: unresolved link to `next_reconnect_peer`
  --> zebra-network/src/peer_set/candidate_set/crawl.rs:69

## Solution

<!-- Describe the changes in the PR. -->

Fixed by adding a reference-style link definition pointing at the item's
actual path, alongside the other link definitions already at the end of
that doc comment

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

Reproduced the failure locally and confirmed the fix resolves it:
  ```
  RUSTDOCFLAGS="--html-in-header katex-header.html -D warnings -A rustdoc::private_intra_doc_links --cfg docsrs -Zunstable-options" \
  cargo +nightly doc --no-deps -p zebra-network --all-features --document-private-items
  ```
  
### Specifications & References

<!-- Provide any relevant references. -->

- Failing run: https://github.com/ZcashFoundation/zebra/actions/runs/32825589745/job/97732758515
- Link last touched in #11243 ("chore: fix nightly and links")
- Surfaced after #11321 merged (unrelated to that PR's changes)

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
-->

- Consider adding a `cargo doc` / rustdoc-link check to PR CI (or gating it
  on the same `path-filters.yml` paths as the Book workflow), so broken
  intra-doc links are caught before merge instead of on the next `main`
  push. Currently the only rustdoc-link check runs post-merge, which is
  how this went unnoticed since #11243.


### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude helped diagnose the CI failure (tracing the unresolved link to its scope-resolution cause), locate the exact fix, and draft this PR description. I verified the fix locally before opening this PR.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [X] The solution is tested.
- [ ] The documentation and changelogs are up to date.
