### PR TITLE
fix(sync): stop restarting the syncer on near-tip UTXO-lookup and post-checkpoint verify timeouts

### DIFF
--- a/.changes/unreleased/zebrad-Fixed-20260902-120000.yaml
+++ b/.changes/unreleased/zebrad-Fixed-20260902-120000.yaml
@@ -1,0 +1,4 @@
+project: zebrad
+kind: Fixed
+body: 'The syncer no longer restarts when a block''s transparent input lookup times out near the tip, or when the short post-checkpoint verify timeout fires. Both are transient UTXO races, and restarting cancelled the in-flight parent commit, causing a sync restart loop ([#11168](https://github.com/ZcashFoundation/zebra/issues/11168), [#11132](https://github.com/ZcashFoundation/zebra/issues/11132)).'
+time: 2026-09-02T12:00:00.000000000Z

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -79,6 +79,10 @@ const BLOCK_DOWNLOAD_RETRY_LIMIT: usize = 3;
 /// is a coarse, hash-scoped retry on top of an exhausted per-request retry.
 const MAX_BLOCK_REOBTAIN_RETRIES: u8 = 3;
 
+/// The fewest `TransparentInputNotFound` drops without a verified block before the sync
+/// restarts, so a low `full_verify_concurrency_limit` can't disable the #11168 exemption.
+const MIN_UTXO_RACE_DROPS_BEFORE_RESTART: usize = 4;
+
 /// A lower bound on the user-specified checkpoint verification concurrency limit.
 ///
 /// Set to the maximum checkpoint interval, so the pipeline holds around a checkpoint's
@@ -1261,8 +1265,10 @@ where
         //   still missing (GHSA-g95h-hw6g-pvgv). This re-request runs whether or not the peer could
         //   be attributed, and covers the window before a score reaches the address book, which
         //   only applies misbehavior reports in batches.
-        // Consensus failures (`Invalid`/`ValidationRequestError`) are deliberately excluded —
-        // re-downloading a block the network already rejected is pointless.
+        // - UTXO races (#11168): the block was never rejected, and the state parks its
+        //   children until it arrives, so re-request it instead of waiting for a tip walk.
+        // Other consensus failures (`Invalid`/`ValidationRequestError`) are deliberately
+        // excluded — re-downloading a block the network already rejected is pointless.
         let reobtain_hash = match &response {
             Err(BlockDownloadVerifyError::DownloadFailed { error, hash })
                 if format!("{error:?}").contains("NotFound") =>
@@ -1270,6 +1276,16 @@ where
                 Some(*hash)
             }
             Err(BlockDownloadVerifyError::BehindTipHeightLimit { hash, .. }) => Some(*hash),
+            Err(e @ BlockDownloadVerifyError::Invalid { hash, .. })
+                if Self::is_utxo_lookup_timeout(e) =>
+            {
+                Some(*hash)
+            }
+            Err(e @ BlockDownloadVerifyError::ValidationRequestError { hash, .. })
+                if Self::is_post_checkpoint_verify_timeout(e) =>
+            {
+                Some(*hash)
+            }
             _ => None,
         };
 
