### PR TITLE
fix(ci): give GCP test resource names run identity

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,4 @@
 self-hosted-runner:
   labels:
     - ubuntu-latest-xl
+    - zfnd-runners

--- a/.github/workflows/scripts/gcp-delete-old-disks.sh
+++ b/.github/workflows/scripts/gcp-delete-old-disks.sh
@@ -28,10 +28,8 @@ delete_disks() {
 }
 
 # Disks from PR jobs and other jobs whose name ends in a run id or a commit hash.
-#
-# Integration test disks end in the GitHub run id. Decimal digits are a subset of
-# `[0-9a-f]`, so they match this pattern, but only incidentally: do not tighten it to
-# assume a hexadecimal commit hash, or those disks will never be reaped.
+# Same selector contract as gcp-delete-old-instances.sh: decimal run ids match
+# `[0-9a-f]` only incidentally - do not tighten this to a hex commit hash.
 delete_disks 'name~-[0-9a-f]{7,}$'
 # Disks prefixed with "zebrad-", but never the persistent "zebrad-cache-*" chain-state disks.
 delete_disks 'name~^zebrad- AND NOT name~^zebrad-cache'

--- a/.github/workflows/scripts/gcp-delete-old-disks.sh
+++ b/.github/workflows/scripts/gcp-delete-old-disks.sh
@@ -27,7 +27,11 @@ delete_disks() {
     done <<< "${disks}"
 }
 
-# Disks from PR jobs and other jobs that use a commit hash.
+# Disks from PR jobs and other jobs whose name ends in a run id or a commit hash.
+#
+# Integration test disks end in the GitHub run id. Decimal digits are a subset of
+# `[0-9a-f]`, so they match this pattern, but only incidentally: do not tighten it to
+# assume a hexadecimal commit hash, or those disks will never be reaped.
 delete_disks 'name~-[0-9a-f]{7,}$'
 # Disks prefixed with "zebrad-", but never the persistent "zebrad-cache-*" chain-state disks.
 delete_disks 'name~^zebrad- AND NOT name~^zebrad-cache'

--- a/.github/workflows/scripts/gcp-delete-old-instances.sh
+++ b/.github/workflows/scripts/gcp-delete-old-instances.sh
@@ -18,7 +18,11 @@ if ! command -v gcloud &> /dev/null; then
     exit 1
 fi
 
-# Fetch the list of instances to delete
+# Fetch the list of instances to delete.
+#
+# Integration test instances end in the GitHub run id, not a commit hash. Decimal digits
+# are a subset of `[0-9a-f]`, so they match this pattern, but only incidentally: do not
+# tighten it to assume a hexadecimal commit hash, or those instances will never be reaped.
 if ! INSTANCES=$(gcloud compute instances list --sort-by=creationTimestamp --filter="name~-[0-9a-f]{7,}$ AND creationTimestamp < ${DELETE_BEFORE_DATE}" --format='value(NAME,ZONE)'); then
     echo "Error fetching instances."
     exit 1

--- a/.github/workflows/zfnd-delete-gcp-resources.yml
+++ b/.github/workflows/zfnd-delete-gcp-resources.yml
@@ -58,12 +58,9 @@ jobs:
       #
       # We only delete instances that end in 7 or more hex characters,
       # to avoid deleting managed instance groups and manually created instances.
-      #
-      # Integration test instances end in the GitHub run id, not a commit hash - see the
-      # naming block in zfnd-deploy-integration-tests-gcp.yml, which depends on this
-      # selector still matching them. Decimal digits are a subset of `[0-9a-f]`, so they
-      # do match, but only incidentally: tightening this pattern to assume a hexadecimal
-      # commit hash would silently orphan every test VM and its 400 GB state disk.
+      # The selector must keep matching run-id-suffixed integration test resources:
+      # rationale in the script below, contract asserted in
+      # zfnd-deploy-integration-tests-gcp.yml's `determine-environment` guard.
       - name: Delete old instances
         run: |
           ./.github/workflows/scripts/gcp-delete-old-instances.sh

--- a/.github/workflows/zfnd-delete-gcp-resources.yml
+++ b/.github/workflows/zfnd-delete-gcp-resources.yml
@@ -2,7 +2,7 @@
 #
 # 1. Deletes specific instances in GCP older than a defined number of days.
 # 2. Deletes instance templates older than a set number of days.
-# 3. Deletes older disks not currently in use, with certain ones prefixed by commit hashes or "zebrad-".
+# 3. Deletes older disks not currently in use: those whose name ends in a run id or a commit hash, and those prefixed with "zebrad-".
 # 4. Deletes cache images from GCP, retaining a specified number of the latest images for certain types like zebrad checkpoint cache, zebrad tip cache, and lightwalletd + zebrad tip cache.
 #
 # It uses the gcloud CLI for its operations and is scheduled to run daily at 0700 UTC against the dev project.
@@ -58,6 +58,12 @@ jobs:
       #
       # We only delete instances that end in 7 or more hex characters,
       # to avoid deleting managed instance groups and manually created instances.
+      #
+      # Integration test instances end in the GitHub run id, not a commit hash - see the
+      # naming block in zfnd-deploy-integration-tests-gcp.yml, which depends on this
+      # selector still matching them. Decimal digits are a subset of `[0-9a-f]`, so they
+      # do match, but only incidentally: tightening this pattern to assume a hexadecimal
+      # commit hash would silently orphan every test VM and its 400 GB state disk.
       - name: Delete old instances
         run: |
           ./.github/workflows/scripts/gcp-delete-old-instances.sh

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -244,8 +244,11 @@ jobs:
         uses: rlespinasse/github-slug-action@e6f261660910b273384c5c42b17a0217881b217a #v5.6.0
         with:
           short-length: 7
-          # GCP instance names are limited to 63 chars. With test_id (max ~31) + sha (7) + hyphens (2),
-          # we need to limit the slug to 23 chars to stay under the limit.
+          # The slug is no longer part of any resource name - names are resolved in
+          # `determine-environment` from the test id and the run identity. Its only
+          # consumer here is the `github_ref` instance label, where the GCP limit is
+          # 63 characters, so 23 is now a free choice; it is kept so that existing
+          # label values do not change.
           slug-maxlength: 23
 
       - name: Downcase network name for disks and labels
@@ -309,8 +312,6 @@ jobs:
           # value containing shell metacharacters would escape its quoting context.
           APP_NAME: ${{ inputs.app_name }}
           TEST_ID: ${{ inputs.test_id }}
-          GITHUB_REF_SLUG_URL: ${{ env.GITHUB_REF_SLUG_URL }}
-          GITHUB_SHA_SHORT: ${{ env.GITHUB_SHA_SHORT }}
         run: |
 
           CONTAINER_MOUNT_DISKS="--container-mount-disk=mount-path=${{ inputs.zebra_state_dir }},name=${NAME},mode=rw"

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -744,6 +744,11 @@ jobs:
 
           echo "Fetching first 1000 log entries via SSH for instance ${INSTANCE_NAME} to find DB versions..."
           CONTAINER_ID="${{ needs.test-result.outputs.container_id }}"
