### PR TITLE
fix(ci): harden the GCP teardown, name guard, and cleanup contract

### DIFF
--- a/.github/workflows/scripts/gcp-delete-old-disks.sh
+++ b/.github/workflows/scripts/gcp-delete-old-disks.sh
@@ -28,10 +28,8 @@ delete_disks() {
 }
 
 # Disks from PR jobs and other jobs whose name ends in a run id or a commit hash.
-#
-# Integration test disks end in the GitHub run id. Decimal digits are a subset of
-# `[0-9a-f]`, so they match this pattern, but only incidentally: do not tighten it to
-# assume a hexadecimal commit hash, or those disks will never be reaped.
+# Same selector contract as gcp-delete-old-instances.sh: decimal run ids match
+# `[0-9a-f]` only incidentally - do not tighten this to a hex commit hash.
 delete_disks 'name~-[0-9a-f]{7,}$'
 # Disks prefixed with "zebrad-", but never the persistent "zebrad-cache-*" chain-state disks.
 delete_disks 'name~^zebrad- AND NOT name~^zebrad-cache'

--- a/.github/workflows/scripts/gcp-delete-old-disks.sh
+++ b/.github/workflows/scripts/gcp-delete-old-disks.sh
@@ -27,7 +27,11 @@ delete_disks() {
     done <<< "${disks}"
 }
 
-# Disks from PR jobs and other jobs that use a commit hash.
+# Disks from PR jobs and other jobs whose name ends in a run id or a commit hash.
+#
+# Integration test disks end in the GitHub run id. Decimal digits are a subset of
+# `[0-9a-f]`, so they match this pattern, but only incidentally: do not tighten it to
+# assume a hexadecimal commit hash, or those disks will never be reaped.
 delete_disks 'name~-[0-9a-f]{7,}$'
 # Disks prefixed with "zebrad-", but never the persistent "zebrad-cache-*" chain-state disks.
 delete_disks 'name~^zebrad- AND NOT name~^zebrad-cache'

--- a/.github/workflows/scripts/gcp-delete-old-instances.sh
+++ b/.github/workflows/scripts/gcp-delete-old-instances.sh
@@ -18,7 +18,11 @@ if ! command -v gcloud &> /dev/null; then
     exit 1
 fi
 
-# Fetch the list of instances to delete
+# Fetch the list of instances to delete.
+#
+# Integration test instances end in the GitHub run id, not a commit hash. Decimal digits
+# are a subset of `[0-9a-f]`, so they match this pattern, but only incidentally: do not
+# tighten it to assume a hexadecimal commit hash, or those instances will never be reaped.
 if ! INSTANCES=$(gcloud compute instances list --sort-by=creationTimestamp --filter="name~-[0-9a-f]{7,}$ AND creationTimestamp < ${DELETE_BEFORE_DATE}" --format='value(NAME,ZONE)'); then
     echo "Error fetching instances."
     exit 1

--- a/.github/workflows/zfnd-delete-gcp-resources.yml
+++ b/.github/workflows/zfnd-delete-gcp-resources.yml
@@ -58,12 +58,9 @@ jobs:
       #
       # We only delete instances that end in 7 or more hex characters,
       # to avoid deleting managed instance groups and manually created instances.
-      #
-      # Integration test instances end in the GitHub run id, not a commit hash - see the
-      # naming block in zfnd-deploy-integration-tests-gcp.yml, which depends on this
-      # selector still matching them. Decimal digits are a subset of `[0-9a-f]`, so they
-      # do match, but only incidentally: tightening this pattern to assume a hexadecimal
-      # commit hash would silently orphan every test VM and its 400 GB state disk.
+      # The selector must keep matching run-id-suffixed integration test resources:
+      # rationale in the script below, contract asserted in
+      # zfnd-deploy-integration-tests-gcp.yml's `determine-environment` guard.
       - name: Delete old instances
         run: |
           ./.github/workflows/scripts/gcp-delete-old-instances.sh

--- a/.github/workflows/zfnd-delete-gcp-resources.yml
+++ b/.github/workflows/zfnd-delete-gcp-resources.yml
@@ -2,7 +2,7 @@
 #
 # 1. Deletes specific instances in GCP older than a defined number of days.
 # 2. Deletes instance templates older than a set number of days.
