### PR TITLE
ci: gate PRs on public API and dependency diffs with zc

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist-legacy.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist-legacy.md
@@ -136,7 +136,7 @@ when the gate could not run (for example, the previous release was yanked, which
 - [ ] For each crate, confirm the chosen release level matches the API surface:
       `cargo semver-checks -p <crate> --default-features`. List the full API diff
       with `cargo public-api diff latest -p <crate> -sss`, or run
-      [`ziff`](https://github.com/ZcashFoundation/ziff) `<previous_tag>` once to
+      [`zc`](https://github.com/ZcashFoundation/zc) `<previous_tag>` once to
       get the per-crate diff plus dependency and (with `--with-values`)
       const/static value and doc changes in one pass.
 

--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -35,6 +35,13 @@ semver:
   - ".github/workflows/pr-gate.yml"
   - ".github/path-filters.yml"
 
+api_diff:
+  - "**/*.rs"
+  - "**/Cargo.toml"
+  - "**/Cargo.lock"
+  - ".github/workflows/pr-gate.yml"
+  - ".github/path-filters.yml"
+
 unit_tests:
   - "**/*.rs"
   - "**/Cargo.toml"

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -62,6 +62,7 @@ jobs:
     outputs:
       queue_candidate: ${{ steps.classify.outputs.queue_candidate || 'false' }}
       semver: ${{ steps.filter.outputs.semver || 'true' }}
+      api_diff: ${{ steps.filter.outputs.api_diff || 'true' }}
       breaking: ${{ steps.title.outputs.breaking }}
       type: ${{ steps.title.outputs.type }}
       conventional: ${{ steps.title.outputs.conventional }}
@@ -155,6 +156,94 @@ jobs:
           exclude: zebrad, zebra-test, zebra-utils
           feature-group: default-features
           baseline-rev: ${{ steps.baseline.outputs.rev }}
+
+  api-diff:
+    needs: changes
+    # Real work runs only on contributor pull requests that change Rust. A declared break runs
+    # too: the diff is the evidence a reviewer needs to judge what the `!` actually covers.
+    if: >-
+      github.event_name == 'pull_request' &&
+      needs.changes.outputs.queue_candidate != 'true' &&
+      needs.changes.outputs.api_diff == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Check out the PR head, not the merge commit, so the API delta is the PR's own.
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Compute the baseline from the PR's fork point
+        id: baseline
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          # `fetch-depth: 0` populates the base branch without persisting credentials.
+          echo "rev=$(git merge-base "origin/$BASE_REF" HEAD)" >> "$GITHUB_OUTPUT"
+      # zc builds the workspace crates at both refs, so librocksdb-sys needs libclang.
+      - uses: ./.github/actions/setup-zebra-build
+      - name: Restore the zc rustdoc cache
+        # Restores what `api-diff-warm` writes on main; a pull request must never save.
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: target/zc-cache
+          # zc keys entries by commit SHA and prunes them after 14 days, so a prefix restore is safe.
+          key: zc-cache-${{ runner.os }}-v0.5.0-${{ steps.baseline.outputs.rev }}
+          restore-keys: zc-cache-${{ runner.os }}-v0.5.0-
+      # A declared break only has to analyse cleanly; an undeclared one must not break the API.
+      - name: Diff the public API and dependencies
+        uses: ZcashFoundation/zc@15a7a89df262cf68bdf5daac807d14638307488b # v0.5.0
+        with:
+          baseline: ${{ steps.baseline.outputs.rev }}
+          fail-on: ${{ needs.changes.outputs.breaking == 'true' && 'error' || 'api-breaking' }}
+
+  # A pull request can only restore caches written on its own ref or on main, so this
+  # push-only job is what makes the pull request side's `restore-keys` prefix hit.
+  api-diff-warm:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    concurrency:
+      group: api-diff-warm-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Resolve the baseline this push builds on
+        id: baseline
+        env:
+          BEFORE: ${{ github.event.before }}
+        run: |
+          # A force push or a new branch reports an all-zero or unreachable predecessor.
+          baseline="$BEFORE"
+          if [[ "$baseline" =~ ^0+$ ]] || ! git cat-file -e "${baseline}^{commit}" 2> /dev/null; then
+            baseline="$(git rev-parse 'HEAD^')"
+          fi
+          echo "rev=$baseline" >> "$GITHUB_OUTPUT"
+      # zc builds the workspace crates at both refs, so librocksdb-sys needs libclang.
+      - uses: ./.github/actions/setup-zebra-build
+      - name: Restore the zc rustdoc cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: target/zc-cache
+          key: zc-cache-${{ runner.os }}-v0.5.0-${{ github.sha }}
+          restore-keys: zc-cache-${{ runner.os }}-v0.5.0-
+      - name: Diff the public API and dependencies
+        # Warming only has to populate the cache, so findings and environmental failures both pass.
+        continue-on-error: true
+        uses: ZcashFoundation/zc@15a7a89df262cf68bdf5daac807d14638307488b # v0.5.0
+        with:
+          baseline: ${{ steps.baseline.outputs.rev }}
+          fail-on: none
+      - name: Save the zc rustdoc cache
+        if: always() && hashFiles('target/zc-cache/**') != ''
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: target/zc-cache
+          key: zc-cache-${{ runner.os }}-v0.5.0-${{ github.sha }}
 
   # This checks for changelog entries depending on the type of the PR (per title).
   # An entry is required for a crate if any file in the crate changed.
@@ -310,7 +399,7 @@ jobs:
       github.event.label.name == 'A-release') &&
       (github.event.action != 'edited' ||
       github.event.changes.title != null || github.event.changes.base != null)
-    needs: [changes, semver-checks, changelog-gate, release-readiness]
+    needs: [changes, semver-checks, api-diff, changelog-gate, release-readiness]
     timeout-minutes: 5
     steps:
       - name: Decide whether the needed jobs succeeded or failed
@@ -322,4 +411,4 @@ jobs:
           # must not be combined with `allowed-skips`: alls-green requires every
           # `allowed-skips` job to be skipped or successful, even a failure-allowed one.
           allowed-failures: changelog-gate
-          allowed-skips: semver-checks, release-readiness
+          allowed-skips: semver-checks, api-diff, release-readiness

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -16,7 +16,8 @@ git_release_enable = false
 # entries under versioned headings and add dependency-only release notes.
 changelog_update = true
 
-# Breaking-change detection runs per PR via ziff, not in the release-pr job.
+# The PR gate detects breaking changes per PR with cargo-semver-checks and zc,
+# so the release-pr job does not repeat that work.
 semver_check = false
 
 # These commits trigger version bumps. Other commits can still cascade through


### PR DESCRIPTION
## Motivation

The PR gate only checks the library API with cargo-semver-checks. It misses consumer-visible dependency changes, breaks hidden behind re-exposed foreign types, and all of `zebrad`, which the semver job must exclude. [zc](https://github.com/ZcashFoundation/zc) covers that ground.

## Solution

A new `api-diff` gate job runs the zc v0.5.0 action against the PR's fork point. The gate policy is one input: `fail-on: api-breaking` for ordinary PRs (undeclared public API breaks fail; dependency-only changes pass with a warning), relaxed to `fail-on: error` when the title declares a break with `!`, so the diff lands in the log as review evidence. zc writes its own annotations and step summary.

Caching: pull requests restore `target/zc-cache` read-only; a push-only `api-diff-warm` job keeps main's baseline entries warm, which is the only cache PRs can restore on first run.

`semver-checks` stays: the two catch different classes of breakage. Also fixes two stale references to zc's old name (ziff).

### Tests

Validated locally on two merged PRs: #11321 (undeclared dep swap) reports zero API changes across all 12 crates, and #10461 (declared `!`) reports 122 API breaks correctly localized to `zebra-chain`, `zebra-consensus`, and `zebra-script`. In CI: cold 12m36s, warm baseline ~8m, versus semver-checks at 3.5 to 7m. The `fail-on`, report, and annotation surface ships in [zc v0.5.0](https://github.com/ZcashFoundation/zc/releases/tag/v0.5.0), byte-identical to v0.4.1 in default mode.

### Follow-up Work

- Decide with CI data whether zc replaces cargo-semver-checks.
- Feed the zc report to `/changelog` as an artifact (fragments are drafted from a diff truncated at 20KB).
- Upstream: prebuilt zc binary in the action (the self-compile is ~5m of the job).

### AI Disclosure

Claude drafted the workflow changes, the zc v0.5.0 surface, and this description; validation runs were reviewed by the author.