+          # The status has to be collected through `||`. GitHub runs `run:` blocks
+          # under `bash -e`, so a bare `DOCKER_LOGS=$(...)` aborts the step the moment
+          # gcloud exits non-zero - before any status line can run - and the message
+          # below would never be reached.
+          SSH_STATUS=0
           DOCKER_LOGS=$( \
           gcloud compute ssh "${INSTANCE_NAME}" \
           --zone ${{ needs.test-result.outputs.instance_zone }} \
@@ -751,8 +756,7 @@ jobs:
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
           --command="sudo docker logs ${CONTAINER_ID} | head -1000" \
-          )
-          SSH_STATUS=$?
+          ) || SSH_STATUS=$?
 
           if [[ $SSH_STATUS -ne 0 ]] || [[ -z "$DOCKER_LOGS" ]]; then
               echo "Failed to retrieve logs via SSH."
@@ -841,6 +845,9 @@ jobs:
 
           echo "Fetching last 200 log entries via SSH for instance ${INSTANCE_NAME} to find sync height..."
           CONTAINER_ID="${{ needs.test-result.outputs.container_id }}"
+          # See the note in "Get database versions from logs": under `bash -e` the
+          # status has to be collected through `||` or the step aborts first.
+          SSH_STATUS=0
           DOCKER_LOGS=$( \
           gcloud compute ssh "${INSTANCE_NAME}" \
           --zone ${{ needs.test-result.outputs.instance_zone }} \
@@ -848,8 +855,7 @@ jobs:
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
           --command="sudo docker logs --tail 200 ${CONTAINER_ID}" \
-          )
-          SSH_STATUS=$?
+          ) || SSH_STATUS=$?
 
           if [[ $SSH_STATUS -ne 0 ]] || [[ -z "$DOCKER_LOGS" ]]; then
               echo "Failed to retrieve logs via SSH."
@@ -1025,12 +1031,21 @@ jobs:
         run: |
           # The test job fails over across zones, so discover the zone the instance
           # actually landed in instead of assuming the primary zone.
-          # `|| true` keeps `set -e` from aborting on an empty result: with no match,
-          # read hits EOF and returns non-zero, and the "nothing to delete" case is
-          # handled below.
-          read -r INSTANCE ZONE < <(gcloud compute instances list \
+          #
+          # The lookup's exit status is checked separately from its output. A failed
+          # `instances list` - expired credentials on a multi-day run, a transient API
+          # error - also returns nothing, and folding that into the "no match" case
+          # would report a successful teardown while the instance keeps running, which
+          # is the silent orphan this job exists to prevent. The step is
+          # `continue-on-error`, so the annotation surfaces without failing the run.
+          if ! MATCHED=$(gcloud compute instances list \
             --filter="name=${INSTANCE_NAME}" \
-            --format='value(name,zone.basename())') || true
+            --format='value(name,zone.basename())'); then
+            echo "::error::Could not list instances while looking for ${INSTANCE_NAME}; it may still be running"
+            exit 1
+          fi
+
+          read -r INSTANCE ZONE <<< "${MATCHED}"
           if [ -z "${INSTANCE}" ]; then
             echo "No instance to delete"
           else
@@ -1043,6 +1058,9 @@ jobs:
     # Always run this job to check the status of dependent jobs
     if: always()
     needs:
+      # determine-environment resolves the resource names and can fail on its own
+      # guards, so it is reported directly rather than through the jobs it skips.
+      - determine-environment
       - get-disk-name
       - test-result
       - create-state-image

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -1060,11 +1060,31 @@ jobs:
             exit 1
           fi
 
-          read -r INSTANCE ZONE <<< "${MATCHED}"
-          if [ -z "${INSTANCE}" ]; then
+          if [ -z "${MATCHED}" ]; then
             echo "No instance to delete"
           else
-            gcloud compute instances delete "${INSTANCE}" --zone "${ZONE}" --delete-disks all --quiet
+            # Delete every match, not just the first row. A name identifies a run, but
+            # GCE names are unique per zone rather than per project, so one run can own
+            # instances in more than one zone: the failover path's cleanup delete is
+            # `|| true` and may leave a partial instance behind before the next zone
+            # succeeds, and a re-run addresses the same names by design. Reading a
+            # single row would delete one and leave the rest running - the orphan this
+            # job exists to prevent.
+            #
+            # A failed delete is recorded rather than propagated, so one failure does
+            # not abort the loop and strand the instances after it.
+            DELETE_FAILED=0
+            while read -r INSTANCE ZONE; do
+              if [ -n "${INSTANCE}" ]; then
+                echo "Deleting ${INSTANCE} in ${ZONE}"
+                gcloud compute instances delete "${INSTANCE}" --zone "${ZONE}" --delete-disks all --quiet \
+                  || { echo "::error::Failed to delete ${INSTANCE} in ${ZONE}"; DELETE_FAILED=1; }
+              fi
+            done <<< "${MATCHED}"
+
+            if [ "${DELETE_FAILED}" -ne 0 ]; then
+              exit 1
+            fi
           fi
 
   deployment-success:

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -165,11 +165,18 @@ jobs:
           INSTANCE_NAME="${TEST_ID}-${REPO_ID}-${RUN_ID}"
           DISK_NAME="${TEST_ID}-dsk-${REPO_ID}-${RUN_ID}"
 
-          # GCE rejects names over 63 characters. Fail here with a clear message
-          # rather than at instance creation with an opaque one.
+          # GCE rejects names over 63 characters, and names that are not lowercase
+          # RFC 1035 labels. Fail here with a clear message rather than at instance
+          # creation with an opaque one. Length alone is not enough: a `test_id`
+          # carrying an underscore or a capital would pass a length-only check and
+          # still fail creation with exactly the error this guard exists to prevent.
           for name in "${INSTANCE_NAME}" "${DISK_NAME}"; do
             if [ "${#name}" -gt 63 ]; then
               echo "::error::Generated name is ${#name} characters, over the GCE limit of 63: ${name}"
+              exit 1
+            fi
+            if [[ ! "${name}" =~ ^[a-z]([-a-z0-9]*[a-z0-9])?$ ]]; then
+              echo "::error::Generated name is not a valid GCE resource name: ${name}"
               exit 1
             fi
           done
@@ -950,14 +957,21 @@ jobs:
           FORCE_SAVE_TO_DISK: ${{ inputs.force_save_to_disk }}
           TEST_ID: ${{ inputs.test_id }}
           APP_NAME: ${{ inputs.app_name }}
-          GITHUB_REF_SLUG_URL: ${{ env.GITHUB_REF_SLUG_URL }}
-          GITHUB_SHA_SHORT: ${{ env.GITHUB_SHA_SHORT }}
         run: |