-# 3. Deletes older disks not currently in use, with certain ones prefixed by commit hashes or "zebrad-".
+# 3. Deletes older disks not currently in use: those whose name ends in a run id or a commit hash, and those prefixed with "zebrad-".
 # 4. Deletes cache images from GCP, retaining a specified number of the latest images for certain types like zebrad checkpoint cache, zebrad tip cache, and lightwalletd + zebrad tip cache.
 #
 # It uses the gcloud CLI for its operations and is scheduled to run daily at 0700 UTC against the dev project.
@@ -58,6 +58,12 @@ jobs:
       #
       # We only delete instances that end in 7 or more hex characters,
       # to avoid deleting managed instance groups and manually created instances.
+      #
+      # Integration test instances end in the GitHub run id, not a commit hash - see the
+      # naming block in zfnd-deploy-integration-tests-gcp.yml, which depends on this
+      # selector still matching them. Decimal digits are a subset of `[0-9a-f]`, so they
+      # do match, but only incidentally: tightening this pattern to assume a hexadecimal
+      # commit hash would silently orphan every test VM and its 400 GB state disk.
       - name: Delete old instances
         run: |
           ./.github/workflows/scripts/gcp-delete-old-instances.sh

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -244,8 +244,11 @@ jobs:
         uses: rlespinasse/github-slug-action@e6f261660910b273384c5c42b17a0217881b217a #v5.6.0
         with:
           short-length: 7
-          # GCP instance names are limited to 63 chars. With test_id (max ~31) + sha (7) + hyphens (2),
-          # we need to limit the slug to 23 chars to stay under the limit.
+          # The slug is no longer part of any resource name - names are resolved in
+          # `determine-environment` from the test id and the run identity. Its only
+          # consumer here is the `github_ref` instance label, where the GCP limit is
+          # 63 characters, so 23 is now a free choice; it is kept so that existing
+          # label values do not change.
           slug-maxlength: 23
 
       - name: Downcase network name for disks and labels
@@ -309,8 +312,6 @@ jobs:
           # value containing shell metacharacters would escape its quoting context.
           APP_NAME: ${{ inputs.app_name }}
           TEST_ID: ${{ inputs.test_id }}
-          GITHUB_REF_SLUG_URL: ${{ env.GITHUB_REF_SLUG_URL }}
-          GITHUB_SHA_SHORT: ${{ env.GITHUB_SHA_SHORT }}
         run: |
 
           CONTAINER_MOUNT_DISKS="--container-mount-disk=mount-path=${{ inputs.zebra_state_dir }},name=${NAME},mode=rw"

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -744,6 +744,11 @@ jobs:
 
           echo "Fetching first 1000 log entries via SSH for instance ${INSTANCE_NAME} to find DB versions..."
           CONTAINER_ID="${{ needs.test-result.outputs.container_id }}"
+          # The status has to be collected through `||`. GitHub runs `run:` blocks
+          # under `bash -e`, so a bare `DOCKER_LOGS=$(...)` aborts the step the moment
+          # gcloud exits non-zero - before any status line can run - and the message
+          # below would never be reached.
+          SSH_STATUS=0
           DOCKER_LOGS=$( \
           gcloud compute ssh "${INSTANCE_NAME}" \
           --zone ${{ needs.test-result.outputs.instance_zone }} \
@@ -751,8 +756,7 @@ jobs:
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
           --command="sudo docker logs ${CONTAINER_ID} | head -1000" \
-          )
-          SSH_STATUS=$?
+          ) || SSH_STATUS=$?
 
           if [[ $SSH_STATUS -ne 0 ]] || [[ -z "$DOCKER_LOGS" ]]; then
               echo "Failed to retrieve logs via SSH."
@@ -841,6 +845,9 @@ jobs:
 
           echo "Fetching last 200 log entries via SSH for instance ${INSTANCE_NAME} to find sync height..."
           CONTAINER_ID="${{ needs.test-result.outputs.container_id }}"
