### PR TITLE
fix(ci): give long-test instances a reaper retention past their timeout

### DIFF
--- a/.github/workflows/scripts/gcp-delete-old-instances.sh
+++ b/.github/workflows/scripts/gcp-delete-old-instances.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
 
-# Check if DELETE_INSTANCE_DAYS is set and is a number
+# Check that the retention thresholds are set and are numbers
 if ! [[ "${DELETE_INSTANCE_DAYS}" =~ ^[0-9]+$ ]]; then
     echo "ERROR: DELETE_INSTANCE_DAYS is not set or not a number"
+    exit 1
+fi
+if ! [[ "${DELETE_LONG_TEST_INSTANCE_DAYS}" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: DELETE_LONG_TEST_INSTANCE_DAYS is not set or not a number"
     exit 1
 fi
 
 # Set pipefail to catch errors in pipelines
 set -o pipefail
-
-# Calculate the date before which instances should be deleted
-DELETE_BEFORE_DATE=$(date --date="${DELETE_INSTANCE_DAYS} days ago" '+%Y%m%d')
 
 # Check if gcloud command is available
 if ! command -v gcloud &> /dev/null; then
@@ -18,20 +19,35 @@ if ! command -v gcloud &> /dev/null; then
     exit 1
 fi
 
-# Fetch the list of instances to delete.
-#
+# Deletes instances matching the gcloud name/label filter in $1 that were
+# created more than $2 days ago.
+delete_instances() {
+    local filter="$1"
+    local days="$2"
+    local before instances
+    before=$(date --date="${days} days ago" '+%Y%m%d')
+
+    if ! instances=$(gcloud compute instances list --sort-by=creationTimestamp --filter="${filter} AND creationTimestamp < ${before}" --format='value(NAME,ZONE)'); then
+        echo "Error fetching instances for filter: ${filter}"
+        exit 1
+    fi
+    while IFS=$'\t' read -r NAME ZONE; do
+        [[ -z "${NAME}" ]] && continue
+        echo "Deleting instance: ${NAME} (--zone=${ZONE})"
+        gcloud compute instances delete "${NAME}" --zone="${ZONE}" --delete-disks=all --quiet --verbosity=info \
+            || echo "Failed to delete instance: ${NAME}"
+    done <<< "${instances}"
+}
+
 # Integration test instances end in the GitHub run id, not a commit hash. Decimal digits
 # are a subset of `[0-9a-f]`, so they match this pattern, but only incidentally: do not
 # tighten it to assume a hexadecimal commit hash, or those instances will never be reaped.
-if ! INSTANCES=$(gcloud compute instances list --sort-by=creationTimestamp --filter="name~-[0-9a-f]{7,}$ AND creationTimestamp < ${DELETE_BEFORE_DATE}" --format='value(NAME,ZONE)'); then
-    echo "Error fetching instances."
-    exit 1
-fi
-
-# Delete each instance
-while IFS=$'\t' read -r NAME ZONE; do
-    [[ -z "${NAME}" ]] && continue
-    echo "Deleting instance: ${NAME} (--zone=${ZONE})"
-    gcloud compute instances delete "${NAME}" --zone="${ZONE}" --delete-disks=all --quiet --verbosity=info \
-        || echo "Failed to delete instance: ${NAME}"
-done <<< "${INSTANCES}"
+#
+# Instances labelled `long-test=true` run tests whose job timeout is longer than the
+# default retention (see `is_long_test` in zfnd-deploy-integration-tests-gcp.yml), so
+# they get their own threshold: reaping them at the default one would delete the VM and
+# its state disk mid-test, days into a sync. An instance without the label falls only
+# under the first tier - `NOT labels.long-test=true` also matches instances that don't
+# carry the label at all.
+delete_instances "name~-[0-9a-f]{7,}$ AND NOT labels.long-test=true" "${DELETE_INSTANCE_DAYS}"
+delete_instances "name~-[0-9a-f]{7,}$ AND labels.long-test=true" "${DELETE_LONG_TEST_INSTANCE_DAYS}"

--- a/.github/workflows/zfnd-delete-gcp-resources.yml
+++ b/.github/workflows/zfnd-delete-gcp-resources.yml
@@ -19,6 +19,12 @@ env:
   # Delete all resources created before $DELETE_INSTANCE_DAYS days ago.
   # We keep this short to reduce CPU, RAM, and storage costs.
   DELETE_INSTANCE_DAYS: 3
+  # Instances labelled `long-test=true` get a longer retention instead: their jobs
+  # are allowed to run for up to 5 days (`is_long_test` grants a 7200-minute timeout
+  # in zfnd-deploy-integration-tests-gcp.yml), so the default threshold would delete
+  # a VM and its state disk mid-test, days into a sync. One day past the timeout,
+  # so an instance the workflow failed to tear down still only survives one extra day.
+  DELETE_LONG_TEST_INSTANCE_DAYS: 6
   # Delete all other resources created before $DELETE_AGE_DAYS days ago.
   # We keep this short to reduce storage costs.
   DELETE_AGE_DAYS: 2

--- a/.github/workflows/zfnd-delete-gcp-resources.yml
+++ b/.github/workflows/zfnd-delete-gcp-resources.yml
@@ -22,8 +22,10 @@ env:
   # Instances labelled `long-test=true` get a longer retention instead: their jobs
   # are allowed to run for up to 5 days (`is_long_test` grants a 7200-minute timeout
   # in zfnd-deploy-integration-tests-gcp.yml), so the default threshold would delete
-  # a VM and its state disk mid-test, days into a sync. One day past the timeout,
-  # so an instance the workflow failed to tear down still only survives one extra day.
+  # a VM and its state disk mid-test, days into a sync. One day past the timeout - and
+  # because the cutoff is truncated to a date and the cron runs at 0700 UTC, the actual
+  # deletion lands 6 to 7 days after creation. So an instance the workflow failed to
+  # tear down survives three days longer than it would under the default tier.
   DELETE_LONG_TEST_INSTANCE_DAYS: 6
   # Delete all other resources created before $DELETE_AGE_DAYS days ago.
   # We keep this short to reduce storage costs.

--- a/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-deploy-integration-tests-gcp.yml
@@ -318,6 +318,11 @@ jobs:
           # value containing shell metacharacters would escape its quoting context.
           APP_NAME: ${{ inputs.app_name }}
           TEST_ID: ${{ inputs.test_id }}
+          # `true` or `false`. The daily cleanup gives `long-test=true` instances a
+          # longer retention than its default, which is shorter than these jobs'
+          # 5-day timeout - see DELETE_LONG_TEST_INSTANCE_DAYS in
+          # zfnd-delete-gcp-resources.yml.
+          IS_LONG_TEST: ${{ inputs.is_long_test }}
         run: |
 
           CONTAINER_MOUNT_DISKS="--container-mount-disk=mount-path=${{ inputs.zebra_state_dir }},name=${NAME},mode=rw"
@@ -384,7 +389,7 @@ jobs:
             --service-account=${{ vars.GCP_DEPLOYMENTS_SA }} \
             --metadata=google-logging-enabled=true,google-logging-use-fluentbit=true,google-monitoring-enabled=true \
             --metadata-from-file=startup-script=.github/workflows/scripts/gcp-vm-startup-script.sh \
-            --labels="app=${APP_NAME},environment=${WORKFLOW_ENVIRONMENT},network=${NETWORK},github_ref=${GITHUB_REF_SLUG_URL},test=${TEST_ID},commit=${GITHUB_SHA_SHORT}" \
+            --labels="app=${APP_NAME},environment=${WORKFLOW_ENVIRONMENT},network=${NETWORK},github_ref=${GITHUB_REF_SLUG_URL},test=${TEST_ID},commit=${GITHUB_SHA_SHORT},long-test=${IS_LONG_TEST}" \
             --tags ${{ inputs.app_name }} \
             --zone "${zone}"
           }


### PR DESCRIPTION
## Motivation

Closes #11369.

The daily reaper (`DELETE_INSTANCE_DAYS: 3`) and the long-test job timeout (`is_long_test` → 7200 minutes = 5 days) contradict each other: a sync that legitimately runs past day 3 gets `instances delete --delete-disks=all` under it at 07:00 UTC. From the job's side that is an SSH drop and a `docker wait` that hangs until the timeout cancels the run — the same hard-to-attribute shape as the runner-recycling loss in #11232, with nothing pointing at the cleanup cron. The disk reaper protects itself with `-users:*`; the instance reaper has no equivalent predicate.

Latent today — the last successful `sync-full-mainnet` took ~20 hours (#11232) — but the 5-day budget exists precisely for the runs that would trip it.

Builds on #11364, which adds the instance labels this change extends.

## Solution

The label-based exemption from #11369, the cheapest of its three directions and the one #11364's label work makes natural:

- The instance is created with `long-test=${{ inputs.is_long_test }}` (`true`/`false`) alongside the existing labels.
- `gcp-delete-old-instances.sh` splits into two tiers: the default 3-day threshold with `NOT labels.long-test=true`, and a new `DELETE_LONG_TEST_INSTANCE_DAYS: 6` for `labels.long-test=true`. Nominally one day past the 5-day timeout; since the cutoff is a date and the cron runs at 07:00 UTC, deletion lands 6 to 7 days after creation. An instance the workflow failed to tear down survives three days longer than under the default tier, and only if it belongs to a long test.
- `NOT labels.long-test=true` also matches instances that do not carry the label at all, so everything the reaper covered before stays in the first tier — including instances created before this change and by workflows that never set the label.
- The script takes on the same filter-parameterised function shape as `gcp-delete-old-disks.sh`, rather than growing a second hand-rolled list-and-loop.

### Tests

- `shellcheck` and `bash -n` clean on the script; `actionlint` clean on both workflows; repo-wide actionlint count unchanged (9, all in untouched files).
- The script was exercised end-to-end with a mocked `gcloud` and `date`: each tier issues exactly one list call, with the expected filter and cutoff —

  ```
  name~-[0-9a-f]{7,}$ AND NOT labels.long-test=true AND creationTimestamp < 20260829
  name~-[0-9a-f]{7,}$ AND labels.long-test=true AND creationTimestamp < 20260826
  ```

  and deletes the rows each list returns.
- Missing `DELETE_LONG_TEST_INSTANCE_DAYS` fails fast with the same message shape as the existing `DELETE_INSTANCE_DAYS` check.

- The absent-key semantics behind the tier split was verified against the live project: of 17 instances currently in it, none carrying the label, `NOT labels.long-test=true` matches all 17 and `labels.long-test=true` matches 0 — so the first tier keeps covering every unlabelled instance, including ones created before this change.

### Specifications & References

- #11369 — the threshold mismatch this closes
- #11232 — the 20-hour observed duration and the other way long runs die mid-flight
- [gcloud topic filters](https://cloud.google.com/sdk/gcloud/reference/topic/filters) — absent-key comparison semantics behind `NOT labels.long-test=true`

### Follow-up Work

- An in-use predicate (paralleling the disk reaper's `-users:*`) would protect even mislabelled instances, at the cost of a describe per candidate; #11369 records it as the heavier alternative if labels ever prove insufficient.
- #11202's weekly-maintenance redesign should keep this interaction in mind when scheduling full syncs.

### AI Disclosure

- [x] AI tools were used: Claude Code for the implementation, the mocked-`gcloud` test harness, and this description. Author is responsible for the content.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand. <!-- #11369 -->
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date. <!-- CI-only change; no changie fragment required -->

