### PR TITLE
fix(chain): restore the fallible Sprout aggregate value-balance check dropped by the zcash_primitives refactor

### DIFF
--- a/book/src/dev/consensus-refactors.md
+++ b/book/src/dev/consensus-refactors.md
@@ -30,7 +30,10 @@ refactor does not repeat that.
 - **Audit fallible conversions that feed consensus checks.** Any `.ok()`, `unwrap_or`, or
   defaulted `try_from` between the wire format and a value a check reads can turn an invalid
   wire value into one the check treats as benign. A check that skips `None` is only correct
-  if `None` can never mean "an invalid value was collapsed".
+  if `None` can never mean "an invalid value was collapsed". A shared default is the same
+  trap: `unwrap_or(default)` conflates "absent" with "failed". Audit look-alike accessors
+  individually — the second instance of this class (#11386) differed from its three correct
+  siblings by a single `and_then`.
 - **Pick test boundaries from the types, not only the spec.** Cover the maximum wire value,
   the first value each conversion cannot represent, and the largest honest value — not just
   the values the specification names.

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,5 @@
 type-complexity-threshold = 999999
+
+disallowed-methods = [
+    { path = "zcash_primitives::transaction::components::sprout::Bundle::value_balance", reason = "collapses an out-of-range aggregate to None, which callers conflate with 'no bundle'; use Transaction::sprout_value_balance" },
+]

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -677,16 +677,26 @@ impl Transaction {
     }
 
     /// Return the sprout value balance.
-    pub fn sprout_value_balance(&self) -> ValueBalance<NegativeAllowed> {
-        let balance = self
-            .sprout_bundle()
-            .and_then(|b| b.value_balance())
-            .unwrap_or(ZatBalance::zero());
+    ///
+    /// Errors when the aggregate JoinSplit value balance (or any prefix of it, matching the
+    /// pre-refactor fold) leaves the valid monetary range. Aggregated here because
+    /// `zcash_primitives` collapses that case to `None`, conflating it with "no Sprout
+    /// bundle". The net-sum bound matches zcashd from Canopy onward, where `vpub_old` is
+    /// always zero; pre-Canopy heights are checkpointed.
+    pub fn sprout_value_balance(
+        &self,
+    ) -> Result<ValueBalance<NegativeAllowed>, crate::value_balance::ValueBalanceError> {
+        let total = self
+            .sprout_joinsplit_descriptions()
+            .try_fold(Amount::<NegativeAllowed>::zero(), |total, js| {
+                // Not `js.net_value()`: its `expect` trusts upstream parse bounds. The
+                // subtraction can't overflow `i64`, each `vpub` is at most `MAX_MONEY`.
+                let net = Amount::try_from(i64::from(js.vpub_new()) - i64::from(js.vpub_old()))?;
+                total + net
+            })
+            .map_err(crate::value_balance::ValueBalanceError::Sprout)?;
 
-        let amount: Amount<NegativeAllowed> = Amount::try_from(i64::from(balance))
-            .expect("sprout value balance should be a valid Amount");
-
-        ValueBalance::from_sprout_amount(amount)
+        Ok(ValueBalance::from_sprout_amount(total))
     }
 
     /// Get the overall value balance for this transaction.
@@ -707,7 +717,7 @@ impl Transaction {
             .collect();
 
         let transparent = self.transparent_value_balance_from_outputs(&outputs)?;
-        let sprout = self.sprout_value_balance();
+        let sprout = self.sprout_value_balance()?;
         let sapling = self.sapling_value_balance();
         let orchard = self.orchard_value_balance();
         let ironwood = self.ironwood_value_balance();

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -9,13 +9,16 @@ use rand::{seq::IteratorRandom, thread_rng};
 use std::sync::Arc;
 
 use crate::{
+    amount::MAX_MONEY,
     block::{Block, Height, MAX_BLOCK_BYTES},
     orchard,
     parameters::Network,
-    primitives::zcash_primitives::PrecomputedTxData,
+    primitives::{x25519, zcash_primitives::PrecomputedTxData, Groth16Proof},
     serialization::{SerializationError, ZcashDeserialize, ZcashDeserializeInto, ZcashSerialize},
+    sprout,
     transaction::sighash::SigHasher,
     transparent::Script,
+    value_balance::ValueBalanceError,
 };
 
 use zebra_test::{
@@ -1629,4 +1632,65 @@ fn expiry_height_preserves_out_of_range_values() {
             .expect("parsing does not enforce the expiry maximum, the verifier does");
         assert_eq!(parsed.expiry_height(), expected);
     }
+}
+
+/// A transaction whose aggregate Sprout JoinSplit value balance is outside the valid
+/// monetary range must report a value-balance error, not a zero Sprout balance.
+/// Each `vpub_new` is individually valid; only the aggregate is out of range.
+#[test]
+fn sprout_aggregate_value_balance_out_of_range_is_rejected() {
+    let _init_guard = zebra_test::init();
+
+    let zero = Amount::zero();
+    let max_money = Amount::try_from(MAX_MONEY).expect("MAX_MONEY is a valid nonnegative amount");
+    let mac = sprout::note::Mac::from([0u8; 32]);
+
+    // A dummy JoinSplit moving MAX_MONEY into the transparent pool: individually in range.
+    let joinsplit = sprout::JoinSplit {
+        vpub_old: zero,
+        vpub_new: max_money,
+        anchor: sprout::tree::Root::default(),
+        nullifiers: [
+            sprout::note::Nullifier([0u8; 32].into()),
+            sprout::note::Nullifier([1u8; 32].into()),
+        ],
+        commitments: [sprout::commitment::NoteCommitment::from([0u8; 32]); 2],
+        ephemeral_key: x25519::PublicKey::from([0u8; 32]),
+        random_seed: sprout::RandomSeed::from([0u8; 32]),
+        vmacs: [mac.clone(), mac],
+        zkproof: Groth16Proof([0u8; 192]),
+        enc_ciphertexts: [sprout::note::EncryptedNote([0u8; 601]); 2],
+    };
+
+    // One JoinSplit: the aggregate is exactly MAX_MONEY, still in range.
+    let in_range = Transaction::test_v4_with_joinsplit_data(Some(&JoinSplitData {
+        first: joinsplit.clone(),
+        rest: vec![],
+        pub_key: [0u8; 32].into(),
+        sig: [0u8; 64].into(),
+    }));
+    in_range
+        .sprout_value_balance()
+        .expect("an aggregate of MAX_MONEY is in range");
+
+    // Two JoinSplits: the aggregate is 2 * MAX_MONEY, out of range.
+    let out_of_range = Transaction::test_v4_with_joinsplit_data(Some(&JoinSplitData {
+        first: joinsplit.clone(),
+        rest: vec![joinsplit],
+        pub_key: [0u8; 32].into(),
+        sig: [0u8; 64].into(),
+    }));
+    assert!(
+        matches!(
+            out_of_range.sprout_value_balance(),
+            Err(ValueBalanceError::Sprout(_))
+        ),
+        "an out-of-range Sprout aggregate must error, not zero"
+    );
+    assert!(
+        out_of_range
+            .value_balance(&std::collections::HashMap::new())
+            .is_err(),
+        "the transaction value balance must propagate the error"
+    );
 }

--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -255,7 +255,7 @@ impl ValueBalance<NonNegative> {
         // transaction value balances (inputs - outputs)
         let tx = transaction.borrow();
         let transparent = tx.transparent_value_balance_from_outputs(utxos)?;
-        let sprout = tx.sprout_value_balance();
+        let sprout = tx.sprout_value_balance()?;
         let sapling = tx.sapling_value_balance();
         let orchard = tx.orchard_value_balance();
         let ironwood = tx.ironwood_value_balance();


### PR DESCRIPTION
The `zcash_primitives` refactor (#10461) turned `sprout_value_balance()` into an infallible accessor whose `unwrap_or(zero)` conflates "no Sprout bundle" with "aggregate JoinSplit balance out of range", so an invalid aggregate was reported as moving no Sprout value. This restores the fallible checked aggregation (the v6.3.0 shape, redone Zebra-side so the two cases can never share a representation) and propagates the error through `value_balance()`.

No released version is affected, and per the issue's analysis this is not exploitable on any network — it restores a lost invariant and `zcashd` parity.

Fixes #11386. Reported by the Zakura security team.

## Commits

1. `fix(chain)`: the checked aggregation, plus an `Added` changelog fragment — the method was private in v6.3.0, so relative to the last release this is new public API, and per the #10461 precedent there is no `Fixed` entry for a never-released bug.
2. `test(chain)`: one `MAX_MONEY` JoinSplit is accepted, two are rejected with `ValueBalanceError::Sprout`, and the error propagates through `value_balance()`. The signature change means unfixed code does not compile against this test.
3. `docs(book)`: extends the consensus-refactor checklist with the `unwrap_or(default)` absence-vs-failure trap this defect exemplifies.

## Remaining accessor audit from the issue

- `network_upgrade()`: fails closed — a V5+ transaction can carry branch ID 0 (parses upstream as Sprout), but the only consensus consumer returns `MissingConsensusBranchId` for `None`, and sighash construction errors on mismatch.
- `lock_time()`: total conversion (every `u32` is a valid `LockTime`); the `None` cases are protocol semantics identical to the pre-refactor accessor.
- `version_group_id()`: derived from the version table, not a stored wire field; upstream parse rejects a mismatched wire value.
- `auth_digest()`: always a 32-byte digest; the conversion cannot fail; `None` only for pre-V5.
- `orchard_flags()` / `ironwood_flags()`: direct copies of upstream-validated flag bytes; `None` means only "no bundle".

No further instances of the class.

Stacked on #11387 (shares the book page); will be retargeted to `main` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ru9voWr8B6XbyqDy3LvTEA