+          # See the note in "Get database versions from logs": under `bash -e` the
+          # status has to be collected through `||` or the step aborts first.
+          SSH_STATUS=0
           DOCKER_LOGS=$( \
           gcloud compute ssh "${INSTANCE_NAME}" \
           --zone ${{ needs.test-result.outputs.instance_zone }} \
@@ -848,8 +855,7 @@ jobs:
           --ssh-flag="-o ConnectionAttempts=20" \
           --ssh-flag="-o ConnectTimeout=5" \
           --command="sudo docker logs --tail 200 ${CONTAINER_ID}" \
-          )
-          SSH_STATUS=$?
+          ) || SSH_STATUS=$?
 
           if [[ $SSH_STATUS -ne 0 ]] || [[ -z "$DOCKER_LOGS" ]]; then
               echo "Failed to retrieve logs via SSH."
@@ -1025,12 +1031,21 @@ jobs:
         run: |
           # The test job fails over across zones, so discover the zone the instance
           # actually landed in instead of assuming the primary zone.
-          # `|| true` keeps `set -e` from aborting on an empty result: with no match,
-          # read hits EOF and returns non-zero, and the "nothing to delete" case is
-          # handled below.
-          read -r INSTANCE ZONE < <(gcloud compute instances list \
+          #
+          # The lookup's exit status is checked separately from its output. A failed
+          # `instances list` - expired credentials on a multi-day run, a transient API
+          # error - also returns nothing, and folding that into the "no match" case
+          # would report a successful teardown while the instance keeps running, which
+          # is the silent orphan this job exists to prevent. The step is
+          # `continue-on-error`, so the annotation surfaces without failing the run.
+          if ! MATCHED=$(gcloud compute instances list \
             --filter="name=${INSTANCE_NAME}" \
-            --format='value(name,zone.basename())') || true
+            --format='value(name,zone.basename())'); then
+            echo "::error::Could not list instances while looking for ${INSTANCE_NAME}; it may still be running"
+            exit 1
+          fi
+
+          read -r INSTANCE ZONE <<< "${MATCHED}"
           if [ -z "${INSTANCE}" ]; then
             echo "No instance to delete"
           else
@@ -1043,6 +1058,9 @@ jobs:
     # Always run this job to check the status of dependent jobs
     if: always()
     needs:
+      # determine-environment resolves the resource names and can fail on its own
+      # guards, so it is reported directly rather than through the jobs it skips.
+      - determine-environment
       - get-disk-name
       - test-result
       - create-state-image

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -1060,11 +1060,31 @@ jobs:
             exit 1
           fi
 
-          read -r INSTANCE ZONE <<< "${MATCHED}"
-          if [ -z "${INSTANCE}" ]; then
+          if [ -z "${MATCHED}" ]; then
             echo "No instance to delete"
           else
-            gcloud compute instances delete "${INSTANCE}" --zone "${ZONE}" --delete-disks all --quiet
+            # Delete every match, not just the first row. A name identifies a run, but
+            # GCE names are unique per zone rather than per project, so one run can own
+            # instances in more than one zone: the failover path's cleanup delete is
+            # `|| true` and may leave a partial instance behind before the next zone
+            # succeeds, and a re-run addresses the same names by design. Reading a
+            # single row would delete one and leave the rest running - the orphan this
+            # job exists to prevent.
+            #
+            # A failed delete is recorded rather than propagated, so one failure does
+            # not abort the loop and strand the instances after it.
+            DELETE_FAILED=0
+            while read -r INSTANCE ZONE; do
+              if [ -n "${INSTANCE}" ]; then
+                echo "Deleting ${INSTANCE} in ${ZONE}"
+                gcloud compute instances delete "${INSTANCE}" --zone "${ZONE}" --delete-disks all --quiet \
+                  || { echo "::error::Failed to delete ${INSTANCE} in ${ZONE}"; DELETE_FAILED=1; }
+              fi
+            done <<< "${MATCHED}"
+
+            if [ "${DELETE_FAILED}" -ne 0 ]; then
+              exit 1
+            fi
           fi
 
   deployment-success:

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -165,11 +165,18 @@ jobs:
           INSTANCE_NAME="${TEST_ID}-${REPO_ID}-${RUN_ID}"
           DISK_NAME="${TEST_ID}-dsk-${REPO_ID}-${RUN_ID}"
 