@@ -1297,7 +1313,11 @@ where
         if let Err(error) = &response {
             if Self::is_utxo_lookup_timeout(error) {
                 self.utxo_race_drops += 1;
-                if self.utxo_race_drops >= self.full_verify_concurrency_limit {
+                if self.utxo_race_drops
+                    >= self
+                        .full_verify_concurrency_limit
+                        .max(MIN_UTXO_RACE_DROPS_BEFORE_RESTART)
+                {
                     warn!(
                         drops = self.utxo_race_drops,
                         "no block verified across a full wave of UTXO lookup timeouts, restarting sync"
@@ -1321,6 +1341,16 @@ where
                 **source,
                 VerifyBlockError::Transaction(TransactionError::TransparentInputNotFound)
             )
+        )
+    }
+
+    /// Returns `true` for the short post-final-checkpoint verify timeout (#5125) that
+    /// `should_restart_sync` exempts; the 8-minute tower timeout is a different type.
+    fn is_post_checkpoint_verify_timeout(e: &BlockDownloadVerifyError) -> bool {
+        matches!(
+            e,
+            BlockDownloadVerifyError::ValidationRequestError { error, .. }
+                if error.is::<tokio::time::error::Elapsed>()
         )
     }
 
@@ -1394,7 +1424,7 @@ where
             // An `AwaitUtxo` timeout: the spent output is usually in a recent block whose
             // commit a restart would cancel, looping near the tip (#11168, #11132).
             e if Self::is_utxo_lookup_timeout(e) => {
-                debug!(error = ?e, "block spends an output that is not in our state yet, re-requesting on the next tip walk, continuing");
+                debug!(error = ?e, "block spends an output that is not in our state yet, re-requesting, continuing");
                 false
             }
 
@@ -1452,10 +1482,8 @@ where
 
             // The short post-final-checkpoint verify timeout is a UTXO race (#5125), not an
             // invalid block; the 8-minute tower timeout stays in the catch-all (#5709).
-            BlockDownloadVerifyError::ValidationRequestError { error, .. }
-                if error.is::<tokio::time::error::Elapsed>() =>
-            {
-                debug!(error = ?e, "initial fully verified block timed out waiting for its parent's outputs, continuing");
+            e if Self::is_post_checkpoint_verify_timeout(e) => {
+                debug!(error = ?e, "initial fully verified block timed out waiting for its parent's outputs, re-requesting, continuing");
                 false
             }
 

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -29,6 +29,7 @@ use zebra_chain::{
     block::{self, Height, HeightDiff},
     chain_tip::ChainTip,
 };
+use zebra_consensus::{error::TransactionError, RouterError, VerifyBlockError};
 use zebra_network::{self as zn, PeerSocketAddr};
 use zebra_state as zs;
 
@@ -1354,6 +1355,19 @@ where
                 debug!(error = ?e, "block was already verified or committed, possibly from a previous sync run, continuing");
                 false
             }
+            // An `AwaitUtxo` timeout: the spent output is usually in a recent block whose
+            // commit a restart would cancel, looping near the tip (#11168, #11132).
+            BlockDownloadVerifyError::Invalid {
+                error: RouterError::Block { source },
+                ..
+            } if matches!(
+                **source,
+                VerifyBlockError::Transaction(TransactionError::TransparentInputNotFound)
+            ) =>
+            {
+                debug!(error = ?e, "block spends an output that is not in our state yet, re-requesting on the next tip walk, continuing");
+                false
+            }
 
             // Structural matches: direct
             BlockDownloadVerifyError::CancelledDuringDownload { .. }
@@ -1404,6 +1418,15 @@ where
                 // TODO: improve this by checking the type (#2908)
                 //       restart after a certain number of NotFound errors?
                 debug!(error = ?e, "block was not found, possibly from a peer that doesn't have the block yet, continuing");
+                false
+            }
+
+            // The short post-final-checkpoint verify timeout is a UTXO race (#5125), not an
+            // invalid block; the 8-minute tower timeout stays in the catch-all (#5709).
+            BlockDownloadVerifyError::ValidationRequestError { error, .. }
+                if error.is::<tokio::time::error::Elapsed>() =>
+            {
+                debug!(error = ?e, "initial fully verified block timed out waiting for its parent's outputs, continuing");
                 false
             }
 

--- a/zebrad/src/components/sync.rs
+++ b/zebrad/src/components/sync.rs
@@ -424,6 +424,10 @@ where
     /// Per-hash count of how many times a `NotFound` block has been re-requested,
     /// bounded by [`MAX_BLOCK_REOBTAIN_RETRIES`].
     block_reobtain_retries: HashMap<block::Hash, u8>,
+
+    /// `TransparentInputNotFound` drops since the last verified block, bounded by the
+    /// full-verify concurrency limit so a poisoned hash batch can't suppress restarts.
+    utxo_race_drops: usize,
 }
 
 /// Polls the network to determine whether further blocks are available and
@@ -572,6 +576,7 @@ where
             misbehavior_sender,
             reobtain_hashes: IndexSet::new(),
             block_reobtain_retries: HashMap::new(),
+            utxo_race_drops: 0,
         };
 
         (new_syncer, sync_status)
@@ -623,6 +628,7 @@ where
 
         self.reobtain_hashes.clear();
         self.block_reobtain_retries.clear();
+        self.utxo_race_drops = 0;
 
         info!(
             state_tip = ?self.latest_chain_tip.best_tip_height(),
@@ -1201,6 +1207,7 @@ where
 
                 // The block arrived, so forget any re-request bookkeeping for it.
                 self.block_reobtain_retries.remove(&hash);
+                self.utxo_race_drops = 0;
 
                 return Ok(());
             }
@@ -1285,7 +1292,36 @@ where
             }
         }
 