-          # GCP label values accept only lowercase letters, digits, `-` and `_`, so the
-          # `owner/name` form of GITHUB_REPOSITORY has to be folded before use. Without
-          # this the whole `gcloud compute images create` call is rejected.
+          # GCP label values accept only lowercase letters, digits, `-` and `_`, and are
+          # capped at 63 characters, so the `owner/name` form of GITHUB_REPOSITORY has to
+          # be folded before use. Replacing `/` alone is not enough: an owner is limited
+          # to alphanumerics and hyphens, but a repository name may also contain `.`
+          # (`next.js` and `socket.io` are ordinary names), so after lowercasing the
+          # offending characters are exactly `.` and `/`. Either one makes GCP reject the
+          # whole `gcloud compute images create` call - which would discard the image at
+          # the very end of a multi-day sync, for a label that is purely informational.
+          # The cap matters too: an owner of 39 plus a name of 100 is well over 63.
+          # Substituting the complement of the accepted set keeps `ZcashFoundation/zebra`
+          # folding to `zcashfoundation-zebra` exactly as before.
           REPOSITORY_LABEL="${GITHUB_REPOSITORY,,}"
-          REPOSITORY_LABEL="${REPOSITORY_LABEL//\//-}"
+          REPOSITORY_LABEL="${REPOSITORY_LABEL//[^a-z0-9_-]/-}"
+          REPOSITORY_LABEL="${REPOSITORY_LABEL:0:63}"
 
           MINIMUM_UPDATE_HEIGHT=$((ORIGINAL_HEIGHT+CACHED_STATE_UPDATE_LIMIT))
           if [[ -z "$UPDATE_SUFFIX" ]] || [[ "$SYNC_HEIGHT" -gt "$MINIMUM_UPDATE_HEIGHT" ]] || [[ "${FORCE_SAVE_TO_DISK}" == "true" ]]; then

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -110,16 +110,50 @@ permissions:
 jobs:
   # Resolve the workflow environment once so every downstream job and the
   # SENTRY_ENVIRONMENT / GCP labels stay in lockstep.
+  #
+  # Also resolve the GCE instance and data-disk names once, here, so every job that
+  # creates, inspects or deletes them agrees. Both names identify the run that owns
+  # them: without that, two runs at the same commit generate identical names and race
+  # for the same instance and the same 400 GB state disk. That happens routinely — a
+  # push and the weekly schedule sit in different concurrency groups, and a copy of
+  # this workflow in another repository is scheduled independently.
+  #
+  # The pair `(repository_id, run_id)` is what makes a name unique:
+  #   - `run_id` alone is NOT enough. GitHub documents it as "a unique number for each
+  #     workflow run within a repository", so two repositories may legally produce the
+  #     same value. It happens to be globally sequential today, but that is an
+  #     unspecified implementation detail and not something to rely on.
+  #   - `repository_id` rather than `github.repository`: it is numeric, stable across
+  #     repository renames, and free of the uppercase and `/` that GCP names reject.
+  #   - `run_id`, not `run_attempt`, so a re-run addresses its own resources rather
+  #     than creating a second set.
+  #
+  # Two constraints on the format:
+  #   - `run_id` must stay the TRAILING component. The daily cleanup selects on
+  #     `name~-[0-9a-f]{7,}$` (scripts/gcp-delete-old-instances.sh, -disks.sh); a
+  #     decimal run id satisfies that, but anything appended after it would not, and
+  #     the resources would leak.
+  #   - The two names must DIFFER. GCE names an instance's boot disk after the
+  #     instance when none is given, and `create-with-container` gives none, so an
+  #     identical data-disk name collides with the boot disk and creation fails.
+  #
+  # Neither the branch nor the commit is part of the name: both are carried on the
+  # instance labels, where there is no 63-character budget to compete for.
   determine-environment:
     name: Determine environment
     runs-on: ubuntu-latest
     timeout-minutes: 1
     outputs:
       environment: ${{ steps.set.outputs.environment }}
+      instance_name: ${{ steps.set.outputs.instance_name }}
+      disk_name: ${{ steps.set.outputs.disk_name }}
     steps:
       - id: set
         env:
           EVENT_NAME: ${{ github.event_name }}
+          TEST_ID: ${{ inputs.test_id }}
+          REPO_ID: ${{ github.repository_id }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           case "$EVENT_NAME" in
             release)      ENV="prod" ;;
@@ -127,6 +161,21 @@ jobs:
             *)            ENV="stage" ;;
           esac
           echo "environment=$ENV" >> "$GITHUB_OUTPUT"
+
+          INSTANCE_NAME="${TEST_ID}-${REPO_ID}-${RUN_ID}"
+          DISK_NAME="${TEST_ID}-dsk-${REPO_ID}-${RUN_ID}"
+
+          # GCE rejects names over 63 characters. Fail here with a clear message
+          # rather than at instance creation with an opaque one.
+          for name in "${INSTANCE_NAME}" "${DISK_NAME}"; do
+            if [ "${#name}" -gt 63 ]; then
+              echo "::error::Generated name is ${#name} characters, over the GCE limit of 63: ${name}"
+              exit 1
+            fi
+          done
+
+          echo "instance_name=${INSTANCE_NAME}" >> "$GITHUB_OUTPUT"
+          echo "disk_name=${DISK_NAME}" >> "$GITHUB_OUTPUT"
 
   # Find a cached state disk for ${{ inputs.test_id }}, matching all of:
   # - disk cached state prefix -> zebrad-cache or lwd-cache
@@ -246,9 +295,9 @@ jobs:
         env:
           WORKFLOW_ENVIRONMENT: ${{ needs.determine-environment.outputs.environment }}
           PRIMARY_ZONE: ${{ vars.GCP_ZONE }}
+          INSTANCE_NAME: ${{ needs.determine-environment.outputs.instance_name }}
+          NAME: ${{ needs.determine-environment.outputs.disk_name }}
         run: |
-          NAME="${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}"
-          INSTANCE_NAME="${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}"
 
           CONTAINER_MOUNT_DISKS="--container-mount-disk=mount-path=${{ inputs.zebra_state_dir }},name=${NAME},mode=rw"
 
@@ -293,6 +342,9 @@ jobs:
               DISK_ATTACH_PARAMS="--create-disk=size=400GB,type=pd-balanced,name=${NAME},device-name=${NAME}"
             fi
 
+            # DISK_ATTACH_PARAMS and CONTAINER_MOUNT_DISKS each expand to one or more
+            # separate gcloud arguments, so they are deliberately left unquoted.
+            # shellcheck disable=SC2086
             gcloud compute instances create-with-container "${INSTANCE_NAME}" \
             --machine-type ${{ inputs.is_long_test && vars.GCP_LARGE_MACHINE || vars.GCP_SMALL_MACHINE }} \
             --boot-disk-size=50GB \
@@ -311,7 +363,7 @@ jobs:
             --service-account=${{ vars.GCP_DEPLOYMENTS_SA }} \
             --metadata=google-logging-enabled=true,google-logging-use-fluentbit=true,google-monitoring-enabled=true \
             --metadata-from-file=startup-script=.github/workflows/scripts/gcp-vm-startup-script.sh \
-            --labels=app=${{ inputs.app_name }},environment=${WORKFLOW_ENVIRONMENT},network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }} \
+            --labels=app=${{ inputs.app_name }},environment=${WORKFLOW_ENVIRONMENT},network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }},commit=${{ env.GITHUB_SHA_SHORT }} \
             --tags ${{ inputs.app_name }} \
             --zone "${zone}"
           }