-          # GCE rejects names over 63 characters. Fail here with a clear message
-          # rather than at instance creation with an opaque one.
+          # GCE rejects names over 63 characters, and names that are not lowercase
+          # RFC 1035 labels. Fail here with a clear message rather than at instance
+          # creation with an opaque one. Length alone is not enough: a `test_id`
+          # carrying an underscore or a capital would pass a length-only check and
+          # still fail creation with exactly the error this guard exists to prevent.
           for name in "${INSTANCE_NAME}" "${DISK_NAME}"; do
             if [ "${#name}" -gt 63 ]; then
               echo "::error::Generated name is ${#name} characters, over the GCE limit of 63: ${name}"
+              exit 1
+            fi
+            if [[ ! "${name}" =~ ^[a-z]([-a-z0-9]*[a-z0-9])?$ ]]; then
+              echo "::error::Generated name is not a valid GCE resource name: ${name}"
               exit 1
             fi
           done
@@ -950,14 +957,21 @@ jobs:
           FORCE_SAVE_TO_DISK: ${{ inputs.force_save_to_disk }}
           TEST_ID: ${{ inputs.test_id }}
           APP_NAME: ${{ inputs.app_name }}
-          GITHUB_REF_SLUG_URL: ${{ env.GITHUB_REF_SLUG_URL }}
-          GITHUB_SHA_SHORT: ${{ env.GITHUB_SHA_SHORT }}
         run: |
-          # GCP label values accept only lowercase letters, digits, `-` and `_`, so the
-          # `owner/name` form of GITHUB_REPOSITORY has to be folded before use. Without
-          # this the whole `gcloud compute images create` call is rejected.
+          # GCP label values accept only lowercase letters, digits, `-` and `_`, and are
+          # capped at 63 characters, so the `owner/name` form of GITHUB_REPOSITORY has to
+          # be folded before use. Replacing `/` alone is not enough: an owner is limited
+          # to alphanumerics and hyphens, but a repository name may also contain `.`
+          # (`next.js` and `socket.io` are ordinary names), so after lowercasing the
+          # offending characters are exactly `.` and `/`. Either one makes GCP reject the
+          # whole `gcloud compute images create` call - which would discard the image at
+          # the very end of a multi-day sync, for a label that is purely informational.
+          # The cap matters too: an owner of 39 plus a name of 100 is well over 63.
+          # Substituting the complement of the accepted set keeps `ZcashFoundation/zebra`
+          # folding to `zcashfoundation-zebra` exactly as before.
           REPOSITORY_LABEL="${GITHUB_REPOSITORY,,}"
-          REPOSITORY_LABEL="${REPOSITORY_LABEL//\//-}"
+          REPOSITORY_LABEL="${REPOSITORY_LABEL//[^a-z0-9_-]/-}"
+          REPOSITORY_LABEL="${REPOSITORY_LABEL:0:63}"
 
           MINIMUM_UPDATE_HEIGHT=$((ORIGINAL_HEIGHT+CACHED_STATE_UPDATE_LIMIT))
           if [[ -z "$UPDATE_SUFFIX" ]] || [[ "$SYNC_HEIGHT" -gt "$MINIMUM_UPDATE_HEIGHT" ]] || [[ "${FORCE_SAVE_TO_DISK}" == "true" ]]; then

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -1021,10 +1021,15 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
-        with:
-          persist-credentials: false
-          fetch-depth: '2'
+      # This job deliberately does NOT check out the repository, and should not be
+      # given a checkout step by reflex when one is added elsewhere in this file.
+      # Nothing here reads the working tree: authentication is by workload identity,
+      # `setup-gcloud` downloads the SDK, and the teardown below is an inline script
+      # that names no repository path. `ensure-health-checks` in
+      # zfnd-deploy-prebuilt-nodes-gcp.yml is the same shape and runs without one.
+      #
+      # Contrast zfnd-delete-gcp-resources.yml, which does need a checkout: its steps
+      # execute ./.github/workflows/scripts/*.sh from the repository.
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -170,13 +170,22 @@ jobs:
           # creation with an opaque one. Length alone is not enough: a `test_id`
           # carrying an underscore or a capital would pass a length-only check and
           # still fail creation with exactly the error this guard exists to prevent.