+        // A UTXO race resolves as soon as the parent commits. A whole lookahead wave of
+        // timeouts with no commit isn't the race, so restart instead of draining the batch.
+        if let Err(error) = &response {
+            if Self::is_utxo_lookup_timeout(error) {
+                self.utxo_race_drops += 1;
+                if self.utxo_race_drops >= self.full_verify_concurrency_limit {
+                    warn!(
+                        drops = self.utxo_race_drops,
+                        "no block verified across a full wave of UTXO lookup timeouts, restarting sync"
+                    );
+                    return response.map(|_| ());
+                }
+            }
+        }
+
         Self::handle_response(response)
+    }
+
+    /// Returns `true` for the `AwaitUtxo` timeout that `should_restart_sync` exempts (#11168).
+    fn is_utxo_lookup_timeout(e: &BlockDownloadVerifyError) -> bool {
+        matches!(
+            e,
+            BlockDownloadVerifyError::Invalid {
+                error: RouterError::Block { source },
+                ..
+            } if matches!(
+                **source,
+                VerifyBlockError::Transaction(TransactionError::TransparentInputNotFound)
+            )
+        )
     }
 
     /// Handles a response to block hash submission, passing through any extra hashes.
@@ -1357,14 +1393,7 @@ where
             }
             // An `AwaitUtxo` timeout: the spent output is usually in a recent block whose
             // commit a restart would cancel, looping near the tip (#11168, #11132).
