### PR TITLE
fix(zebra-consensus): Only reset verifier progress on state commit failure

### DIFF
--- a/zebra-consensus/src/checkpoint.rs
+++ b/zebra-consensus/src/checkpoint.rs
@@ -1154,10 +1154,27 @@ where
             } else {
                 result.expect("commit_checkpoint_verified should not panic")
             };
-            if result.is_err() {
-                // If there was an error committing the block, then this verifier
-                // will be out of sync with the state. In that case, reset
-                // its progress back to the state tip.
+            // Only reset the verifier's progress when a block that the verifier
+            // accepted failed to commit to the state. Then the verifier's
+            // progress can be ahead of the state's committed blocks, so it must
+            // be re-aligned to the state tip.
+            //
+            // Other errors are rejections of this specific block (side-chain
+            // fork candidates, duplicates, or invalid block data). They don't
+            // change the committed chain, so the verifier's progress stays in
+            // sync with the state, and resetting would be harmful:
+            //
+            // # Correctness
+            //
+            // Verified checkpoint ranges commit to the state in height order,
+            // so the state tip can temporarily lag the verifier's progress
+            // while a range is still committing. Resetting to that lagging tip
+            // on unrelated errors rewinds the verifier below the last verified
+            // checkpoint. The blocks in between have already been consumed
+            // from the verifier's queue, so verification would stall until
+            // they are submitted again. The syncer re-downloads them, but
+            // other submitters (like the zcashd state migration) don't.
+            if let Err(VerifyCheckpointError::CommitCheckpointVerified(_)) = result {
                 let tip = match state_service
                     .oneshot(zs::Request::Tip)
                     .await


### PR DESCRIPTION
## Motivation

In this error case, the verifier's progress can be ahead of the state's committed blocks, so it must be re-aligned to the state tip.

Other errors are rejections of this specific block (side-chain fork candidates, duplicates, or invalid block data). They don't change the committed chain, so the verifier's progress stays in sync with the state, and resetting would be harmful:

Verified checkpoint ranges commit to the state in height order, so the state tip can temporarily lag the verifier's progress while a range is still committing. Resetting to that lagging tip on unrelated errors rewinds the verifier below the last verified checkpoint. The blocks in between have already been consumed from the verifier's queue, so verification would stall until they are submitted again. The syncer re-downloads them, but other submitters (like the zcashd state migration) don't.

## Solution

Only reset verifier progress on `VerifyCheckpointError::CommitCheckpointVerified(_)`.

### Tests

Tested this by using `BlockVerifierRouter` to migrate `zcashd` blocks to `zebrad` (otherwise it would complicate the rescanning process). I have also run zebrad briefly afterwards and it was able to sync for a while; it has stopped now but not clear whether that is related to this change, or an unrelated zebra problem.

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
-->

### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Either Codex Sol or GLM 5.3 figured out the bug while diagnosing issues with the `migrate-from-zcashd` command.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [ ] The solution is tested.
- [ ] The documentation and changelogs are up to date.
