### PR TITLE
docs(security): scope advisories and CVEs to tagged releases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,10 @@ SECURITY.md's "Before You Report" section:
   exact release version or `main` commit hash tested in the report.
 - Do not submit speculative findings. "This code looks vulnerable" without a
   reproduction against current code wastes triage time and may be dismissed.
+- A finding that exists only in unreleased code (`main` or an unmerged PR) will
+  not get a security advisory or CVE, but it is still worth reporting and the
+  reporter is credited in the issue, the fixing PR, and the release notes. See
+  SECURITY.md, "Advisories, CVEs, and Credit".
 
 ## AI Disclosure
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,6 +36,11 @@ substantially longer to triage.
 In your report, state the exact release version or `main` commit hash you
 tested against.
 
+Reports against `main` are welcome and part of how we catch issues before they
+ship. Note that findings which exist only in unreleased code are handled
+differently from findings in a shipped release; see "Advisories, CVEs, and
+Credit" below.
+
 For critical vulnerabilities, notify us on Signal. Create a new Signal group
 (do not reuse a previous group for a separate issue) that includes all of the
 following handles:
@@ -77,6 +82,29 @@ jlOOQUwFoIKfgAk=
 =K4Oq
 -----END PGP PUBLIC KEY BLOCK-----
 ```
+
+### Advisories, CVEs, and Credit
+
+We publish a GitHub Security Advisory (GHSA), and request a CVE where
+appropriate, for vulnerabilities that affect a tagged Zebra release, including
+release candidates and other pre-release tags. Advisories exist to tell
+operators whether they are exposed and which version fixes the issue, so they
+are scoped to code that has actually been shipped.
+
+Vulnerabilities that exist only in unreleased code (the `main` branch or an
+unmerged pull request) and are fixed before appearing in any tagged release do
+not receive an advisory or CVE. This matches the practice of the CVE program
+and of most major open source projects, and avoids generating alerts for
+downstream users who were never affected. Such findings are fixed as ordinary
+public issues once a fix is ready, and we credit the reporter in the issue, the
+fixing pull request, and the release notes of the next release, unless they ask
+not to be named.
+
+If an unreleased vulnerability is later found to have shipped in a tagged
+release before the fix landed, we will publish an advisory for it at that
+point.
+
+We do not currently operate a bug bounty program and do not pay for reports.
 
 ## Sending Disclosures
 


### PR DESCRIPTION
## Motivation

`SECURITY.md` says nothing about when we publish a GitHub Security Advisory or request a CVE, while "Before You Report" names `main` as an in-scope reporting target. That combination lets a reporter argue that a bug which only ever existed in unreleased code is advisory-worthy. Advisories exist to tell operators whether they are exposed and which version fixes the issue, so they belong to code that actually shipped.

## Solution

Keep `main` in scope for reporting — we want to hear about these before they ship — and state the advisory handling separately.

A new "Advisories, CVEs, and Credit" subsection says we publish a GHSA, and request a CVE where appropriate, for vulnerabilities affecting a tagged release (including release candidates); findings that exist only in unreleased code and are fixed before shipping get no advisory or CVE, but are fixed as ordinary public issues with the reporter credited in the issue, the fixing PR, and the release notes. If such a finding turns out to have shipped after all, we publish an advisory at that point. It also states that we do not operate a bug bounty program.

`AGENTS.md` gets a matching bullet so agents helping a user file a report set the same expectation.

### Tests

Documentation only, no code changes. `markdownlint` passes via the pre-commit hook.

### Specifications & References

Matches the CVE program's practice of assigning identifiers to released software, and the handling used by most major open source projects.

### AI Disclosure

- [x] AI tools were used: Claude for drafting the policy text; wording and policy decisions are mine.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
