### PR TITLE
ci: only run the weekly integration schedule in this repository

### DIFF
--- a/.github/workflows/zfnd-ci-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-ci-integration-tests-gcp.yml
@@ -19,6 +19,26 @@ on:
     # This is limited to the Zebra and lightwalletd Full Sync jobs
     - cron: 0 12 * * 5
 
+  #! Only this repository runs the weekly `schedule`. A copy of this workflow in any other
+  #! repository is scheduled independently by GitHub and would deploy into the same GCP
+  #! project, colliding on instance and disk names.
+  #!
+  #! The schedule guard means: "Run unless this is a scheduled event in the wrong repository."
+  #!
+  #! | Event           | Repository               | Guard |
+  #! |-----------------|--------------------------|-------|
+  #! | `schedule`      | `ZcashFoundation/zebra`  | true  |
+  #! | `schedule`      | any clone                | false |
+  #! | anything else   | any repository           | true  |
+  #!
+  #! The guard is on the three jobs that have no `needs:` — `build`, `get-available-disks`
+  #! and `get-available-disks-testnet` — so everything downstream skips with them, plus
+  #! `integration-tests-success` because it is `always()` and does not allow `build` to skip.
+  #! Guard any new job without `needs:`, and any downstream job whose `if:` can still be true
+  #! when its guarded dependencies are skipped, such as a job using `always()`.
+  #!
+  #! `workflow_dispatch`, `push` and `pull_request` are deliberately unaffected everywhere.
+
   workflow_dispatch:
     inputs:
       network:
@@ -126,7 +146,7 @@ jobs:
   build:
     name: Build CI Docker
     # Skip PRs from external repositories, let them pass, and then GitHub's Merge Queue will check them
