### PR TITLE
feat(zebra-state): Add standard metrics for chain tip state of value pools

### DIFF
--- a/.changes/unreleased/zebra-state-Added-20260909-104812.yaml
+++ b/.changes/unreleased/zebra-state-Added-20260909-104812.yaml
@@ -1,0 +1,4 @@
+project: zebra-state
+kind: Added
+body: '`NonFinalizedState` now reports `zcash.pool.value.zatoshis` and `zcash.pool.notes.created` gauges, labeled by pool `name`, for the best chain tip rather than the finalized state ([#11391](https://github.com/ZcashFoundation/zebra/pull/11391)).'
+time: 2026-09-09T10:48:12.557765+02:00

--- a/.changes/unreleased/zebra-state-Added-20260909-104812.yaml
+++ b/.changes/unreleased/zebra-state-Added-20260909-104812.yaml
@@ -1,4 +1,3 @@
 project: zebra-state
 kind: Added
 body: '`NonFinalizedState` now reports `zcash.pool.value.zatoshis` and `zcash.pool.notes.created` gauges, labeled by pool `name`, for the best chain tip rather than the finalized state ([#11391](https://github.com/ZcashFoundation/zebra/pull/11391)).'
-time: 2026-09-09T10:48:12.557765+02:00

--- a/.changes/unreleased/zebrad-Added-20260909-104746.yaml
+++ b/.changes/unreleased/zebrad-Added-20260909-104746.yaml
@@ -1,0 +1,4 @@
+project: zebrad
+kind: Added
+body: Add metrics `zcash.pool.value.zatoshis` (labeled by pool name) and `zcash.pool.notes.created` (labeled by pool name) reporting value pool balances in zatoshis and note commitment counts at the non-finalized chain tip ([#11391](https://github.com/ZcashFoundation/zebra/pull/11391))
+time: 2026-09-09T10:47:46.863504+02:00

--- a/.changes/unreleased/zebrad-Added-20260909-104746.yaml
+++ b/.changes/unreleased/zebrad-Added-20260909-104746.yaml
@@ -1,4 +1,3 @@
 project: zebrad
 kind: Added
 body: Add metrics `zcash.pool.value.zatoshis` (labeled by pool name) and `zcash.pool.notes.created` (labeled by pool name) reporting value pool balances in zatoshis and note commitment counts at the non-finalized chain tip ([#11391](https://github.com/ZcashFoundation/zebra/pull/11391))
-time: 2026-09-09T10:47:46.863504+02:00

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -935,6 +935,8 @@ impl NonFinalizedState {
                 .set(u64::from(value_pools.sapling_amount()) as f64);
             metrics::gauge!("zcash.pool.value.zatoshis", "name" => "orchard")
                 .set(u64::from(value_pools.orchard_amount()) as f64);
+            metrics::gauge!("zcash.pool.value.zatoshis", "name" => "ironwood")
+                .set(u64::from(value_pools.ironwood_amount()) as f64);
 
             metrics::gauge!("zcash.pool.notes.created", "name" => "sprout")
                 .set(best_chain.sprout_note_commitment_tree_for_tip().count() as f64);
@@ -942,6 +944,8 @@ impl NonFinalizedState {
                 .set(best_chain.sapling_note_commitment_tree_for_tip().count() as f64);
             metrics::gauge!("zcash.pool.notes.created", "name" => "orchard")
                 .set(best_chain.orchard_note_commitment_tree_for_tip().count() as f64);
+            metrics::gauge!("zcash.pool.notes.created", "name" => "ironwood")
+                .set(best_chain.ironwood_note_commitment_tree_for_tip().count() as f64);
         }
     }
 

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -924,6 +924,25 @@ impl NonFinalizedState {
         metrics::gauge!("state.memory.chain.count").set(self.chain_set.len() as f64);
         metrics::gauge!("state.memory.best.chain.length",)
             .set(self.best_chain_len().unwrap_or_default() as f64);
+
+        if let Some(best_chain) = self.best_chain() {
+            let value_pools = best_chain.chain_value_pools;
+            metrics::gauge!("zcash.pool.value.zatoshis", "name" => "transparent")
+                .set(u64::from(value_pools.transparent_amount()) as f64);
+            metrics::gauge!("zcash.pool.value.zatoshis", "name" => "sprout")
+                .set(u64::from(value_pools.sprout_amount()) as f64);
+            metrics::gauge!("zcash.pool.value.zatoshis", "name" => "sapling")
+                .set(u64::from(value_pools.sapling_amount()) as f64);
+            metrics::gauge!("zcash.pool.value.zatoshis", "name" => "orchard")
+                .set(u64::from(value_pools.orchard_amount()) as f64);
+
+            metrics::gauge!("zcash.pool.notes.created", "name" => "sprout")
+                .set(best_chain.sprout_note_commitment_tree_for_tip().count() as f64);
+            metrics::gauge!("zcash.pool.notes.created", "name" => "sapling")
+                .set(best_chain.sapling_note_commitment_tree_for_tip().count() as f64);
+            metrics::gauge!("zcash.pool.notes.created", "name" => "orchard")
+                .set(best_chain.orchard_note_commitment_tree_for_tip().count() as f64);
+        }
     }
 
     /// Update the progress bars after any chain is modified.


### PR DESCRIPTION
## Motivation

`zcashd` tracked these metrics since its 4.4.0 release in April 2021. They are thus standard Zcash metrics names (like the `zcash.mempool` metrics that Zebra already tracks).

I also added Ironwood to the list, given that it was created after `zcashd` EoL.

Related to #8820 (the PR currently referenced therein only added metrics tracking the finalized state AFAICT, not the current chain tip).

## Solution

Produce metrics tracking the size of the various value pools at the current chain tip (not the finalized state, which lags).

### Tests

Ran this with my local Zebra against my local Grafana dashboard, and confirmed the amounts looked right.

### Specifications & References

https://github.com/zcash/zcash/pull/4947

### Follow-up Work

`zcashd` never exposed the dev fund lockbox via these metrics, but it did do so via JSON-RPC with the label `lockbox`. If desired, I can include that as well here (see also 

### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [ ] No AI tools were used in this PR
- [x] AI tools were used: GPT 5.6 Sol to find the right place in Zebra to add the gauges that would correspond to the current chain tip.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand.
- [ ] The solution is tested.
- [ ] The documentation and changelogs are up to date.