@@ -351,8 +403,9 @@ jobs:
       # Find the container ID and save it for use in subsequent steps
       - name: Find container ID
         id: find-container
+        env:
+          INSTANCE_NAME: ${{ needs.determine-environment.outputs.instance_name }}
         run: |
-          INSTANCE_NAME="${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}"
           CONTAINER_PREFIX="klt-${INSTANCE_NAME}"
 
           echo "Looking for container with prefix: ${CONTAINER_PREFIX}"
@@ -360,7 +413,7 @@ jobs:
           # Wait up to 60 seconds for container to start
           for attempt in {1..30}; do
             echo "Attempt ${attempt}/30: Checking for running container..."
-            CONTAINER_ID=$(gcloud compute ssh ${INSTANCE_NAME} \
+            CONTAINER_ID=$(gcloud compute ssh "${INSTANCE_NAME}" \
               --zone ${{ steps.create-instance.outputs.instance_zone }} \
               --ssh-flag="-o ServerAliveInterval=5" \
               --ssh-flag="-o ConnectionAttempts=20" \
@@ -368,7 +421,7 @@ jobs:
               --command="sudo docker ps --filter name=${CONTAINER_PREFIX} -q --no-trunc" 2>/dev/null || echo "")
             if [ -n "${CONTAINER_ID}" ]; then
               echo "Found running container: ${CONTAINER_ID}"
-              echo "CONTAINER_ID=${CONTAINER_ID}" >> $GITHUB_OUTPUT
+              echo "CONTAINER_ID=${CONTAINER_ID}" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             echo "No running container found yet, waiting 2 seconds..."
@@ -389,10 +442,12 @@ jobs:
       # with that status.
       # (`docker wait` can also wait for multiple containers, but we only ever wait for a single container.)
       - name: Result of ${{ inputs.test_id }} test
+        env:
+          INSTANCE_NAME: ${{ needs.determine-environment.outputs.instance_name }}
         run: |
           CONTAINER_ID="${{ steps.find-container.outputs.CONTAINER_ID }}"
           echo "Using pre-discovered container ID: ${CONTAINER_ID}"
-          gcloud compute ssh ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }} \
+          gcloud compute ssh "${INSTANCE_NAME}" \
           --zone ${{ steps.create-instance.outputs.instance_zone }} \
           --ssh-flag="-o ServerAliveInterval=5" \
           --ssh-flag="-o ConnectionAttempts=20" \
@@ -440,11 +495,11 @@ jobs:
         # logs must not replace the real outcome with a misleading one.
         continue-on-error: true
         env:
-          INSTANCE_NAME: ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}
+          INSTANCE_NAME: ${{ needs.determine-environment.outputs.instance_name }}
           GCP_ZONE: ${{ steps.create-instance.outputs.instance_zone }}
-          # The data disk is attached with `device-name=<test_id>-<sha>`, which the
-          # guest exposes under /dev/disk/by-id/google-<device-name>.
-          DISK_DEVICE: /dev/disk/by-id/google-${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }}
+          # The data disk is attached with `device-name=<disk_name>`, which the guest
+          # exposes under /dev/disk/by-id/google-<device-name>.
+          DISK_DEVICE: /dev/disk/by-id/google-${{ needs.determine-environment.outputs.disk_name }}
           CONTAINER_ID: ${{ steps.find-container.outputs.CONTAINER_ID }}
         run: |
           gcloud compute ssh "${INSTANCE_NAME}" \
@@ -490,7 +545,7 @@ jobs:
         if: ${{ startsWith(inputs.test_id, 'generate-checkpoints-') }}
         env:
           CONTAINER_ID: ${{ steps.find-container.outputs.CONTAINER_ID }}
-          INSTANCE_NAME: ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}
+          INSTANCE_NAME: ${{ needs.determine-environment.outputs.instance_name }}
           GCP_ZONE: ${{ steps.create-instance.outputs.instance_zone }}
         run: |
           gcloud compute ssh "${INSTANCE_NAME}" \
@@ -515,6 +570,7 @@ jobs:
     env:
       TEST_ID: ${{ inputs.test_id }}
       GCP_ZONE: ${{ needs.test-result.outputs.instance_zone }}
+      INSTANCE_NAME: ${{ needs.determine-environment.outputs.instance_name }}
     permissions:
       contents: read
       id-token: write
@@ -522,11 +578,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: false
-      - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@e6f261660910b273384c5c42b17a0217881b217a #v5.6.0
-        with:
-          short-length: 7
-          slug-maxlength: 23
       - uses: shimataro/ssh-key-action@87a8f067114a8ce263df83e9ed5c849953548bc3 #v2.8.1
         with:
           key: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
@@ -546,7 +597,6 @@ jobs:
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db #v3.0.1
       - name: Pull checkpoint file from instance
         run: |
-          INSTANCE_NAME="${TEST_ID}-${GITHUB_REF_SLUG_URL}-${GITHUB_SHA_SHORT}"
           # Match the repo file naming used by checkpoint-update.yml.
           if echo "${TEST_ID}" | grep -qi "testnet"; then
             OUT="test-checkpoints.txt"
@@ -678,26 +728,26 @@ jobs:
       # Passes the versions to subsequent steps using the $INITIAL_DISK_DB_VERSION,
       # $RUNNING_DB_VERSION, and $DB_VERSION_SUMMARY env variables.
       - name: Get database versions from logs
+        env:
+          INSTANCE_NAME: ${{ needs.determine-environment.outputs.instance_name }}
         run: |
           INITIAL_DISK_DB_VERSION=""
           RUNNING_DB_VERSION=""
           DB_VERSION_SUMMARY=""
 
-          # Get Instance Name
-          INSTANCE_NAME="${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}"
-
           echo "Fetching first 1000 log entries via SSH for instance ${INSTANCE_NAME} to find DB versions..."
           CONTAINER_ID="${{ needs.test-result.outputs.container_id }}"
           DOCKER_LOGS=$( \
-          gcloud compute ssh ${INSTANCE_NAME} \
+          gcloud compute ssh "${INSTANCE_NAME}" \
           --zone ${{ needs.test-result.outputs.instance_zone }} \
           --ssh-flag="-o ServerAliveInterval=5" \
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
           --command="sudo docker logs ${CONTAINER_ID} | head -1000" \
           )
+          SSH_STATUS=$?
 
-          if [[ $? -ne 0 ]] || [[ -z "$DOCKER_LOGS" ]]; then
+          if [[ $SSH_STATUS -ne 0 ]] || [[ -z "$DOCKER_LOGS" ]]; then
               echo "Failed to retrieve logs via SSH."
               exit 1
           fi
@@ -777,24 +827,24 @@ jobs:
       #
       # Passes the sync height to subsequent steps using the $SYNC_HEIGHT env variable.
       - name: Get sync height from logs
+        env:
+          INSTANCE_NAME: ${{ needs.determine-environment.outputs.instance_name }}
         run: |
           SYNC_HEIGHT=""
