### PR TITLE
fix(ci): write the renamed ci-fail/release label from the prebuilt-nodes deploy workflow

### DIFF
--- a/.github/workflows/zfnd-deploy-prebuilt-nodes-gcp.yml
+++ b/.github/workflows/zfnd-deploy-prebuilt-nodes-gcp.yml
@@ -536,6 +536,6 @@ jobs:
       - uses: jayqi/failed-build-issue-action@1a893bbf43ef1c2a8705e2b115cd4f0fe3c5649b #v1.2.0
         with:
           title-template: "{{refname}} branch CI failed: {{eventName}} in {{workflow}}"
-          label-name: S-ci-fail-release-auto-issue
+          label-name: ci-fail/release
           always-create-new-issue: false
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The prebuilt-nodes deploy workflow still opened failure issues under `S-ci-fail-release-auto-issue`, the only writer left after #11323 and #11350 renamed the CI-written labels. Switch it to `ci-fail/release`, the same key the regular node-deploy workflow uses, so both deploy paths share one dedup issue and the old label can be deleted.

Workflow-only change, no changelog fragment.