+          #
+          # The third check asserts the selector contract from the naming block
+          # above: a name the daily cleanup cannot match would leak silently, so a
+          # format change that breaks the match must fail here, at composition time.
+          REAPER_SELECTOR='-[0-9a-f]{7,}$'
           for name in "${INSTANCE_NAME}" "${DISK_NAME}"; do
             if [ "${#name}" -gt 63 ]; then
-              echo "::error::Generated name is ${#name} characters, over the GCE limit of 63: ${name}"
+              echo "::error::Generated name is ${#name} characters, over the GCE limit of 63 (is test_id too long?): ${name}"
               exit 1
             fi
             if [[ ! "${name}" =~ ^[a-z]([-a-z0-9]*[a-z0-9])?$ ]]; then
-              echo "::error::Generated name is not a valid GCE resource name: ${name}"
+              echo "::error::Generated name is not a valid GCE resource name (check test_id): ${name}"
+              exit 1
+            fi
+            if [[ ! "${name}" =~ ${REAPER_SELECTOR} ]]; then
+              echo "::error::Generated name does not match the daily cleanup selector ${REAPER_SELECTOR} and would leak: ${name}"
               exit 1
             fi
           done
@@ -244,11 +253,8 @@ jobs:
         uses: rlespinasse/github-slug-action@e6f261660910b273384c5c42b17a0217881b217a #v5.6.0
         with:
           short-length: 7
-          # The slug is no longer part of any resource name - names are resolved in
-          # `determine-environment` from the test id and the run identity. Its only
-          # consumer here is the `github_ref` instance label, where the GCP limit is
-          # 63 characters, so 23 is now a free choice; it is kept so that existing
-          # label values do not change.
+          # The slug now only feeds the `github_ref` instance label (GCP limit 63);
+          # 23 is kept so existing label values do not change.
           slug-maxlength: 23
 
       - name: Downcase network name for disks and labels
@@ -959,17 +965,12 @@ jobs:
           TEST_ID: ${{ inputs.test_id }}
           APP_NAME: ${{ inputs.app_name }}
         run: |
-          # GCP label values accept only lowercase letters, digits, `-` and `_`, and are
-          # capped at 63 characters, so the `owner/name` form of GITHUB_REPOSITORY has to
-          # be folded before use. Replacing `/` alone is not enough: an owner is limited
-          # to alphanumerics and hyphens, but a repository name may also contain `.`
-          # (`next.js` and `socket.io` are ordinary names), so after lowercasing the
-          # offending characters are exactly `.` and `/`. Either one makes GCP reject the
-          # whole `gcloud compute images create` call - which would discard the image at
-          # the very end of a multi-day sync, for a label that is purely informational.
-          # The cap matters too: an owner of 39 plus a name of 100 is well over 63.
-          # Substituting the complement of the accepted set keeps `ZcashFoundation/zebra`
-          # folding to `zcashfoundation-zebra` exactly as before.
+          # GCP label values accept only `[a-z0-9_-]`, capped at 63 characters; anything
+          # else makes GCP reject the whole `images create` call, discarding the image at
+          # the very end of a multi-day sync. Replacing `/` alone is not enough: an owner
+          # is limited to alphanumerics and hyphens, but a repository name may also
+          # contain `.` (`next.js`, `socket.io`), and an owner of 39 plus a name of 100
+          # is well over the cap.
           REPOSITORY_LABEL="${GITHUB_REPOSITORY,,}"
           REPOSITORY_LABEL="${REPOSITORY_LABEL//[^a-z0-9_-]/-}"
           REPOSITORY_LABEL="${REPOSITORY_LABEL:0:63}"
@@ -1027,9 +1028,8 @@ jobs:
       # `setup-gcloud` downloads the SDK, and the teardown below is an inline script
       # that names no repository path. `ensure-health-checks` in
       # zfnd-deploy-prebuilt-nodes-gcp.yml is the same shape and runs without one.