-
-          # Get Instance Name
-          INSTANCE_NAME="${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}"
 
           echo "Fetching last 200 log entries via SSH for instance ${INSTANCE_NAME} to find sync height..."
           CONTAINER_ID="${{ needs.test-result.outputs.container_id }}"
           DOCKER_LOGS=$( \
-          gcloud compute ssh ${INSTANCE_NAME} \
+          gcloud compute ssh "${INSTANCE_NAME}" \
           --zone ${{ needs.test-result.outputs.instance_zone }} \
           --ssh-flag="-o ServerAliveInterval=5" \
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
           --command="sudo docker logs --tail 200 ${CONTAINER_ID}" \
           )
+          SSH_STATUS=$?
 
-          if [[ $? -ne 0 ]] || [[ -z "$DOCKER_LOGS" ]]; then
+          if [[ $SSH_STATUS -ne 0 ]] || [[ -z "$DOCKER_LOGS" ]]; then
               echo "Failed to retrieve logs via SSH."
               exit 1
           fi
@@ -877,7 +927,15 @@ jobs:
       # Force the image creation (--force) as the disk is still attached even though is not being
       # used by the container.
       - name: Create image from state disk
+        env:
+          DISK_NAME: ${{ needs.determine-environment.outputs.disk_name }}
         run: |
+          # GCP label values accept only lowercase letters, digits, `-` and `_`, so the
+          # `owner/name` form of GITHUB_REPOSITORY has to be folded before use. Without
+          # this the whole `gcloud compute images create` call is rejected.
+          REPOSITORY_LABEL="${GITHUB_REPOSITORY,,}"
+          REPOSITORY_LABEL="${REPOSITORY_LABEL//\//-}"
+
           MINIMUM_UPDATE_HEIGHT=$((ORIGINAL_HEIGHT+CACHED_STATE_UPDATE_LIMIT))
           if [[ -z "$UPDATE_SUFFIX" ]] || [[ "$SYNC_HEIGHT" -gt "$MINIMUM_UPDATE_HEIGHT" ]] || [[ "${{ inputs.force_save_to_disk }}" == "true" ]]; then
 
@@ -900,11 +958,11 @@ jobs:
              gcloud compute images create \
               "${{ inputs.disk_prefix }}-${SHORT_GITHUB_REF}-${{ env.GITHUB_SHA_SHORT }}-v${IMAGE_VERSION_FOR_NAME}-${NETWORK}-${{ inputs.disk_suffix }}${UPDATE_SUFFIX}-${TIME_SUFFIX}" \
               --force \
-              --source-disk=${{ inputs.test_id }}-${{ env.GITHUB_SHA_SHORT }} \
+              --source-disk="${DISK_NAME}" \
               --source-disk-zone=${{ needs.test-result.outputs.instance_zone }} \
               --storage-location=us \
               --description="Created from commit ${{ env.GITHUB_SHA_SHORT }} with height ${{ env.SYNC_HEIGHT }} and database format ${{ env.DB_VERSION_SUMMARY }}" \
-              --labels="height=${{ env.SYNC_HEIGHT }},purpose=${{ inputs.disk_prefix }},branch=${{ env.GITHUB_REF_SLUG_URL }},commit=${{ env.GITHUB_SHA_SHORT }},state-version=${IMAGE_VERSION_FOR_NAME},state-running-version=${RUNNING_DB_VERSION},initial-state-disk-version=${INITIAL_DISK_DB_VERSION},network=${NETWORK},target-height-kind=${{ inputs.disk_suffix }},update-flag=${UPDATE_SUFFIX},force-save=${{ inputs.force_save_to_disk }},updated-from-height=${ORIGINAL_HEIGHT},updated-from-disk=${ORIGINAL_DISK_NAME},test-id=${{ inputs.test_id }},app-name=${{ inputs.app_name }}"
+              --labels="height=${{ env.SYNC_HEIGHT }},purpose=${{ inputs.disk_prefix }},branch=${{ env.GITHUB_REF_SLUG_URL }},commit=${{ env.GITHUB_SHA_SHORT }},state-version=${IMAGE_VERSION_FOR_NAME},state-running-version=${RUNNING_DB_VERSION},initial-state-disk-version=${INITIAL_DISK_DB_VERSION},network=${NETWORK},target-height-kind=${{ inputs.disk_suffix }},update-flag=${UPDATE_SUFFIX},force-save=${{ inputs.force_save_to_disk }},updated-from-height=${ORIGINAL_HEIGHT},updated-from-disk=${ORIGINAL_DISK_NAME},test-id=${{ inputs.test_id }},app-name=${{ inputs.app_name }},repository=${REPOSITORY_LABEL}"
           else
               echo "Skipped cached state update because the new sync height $SYNC_HEIGHT was less than $CACHED_STATE_UPDATE_LIMIT blocks above the original height $ORIGINAL_HEIGHT of $ORIGINAL_DISK_NAME"
           fi
@@ -930,12 +988,6 @@ jobs:
           persist-credentials: false
           fetch-depth: '2'
 
-      - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@e6f261660910b273384c5c42b17a0217881b217a #v5.6.0
-        with:
-          short-length: 7
-          slug-maxlength: 23
-
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
         id: auth
@@ -952,7 +1004,7 @@ jobs:
       - name: Delete test instance
         continue-on-error: true
         env:
-          INSTANCE_NAME: ${{ inputs.test_id }}-${{ env.GITHUB_REF_SLUG_URL }}-${{ env.GITHUB_SHA_SHORT }}
+          INSTANCE_NAME: ${{ needs.determine-environment.outputs.instance_name }}
         run: |
           # The test job fails over across zones, so discover the zone the instance
           # actually landed in instead of assuming the primary zone.

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -297,6 +297,13 @@ jobs:
           PRIMARY_ZONE: ${{ vars.GCP_ZONE }}
           INSTANCE_NAME: ${{ needs.determine-environment.outputs.instance_name }}
           NAME: ${{ needs.determine-environment.outputs.disk_name }}
+          # Bound here rather than expanded inline in the `--labels` argument below:
+          # a `${{ }}` expansion is substituted before the shell parses the line, so a
+          # value containing shell metacharacters would escape its quoting context.
+          APP_NAME: ${{ inputs.app_name }}
+          TEST_ID: ${{ inputs.test_id }}
+          GITHUB_REF_SLUG_URL: ${{ env.GITHUB_REF_SLUG_URL }}
+          GITHUB_SHA_SHORT: ${{ env.GITHUB_SHA_SHORT }}
         run: |
 
           CONTAINER_MOUNT_DISKS="--container-mount-disk=mount-path=${{ inputs.zebra_state_dir }},name=${NAME},mode=rw"
@@ -363,7 +370,7 @@ jobs:
             --service-account=${{ vars.GCP_DEPLOYMENTS_SA }} \
             --metadata=google-logging-enabled=true,google-logging-use-fluentbit=true,google-monitoring-enabled=true \
             --metadata-from-file=startup-script=.github/workflows/scripts/gcp-vm-startup-script.sh \
