### PR TITLE
perf(rpc): rebuild the block template when the mempool changes

### DIFF
--- a/.changes/unreleased/zebra-rpc-Added-20260901-141500.yaml
+++ b/.changes/unreleased/zebra-rpc-Added-20260901-141500.yaml
@@ -1,6 +1,7 @@
 project: zebra-rpc
 kind: Added
-body: 'Method `RpcImpl::spawn_block_template_updater()`, which spawns a task that keeps a block
-  template precomputed for the current chain tip, and returns `None` when mining isn''t configured
+body: 'Method `RpcImpl::spawn_block_template_updater()`, which takes a
+  `MempoolTxSubscriber` and spawns a task that keeps a block template precomputed for the current
+  chain tip, and returns `None` when mining isn''t configured
   ([#11370](https://github.com/ZcashFoundation/zebra/issues/11370)).'
 time: 2026-09-01T14:15:00.000000000Z

--- a/.changes/unreleased/zebra-rpc-Added-20260901-141500.yaml
+++ b/.changes/unreleased/zebra-rpc-Added-20260901-141500.yaml
@@ -1,0 +1,6 @@
+project: zebra-rpc
+kind: Added
+body: 'Method `RpcImpl::spawn_block_template_updater()`, which spawns a task that keeps a block
+  template precomputed for the current chain tip, and returns `None` when mining isn''t configured
+  ([#11370](https://github.com/ZcashFoundation/zebra/issues/11370)).'
+time: 2026-09-01T14:15:00.000000000Z

--- a/.changes/unreleased/zebra-rpc-Changed-20260901-141501.yaml
+++ b/.changes/unreleased/zebra-rpc-Changed-20260901-141501.yaml
@@ -4,7 +4,8 @@ body: 'The `getblocktemplate` RPC answers from the template precomputed by
   `RpcImpl::spawn_block_template_updater()`, so a call validates the chain tip against the state
   instead of reading the mempool, selecting transactions, and building a coinbase transaction. A
   long polling call waits on that template, and returns when the task publishes a new one, when the
-  chain tip changes, or when `max_time` is reached. A precomputed template''s transactions can be a
-  few seconds behind the mempool, but it always extends the tip the state has committed
+  chain tip changes, or when `max_time` is reached. The task rebuilds when the chain tip changes and
+  when the mempool changes, rather than on a fixed interval, so a precomputed template''s
+  transactions trail the mempool by a rebuild, and it always extends the tip the state has committed
   ([#11370](https://github.com/ZcashFoundation/zebra/issues/11370)).'
 time: 2026-09-01T14:15:01.000000000Z

--- a/.changes/unreleased/zebra-rpc-Changed-20260901-141501.yaml
+++ b/.changes/unreleased/zebra-rpc-Changed-20260901-141501.yaml
@@ -3,7 +3,8 @@ kind: Changed
 body: 'The `getblocktemplate` RPC answers from the template precomputed by
   `RpcImpl::spawn_block_template_updater()`, so a call validates the chain tip against the state
   instead of reading the mempool, selecting transactions, and building a coinbase transaction. A
-  precomputed template''s transactions can be a few seconds behind the mempool, but it always
-  extends the tip the state has committed
+  long polling call waits on that template, and returns when the task publishes a new one, when the
+  chain tip changes, or when `max_time` is reached. A precomputed template''s transactions can be a
+  few seconds behind the mempool, but it always extends the tip the state has committed
   ([#11370](https://github.com/ZcashFoundation/zebra/issues/11370)).'
 time: 2026-09-01T14:15:01.000000000Z

--- a/.changes/unreleased/zebra-rpc-Changed-20260901-141501.yaml
+++ b/.changes/unreleased/zebra-rpc-Changed-20260901-141501.yaml
@@ -1,0 +1,9 @@
+project: zebra-rpc
+kind: Changed
+body: 'The `getblocktemplate` RPC answers from the template precomputed by
+  `RpcImpl::spawn_block_template_updater()`, so a call validates the chain tip against the state
+  instead of reading the mempool, selecting transactions, and building a coinbase transaction. A
+  precomputed template''s transactions can be a few seconds behind the mempool, but it always
+  extends the tip the state has committed
+  ([#11370](https://github.com/ZcashFoundation/zebra/issues/11370)).'
+time: 2026-09-01T14:15:01.000000000Z

--- a/.changes/unreleased/zebra-rpc-Fixed-20260901-141503.yaml
+++ b/.changes/unreleased/zebra-rpc-Fixed-20260901-141503.yaml
@@ -1,0 +1,7 @@
+project: zebra-rpc
+kind: Fixed
+body: 'Long polling `getblocktemplate` requests no longer build a coinbase transaction each, which
+  ran a shielded proof per request for a miner address with a shielded component. The next tip''s
+  coinbase is built once and shared
+  ([#10747](https://github.com/ZcashFoundation/zebra/issues/10747)).'
+time: 2026-09-01T14:15:03.000000000Z

--- a/.changes/unreleased/zebrad-Changed-20260901-141502.yaml
+++ b/.changes/unreleased/zebrad-Changed-20260901-141502.yaml
@@ -2,8 +2,8 @@ project: zebrad
 kind: Changed
 body: 'The `getblocktemplate` RPC returns a block template that Zebra keeps ready for the current
   chain tip, rather than assembling one while the miner waits. Zebra keeps one ready whenever a
-  miner address is configured and either the RPC server or the internal miner is enabled, refreshing
-  it on every chain tip change and every few seconds, so a template can be a few seconds behind the
-  mempool but is never behind the chain
+  miner address is configured and either the RPC server or the internal miner is enabled, rebuilding
+  it when the chain tip changes and when the mempool changes, instead of every few seconds, so a new
+  transaction reaches miners in the next rebuild and a template is never behind the chain
   ([#11370](https://github.com/ZcashFoundation/zebra/issues/11370)).'
 time: 2026-09-01T14:15:02.000000000Z

--- a/.changes/unreleased/zebrad-Changed-20260901-141502.yaml
+++ b/.changes/unreleased/zebrad-Changed-20260901-141502.yaml
@@ -1,0 +1,8 @@
+project: zebrad
+kind: Changed
+body: 'The `getblocktemplate` RPC returns a block template that Zebra keeps ready for the current
+  chain tip, rather than assembling one while the miner waits. Templates are refreshed on every
+  chain tip change and every few seconds, so a template can be a few seconds behind the mempool,
+  but it is never behind the chain
+  ([#11370](https://github.com/ZcashFoundation/zebra/issues/11370)).'
+time: 2026-09-01T14:15:02.000000000Z

--- a/.changes/unreleased/zebrad-Changed-20260901-141502.yaml
+++ b/.changes/unreleased/zebrad-Changed-20260901-141502.yaml
@@ -1,8 +1,9 @@
 project: zebrad
 kind: Changed
 body: 'The `getblocktemplate` RPC returns a block template that Zebra keeps ready for the current
-  chain tip, rather than assembling one while the miner waits. Templates are refreshed on every
-  chain tip change and every few seconds, so a template can be a few seconds behind the mempool,
-  but it is never behind the chain
+  chain tip, rather than assembling one while the miner waits. Zebra keeps one ready whenever a
+  miner address is configured and either the RPC server or the internal miner is enabled, refreshing
+  it on every chain tip change and every few seconds, so a template can be a few seconds behind the
+  mempool but is never behind the chain
   ([#11370](https://github.com/ZcashFoundation/zebra/issues/11370)).'
 time: 2026-09-01T14:15:02.000000000Z

--- a/.changes/unreleased/zebrad-Fixed-20260901-141504.yaml
+++ b/.changes/unreleased/zebrad-Fixed-20260901-141504.yaml
@@ -1,0 +1,6 @@
+project: zebrad
+kind: Fixed
+body: 'Zebra no longer runs a shielded coinbase proof for each outstanding `getblocktemplate` long
+  poll when the configured miner address has a shielded component
+  ([#10747](https://github.com/ZcashFoundation/zebra/issues/10747)).'
+time: 2026-09-01T14:15:04.000000000Z

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -117,6 +117,7 @@ use types::{
             DEFAULT_SOLUTION_RATE_WINDOW_SIZE, MEMPOOL_LONG_POLL_INTERVAL,
             ZCASHD_FUNDING_STREAM_ORDER,
         },
+        precompute,
         proposal::proposal_block_from_template,
         BlockTemplateResponse, BlockTemplateTimeSource, GetBlockTemplateHandler,
         GetBlockTemplateParameters, GetBlockTemplateResponse, MinerParams,
@@ -1002,6 +1003,30 @@ where
         );
 
         (rpc_impl, rpc_tx_queue_task_handle)
+    }
+
+    /// Spawns a task that keeps a block template for the current chain tip precomputed, so
+    /// `getblocktemplate` calls don't have to read the state and the mempool, select transactions,
+    /// and build a coinbase transaction.
+    ///
+    /// Returns `None` if mining isn't configured.
+    pub fn spawn_block_template_updater(&self) -> Option<JoinHandle<()>> {
+        let miner_params = self.gbt.miner_params()?.clone();
+        let template_cache = self.gbt.template_cache()?.clone();
+
+        Some(tokio::spawn(
+            precompute::run(
+                self.network.clone(),
+                miner_params,
+                self.gbt.coinbase_cache(),
+                template_cache,
+                self.mempool.clone(),
+                self.read_state.clone(),
+                self.latest_chain_tip.clone(),
+                self.gbt.sync_status(),
+            )
+            .in_current_span(),
+        ))
     }
 
     /// Returns a reference to the configured network.
@@ -2474,6 +2499,34 @@ where
             .gbt
             .miner_params()
             .ok_or_error(0, "miner parameters are required for get_block_template")?;
+
+        // - Precomputed template
+        //
+        // Serve the template that the block template updater task keeps ready, as long as it
+        // extends the current chain tip. Its mempool transactions can be a few seconds old, which
+        // only costs the miner the fees of the transactions that arrived in the meantime, and the
+        // next call picks them up.
+        //
+        // Long polling clients keep waiting if the precomputed template is the one they already
+        // have.
+        check_synced_to_tip(&self.network, latest_chain_tip.clone(), sync_status.clone())?;
+
+        if let (Some(cache), Some(tip_hash)) =
+            (self.gbt.template_cache(), latest_chain_tip.best_tip_hash())
+        {
+            if let Some(template) = cache.wait_for_tip(tip_hash).await {
+                if Some(template.long_poll_id) != client_long_poll_id {
+                    let submit_old = client_long_poll_id
+                        .as_ref()
+                        .map(|old_long_poll_id| template.long_poll_id.submit_old(old_long_poll_id));
+
+                    let mut template = (*template).clone();
+                    template.submit_old = submit_old;
+
+                    return Ok(template.into());
+                }
+            }
+        }
 
         // - Checks and fetches that can change during long polling
         //

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -92,7 +92,6 @@ use zebra_state::{
 };
 
 use crate::{
-    client::TransactionTemplate,
     client::Treestate,
     config,
     methods::types::{
@@ -127,7 +126,7 @@ use types::{
     get_mining_info::GetMiningInfoResponse,
     get_raw_mempool::{self, GetRawMempoolResponse},
     get_standard_fee::GetStandardFeeResponse,
-    long_poll::LongPollInput,
+    long_poll::{LongPollId, LongPollInput},
     network_info::{GetNetworkInfoResponse, NetworkInfo},
     peer_info::PeerInfo,
     submit_block::{SubmitBlockErrorResponse, SubmitBlockParameters, SubmitBlockResponse},
@@ -1027,6 +1026,39 @@ where
             )
             .in_current_span(),
         ))
+    }
+
+    /// Returns the block template that [`Self::spawn_block_template_updater()`] keeps precomputed,
+    /// if it extends the current chain tip, and if it isn't the template the client already has.
+    ///
+    /// The precomputed template's mempool transactions can be a few seconds old, which only costs
+    /// the miner the fees of the transactions that arrived in the meantime, and the next call picks
+    /// them up. But it always extends the current tip, so miners never work on a chain that Zebra
+    /// has already seen a block for.
+    ///
+    /// Returns `None` if there is no updater task, if it hasn't caught up with a recent chain tip
+    /// change, or if the client is long polling on this exact template.
+    async fn precomputed_block_template(
+        &self,
+        client_long_poll_id: Option<LongPollId>,
+    ) -> Option<BlockTemplateResponse> {
+        let cache = self.gbt.template_cache()?;
+        let tip_hash = self.latest_chain_tip.best_tip_hash()?;
+
+        let template = cache.wait_for_tip(tip_hash).await?;
+
+        if Some(template.long_poll_id) == client_long_poll_id {
+            return None;
+        }
+
+        let submit_old = client_long_poll_id
+            .as_ref()
+            .map(|old_long_poll_id| template.long_poll_id.submit_old(old_long_poll_id));
+
+        let mut template = (*template).clone();
+        template.submit_old = submit_old;
+
+        Some(template)
     }
 
     /// Returns a reference to the configured network.
@@ -2503,29 +2535,11 @@ where
         // - Precomputed template
         //
         // Serve the template that the block template updater task keeps ready, as long as it
-        // extends the current chain tip. Its mempool transactions can be a few seconds old, which
-        // only costs the miner the fees of the transactions that arrived in the meantime, and the
-        // next call picks them up.
-        //
-        // Long polling clients keep waiting if the precomputed template is the one they already
-        // have.
+        // extends the current chain tip.
         check_synced_to_tip(&self.network, latest_chain_tip.clone(), sync_status.clone())?;
 
-        if let (Some(cache), Some(tip_hash)) =
-            (self.gbt.template_cache(), latest_chain_tip.best_tip_hash())
-        {
-            if let Some(template) = cache.wait_for_tip(tip_hash).await {
-                if Some(template.long_poll_id) != client_long_poll_id {
-                    let submit_old = client_long_poll_id
-                        .as_ref()
-                        .map(|old_long_poll_id| template.long_poll_id.submit_old(old_long_poll_id));
-
-                    let mut template = (*template).clone();
-                    template.submit_old = submit_old;
-
-                    return Ok(template.into());
-                }
-            }
+        if let Some(template) = self.precomputed_block_template(client_long_poll_id).await {
+            return Ok(template.into());
         }
 
         // - Checks and fetches that can change during long polling
@@ -2635,35 +2649,6 @@ where
             // The clone preserves the seen status of the chain tip.
             let mut wait_for_new_tip = latest_chain_tip.clone();
             let wait_for_new_tip = wait_for_new_tip.best_tip_changed();
-            // `+2`: we expect the tip to advance by one block before waking us up.
-            let precomputed_height = Height(chain_info.tip_height.0 + 2);
-            let wait_for_new_tip = async {
-                // Precompute the coinbase tx for an empty block that will sit on the new tip. We
-                // will return this provisional block upon a chain tip change so that miners can
-                // mine on the newest tip, and don't waste their effort on a shorter chain while we
-                // compute a new template for a properly filled block. We do this precomputation
-                // before we start waiting for a new tip since computing the coinbase tx takes a few
-                // seconds if the miner mines to a shielded address, and we want to return fast
-                // when the tip changes.
-                let precompute_coinbase = |network, height, params| {
-                    tokio::task::spawn_blocking(move || {
-                        TransactionTemplate::new_coinbase(&network, height, &params, Amount::zero())
-                            .expect("valid coinbase tx")
-                    })
-                };
-
-                let precomputed_coinbase = precompute_coinbase(
-                    self.network.clone(),
-                    precomputed_height,
-                    miner_params.clone(),
-                )
-                .await
-                .expect("valid coinbase tx");
-
-                let _ = wait_for_new_tip.await;
-
-                precomputed_coinbase
-            };
 
             // Wait for the maximum block time to elapse. This can change the block header
             // on testnet. (On mainnet it can happen due to a network disconnection, or a
@@ -2686,8 +2671,7 @@ where
 
             // Optional TODO:
             // `zcashd` generates the next coinbase transaction while waiting for changes.
-            // When Zebra supports shielded coinbase, we might want to do this in parallel.
-            // But the coinbase value depends on the selected transactions, so this needs
+            // The coinbase value depends on the selected transactions, so this needs
             // further analysis to check if it actually saves us any time.
 
             tokio::select! {
@@ -2707,42 +2691,15 @@ where
                     );
                 }
 
-                precomputed_coinbase = wait_for_new_tip => {
-                    let chain_info = fetch_chain_info(read_state.clone()).await?;
-
-                    let server_long_poll_id = LongPollInput::new(
-                        chain_info.tip_height,
-                        chain_info.tip_hash,
-                        chain_info.max_time,
-                        vec![]
-                    )
-                    .generate_id();
-
-                    let submit_old = client_long_poll_id
-                        .as_ref()
-                        .map(|old_long_poll_id| server_long_poll_id.submit_old(old_long_poll_id));
-
-                    // Discard the precomputed coinbase if our `+2` guess was wrong
-                    // (multi-block advance, reorg, or spurious notification) — its
-                    // BIP-34 height and subsidies wouldn't match the block.
-                    let next_height = chain_info.tip_height.next().map_misc_error()?;
-                    let precomputed_coinbase = (next_height == precomputed_height)
-                        .then_some(precomputed_coinbase);
-
-                    // Respond instantly with an empty block upon a chain tip change so that
-                    // the miner doesn't waste their effort trying to extend a shorter
-                    // chain.
-                    return Ok(BlockTemplateResponse::new_internal(
-                        &self.network,
-                        precomputed_coinbase,
-                        None,
-                        miner_params,
-                        &chain_info,
-                        server_long_poll_id,
-                        vec![],
-                        submit_old,
-                    )
-                    .into())
+                _ = wait_for_new_tip => {
+                    // Serve the template that the updater task precomputed for the new tip, so the
+                    // miner doesn't waste any effort extending the shorter chain. Otherwise, loop
+                    // around to build a template for the new tip from the state and the mempool.
+                    if let Some(template) =
+                        self.precomputed_block_template(client_long_poll_id).await
+                    {
+                        return Ok(template.into());
+                    }
                 }
 
                 // The max time does not elapse during normal operation on mainnet,
@@ -2801,8 +2758,7 @@ where
 
         Ok(BlockTemplateResponse::new_internal(
             &self.network,
-            None,
-            Some(self.gbt.coinbase_cache()),
+            &coinbase_cache,
             miner_params,
             &chain_info,
             server_long_poll_id,

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1036,8 +1036,19 @@ where
     /// them up. But it always extends the current tip, so miners never work on a chain that Zebra
     /// has already seen a block for.
     ///
+    /// A long polling client waits here until the updater publishes a template it doesn't have
+    /// yet, the chain tip changes, or `max_time` is reached.
+    ///
+    /// # Correctness
+    ///
+    /// Long polling must not fall through to the synchronous path below while this cache is
+    /// serving. That path derives its own long poll ID from a fresh state and mempool read, so
+    /// with two independent ID sources neither side ever matches the other: the client alternates
+    /// between a cached template and a freshly built one, each call returning immediately, and it
+    /// never waits. Its work is cancelled on every response, so it mines nothing.
+    ///
     /// Returns `None` if there is no updater task, if it hasn't caught up with a recent chain tip
-    /// change, or if the client is long polling on this exact template.
+    /// change, or if the chain tip channel closed.
     async fn precomputed_block_template(
         &self,
         client_long_poll_id: Option<LongPollId>,
@@ -1050,6 +1061,76 @@ where
             return None;
         }
 
+        // Subscribe before the first read below. A template published between reading the cache
+        // and waiting on it would otherwise be marked seen and skipped, and the only other wakes
+        // are a chain tip change and `max_time`, neither of which fires when the mempool alone
+        // changes: the caller would wait out the updater's backstop on a template it has already
+        // been told about.
+        let mut template_changes = cache.subscribe();
+
+        // Clone the chain tip once, and mark the current tip seen: a receiver created fresh on
+        // every iteration reports the tip it was created with as a change, so waiting on it would
+        // return immediately and spin this loop instead of parking it.
+        let mut tip_change = self.latest_chain_tip.clone();
+        tip_change.mark_best_tip_seen();
+
+        loop {
+            let template = self.precomputed_template_for_state_tip(cache).await?;
+
+            let is_client_template = Some(template.long_poll_id) == client_long_poll_id;
+
+            if !is_client_template {
+                let mut template = (*template).clone();
+                template.submit_old = client_long_poll_id
+                    .as_ref()
+                    .map(|old_long_poll_id| template.long_poll_id.submit_old(old_long_poll_id));
+
+                return Some(template);
+            }
+
+            // The client is long polling on exactly this template, so wait for a reason to send
+            // another one.
+            let max_time = template.max_time;
+            let cur_time = template.cur_time;
+
+            // On Testnet the max time changes the block difficulty, so old shares become invalid.
+            // On Mainnet this means 90 minutes without a block or a mempool transaction.
+            let duration_until_max_time = max_time.saturating_duration_since(cur_time);
+            let wait_for_max_time: OptionFuture<_> = if duration_until_max_time.seconds() > 0 {
+                Some(tokio::time::sleep(duration_until_max_time.to_std()))
+            } else {
+                None
+            }
+            .into();
+
+            tokio::select! {
+                biased;
+
+                tip_changed = tip_change.best_tip_changed() => {
+                    // A closed chain tip channel means Zebra is shutting down.
+                    tip_changed.ok()?;
+                }
+
+                () = template_changes.changed() => {}
+
+                Some(()) = wait_for_max_time => {
+                    let template = self.precomputed_template_for_state_tip(cache).await?;
+                    let mut template = (*template).clone();
+                    template.submit_old = Some(false);
+
+                    return Some(template);
+                }
+            }
+        }
+    }
+
+    /// Returns the precomputed template, if it extends the tip the state has committed.
+    ///
+    /// Waits up to `NEW_TIP_TIMEOUT` for the updater task to catch up with a recent tip change.
+    async fn precomputed_template_for_state_tip(
+        &self,
+        cache: &precompute::TemplateCache,
+    ) -> Option<Arc<BlockTemplateResponse>> {
         // # Correctness
         //
         // The tip has to come from the state, not from `latest_chain_tip`. The state's write task
@@ -1070,20 +1151,7 @@ where
             return None;
         };
 
-        let template = cache.wait_for_tip(tip_hash).await?;
-
-        if Some(template.long_poll_id) == client_long_poll_id {
-            return None;
-        }
-
-        let submit_old = client_long_poll_id
-            .as_ref()
-            .map(|old_long_poll_id| template.long_poll_id.submit_old(old_long_poll_id));
-
-        let mut template = (*template).clone();
-        template.submit_old = submit_old;
-
-        Some(template)
+        cache.wait_for_tip(tip_hash).await
     }
 
     /// Returns a reference to the configured network.

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -85,7 +85,7 @@ use zebra_consensus::{
     funding_stream_address, router::service_trait::BlockVerifierService, RouterError,
 };
 use zebra_network::{address_book_peers::AddressBookPeers, types::PeerServices, PeerSocketAddr};
-use zebra_node_services::mempool::{self, CreatedOrSpent, MempoolService};
+use zebra_node_services::mempool::{self, CreatedOrSpent, MempoolService, MempoolTxSubscriber};
 use zebra_state::{
     AnyTx, HashOrHeight, OutputLocation, ReadRequest, ReadResponse, ReadState as ReadStateService,
     State as StateService, TransactionLocation,
@@ -1008,8 +1008,14 @@ where
     /// `getblocktemplate` calls don't have to read the state and the mempool, select transactions,
     /// and build a coinbase transaction.
     ///
+    /// The task rebuilds when the chain tip changes and when `mempool_change` reports a change
+    /// that affects the template, so a new transaction reaches miners without waiting for a timer.
+    ///
     /// Returns `None` if mining isn't configured.
-    pub fn spawn_block_template_updater(&self) -> Option<JoinHandle<()>> {
+    pub fn spawn_block_template_updater(
+        &self,
+        mempool_change: MempoolTxSubscriber,
+    ) -> Option<JoinHandle<()>> {
         let miner_params = self.gbt.miner_params()?.clone();
         let template_cache = self.gbt.template_cache()?.clone();
 
@@ -1020,6 +1026,7 @@ where
                 self.gbt.coinbase_cache(),
                 template_cache,
                 self.mempool.clone(),
+                mempool_change.subscribe(),
                 self.read_state.clone(),
                 self.latest_chain_tip.clone(),
                 self.gbt.sync_status(),

--- a/zebra-rpc/src/methods.rs
+++ b/zebra-rpc/src/methods.rs
@@ -1043,7 +1043,32 @@ where
         client_long_poll_id: Option<LongPollId>,
     ) -> Option<BlockTemplateResponse> {
         let cache = self.gbt.template_cache()?;
-        let tip_hash = self.latest_chain_tip.best_tip_hash()?;
+
+        // Skip the tip read when there's nothing to serve: without an updater task, every request
+        // builds its own template anyway.
+        if cache.is_empty() {
+            return None;
+        }
+
+        // # Correctness
+        //
+        // The tip has to come from the state, not from `latest_chain_tip`. The state's write task
+        // publishes a committed block to the read state before it updates the chain tip channel
+        // (`update_latest_chain_channels()`), so between those two sends the channel still names
+        // the parent of a block the state has already committed. Trusting the channel there would
+        // serve a template for a chain this node has itself extended.
+        //
+        // `ReadRequest::Tip` reads the same non-finalized state channel that
+        // `ReadRequest::ChainInfo` builds templates from, so the two can't disagree about the tip.
+        let ReadResponse::Tip(Some((_, tip_hash))) = self
+            .read_state
+            .clone()
+            .oneshot(ReadRequest::Tip)
+            .await
+            .ok()?
+        else {
+            return None;
+        };
 
         let template = cache.wait_for_tip(tip_hash).await?;
 

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -2761,6 +2761,176 @@ async fn gbt_with(net: Network, addr: ZcashAddress) {
     mempool.expect_no_requests().await;
 }
 
+/// Checks that `getblocktemplate` answers from the template precomputed by the block template
+/// updater task, without reading the state or the mempool, and that it never answers with a
+/// template for a stale chain tip.
+#[tokio::test(flavor = "multi_thread")]
+async fn getblocktemplate_precomputed() {
+    let _init_guard = zebra_test::init();
+
+    let net = Network::Mainnet;
+
+    // The updater task only queries the mocks every few seconds, so the responder tasks below have
+    // to wait for much longer than the default request delay.
+    let request_delay = Duration::from_secs(30);
+    let mempool: MockService<_, _, _, BoxError> = MockService::build()
+        .with_max_request_delay(request_delay)
+        .for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let read_state: MockService<_, _, _, BoxError> = MockService::build()
+        .with_max_request_delay(request_delay)
+        .for_unit_tests();
+
+    let mut mock_sync_status = MockSyncStatus::default();
+    mock_sync_status.set_is_close_to_tip(true);
+
+    let mining_conf = mining::Config {
+        miner_address: Some(ZcashAddress::from_transparent_p2pkh(
+            NetworkType::from(NetworkKind::from(&net)),
+            [0x7e; 20],
+        )),
+        extra_coinbase_data: None,
+        miner_memo: None,
+        internal_miner: false,
+    };
+
+    let tip_height = NetworkUpgrade::Nu5
+        .activation_height(&net)
+        .expect("nu5 activation height");
+    let tip_hash =
+        Hash::from_hex("0000000000d723156d9b65ffcf4984da7a19675ed7e2f06d9e5d5188af087bf8").unwrap();
+
+    let (mock_tip, mock_tip_sender) = MockChainTip::new();
+    mock_tip_sender.send_best_tip_height(tip_height);
+    mock_tip_sender.send_best_tip_hash(tip_hash);
+    mock_tip_sender.send_estimated_distance_to_network_chain_tip(Some(0));
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, _) = RpcImpl::new(
+        net.clone(),
+        mining_conf,
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool.clone(), 1),
+        state.clone(),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        mock_sync_status,
+        mock_tip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    // Answers the updater task's state and mempool requests for a chain tip, until the returned
+    // tasks are aborted.
+    let spawn_responders = |tip_height: Height, tip_hash: Hash| {
+        let mut read_state = read_state.clone();
+        let mut mempool = mempool.clone();
+        let chain_history_root = fake_history_tree(&net).hash();
+
+        let read_state_responder = tokio::spawn(async move {
+            loop {
+                read_state
+                    .expect_request_that(|req| matches!(req, ReadRequest::ChainInfo))
+                    .await
+                    .respond(ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
+                        expected_difficulty: CompactDifficulty::from(ExpandedDifficulty::from(
+                            U256::one(),
+                        )),
+                        tip_height,
+                        tip_hash,
+                        cur_time: DateTime32::from(1654008617),
+                        min_time: DateTime32::from(1654008606),
+                        max_time: DateTime32::from(1654008728),
+                        chain_history_root,
+                    }));
+            }
+        });
+
+        let mempool_responder = tokio::spawn(async move {
+            loop {
+                mempool
+                    .expect_request(mempool::Request::FullTransactions)
+                    .await
+                    .respond(mempool::Response::FullTransactions {
+                        transactions: vec![],
+                        transaction_dependencies: Default::default(),
+                        last_seen_tip_hash: tip_hash,
+                    });
+            }
+        });
+
+        (read_state_responder, mempool_responder)
+    };
+
+    let (read_state_responder, mempool_responder) = spawn_responders(tip_height, tip_hash);
+
+    let updater = rpc
+        .spawn_block_template_updater()
+        .expect("mining is configured");
+
+    // Wait for the updater task to precompute a template for the mock chain tip.
+    let template_cache = rpc
+        .gbt
+        .template_cache()
+        .expect("the miner params were not overridden")
+        .clone();
+
+    tokio::time::timeout(Duration::from_secs(30), async {
+        while template_cache.wait_for_tip(tip_hash).await.is_none() {}
+    })
+    .await
+    .expect("the updater task should precompute a template for the chain tip");
+
+    // The RPC must answer from the precomputed template: the state and the mempool never respond
+    // again, so building a template would block forever.
+    read_state_responder.abort();
+    mempool_responder.abort();
+
+    let template = tokio::time::timeout(Duration::from_secs(1), rpc.get_block_template(None))
+        .await
+        .expect("getblocktemplate should answer without reading the state or the mempool")
+        .expect("getblocktemplate should succeed")
+        .try_into_template()
+        .expect("getblocktemplate without parameters should return a template");
+
+    assert_eq!(template.previous_block_hash, tip_hash);
+    assert_eq!(template.height, tip_height.0 + 1);
+    // `submit_old` is only set for long polling clients.
+    assert_eq!(template.submit_old, None);
+
+    // After the chain tip changes, the RPC must answer with a template for the new tip, and never
+    // with the precomputed template for the tip that Zebra has already extended.
+    let next_tip_height = tip_height.next().expect("height is below Height::MAX");
+    let next_tip_hash =
+        Hash::from_hex("0000000000b6a5024aa412120b684a509ba8fd57e01de07bc2a84e4d3719a9f1").unwrap();
+
+    let (read_state_responder, mempool_responder) =
+        spawn_responders(next_tip_height, next_tip_hash);
+
+    mock_tip_sender.send_best_tip_height(next_tip_height);
+    mock_tip_sender.send_best_tip_hash(next_tip_hash);
+
+    let template = tokio::time::timeout(Duration::from_secs(10), rpc.get_block_template(None))
+        .await
+        .expect("getblocktemplate should answer after a chain tip change")
+        .expect("getblocktemplate should succeed")
+        .try_into_template()
+        .expect("getblocktemplate without parameters should return a template");
+
+    assert_eq!(
+        template.previous_block_hash, next_tip_hash,
+        "getblocktemplate must not return a template for a tip that Zebra has already extended",
+    );
+    assert_eq!(template.height, next_tip_height.0 + 1);
+
+    read_state_responder.abort();
+    mempool_responder.abort();
+    updater.abort();
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn rpc_submitblock_errors() {
     let _init_guard = zebra_test::init();

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use futures::FutureExt;
+use tokio::sync::broadcast;
 use tower::buffer::Buffer;
 
 use zcash_address::{ToAddress, ZcashAddress};
@@ -36,7 +37,10 @@ use zebra_consensus::MAX_BLOCK_SIGOPS;
 use zebra_network::{
     address_book_peers::MockAddressBookPeers, types::PeerServices, PeerSocketAddr,
 };
-use zebra_node_services::BoxError;
+use zebra_node_services::{
+    mempool::{MempoolChange, MempoolTxSubscriber},
+    BoxError,
+};
 use zebra_state::{
     GetBlockTemplateChainInfo, IntoDisk, LatestChainTip, ReadRequest, ReadResponse,
     ReadStateService,
@@ -2880,8 +2884,11 @@ async fn getblocktemplate_precomputed() {
 
     let (read_state_responder, mempool_responder) = spawn_responders(tip_height, tip_hash);
 
+    // Holding the sender keeps the updater's change receiver open.
+    let (mempool_change_tx, _mempool_change_rx) = broadcast::channel(100);
+
     let updater = rpc
-        .spawn_block_template_updater()
+        .spawn_block_template_updater(MempoolTxSubscriber::new(mempool_change_tx.clone()))
         .expect("mining is configured");
 
     // Wait for the updater task to precompute a template for the mock chain tip.
@@ -3107,8 +3114,11 @@ async fn getblocktemplate_long_poll_waits_for_a_new_template() {
         }
     });
 
+    // Holding the sender keeps the updater's change receiver open.
+    let (mempool_change_tx, _mempool_change_rx) = broadcast::channel(100);
+
     let updater = rpc
-        .spawn_block_template_updater()
+        .spawn_block_template_updater(MempoolTxSubscriber::new(mempool_change_tx.clone()))
         .expect("mining is configured");
 
     let template_cache = rpc
@@ -3301,8 +3311,11 @@ async fn getblocktemplate_ignores_precomputed_template_when_tip_channel_lags_sta
     // Fill the cache with a template for the tip both the state and the channel agree on.
     let (read_state_responder, mempool_responder) = spawn_responders(tip_height, tip_hash);
 
+    // Holding the sender keeps the updater's change receiver open.
+    let (mempool_change_tx, _mempool_change_rx) = broadcast::channel(100);
+
     let updater = rpc
-        .spawn_block_template_updater()
+        .spawn_block_template_updater(MempoolTxSubscriber::new(mempool_change_tx.clone()))
         .expect("mining is configured");
 
     let template_cache = rpc
@@ -3336,6 +3349,631 @@ async fn getblocktemplate_ignores_precomputed_template_when_tip_channel_lags_sta
          tip channel still reports",
     );
     assert_eq!(template.height, committed_height.0 + 1);
+
+    read_state_responder.abort();
+    mempool_responder.abort();
+    updater.abort();
+}
+
+/// How long the tests below wait for a rebuild they expect.
+///
+/// [`wait_for_count`] returns as soon as the rebuild lands, so this is only a ceiling. It has to
+/// stay well under `BACKSTOP_REFRESH`, or the updater's own backstop rebuild could satisfy an
+/// assertion that the change under test was supposed to satisfy, and the test would pass against
+/// an updater that ignored the change entirely.
+const REBUILD_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Waits for `counter` to reach `target`, polling until `timeout` elapses.
+///
+/// Returns `true` as soon as it does, so a test that expects an event pays only for the event.
+/// Returns `false` if it never does, which is how the tests below assert that a change the updater
+/// should ignore cost no rebuild: a rebuild it decided to make starts one [`MEMPOOL_DEBOUNCE`]
+/// after the change that prompted it, so a window longer than that catches one.
+async fn wait_for_count(counter: &AtomicUsize, target: usize, timeout: Duration) -> bool {
+    tokio::time::timeout(timeout, async {
+        while counter.load(Ordering::SeqCst) < target {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .is_ok()
+}
+
+/// Checks that a mempool change reaches the block template updater and makes it rebuild.
+///
+/// Which changes are worth a rebuild, how a burst is coalesced, and what a lagging change channel
+/// costs are covered by the wait-phase tests in `precompute::tests`, which read the decision
+/// straight off a paused clock. This test covers the wiring those tests can't: a change sent on
+/// the mempool's channel reaching a running updater task, and that task reading the mempool again.
+#[tokio::test(flavor = "multi_thread")]
+async fn getblocktemplate_precompute_rebuilds_on_a_mempool_change() {
+    let _init_guard = zebra_test::init();
+
+    let net = Network::Mainnet;
+
+    let request_delay = Duration::from_secs(60);
+    let mempool: MockService<_, _, _, BoxError> = MockService::build()
+        .with_max_request_delay(request_delay)
+        .for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let read_state: MockService<_, _, _, BoxError> = MockService::build()
+        .with_max_request_delay(request_delay)
+        .for_unit_tests();
+
+    let mut mock_sync_status = MockSyncStatus::default();
+    mock_sync_status.set_is_close_to_tip(true);
+
+    let mining_conf = mining::Config {
+        miner_address: Some(ZcashAddress::from_transparent_p2pkh(
+            NetworkType::from(NetworkKind::from(&net)),
+            [0x7e; 20],
+        )),
+        extra_coinbase_data: None,
+        miner_memo: None,
+        internal_miner: false,
+    };
+
+    let tip_height = NetworkUpgrade::Nu5
+        .activation_height(&net)
+        .expect("nu5 activation height");
+    let tip_hash =
+        Hash::from_hex("0000000000d723156d9b65ffcf4984da7a19675ed7e2f06d9e5d5188af087bf8").unwrap();
+
+    let (mock_tip, mock_tip_sender) = MockChainTip::new();
+    mock_tip_sender.send_best_tip_height(tip_height);
+    mock_tip_sender.send_best_tip_hash(tip_hash);
+    mock_tip_sender.send_estimated_distance_to_network_chain_tip(Some(0));
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, _) = RpcImpl::new(
+        net.clone(),
+        mining_conf,
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool.clone(), 1),
+        state.clone(),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        mock_sync_status,
+        mock_tip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    // Counts the mempool reads a rebuild makes, which is one `FullTransactions` request each.
+    let rebuilds = Arc::new(AtomicUsize::new(0));
+
+    let chain_history_root = fake_history_tree(&net).hash();
+    let read_state_responder = tokio::spawn({
+        let mut read_state = read_state.clone();
+        async move {
+            loop {
+                read_state
+                    .expect_request_that(|req| {
+                        matches!(req, ReadRequest::ChainInfo | ReadRequest::Tip)
+                    })
+                    .await
+                    .respond_with(move |req| match req {
+                        ReadRequest::ChainInfo => {
+                            ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
+                                expected_difficulty: CompactDifficulty::from(
+                                    ExpandedDifficulty::from(U256::one()),
+                                ),
+                                tip_height,
+                                tip_hash,
+                                cur_time: DateTime32::from(1654008617),
+                                min_time: DateTime32::from(1654008606),
+                                max_time: DateTime32::from(1654008719),
+                                chain_history_root,
+                            })
+                        }
+                        ReadRequest::Tip => ReadResponse::Tip(Some((tip_height, tip_hash))),
+                        other => panic!("unexpected read state request: {other:?}"),
+                    });
+            }
+        }
+    });
+
+    let mempool_responder = tokio::spawn({
+        let mut mempool = mempool.clone();
+        let rebuilds = rebuilds.clone();
+        async move {
+            loop {
+                mempool
+                    .expect_request(mempool::Request::FullTransactions)
+                    .await
+                    .respond(mempool::Response::FullTransactions {
+                        transactions: vec![],
+                        transaction_dependencies: Default::default(),
+                        last_seen_tip_hash: tip_hash,
+                    });
+                rebuilds.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+    });
+
+    let (mempool_change_tx, _mempool_change_rx) = broadcast::channel(100);
+
+    let updater = rpc
+        .spawn_block_template_updater(MempoolTxSubscriber::new(mempool_change_tx.clone()))
+        .expect("mining is configured");
+
+    let template_cache = rpc
+        .gbt
+        .template_cache()
+        .expect("the miner params were not overridden")
+        .clone();
+
+    tokio::time::timeout(Duration::from_secs(30), async {
+        while template_cache.wait_for_tip(tip_hash).await.is_none() {}
+    })
+    .await
+    .expect("the updater task should precompute a template for the chain tip");
+
+    // The mempool responder counts a read after it answers, so wait for the first rebuild's read
+    // rather than assuming it has landed.
+    assert!(
+        wait_for_count(&rebuilds, 1, REBUILD_TIMEOUT).await,
+        "the updater should read the mempool once while precomputing the first template",
+    );
+    let before_change = rebuilds.load(Ordering::SeqCst);
+
+    mempool_change_tx
+        .send(MempoolChange::added(
+            [UnminedTxId::from_legacy_id(transaction::Hash([1; 32]))]
+                .into_iter()
+                .collect(),
+        ))
+        .expect("the updater task holds a receiver");
+
+    assert!(
+        wait_for_count(&rebuilds, before_change + 1, REBUILD_TIMEOUT).await,
+        "a mempool addition should make the updater read the mempool and rebuild",
+    );
+
+    read_state_responder.abort();
+    mempool_responder.abort();
+    updater.abort();
+}
+
+/// Checks that a long polling `getblocktemplate` call returns as soon as the block template
+/// updater publishes a template for a changed mempool, rather than waiting for the RPC's own
+/// mempool poll.
+#[tokio::test(flavor = "multi_thread")]
+async fn getblocktemplate_long_poll_returns_on_mempool_change() {
+    let _init_guard = zebra_test::init();
+
+    let net = Network::Mainnet;
+
+    let request_delay = Duration::from_secs(60);
+    let mempool: MockService<_, _, _, BoxError> = MockService::build()
+        .with_max_request_delay(request_delay)
+        .for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let read_state: MockService<_, _, _, BoxError> = MockService::build()
+        .with_max_request_delay(request_delay)
+        .for_unit_tests();
+
+    let mut mock_sync_status = MockSyncStatus::default();
+    mock_sync_status.set_is_close_to_tip(true);
+
+    let mining_conf = mining::Config {
+        miner_address: Some(ZcashAddress::from_transparent_p2pkh(
+            NetworkType::from(NetworkKind::from(&net)),
+            [0x7e; 20],
+        )),
+        extra_coinbase_data: None,
+        miner_memo: None,
+        internal_miner: false,
+    };
+
+    let tip_height = NetworkUpgrade::Nu5
+        .activation_height(&net)
+        .expect("nu5 activation height");
+    let tip_hash =
+        Hash::from_hex("0000000000d723156d9b65ffcf4984da7a19675ed7e2f06d9e5d5188af087bf8").unwrap();
+
+    let (mock_tip, mock_tip_sender) = MockChainTip::new();
+    mock_tip_sender.send_best_tip_height(tip_height);
+    mock_tip_sender.send_best_tip_hash(tip_hash);
+    mock_tip_sender.send_estimated_distance_to_network_chain_tip(Some(0));
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, _) = RpcImpl::new(
+        net.clone(),
+        mining_conf,
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool.clone(), 1),
+        state.clone(),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        mock_sync_status,
+        mock_tip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    // A transaction the mempool only starts returning once the test asks it to, standing in for a
+    // transaction that arrives while a miner is long polling.
+    let tx = Arc::new(Transaction::test_v1(
+        vec![],
+        vec![],
+        transaction::LockTime::unlocked(),
+    ));
+    let unmined_tx = UnminedTx {
+        transaction: tx.clone(),
+        id: tx.unmined_id(),
+        size: tx.zcash_serialized_size(),
+        conventional_fee: 0.try_into().unwrap(),
+    };
+    let new_tx_id = unmined_tx.id;
+    let new_tx = VerifiedUnminedTx {
+        conventional_actions: zip317::conventional_actions(&unmined_tx.transaction),
+        transaction: unmined_tx,
+        miner_fee: 0.try_into().unwrap(),
+        legacy_sigop_count: 0,
+        p2sh_sigop_count: 0,
+        unpaid_actions: 0,
+        fee_weight_ratio: 1.0,
+        time: None,
+        height: None,
+        spent_outputs: Arc::new(vec![]),
+    };
+
+    // Switched from an empty mempool to one holding `new_tx`.
+    let mempool_has_tx = Arc::new(AtomicBool::new(false));
+
+    // Counts the state tip reads, so the test can tell when the long polling call is waiting.
+    //
+    // Long polling is served from the precomputed cache, which validates the template against the
+    // state tip on every wake and never reads the mempool, so this is the observable that says the
+    // call has parked.
+    let tip_reads = Arc::new(AtomicUsize::new(0));
+
+    let chain_history_root = fake_history_tree(&net).hash();
+    let read_state_responder = tokio::spawn({
+        let mut read_state = read_state.clone();
+        let tip_reads = tip_reads.clone();
+        async move {
+            loop {
+                let tip_reads = tip_reads.clone();
+                read_state
+                    .expect_request_that(|req| {
+                        matches!(req, ReadRequest::ChainInfo | ReadRequest::Tip)
+                    })
+                    .await
+                    .respond_with(move |req| match req {
+                        ReadRequest::ChainInfo => {
+                            ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
+                                expected_difficulty: CompactDifficulty::from(
+                                    ExpandedDifficulty::from(U256::one()),
+                                ),
+                                tip_height,
+                                tip_hash,
+                                cur_time: DateTime32::from(1654008617),
+                                min_time: DateTime32::from(1654008606),
+                                max_time: DateTime32::from(1654008719),
+                                chain_history_root,
+                            })
+                        }
+                        ReadRequest::Tip => {
+                            tip_reads.fetch_add(1, Ordering::SeqCst);
+                            ReadResponse::Tip(Some((tip_height, tip_hash)))
+                        }
+                        other => panic!("unexpected read state request: {other:?}"),
+                    });
+            }
+        }
+    });
+
+    let mempool_responder = tokio::spawn({
+        let mut mempool = mempool.clone();
+        let mempool_has_tx = mempool_has_tx.clone();
+        async move {
+            loop {
+                // Read the switch when the request is answered, not when this iteration starts:
+                // the responder parks in `expect_request`, so deciding earlier answers a request
+                // that arrives after the switch flips with the contents from before it.
+                let mempool_has_tx = mempool_has_tx.clone();
+                let new_tx = new_tx.clone();
+
+                mempool
+                    .expect_request(mempool::Request::FullTransactions)
+                    .await
+                    .respond_with(move |_| mempool::Response::FullTransactions {
+                        transactions: if mempool_has_tx.load(Ordering::SeqCst) {
+                            vec![new_tx]
+                        } else {
+                            vec![]
+                        },
+                        transaction_dependencies: Default::default(),
+                        last_seen_tip_hash: tip_hash,
+                    });
+            }
+        }
+    });
+
+    let (mempool_change_tx, _mempool_change_rx) = broadcast::channel(100);
+
+    let updater = rpc
+        .spawn_block_template_updater(MempoolTxSubscriber::new(mempool_change_tx.clone()))
+        .expect("mining is configured");
+
+    let template_cache = rpc
+        .gbt
+        .template_cache()
+        .expect("the miner params were not overridden")
+        .clone();
+
+    tokio::time::timeout(Duration::from_secs(30), async {
+        while template_cache.wait_for_tip(tip_hash).await.is_none() {}
+    })
+    .await
+    .expect("the updater task should precompute a template for the chain tip");
+
+    let template = rpc
+        .get_block_template(None)
+        .await
+        .expect("getblocktemplate should succeed")
+        .try_into_template()
+        .expect("getblocktemplate without parameters should return a template");
+
+    assert!(
+        template.transactions.is_empty(),
+        "the mempool is empty before the change, so its template should be too",
+    );
+
+    // Long poll on the template the client already has, which can only return once something
+    // changes.
+    let long_poll = tokio::spawn({
+        let rpc = rpc.clone();
+        let long_poll_id = template.long_poll_id;
+        async move {
+            rpc.get_block_template(Some(GetBlockTemplateParameters {
+                mode: GetBlockTemplateRequestMode::Template,
+                data: None,
+                capabilities: vec![],
+                long_poll_id: Some(long_poll_id),
+                _work_id: None,
+            }))
+            .await
+        }
+    });
+
+    // The call above validated the cached template against the state tip, and the long polling
+    // call does the same before it parks, so a second tip read means it is waiting.
+    assert!(
+        wait_for_count(&tip_reads, 2, REBUILD_TIMEOUT).await,
+        "the long polling call should validate the tip before it waits",
+    );
+
+    mempool_has_tx.store(true, Ordering::SeqCst);
+    mempool_change_tx
+        .send(MempoolChange::added([new_tx_id].into_iter().collect()))
+        .expect("the updater task holds a receiver");
+
+    // The updater debounces for half a second and then publishes, so this budget is several times
+    // the event-driven path, and less than the RPC's own mempool poll interval.
+    assert!(
+        Duration::from_secs(MEMPOOL_LONG_POLL_INTERVAL) > Duration::from_millis(2500),
+        "this test's budget has to be shorter than the poll it proves the RPC doesn't wait for",
+    );
+
+    let template = tokio::time::timeout(Duration::from_millis(2500), long_poll)
+        .await
+        .expect(
+            "long polling should return once the updater publishes a template, without \
+                 waiting for the RPC's own mempool poll",
+        )
+        .expect("the long polling task should not panic")
+        .expect("getblocktemplate should succeed")
+        .try_into_template()
+        .expect("getblocktemplate in template mode should return a template");
+
+    assert_eq!(
+        template.transactions.len(),
+        1,
+        "the template should contain the transaction that was added to the mempool",
+    );
+
+    read_state_responder.abort();
+    mempool_responder.abort();
+    updater.abort();
+}
+
+/// Checks that the block template updater rebuilds when a transaction ZIP-317 left out of the
+/// template is invalidated.
+///
+/// The template's long poll ID covers every transaction in the mempool, not just the selected
+/// ones, so a template built from a mempool that no longer exists has to be replaced.
+#[tokio::test(flavor = "multi_thread")]
+async fn getblocktemplate_precompute_rebuilds_when_an_unselected_transaction_is_invalidated() {
+    let _init_guard = zebra_test::init();
+
+    let net = Network::Mainnet;
+
+    let request_delay = Duration::from_secs(60);
+    let mempool: MockService<_, _, _, BoxError> = MockService::build()
+        .with_max_request_delay(request_delay)
+        .for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let read_state: MockService<_, _, _, BoxError> = MockService::build()
+        .with_max_request_delay(request_delay)
+        .for_unit_tests();
+
+    let mut mock_sync_status = MockSyncStatus::default();
+    mock_sync_status.set_is_close_to_tip(true);
+
+    let mining_conf = mining::Config {
+        miner_address: Some(ZcashAddress::from_transparent_p2pkh(
+            NetworkType::from(NetworkKind::from(&net)),
+            [0x7e; 20],
+        )),
+        extra_coinbase_data: None,
+        miner_memo: None,
+        internal_miner: false,
+    };
+
+    let tip_height = NetworkUpgrade::Nu5
+        .activation_height(&net)
+        .expect("nu5 activation height");
+    let tip_hash =
+        Hash::from_hex("0000000000d723156d9b65ffcf4984da7a19675ed7e2f06d9e5d5188af087bf8").unwrap();
+
+    let (mock_tip, mock_tip_sender) = MockChainTip::new();
+    mock_tip_sender.send_best_tip_height(tip_height);
+    mock_tip_sender.send_best_tip_hash(tip_hash);
+    mock_tip_sender.send_estimated_distance_to_network_chain_tip(Some(0));
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, _) = RpcImpl::new(
+        net.clone(),
+        mining_conf,
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool.clone(), 1),
+        state.clone(),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        mock_sync_status,
+        mock_tip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    // A mempool transaction with more sigops than a block can hold, so ZIP-317 selection can never
+    // put it in a template, while it still counts towards the template's long poll ID.
+    let tx = Arc::new(Transaction::test_v1(
+        vec![],
+        vec![],
+        transaction::LockTime::unlocked(),
+    ));
+    let unmined_tx = UnminedTx {
+        transaction: tx.clone(),
+        id: tx.unmined_id(),
+        size: tx.zcash_serialized_size(),
+        conventional_fee: 0.try_into().unwrap(),
+    };
+    let unselectable_tx_id = unmined_tx.id;
+    let unselectable_tx = VerifiedUnminedTx {
+        conventional_actions: zip317::conventional_actions(&unmined_tx.transaction),
+        transaction: unmined_tx,
+        miner_fee: 0.try_into().unwrap(),
+        legacy_sigop_count: MAX_BLOCK_SIGOPS + 1,
+        p2sh_sigop_count: 0,
+        unpaid_actions: 0,
+        fee_weight_ratio: 1.0,
+        time: None,
+        height: None,
+        spent_outputs: Arc::new(vec![]),
+    };
+
+    let rebuilds = Arc::new(AtomicUsize::new(0));
+
+    let chain_history_root = fake_history_tree(&net).hash();
+    let read_state_responder = tokio::spawn({
+        let mut read_state = read_state.clone();
+        async move {
+            loop {
+                read_state
+                    .expect_request_that(|req| {
+                        matches!(req, ReadRequest::ChainInfo | ReadRequest::Tip)
+                    })
+                    .await
+                    .respond_with(move |req| match req {
+                        ReadRequest::ChainInfo => {
+                            ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
+                                expected_difficulty: CompactDifficulty::from(
+                                    ExpandedDifficulty::from(U256::one()),
+                                ),
+                                tip_height,
+                                tip_hash,
+                                cur_time: DateTime32::from(1654008617),
+                                min_time: DateTime32::from(1654008606),
+                                max_time: DateTime32::from(1654008719),
+                                chain_history_root,
+                            })
+                        }
+                        ReadRequest::Tip => ReadResponse::Tip(Some((tip_height, tip_hash))),
+                        other => panic!("unexpected read state request: {other:?}"),
+                    });
+            }
+        }
+    });
+
+    let mempool_responder = tokio::spawn({
+        let mut mempool = mempool.clone();
+        let rebuilds = rebuilds.clone();
+        async move {
+            loop {
+                mempool
+                    .expect_request(mempool::Request::FullTransactions)
+                    .await
+                    .respond(mempool::Response::FullTransactions {
+                        transactions: vec![unselectable_tx.clone()],
+                        transaction_dependencies: Default::default(),
+                        last_seen_tip_hash: tip_hash,
+                    });
+                rebuilds.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+    });
+
+    let (mempool_change_tx, _mempool_change_rx) = broadcast::channel(100);
+
+    let updater = rpc
+        .spawn_block_template_updater(MempoolTxSubscriber::new(mempool_change_tx.clone()))
+        .expect("mining is configured");
+
+    let template_cache = rpc
+        .gbt
+        .template_cache()
+        .expect("the miner params were not overridden")
+        .clone();
+
+    tokio::time::timeout(Duration::from_secs(30), async {
+        while template_cache.wait_for_tip(tip_hash).await.is_none() {}
+    })
+    .await
+    .expect("the updater task should precompute a template for the chain tip");
+
+    let template = tokio::time::timeout(Duration::from_secs(10), rpc.get_block_template(None))
+        .await
+        .expect("getblocktemplate should answer from the precomputed template")
+        .expect("getblocktemplate should succeed")
+        .try_into_template()
+        .expect("getblocktemplate without parameters should return a template");
+
+    assert!(
+        template.transactions.is_empty(),
+        "the mempool transaction should be too large for the block sigop limit, so this test's \
+         premise requires the template to leave it out",
+    );
+
+    assert!(
+        wait_for_count(&rebuilds, 1, REBUILD_TIMEOUT).await,
+        "the updater should read the mempool once while precomputing the first template",
+    );
+    let before_invalidation = rebuilds.load(Ordering::SeqCst);
+
+    mempool_change_tx
+        .send(MempoolChange::invalidated(
+            [unselectable_tx_id].into_iter().collect(),
+        ))
+        .expect("the updater task holds a receiver");
+
+    assert!(
+        wait_for_count(&rebuilds, before_invalidation + 1, REBUILD_TIMEOUT).await,
+        "invalidating a transaction the template's long poll ID covers should rebuild the \
+         template, even though ZIP-317 didn't select it",
+    );
 
     read_state_responder.abort();
     mempool_responder.abort();

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -2824,7 +2824,8 @@ async fn getblocktemplate_precomputed() {
     );
 
     // Answers the updater task's state and mempool requests for a chain tip, until the returned
-    // tasks are aborted.
+    // tasks are aborted. `ReadRequest::Tip` and `ReadRequest::ChainInfo` always report the same
+    // tip, like the state does: both read the same non-finalized state channel.
     let spawn_responders = |tip_height: Height, tip_hash: Hash| {
         let mut read_state = read_state.clone();
         let mut mempool = mempool.clone();
@@ -2833,19 +2834,25 @@ async fn getblocktemplate_precomputed() {
         let read_state_responder = tokio::spawn(async move {
             loop {
                 read_state
-                    .expect_request_that(|req| matches!(req, ReadRequest::ChainInfo))
+                    .expect_request_that(|_| true)
                     .await
-                    .respond(ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
-                        expected_difficulty: CompactDifficulty::from(ExpandedDifficulty::from(
-                            U256::one(),
-                        )),
-                        tip_height,
-                        tip_hash,
-                        cur_time: DateTime32::from(1654008617),
-                        min_time: DateTime32::from(1654008606),
-                        max_time: DateTime32::from(1654008728),
-                        chain_history_root,
-                    }));
+                    .respond_with(move |req| match req {
+                        ReadRequest::ChainInfo => {
+                            ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
+                                expected_difficulty: CompactDifficulty::from(
+                                    ExpandedDifficulty::from(U256::one()),
+                                ),
+                                tip_height,
+                                tip_hash,
+                                cur_time: DateTime32::from(1654008617),
+                                min_time: DateTime32::from(1654008606),
+                                max_time: DateTime32::from(1654008728),
+                                chain_history_root,
+                            })
+                        }
+                        ReadRequest::Tip => ReadResponse::Tip(Some((tip_height, tip_hash))),
+                        other => panic!("unexpected read state request: {other:?}"),
+                    });
             }
         });
 
@@ -2884,14 +2891,14 @@ async fn getblocktemplate_precomputed() {
     .await
     .expect("the updater task should precompute a template for the chain tip");
 
-    // The RPC must answer from the precomputed template: the state and the mempool never respond
-    // again, so building a template would block forever.
-    read_state_responder.abort();
+    // The RPC validates the tip against the state, then must answer from the precomputed template:
+    // the mempool never responds again, so selecting transactions for a fresh template would block
+    // forever.
     mempool_responder.abort();
 
     let template = tokio::time::timeout(Duration::from_secs(1), rpc.get_block_template(None))
         .await
-        .expect("getblocktemplate should answer without reading the state or the mempool")
+        .expect("getblocktemplate should answer without reading the mempool")
         .expect("getblocktemplate should succeed")
         .try_into_template()
         .expect("getblocktemplate without parameters should return a template");
@@ -2906,6 +2913,8 @@ async fn getblocktemplate_precomputed() {
     let next_tip_height = tip_height.next().expect("height is below Height::MAX");
     let next_tip_hash =
         Hash::from_hex("0000000000b6a5024aa412120b684a509ba8fd57e01de07bc2a84e4d3719a9f1").unwrap();
+
+    read_state_responder.abort();
 
     let (read_state_responder, mempool_responder) =
         spawn_responders(next_tip_height, next_tip_hash);
@@ -2925,6 +2934,169 @@ async fn getblocktemplate_precomputed() {
         "getblocktemplate must not return a template for a tip that Zebra has already extended",
     );
     assert_eq!(template.height, next_tip_height.0 + 1);
+
+    read_state_responder.abort();
+    mempool_responder.abort();
+    updater.abort();
+}
+
+/// Checks that `getblocktemplate` doesn't serve a precomputed template for a block the state has
+/// already committed, even while the chain tip channel still names that block's parent.
+///
+/// The state's write task publishes a committed block to the read state before it updates the chain
+/// tip channel (`update_latest_chain_channels()`), so there is an interval where `ReadRequest::Tip`
+/// and `ReadRequest::ChainInfo` report the new tip and `latest_chain_tip` still reports the old one.
+/// A precomputed template for the old tip is stale work in that interval: the node has extended the
+/// chain itself, and every share a miner computes on it is wasted.
+///
+/// The interval is microseconds wide in production, so this test holds it open instead: the mock
+/// chain tip never advances past the first tip, while the state reports the second one.
+#[tokio::test(flavor = "multi_thread")]
+async fn getblocktemplate_ignores_precomputed_template_when_tip_channel_lags_state() {
+    let _init_guard = zebra_test::init();
+
+    let net = Network::Mainnet;
+
+    let request_delay = Duration::from_secs(30);
+    let mempool: MockService<_, _, _, BoxError> = MockService::build()
+        .with_max_request_delay(request_delay)
+        .for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let read_state: MockService<_, _, _, BoxError> = MockService::build()
+        .with_max_request_delay(request_delay)
+        .for_unit_tests();
+
+    let mut mock_sync_status = MockSyncStatus::default();
+    mock_sync_status.set_is_close_to_tip(true);
+
+    let mining_conf = mining::Config {
+        miner_address: Some(ZcashAddress::from_transparent_p2pkh(
+            NetworkType::from(NetworkKind::from(&net)),
+            [0x7e; 20],
+        )),
+        extra_coinbase_data: None,
+        miner_memo: None,
+        internal_miner: false,
+    };
+
+    let tip_height = NetworkUpgrade::Nu5
+        .activation_height(&net)
+        .expect("nu5 activation height");
+    let tip_hash =
+        Hash::from_hex("0000000000d723156d9b65ffcf4984da7a19675ed7e2f06d9e5d5188af087bf8").unwrap();
+
+    // The block the state commits while the chain tip channel still reports its parent.
+    let committed_height = tip_height.next().expect("height is below Height::MAX");
+    let committed_hash =
+        Hash::from_hex("0000000000b6a5024aa412120b684a509ba8fd57e01de07bc2a84e4d3719a9f1").unwrap();
+
+    let (mock_tip, mock_tip_sender) = MockChainTip::new();
+    mock_tip_sender.send_best_tip_height(tip_height);
+    mock_tip_sender.send_best_tip_hash(tip_hash);
+    mock_tip_sender.send_estimated_distance_to_network_chain_tip(Some(0));
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, _) = RpcImpl::new(
+        net.clone(),
+        mining_conf,
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool.clone(), 1),
+        state.clone(),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        mock_sync_status,
+        mock_tip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    let spawn_responders = |tip_height: Height, tip_hash: Hash| {
+        let mut read_state = read_state.clone();
+        let mut mempool = mempool.clone();
+        let chain_history_root = fake_history_tree(&net).hash();
+
+        let read_state_responder = tokio::spawn(async move {
+            loop {
+                read_state
+                    .expect_request_that(|_| true)
+                    .await
+                    .respond_with(move |req| match req {
+                        ReadRequest::ChainInfo => {
+                            ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
+                                expected_difficulty: CompactDifficulty::from(
+                                    ExpandedDifficulty::from(U256::one()),
+                                ),
+                                tip_height,
+                                tip_hash,
+                                cur_time: DateTime32::from(1654008617),
+                                min_time: DateTime32::from(1654008606),
+                                max_time: DateTime32::from(1654008728),
+                                chain_history_root,
+                            })
+                        }
+                        ReadRequest::Tip => ReadResponse::Tip(Some((tip_height, tip_hash))),
+                        other => panic!("unexpected read state request: {other:?}"),
+                    });
+            }
+        });
+
+        let mempool_responder = tokio::spawn(async move {
+            loop {
+                mempool
+                    .expect_request(mempool::Request::FullTransactions)
+                    .await
+                    .respond(mempool::Response::FullTransactions {
+                        transactions: vec![],
+                        transaction_dependencies: Default::default(),
+                        last_seen_tip_hash: tip_hash,
+                    });
+            }
+        });
+
+        (read_state_responder, mempool_responder)
+    };
+
+    // Fill the cache with a template for the tip both the state and the channel agree on.
+    let (read_state_responder, mempool_responder) = spawn_responders(tip_height, tip_hash);
+
+    let updater = rpc
+        .spawn_block_template_updater()
+        .expect("mining is configured");
+
+    let template_cache = rpc
+        .gbt
+        .template_cache()
+        .expect("the miner params were not overridden")
+        .clone();
+
+    tokio::time::timeout(Duration::from_secs(30), async {
+        while template_cache.wait_for_tip(tip_hash).await.is_none() {}
+    })
+    .await
+    .expect("the updater task should precompute a template for the chain tip");
+
+    // Commit a block in the state without advancing the chain tip channel.
+    read_state_responder.abort();
+    mempool_responder.abort();
+    let (read_state_responder, mempool_responder) =
+        spawn_responders(committed_height, committed_hash);
+
+    let template = tokio::time::timeout(Duration::from_secs(30), rpc.get_block_template(None))
+        .await
+        .expect("getblocktemplate should answer while the chain tip channel lags the state")
+        .expect("getblocktemplate should succeed")
+        .try_into_template()
+        .expect("getblocktemplate without parameters should return a template");
+
+    assert_eq!(
+        template.previous_block_hash, committed_hash,
+        "getblocktemplate must build on the block the state committed, not on the tip the chain \
+         tip channel still reports",
+    );
+    assert_eq!(template.height, committed_height.0 + 1);
 
     read_state_responder.abort();
     mempool_responder.abort();

--- a/zebra-rpc/src/methods/tests/vectors.rs
+++ b/zebra-rpc/src/methods/tests/vectors.rs
@@ -1,6 +1,12 @@
 //! Fixed test vectors for RPC methods.
 
-use std::{str::FromStr, sync::Arc};
+use std::{
+    str::FromStr,
+    sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+        Arc,
+    },
+};
 
 use futures::FutureExt;
 use tower::buffer::Buffer;
@@ -2934,6 +2940,239 @@ async fn getblocktemplate_precomputed() {
         "getblocktemplate must not return a template for a tip that Zebra has already extended",
     );
     assert_eq!(template.height, next_tip_height.0 + 1);
+
+    read_state_responder.abort();
+    mempool_responder.abort();
+    updater.abort();
+}
+
+/// Checks that a long polling client waits, instead of being handed a template immediately on
+/// every call.
+///
+/// Long polling has to be decided against one source. Answering from the precomputed cache while
+/// falling through to a fresh state and mempool read derives two independent long poll IDs that
+/// never match each other, so a client alternates between them, every call returns at once, and
+/// the miner's work is cancelled each time.
+#[tokio::test(flavor = "multi_thread")]
+async fn getblocktemplate_long_poll_waits_for_a_new_template() {
+    let _init_guard = zebra_test::init();
+
+    let net = Network::Mainnet;
+
+    let request_delay = Duration::from_secs(60);
+    let mempool: MockService<_, _, _, BoxError> = MockService::build()
+        .with_max_request_delay(request_delay)
+        .for_unit_tests();
+    let state: MockService<_, _, _, BoxError> = MockService::build().for_unit_tests();
+    let read_state: MockService<_, _, _, BoxError> = MockService::build()
+        .with_max_request_delay(request_delay)
+        .for_unit_tests();
+
+    let mut mock_sync_status = MockSyncStatus::default();
+    mock_sync_status.set_is_close_to_tip(true);
+
+    let mining_conf = mining::Config {
+        miner_address: Some(ZcashAddress::from_transparent_p2pkh(
+            NetworkType::from(NetworkKind::from(&net)),
+            [0x7e; 20],
+        )),
+        extra_coinbase_data: None,
+        miner_memo: None,
+        internal_miner: false,
+    };
+
+    let tip_height = NetworkUpgrade::Nu5
+        .activation_height(&net)
+        .expect("nu5 activation height");
+    let tip_hash =
+        Hash::from_hex("0000000000d723156d9b65ffcf4984da7a19675ed7e2f06d9e5d5188af087bf8").unwrap();
+
+    let (mock_tip, mock_tip_sender) = MockChainTip::new();
+    mock_tip_sender.send_best_tip_height(tip_height);
+    mock_tip_sender.send_best_tip_hash(tip_hash);
+    mock_tip_sender.send_estimated_distance_to_network_chain_tip(Some(0));
+
+    let (_tx, rx) = tokio::sync::watch::channel(None);
+    let (rpc, _) = RpcImpl::new(
+        net.clone(),
+        mining_conf,
+        Default::default(),
+        "0.0.1",
+        "RPC test",
+        Buffer::new(mempool.clone(), 1),
+        state.clone(),
+        Buffer::new(read_state.clone(), 1),
+        MockService::build().for_unit_tests(),
+        mock_sync_status,
+        mock_tip,
+        MockAddressBookPeers::default(),
+        rx,
+        None,
+    );
+
+    // Counts the state tip reads: the long poll validates the cached template against the state
+    // tip once per wake, so this separates a parked call from one spinning through its wait.
+    let tip_reads = Arc::new(AtomicUsize::new(0));
+
+    let chain_history_root = fake_history_tree(&net).hash();
+    let read_state_responder = tokio::spawn({
+        let mut read_state = read_state.clone();
+        let tip_reads = tip_reads.clone();
+        async move {
+            loop {
+                let tip_reads = tip_reads.clone();
+                read_state
+                    .expect_request_that(|req| {
+                        matches!(req, ReadRequest::ChainInfo | ReadRequest::Tip)
+                    })
+                    .await
+                    .respond_with(move |req| match req {
+                        ReadRequest::ChainInfo => {
+                            ReadResponse::ChainInfo(GetBlockTemplateChainInfo {
+                                expected_difficulty: CompactDifficulty::from(
+                                    ExpandedDifficulty::from(U256::one()),
+                                ),
+                                tip_height,
+                                tip_hash,
+                                cur_time: DateTime32::from(1654008617),
+                                min_time: DateTime32::from(1654008606),
+                                max_time: DateTime32::from(1654008719),
+                                chain_history_root,
+                            })
+                        }
+                        ReadRequest::Tip => {
+                            tip_reads.fetch_add(1, Ordering::SeqCst);
+                            ReadResponse::Tip(Some((tip_height, tip_hash)))
+                        }
+                        other => panic!("unexpected read state request: {other:?}"),
+                    });
+            }
+        }
+    });
+
+    // A transaction the mempool only reports once the test asks it to.
+    //
+    // The precomputed template is built before that, so afterwards a fresh mempool read derives a
+    // different long poll ID than the cached template's. That disagreement is what a fall-through
+    // turns into an immediate answer, and it is the whole point of this test: with an empty
+    // mempool both sources agree and nothing is exercised.
+    let tx = Arc::new(Transaction::test_v1(
+        vec![],
+        vec![],
+        transaction::LockTime::unlocked(),
+    ));
+    let unmined_tx = UnminedTx {
+        transaction: tx.clone(),
+        id: tx.unmined_id(),
+        size: tx.zcash_serialized_size(),
+        conventional_fee: 0.try_into().unwrap(),
+    };
+    let mempool_tx = VerifiedUnminedTx {
+        conventional_actions: zip317::conventional_actions(&unmined_tx.transaction),
+        transaction: unmined_tx,
+        miner_fee: 0.try_into().unwrap(),
+        legacy_sigop_count: 0,
+        p2sh_sigop_count: 0,
+        unpaid_actions: 0,
+        fee_weight_ratio: 1.0,
+        time: None,
+        height: None,
+        spent_outputs: Arc::new(vec![]),
+    };
+
+    let mempool_has_tx = Arc::new(AtomicBool::new(false));
+
+    // A mempool that keeps answering, so a fall-through to the synchronous path would succeed and
+    // return a competing template rather than blocking this test.
+    let mempool_responder = tokio::spawn({
+        let mut mempool = mempool.clone();
+        let mempool_has_tx = mempool_has_tx.clone();
+        async move {
+            loop {
+                let transactions = if mempool_has_tx.load(Ordering::SeqCst) {
+                    vec![mempool_tx.clone()]
+                } else {
+                    vec![]
+                };
+
+                mempool
+                    .expect_request(mempool::Request::FullTransactions)
+                    .await
+                    .respond(mempool::Response::FullTransactions {
+                        transactions,
+                        transaction_dependencies: Default::default(),
+                        last_seen_tip_hash: tip_hash,
+                    });
+            }
+        }
+    });
+
+    let updater = rpc
+        .spawn_block_template_updater()
+        .expect("mining is configured");
+
+    let template_cache = rpc
+        .gbt
+        .template_cache()
+        .expect("the miner params were not overridden")
+        .clone();
+
+    tokio::time::timeout(Duration::from_secs(30), async {
+        while template_cache.wait_for_tip(tip_hash).await.is_none() {}
+    })
+    .await
+    .expect("the updater task should precompute a template for the chain tip");
+
+    let template = rpc
+        .get_block_template(None)
+        .await
+        .expect("getblocktemplate should succeed")
+        .try_into_template()
+        .expect("getblocktemplate without parameters should return a template");
+
+    // From here a fresh mempool read disagrees with the cached template, while the cache keeps
+    // serving the template the client already has.
+    mempool_has_tx.store(true, Ordering::SeqCst);
+
+    // Long polling on the template this client just received: the cache still holds it, so the
+    // call has to wait. The chain tip is fixed and `max_time` is over a minute away, so returning
+    // at all within this window means it answered from a second, disagreeing ID source.
+    let long_poll = tokio::spawn({
+        let rpc = rpc.clone();
+        let long_poll_id = template.long_poll_id;
+        async move {
+            rpc.get_block_template(Some(GetBlockTemplateParameters {
+                mode: GetBlockTemplateRequestMode::Template,
+                data: None,
+                capabilities: vec![],
+                long_poll_id: Some(long_poll_id),
+                _work_id: None,
+            }))
+            .await
+        }
+    });
+
+    // A client alternating between two ID sources gets its answer in milliseconds, so these
+    // windows only have to outlast that.
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    let tip_reads_settled = tip_reads.load(Ordering::SeqCst);
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    assert!(
+        !long_poll.is_finished(),
+        "long polling on the current template must wait for a change, not return immediately",
+    );
+
+    // Parking and spinning both fail to return, so check the work too: each wake costs a state
+    // tip read, and a parked call makes none, while a call spinning through its wait makes
+    // thousands in this window.
+    assert_eq!(
+        tip_reads.load(Ordering::SeqCst),
+        tip_reads_settled,
+        "long polling should park after validating the tip, not spin through its wait",
+    );
+
+    long_poll.abort();
 
     read_state_responder.abort();
     mempool_responder.abort();

--- a/zebra-rpc/src/methods/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/types/get_block_template.rs
@@ -2,6 +2,7 @@
 
 pub mod constants;
 pub mod parameters;
+pub(crate) mod precompute;
 pub mod proposal;
 pub mod zip317;
 
@@ -624,14 +625,6 @@ impl CoinbaseCache {
         }
         map.insert((height, fee), coinbase);
     }
-
-    /// Discards all cached coinbases, forcing the next request to rebuild them.
-    fn clear(&self) {
-        self.0
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .clear();
-    }
 }
 
 /// Handler for the `getblocktemplate` RPC.
@@ -657,6 +650,14 @@ where
     /// Caches the most recently built coinbase transaction, so short-polling miners don't re-run
     /// the shielded-coinbase proof on every request within a block.
     coinbase_cache: CoinbaseCache,
+
+    /// A block template for the current chain tip, kept up to date by the task spawned by
+    /// `RpcImpl::spawn_block_template_updater()`, so `getblocktemplate` can answer without reading
+    /// the state and the mempool.
+    ///
+    /// This is `None` on handlers whose miner parameters were overridden after cloning, because the
+    /// precomputed template pays the configured miner address.
+    template_cache: Option<precompute::TemplateCache>,
 }
 
 impl<BlockVerifierRouter, SyncStatus> GetBlockTemplateHandler<BlockVerifierRouter, SyncStatus>
@@ -679,6 +680,7 @@ where
             mined_block_sender: mined_block_sender
                 .unwrap_or(SubmitBlockChannel::default().sender()),
             coinbase_cache: CoinbaseCache::default(),
+            template_cache: Some(precompute::TemplateCache::default()),
         }
     }
 
@@ -697,11 +699,20 @@ where
         // its cache with the handler it was cloned from. Detach to a fresh cache so
         // neither handler can serve a coinbase built for the other's address.
         self.coinbase_cache = CoinbaseCache::default();
+        // The precomputed template pays the previous miner address, and it's shared with the
+        // handler this one was cloned from, so stop using it.
+        self.template_cache = None;
     }
 
     /// Returns a handle to the coinbase transaction cache.
     pub(crate) fn coinbase_cache(&self) -> CoinbaseCache {
         self.coinbase_cache.clone()
+    }
+
+    /// Returns a handle to the precomputed block template, unless this handler's miner parameters
+    /// were overridden after cloning.
+    pub(crate) fn template_cache(&self) -> Option<&precompute::TemplateCache> {
+        self.template_cache.as_ref()
     }
 
     /// Returns the sync status.
@@ -728,8 +739,11 @@ where
         if let Some(miner_params) = &mut self.miner_params {
             miner_params.randomize_data();
             miner_params.randomize_memo();
-            // The cached coinbase was built with the previous data, so it's now stale.
-            self.coinbase_cache.clear();
+            // The cached coinbases were built with the previous data, and both caches are shared
+            // with the handler this one was cloned from. Detach from them, so neither handler can
+            // serve a coinbase built for the other's data.
+            self.coinbase_cache = CoinbaseCache::default();
+            self.template_cache = None;
         }
     }
 }

--- a/zebra-rpc/src/methods/types/get_block_template.rs
+++ b/zebra-rpc/src/methods/types/get_block_template.rs
@@ -273,8 +273,7 @@ impl BlockTemplateResponse {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_internal(
         net: &Network,
-        precomputed_coinbase: Option<TransactionTemplate<amount::NegativeOrZero>>,
-        coinbase_cache: Option<CoinbaseCache>,
+        coinbase_cache: &CoinbaseCache,
         miner_params: &MinerParams,
         chain_info: &GetBlockTemplateChainInfo,
         long_poll_id: LongPollId,
@@ -330,26 +329,18 @@ impl BlockTemplateResponse {
             .sum::<amount::Result<Amount<NonNegative>>>()
             .expect("mempool tx fees must be non-negative");
 
-        // Prefer the long-poll precomputed coinbase, then the per-block cache, and only build (and
-        // re-prove, for a shielded address) as a last resort — caching the result so subsequent
-        // short-poll requests for the same height and fees reuse it.
-        let coinbase_txn = precomputed_coinbase
-            .or_else(|| {
-                coinbase_cache
-                    .as_ref()
-                    .and_then(|cache| cache.get(height, txs_fee))
-            })
-            .unwrap_or_else(|| {
-                let coinbase_txn =
-                    TransactionTemplate::new_coinbase(net, height, miner_params, txs_fee)
-                        .expect("valid coinbase tx");
+        // Reuse the cached coinbase for this height and fee, and only build (and re-prove, for a
+        // shielded address) as a last resort — caching the result so subsequent requests for the
+        // same height and fees reuse it.
+        let coinbase_txn = coinbase_cache.get(height, txs_fee).unwrap_or_else(|| {
+            let coinbase_txn =
+                TransactionTemplate::new_coinbase(net, height, miner_params, txs_fee)
+                    .expect("valid coinbase tx");
 
-                if let Some(cache) = &coinbase_cache {
-                    cache.store(height, txs_fee, coinbase_txn.clone());
-                }
+            coinbase_cache.store(height, txs_fee, coinbase_txn.clone());
 
-                coinbase_txn
-            });
+            coinbase_txn
+        });
 
         let default_roots = DefaultRoots::from_coinbase(
             net,

--- a/zebra-rpc/src/methods/types/get_block_template/precompute.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/precompute.rs
@@ -1,0 +1,370 @@
+//! A precomputed block template for the `getblocktemplate` RPC.
+//!
+//! Miners call `getblocktemplate` far more often than the chain tip or the mempool change, and
+//! building a template needs a state read, a mempool read, ZIP-317 transaction selection, and a
+//! coinbase transaction, which re-runs a shielded proof when the miner address has a shielded
+//! component. So [`run()`] keeps a template for the current chain tip ready in a [`TemplateCache`],
+//! and the RPC only has to check that the template still extends the tip.
+//!
+//! The precomputed template can be a few seconds behind the mempool, which costs the miner the fees
+//! of the transactions that arrived in the meantime, until the next refresh. But it is never behind
+//! the chain: the RPC ignores a template whose previous block hash isn't the current tip, and
+//! [`run()`] publishes a coinbase-only template for a new tip as soon as it sees one.
+
+use std::{sync::Arc, time::Duration};
+
+use jsonrpsee::core::RpcResult;
+use tokio::{
+    sync::watch,
+    task::JoinHandle,
+    time::{sleep, timeout},
+};
+
+use zebra_chain::{
+    amount::{Amount, NegativeOrZero},
+    block::{self, Height},
+    chain_sync_status::ChainSyncStatus,
+    chain_tip::ChainTip,
+    parameters::Network,
+};
+use zebra_node_services::mempool::MempoolService;
+use zebra_state::ReadState;
+
+use crate::{
+    methods::types::{long_poll::LongPollInput, transaction::TransactionTemplate},
+    server::error::MapError,
+};
+
+use super::{
+    check_synced_to_tip, constants::MEMPOOL_LONG_POLL_INTERVAL, fetch_chain_info,
+    fetch_mempool_transactions, zip317::select_mempool_transactions, BlockTemplateResponse,
+    CoinbaseCache, MinerParams,
+};
+
+/// How long `getblocktemplate` waits for [`run()`] to publish a template for a new chain tip,
+/// before building a template itself.
+///
+/// [`run()`] publishes a coinbase-only template as soon as it sees a tip change, so this timeout
+/// only expires if that task is busy building a template, or isn't running at all.
+const NEW_TIP_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// How long [`run()`] waits before retrying, when Zebra isn't synced to the chain tip, or the state
+/// and the mempool disagree about the tip.
+const RETRY_DELAY: Duration = Duration::from_secs(1);
+
+/// A block template for the block after the current chain tip, shared between [`run()`] and the
+/// `getblocktemplate` RPC.
+#[derive(Clone)]
+pub(crate) struct TemplateCache(Arc<watch::Sender<Option<Arc<BlockTemplateResponse>>>>);
+
+impl Default for TemplateCache {
+    fn default() -> Self {
+        Self(Arc::new(watch::Sender::new(None)))
+    }
+}
+
+impl TemplateCache {
+    /// Returns `true` if the precomputed template extends `tip_hash`.
+    fn holds_tip(&self, tip_hash: block::Hash) -> bool {
+        self.0
+            .borrow()
+            .as_ref()
+            .is_some_and(|template| template.previous_block_hash == tip_hash)
+    }
+
+    /// Publishes `template` as the precomputed template.
+    fn publish(&self, template: BlockTemplateResponse) {
+        self.0.send_replace(Some(Arc::new(template)));
+    }
+
+    /// Returns the precomputed template if it extends `tip_hash`, waiting up to
+    /// [`NEW_TIP_TIMEOUT`] for [`run()`] to catch up with a recent tip change.
+    ///
+    /// Returns `None` if no [`run()`] task has published a template yet, or if it didn't catch up
+    /// in time. Never returns a template for a different tip: mining on it would extend a chain
+    /// that Zebra has already seen a block for.
+    pub(crate) async fn wait_for_tip(
+        &self,
+        tip_hash: block::Hash,
+    ) -> Option<Arc<BlockTemplateResponse>> {
+        let mut receiver = self.0.subscribe();
+
+        // An empty cache means no `run()` task has published a template, so there's nothing to wait
+        // for.
+        let mut template = receiver.borrow_and_update().clone()?;
+
+        timeout(NEW_TIP_TIMEOUT, async move {
+            loop {
+                if template.previous_block_hash == tip_hash {
+                    return Some(template);
+                }
+
+                receiver.changed().await.ok()?;
+                template = receiver.borrow_and_update().clone()?;
+            }
+        })
+        .await
+        .ok()
+        .flatten()
+    }
+}
+
+/// Keeps `cache` filled with a block template for the current chain tip.
+///
+/// Publishes a coinbase-only template as soon as the chain tip changes, then replaces it with a
+/// template that contains mempool transactions. Refreshes that template every
+/// [`MEMPOOL_LONG_POLL_INTERVAL`] seconds, so it picks up new mempool transactions and a recent
+/// `cur_time`.
+///
+/// Runs until the task is aborted.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn run<Mempool, ReadStateService, Tip, SyncStatus>(
+    network: Network,
+    miner_params: MinerParams,
+    coinbase_cache: CoinbaseCache,
+    cache: TemplateCache,
+    mempool: Mempool,
+    read_state: ReadStateService,
+    mut latest_chain_tip: Tip,
+    sync_status: SyncStatus,
+) where
+    Mempool: MempoolService,
+    ReadStateService: ReadState,
+    Tip: ChainTip + Clone + Send + Sync + 'static,
+    SyncStatus: ChainSyncStatus + Clone + Send + Sync + 'static,
+{
+    // The coinbase transaction for a coinbase-only block at this height, built while we're idle. A
+    // shielded coinbase takes seconds to prove, which is too slow to do after the tip changes.
+    let mut next_coinbase: Option<(Height, JoinHandle<TransactionTemplate<NegativeOrZero>>)> = None;
+
+    loop {
+        // `getblocktemplate` returns an error until Zebra is synced to the tip, so there's nothing
+        // to precompute before then.
+        if let Err(error) =
+            check_synced_to_tip(&network, latest_chain_tip.clone(), sync_status.clone())
+        {
+            tracing::trace!(
+                ?error,
+                "waiting to sync to the tip before building templates"
+            );
+            sleep(RETRY_DELAY).await;
+            continue;
+        }
+
+        // Mark tip changes up to this point as seen, so a change while we build a template wakes up
+        // the wait at the end of this iteration, rather than being missed.
+        latest_chain_tip.mark_best_tip_seen();
+
+        // If we have no template for the current tip, publish a coinbase-only one immediately, so
+        // miners extend the new tip instead of wasting work on a shorter chain while we select
+        // mempool transactions for it.
+        if let Some((tip_height, tip_hash)) = latest_chain_tip.best_tip_height_and_hash() {
+            if !cache.holds_tip(tip_hash) {
+                if let Ok(height) = tip_height.next() {
+                    store_precomputed_coinbase(&mut next_coinbase, height, &coinbase_cache).await;
+                }
+
+                match build(
+                    &network,
+                    &miner_params,
+                    &coinbase_cache,
+                    read_state.clone(),
+                    None::<Mempool>,
+                )
+                .await
+                {
+                    Ok(Some(template)) => cache.publish(template),
+                    // A coinbase-only template doesn't read the mempool, so it can't be out of
+                    // sync with the state.
+                    Ok(None) => {}
+                    Err(error) => {
+                        tracing::debug!(?error, "failed to build a template for the new tip")
+                    }
+                }
+            }
+        }
+
+        // Build a template with mempool transactions, and give up if the tip changes while we're
+        // building it: that template is already stale, and the next iteration replaces it.
+        let mut tip_change = latest_chain_tip.clone();
+        let build_with_mempool = build(
+            &network,
+            &miner_params,
+            &coinbase_cache,
+            read_state.clone(),
+            Some(mempool.clone()),
+        );
+
+        let built = tokio::select! {
+            biased;
+            tip_changed = tip_change.best_tip_changed() => {
+                // A closed channel means the state service has shut down, so there are no more
+                // templates to build.
+                if tip_changed.is_err() {
+                    return;
+                }
+
+                continue;
+            }
+            built = build_with_mempool => built,
+        };
+
+        match built {
+            Ok(Some(template)) => cache.publish(template),
+            // The state and the mempool disagreed about the tip, so retry with fresh data.
+            Ok(None) => {
+                sleep(RETRY_DELAY).await;
+                continue;
+            }
+            Err(error) => {
+                tracing::debug!(?error, "failed to build a block template");
+                sleep(RETRY_DELAY).await;
+                continue;
+            }
+        }
+
+        // Build the coinbase transaction for the block after next while we're idle, so the next tip
+        // change doesn't have to wait for a shielded coinbase proof.
+        if let Some(height) = latest_chain_tip
+            .best_tip_height()
+            .and_then(|tip_height| tip_height.next().ok())
+            .and_then(|next_height| next_height.next().ok())
+        {
+            start_precomputing_coinbase(&mut next_coinbase, &network, &miner_params, height);
+        }
+
+        // Refresh the template when the chain tip changes, or when the mempool has had time to
+        // change. Miners can keep working on an old set of transactions, so they don't need to know
+        // about new mempool transactions immediately.
+        let mut tip_change = latest_chain_tip.clone();
+        tokio::select! {
+            biased;
+            tip_changed = tip_change.best_tip_changed() => {
+                if tip_changed.is_err() {
+                    return;
+                }
+            }
+            _ = sleep(Duration::from_secs(MEMPOOL_LONG_POLL_INTERVAL)) => {}
+        }
+    }
+}
+
+/// Builds a block template for the block after the current chain tip.
+///
+/// Selects mempool transactions if `mempool` is `Some`, and builds a coinbase-only template
+/// otherwise. Returns `None` if the state and the mempool disagree about the chain tip.
+async fn build<Mempool, ReadStateService>(
+    network: &Network,
+    miner_params: &MinerParams,
+    coinbase_cache: &CoinbaseCache,
+    read_state: ReadStateService,
+    mempool: Option<Mempool>,
+) -> RpcResult<Option<BlockTemplateResponse>>
+where
+    Mempool: MempoolService,
+    ReadStateService: ReadState,
+{
+    let chain_info = fetch_chain_info(read_state).await?;
+    let height = chain_info.tip_height.next().map_misc_error()?;
+
+    let (mempool_txs, mempool_tx_deps) = match mempool {
+        Some(mempool) => {
+            match fetch_mempool_transactions(mempool, chain_info.tip_hash).await? {
+                Some(mempool_data) => mempool_data,
+                // The state and the mempool were out of sync, so a template built from this data
+                // could contain transactions that are already mined.
+                None => return Ok(None),
+            }
+        }
+        None => Default::default(),
+    };
+
+    let long_poll_id = LongPollInput::new(
+        chain_info.tip_height,
+        chain_info.tip_hash,
+        chain_info.max_time,
+        mempool_txs.iter().map(|tx| tx.transaction.id),
+    )
+    .generate_id();
+
+    let network = network.clone();
+    let miner_params = miner_params.clone();
+    let coinbase_cache = coinbase_cache.clone();
+
+    // Transaction selection, the coinbase transaction, and the block roots are all CPU-bound, and
+    // a shielded coinbase takes seconds to prove, so keep them off the async executor.
+    tokio::task::spawn_blocking(move || {
+        let mempool_txs = select_mempool_transactions(
+            &network,
+            height,
+            &miner_params,
+            mempool_txs,
+            mempool_tx_deps,
+            Some(&coinbase_cache),
+        );
+
+        // `submit_old` depends on the long poll ID the client sent, so the RPC sets it.
+        Some(BlockTemplateResponse::new_internal(
+            &network,
+            None,
+            Some(coinbase_cache),
+            &miner_params,
+            &chain_info,
+            long_poll_id,
+            mempool_txs,
+            None,
+        ))
+    })
+    .await
+    .map_misc_error()
+}
+
+/// Starts building the coinbase transaction for a coinbase-only block at `height`, unless it is
+/// already built or being built.
+fn start_precomputing_coinbase(
+    next_coinbase: &mut Option<(Height, JoinHandle<TransactionTemplate<NegativeOrZero>>)>,
+    network: &Network,
+    miner_params: &MinerParams,
+    height: Height,
+) {
+    if next_coinbase
+        .as_ref()
+        .is_some_and(|(precomputed_height, _)| *precomputed_height == height)
+    {
+        return;
+    }
+
+    let (network, miner_params) = (network.clone(), miner_params.clone());
+
+    *next_coinbase = Some((
+        height,
+        tokio::task::spawn_blocking(move || {
+            TransactionTemplate::new_coinbase(&network, height, &miner_params, Amount::zero())
+                .expect("valid coinbase tx")
+        }),
+    ));
+}
+
+/// Moves the precomputed coinbase transaction into `coinbase_cache`, if it was built for `height`.
+///
+/// A coinbase built for another height has the wrong BIP-34 height and subsidy, so it is discarded:
+/// the chain advanced by more than one block, or there was a reorg.
+async fn store_precomputed_coinbase(
+    next_coinbase: &mut Option<(Height, JoinHandle<TransactionTemplate<NegativeOrZero>>)>,
+    height: Height,
+    coinbase_cache: &CoinbaseCache,
+) {
+    let Some((_, coinbase)) = next_coinbase
+        .take()
+        .filter(|(precomputed_height, _)| *precomputed_height == height)
+    else {
+        return;
+    };
+
+    match coinbase.await {
+        // A coinbase-only block pays no fees, so this also caches the zero-fee coinbase that
+        // ZIP-317 transaction selection needs for its size and sigop limits.
+        Ok(coinbase) => coinbase_cache.store(height, Amount::zero(), coinbase),
+        Err(error) => tracing::warn!(?error, "precomputed coinbase transaction task failed"),
+    }
+}

--- a/zebra-rpc/src/methods/types/get_block_template/precompute.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/precompute.rs
@@ -11,23 +11,25 @@
 //! the chain: the RPC ignores a template whose previous block hash isn't the current tip, and
 //! [`run()`] publishes a coinbase-only template for a new tip as soon as it sees one.
 
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use jsonrpsee::core::RpcResult;
 use tokio::{
-    sync::watch,
+    sync::{broadcast, watch},
     task::JoinHandle,
     time::{sleep, timeout},
 };
 
+use tower::ServiceExt;
 use zebra_chain::{
     amount::{Amount, NegativeOrZero},
     block::{self, Height},
     chain_sync_status::ChainSyncStatus,
     chain_tip::ChainTip,
     parameters::Network,
+    transaction::UnminedTxId,
 };
-use zebra_node_services::mempool::MempoolService;
+use zebra_node_services::mempool::{self, MempoolChange, MempoolChangeKind, MempoolService};
 use zebra_state::ReadState;
 
 use crate::{
@@ -36,9 +38,8 @@ use crate::{
 };
 
 use super::{
-    check_synced_to_tip, constants::MEMPOOL_LONG_POLL_INTERVAL, fetch_chain_info,
-    fetch_mempool_transactions, zip317::select_mempool_transactions, BlockTemplateResponse,
-    CoinbaseCache, MinerParams,
+    check_synced_to_tip, fetch_chain_info, fetch_mempool_transactions,
+    zip317::select_mempool_transactions, BlockTemplateResponse, CoinbaseCache, MinerParams,
 };
 
 #[cfg(test)]
@@ -55,10 +56,34 @@ const NEW_TIP_TIMEOUT: Duration = Duration::from_secs(1);
 /// and the mempool disagree about the tip.
 const RETRY_DELAY: Duration = Duration::from_secs(1);
 
+/// How long [`run()`] waits after a mempool change before rebuilding, so a burst of changes costs
+/// one rebuild rather than one per transaction.
+///
+/// Rebuilding reads the whole mempool, re-runs ZIP-317 selection, and rebuilds the coinbase, so it
+/// is far more expensive than the change notification that triggers it.
+const MEMPOOL_DEBOUNCE: Duration = Duration::from_millis(500);
+
+/// How long [`run()`] waits before rebuilding when nothing has changed.
+///
+/// Mempool and chain tip changes drive rebuilds, so this only has to keep `cur_time` from ageing:
+/// on Testnet the difficulty depends on it through the minimum-difficulty rule. It also bounds how
+/// long a lost notification can stall the template.
+const BACKSTOP_REFRESH: Duration = Duration::from_secs(30);
+
+/// A precomputed template, with the mempool it was built from.
+///
+/// The template's long poll ID is derived from every ID in the mempool, not just the transactions
+/// ZIP-317 selected, so deciding whether a mempool change invalidates the template needs the whole
+/// set.
+struct Precomputed {
+    template: Arc<BlockTemplateResponse>,
+    mempool_tx_ids: Arc<HashSet<UnminedTxId>>,
+}
+
 /// A block template for the block after the current chain tip, shared between [`run()`] and the
 /// `getblocktemplate` RPC.
 #[derive(Clone)]
-pub(crate) struct TemplateCache(Arc<watch::Sender<Option<Arc<BlockTemplateResponse>>>>);
+pub(crate) struct TemplateCache(Arc<watch::Sender<Option<Precomputed>>>);
 
 impl Default for TemplateCache {
     fn default() -> Self {
@@ -67,7 +92,7 @@ impl Default for TemplateCache {
 }
 
 /// A subscription to the templates [`run()`] publishes.
-pub(crate) struct TemplateChanges(watch::Receiver<Option<Arc<BlockTemplateResponse>>>);
+pub(crate) struct TemplateChanges(watch::Receiver<Option<Precomputed>>);
 
 impl TemplateChanges {
     /// Waits for a template published since this subscription was created, or since the last wait
@@ -90,7 +115,7 @@ impl TemplateCache {
         self.0
             .borrow()
             .as_ref()
-            .is_some_and(|template| template.previous_block_hash == tip_hash)
+            .is_some_and(|precomputed| precomputed.template.previous_block_hash == tip_hash)
     }
 
     /// Returns `true` if no [`run()`] task has published a template yet.
@@ -108,9 +133,33 @@ impl TemplateCache {
         TemplateChanges(self.0.subscribe())
     }
 
-    /// Publishes `template` as the precomputed template.
-    fn publish(&self, template: BlockTemplateResponse) {
-        self.0.send_replace(Some(Arc::new(template)));
+    /// Returns the mempool IDs the precomputed template was built from, if there is one.
+    fn mempool_tx_ids(&self) -> Option<Arc<HashSet<UnminedTxId>>> {
+        self.0
+            .borrow()
+            .as_ref()
+            .map(|precomputed| precomputed.mempool_tx_ids.clone())
+    }
+
+    /// Returns `true` if any of `tx_ids` was in the mempool the template was built from.
+    ///
+    /// This is the set behind the template's long poll ID, so it includes transactions ZIP-317 left
+    /// out: removing one of those still has to produce a new long poll ID, or a long polling miner
+    /// waits on work whose mempool no longer exists.
+    fn built_from_any(&self, tx_ids: &HashSet<UnminedTxId>) -> bool {
+        let Some(mempool_tx_ids) = self.mempool_tx_ids() else {
+            return false;
+        };
+
+        tx_ids.iter().any(|tx_id| mempool_tx_ids.contains(tx_id))
+    }
+
+    /// Publishes `template`, built from the mempool holding `mempool_tx_ids`.
+    fn publish(&self, template: BlockTemplateResponse, mempool_tx_ids: HashSet<UnminedTxId>) {
+        self.0.send_replace(Some(Precomputed {
+            template: Arc::new(template),
+            mempool_tx_ids: Arc::new(mempool_tx_ids),
+        }));
     }
 
     /// Returns the precomputed template if it extends `tip_hash`, waiting up to
@@ -127,7 +176,7 @@ impl TemplateCache {
 
         // An empty cache means no `run()` task has published a template, so there's nothing to wait
         // for.
-        let mut template = receiver.borrow_and_update().clone()?;
+        let mut template = receiver.borrow_and_update().as_ref()?.template.clone();
 
         timeout(NEW_TIP_TIMEOUT, async move {
             loop {
@@ -136,7 +185,7 @@ impl TemplateCache {
                 }
 
                 receiver.changed().await.ok()?;
-                template = receiver.borrow_and_update().clone()?;
+                template = receiver.borrow_and_update().as_ref()?.template.clone();
             }
         })
         .await
@@ -148,9 +197,9 @@ impl TemplateCache {
 /// Keeps `cache` filled with a block template for the current chain tip.
 ///
 /// Publishes a coinbase-only template as soon as the chain tip changes, then replaces it with a
-/// template that contains mempool transactions. Refreshes that template every
-/// [`MEMPOOL_LONG_POLL_INTERVAL`] seconds, so it picks up new mempool transactions and a recent
-/// `cur_time`.
+/// template that contains mempool transactions. Rebuilds when the chain tip changes, when the
+/// mempool changes in a way that affects the template (debounced by [`MEMPOOL_DEBOUNCE`]), and
+/// every [`BACKSTOP_REFRESH`] otherwise, which keeps `cur_time` current.
 ///
 /// Runs until the task is aborted.
 #[allow(clippy::too_many_arguments)]
@@ -160,6 +209,7 @@ pub(crate) async fn run<Mempool, ReadStateService, Tip, SyncStatus>(
     coinbase_cache: CoinbaseCache,
     cache: TemplateCache,
     mempool: Mempool,
+    mut mempool_changes: broadcast::Receiver<MempoolChange>,
     read_state: ReadStateService,
     mut latest_chain_tip: Tip,
     sync_status: SyncStatus,
@@ -212,7 +262,7 @@ pub(crate) async fn run<Mempool, ReadStateService, Tip, SyncStatus>(
                 )
                 .await
                 {
-                    Ok(Some(template)) => cache.publish(template),
+                    Ok(Some((template, mempool_tx_ids))) => cache.publish(template, mempool_tx_ids),
                     // A coinbase-only template doesn't read the mempool, so it can't be out of
                     // sync with the state.
                     Ok(None) => {}
@@ -249,13 +299,13 @@ pub(crate) async fn run<Mempool, ReadStateService, Tip, SyncStatus>(
         };
 
         match built {
-            Ok(Some(template)) => {
+            Ok(Some((template, mempool_tx_ids))) => {
                 if was_failing {
                     tracing::info!("block template builds recovered");
                     was_failing = false;
                 }
 
-                cache.publish(template)
+                cache.publish(template, mempool_tx_ids)
             }
             // The state and the mempool disagreed about the tip, so retry with fresh data.
             Ok(None) => {
@@ -293,19 +343,125 @@ pub(crate) async fn run<Mempool, ReadStateService, Tip, SyncStatus>(
             start_precomputing_coinbase(&mut next_coinbase, &network, &miner_params, height);
         }
 
-        // Refresh the template when the chain tip changes, or when the mempool has had time to
-        // change. Miners can keep working on an old set of transactions, so they don't need to know
-        // about new mempool transactions immediately.
-        let mut tip_change = latest_chain_tip.clone();
+        // Wait for something that changes the template.
+        if !wait_for_change(&latest_chain_tip, &mut mempool_changes, &cache, &mempool).await {
+            // The chain tip channel or the mempool change channel closed: Zebra is shutting down.
+            return;
+        }
+    }
+}
+
+/// Waits until the precomputed template is worth rebuilding: the chain tip changed, the mempool
+/// changed in a way that affects the template, or [`BACKSTOP_REFRESH`] elapsed.
+///
+/// Returns `false` when a channel closes, which means Zebra is shutting down.
+async fn wait_for_change<Mempool, Tip>(
+    latest_chain_tip: &Tip,
+    mempool_changes: &mut broadcast::Receiver<MempoolChange>,
+    cache: &TemplateCache,
+    mempool: &Mempool,
+) -> bool
+where
+    Mempool: MempoolService,
+    Tip: ChainTip + Clone + Send + Sync + 'static,
+{
+    let mut tip_change = latest_chain_tip.clone();
+    let backstop = sleep(BACKSTOP_REFRESH);
+    tokio::pin!(backstop);
+
+    loop {
         tokio::select! {
             biased;
+
             tip_changed = tip_change.best_tip_changed() => {
-                if tip_changed.is_err() {
-                    return;
+                return tip_changed.is_ok();
+            }
+
+            change = mempool_changes.recv() => {
+                match change {
+                    Ok(change) if affects_template(&change, cache) => {
+                        // Collapse the rest of the burst into this rebuild: a busy mempool
+                        // notifies far more often than a template is worth rebuilding.
+                        sleep(MEMPOOL_DEBOUNCE).await;
+                        while mempool_changes.try_recv().is_ok() {}
+                        return true;
+                    }
+                    // A change that can't affect the template. Keep waiting, so a peer spraying
+                    // rejected transactions can't make us rebuild.
+                    Ok(_) => continue,
+                    // Changes were dropped, so we don't know what they were.
+                    //
+                    // # Security
+                    //
+                    // Rebuilding unconditionally here would undo the filter above: a peer sending
+                    // invalid transactions fast enough overflows this channel, and every overflow
+                    // would buy the rebuild its rejected transactions could not. So compare the
+                    // mempool with the set the template was built from instead.
+                    Err(broadcast::error::RecvError::Lagged(dropped)) => {
+                        tracing::debug!(?dropped, "mempool change channel lagged");
+                        while mempool_changes.try_recv().is_ok() {}
+
+                        match current_mempool_tx_ids(mempool.clone()).await {
+                            Some(current)
+                                if Some(&current) != cache.mempool_tx_ids().as_deref() =>
+                            {
+                                sleep(MEMPOOL_DEBOUNCE).await;
+                                while mempool_changes.try_recv().is_ok() {}
+                                return true;
+                            }
+                            // The same mempool, or the mempool didn't answer: nothing to do, and
+                            // the backstop still bounds how long the template can go unrefreshed.
+                            _ => continue,
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Closed) => return false,
                 }
             }
-            _ = sleep(Duration::from_secs(MEMPOOL_LONG_POLL_INTERVAL)) => {}
+
+            _ = &mut backstop => return true,
         }
+    }
+}
+
+/// Returns the IDs currently in the mempool, or `None` if it didn't answer.
+///
+/// `TransactionIds` is much cheaper than the `FullTransactions` a rebuild needs: it copies IDs
+/// rather than whole transactions.
+async fn current_mempool_tx_ids<Mempool>(mempool: Mempool) -> Option<HashSet<UnminedTxId>>
+where
+    Mempool: MempoolService,
+{
+    let response = mempool
+        .oneshot(mempool::Request::TransactionIds)
+        .await
+        .ok()?;
+
+    match response {
+        mempool::Response::TransactionIds(tx_ids) => Some(tx_ids),
+        _ => None,
+    }
+}
+
+/// Returns `true` if `change` can change what the next template should contain.
+fn affects_template(change: &MempoolChange, cache: &TemplateCache) -> bool {
+    match change.kind() {
+        // New transactions are candidates for the next template.
+        MempoolChangeKind::Added => true,
+
+        // A transaction leaving the mempool only matters if the template names it: a template that
+        // still contains it would produce a block that can't be mined.
+        //
+        // # Security
+        //
+        // This variant also fires for transactions that failed verification and were never in the
+        // mempool, so rebuilding for every one of them would let a peer force sustained rebuilds
+        // by sending invalid transactions. Debouncing alone doesn't fix that, since the peer can
+        // simply keep sending.
+        MempoolChangeKind::Invalidated => cache.built_from_any(change.tx_ids()),
+
+        // Mined transactions arrive with the chain tip change that mined them, which rebuilds the
+        // template anyway.
+        MempoolChangeKind::Mined => false,
     }
 }
 
@@ -319,7 +475,7 @@ async fn build<Mempool, ReadStateService>(
     coinbase_cache: &CoinbaseCache,
     read_state: ReadStateService,
     mempool: Option<Mempool>,
-) -> RpcResult<Option<BlockTemplateResponse>>
+) -> RpcResult<Option<(BlockTemplateResponse, HashSet<UnminedTxId>)>>
 where
     Mempool: MempoolService,
     ReadStateService: ReadState,
@@ -339,11 +495,14 @@ where
         None => Default::default(),
     };
 
+    let mempool_tx_ids: HashSet<UnminedTxId> =
+        mempool_txs.iter().map(|tx| tx.transaction.id).collect();
+
     let long_poll_id = LongPollInput::new(
         chain_info.tip_height,
         chain_info.tip_hash,
         chain_info.max_time,
-        mempool_txs.iter().map(|tx| tx.transaction.id),
+        mempool_tx_ids.iter().copied(),
     )
     .generate_id();
 
@@ -364,14 +523,17 @@ where
         );
 
         // `submit_old` depends on the long poll ID the client sent, so the RPC sets it.
-        Some(BlockTemplateResponse::new_internal(
-            &network,
-            &coinbase_cache,
-            &miner_params,
-            &chain_info,
-            long_poll_id,
-            mempool_txs,
-            None,
+        Some((
+            BlockTemplateResponse::new_internal(
+                &network,
+                &coinbase_cache,
+                &miner_params,
+                &chain_info,
+                long_poll_id,
+                mempool_txs,
+                None,
+            ),
+            mempool_tx_ids,
         ))
     })
     .await

--- a/zebra-rpc/src/methods/types/get_block_template/precompute.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/precompute.rs
@@ -41,6 +41,9 @@ use super::{
     CoinbaseCache, MinerParams,
 };
 
+#[cfg(test)]
+mod tests;
+
 /// How long `getblocktemplate` waits for [`run()`] to publish a template for a new chain tip,
 /// before building a template itself.
 ///
@@ -63,6 +66,24 @@ impl Default for TemplateCache {
     }
 }
 
+/// A subscription to the templates [`run()`] publishes.
+pub(crate) struct TemplateChanges(watch::Receiver<Option<Arc<BlockTemplateResponse>>>);
+
+impl TemplateChanges {
+    /// Waits for a template published since this subscription was created, or since the last wait
+    /// returned.
+    ///
+    /// Returns immediately if one was published in the meantime, so a caller that reads the cache
+    /// and then waits cannot miss the publish in between.
+    pub(crate) async fn changed(&mut self) {
+        if self.0.changed().await.is_err() {
+            // No sender, so no template will ever be published. Waiting forever lets the caller's
+            // other wait conditions drive it, where returning would spin it.
+            std::future::pending::<()>().await
+        }
+    }
+}
+
 impl TemplateCache {
     /// Returns `true` if the precomputed template extends `tip_hash`.
     fn holds_tip(&self, tip_hash: block::Hash) -> bool {
@@ -75,6 +96,16 @@ impl TemplateCache {
     /// Returns `true` if no [`run()`] task has published a template yet.
     pub(crate) fn is_empty(&self) -> bool {
         self.0.borrow().is_none()
+    }
+
+    /// Subscribes to the templates [`run()`] publishes from now on.
+    ///
+    /// Subscribe before reading the cache, and keep the subscription across the wait:
+    /// `watch::Sender::subscribe()` marks the current template as seen and everything published
+    /// after it as unseen, so a template published while the caller decides what to do with the
+    /// one it just read still wakes it.
+    pub(crate) fn subscribe(&self) -> TemplateChanges {
+        TemplateChanges(self.0.subscribe())
     }
 
     /// Publishes `template` as the precomputed template.

--- a/zebra-rpc/src/methods/types/get_block_template/precompute.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/precompute.rs
@@ -72,6 +72,11 @@ impl TemplateCache {
             .is_some_and(|template| template.previous_block_hash == tip_hash)
     }
 
+    /// Returns `true` if no [`run()`] task has published a template yet.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.borrow().is_none()
+    }
+
     /// Publishes `template` as the precomputed template.
     fn publish(&self, template: BlockTemplateResponse) {
         self.0.send_replace(Some(Arc::new(template)));

--- a/zebra-rpc/src/methods/types/get_block_template/precompute.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/precompute.rs
@@ -306,8 +306,7 @@ where
         // `submit_old` depends on the long poll ID the client sent, so the RPC sets it.
         Some(BlockTemplateResponse::new_internal(
             &network,
-            None,
-            Some(coinbase_cache),
+            &coinbase_cache,
             &miner_params,
             &chain_info,
             long_poll_id,

--- a/zebra-rpc/src/methods/types/get_block_template/precompute.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/precompute.rs
@@ -173,6 +173,9 @@ pub(crate) async fn run<Mempool, ReadStateService, Tip, SyncStatus>(
     // shielded coinbase takes seconds to prove, which is too slow to do after the tip changes.
     let mut next_coinbase: Option<(Height, JoinHandle<TransactionTemplate<NegativeOrZero>>)> = None;
 
+    // Whether the last build failed, so a failing spell is logged once rather than every second.
+    let mut was_failing = false;
+
     loop {
         // `getblocktemplate` returns an error until Zebra is synced to the tip, so there's nothing
         // to precompute before then.
@@ -246,14 +249,35 @@ pub(crate) async fn run<Mempool, ReadStateService, Tip, SyncStatus>(
         };
 
         match built {
-            Ok(Some(template)) => cache.publish(template),
+            Ok(Some(template)) => {
+                if was_failing {
+                    tracing::info!("block template builds recovered");
+                    was_failing = false;
+                }
+
+                cache.publish(template)
+            }
             // The state and the mempool disagreed about the tip, so retry with fresh data.
             Ok(None) => {
                 sleep(RETRY_DELAY).await;
                 continue;
             }
             Err(error) => {
-                tracing::debug!(?error, "failed to build a block template");
+                // While this keeps failing the RPC serves the last template, so miners silently
+                // lose the fees of everything that has arrived since. Log the start of a failing
+                // spell loudly, then stay quiet: the retry delay is a second, so warning on every
+                // attempt would bury the rest of the log.
+                if was_failing {
+                    tracing::debug!(?error, "failed to build a block template");
+                } else {
+                    tracing::warn!(
+                        ?error,
+                        "failed to build a block template, serving the last one until this \
+                         recovers"
+                    );
+                    was_failing = true;
+                }
+
                 sleep(RETRY_DELAY).await;
                 continue;
             }

--- a/zebra-rpc/src/methods/types/get_block_template/precompute/tests.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/precompute/tests.rs
@@ -1,16 +1,28 @@
-//! Fixed test vectors for the precomputed block template cache.
+//! Fixed test vectors for the block template updater's wait phase.
+//!
+//! [`wait_for_change`] decides whether a mempool change is worth rebuilding the template for, and
+//! debounces the ones that are. Every decision shows up as *when* it returns: after
+//! [`MEMPOOL_DEBOUNCE`] if a change woke it, or after [`BACKSTOP_REFRESH`] if nothing did. These
+//! tests run on a paused clock and assert on that duration, so each costs no real time and says
+//! which of the two happened, instead of waiting to see whether a rebuild arrives.
 
-use std::time::Duration;
+use std::{collections::HashSet, time::Duration};
+
+use tokio::{sync::broadcast, time::Instant};
 
 use zcash_keys::address::Address;
 
 use zebra_chain::{
     block,
+    chain_tip::mock::MockChainTip,
     parameters::{Network, NetworkUpgrade},
     serialization::DateTime32,
+    transaction::{self, UnminedTxId},
     work::difficulty::{CompactDifficulty, ExpandedDifficulty, U256},
 };
+use zebra_node_services::{mempool, BoxError};
 use zebra_state::GetBlockTemplateChainInfo;
+use zebra_test::mock_service::{MockService, PanicAssertion};
 
 use crate::{
     config::mining::{default_miner_address, MinerAddressType},
@@ -19,9 +31,30 @@ use crate::{
 
 use super::*;
 
-/// Returns a template to publish. Its contents don't matter here, only that publishing it is a
-/// change.
-fn template() -> BlockTemplateResponse {
+/// A [`MockService`] standing in for the mempool.
+type MockMempool = MockService<mempool::Request, mempool::Response, PanicAssertion, BoxError>;
+
+/// Returns a mempool mock whose request deadline outlasts [`BACKSTOP_REFRESH`].
+///
+/// On a paused clock an unanswered request would otherwise become the earliest deadline, and the
+/// mock would panic before the wait reached the backstop.
+fn mock_mempool() -> MockMempool {
+    MockService::build()
+        .with_max_request_delay(BACKSTOP_REFRESH * 2)
+        .for_unit_tests()
+}
+
+/// Returns a transaction ID derived from `byte`, so tests can name IDs without building
+/// transactions.
+fn tx_id(byte: u8) -> UnminedTxId {
+    UnminedTxId::from_legacy_id(transaction::Hash([byte; 32]))
+}
+
+/// Returns a template whose long poll ID covers `mempool_tx_ids`.
+///
+/// The template itself contains no transactions, so every ID here is one the template's long poll
+/// ID covers without being in the template: the difference one of the tests below covers.
+fn template(mempool_tx_ids: &HashSet<UnminedTxId>) -> BlockTemplateResponse {
     let net = Network::Mainnet;
     let tip_height = NetworkUpgrade::Nu5
         .activation_height(&net)
@@ -49,7 +82,7 @@ fn template() -> BlockTemplateResponse {
         chain_info.tip_height,
         chain_info.tip_hash,
         chain_info.max_time,
-        std::iter::empty(),
+        mempool_tx_ids.iter().copied(),
     )
     .generate_id();
 
@@ -62,6 +95,223 @@ fn template() -> BlockTemplateResponse {
         vec![],
         None,
     )
+}
+
+/// Returns a cache holding a template built from `mempool_tx_ids`.
+fn cache_built_from(mempool_tx_ids: HashSet<UnminedTxId>) -> TemplateCache {
+    let cache = TemplateCache::default();
+    cache.publish(template(&mempool_tx_ids), mempool_tx_ids);
+
+    cache
+}
+
+/// Runs one wait phase and returns whether it asks for a rebuild, and how long it waited.
+///
+/// The clock is paused, so the duration is exactly the deadline the wait ended on, which separates
+/// a change waking the updater from the backstop expiring.
+async fn wait_once(
+    cache: &TemplateCache,
+    mempool_changes: &mut broadcast::Receiver<MempoolChange>,
+    mempool: &MockMempool,
+) -> (bool, Duration) {
+    // A tip that never changes, so only the mempool paths are under test.
+    let (tip, _tip_sender) = MockChainTip::new();
+    let started = Instant::now();
+    let rebuild = wait_for_change(&tip, mempool_changes, cache, mempool).await;
+
+    (rebuild, started.elapsed())
+}
+
+/// Checks that a burst of additions costs one wait, and that the wait consumes the whole burst.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn a_burst_of_additions_is_one_debounced_wait() {
+    let _init_guard = zebra_test::init();
+
+    let (change_sender, mut change_receiver) = broadcast::channel(200);
+    let mempool = mock_mempool();
+    let cache = cache_built_from(HashSet::new());
+
+    for byte in 0..20 {
+        change_sender
+            .send(MempoolChange::added([tx_id(byte)].into_iter().collect()))
+            .expect("the receiver below is open");
+    }
+
+    let (rebuild, waited) = wait_once(&cache, &mut change_receiver, &mempool).await;
+
+    assert!(rebuild, "an addition should ask for a rebuild");
+    assert_eq!(
+        waited, MEMPOOL_DEBOUNCE,
+        "the wait should end one debounce after the first addition, neither immediately nor at \
+         the backstop",
+    );
+    assert!(
+        change_receiver.try_recv().is_err(),
+        "the debounce should consume the rest of the burst, so the next wait doesn't rebuild \
+         again for changes this one already covered",
+    );
+}
+
+/// Checks that invalidating transactions the template was not built from doesn't wake the wait.
+///
+/// The mempool sends `Invalidated` for transactions that failed verification and were never in the
+/// mempool, so rebuilding for those would let a peer spend Zebra's CPU by sending invalid
+/// transactions.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn invalidating_unused_transactions_waits_for_the_backstop() {
+    let _init_guard = zebra_test::init();
+
+    let (change_sender, mut change_receiver) = broadcast::channel(200);
+    let mempool = mock_mempool();
+    let cache = cache_built_from([tx_id(1)].into_iter().collect());
+
+    for byte in 100..120 {
+        change_sender
+            .send(MempoolChange::invalidated(
+                [tx_id(byte)].into_iter().collect(),
+            ))
+            .expect("the receiver below is open");
+    }
+
+    let (rebuild, waited) = wait_once(&cache, &mut change_receiver, &mempool).await;
+
+    assert!(rebuild, "the backstop should ask for a rebuild");
+    assert_eq!(
+        waited, BACKSTOP_REFRESH,
+        "invalidating transactions the template wasn't built from should leave the wait to the \
+         backstop",
+    );
+}
+
+/// Checks that invalidating a transaction the template's long poll ID covers wakes the wait, even
+/// though ZIP-317 left it out of the template.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn invalidating_an_unselected_transaction_ends_the_wait() {
+    let _init_guard = zebra_test::init();
+
+    let (change_sender, mut change_receiver) = broadcast::channel(200);
+    let mempool = mock_mempool();
+
+    // The template holds no transactions, so this ID is in the mempool the template was built
+    // from without being in the template.
+    let unselected = tx_id(1);
+    let cache = cache_built_from([unselected].into_iter().collect());
+
+    change_sender
+        .send(MempoolChange::invalidated(
+            [unselected].into_iter().collect(),
+        ))
+        .expect("the receiver below is open");
+
+    let (rebuild, waited) = wait_once(&cache, &mut change_receiver, &mempool).await;
+
+    assert!(
+        rebuild,
+        "the invalidated transaction should ask for a rebuild"
+    );
+    assert_eq!(
+        waited, MEMPOOL_DEBOUNCE,
+        "a transaction the template's long poll ID covers should end the wait even when ZIP-317 \
+         didn't select it, because the mempool the template was built from no longer exists",
+    );
+}
+
+/// Checks that overflowing the change channel doesn't wake the wait while the mempool still holds
+/// what the template was built from.
+///
+/// Waking on a lagged channel would undo the filter the other tests cover: a peer sending invalid
+/// transactions fast enough makes the channel lag, and every overflow would buy the rebuild its
+/// rejected transactions could not.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn a_lagging_channel_with_an_unchanged_mempool_waits_for_the_backstop() {
+    let _init_guard = zebra_test::init();
+
+    let capacity = 4;
+    let (change_sender, mut change_receiver) = broadcast::channel(capacity);
+    let template_tx_ids: HashSet<UnminedTxId> = [tx_id(1)].into_iter().collect();
+    let cache = cache_built_from(template_tx_ids.clone());
+
+    // The wait and the responder have to share one mock: a `MockService` clone only sees requests
+    // made after it was cloned, and answering on an unrelated instance would leave the request
+    // unanswered, which takes the same branch as an unchanged mempool and proves nothing.
+    let mut responding_mempool = mock_mempool();
+    let mempool = responding_mempool.clone();
+
+    for byte in 0..(capacity as u8 + 2) {
+        change_sender
+            .send(MempoolChange::invalidated(
+                [tx_id(byte)].into_iter().collect(),
+            ))
+            .expect("the receiver below is open");
+    }
+
+    // The same mempool the template was built from, so there is nothing to rebuild for.
+    let responder = tokio::spawn(async move {
+        responding_mempool
+            .expect_request(mempool::Request::TransactionIds)
+            .await
+            .respond(mempool::Response::TransactionIds(template_tx_ids));
+    });
+
+    let (rebuild, waited) = wait_once(&cache, &mut change_receiver, &mempool).await;
+
+    // Joining the responder is what keeps this test honest: it panics if the lagged channel never
+    // made the wait ask the mempool what it holds.
+    responder
+        .await
+        .expect("the lagged wait should request the mempool's transaction IDs");
+
+    assert!(rebuild, "the backstop should ask for a rebuild");
+    assert_eq!(
+        waited, BACKSTOP_REFRESH,
+        "a lagging channel should leave the wait to the backstop while the mempool still holds \
+         what the template was built from",
+    );
+}
+
+/// Checks that overflowing the change channel does wake the wait when the mempool no longer holds
+/// what the template was built from, which is the case the comparison above exists to allow.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn a_lagging_channel_with_a_changed_mempool_ends_the_wait() {
+    let _init_guard = zebra_test::init();
+
+    let capacity = 4;
+    let (change_sender, mut change_receiver) = broadcast::channel(capacity);
+    let cache = cache_built_from([tx_id(1)].into_iter().collect());
+
+    let mut responding_mempool = mock_mempool();
+    let mempool = responding_mempool.clone();
+
+    for byte in 0..(capacity as u8 + 2) {
+        change_sender
+            .send(MempoolChange::invalidated(
+                [tx_id(byte)].into_iter().collect(),
+            ))
+            .expect("the receiver below is open");
+    }
+
+    // A different mempool from the one the template was built from.
+    let responder = tokio::spawn(async move {
+        responding_mempool
+            .expect_request(mempool::Request::TransactionIds)
+            .await
+            .respond(mempool::Response::TransactionIds(
+                [tx_id(2)].into_iter().collect(),
+            ));
+    });
+
+    let (rebuild, waited) = wait_once(&cache, &mut change_receiver, &mempool).await;
+
+    responder
+        .await
+        .expect("the lagged wait should request the mempool's transaction IDs");
+
+    assert!(rebuild, "the changed mempool should ask for a rebuild");
+    assert_eq!(
+        waited, MEMPOOL_DEBOUNCE,
+        "a lagging channel over a mempool that no longer holds what the template was built from \
+         should end the wait",
+    );
 }
 
 /// Checks that a subscription taken before a template is published still reports it.
@@ -81,7 +331,7 @@ async fn a_subscription_reports_a_template_published_before_the_wait() {
     let mut changes = cache.subscribe();
     assert!(cache.is_empty(), "nothing is published yet");
 
-    cache.publish(template());
+    cache.publish(template(&HashSet::new()), HashSet::new());
 
     tokio::time::timeout(Duration::from_secs(10), changes.changed())
         .await
@@ -98,7 +348,7 @@ async fn a_subscription_reports_each_later_publish() {
     let mut changes = cache.subscribe();
 
     for _ in 0..3 {
-        cache.publish(template());
+        cache.publish(template(&HashSet::new()), HashSet::new());
 
         tokio::time::timeout(Duration::from_secs(10), changes.changed())
             .await

--- a/zebra-rpc/src/methods/types/get_block_template/precompute/tests.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/precompute/tests.rs
@@ -1,0 +1,115 @@
+//! Fixed test vectors for the precomputed block template cache.
+
+use std::time::Duration;
+
+use zcash_keys::address::Address;
+
+use zebra_chain::{
+    block,
+    parameters::{Network, NetworkUpgrade},
+    serialization::DateTime32,
+    work::difficulty::{CompactDifficulty, ExpandedDifficulty, U256},
+};
+use zebra_state::GetBlockTemplateChainInfo;
+
+use crate::{
+    config::mining::{default_miner_address, MinerAddressType},
+    methods::tests::utils::fake_history_tree,
+};
+
+use super::*;
+
+/// Returns a template to publish. Its contents don't matter here, only that publishing it is a
+/// change.
+fn template() -> BlockTemplateResponse {
+    let net = Network::Mainnet;
+    let tip_height = NetworkUpgrade::Nu5
+        .activation_height(&net)
+        .expect("Nu5 is active on Mainnet");
+
+    let miner_params = MinerParams::from(
+        Address::decode(
+            &net,
+            default_miner_address(net.kind(), &MinerAddressType::Transparent),
+        )
+        .expect("hard-coded transparent address is valid"),
+    );
+
+    let chain_info = GetBlockTemplateChainInfo {
+        expected_difficulty: CompactDifficulty::from(ExpandedDifficulty::from(U256::one())),
+        tip_height,
+        tip_hash: block::Hash([0xab; 32]),
+        cur_time: DateTime32::from(1654008617),
+        min_time: DateTime32::from(1654008606),
+        max_time: DateTime32::from(1654008719),
+        chain_history_root: fake_history_tree(&net).hash(),
+    };
+
+    let long_poll_id = LongPollInput::new(
+        chain_info.tip_height,
+        chain_info.tip_hash,
+        chain_info.max_time,
+        std::iter::empty(),
+    )
+    .generate_id();
+
+    BlockTemplateResponse::new_internal(
+        &net,
+        &CoinbaseCache::default(),
+        &miner_params,
+        &chain_info,
+        long_poll_id,
+        vec![],
+        None,
+    )
+}
+
+/// Checks that a subscription taken before a template is published still reports it.
+///
+/// `getblocktemplate` reads the cache, decides the client already has that template, and only then
+/// waits. A subscription taken at the point of waiting would mark anything published in between as
+/// seen, and the caller's other wake conditions are a chain tip change and `max_time`, neither of
+/// which fires when the mempool alone changes: it would sit on a template it had already been told
+/// about until the updater's backstop.
+#[tokio::test]
+async fn a_subscription_reports_a_template_published_before_the_wait() {
+    let _init_guard = zebra_test::init();
+
+    let cache = TemplateCache::default();
+
+    // The order the RPC uses: subscribe, read, then wait.
+    let mut changes = cache.subscribe();
+    assert!(cache.is_empty(), "nothing is published yet");
+
+    cache.publish(template());
+
+    tokio::time::timeout(Duration::from_secs(10), changes.changed())
+        .await
+        .expect("a template published before the wait should still end it");
+}
+
+/// Checks that a subscription reports each later publish, so a long poll that loops keeps waiting
+/// on templates it hasn't seen rather than on the one it just read.
+#[tokio::test]
+async fn a_subscription_reports_each_later_publish() {
+    let _init_guard = zebra_test::init();
+
+    let cache = TemplateCache::default();
+    let mut changes = cache.subscribe();
+
+    for _ in 0..3 {
+        cache.publish(template());
+
+        tokio::time::timeout(Duration::from_secs(10), changes.changed())
+            .await
+            .expect("each publish should end a wait");
+    }
+
+    // With nothing published since, the next wait doesn't return.
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), changes.changed())
+            .await
+            .is_err(),
+        "a subscription that has seen every publish should keep waiting",
+    );
+}

--- a/zebra-rpc/src/methods/types/get_block_template/tests.rs
+++ b/zebra-rpc/src/methods/types/get_block_template/tests.rs
@@ -191,14 +191,12 @@ fn coinbase_cache_reuses_built_coinbase() {
         "a cache hit reuses the stored coinbase",
     );
 
-    // A different height key or a cleared cache misses, so the next request rebuilds.
+    // A different height key misses, so the next request rebuilds.
     let next_height = height.next().expect("height is below Height::MAX");
     assert!(
         cache.get(next_height, fee).is_none(),
         "a different height misses"
     );
-    cache.clear();
-    assert!(cache.get(height, fee).is_none(), "a cleared cache misses");
 }
 
 /// Verifies the fix for #10907: the multi-entry coinbase cache retains both the zero-fee fake

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -497,7 +497,7 @@ impl StartCmd {
         let block_template_task_handle =
             if config.rpc.listen_addr.is_some() || is_internal_miner_enabled {
                 rpc_impl
-                    .spawn_block_template_updater()
+                    .spawn_block_template_updater(mempool_transaction_subscriber.clone())
                     .inspect(|_| info!("spawned block template updater task"))
             } else {
                 None

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -486,10 +486,28 @@ impl StartCmd {
         );
 
         // Keep a block template ready for the `getblocktemplate` RPC, if this node is configured
-        // for mining.
-        let block_template_task_handle = rpc_impl
-            .spawn_block_template_updater()
-            .inspect(|_| info!("spawned block template updater task"));
+        // for mining, and something can actually ask for a template. Without the RPC server and
+        // without the internal miner, nothing can call `getblocktemplate`, so precomputing
+        // templates would build coinbase transactions that no one reads.
+        #[cfg(feature = "internal-miner")]
+        let is_internal_miner_enabled = config.mining.is_internal_miner_enabled();
+        #[cfg(not(feature = "internal-miner"))]
+        let is_internal_miner_enabled = false;
+
+        let block_template_task_handle =
+            if config.rpc.listen_addr.is_some() || is_internal_miner_enabled {
+                rpc_impl
+                    .spawn_block_template_updater()
+                    .inspect(|_| info!("spawned block template updater task"))
+            } else {
+                None
+            };
+
+        // Supervise the updater like every other ongoing task: if it exits or panics, the RPC
+        // keeps serving the last template it published, and pays `NEW_TIP_TIMEOUT` on every call
+        // after the next tip change, so a silent exit has to be visible.
+        let block_template_task_handle: tokio::task::JoinHandle<()> = block_template_task_handle
+            .unwrap_or_else(|| tokio::spawn(std::future::pending().in_current_span()));
 
         let rpc_task_handle = if config.rpc.listen_addr.is_some() {
             RpcServer::start(rpc_impl.clone(), config.rpc.clone())
@@ -723,6 +741,7 @@ impl StartCmd {
         pin!(progress_task_handle);
         pin!(end_of_support_task_handle);
         pin!(miner_task_handle);
+        pin!(block_template_task_handle);
 
         // startup tasks
         let BackgroundTaskHandles {
@@ -835,6 +854,14 @@ impl StartCmd {
                     Ok(())
                 }
 
+                block_template_result = &mut block_template_task_handle => {
+                    block_template_result
+                        .expect("unexpected panic in the block template updater task");
+                    info!("block template updater task exited");
+
+                    Ok(())
+                }
+
                 miner_result = &mut miner_task_handle => miner_result
                     .expect("unexpected panic in the miner task")
                     .map(|_| info!("miner task exited")),
@@ -863,9 +890,7 @@ impl StartCmd {
         // ongoing tasks
         rpc_task_handle.abort();
         rpc_tx_queue_handle.abort();
-        if let Some(block_template_task_handle) = block_template_task_handle {
-            block_template_task_handle.abort();
-        }
+        block_template_task_handle.abort();
         health_task_handle.abort();
         syncer_task_handle.abort();
         block_gossip_task_handle.abort();

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -485,6 +485,12 @@ impl StartCmd {
             sync::end_of_support::end_of_support_height(&config.network.network),
         );
 
+        // Keep a block template ready for the `getblocktemplate` RPC, if this node is configured
+        // for mining.
+        let block_template_task_handle = rpc_impl
+            .spawn_block_template_updater()
+            .inspect(|_| info!("spawned block template updater task"));
+
         let rpc_task_handle = if config.rpc.listen_addr.is_some() {
             RpcServer::start(rpc_impl.clone(), config.rpc.clone())
                 .await
@@ -857,6 +863,9 @@ impl StartCmd {
         // ongoing tasks
         rpc_task_handle.abort();
         rpc_tx_queue_handle.abort();
+        if let Some(block_template_task_handle) = block_template_task_handle {
+            block_template_task_handle.abort();
+        }
         health_task_handle.abort();
         syncer_task_handle.abort();
         block_gossip_task_handle.abort();


### PR DESCRIPTION
Based on #11371's branch, not `main`: that PR moves template production into the block template updater task, and this changes what makes that task rebuild. Please review and merge #11371 first.

## Motivation

Part of #5891.

## Solution

The updater task subscribes to the mempool change channel instead of rebuilding
on a five second timer, and a long polling `getblocktemplate` call returns when
the updater publishes a template instead of waiting for its own mempool poll.

A rebuild reads the whole mempool, re-runs ZIP-317 selection, and rebuilds the
coinbase transaction, so it costs far more than the notification that triggers
it. Changes that cannot alter the template do not cause one:

- A burst of additions coalesces into one rebuild, debounced by 500 ms. The
  debounce is also what #5891 asks for after a chain fork: the mempool resets
  and re-verifies, so waiting lets re-verified transactions rejoin the template
  instead of publishing the emptied mempool.
- `Invalidated` also fires for transactions that failed verification and were
  never in the mempool, so it only rebuilds when the template's long poll ID
  covers the transaction. That ID is derived from every ID in the mempool
  rather than the transactions ZIP-317 selected, so the cache keeps the whole
  set: a template built from a mempool that no longer exists must be replaced
  even for a transaction that was never selected.
- Overflowing the channel compares the mempool against that set rather than
  rebuilding. Debouncing alone would not help, because a peer sending invalid
  transactions can keep sending: without the comparison, making the channel lag
  would buy the rebuilds the filter denies.
- `Mined` arrives with the chain tip change that mined it, which rebuilds
  anyway.

A thirty second backstop keeps `cur_time` current, which Testnet's
minimum-difficulty rule depends on, and bounds a lost notification. It replaces
a five second poll, so an idle node does six times less of this work.

This does not close #5891 on its own. The mempool announces newly verified
transactions from its `poll_ready`, so a change is announced only when the
mempool is next polled, which the queue checker guarantees at a five second
rate limit. That is the remaining fixed interval the issue asks to remove, and
it needs a notification from the verifier rather than a change here.

## Tests

- A burst of twenty additions rebuilds the template once. Without the debounce,
  it rebuilds twenty times.
- Invalidating transactions the template was not built from does not rebuild
  it, so rejected transactions cannot force rebuilds. Making `Invalidated`
  always rebuild fails this.
- Invalidating a transaction ZIP-317 left out of the template does rebuild it,
  because the template's long poll ID still covers it. Checking the selected
  transactions instead of the mempool ID set fails this.
- Overflowing the change channel while the mempool still holds what the
  template was built from does not rebuild it. Treating a lagged channel as a
  change fails this.
- A long polling call returns once the updater publishes, well inside the RPC's
  own poll interval. Without the new wake-up it waits for that interval.

On a Regtest node, rejecting an invalid transaction broadcasts the change and a
long poll stays asleep afterwards; long polling still wakes on a chain tip
change; and an idle node holds a long poll open without returning or spinning.

---
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.

AI disclosure: written with Claude Code.
