### PR TITLE
test(zebra-consensus): assert the Orchard proof failure, not a UTXO timeout

### DIFF
--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -4598,7 +4598,7 @@ async fn block_with_garbage_orchard_proofs_is_rejected() {
         .activation_height(&Network::Mainnet)
         .expect("Nu6 activation height is specified");
     let fund_height = (height - 1).expect("too small");
-    let (input, output, _known_utxos) = mock_transparent_transfer(
+    let (input, output, known_utxos) = mock_transparent_transfer(
         fund_height,
         true,
         0,
@@ -4620,19 +4620,31 @@ async fn block_with_garbage_orchard_proofs_is_rejected() {
     let garbage_tx = with_garbage_orchard_authorization(tx.clone());
     assert_eq!(tx.hash(), garbage_tx.hash());
 
-    // submit garbage version as block tx, must be rejected
+    // Submit the garbage version as a block tx, which must be rejected.
+    //
+    // The funding UTXO has to be in `known_utxos`: the mock state never answers a lookup, so
+    // without it the request fails on `UTXO_LOOKUP_TIMEOUT` six minutes later and never reaches
+    // proof verification, which would make this test pass without checking any proof.
     let resp = verifier
         .clone()
         .oneshot(BlockRequest {
             transaction_hash: tx_hash,
             transaction: Arc::new(garbage_tx),
-            known_utxos: Arc::new(HashMap::new()),
+            known_utxos: Arc::new(known_utxos),
             height,
             time: Utc::now(),
         })
         .await;
 
-    assert!(resp.is_err(), "garbage proof must be rejected");
+    // Buffer boxes the service error, so downcast to check the specific variant.
+    let err = resp.expect_err("garbage proof must be rejected");
+    let tx_err = err
+        .downcast::<TransactionError>()
+        .expect("error should downcast to TransactionError");
+    assert!(
+        matches!(*tx_err, TransactionError::Halo2VerificationFailed),
+        "expected Halo2VerificationFailed for garbage Orchard proofs; got: {tx_err:?}"
+    );
 }
 
 /// Regression test for the mempool-cache expiry bypass vulnerability.


### PR DESCRIPTION
## Motivation

Closes #11396.

## Solution

Pass the funding UTXO from `mock_transparent_transfer` into the block request, and
assert the specific `TransactionError::Halo2VerificationFailed` variant instead of any
error.

### Tests

`block_with_garbage_orchard_proofs_is_rejected` sent an empty `known_utxos` for a
transaction with a transparent input, so the mock state's unanswered UTXO lookup failed
on `UTXO_LOOKUP_TIMEOUT` and satisfied `assert!(resp.is_err())` six minutes later,
without ever verifying a proof: the test passed whether or not Orchard proofs were
checked, which is the property CVE-2026-34377 is about. It now reaches proof
verification and pins the error variant, so removing or weakening Halo2 verification
fails it. It also drops from 360s to 0.7s — it was the slowest test in the CI profile.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude, to diagnose the timeout and write the fix.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