-            --labels=app=${{ inputs.app_name }},environment=${WORKFLOW_ENVIRONMENT},network=${NETWORK},github_ref=${{ env.GITHUB_REF_SLUG_URL }},test=${{ inputs.test_id }},commit=${{ env.GITHUB_SHA_SHORT }} \
+            --labels="app=${APP_NAME},environment=${WORKFLOW_ENVIRONMENT},network=${NETWORK},github_ref=${GITHUB_REF_SLUG_URL},test=${TEST_ID},commit=${GITHUB_SHA_SHORT}" \
             --tags ${{ inputs.app_name }} \
             --zone "${zone}"
           }
@@ -929,6 +936,16 @@ jobs:
       - name: Create image from state disk
         env:
           DISK_NAME: ${{ needs.determine-environment.outputs.disk_name }}
+          # Bound here rather than expanded inline in the `--labels` argument below:
+          # a `${{ }}` expansion is substituted before the shell parses the line, so a
+          # value containing shell metacharacters would escape its quoting context.
+          DISK_PREFIX: ${{ inputs.disk_prefix }}
+          DISK_SUFFIX: ${{ inputs.disk_suffix }}
+          FORCE_SAVE_TO_DISK: ${{ inputs.force_save_to_disk }}
+          TEST_ID: ${{ inputs.test_id }}
+          APP_NAME: ${{ inputs.app_name }}
+          GITHUB_REF_SLUG_URL: ${{ env.GITHUB_REF_SLUG_URL }}
+          GITHUB_SHA_SHORT: ${{ env.GITHUB_SHA_SHORT }}
         run: |
           # GCP label values accept only lowercase letters, digits, `-` and `_`, so the
           # `owner/name` form of GITHUB_REPOSITORY has to be folded before use. Without
@@ -937,7 +954,7 @@ jobs:
           REPOSITORY_LABEL="${REPOSITORY_LABEL//\//-}"
 
           MINIMUM_UPDATE_HEIGHT=$((ORIGINAL_HEIGHT+CACHED_STATE_UPDATE_LIMIT))
-          if [[ -z "$UPDATE_SUFFIX" ]] || [[ "$SYNC_HEIGHT" -gt "$MINIMUM_UPDATE_HEIGHT" ]] || [[ "${{ inputs.force_save_to_disk }}" == "true" ]]; then
+          if [[ -z "$UPDATE_SUFFIX" ]] || [[ "$SYNC_HEIGHT" -gt "$MINIMUM_UPDATE_HEIGHT" ]] || [[ "${FORCE_SAVE_TO_DISK}" == "true" ]]; then
 
              # Use RUNNING_DB_VERSION for image naming (more reliable than STATE_VERSION)
              # Extract just the major version number for the image name
@@ -948,7 +965,7 @@ jobs:
              if [[ -z $IMAGE_VERSION_FOR_NAME ]] || [[ ! $IMAGE_VERSION_FOR_NAME =~ ^[0-9]+$ ]]; then
                  echo "ERROR: Invalid version extracted for image naming: $IMAGE_VERSION_FOR_NAME"
                  echo "RUNNING_DB_VERSION was: $RUNNING_DB_VERSION"
-                 echo "STATE_VERSION was: ${{ env.STATE_VERSION }}"
+                 echo "STATE_VERSION was: ${STATE_VERSION}"
                  exit 1
              fi
              
@@ -956,13 +973,13 @@ jobs:
 
              # Create image from the test disk
              gcloud compute images create \
-              "${{ inputs.disk_prefix }}-${SHORT_GITHUB_REF}-${{ env.GITHUB_SHA_SHORT }}-v${IMAGE_VERSION_FOR_NAME}-${NETWORK}-${{ inputs.disk_suffix }}${UPDATE_SUFFIX}-${TIME_SUFFIX}" \
+              "${DISK_PREFIX}-${SHORT_GITHUB_REF}-${GITHUB_SHA_SHORT}-v${IMAGE_VERSION_FOR_NAME}-${NETWORK}-${DISK_SUFFIX}${UPDATE_SUFFIX}-${TIME_SUFFIX}" \
               --force \
               --source-disk="${DISK_NAME}" \
               --source-disk-zone=${{ needs.test-result.outputs.instance_zone }} \
               --storage-location=us \
-              --description="Created from commit ${{ env.GITHUB_SHA_SHORT }} with height ${{ env.SYNC_HEIGHT }} and database format ${{ env.DB_VERSION_SUMMARY }}" \
-              --labels="height=${{ env.SYNC_HEIGHT }},purpose=${{ inputs.disk_prefix }},branch=${{ env.GITHUB_REF_SLUG_URL }},commit=${{ env.GITHUB_SHA_SHORT }},state-version=${IMAGE_VERSION_FOR_NAME},state-running-version=${RUNNING_DB_VERSION},initial-state-disk-version=${INITIAL_DISK_DB_VERSION},network=${NETWORK},target-height-kind=${{ inputs.disk_suffix }},update-flag=${UPDATE_SUFFIX},force-save=${{ inputs.force_save_to_disk }},updated-from-height=${ORIGINAL_HEIGHT},updated-from-disk=${ORIGINAL_DISK_NAME},test-id=${{ inputs.test_id }},app-name=${{ inputs.app_name }},repository=${REPOSITORY_LABEL}"
+              --description="Created from commit ${GITHUB_SHA_SHORT} with height ${SYNC_HEIGHT} and database format ${DB_VERSION_SUMMARY}" \
+              --labels="height=${SYNC_HEIGHT},purpose=${DISK_PREFIX},branch=${GITHUB_REF_SLUG_URL},commit=${GITHUB_SHA_SHORT},state-version=${IMAGE_VERSION_FOR_NAME},state-running-version=${RUNNING_DB_VERSION},initial-state-disk-version=${INITIAL_DISK_DB_VERSION},network=${NETWORK},target-height-kind=${DISK_SUFFIX},update-flag=${UPDATE_SUFFIX},force-save=${FORCE_SAVE_TO_DISK},updated-from-height=${ORIGINAL_HEIGHT},updated-from-disk=${ORIGINAL_DISK_NAME},test-id=${TEST_ID},app-name=${APP_NAME},repository=${REPOSITORY_LABEL}"
           else
               echo "Skipped cached state update because the new sync height $SYNC_HEIGHT was less than $CACHED_STATE_UPDATE_LIMIT blocks above the original height $ORIGINAL_HEIGHT of $ORIGINAL_DISK_NAME"
           fi

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -1021,10 +1021,15 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-        with:
-          persist-credentials: false
-          fetch-depth: '2'
+      # This job deliberately does NOT check out the repository, and should not be
+      # given a checkout step by reflex when one is added elsewhere in this file.
+      # Nothing here reads the working tree: authentication is by workload identity,
+      # `setup-gcloud` downloads the SDK, and the teardown below is an inline script
+      # that names no repository path. `ensure-health-checks` in
+      # zfnd-deploy-prebuilt-nodes-gcp.yml is the same shape and runs without one.
+      #
+      # Contrast zfnd-delete-gcp-resources.yml, which does need a checkout: its steps
+      # execute ./.github/workflows/scripts/*.sh from the repository.
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -170,13 +170,22 @@ jobs:
           # creation with an opaque one. Length alone is not enough: a `test_id`
           # carrying an underscore or a capital would pass a length-only check and
           # still fail creation with exactly the error this guard exists to prevent.
