### PR TITLE
ci(labels): apply external-contribution automatically from the author's association

### DIFF
--- a/.github/workflows/label-external.yml
+++ b/.github/workflows/label-external.yml
@@ -1,0 +1,35 @@
+# Labels issues and PRs opened by people outside the maintainer team, so outside work can be
+# filtered. GitHub already classifies every author (`author_association`); this only turns that
+# into the `external-contribution` label, which used to be applied by hand and drifted.
+name: Label External Contributions
+
+on:
+  issues:
+    types: [opened]
+  # zizmor: ignore[dangerous-triggers] -- nothing is checked out and no PR code runs; the job
+  # reads the trusted event payload and applies a label.
+  pull_request_target:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  label:
+    name: Label outside author
+    # Owners, members and collaborators are the team; bots (dependabot, release-plz, CI) are not
+    # contributions.
+    if: >-
+      github.event.sender.type != 'Bot' &&
+      !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                github.event.issue.author_association || github.event.pull_request.author_association)
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Add the external-contribution label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: gh issue edit "${NUMBER}" --repo "${REPOSITORY}" --add-label external-contribution

--- a/book/src/dev/labels.md
+++ b/book/src/dev/labels.md
@@ -32,7 +32,7 @@ title prefix (`fix:`, `feat:`, `ci:`, `docs:`, and so on).
 | `blocked` | Waiting on something outside the issue or PR | The comment that applies it must say _what_ it is blocked on and give a **re-check date**; a label that is never revisited goes on describing a condition that fixed itself |
 | `do-not-merge` | Must not merge yet, even if approved and green | Removed by whoever applied it |
 | `needs-issue` | A PR that should have an issue behind it | Ask the author to open one, or open it for them |
-| `external-contribution` | Filed by someone outside the maintainer team | Lets maintainers find and follow up on outside contributions |
+| `external-contribution` | Filed by someone outside the maintainer team | Applied by `label-external.yml` when the author is not an owner, member or collaborator; lets maintainers find and follow up on outside contributions |
 | `help wanted` | Maintainers would welcome outside help | GitHub-native name; keep it spelled exactly like this |
 | `good first issue` | Suitable for a first contribution | GitHub-native name; keep it spelled exactly like this |
 | `nu-7` | NU7 network-upgrade work | Temporary, removed after the upgrade ships |


### PR DESCRIPTION
`external-contribution` has been applied by hand, and it drifted: about 70% of open outsider issues carry it, the three newest outside PRs don't, and a bot issue and two team PRs do. GitHub already classifies every author through `author_association`, so this workflow turns that into the label.

It runs on `issues: opened` and `pull_request_target: opened`, checks nothing out and runs no PR code. It applies the label when the sender isn't a bot and the author isn't an owner, member, or collaborator. Former maintainers show as contributors, so their future issues get the label; that's the honest reading of "outside the current team".

After merge I'll backfill the seven open outsider issues that lack the label. The book row is updated to say the label is written by CI.

Follows up on #11170.