-      #
-      # Contrast zfnd-delete-gcp-resources.yml, which does need a checkout: its steps
-      # execute ./.github/workflows/scripts/*.sh from the repository.
+      # (zfnd-delete-gcp-resources.yml, by contrast, needs its checkout: it executes
+      # scripts from the repository.)
 
       # Setup gcloud CLI
       - name: Authenticate to Google Cloud
@@ -1045,6 +1045,9 @@ jobs:
       # Deletes the instances that has been recently deployed in the actual commit after all
       # previous jobs have run, no matter the outcome of the job.
       - name: Delete test instance
+        # An empty name means determine-environment never resolved one, so nothing
+        # can have been created - and an empty `name=` filter is a gcloud error.
+        if: ${{ needs.determine-environment.outputs.instance_name != '' }}
         continue-on-error: true
         env:
           INSTANCE_NAME: ${{ needs.determine-environment.outputs.instance_name }}
@@ -1068,28 +1071,25 @@ jobs:
           if [ -z "${MATCHED}" ]; then
             echo "No instance to delete"
           else
-            # Delete every match, not just the first row. A name identifies a run, but
-            # GCE names are unique per zone rather than per project, so one run can own
-            # instances in more than one zone: the failover path's cleanup delete is
-            # `|| true` and may leave a partial instance behind before the next zone
-            # succeeds, and a re-run addresses the same names by design. Reading a
-            # single row would delete one and leave the rest running - the orphan this
-            # job exists to prevent.
+            # Delete every match, not just the first row. GCE names are unique per
+            # zone rather than per project, so one run can own instances in more than
+            # one zone: the failover path's cleanup delete is `|| true` and may leave
+            # a partial instance behind before the next zone succeeds, and a re-run
+            # addresses the same names by design.
             #
             # A failed delete is recorded rather than propagated, so one failure does
-            # not abort the loop and strand the instances after it.
+            # not abort the loop and strand the instances after it. This deliberately
+            # duplicates the loop in scripts/gcp-delete-old-instances.sh - this job
+            # has no checkout to call it from - so keep the two in sync.
             DELETE_FAILED=0
             while read -r INSTANCE ZONE; do
-              if [ -n "${INSTANCE}" ]; then
-                echo "Deleting ${INSTANCE} in ${ZONE}"
-                gcloud compute instances delete "${INSTANCE}" --zone "${ZONE}" --delete-disks all --quiet \
-                  || { echo "::error::Failed to delete ${INSTANCE} in ${ZONE}"; DELETE_FAILED=1; }
-              fi
+              [ -n "${INSTANCE}" ] || continue
+              echo "Deleting ${INSTANCE} in ${ZONE}"
+              gcloud compute instances delete "${INSTANCE}" --zone "${ZONE}" --delete-disks all --quiet \
+                || { echo "::error::Failed to delete ${INSTANCE} in ${ZONE}"; DELETE_FAILED=1; }
             done <<< "${MATCHED}"
 
-            if [ "${DELETE_FAILED}" -ne 0 ]; then
-              exit 1
-            fi
+            [ "${DELETE_FAILED}" -eq 0 ] || exit 1
           fi
 
   deployment-success:


### PR DESCRIPTION
## Motivation

Stacked on #11364. That PR moves the GCE instance and disk names into `determine-environment` and keys them on the run. Reviewing it surfaced a set of defects around the edges of that change: paths that report success where the operation failed, a guard that validates half of what it needs to, and a cleanup selector the rename now depends on whose own documentation says it matches something else.

None of these are regressions introduced by #11364 alone — most predate it — but each one either sits in code that PR touches, or is a premise it now leans on. Left alone they blunt exactly the failure mode it was written to eliminate.

Nothing here changes the resource name format, and no existing label value changes.

## Solution

Six commits, each independently droppable.

**Surface failures instead of swallowing them.**

`delete-instance` folded a failed `gcloud compute instances list` into its "no instance to delete" branch. `read` was fed by a process substitution and any non-zero exit was absorbed by `|| true`, so expired credentials on a multi-day run, or a transient API error, produced a clean "nothing to delete" while the instance kept running. The lookup's status is now captured separately and annotated. This is the silent orphan #11364's description names as the highest risk of the rename.