+          #
+          # The third check asserts the selector contract from the naming block
+          # above: a name the daily cleanup cannot match would leak silently, so a
+          # format change that breaks the match must fail here, at composition time.
+          REAPER_SELECTOR='-[0-9a-f]{7,}$'
           for name in "${INSTANCE_NAME}" "${DISK_NAME}"; do
             if [ "${#name}" -gt 63 ]; then
-              echo "::error::Generated name is ${#name} characters, over the GCE limit of 63: ${name}"
+              echo "::error::Generated name is ${#name} characters, over the GCE limit of 63 (is test_id too long?): ${name}"
               exit 1
             fi
             if [[ ! "${name}" =~ ^[a-z]([-a-z0-9]*[a-z0-9])?$ ]]; then
-              echo "::error::Generated name is not a valid GCE resource name: ${name}"
+              echo "::error::Generated name is not a valid GCE resource name (check test_id): ${name}"
+              exit 1
+            fi
+            if [[ ! "${name}" =~ ${REAPER_SELECTOR} ]]; then
+              echo "::error::Generated name does not match the daily cleanup selector ${REAPER_SELECTOR} and would leak: ${name}"
               exit 1
             fi
           done
@@ -244,11 +253,8 @@ jobs:
         uses: rlespinasse/github-slug-action@e6f261660910b273384c5c42b17a0217881b217a #v5.6.0
         with:
           short-length: 7
-          # The slug is no longer part of any resource name - names are resolved in
-          # `determine-environment` from the test id and the run identity. Its only
-          # consumer here is the `github_ref` instance label, where the GCP limit is
-          # 63 characters, so 23 is now a free choice; it is kept so that existing
-          # label values do not change.
+          # The slug now only feeds the `github_ref` instance label (GCP limit 63);
+          # 23 is kept so existing label values do not change.
           slug-maxlength: 23
 
       - name: Downcase network name for disks and labels
@@ -959,17 +965,12 @@ jobs:
           TEST_ID: ${{ inputs.test_id }}
           APP_NAME: ${{ inputs.app_name }}
         run: |
-          # GCP label values accept only lowercase letters, digits, `-` and `_`, and are
-          # capped at 63 characters, so the `owner/name` form of GITHUB_REPOSITORY has to
-          # be folded before use. Replacing `/` alone is not enough: an owner is limited
-          # to alphanumerics and hyphens, but a repository name may also contain `.`
-          # (`next.js` and `socket.io` are ordinary names), so after lowercasing the
-          # offending characters are exactly `.` and `/`. Either one makes GCP reject the
-          # whole `gcloud compute images create` call - which would discard the image at
-          # the very end of a multi-day sync, for a label that is purely informational.
-          # The cap matters too: an owner of 39 plus a name of 100 is well over 63.
-          # Substituting the complement of the accepted set keeps `ZcashFoundation/zebra`
-          # folding to `zcashfoundation-zebra` exactly as before.
+          # GCP label values accept only `[a-z0-9_-]`, capped at 63 characters; anything
+          # else makes GCP reject the whole `images create` call, discarding the image at
+          # the very end of a multi-day sync. Replacing `/` alone is not enough: an owner
+          # is limited to alphanumerics and hyphens, but a repository name may also
+          # contain `.` (`next.js`, `socket.io`), and an owner of 39 plus a name of 100
+          # is well over the cap.
           REPOSITORY_LABEL="${GITHUB_REPOSITORY,,}"
           REPOSITORY_LABEL="${REPOSITORY_LABEL//[^a-z0-9_-]/-}"
           REPOSITORY_LABEL="${REPOSITORY_LABEL:0:63}"
@@ -1027,9 +1028,8 @@ jobs:
       # `setup-gcloud` downloads the SDK, and the teardown below is an inline script
       # that names no repository path. `ensure-health-checks` in
       # zfnd-deploy-prebuilt-nodes-gcp.yml is the same shape and runs without one.
-      #
-      # Contrast zfnd-delete-gcp-resources.yml, which does need a checkout: its steps
-      # execute ./.github/workflows/scripts/*.sh from the repository.
+      # (zfnd-delete-gcp-resources.yml, by contrast, needs its checkout: it executes
+      # scripts from the repository.)
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
@@ -1045,6 +1045,9 @@ jobs:
       # Deletes the instances that has been recently deployed in the actual commit after all
       # previous jobs have run, no matter the outcome of the job.
       - name: Delete test instance
+        # An empty name means determine-environment never resolved one, so nothing
+        # can have been created - and an empty `name=` filter is a gcloud error.
+        if: ${{ needs.determine-environment.outputs.instance_name != '' }}
         continue-on-error: true
         env:
           INSTANCE_NAME: ${{ needs.determine-environment.outputs.instance_name }}
@@ -1068,28 +1071,25 @@ jobs:
           if [ -z "${MATCHED}" ]; then
             echo "No instance to delete"
           else
-            # Delete every match, not just the first row. A name identifies a run, but
-            # GCE names are unique per zone rather than per project, so one run can own
-            # instances in more than one zone: the failover path's cleanup delete is
-            # `|| true` and may leave a partial instance behind before the next zone
-            # succeeds, and a re-run addresses the same names by design. Reading a
-            # single row would delete one and leave the rest running - the orphan this
-            # job exists to prevent.
+            # Delete every match, not just the first row. GCE names are unique per
+            # zone rather than per project, so one run can own instances in more than
+            # one zone: the failover path's cleanup delete is `|| true` and may leave
+            # a partial instance behind before the next zone succeeds, and a re-run
+            # addresses the same names by design.
             #
             # A failed delete is recorded rather than propagated, so one failure does
-            # not abort the loop and strand the instances after it.
+            # not abort the loop and strand the instances after it. This deliberately
+            # duplicates the loop in scripts/gcp-delete-old-instances.sh - this job
+            # has no checkout to call it from - so keep the two in sync.
             DELETE_FAILED=0
             while read -r INSTANCE ZONE; do
-              if [ -n "${INSTANCE}" ]; then
-                echo "Deleting ${INSTANCE} in ${ZONE}"
-                gcloud compute instances delete "${INSTANCE}" --zone "${ZONE}" --delete-disks all --quiet \
-                  || { echo "::error::Failed to delete ${INSTANCE} in ${ZONE}"; DELETE_FAILED=1; }
-              fi
+              [ -n "${INSTANCE}" ] || continue
+              echo "Deleting ${INSTANCE} in ${ZONE}"
+              gcloud compute instances delete "${INSTANCE}" --zone "${ZONE}" --delete-disks all --quiet \
+                || { echo "::error::Failed to delete ${INSTANCE} in ${ZONE}"; DELETE_FAILED=1; }
             done <<< "${MATCHED}"
 
-            if [ "${DELETE_FAILED}" -ne 0 ]; then
-              exit 1
-            fi
+            [ "${DELETE_FAILED}" -eq 0 ] || exit 1
           fi
 
   deployment-success:


### PR DESCRIPTION
## Motivation

GCE instance and disk names were built from the test id, the branch slug and the commit SHA — nothing identifying the *run*. Two runs at the same commit therefore produced identical names and raced for the same VM and the same 400 GB state disk.

