### PR TITLE
fix(script)!: do not load a quadratic number of inputs into memory while validating

### DIFF
--- a/.changes/unreleased/zebra-consensus-Fixed-20260826-211511.yaml
+++ b/.changes/unreleased/zebra-consensus-Fixed-20260826-211511.yaml
@@ -1,0 +1,4 @@
+project: zebra-consensus
+kind: Fixed
+body: 'Do not keep the entire input list in memory while verifying a transparent input. This caused quadratic memory consumption since all inputs are verified concurrently ([#10461](https://github.com/ZcashFoundation/zebra/pull/10461)).'
+time: 2026-08-26T21:15:11.000000000Z

--- a/.changes/unreleased/zebra-script-breaking-20260826-233448.yaml
+++ b/.changes/unreleased/zebra-script-breaking-20260826-233448.yaml
@@ -1,0 +1,4 @@
+project: zebra-script
+kind: breaking
+body: 'Removed `CachedFfiTransaction::inputs()` since it returned a copy of the inputs which could cause quadratic memory consumption, and it is no longer needed inside Zebra. Eventually it might be replaced by a method that returns a reference to the original zcash_transparent Inputs ([#10461](https://github.com/ZcashFoundation/zebra/pull/10461)).'
+time: 2026-08-26T23:34:48.000000000Z

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7500,6 +7500,7 @@ dependencies = [
  "thiserror 2.0.18",
  "zcash_primitives",
  "zcash_script",
+ "zcash_transparent",
  "zebra-chain",
  "zebra-test",
 ]

--- a/zebra-consensus/src/script.rs
+++ b/zebra-consensus/src/script.rs
@@ -2,7 +2,6 @@ use std::{future::Future, pin::Pin, sync::Arc};
 
 use tracing::Instrument;
 
-use zebra_chain::transparent;
 use zebra_script::CachedFfiTransaction;
 
 use crate::{primitives::spawn_fifo_and_convert, BoxError};
@@ -58,25 +57,11 @@ impl tower::Service<Request> for Verifier {
 
         let span = tracing::trace_span!("script");
         async move {
-            // `inputs()` rebuilds an owned Vec, so bind it before indexing into it.
-            let inputs = cached_ffi_transaction.inputs();
-            let input = inputs.get(input_index).ok_or_else(|| {
-                format!("cached_ffi_transaction missing input at index {input_index}")
-            })?;
+            // Script verification is CPU-bound so run in Rayon thread
+            spawn_fifo_and_convert(move || cached_ffi_transaction.is_valid(input_index)).await?;
+            tracing::trace!(input_index, "script verification succeeded");
 
-            match input {
-                transparent::Input::PrevOut { outpoint, .. } => {
-                    let outpoint = *outpoint;
-
-                    // Script verification is CPU-bound so run in Rayon thread
-                    spawn_fifo_and_convert(move || cached_ffi_transaction.is_valid(input_index))
-                        .await?;
-                    tracing::trace!(?outpoint, "script verification succeeded");
-
-                    Ok(())
-                }
-                transparent::Input::Coinbase { .. } => Err("unexpected coinbase input".into()),
-            }
+            Ok(())
         }
         .instrument(span)
         .boxed()

--- a/zebra-consensus/src/script/tests.rs
+++ b/zebra-consensus/src/script/tests.rs
@@ -60,7 +60,7 @@ async fn verifier_returns_error_for_out_of_range_input_index() {
 
     let err = result.expect_err("out-of-range input_index must error, not panic");
     assert!(
-        err.to_string().contains("missing input"),
+        err.to_string().contains("input index out of bounds"),
         "unexpected error message: {err}",
     );
 }

--- a/zebra-script/Cargo.toml
+++ b/zebra-script/Cargo.toml
@@ -26,6 +26,7 @@ comparison-interpreter = []
 libzcash_script = { workspace = true }
 zcash_script = { workspace = true }
 zcash_primitives = { workspace = true }
+zcash_transparent = { workspace = true }
 zebra-chain = { path = "../zebra-chain", version = "12.0.0" }
 
 rand = { workspace = true }

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -16,6 +16,7 @@ use thiserror::Error;
 use libzcash_script::ZcashScript;
 
 use zcash_script::{opcode::PossiblyBad, script, script::Evaluable as _, Opcode};
+use zcash_transparent::bundle as zp_transparent;
 use zebra_chain::{
     parameters::NetworkUpgrade,
     transaction::{HashType, SigHasher},
@@ -109,9 +110,13 @@ impl CachedFfiTransaction {
         })
     }
 