-            BlockDownloadVerifyError::Invalid {
-                error: RouterError::Block { source },
-                ..
-            } if matches!(
-                **source,
-                VerifyBlockError::Transaction(TransactionError::TransparentInputNotFound)
-            ) =>
-            {
+            e if Self::is_utxo_lookup_timeout(e) => {
                 debug!(error = ?e, "block spends an output that is not in our state yet, re-requesting on the next tip walk, continuing");
                 false
             }

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -610,7 +610,9 @@ where
 
                 // Add a shorter timeout to workaround a known bug (#5125)
                 let short_timeout_max = (max_checkpoint_height + FINAL_CHECKPOINT_BLOCK_VERIFY_TIMEOUT_LIMIT).expect("checkpoint block height is in valid range");
-                if block_height >= max_checkpoint_height && block_height <= short_timeout_max {
+                // Only fully verified blocks: the checkpoint verifier holds the final checkpoint
+                // block until its whole range arrives, which can legitimately take longer.
+                if block_height > max_checkpoint_height && block_height <= short_timeout_max {
                     // Keep the typed `Elapsed` so `should_restart_sync` can match it (#11168).
                     rsp = timeout(FINAL_CHECKPOINT_BLOCK_VERIFY_TIMEOUT, rsp)
                         .map_err(BoxError::from)

--- a/zebrad/src/components/sync/downloads.rs
+++ b/zebrad/src/components/sync/downloads.rs
@@ -611,8 +611,9 @@ where
                 // Add a shorter timeout to workaround a known bug (#5125)
                 let short_timeout_max = (max_checkpoint_height + FINAL_CHECKPOINT_BLOCK_VERIFY_TIMEOUT_LIMIT).expect("checkpoint block height is in valid range");
                 if block_height >= max_checkpoint_height && block_height <= short_timeout_max {
+                    // Keep the typed `Elapsed` so `should_restart_sync` can match it (#11168).
                     rsp = timeout(FINAL_CHECKPOINT_BLOCK_VERIFY_TIMEOUT, rsp)
-                        .map_err(|timeout| format!("initial fully verified block timed out: retrying: {timeout:?}").into())
+                        .map_err(BoxError::from)
                         .map(|nested_result| nested_result.and_then(convert::identity)).boxed();
                 }
 

--- a/zebrad/src/components/sync/tests/vectors.rs
+++ b/zebrad/src/components/sync/tests/vectors.rs
@@ -13,7 +13,9 @@ use zebra_chain::{
     parameters::subsidy::SubsidyError,
     serialization::ZcashDeserializeInto,
 };
-use zebra_consensus::{Config as ConsensusConfig, RouterError, VerifyBlockError};
+use zebra_consensus::{
+    error::TransactionError, Config as ConsensusConfig, RouterError, VerifyBlockError,
+};
 use zebra_network::{InventoryResponse, PeerSocketAddr};
 use zebra_state::Config as StateConfig;
 use zebra_test::mock_service::{MockService, PanicAssertion};
@@ -1396,6 +1398,68 @@ async fn invalid_height_does_not_restart_sync() {
     assert!(
         has_addr,
         "InvalidHeight should carry advertiser_addr for peer scoring"
+    );
+}
+
+/// A concrete `ChainSync` type for calling associated functions in tests.
+type TestChainSync = ChainSync<
+    MockService<zn::Request, zn::Response, PanicAssertion>,
+    MockService<zs::Request, zs::Response, PanicAssertion>,
+    MockService<zs::ReadRequest, zs::ReadResponse, PanicAssertion>,
+    MockService<zebra_consensus::Request, block::Hash, PanicAssertion>,
+    MockChainTip,
+>;
+
+/// Verifies fix for #11168 and #11132: a `TransparentInputNotFound` from an `AwaitUtxo`
+/// timeout does not trigger a sync restart, but other transaction errors still do.
+#[tokio::test]
+async fn transparent_input_not_found_does_not_restart_sync() {
+    let make_invalid = |tx_error| BlockDownloadVerifyError::Invalid {
+        error: RouterError::Block {
+            source: Box::new(VerifyBlockError::Transaction(tx_error)),
+        },
+        height: block::Height(3_427_629),
+        hash: block::Hash::from([0xCC; 32]),
+        advertiser_addr: None,
+    };
+
+    assert!(
+        !TestChainSync::should_restart_sync(&make_invalid(
+            TransactionError::TransparentInputNotFound
+        )),
+        "a transparent input UTXO lookup timeout should NOT trigger sync restart (#11168)"
+    );
+
+    assert!(
+        TestChainSync::should_restart_sync(&make_invalid(TransactionError::CoinbasePosition)),
+        "other transaction errors should still trigger sync restart"
+    );
+}
+
+/// Verifies fix for #11168: the short post-final-checkpoint verify timeout (#5125) does
+/// not trigger a sync restart, but the tower-level `BLOCK_VERIFY_TIMEOUT` still does (#5709).
+#[tokio::test]
+async fn verify_timeout_elapsed_does_not_restart_sync() {
+    let tokio_elapsed = tokio::time::timeout(Duration::ZERO, std::future::pending::<()>())
+        .await
+        .expect_err("timeout on a pending future always elapses");
+
+    let make_error = |error: crate::BoxError| BlockDownloadVerifyError::ValidationRequestError {
+        error,
+        height: block::Height(3_428_007),
+        hash: block::Hash::from([0xCD; 32]),
+    };
+
+    assert!(
+        !TestChainSync::should_restart_sync(&make_error(tokio_elapsed.into())),
+        "the post-final-checkpoint verify timeout should NOT trigger sync restart (#11168)"
+    );
+
+    assert!(
+        TestChainSync::should_restart_sync(&make_error(
+            tower::timeout::error::Elapsed::new().into()
+        )),
+        "the tower block verify timeout should still trigger sync restart (#5709)"
     );
 }
 

--- a/zebrad/src/components/sync/tests/vectors.rs
+++ b/zebrad/src/components/sync/tests/vectors.rs
@@ -1442,7 +1442,9 @@ async fn transparent_input_not_found_does_not_restart_sync() {
 #[tokio::test]
 async fn utxo_lookup_timeouts_without_a_commit_restart_sync() {
     let (mut chain_sync, _misbehavior_rx) = new_chain_sync_with_misbehavior();
-    let limit = chain_sync.full_verify_concurrency_limit;
+    let limit = chain_sync
+        .full_verify_concurrency_limit
+        .max(sync::MIN_UTXO_RACE_DROPS_BEFORE_RESTART);
 
     let utxo_timeout = |i: u8| {
         Err(BlockDownloadVerifyError::Invalid {
@@ -1463,6 +1465,12 @@ async fn utxo_lookup_timeouts_without_a_commit_restart_sync() {
                 .handle_block_response(utxo_timeout(i as u8))
                 .is_ok(),
             "UTXO lookup timeouts below the lookahead limit should not restart sync (#11168)"
+        );
+        assert!(
+            chain_sync
+                .reobtain_hashes
+                .contains(&block::Hash::from([i as u8; 32])),
+            "a dropped UTXO-race block must be re-requested, not left for a tip walk"
         );
     }
 
@@ -1512,6 +1520,20 @@ async fn verify_timeout_elapsed_does_not_restart_sync() {
             tower::timeout::error::Elapsed::new().into()
         )),
         "the tower block verify timeout should still trigger sync restart (#5709)"
+    );
+
+    let (mut chain_sync, _misbehavior_rx) = new_chain_sync_with_misbehavior();
+    let tokio_elapsed = tokio::time::timeout(Duration::ZERO, std::future::pending::<()>())
+        .await
+        .expect_err("timeout on a pending future always elapses");
+    assert!(chain_sync
+        .handle_block_response(Err(make_error(tokio_elapsed.into())))
+        .is_ok());
+    assert!(
+        chain_sync
+            .reobtain_hashes
+            .contains(&block::Hash::from([0xCD; 32])),
+        "a block dropped on the post-checkpoint verify timeout must be re-requested"
     );
 }
 

--- a/zebrad/src/components/sync/tests/vectors.rs
+++ b/zebrad/src/components/sync/tests/vectors.rs
@@ -1436,6 +1436,58 @@ async fn transparent_input_not_found_does_not_restart_sync() {
     );
 }
 
+/// A poisoned `FindBlocks` batch can make every block in a lookahead wave time out on its
+/// UTXO lookup with nothing committing in between. The #11168 exemption is bounded so that
+/// case still restarts the sync, while a single near-tip race followed by a commit does not.
+#[tokio::test]
+async fn utxo_lookup_timeouts_without_a_commit_restart_sync() {
+    let (mut chain_sync, _misbehavior_rx) = new_chain_sync_with_misbehavior();
+    let limit = chain_sync.full_verify_concurrency_limit;
+
+    let utxo_timeout = |i: u8| {
+        Err(BlockDownloadVerifyError::Invalid {
+            error: RouterError::Block {
+                source: Box::new(VerifyBlockError::Transaction(
+                    TransactionError::TransparentInputNotFound,
+                )),
+            },
+            height: block::Height(3_427_629 + u32::from(i)),
+            hash: block::Hash::from([i; 32]),
+            advertiser_addr: None,
+        })
+    };
+
+    for i in 0..(limit - 1) {
+        assert!(
+            chain_sync
+                .handle_block_response(utxo_timeout(i as u8))
+                .is_ok(),
+            "UTXO lookup timeouts below the lookahead limit should not restart sync (#11168)"
+        );
+    }
+
+    // A verified block means the race resolved, so the count starts over.
+    assert!(chain_sync
+        .handle_block_response(Ok((
+            block::Height(3_427_628),
+            block::Hash::from([0xAA; 32])
+        )))
+        .is_ok());
+    assert!(chain_sync.handle_block_response(utxo_timeout(0)).is_ok());
+
+    for i in 1..(limit - 1) {
+        assert!(chain_sync
+            .handle_block_response(utxo_timeout(i as u8))
+            .is_ok());
+    }
+    assert!(
+        chain_sync
+            .handle_block_response(utxo_timeout(0xFF))
+            .is_err(),
+        "a full lookahead wave of UTXO lookup timeouts with no verified block should restart sync"
+    );
+}
+
 /// Verifies fix for #11168: the short post-final-checkpoint verify timeout (#5125) does
 /// not trigger a sync restart, but the tower-level `BLOCK_VERIFY_TIMEOUT` still does (#5709).
 #[tokio::test]


### PR DESCRIPTION
## Motivation

Near the tip, a block often spends an output from a parent whose commit is still in flight. The resulting timeouts hit `should_restart_sync()`'s catch-all, which restarts the sync — cancelling the very parent commit being awaited, so the race recurs and the node loops just below the tip. This is why all the cached-state lightwalletd GCP jobs have failed since NU6.3.

Fixes #11168
Closes #11132

## Solution

- Add a `should_restart_sync()` arm for `TransparentInputNotFound` (the `AwaitUtxo` timeout, classified by #10810): drop the block and let the next tip walk re-request it. Matching by type also stops its debug string reaching the catch-all's `NotFound` substring check, removing the spurious "downcast programming error" log (#11132).
- Keep the post-final-checkpoint verify timeout (#5125 workaround) as a typed `Elapsed` instead of stringifying it, and drop those blocks too. The 8-minute tower `BLOCK_VERIFY_TIMEOUT` is a different `Elapsed` type and still restarts, preserving the #5709 wedge recovery.

This only changes scheduling: a failed block is never committed either way, and blocks queued behind a genuinely invalid one still trigger the 8-minute restart backstop.

## Tests

Unit tests assert both new arms return `false` while a different transaction error and the tower timeout still restart. The full loop only reproduces in the stateful GCP jobs — a manual dispatch of the lightwalletd suite on this branch can confirm.
