### PR TITLE
docs(book): add the labels page and rename the CI-written labels

### DIFF
--- a/.github/workflows/advisory.yml
+++ b/.github/workflows/advisory.yml
@@ -172,6 +172,6 @@ jobs:
       - uses: jayqi/failed-build-issue-action@1a893bbf43ef1c2a8705e2b115cd4f0fe3c5649b #v1.2.0
         with:
           title-template: "{{refname}} advisory checks failed: {{eventName}} in {{workflow}}"
-          label-name: S-ci-fail-auto-issue
+          label-name: ci-fail/advisory
           always-create-new-issue: false
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -95,13 +95,13 @@ jobs:
           fail-on-alert: false
 
   # Compares benchmarks between the PR branch and the base branch.
-  # Runs when the `C-benchmark` label is present: both when it is first added
+  # Runs when the `run-benchmarks` label is present: both when it is first added
   # and on subsequent pushes to the PR.
   compare:
     name: Compare Benchmarks
     if: >-
       github.event_name == 'pull_request' &&
-      contains(github.event.pull_request.labels.*.name, 'C-benchmark')
+      contains(github.event.pull_request.labels.*.name, 'run-benchmarks')
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -159,7 +159,7 @@ jobs:
         with:
           title-template: "{{refname}} branch CI failed: {{eventName}} in {{workflow}}"
           # New failures open an issue with this label.
-          label-name: S-ci-fail-binaries-auto-issue
+          label-name: ci-fail/binaries
           # If there is already an open issue with this label, any failures become comments on that issue.
           always-create-new-issue: false
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zfnd-ci-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-ci-integration-tests-gcp.yml
@@ -623,7 +623,7 @@ jobs:
         with:
           title-template: "{{refname}} branch CI failed: {{eventName}} in {{workflow}}"
           # New failures open an issue with this label.
-          label-name: S-ci-fail-main-branch-auto-issue
+          label-name: ci-fail/main
           # If there is already an open issue with this label, any failures become comments on that issue.
           always-create-new-issue: false
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zfnd-deploy-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-nodes-gcp.yml
@@ -283,6 +283,8 @@ jobs:
       - uses: jayqi/failed-build-issue-action@1a893bbf43ef1c2a8705e2b115cd4f0fe3c5649b #v1.2.0
         with:
           title-template: "{{refname}} branch CI failed: {{eventName}} in {{workflow}}"
-          label-name: S-ci-fail-release-auto-issue
+          # New failures open an issue with this label.
+          label-name: ci-fail/release
+          # If there is already an open issue with this label, any failures become comments on that issue.
           always-create-new-issue: false
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -35,6 +35,7 @@
   - [Upgrading the State Database](dev/state-db-upgrades.md)
   - [Zebra versioning and releases](dev/release-process.md)
   - [Changelog Guidelines](dev/changelog-guidelines.md)
+  - [Labels and Issue Types](dev/labels.md)
   - [Continuous Integration](dev/continuous-integration.md)
   - [Continuous Delivery](dev/continuous-delivery.md)
     - [GCP Deployment Operations](dev/gcp-deployment-operations.md)

--- a/book/src/dev/gcp-deployment-operations.md
+++ b/book/src/dev/gcp-deployment-operations.md
@@ -21,7 +21,7 @@ Each `deploy-nodes` matrix cell reports two sequential signals:
 - **Template rollout** waits up to 10 minutes for the requested template to reach the zonal MIG. A failure means the deployment infrastructure did not converge.
 - **Application health**, when enabled, then waits up to 90 minutes for the zonal MIG to reach HEALTHY. A failure means the node took longer than that to establish peers and catch up to chain tip; on-call action is usually "wait, or investigate why sync is slow".
 
-The per-MIG concurrency lock covers both stages, so another run cannot replace the template while health is being verified. Either failure uses `failure-issue` with label `S-ci-fail-release-auto-issue`.
+The per-MIG concurrency lock covers both stages, so another run cannot replace the template while health is being verified. Either failure uses `failure-issue` with label `ci-fail/release`.
 
 ## Quick reference
 