-    /// Returns the transparent inputs for this transaction.
-    pub fn inputs(&self) -> Vec<transparent::Input> {
-        self.transaction.inputs()
+    /// Returns the transparent inputs of this transaction, borrowed from the underlying
+    /// `zcash_primitives` transaction.
+    fn vin(&self) -> &[zp_transparent::TxIn<zp_transparent::Authorized>] {
+        self.transaction
+            .transparent_bundle()
+            .map(|bundle| bundle.vin.as_slice())
+            .unwrap_or_default()
     }
 
     /// Returns the outputs from previous transactions that match each input in the transaction
@@ -148,7 +153,7 @@ impl CachedFfiTransaction {
         let previous_output = self
             .all_previous_outputs
             .get(input_index)
-            .filter(|_| self.all_previous_outputs.len() == self.transaction.inputs().len())
+            .filter(|_| self.all_previous_outputs.len() == self.vin().len())
             .ok_or(Error::TxIndex)?
             .clone();
 
@@ -162,16 +167,20 @@ impl CachedFfiTransaction {
             | zcash_script::interpreter::Flags::CHECKLOCKTIMEVERIFY;
 
         let lock_time = self.transaction.raw_lock_time();
-        let inputs = self.transaction.inputs();
-        let is_final = inputs[input_index].sequence() == u32::MAX;
-        let signature_script = match &inputs[input_index] {
-            transparent::Input::PrevOut {
-                outpoint: _,
-                unlock_script,
-                sequence: _,
-            } => unlock_script.as_raw_bytes(),
-            transparent::Input::Coinbase { .. } => Err(Error::TxCoinbase)?,
-        };
+        // `vin()` is used instead of `Transaction::inputs()` because the latter
+        // rebuilds an owned `Vec<transparent::Input>` on every call, and every
+        // input of a transaction is script-verified concurrently, so calling it
+        // per input makes the live footprint quadratic in the input count.
+        // Nothing in script verification needs the converted Zebra type, so
+        // borrow the librustzcash inputs instead.
+        let txin = self.vin().get(input_index).ok_or(Error::TxIndex)?;
+        let is_final = txin.sequence() == u32::MAX;
+
+        if *txin.prevout() == zp_transparent::OutPoint::NULL {
+            Err(Error::TxCoinbase)?;
+        }
+
+        let signature_script: &[u8] = &txin.script_sig().0 .0;
 
         let script =
             script::Raw::from_raw_parts(signature_script.to_vec(), script_pub_key.to_vec());

--- a/zebra-script/src/lib.rs
+++ b/zebra-script/src/lib.rs
@@ -167,12 +167,6 @@ impl CachedFfiTransaction {
             | zcash_script::interpreter::Flags::CHECKLOCKTIMEVERIFY;
 
         let lock_time = self.transaction.raw_lock_time();
-        // `vin()` is used instead of `Transaction::inputs()` because the latter
-        // rebuilds an owned `Vec<transparent::Input>` on every call, and every
-        // input of a transaction is script-verified concurrently, so calling it
-        // per input makes the live footprint quadratic in the input count.
-        // Nothing in script verification needs the converted Zebra type, so
-        // borrow the librustzcash inputs instead.
         let txin = self.vin().get(input_index).ok_or(Error::TxIndex)?;
         let is_final = txin.sequence() == u32::MAX;
 


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

Fixes #11352

## Solution

The first solution Claude suggested involved keeps the input list in `CachedFfiTransaction` which avoids the problem. But I noticed that `CachedFfiTransaction` doesn't really need the whole input list, and could get the information it needs directly from the lrz type. So I did that instead, and removed `CachedFfiTransaction::inputs()` which was no longer needed.

### Tests

Current tests should pass.
I'm adding the `run-stateful-tests` label to see if this fixes the sync-past-mandatory-checkpoint test. Edit: [seemed to work](https://github.com/ZcashFoundation/zebra/actions/runs/33081604579/job/98554878673?pr=11353#logs)


### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

It might make sense to make `Input` a newtype over the lrz Input, in the same way we did for the Transaction

### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude, cleaned up manually

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [ ] The documentation and changelogs are up to date.
