### PR TITLE
fix(consensus): restore the null-prevout check for non-coinbase transaction inputs

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -226,9 +226,25 @@ impl Transaction {
         self.transparent_bundle().is_some_and(|b| b.is_coinbase())
     }
 
-    /// Returns `true` if this is a valid non-coinbase transaction.
+    /// Returns `true` if this transaction has valid inputs for a non-coinbase
+    /// transaction, that is, none of its transparent inputs has a null prevout.
+    ///
+    /// # Consensus
+    ///
+    /// > A transparent input in a non-coinbase transaction MUST NOT have a null prevout.
+    ///
+    /// <https://zips.z.cash/protocol/protocol.pdf#txnconsensus>
+    ///
+    /// Note that a transaction can return `false` from both [`Transaction::is_coinbase`] and
+    /// this method, for example a transaction with a null-prevout input alongside other
+    /// inputs. Such transactions are rejected by the verifier.
     pub fn is_valid_non_coinbase(&self) -> bool {
-        !self.is_coinbase()
+        self.transparent_bundle().is_none_or(|bundle| {
+            bundle
+                .vin
+                .iter()
+                .all(|txin| *txin.prevout() != zcash_transparent::bundle::OutPoint::NULL)
+        })
     }
 
     /// Returns the outpoints spent by this transaction's transparent inputs.

--- a/zebra-chain/src/transaction/tests/vectors.rs
+++ b/zebra-chain/src/transaction/tests/vectors.rs
@@ -1694,3 +1694,57 @@ fn sprout_aggregate_value_balance_out_of_range_is_rejected() {
         "the transaction value balance must propagate the error"
     );
 }
+
+/// A non-coinbase transaction with a null-prevout input alongside a regular input parses
+/// through the production entry point, is not a coinbase, and is not a valid non-coinbase.
+///
+/// # Consensus
+///
+/// > A transparent input in a non-coinbase transaction MUST NOT have a null prevout.
+///
+/// <https://zips.z.cash/protocol/protocol.pdf#txnconsensus>
+#[test]
+fn non_coinbase_with_null_prevout_input_is_not_valid_non_coinbase() {
+    let mut raw = Vec::new();
+    raw.extend_from_slice(&1_u32.to_le_bytes()); // version 1
+    raw.push(2); // input count
+                 // Input 0: null prevout with a valid height-1 coinbase script.
+    raw.extend_from_slice(&[0; 32]);
+    raw.extend_from_slice(&0xFFFF_FFFF_u32.to_le_bytes());
+    raw.push(2);
+    raw.extend_from_slice(&[0x51, 0x00]);
+    raw.extend_from_slice(&0xFFFF_FFFF_u32.to_le_bytes());
+    // Input 1: a regular spend.
+    raw.extend_from_slice(&[1; 32]);
+    raw.extend_from_slice(&0_u32.to_le_bytes());
+    raw.push(0);
+    raw.extend_from_slice(&0xFFFF_FFFF_u32.to_le_bytes());
+    raw.push(1); // output count
+    raw.extend_from_slice(&1_u64.to_le_bytes());
+    raw.push(0);
+    raw.extend_from_slice(&0_u32.to_le_bytes()); // lock time
+
+    let tx: Transaction = raw
+        .zcash_deserialize_into()
+        .expect("a null-prevout input with a valid height script parses");
+
+    assert!(
+        matches!(tx.inputs()[0], crate::transparent::Input::Coinbase { .. }),
+        "the null-prevout input is parsed as a coinbase input"
+    );
+    assert!(!tx.is_coinbase(), "two inputs is never a coinbase");
+    assert!(
+        !tx.is_valid_non_coinbase(),
+        "a non-coinbase transaction with a null-prevout input is invalid"
+    );
+
+    // The regular shape of a non-coinbase transaction stays valid.
+    let mut regular = raw.clone();
+    regular[4] = 1; // input count
+    regular.drain(5..5 + 32 + 4 + 1 + 2 + 4); // drop input 0
+    let tx: Transaction = regular
+        .zcash_deserialize_into()
+        .expect("a single regular input parses");
+    assert!(!tx.is_coinbase());
+    assert!(tx.is_valid_non_coinbase());
+}

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -5648,3 +5648,98 @@ fn non_coinbase_expiry_height_accepts_zero_and_spec_max() {
         );
     }
 }