This is not hypothetical or rare. A `push` and the weekly `schedule` sit in different concurrency groups and run concurrently by design, and a copy of this workflow in another repository is scheduled independently. It has already broken scheduled runs on 2026-08-07 and 2026-08-28.

The `already exists` failure at instance creation is the *benign* face of the bug. The dangerous one is quieter: both runs attach the same data disk, and `create-state-image` snapshots it with `--force` while the other run's container is still writing — which can publish a corrupt cached state image into the shared pool.

Addresses the naming half of #11226 (its second suggested fix, "make the name unique per run"). It does not close that issue — see Follow-up.

## Solution

Resolve both names once, in `determine-environment`, and read them from its outputs everywhere:

```
instance:  <test_id>-<repository_id>-<run_id>
disk:      <test_id>-dsk-<repository_id>-<run_id>
```

**Twelve sites** previously rebuilt these names independently. Six were inline, and two would have failed *silently* if missed: the `--source-disk` flag on image creation, and the `delete-instance` filter — which would have matched nothing and orphaned every VM for the 3–4 days until the daily cleanup reaped it. `determine-environment` is already in `needs:` for all four consuming jobs, so no dependency changes were required.

Design points worth reviewing:

- **`(repository_id, run_id)`, not `run_id` alone.** GitHub documents `run_id` as unique *"within a repository"*, so two repositories may legally produce the same value — which is the cross-repository case this is meant to fix. It is globally sequential in practice, but that is an unspecified implementation detail and not something to build on. `repository_id` is numeric, stable across renames, and free of the uppercase and `/` that GCP names reject.
- **`run_id`, not `run_attempt`**, so a re-run addresses its own resources rather than creating a second set. It stays the *trailing* component so the daily cleanup's `-[0-9a-f]{7,}$` selector still matches — a decimal run id satisfies `[0-9a-f]`, but anything appended after it would not, and the resources would leak.
- **The two names must differ.** GCE names an instance's boot disk after the instance when none is given, and `create-with-container` gives none, so an identical data-disk name collides with the boot disk and fails creation. Hence the `-dsk-` infix.
- **Neither the branch nor the commit is in the name** any more; both are instance labels instead, where there is no 63-character budget to compete for. `commit` is *added* to those labels, since it was previously only recoverable from the name.

Also in this change:

- Created cached-state images gain a `repository` label. The value is folded to GCP's accepted character set (`[a-z0-9_-]`) and capped at 63 characters, since repository names may contain `.` and label values reject anything else.
- Names are bound through `env:` rather than interpolated into `run:` blocks, per GitHub's [security-hardening guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable) and consistent with the direction of #11214.
- `determine-environment` also checks that the generated names are valid GCE names and match the daily cleanup's `-[0-9a-f]{7,}$` selector, so a format change that would leak resources fails at composition time.
- `delete-instance` deletes every instance matching the run's name — GCE names are unique per zone, so a failover or re-run can leave more than one — and reports a failed lookup instead of "No instance to delete". It no longer checks out the repository, which it never read.
- The two `$?` checks after `gcloud compute ssh` are made reachable under `bash -e` by collecting the status through `||`.
- `deployment-success` now also depends on `determine-environment`, so its failures are reported directly.
- Dropping the branch from the names leaves the slug action unused in `upload-checkpoint-artifact` and `delete-instance`, so those steps are removed. `test-result` and `create-state-image` still need theirs.
- The cleanup scripts' comments now say the selector matches a run id, not a commit hash.
- `.github/actionlint.yaml` declared `ubuntu-latest-xl` but not `zfnd-runners`; added.

### Tests

Worst case computed against the longest `test_id` (`sync-past-mandatory-checkpoint`, 30 chars) and the largest of the relevant repository ids (10 digits):

```
instance: sync-past-mandatory-checkpoint-1251412320-33188532747      53 chars
disk:     sync-past-mandatory-checkpoint-dsk-1251412320-33188532747   57 chars
```

- Both ≤ 63, distinct, and both still match the cleanup selector `-[0-9a-f]{7,}$`.
- A runtime guard in `determine-environment` fails fast if a generated name exceeds 63 characters, is not a valid GCE name, or does not match the cleanup selector. Verified at 53/57, and that it trips on 73 characters, an underscore, a capital, and a short run id.
- `delete-instance` exercised under `bash -e -o pipefail` for one match, two zones, no match, a failed lookup, and a failed delete followed by a second match.
- `actionlint` clean on the changed workflow (it previously reported 7 findings in this file; the repo-wide count drops from 13 to 9).
- All 18 `run:` scripts in the file extracted and checked with `bash -n`; plus an assertion that no comment follows a line continuation anywhere in the file.
- Verified no construction site was missed: zero remaining occurrences of the old name pattern, and each job's slug-action step matched against whether it still consumes a slug variable.

Not verifiable without a live run: that teardown actually finds the renamed instance. That is the highest-risk regression here — a silent miss orphans every VM — so the first run on this branch should be checked for `delete-instance` logging the instance name rather than "No instance to delete".

### Specifications & References

- #11226 — instance name collisions blocking the full-sync cron
- #11202 — *devops: reshape GCP integration CI into weekly maintenance plus recovery*; this reduces a source of noise in the reliability signal that issue depends on
- #11214 / #11189 — `env:`-binding hardening, whose direction this follows
- #11108 — precedent for run identity in a GCP resource name (`TEMPLATE_NAME=zebrad-…-${GITHUB_RUN_ID}-…`)
- [GitHub Actions variables reference](https://docs.github.com/en/actions/reference/workflows-and-actions/variables) — `run_id` uniqueness scope

### Follow-up Work

This does not close #11226. Its remaining points are separate:

- The failed-create path still runs the debug step with an empty zone, producing a spurious secondary error. `continue-on-error: true` (added in #11340) stops it masking the real failure, but gating the step on a non-empty `instance_zone` would remove the noise.
- Point 2 of that issue — the "out of capacity" misreport — appears to be a misreading of the log; details in [this comment](https://github.com/ZcashFoundation/zebra/issues/11226#issuecomment-5456742994).

Two shared-namespace problems remain, both distinct from resource naming and now filed separately:

- **#11362** — the cached-image pool is shared and its selector matches any branch from any repository, with a `main-[0-9a-f]+` fallback tier that cannot distinguish sources. The `repository` label added in this PR makes that pool auditable, which is a prerequisite for fixing it.
- **#11363** — the container registry is shared, and `zebrad-test:sha-<sha7>` is mutable, consumed by the test VM, and can be written by more than one repository at the same commit with differing build features. There is a clean fix available: the build workflow already exposes an immutable `image` output (#11105) that the deployment path consumes, and the integration caller could do the same.

Resumability (#11232 — preserving the VM when a runner is evicted) also depends on this change: re-attaching to a prior attempt's VM is only safe once a name provably identifies one run.

### AI Disclosure

- [x] AI tools were used: Claude Code for the investigation, implementation and this description; reviewed with OpenAI Codex, which caught the `run_id` uniqueness scope. Author is responsible for the content.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date. <!-- CI-only change; no changie fragment required -->