-    if: ${{ (!startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork) && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-stateful-tests')) }}
+    if: ${{ (!startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork) && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-stateful-tests')) && (github.event_name != 'schedule' || github.repository == 'ZcashFoundation/zebra') }}
     permissions:
       contents: read
       id-token: write
@@ -157,7 +177,7 @@ jobs:
   get-available-disks:
     name: Check if cached state disks exist for ${{ inputs.network || vars.ZCASH_NETWORK }}
     # Skip PRs from external repositories, let them pass, and then GitHub's Merge Queue will check them
-    if: ${{ (!startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork) && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-stateful-tests')) }}
+    if: ${{ (!startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork) && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-stateful-tests')) && (github.event_name != 'schedule' || github.repository == 'ZcashFoundation/zebra') }}
     permissions:
       contents: read
       id-token: write
@@ -171,7 +191,7 @@ jobs:
   # Some outputs are ignored, because we don't run those jobs on testnet.
   get-available-disks-testnet:
     name: Check if cached state disks exist for testnet
-    if: ${{ (!startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork) && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-stateful-tests')) }}
+    if: ${{ (!startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork) && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-stateful-tests')) && (github.event_name != 'schedule' || github.repository == 'ZcashFoundation/zebra') }}
     permissions:
       contents: read
       id-token: write
@@ -258,7 +278,7 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/zfnd-deploy-integration-tests-gcp.yml
-    if: ${{ github.event_name == 'schedule' || (needs.get-available-disks.result == 'success' && !fromJSON(needs.get-available-disks.outputs.zebra_tip_disk)) || (github.event.inputs.run-full-sync == 'true' && (inputs.network || vars.ZCASH_NETWORK) == 'Mainnet') }}
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'ZcashFoundation/zebra') && (github.event_name == 'schedule' || (needs.get-available-disks.result == 'success' && !fromJSON(needs.get-available-disks.outputs.zebra_tip_disk)) || (github.event.inputs.run-full-sync == 'true' && (inputs.network || vars.ZCASH_NETWORK) == 'Mainnet')) }}
     concurrency:
       group: ${{ github.event_name == 'workflow_dispatch' && format('manual-{0}-sync-full-mainnet', github.run_id) || 'sync-full-mainnet' }}
       cancel-in-progress: false
@@ -362,7 +382,7 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/zfnd-deploy-integration-tests-gcp.yml
-    if: ${{ github.event_name == 'schedule' || (needs.get-available-disks-testnet.result == 'success' && !fromJSON(needs.get-available-disks-testnet.outputs.zebra_tip_disk)) || (github.event.inputs.run-full-sync == 'true' && (inputs.network || vars.ZCASH_NETWORK) == 'Testnet') }}
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'ZcashFoundation/zebra') && (github.event_name == 'schedule' || (needs.get-available-disks-testnet.result == 'success' && !fromJSON(needs.get-available-disks-testnet.outputs.zebra_tip_disk)) || (github.event.inputs.run-full-sync == 'true' && (inputs.network || vars.ZCASH_NETWORK) == 'Testnet')) }}
     concurrency:
       group: ${{ github.event_name == 'workflow_dispatch' && format('manual-{0}-sync-full-testnet', github.run_id) || 'sync-full-testnet' }}
       cancel-in-progress: false
@@ -615,7 +635,8 @@ jobs:
       ${{
         always() &&
         (!startsWith(github.event_name, 'pull') || !github.event.pull_request.head.repo.fork) &&
-        (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-stateful-tests'))
+        (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-stateful-tests')) &&
+        (github.event_name != 'schedule' || github.repository == 'ZcashFoundation/zebra')
       }}
     needs:
       - build


### PR DESCRIPTION
## Motivation

The `schedule:` trigger lives in the workflow file, so it fires in **every** repository that contains a copy of it. Those runs deploy into the same GCP project and collide on instance and disk names, because the names are derived from `<test_id>-<ref>-<sha>` with no run or repository identity.

Only this repository should run the weekly maintenance fleet.

Related: #11226 (instance name collisions blocking the full-sync cron). This PR does not close it — the underlying naming fix is separate.

## Solution

Append a guard to the relevant `if:` conditions:

```
(github.event_name != 'schedule' || github.repository == 'ZcashFoundation/zebra')
```

| Event | Repository | Guard |
| --- | --- | --- |
| `schedule` | `ZcashFoundation/zebra` | true |
| `schedule` | any other | **false** |
| anything else | any | true |

Six sites:

- **`build`, `get-available-disks`, `get-available-disks-testnet`** — the only three jobs with no `needs:`. Everything downstream skips with them.
- **`integration-tests-success`** — required, because it is `always()` and its `allowed-skips` does not include `build`. Without the guard here, a skipped `build` fails alls-green and opens a failure issue.
- **`sync-full-mainnet`, `sync-full-testnet`** — defensive. Both already skip via the implicit `success()` on their skipped dependencies, but each has `github.event_name == 'schedule'` as a true disjunct, so the condition passes on its own merits. Nine sibling jobs use `!cancelled() && !failure()`, which removes that implicit check; copying that pattern onto either job would silently restart the long syncs elsewhere. These are the two most expensive jobs in the workflow, so they should not rely on implicit behaviour.

`workflow_dispatch`, `push` and `pull_request` are deliberately unaffected everywhere — the clause short-circuits true on its first disjunct for every non-schedule event, so `github.repository` is never consulted.

A comment block above `jobs:` records the rule and the invariant, so a future job without `needs:` gets guarded too.

### Tests

- `actionlint` clean; YAML parses; 17 jobs before and after.
- Verified the guarded set is exactly `{jobs with no needs:} ∪ {integration-tests-success} ∪ {the two full-sync jobs}`.
- Walked all 17 jobs for a `schedule` event in a repository other than this one: every job skips. The nine `!cancelled() && !failure()` jobs each require a `needs.*.result == 'success'` that is false; `failure-issue` stays silent because skipped is neither `failure()` nor `cancelled()`, so no issue is opened.
- Confirmed the guard cannot block `workflow_dispatch` / `push` / `pull_request` in any repository, and cannot admit `schedule` outside this one.
- Checked parenthesisation on the two full-sync jobs: the guard wraps the whole existing disjunction rather than binding to its first term.

Not exercised end-to-end: the change only alters `if:` conditions, and a real scheduled run cannot be simulated on a branch.

### Specifications & References

- #11202 — *devops: reshape GCP integration CI into weekly maintenance plus recovery*. This change is a small step consistent with that design: it makes the weekly maintenance fleet run in exactly one place. It also removes a source of noise from the reliability measurement that issue depends on, since scheduled runs originating outside this repository currently land in the same project and fail against it.
- #11226 — instance name collisions blocking the full-sync cron.

### Follow-up Work

Scheduled runs are not the only trigger that collides — `push` and `pull_request` runs elsewhere hit the same names. The durable fix is to give the GCP resource names run identity, which is tracked in #11226 (its second suggested fix, "make the name unique per run").

### AI Disclosure

- [x] AI tools were used: Claude Code for the investigation, the guard design, and this description. Reviewed by the author.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date. <!-- CI-only change; no changie fragment required -->
