### PR TITLE
test(zebrad): cap the live-sync tests at 2 minutes per attempt

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -30,11 +30,15 @@ filter = 'test(/^integration::sync::/)'
 test-group = 'serial-live-mainnet'
 
 # These tests sync mainnet to genesis from live peers; they normally finish in
-# ~10-30s, but a slow/unreachable peer can stall them. Fail fast after 10m and
-# retry instead of hanging near the old 30m hard limit, where they flaked.
+# ~10-30s, but a slow/unreachable peer can stall them indefinitely: they pass
+# `MempoolBehavior::ShouldNotActivate`, so `sync_until` collects the whole output
+# with `wait_with_output`, which `TestChild::with_timeout` does not bound (see
+# `zebra-test/src/command.rs`). Nextest is therefore the only limit, so keep it
+# close to the runtime the tests actually need: a stalled attempt costs 2m and is
+# retried, instead of holding the serial live-mainnet group for 10m.
 [[profile.ci.overrides]]
 filter = 'test(=integration::sync::sync_one_checkpoint_mainnet) or test(=integration::sync::restart_stop_at_height)'
-slow-timeout = { period = "5m", terminate-after = 2 }
+slow-timeout = { period = "60s", terminate-after = 2 }
 retries = 2
 
 [[profile.ci.overrides]]

--- a/zebrad/tests/common/sync.rs
+++ b/zebrad/tests/common/sync.rs
@@ -177,6 +177,12 @@ impl MempoolBehavior {
 ///
 /// On success, returns the associated `TempDir`. Returns an error if
 /// the child exits or `timeout` elapses before `stop_regex` is found.
+///
+/// `timeout` only bounds the mempool behaviours that check the logs as they arrive.
+/// With `MempoolBehavior::ShouldNotActivate`, `zebrad` has to exit by itself so its
+/// whole output can be collected, and the wait for that exit is unbounded, because
+/// `TestChild::with_timeout` does not apply to `wait_with_output`. A stalled sync in
+/// those tests is caught by the per-test `slow-timeout` in `.config/nextest.toml`.
 #[allow(clippy::too_many_arguments)]
 #[tracing::instrument(skip(reuse_tempdir))]
 pub fn sync_until(


### PR DESCRIPTION
## Motivation

Closes #11399.

## Solution

Lower the per-attempt `slow-timeout` for `integration::sync::sync_one_checkpoint_mainnet`
and `integration::sync::restart_stop_at_height` from 10 minutes to 2, keeping their two
retries, and record in `.config/nextest.toml` and on `sync_until` why nextest has to be
the bound: with `MempoolBehavior::ShouldNotActivate`, `sync_until` waits for `zebrad` to
exit with `wait_with_output`, which `TestChild::with_timeout` does not bound.

### Tests

These two tests sync from live peers, so a slow peer stalls them with no limit of their
own. A run on the changed config reproduced a stall and shows the new bound working: the
attempt was terminated at 120s and the retry passed in 7.6s, for 138s total where the old
600s cap would have spent about 610s.

```
  TRY 1 SLOW [> 60.000s] zebrad::zebrad-tests integration::sync::sync_one_checkpoint_mainnet
TRY 1 TRMNTG [>120.000s] zebrad::zebrad-tests integration::sync::sync_one_checkpoint_mainnet
   TRY 1 TMT [ 120.003s] zebrad::zebrad-tests integration::sync::sync_one_checkpoint_mainnet
  TRY 2 PASS [   7.598s] (2/2) zebrad::zebrad-tests integration::sync::sync_one_checkpoint_mainnet
     Summary [ 138.188s] 2 tests run: 2 passed (1 flaky), 1334 skipped
```

Both tests pass unstalled in 7.6-13.7s, so 2 minutes leaves roughly nine times the
runtime they need. Making the wait itself bounded, so a stall fails where it happens
instead of relying on the test runner, is left to #11399's follow-up discussion.

### AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude, to measure the stall and write the change.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand.
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