+
+/// Returns a raw v1 transaction with two inputs: a null prevout carrying a valid height-1
+/// coinbase script, and a regular spend of a nonexistent UTXO.
+fn non_coinbase_tx_with_null_prevout_input() -> Transaction {
+    let mut raw = Vec::new();
+    raw.extend_from_slice(&1_u32.to_le_bytes()); // version 1
+    raw.push(2); // input count
+    raw.extend_from_slice(&[0; 32]); // null prevout hash
+    raw.extend_from_slice(&0xFFFF_FFFF_u32.to_le_bytes()); // null prevout index
+    raw.push(2); // coinbase script: height 1, one data byte
+    raw.extend_from_slice(&[0x51, 0x00]);
+    raw.extend_from_slice(&0xFFFF_FFFF_u32.to_le_bytes()); // sequence
+    raw.extend_from_slice(&[1; 32]); // regular prevout hash
+    raw.extend_from_slice(&0_u32.to_le_bytes()); // regular prevout index
+    raw.push(0); // empty unlock script
+    raw.extend_from_slice(&0xFFFF_FFFF_u32.to_le_bytes()); // sequence
+    raw.push(1); // output count
+    raw.extend_from_slice(&1_u64.to_le_bytes()); // value
+    raw.push(0); // empty lock script
+    raw.extend_from_slice(&0_u32.to_le_bytes()); // lock time
+
+    raw.zcash_deserialize_into()
+        .expect("a null-prevout input with a valid height script parses")
+}
+
+/// A non-coinbase transaction with a null-prevout input is rejected by the transaction
+/// verifier before any UTXO lookup, and as a later block transaction by `coinbase_is_first`.
+///
+/// # Consensus
+///
+/// > A transparent input in a non-coinbase transaction MUST NOT have a null prevout.
+///
+/// <https://zips.z.cash/protocol/protocol.pdf#txnconsensus>
+///
+/// This rule was silently disabled when `Transaction::is_valid_non_coinbase` became
+/// `!is_coinbase()` in the `zcash_primitives` newtype refactor.
+#[tokio::test]
+async fn non_coinbase_with_null_prevout_input_is_rejected() {
+    let network = Network::Mainnet;
+    let tx = non_coinbase_tx_with_null_prevout_input();
+
+    assert!(!tx.is_coinbase(), "two inputs is never a coinbase");
+    assert!(
+        matches!(tx.inputs()[0], transparent::Input::Coinbase { .. }),
+        "the null-prevout input is parsed as a coinbase input"
+    );
+
+    // As the first block transaction, it is rejected by the coinbase position rule.
+    let block = Block::zcash_deserialize(&zebra_test::vectors::BLOCK_MAINNET_434873_BYTES[..])
+        .expect("block should deserialize");
+    let mut first_block = block.clone();
+    first_block.transactions[0] = Arc::new(tx.clone());
+    assert_eq!(
+        crate::block::check::coinbase_is_first(&first_block)
+            .expect_err("a first transaction that is not a coinbase must be rejected"),
+        crate::error::BlockError::Transaction(TransactionError::CoinbasePosition),
+    );
+
+    // As a later block transaction, it is rejected by the block structure check, which the
+    // block verifier runs before handing any transaction to the transaction verifier.
+    let mut later_block = block;
+    later_block.transactions.push(Arc::new(tx.clone()));
+    assert_eq!(
+        crate::block::check::coinbase_is_first(&later_block)
+            .expect_err("a later transaction with a null-prevout input must be rejected"),
+        crate::error::BlockError::Transaction(TransactionError::CoinbaseAfterFirst),
+    );
+
+    // Both transaction verifiers reject it before any UTXO lookup: the state service is a
+    // mock with no expectations, so a lookup could never be answered.
+    let height = NetworkUpgrade::Nu5
+        .activation_height(&network)
+        .expect("NU5 height must be set");
+
+    let state: MockService<_, _, _, _> = MockService::build().for_unit_tests();
+    let rsp = BlockTxVerifier::new(&network, state)
+        .oneshot(BlockRequest {
+            transaction_hash: tx.hash(),
+            transaction: Arc::new(tx.clone()),
+            known_utxos: Arc::new(HashMap::new()),
+            height,
+            time: DateTime::<Utc>::MAX_UTC,
+        })
+        .await;
+    assert_eq!(rsp, Err(TransactionError::NonCoinbaseHasCoinbaseInput));
+
+    let state: MockService<_, _, _, _> = MockService::build().for_unit_tests();
+    let rsp = MempoolTxVerifier::new_for_tests(&network, state)
+        .oneshot(MempoolRequest {
+            transaction: Arc::new(tx).into(),
+            height,
+        })
+        .await;
+    assert_eq!(rsp, Err(TransactionError::NonCoinbaseHasCoinbaseInput));
+}


### PR DESCRIPTION
<!--
- Use this template to quickly write the PR description.
- Skip or delete items that don't fit.
-->

## Motivation

The behaviour of `is_valid_non_coinbase()` changed in the last refactor, since it originally was not the symmetrical opposite to `is_coinbase()` (a tx can be both an invalid coinbase and invalid non-coinbase tx). While this probably would eventually fail verification in the UTXO lookup, I think it would be better to keep the original semantics out of caution.

The original (pre-refactor) impl for reference: https://github.com/ZcashFoundation/zebra/blob/eb172aada91f2e1665efe2565396de4726ad4016/zebra-chain/src/transaction.rs#L596-L606

In particular note that the consensus rule is quoted by the caller, but was no longer being enforced there:

https://github.com/ZcashFoundation/zebra/blob/eb172aada91f2e1665efe2565396de4726ad4016/zebra-consensus/src/block/check.rs#L62-L66

## Solution

Restore the original behaviour

### Tests

<!--
- Describe how you tested the solution:
  - Describe any manual or automated tests.
  - If you could not test the solution, explain why.
-->

### Specifications & References

<!-- Provide any relevant references. -->

### Follow-up Work

<!--
- If there's anything missing from the solution, describe it here.
- List any follow-up issues or PRs.
-->

### AI Disclosure

<!-- If you used AI tools, let us know — it helps reviewers. -->

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