--- a/book/src/dev/labels.md
+++ b/book/src/dev/labels.md
@@ -1,0 +1,74 @@
+# Labels and Issue Types
+
+Zebra keeps a deliberately small label set. Every label has to answer one question: _what
+decision does it let someone make?_ Labels that only described an issue, without routing it
+anywhere, were removed in August 2026 ([discussion #11170]). This page is the current set and
+the rules for using it.
+
+[discussion #11170]: https://github.com/ZcashFoundation/zebra/discussions/11170
+
+## Issue types replace type labels
+
+The kind of an issue is its GitHub **issue type**, not a label. Pick one when filing:
+
+| Type | Use for |
+|---|---|
+| **Bug** | Zebra does the wrong thing, or something in CI, docs, or tooling is broken |
+| **Task** | Work that is neither a bug nor a user-visible feature: CI and infrastructure changes, refactors, docs, research |
+| **Feature** | New user-visible behaviour |
+| **Epic** | A tracking issue that groups other issues |
+
+Issue types are set on issues only. Pull requests carry their kind in the conventional-commit
+title prefix (`fix:`, `feat:`, `ci:`, `docs:`, and so on).
+
+## Labels people apply
+
+| Label | Meaning | Rule |
+|---|---|---|
+| `security` | Security-relevant, any severity | Also use the private security issue template; never put exploit details in a public issue |
+| `consensus` | Consensus-critical code: validation, cryptography, script | Reviews need a consensus-aware reviewer |
+| `devops` | Build, CI, test infrastructure, release process | Applied automatically by the devops issue template |
+| `urgent` | Needs attention today, not this sprint | Has no automation behind it. A truly urgent fix is admin-merged |
+| `blocked` | Waiting on something outside the issue or PR | The comment that applies it must say _what_ it is blocked on and give a **re-check date**; a label that is never revisited goes on describing a condition that fixed itself |
+| `do-not-merge` | Must not merge yet, even if approved and green | Removed by whoever applied it |
+| `needs-issue` | A PR that should have an issue behind it | Ask the author to open one, or open it for them |
+| `external-contribution` | Filed by someone outside the maintainer team | Lets maintainers find and follow up on outside contributions |
+| `help wanted` | Maintainers would welcome outside help | GitHub-native name; keep it spelled exactly like this |
+| `good first issue` | Suitable for a first contribution | GitHub-native name; keep it spelled exactly like this |
+| `nu-7` | NU7 network-upgrade work | Temporary, removed after the upgrade ships |
+| `ai-generated` | Backlog issue drafted with AI assistance | Temporary provenance marker; not applied to new issues, deleted when the cohort drains |
+
+Priority is not a label's job. `urgent` is the only priority label, and it means "today".
+
+## Labels wired into automation
+
+Renaming or deleting any of these breaks a workflow, and the breakage is silent: an `if:`
+condition just goes false. Change the workflow in the same PR.
+
+| Label | Read by | Effect |
+|---|---|---|
+| `A-release` | `pr-gate.yml`, `tests-unit.yml`, `release.yml`, `checkpoint-update.yml`, `release-plz.toml` | Marks release PRs; gates release readiness checks. Applied by release-plz and by the release templates |
+| `run-stateful-tests` | `zfnd-ci-integration-tests-gcp.yml` | Adding it to a PR runs the stateful GCP integration tests for that PR |
+| `run-benchmarks` | `benchmarks.yml` | Adding it to a PR runs the benchmark comparison against the base branch |
+
+## Labels written by CI
+
+Five labels are dedup keys for the auto-opened CI failure issues: the failure workflow finds the
+open issue carrying its key and appends to it instead of opening a new one. **Never apply these by
+hand**, and close a stale auto-issue rather than relabelling it, so the next failure opens a fresh
+one.
+
+| Label | Workflow |
+|---|---|
+| `ci-fail/advisory` | `advisory.yml` — scheduled cargo-deny advisory checks on `main` |
+| `ci-fail/binaries` | `release-binaries.yml` |
+| `ci-fail/main` | `zfnd-ci-integration-tests-gcp.yml` — integration tests on `main` |
+| `ci-fail/release` | `zfnd-deploy-nodes-gcp.yml` — node deployment |
+| `ci-fail/verify` | `zfnd-deploy-nodes-gcp.yml` — node health verification |
+
+## Adding or removing a label
+
+Propose it in a Team Decisions discussion with the decision it enables. Multi-word labels are
+kebab-case, except the two GitHub-native community labels above. Before renaming or deleting a label, search
+`.github/` for its name, and check any saved project views that filter on it: view filters do not
+follow renames.

--- a/book/src/dev/labels.md
+++ b/book/src/dev/labels.md
@@ -53,7 +53,7 @@ condition just goes false. Change the workflow in the same PR.
 
 ## Labels written by CI
 
-Five labels are dedup keys for the auto-opened CI failure issues: the failure workflow finds the
+Four labels are dedup keys for the auto-opened CI failure issues: the failure workflow finds the
 open issue carrying its key and appends to it instead of opening a new one. **Never apply these by
 hand**, and close a stale auto-issue rather than relabelling it, so the next failure opens a fresh
 one.
@@ -63,8 +63,7 @@ one.
 | `ci-fail/advisory` | `advisory.yml` — scheduled cargo-deny advisory checks on `main` |
 | `ci-fail/binaries` | `release-binaries.yml` |
 | `ci-fail/main` | `zfnd-ci-integration-tests-gcp.yml` — integration tests on `main` |
-| `ci-fail/release` | `zfnd-deploy-nodes-gcp.yml` — node deployment |
-| `ci-fail/verify` | `zfnd-deploy-nodes-gcp.yml` — node health verification |
+| `ci-fail/release` | `zfnd-deploy-nodes-gcp.yml` — node deployment and health verification |
 
 ## Adding or removing a label
 


### PR DESCRIPTION
## Motivation

Last step of the label migration (#11170): the rules for the new 20-label set live nowhere, and the last two legacy-prefixed families are machine labels — `S-ci-fail-*-auto-issue` (dedup keys for the auto-opened CI failure issues) and `C-benchmark` (a workflow trigger wearing a "category" prefix).

## Solution

- New book page **Developer Documentation → Labels and Issue Types**: issue types replace `C-*`, the twelve human labels with the rule each one carries (`blocked` needs a re-check date, `urgent` has no automation, priority is the board's job), the three automation-wired labels, the five CI-written labels ("never apply by hand"), and how to add or remove one.
- Renames in the workflows that read them: `S-ci-fail-auto-issue` → `ci-fail/advisory`, `-binaries-` → `ci-fail/binaries`, `-main-branch-` → `ci-fail/main`, `-release-` → `ci-fail/release`, `-verify-` → `ci-fail/verify` (five `label-name:` lines); `C-benchmark` → `run-benchmarks` (`benchmarks.yml`). The ops page and the ops page that cites two of them is updated; ADRs are left as point-in-time records.

### Labels on GitHub

The six new labels already exist, and the four live auto-issues carry both their old and new key (#10636 `ci-fail/main`, #10645 `ci-fail/verify`, #10885 `ci-fail/release`, #11015 `ci-fail/advisory`), so the failure workflows keep appending to the same issues after this merges. Once merged, the six old labels (`S-ci-fail-*` ×5, `C-benchmark`) can be deleted.

### Tests

`mdbook build` locally; the renames are literal string changes in `label-name:` inputs and one `contains()` expression — the workflows don't run on this PR.

### AI Disclosure

- [x] AI tools were used: Claude Code drafted the page and applied the renames; reviewed locally.

### PR Checklist

- [x] Conventional-commit title · [x] Contribution guidelines · [x] Discussed in #11170 · [x] Tested (book build) · [x] Docs/changelog up to date (`docs:` — no fragment)