### PR TITLE
ci(labels): rename A-release to release, the last prefixed label

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -2,7 +2,7 @@
 name: "🚀 Zebra Release"
 about: "Zebra team use only"
 title: "Publish next Zebra release: (version)"
-labels: "A-release"
+labels: "release"
 type: Task
 assignees: ""
 ---

--- a/.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md
+++ b/.github/PULL_REQUEST_TEMPLATE/hotfix-release-checklist.md
@@ -2,7 +2,7 @@
 name: "Hotfix Release Checklist Template"
 about: "Checklist to create and publish a hotfix Zebra release"
 title: "release: Zebra (version)"
-labels: "A-release"
+labels: "release"
 assignees: ""
 ---
 
@@ -14,7 +14,7 @@ A hotfix release should only be created when a bug or critical issue is discover
       for example: `hotfix-v2.3.1` - this needs to be different to the tag name
 - [ ] Make the required changes
 - [ ] Create a hotfix release PR by adding `&template=hotfix-release-checklist.md` to the comparing url ([Example](https://github.com/ZcashFoundation/zebra/compare/bump-v1.0.0?expand=1&template=hotfix-release-checklist.md)).
-- [ ] Add the `A-release` tag to the release pull request in order for the `check-no-git-dependencies` to run.
+- [ ] Add the `release` tag to the release pull request in order for the `check-no-git-dependencies` to run.
 - [ ] Add the `do-not-merge` tag to keep the PR out of the merge queue, since after PR approval
       the release is done from the branch itself.
 - [ ] Ensure the `check-no-git-dependencies` check passes.

--- a/.github/PULL_REQUEST_TEMPLATE/release-checklist-legacy.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-checklist-legacy.md
@@ -2,7 +2,7 @@
 name: "Legacy Release Checklist Template"
 about: "Manual fallback checklist to create and publish a Zebra release"
 title: "release: Zebra (version)"
-labels: "A-release"
+labels: "release"
 assignees: ""
 ---
 
@@ -80,13 +80,13 @@ fastmod --fixed-strings '1.58' '1.65'
 - [ ] Use Merge Freeze's **Unfreeze 1 pull request** action for this release PR. That
       action requires the project's freeze method to be
       _Push a status update to all PRs_; confirm that before relying on it.
-- [ ] Add the `A-release` tag to the release pull request in order for the `check-no-git-dependencies` to run.
+- [ ] Add the `release` tag to the release pull request in order for the `check-no-git-dependencies` to run.
 
 ## Zebra git sources dependencies
 
 - [ ] Ensure the `check-no-git-dependencies` check passes.
 
-This check runs automatically on pull requests with the `A-release` label. It must pass for crates to be published to crates.io. If the check fails, you should either halt the release process or proceed with the understanding that the crates will not be published on crates.io.
+This check runs automatically on pull requests with the `release` label. It must pass for crates to be published to crates.io. If the check fails, you should either halt the release process or proceed with the understanding that the crates will not be published on crates.io.
 
 # Update Versions and End of Support
 

--- a/.github/workflows/checkpoint-update.yml
+++ b/.github/workflows/checkpoint-update.yml
@@ -175,6 +175,6 @@ jobs:
             **Source:** [Integration test run #${{ steps.resolve-run.outputs.run_id }}](${{ steps.resolve-run.outputs.run_url }})
 
             Checkpoints are consensus-critical. Verify the new hashes against the source run before merging.
-          labels: A-release
+          labels: release
           commit-message: "chore(chain): update checkpoints"
           delete-branch: true

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -20,7 +20,7 @@ concurrency:
   group: >-
     ${{ github.workflow }}-${{ github.event_name == 'push' && github.run_id || github.ref }}-${{
       (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
-      github.event.label.name != 'A-release' &&
+      github.event.label.name != 'release' &&
       'ignored-label' ||
       github.event.action == 'edited' &&
       github.event.changes.title == null &&
@@ -39,12 +39,12 @@ env:
 
 jobs:
   changes:
-    # Only the A-release label affects gate results, and only a title or base edit
+    # Only the release label affects gate results, and only a title or base edit
     # can change the declaration this gate reads. Every other label and edit event
     # is a no-op, so it must not spend a runner or replace the required check.
     if: >-
       ((github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
-      github.event.label.name == 'A-release') &&
+      github.event.label.name == 'release') &&
       (github.event.action != 'edited' ||
       github.event.changes.title != null || github.event.changes.base != null)
     runs-on: ubuntu-latest
@@ -167,11 +167,11 @@ jobs:
     if: >-
       github.event_name == 'pull_request' &&
       ((github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
-      github.event.label.name == 'A-release') &&
+      github.event.label.name == 'release') &&
       (github.event.action != 'edited' ||
       github.event.changes.title != null || github.event.changes.base != null) &&
       startsWith(github.event.pull_request.head.ref, 'release-plz-') &&
-      contains(github.event.pull_request.labels.*.name, 'A-release')
+      contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest-xl
     timeout-minutes: 90
     steps:
@@ -272,7 +272,7 @@ jobs:
     name: >-
       ${{
         (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
-        github.event.label.name != 'A-release' &&
+        github.event.label.name != 'release' &&
         'Label does not affect the PR gate' ||
         github.event.action == 'edited' &&
         github.event.changes.title == null &&
@@ -284,7 +284,7 @@ jobs:
     if: >-
       always() &&
       ((github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
-      github.event.label.name == 'A-release') &&
+      github.event.label.name == 'release') &&
       (github.event.action != 'edited' ||
       github.event.changes.title != null || github.event.changes.base != null)
     needs: [changes, semver-checks, changelog-gate, release-readiness]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,7 +190,7 @@ jobs:
       (github.event_name == 'pull_request' &&
        github.event.pull_request.merged == true &&
        startsWith(github.event.pull_request.head.ref, 'release-plz-') &&
-       contains(github.event.pull_request.labels.*.name, 'A-release'))
+       contains(github.event.pull_request.labels.*.name, 'release'))
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -254,11 +254,11 @@ jobs:
             const pr = result.repository.pullRequest;
             const isReleasePr =
               pr?.headRefName.startsWith("release-plz-") &&
-              pr.labels.nodes.some(({ name }) => name === "A-release");
+              pr.labels.nodes.some(({ name }) => name === "release");
 
             if (!isReleasePr || (pr.state !== "OPEN" && !pr.merged)) {
               throw new Error(
-                `PR #${prNumber} is not a release-plz A-release PR`,
+                `PR #${prNumber} does not carry the release label`,
               );
             }
             if (pr.baseRefName !== "main") {

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -15,7 +15,7 @@ concurrency:
   group: >-
     ${{ github.workflow }}-${{ github.event_name == 'push' && github.run_id || github.ref }}-${{
       github.event.action == 'labeled' &&
-      github.event.label.name != 'A-release' &&
+      github.event.label.name != 'release' &&
       'ignored-label' ||
       'required'
     }}
@@ -34,7 +34,7 @@ env:
 
 jobs:
   changes:
-    if: github.event.action != 'labeled' || github.event.label.name == 'A-release'
+    if: github.event.action != 'labeled' || github.event.label.name == 'release'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -84,7 +84,7 @@ jobs:
   check-no-git-dependencies:
     name: Check no git dependencies
     needs: changes
-    if: needs.changes.outputs.unit_tests == 'true' && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'A-release')
+    if: needs.changes.outputs.unit_tests == 'true' && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release')
     permissions:
       contents: read
       statuses: write
@@ -110,7 +110,7 @@ jobs:
     name: >-
       ${{
         github.event.action == 'labeled' &&
-        github.event.label.name != 'A-release' &&
+        github.event.label.name != 'release' &&
         'Label does not require unit tests' ||
         'unit-tests'
       }}
@@ -118,7 +118,7 @@ jobs:
     if: >-
       always() &&
       (github.event.action != 'labeled' ||
-      github.event.label.name == 'A-release')
+      github.event.label.name == 'release')
     needs:
       - changes
       - run-unit-tests

--- a/book/src/dev/continuous-integration.md
+++ b/book/src/dev/continuous-integration.md
@@ -68,7 +68,7 @@ Two independent hold checks:
   write access can freeze and unfreeze `main` in the Merge Freeze dashboard.
 
 The release PR is meant to pass a freeze through Merge Freeze's **Unfreeze 1 pull
-request** action; the `A-release` label controls Zebra's release checks but does not
+request** action; the `release` label controls Zebra's release checks but does not
 bypass a freeze. That action has been reported returning an error, and Merge Freeze's
 documentation ties it to the _Push a status update to all PRs_ freeze method, so
 confirm which method the installation uses before relying on it for a release.

--- a/book/src/dev/labels.md
+++ b/book/src/dev/labels.md
@@ -47,7 +47,7 @@ condition just goes false. Change the workflow in the same PR.
 
 | Label | Read by | Effect |
 |---|---|---|
-| `A-release` | `pr-gate.yml`, `tests-unit.yml`, `release.yml`, `checkpoint-update.yml`, `release-plz.toml` | Marks release PRs; gates release readiness checks. Applied by release-plz and by the release templates |
+| `release` | `pr-gate.yml`, `tests-unit.yml`, `release.yml`, `checkpoint-update.yml`, `release-plz.toml` | Marks release PRs; gates release readiness checks. Applied by release-plz and by the release templates |
 | `run-stateful-tests` | `zfnd-ci-integration-tests-gcp.yml` | Adding it to a PR runs the stateful GCP integration tests for that PR |
 | `run-benchmarks` | `benchmarks.yml` | Adding it to a PR runs the benchmark comparison against the base branch |
 

--- a/book/src/dev/release-process.md
+++ b/book/src/dev/release-process.md
@@ -123,7 +123,7 @@ The normal release path requires 2 maintainer actions:
 1. Review the latest Release PR after every required check passes.
 2. Approve and merge the latest commit.
 
-Everything else is automatic. release-plz creates and updates a PR whose branch starts with `release-plz-` and carries the `A-release` label, `PR Gate / Release readiness` validates it, and `ZcashFoundation/cargo-release` publishes from that PR's source range after merge.
+Everything else is automatic. release-plz creates and updates a PR whose branch starts with `release-plz-` and carries the `release` label, `PR Gate / Release readiness` validates it, and `ZcashFoundation/cargo-release` publishes from that PR's source range after merge.
 
 ### Review the Release PR
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -25,7 +25,7 @@ release_commits = "^(feat|fix|perf|refactor|build)"
 
 # Release PR metadata. Keep the generated long-lived PR out of the urgent queue
 # until maintainers are ready to publish.
-pr_labels = ["A-release"]
+pr_labels = ["release"]
 pr_name = "chore: release{% if package and version %} v{{ version }}{% endif %}"
 
 pr_body = """


### PR DESCRIPTION
Renames `A-release` to `release`, the only prefixed name left after the label migration (#11170). Covers every site that keys on it: `pr-gate.yml`, `tests-unit.yml`, `release.yml`, `checkpoint-update.yml`, `release-plz.toml`, the three release templates, and the book.

The label is renamed on GitHub right after this merges, which keeps its attachments, so the open release PR #11254 carries `release` immediately. I'll re-run the PR Gate and checkpoint-update workflows on it to confirm the release-readiness checks still fire, since a mismatch there fails silently.

Workflow and docs only, no changelog fragment.