**Delete every instance the run owns.** (Reported by Copilot on this PR.)

The same teardown read a single row from a project-wide lookup. GCE names are unique per zone rather than per project, so one run can own instances in more than one zone, and reading one row deletes one and leaves the rest running. The failover path deletes a partial instance with `|| true` before moving on, so a delete that does not take leaves an instance behind while a later zone succeeds; and a re-run addresses the same names by design, since `run_id` is deliberately stable across attempts. It now loops over every `name,zone` row, and records a failed delete rather than propagating it, so one failure does not abort the loop and strand the instances after it.

The two "get … from logs" steps read `$?` after a bare `DOCKER_LOGS=$(...)`. GitHub runs `run:` blocks under `bash -e`, so a failing command substitution in an assignment aborts the step before the next line executes — the status test was unreachable and `Failed to retrieve logs via SSH.` could never print. Collecting the status through `||` suppresses `-e` for that command and makes the check actually run. Naming the status in a variable had silenced the shellcheck warning without fixing the control flow.

`deployment-success` now lists `determine-environment`. It resolves the names and can fail on its own guards, so its failure should be reported directly rather than inferred from the jobs it skips.

**Validate what the guard claims to validate.**

The new name guard checks length only. A `test_id` carrying an underscore or a capital passes it and then fails at instance creation with exactly the opaque GCE error the guard exists to prevent. Both names are now also checked against the lowercase RFC 1035 grammar GCE requires.

The `repository` image label replaces `/` but nothing else. An owner is limited to alphanumerics and hyphens, but a repository name may also contain `.` — `next.js` and `socket.io` are ordinary names — so after lowercasing, the characters GCP label values reject are exactly `.` and `/`. Either one makes GCP reject the whole `gcloud compute images create` call, discarding the cached state image at the very end of a multi-day sync, for a label that is purely informational. The 63-character cap matters too: an owner of 39 plus a name of 100 is well over it. The fold now substitutes the complement of the accepted set and caps the length.

**Say what the cleanup selector actually matches.**

#11364 keeps the run id as the trailing name component specifically so the daily cleanup's `-[0-9a-f]{7,}$` selector still matches. But all three places that describe that selector still say it matches a commit hash, which these resources no longer end in. The match survives only because decimal digits are a subset of `[0-9a-f]` — a coincidence, not a contract.

The comments actively mislead: `zfnd-delete-gcp-resources.yml` explains the pattern as a guard against reaping "manually created instances", so a future reader tightening it toward a real hash shape would silently orphan every test VM and its 400 GB state disk. Same failure, moved from the per-run teardown to the daily reaper. All three now state what is matched and why it must not be narrowed.

**Drop what the rename left unused.**

The `slug-maxlength: 23` comment explains the value as a budget against the 63-character instance name; the slug is no longer in any name, and its only consumer is the `github_ref` label where the limit is 63. The value is kept so label values do not change. Two `env:` bindings for slug variables are redundant — the slug action exports them to `$GITHUB_ENV`, as the adjacent uses of `GITHUB_REF_POINT_SLUG_URL` and `GITHUB_SHA` show.

**Stop checking out the repository to delete an instance.**

Isolated in its own commit, since unlike the items above it is not a consequence of the rename — `delete-instance` has read nothing from the working tree since the checkout arrived with the bulk CI refactor in 40f042fa5. Authentication is by workload identity, `setup-gcloud` downloads the SDK, and the teardown is an inline script naming no repository path. `ensure-health-checks` in `zfnd-deploy-prebuilt-nodes-gcp.yml` is the same shape and already runs without one, so this is an established pattern here rather than a new assumption.

The reasoning is recorded in the job itself, including the contrast case: `zfnd-delete-gcp-resources.yml` does need a checkout, because its steps execute `./.github/workflows/scripts/*.sh`. The risk is not that removing it breaks something today — it is that someone re-adds it by reflex later.

### Tests

