### PR TITLE
perf(mempool): check the queue as soon as a transaction finishes verifying

### DIFF
--- a/.changes/unreleased/zebrad-Changed-20260902-150244.yaml
+++ b/.changes/unreleased/zebrad-Changed-20260902-150244.yaml
@@ -1,0 +1,7 @@
+project: zebrad
+kind: Changed
+body: 'Zebra stores, gossips, and announces a newly verified transaction as soon as its verification
+  finishes, rather than waiting for the mempool queue checker''s five second rate limit. On a node
+  with little peer or RPC traffic, that rate limit was the only thing driving this work
+  ([#5891](https://github.com/ZcashFoundation/zebra/issues/5891)).'
+time: 2026-09-02T15:02:44.000000000Z

--- a/zebrad/src/commands/start.rs
+++ b/zebrad/src/commands/start.rs
@@ -420,7 +420,7 @@ impl StartCmd {
         );
 
         info!("initializing mempool");
-        let (mempool, mempool_transaction_subscriber) = Mempool::new(
+        let (mempool, mempool_transaction_subscriber, mempool_transaction_verified) = Mempool::new(
             &config.network.network,
             &config.mempool,
             peer_set.clone(),
@@ -599,7 +599,8 @@ impl StartCmd {
             };
 
         info!("spawning mempool queue checker task");
-        let mempool_queue_checker_task_handle = mempool::QueueChecker::spawn(mempool.clone());
+        let mempool_queue_checker_task_handle =
+            mempool::QueueChecker::spawn(mempool.clone(), mempool_transaction_verified);
 
         info!("spawning mempool transaction gossip task");
         let tx_gossip_task_handle = tokio::spawn(

--- a/zebrad/src/components/inbound/tests/fake_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/fake_peer_set.rs
@@ -1084,7 +1084,7 @@ async fn setup(
     // which is called by the gossip_best_tip_block_hashes task once the chain tip changes.
 
     let (misbehavior_tx, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
-    let (mut mempool_service, transaction_subscriber) = Mempool::new(
+    let (mut mempool_service, transaction_subscriber, _transaction_verified) = Mempool::new(
         &network,
         &MempoolConfig::default(),
         buffered_peer_set.clone(),

--- a/zebrad/src/components/inbound/tests/real_peer_set.rs
+++ b/zebrad/src/components/inbound/tests/real_peer_set.rs
@@ -706,7 +706,7 @@ async fn setup(
     // Mempool
     let (misbehavior_tx, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
     let mempool_config = MempoolConfig::default();
-    let (mut mempool_service, transaction_subscriber) = Mempool::new(
+    let (mut mempool_service, transaction_subscriber, _transaction_verified) = Mempool::new(
         &network,
         &mempool_config,
         peer_set.clone(),

--- a/zebrad/src/components/mempool.rs
+++ b/zebrad/src/components/mempool.rs
@@ -23,11 +23,12 @@ use std::{
     future::Future,
     iter,
     pin::{pin, Pin},
+    sync::Arc,
     task::{Context, Poll},
 };
 
 use futures::{future::FutureExt, stream::Stream};
-use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::sync::{broadcast, mpsc, oneshot, Notify};
 use tower::{buffer::Buffer, timeout::Timeout, util::BoxService, Service};
 
 use zebra_chain::{
@@ -305,6 +306,12 @@ pub struct Mempool {
     /// Only displayed after the mempool's first activation.
     #[cfg(feature = "progress-bar")]
     rejected_count_bar: Option<howudoin::Tx>,
+
+    /// Notified by [`TxDownloads`] when a transaction finishes verifying.
+    ///
+    /// Handed to the queue checker, which calls this service in response, so verified transactions
+    /// are stored and announced without waiting for its rate limit.
+    transaction_verified: Arc<Notify>,
 }
 
 impl Mempool {
@@ -319,10 +326,11 @@ impl Mempool {
         latest_chain_tip: zs::LatestChainTip,
         chain_tip_change: ChainTipChange,
         misbehavior_sender: mpsc::Sender<(PeerSocketAddr, u32)>,
-    ) -> (Self, MempoolTxSubscriber) {
+    ) -> (Self, MempoolTxSubscriber, Arc<Notify>) {
         let (transaction_sender, _) =
             tokio::sync::broadcast::channel(gossip::MAX_CHANGES_BEFORE_SEND * 2);
         let transaction_subscriber = MempoolTxSubscriber::new(transaction_sender.clone());
+        let transaction_verified = Arc::new(Notify::new());
 
         let mut service = Mempool {
             network: network.clone(),
@@ -337,6 +345,7 @@ impl Mempool {
             tx_verifier,
             transaction_sender,
             misbehavior_sender,
+            transaction_verified: transaction_verified.clone(),
             #[cfg(feature = "progress-bar")]
             queued_count_bar: None,
             #[cfg(feature = "progress-bar")]
@@ -352,7 +361,7 @@ impl Mempool {
         let is_caught_up_to_start = service.is_caught_up_to_start();
         service.update_state(None, is_caught_up_to_start);
 
-        (service, transaction_subscriber)
+        (service, transaction_subscriber, transaction_verified)
     }
 
     /// Is the mempool enabled by a debug config option?
@@ -397,6 +406,7 @@ impl Mempool {
             Timeout::new(self.outbound.clone(), TRANSACTION_DOWNLOAD_TIMEOUT),
             Timeout::new(self.tx_verifier.clone(), TRANSACTION_VERIFY_TIMEOUT),
             self.state.clone(),
+            self.transaction_verified.clone(),
         ));
         self.active_state = ActiveState::Enabled {
             storage: storage::Storage::new(&self.config),

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -29,6 +29,7 @@ use std::{
     collections::{HashMap, HashSet},
     net::SocketAddr,
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
     time::Duration,
 };
@@ -42,7 +43,7 @@ use futures::{
 use pin_project::{pin_project, pinned_drop};
 use thiserror::Error;
 use tokio::{
-    sync::{mpsc, oneshot},
+    sync::{mpsc, oneshot, Notify},
     task::JoinHandle,
 };
 use tower::{Service, ServiceExt};
@@ -226,6 +227,14 @@ where
     /// has it as the third tuple element. Enforces
     /// [`MAX_INBOUND_CONCURRENCY_PER_PEER`]. See `GHSA-4fc2-h7jh-287c`.
     pending_per_peer: HashMap<SocketAddr, usize>,
+
+    /// Notified when a download and verify task finishes.
+    ///
+    /// The mempool only drains this stream, stores the transactions, and announces them from
+    /// `poll_ready()`, which runs when something calls the mempool. Without this notification the
+    /// only guaranteed caller is the queue checker's rate limit, so a verified transaction could
+    /// wait seconds before any consumer of the change channel heard about it.
+    transaction_verified: Arc<Notify>,
 }
 
 impl<ZN, ZV, ZS> Stream for Downloads<ZN, ZV, ZS>
@@ -333,10 +342,14 @@ where
     /// `verifier` is used to verify transactions.
     /// `state` is used to check if transactions are already in the state.
     ///
+    /// `transaction_verified` is notified whenever a download and verify task finishes, so the
+    /// queue checker can ask the mempool to store and announce the result without waiting for its
+    /// rate limit.
+    ///
     /// The [`Downloads`] stream is agnostic to the network policy, so retry and
     /// timeout limits should be applied to the `network` service passed into
     /// this constructor.
-    pub fn new(network: ZN, verifier: ZV, state: ZS) -> Self {
+    pub fn new(network: ZN, verifier: ZV, state: ZS, transaction_verified: Arc<Notify>) -> Self {
         let (results_sender, results) = mpsc::unbounded_channel();
 
         Self {
@@ -348,6 +361,7 @@ where
             results_sender,
             cancel_handles: HashMap::new(),
             pending_per_peer: HashMap::new(),
+            transaction_verified,
         }
     }
 
@@ -518,6 +532,7 @@ where
         })
         .in_current_span();
 
+        let transaction_verified = self.transaction_verified.clone();
         let results_sender = self.results_sender.clone();
         let task = tokio::spawn(async move {
             let fut = tokio::time::timeout(RATE_LIMIT_DELAY, fut);
@@ -561,8 +576,19 @@ where
                 },
             };
 
-            // A send only fails once `Downloads` has been dropped, along with the receiver.
-            let _ = results_sender.send(result);
+            // # Correctness
+            //
+            // Queue the result before signalling, and never the other way around. Returning the
+            // result from this task instead would only make it visible once the task finished,
+            // which is after this signal: a woken mempool could then find nothing and leave the
+            // transaction until the queue checker's rate limit elapsed. Sending first means any
+            // poll that follows the signal observes the result.
+            //
+            // A send only fails once `Downloads` has been dropped, which drops the mempool's
+            // download stream, so there is nothing left to notify.
+            if results_sender.send(result).is_ok() {
+                transaction_verified.notify_one();
+            }
         });
 
         self.pending.push(task);

--- a/zebrad/src/components/mempool/downloads.rs
+++ b/zebrad/src/components/mempool/downloads.rs
@@ -41,7 +41,10 @@ use futures::{
 };
 use pin_project::{pin_project, pinned_drop};
 use thiserror::Error;
-use tokio::{sync::oneshot, task::JoinHandle};
+use tokio::{
+    sync::{mpsc, oneshot},
+    task::JoinHandle,
+};
 use tower::{Service, ServiceExt};
 use tracing_futures::Instrument;
 
@@ -147,6 +150,23 @@ pub enum TransactionDownloadVerifyError {
     },
 }
 
+/// The outcome of one download and verify task.
+///
+/// Sent to [`Downloads::poll_next`] over a channel rather than returned from the task, so a
+/// completed task is queued for the mempool before [`Downloads`] says a transaction is ready.
+type VerifyResult = Result<
+    Result<
+        (
+            VerifiedUnminedTx,
+            Vec<transparent::OutPoint>,
+            Option<Height>,
+            Option<oneshot::Sender<Result<(), BoxError>>>,
+        ),
+        Box<(TransactionDownloadVerifyError, UnminedTxId)>,
+    >,
+    (UnminedTxId, tokio::time::error::Elapsed),
+>;
+
 /// Represents a [`Stream`] of download and verification tasks.
 #[pin_project(PinnedDrop)]
 #[derive(Debug)]
@@ -175,23 +195,17 @@ where
 
     // Internal downloads state
     /// A list of pending transaction download and verify tasks.
+    ///
+    /// Each task sends its result to [`Self::results`] and returns nothing, so polling this only
+    /// reaps finished tasks and surfaces their panics.
     #[pin]
-    pending: FuturesUnordered<
-        JoinHandle<
-            Result<
-                Result<
-                    (
-                        VerifiedUnminedTx,
-                        Vec<transparent::OutPoint>,
-                        Option<Height>,
-                        Option<oneshot::Sender<Result<(), BoxError>>>,
-                    ),
-                    Box<(TransactionDownloadVerifyError, UnminedTxId)>,
-                >,
-                (UnminedTxId, tokio::time::error::Elapsed),
-            >,
-        >,
-    >,
+    pending: FuturesUnordered<JoinHandle<()>>,
+
+    /// The results of finished download and verify tasks.
+    results: mpsc::UnboundedReceiver<VerifyResult>,
+
+    /// The sender each task uses to queue its result.
+    results_sender: mpsc::UnboundedSender<VerifyResult>,
 
     /// A list of channels that can be used to cancel pending transaction
     /// download and verify tasks. Each entry also stores the corresponding
@@ -240,18 +254,23 @@ where
     >;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        let this = self.project();
+        let mut this = self.project();
+
+        // Reap finished tasks, so the queue length stays accurate and a panicking task is not
+        // silently swallowed. Their results arrive over the channel below, not from these handles.
+        while let Poll::Ready(Some(join_result)) = this.pending.as_mut().poll_next(cx) {
+            join_result.expect("transaction download and verify tasks must not panic");
+        }
+
         // CORRECTNESS
         //
         // The current task must be scheduled for wakeup every time we return
         // `Poll::Pending`.
         //
-        // If no download and verify tasks have exited since the last poll, this
-        // task is scheduled for wakeup when the next task becomes ready.
-        //
-        // TODO: this would be cleaner with poll_map (#2693)
-        let item = if let Some(join_result) = ready!(this.pending.poll_next(cx)) {
-            let result = join_result.expect("transaction download and verify tasks must not panic");
+        // Polling the results channel schedules this task for wakeup when the next result is
+        // queued. A task queues its result before signalling that it finished, so a poll that
+        // follows the signal sees the result here.
+        let item = if let Some(result) = ready!(this.results.poll_recv(cx)) {
             let (result, completed_txid) = match result {
                 Ok(Ok((tx, spent_mempool_outpoints, tip_height, rsp_tx))) => {
                     let hash = tx.transaction.id;
@@ -318,11 +337,15 @@ where
     /// timeout limits should be applied to the `network` service passed into
     /// this constructor.
     pub fn new(network: ZN, verifier: ZV, state: ZS) -> Self {
+        let (results_sender, results) = mpsc::unbounded_channel();
+
         Self {
             network,
             verifier,
             state,
             pending: FuturesUnordered::new(),
+            results,
+            results_sender,
             cancel_handles: HashMap::new(),
             pending_per_peer: HashMap::new(),
         }
@@ -495,6 +518,7 @@ where
         })
         .in_current_span();
 
+        let results_sender = self.results_sender.clone();
         let task = tokio::spawn(async move {
             let fut = tokio::time::timeout(RATE_LIMIT_DELAY, fut);
 
@@ -537,7 +561,8 @@ where
                 },
             };
 
-            result
+            // A send only fails once `Downloads` has been dropped, along with the receiver.
+            let _ = results_sender.send(result);
         });
 
         self.pending.push(task);

--- a/zebrad/src/components/mempool/downloads/tests.rs
+++ b/zebrad/src/components/mempool/downloads/tests.rs
@@ -1,6 +1,8 @@
 //! Fixed test vectors for the mempool transaction downloader.
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
+
+use tokio::sync::Notify;
 
 use futures::StreamExt as _;
 use tower::{service_fn, util::BoxCloneService};
@@ -44,7 +46,7 @@ async fn per_peer_cap_applies_to_pushed_transactions() {
     let state: MockService<zs::Request, zs::Response, PanicAssertion> =
         MockService::build().for_unit_tests();
 
-    let mut downloads = Downloads::new(peer_set, verifier, state);
+    let mut downloads = Downloads::new(peer_set, verifier, state, Arc::new(Notify::new()));
 
     // The first `MAX_INBOUND_CONCURRENCY_PER_PEER` pushes from this peer are admitted.
     for gossip in pushed.iter().take(MAX_INBOUND_CONCURRENCY_PER_PEER) {
@@ -103,6 +105,7 @@ async fn pushed_transaction_attributes_invalid_error_to_peer() {
                 request => Err(format!("unexpected state request: {request:?}").into()),
             }
         })),
+        Arc::new(Notify::new()),
     );
 
     downloads

--- a/zebrad/src/components/mempool/queue_checker.rs
+++ b/zebrad/src/components/mempool/queue_checker.rs
@@ -1,7 +1,7 @@
 //! Zebra Mempool queue checker.
 //!
-//! The queue checker periodically sends a request to the mempool,
-//! so that newly verified transactions are added to the mempool,
+//! The queue checker sends a request to the mempool when a transaction finishes verifying, and
+//! periodically as a backstop, so that newly verified transactions are added to the mempool,
 //! and gossiped to peers.
 //!
 //! The mempool performs these actions on every request,
@@ -11,22 +11,26 @@
 //! Crawler queue requests are also too infrequent,
 //! and they only happen if peers respond within the timeout.
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
-use tokio::{task::JoinHandle, time::sleep};
+use tokio::{sync::Notify, task::JoinHandle, time::sleep};
 use tower::{BoxError, Service, ServiceExt};
 use tracing_futures::Instrument;
 
 use crate::components::mempool;
 
-/// The delay between queue check events.
+/// The longest the queue checker waits between queue check events.
+///
+/// Transaction verification notifies the checker, so this is a backstop rather than the usual
+/// path: it covers a notification the checker was not waiting for, and a mempool that has work to
+/// do for some other reason.
 ///
 /// This interval is chosen so that there are a significant number of
 /// queue checks in each target block interval.
 ///
 /// This allows transactions to propagate across the network for each block,
 /// even if some peers are poorly connected.
-const RATE_LIMIT_DELAY: Duration = Duration::from_secs(5);
+pub(crate) const RATE_LIMIT_DELAY: Duration = Duration::from_secs(5);
 
 /// The mempool queue checker.
 ///
@@ -34,6 +38,9 @@ const RATE_LIMIT_DELAY: Duration = Duration::from_secs(5);
 pub struct QueueChecker<Mempool> {
     /// The mempool service that receives crawled transaction IDs.
     mempool: Mempool,
+
+    /// Notified when a transaction finishes verifying.
+    transaction_verified: Arc<Notify>,
 }
 
 impl<Mempool> QueueChecker<Mempool>
@@ -43,13 +50,23 @@ where
     Mempool::Future: Send,
 {
     /// Spawn an asynchronous task to run the mempool queue checker.
-    pub fn spawn(mempool: Mempool) -> JoinHandle<Result<(), BoxError>> {
-        let queue_checker = QueueChecker { mempool };
+    ///
+    /// `transaction_verified` is the notification the mempool's downloader sends when a
+    /// transaction finishes verifying.
+    pub fn spawn(
+        mempool: Mempool,
+        transaction_verified: Arc<Notify>,
+    ) -> JoinHandle<Result<(), BoxError>> {
+        let queue_checker = QueueChecker {
+            mempool,
+            transaction_verified,
+        };
 
         tokio::spawn(queue_checker.run().in_current_span())
     }
 
-    /// Periodically check if the mempool has newly verified transactions.
+    /// Check if the mempool has newly verified transactions, when one finishes verifying and at
+    /// least every [`RATE_LIMIT_DELAY`].
     ///
     /// Runs until the mempool returns an error,
     /// which happens when Zebra is shutting down.
@@ -57,7 +74,13 @@ where
         info!("initializing mempool queue checker task");
 
         loop {
-            sleep(RATE_LIMIT_DELAY).await;
+            // A notification that arrives while the mempool is being checked is stored, so the
+            // next wait returns immediately and the transaction isn't left until the backstop.
+            tokio::select! {
+                () = self.transaction_verified.notified() => {}
+                () = sleep(RATE_LIMIT_DELAY) => {}
+            }
+
             self.check_queue().await?;
         }
     }

--- a/zebrad/src/components/mempool/tests/prop.rs
+++ b/zebrad/src/components/mempool/tests/prop.rs
@@ -434,7 +434,7 @@ fn setup(
         ChainTipSender::new(None, network);
 
     let (misbehavior_tx, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
-    let (mempool, mempool_transaction_subscriber) = Mempool::new(
+    let (mempool, mempool_transaction_subscriber, _transaction_verified) = Mempool::new(
         network,
         &Config {
             tx_cost_limit: 160_000_000,

--- a/zebrad/src/components/mempool/tests/vector.rs
+++ b/zebrad/src/components/mempool/tests/vector.rs
@@ -5,7 +5,10 @@
 use std::{sync::Arc, time::Duration};
 
 use color_eyre::Report;
-use tokio::time::{self, timeout};
+use tokio::{
+    sync::Notify,
+    time::{self, timeout},
+};
 use tower::{ServiceBuilder, ServiceExt};
 
 use zebra_chain::{
@@ -25,7 +28,7 @@ use zebra_state::{Config as StateConfig, CHAIN_TIP_UPDATE_WAIT_LIMIT};
 use zebra_test::mock_service::{MockService, PanicAssertion};
 
 use crate::components::{
-    mempool::{self, *},
+    mempool::{self, queue_checker::RATE_LIMIT_DELAY, *},
     sync::{RecentSyncLengths, SyncStatus},
 };
 
@@ -1128,6 +1131,7 @@ async fn poll_ready_succeeds_with_no_mempool_change_subscribers() -> Result<(), 
         mut tx_verifier,
         mut recent_syncs,
         mempool_transaction_receiver,
+        _transaction_verified,
     ) = setup_with_mempool_config(&network, mempool_config, true, false).await;
 
     drop(mempool_transaction_receiver);
@@ -1184,6 +1188,115 @@ async fn poll_ready_succeeds_with_no_mempool_change_subscribers() -> Result<(), 
             .unbox_mempool_error(),
         MempoolError::StorageExactTip(ExactTipRejectionError::FailedVerification(_))
     ));
+
+    Ok(())
+}
+
+/// Checks that a verified transaction is stored and announced because verification told the queue
+/// checker, rather than because the queue checker's rate limit elapsed.
+///
+/// The clock is paused, so the only way the rate limit can contribute is by advancing time. If the
+/// change arrives before [`RATE_LIMIT_DELAY`] of virtual time passes, verification is what
+/// prompted it.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn verified_transaction_is_announced_without_the_queue_checker_rate_limit(
+) -> Result<(), Report> {
+    let network = Network::Mainnet;
+
+    let mempool_config = mempool::Config {
+        tx_cost_limit: u64::MAX,
+        ..Default::default()
+    };
+
+    let (
+        mut mempool,
+        mut peer_set,
+        _state_service,
+        _chain_tip_change,
+        mut tx_verifier,
+        mut recent_syncs,
+        mut mempool_transaction_receiver,
+        transaction_verified,
+    ) = setup_with_mempool_config(&network, mempool_config, true, false).await;
+
+    mempool.enable(&mut recent_syncs).await;
+
+    let tx = network
+        .unmined_transactions_in_blocks(1..=10)
+        .next()
+        .expect("mainnet test vectors contain transactions")
+        .transaction;
+
+    // The queue checker holds the only handle that will call the mempool from here on, so nothing
+    // else can drain the verification result on its behalf.
+    let mempool = Buffer::new(BoxService::new(mempool), 1);
+    let queue_checker = QueueChecker::spawn(mempool.clone(), transaction_verified);
+
+    let mut queueing_mempool = mempool.clone();
+    let queued = queueing_mempool
+        .ready()
+        .await
+        .expect("mempool is ready")
+        .call(Request::Queue(vec![tx.id.into()]));
+
+    let download = peer_set
+        .expect_request_that(|req| matches!(req, zn::Request::TransactionsById(_)))
+        .map(|responder| {
+            responder.respond(zn::Response::Transactions(vec![
+                zn::InventoryResponse::Available((tx.clone(), None)),
+            ]));
+        });
+
+    let (queued, ()) = futures::join!(queued, download);
+    assert!(matches!(
+        queued.expect("queue request succeeds"),
+        Response::Queued(_)
+    ));
+
+    // Everything up to here polled the mempool, so measure from the point where only the queue
+    // checker is left to notice the verification.
+    let queued_at = time::Instant::now();
+
+    tx_verifier
+        .expect_request_that(|_| true)
+        .map(|responder| {
+            let transaction = responder.request().clone().transaction;
+
+            responder.respond(transaction::MempoolResponse::from(
+                VerifiedUnminedTx::new(
+                    transaction,
+                    Amount::try_from(1_000_000).expect("valid fee"),
+                    0,
+                    0,
+                    Arc::new(vec![]),
+                )
+                .expect("transaction passes ZIP-317 checks"),
+            ));
+        })
+        .await;
+
+    let change = timeout(
+        time::Duration::from_secs(60),
+        mempool_transaction_receiver.recv(),
+    )
+    .await
+    .expect("the queue checker should store and announce the transaction")
+    .expect("the change channel stays open");
+
+    assert_eq!(
+        change,
+        MempoolChange::added([tx.id].into_iter().collect()),
+        "storing a verified transaction should announce it",
+    );
+
+    assert!(
+        queued_at.elapsed() < RATE_LIMIT_DELAY,
+        "the announcement should follow verification, not the queue checker's {RATE_LIMIT_DELAY:?} \
+         rate limit, but it took {:?}",
+        queued_at.elapsed(),
+    );
+
+    queue_checker.abort();
 
     Ok(())
 }
@@ -1715,6 +1828,7 @@ async fn mempool_reject_op_return_too_large() -> Result<(), Report> {
         _tx_verifier,
         mut recent_syncs,
         _mempool_transaction_receiver,
+        _transaction_verified,
     ) = setup_with_mempool_config(&network, mempool_config, true, true).await;
 
     service.enable(&mut recent_syncs).await;
@@ -2214,7 +2328,26 @@ async fn setup(
         ..Default::default()
     };
 
-    setup_with_mempool_config(network, mempool_config, should_commit_genesis_block, true).await
+    let (
+        mempool,
+        peer_set,
+        state_service,
+        chain_tip_change,
+        tx_verifier,
+        recent_syncs,
+        mempool_transaction_receiver,
+        _transaction_verified,
+    ) = setup_with_mempool_config(network, mempool_config, should_commit_genesis_block, true).await;
+
+    (
+        mempool,
+        peer_set,
+        state_service,
+        chain_tip_change,
+        tx_verifier,
+        recent_syncs,
+        mempool_transaction_receiver,
+    )
 }
 
 async fn setup_with_mempool_config(
@@ -2230,6 +2363,7 @@ async fn setup_with_mempool_config(
     MockTxVerifier,
     RecentSyncLengths,
     tokio::sync::broadcast::Receiver<MempoolChange>,
+    Arc<Notify>,
 ) {
     let peer_set = MockService::build().for_unit_tests();
 
@@ -2243,7 +2377,7 @@ async fn setup_with_mempool_config(
 
     let (sync_status, recent_syncs) = SyncStatus::new();
     let (misbehavior_tx, _misbehavior_rx) = tokio::sync::mpsc::channel(1);
-    let (mempool, mempool_transaction_subscriber) = Mempool::new(
+    let (mempool, mempool_transaction_subscriber, transaction_verified) = Mempool::new(
         network,
         &mempool_config,
         Buffer::new(BoxService::new(peer_set.clone()), 1),
@@ -2295,6 +2429,7 @@ async fn setup_with_mempool_config(
         tx_verifier,
         recent_syncs,
         mempool_transaction_subscriber.subscribe(),
+        transaction_verified,
     )
 }
 
@@ -2328,6 +2463,7 @@ async fn cancel_handles_drained_after_verification_timeout() {
         Timeout::new(peer_set, TRANSACTION_DOWNLOAD_TIMEOUT),
         Timeout::new(tx_verifier, TRANSACTION_VERIFY_TIMEOUT),
         state,
+        Arc::new(Notify::new()),
     ));
 
     let mut iter = Network::Mainnet.unmined_transactions_in_blocks(1..=10);
@@ -2416,6 +2552,7 @@ async fn verification_timeout_releases_peer_slot() {
         Timeout::new(peer_set, TRANSACTION_DOWNLOAD_TIMEOUT),
         Timeout::new(tx_verifier, TRANSACTION_VERIFY_TIMEOUT),
         state,
+        Arc::new(Notify::new()),
     ));
 
     let source: SocketAddr = "127.0.0.1:8233".parse().expect("valid socket addr");


### PR DESCRIPTION
## Motivation

Part of #5891.

## Solution

The mempool stores a newly verified transaction, gossips it, and announces it
on its change channel from `poll_ready()`, so none of that happens until
something calls the mempool. The only guaranteed caller is the queue checker,
on a five second rate limit, so a node with little peer or RPC traffic can sit
on a verified transaction for seconds. A miner's node is that case, and #5891
asks for the mempool to be read when transactions are verified rather than on a
timer.

Each download and verify task now notifies the queue checker, which checks the
queue when notified and at least every five seconds as before.

A task queues its result before it signals. Signalling first would be a race
rather than an optimisation: the woken check could run while the task had not
yet made its result available, find nothing, and leave the transaction until
the rate limit elapsed, which is the delay this removes. Results used to be
returned from the task, and a return value is only visible once the task has
finished, so the first commit moves them onto a channel to make the earlier
hand-off possible.

`Notify` stores one permit, so a signal that arrives while the mempool is being
checked is not lost.

## Tests

`verified_transaction_is_announced_without_the_queue_checker_rate_limit` runs
the whole path: it queues a transaction, answers the download and the verifier,
and requires the announcement on the change channel. The clock is paused, so
the rate limit can only contribute by advancing time, and the test requires the
announcement to arrive before the rate limit's worth of virtual time passes.

Signalling before queueing the result, plus a yield to make that ordering
deterministic, fails the test with a five second delay: the check finds nothing
and waits for the rate limit.

The first commit is a refactor, covered by the existing downloader and mempool
tests. One behaviour differs: an idle downloader's stream returns `Pending`
instead of `Ready(None)`, which its only caller treats the same, and which
means a queued result wakes whoever last polled the stream.

Measured on a Regtest node, where verification finishing and the queue check
are logged: verification finished at `13:00:47.915249` and the check ran at
`13:00:47.915624`, 375 microseconds later, 435 ms after the previous scheduled
check rather than waiting 4.56 s for the next one.

---
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.

AI disclosure: written with Claude Code.