- `actionlint` clean on both changed workflows. Repo-wide finding count is **9, identical to the base branch** — this PR adds none.
- `shellcheck` clean on both changed cleanup scripts.
- All 18 `run:` blocks in the deploy workflow extracted and checked with `bash -n`; plus an assertion that no comment follows a line continuation anywhere in the file.
- `delete-instance` logic simulated under `bash -e -o pipefail` across all five paths: one instance → deletes with the discovered zone; **two zones → deletes both**; no match → "No instance to delete", exit 0; lookup fails → `::error::`, exit 1; two zones where the first delete fails → still attempts the second, then exits 1. Before these changes the lookup-failure case was indistinguishable from "no match", and the two-zone case silently left one instance running.
- The single-row behaviour was confirmed directly: `read -r I Z <<< "$two_row_output"` binds only the first row.
- Name guard simulated against the real repository id and a current run id:

  | `test_id` | result |
  | --- | --- |
  | `sync-past-mandatory-checkpoint` (longest in use, 30) | passes, 52/56 chars |
  | `sync-past-mandatory-checkpoint-testnet` (38) | rejected, disk name is 64 |
  | `Sync-Full-Mainnet` | rejected, invalid grammar |
  | `rpc_get_block` | rejected, invalid grammar — **passed the length-only guard** |

- Label folding verified: `ZcashFoundation/zebra` → `zcashfoundation-zebra`, unchanged. `ZcashFoundation/Zebra.rs` → `zcashfoundation-zebra-rs`, which the previous fold would have left with a `.` and had GCP reject.
- The `bash -e` claim behind the `SSH_STATUS` change verified directly: `V=$(false) || S=$?` yields `S=1`, where a bare assignment aborts.

Not verifiable without a live run: that the annotations fire against real GCP failures. The `delete-instance` step stays `continue-on-error: true`, so the new `exit 1` surfaces an annotation without failing the run.

### Specifications & References

- #11364 — the base of this stack
- #11226 — instance name collisions blocking the full-sync cron
- [GCE resource naming](https://cloud.google.com/compute/docs/naming-resources#resource-name-format) — the RFC 1035 grammar the guard now enforces
- [GCP label requirements](https://cloud.google.com/compute/docs/labeling-resources#requirements) — the character set and 63-character cap on label values

### Follow-up Work

Deliberately **not** included, because each is already owned elsewhere:

- Remaining inline `${{ }}` expansions in `run:` blocks — #11214
- The shared cached-state image pool, and making the new `repository` label actually consumed by the lookup and the cleanup — #11362
- The shared mutable container tag — #11363
- Re-run resumability against a prior attempt's disk — #11232
- Gating the debug step on a non-empty `instance_zone` — #11226, and named as follow-up in #11364

Two things found during review that need their own issues, filed separately rather than folded in here:

1. **The instance reaper has no in-use predicate.** `DELETE_INSTANCE_DAYS` is 3, while `is_long_test` grants a 5-day timeout to four tests. `gcp-delete-old-instances.sh` filters on name and `creationTimestamp` only — unlike the disk reaper, which is protected by `-users:*` — so a sync past day 3 gets `instances delete --delete-disks=all` while it is still running. Latent today: the last successful `sync-full-mainnet` took 20 hours (per #11232). It is orthogonal to naming and would behave identically under the old names, which is why it is not fixed here.

2. **The name budget is tight.** Worst case today is 57 of 63 characters, and the table above shows a plausible next test id (`sync-past-mandatory-checkpoint-testnet`) lands on 64. A fixed-width identity suffix — the `sha256sum | cut -c1-12` idiom already used for `TEMPLATE_IDENTITY` in `zfnd-deploy-prebuilt-nodes-gcp.yml` — would make both the length bound and the `[0-9a-f]` cleanup match true by construction rather than by coincidence. Raised on #11364 rather than implemented here, since changing the name format twice in a stack is worse for review than getting it right once.

### AI Disclosure

- [x] AI tools were used: Claude Code for the review that surfaced these defects, for the verification harness (run-block extraction, the `delete-instance` and name-guard simulations), and for drafting this description. Author is responsible for the content.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand. <!-- review follow-up on #11364 -->
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date. <!-- CI-only change; no changie fragment required -->
