### PR TITLE
test(rpc): put real signed transactions through block templates on regtest

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -20,6 +20,10 @@ mod unmined;
 #[cfg(any(test, feature = "proptest-impl"))]
 #[allow(clippy::unwrap_in_result)]
 pub mod arbitrary;
+#[cfg(any(test, feature = "proptest-impl"))]
+mod test_signing;
+#[cfg(test)]
+mod test_signing_tests;
 #[cfg(test)]
 mod tests;
 
@@ -35,6 +39,8 @@ pub use serialize::{
     MIN_TRANSPARENT_TX_V5_SIZE,
 };
 pub use sighash::{HashType, SigHash, SigHasher};
+#[cfg(any(test, feature = "proptest-impl"))]
+pub use test_signing::TransparentSigningKey;
 pub use unmined::{
     zip317, UnminedTx, UnminedTxId, VerifiedUnminedTx, MEMPOOL_TRANSACTION_COST_THRESHOLD,
 };

--- a/zebra-chain/src/transaction/test_signing.rs
+++ b/zebra-chain/src/transaction/test_signing.rs
@@ -1,0 +1,174 @@
+//! Signing transparent-only transactions in tests.
+//!
+//! Zebra is a node, not a wallet, so this is the only code in the tree that signs a transaction.
+//! Regtest tests use it to put real, spendable transactions into block templates and blocks.
+
+use secp256k1::{PublicKey, Secp256k1, SecretKey};
+use zcash_primitives::transaction::{
+    builder::DEFAULT_TX_EXPIRY_DELTA,
+    fees::{
+        transparent::InputSize,
+        zip317::{FeeRule, P2PKH_STANDARD_OUTPUT_SIZE},
+        FeeRule as _,
+    },
+    sighash::{signature_hash, SignableInput},
+    txid::TxIdDigester,
+    Authorized, TransactionData, TxVersion, Unauthorized,
+};
+use zcash_protocol::{consensus::BranchId, value::Zatoshis};
+use zcash_transparent::{
+    address::TransparentAddress,
+    builder::{TransparentBuilder, TransparentSigningSet},
+    bundle::OutPoint,
+};
+
+use crate::{
+    amount::{Amount, NonNegative},
+    block::Height,
+    parameters::{Network, NetworkKind},
+    transaction::{compat, Transaction},
+    transparent, BoxError,
+};
+
+/// A secp256k1 key that owns pay-to-public-key-hash outputs.
+#[derive(Clone, Debug)]
+pub struct TransparentSigningKey {
+    secret: SecretKey,
+    public: PublicKey,
+}
+
+impl TransparentSigningKey {
+    /// Generates a random key.
+    pub fn random() -> Self {
+        let secret = loop {
+            if let Ok(secret) = SecretKey::from_slice(&rand::random::<[u8; 32]>()) {
+                break secret;
+            }
+        };
+        let public = PublicKey::from_secret_key(&Secp256k1::signing_only(), &secret);
+
+        Self { secret, public }
+    }
+
+    /// Returns the pay-to-public-key-hash address of this key.
+    pub fn address(&self, network_kind: NetworkKind) -> transparent::Address {
+        match TransparentAddress::from_pubkey(&self.public) {
+            TransparentAddress::PublicKeyHash(hash) => {
+                transparent::Address::from_pub_key_hash(network_kind, hash)
+            }
+            _ => unreachable!("a public key always hashes to a P2PKH address"),
+        }
+    }
+}
+
+impl Transaction {
+    /// Builds and signs a transparent-only transaction that spends `inputs`, which must all be
+    /// P2PKH outputs owned by `key`, to `outputs`.
+    ///
+    /// Pays the ZIP-317 conventional fee and returns the remainder to `key` as a final change
+    /// output, so `inputs` must cover `outputs` plus the fee with something left over.
+    pub fn signed_transparent(
+        network: &Network,
+        target_height: Height,
+        key: &TransparentSigningKey,
+        inputs: &[(transparent::OutPoint, transparent::Output)],
+        outputs: &[(transparent::Address, Amount<NonNegative>)],
+    ) -> Result<Self, BoxError> {
+        let target_height = compat::height_to_block_height(target_height);
+
+        // The change output counts towards the fee, so it is always added below.
+        let fee = FeeRule::standard()
+            .fee_required(
+                network,
+                target_height,
+                inputs.iter().map(|_| InputSize::STANDARD_P2PKH),
+                std::iter::repeat_n(P2PKH_STANDARD_OUTPUT_SIZE, outputs.len() + 1),
+                0,
+                0,
+                0,
+                0,
+            )
+            .map_err(|err| format!("{err:?}"))?;
+
+        let input_total: i64 = inputs
+            .iter()
+            .map(|(_, output)| output.value().zatoshis())
+            .sum();
+        let output_total: i64 = outputs.iter().map(|(_, value)| value.zatoshis()).sum();
+        let change = input_total - output_total - i64::try_from(u64::from(fee))?;
+        if change <= 0 {
+            return Err(format!(
+                "inputs ({input_total}) must exceed outputs ({output_total}) plus fee ({fee:?})"
+            )
+            .into());
+        }
+
+        let mut signing_set = TransparentSigningSet::new();
+        let pubkey = signing_set.add_key(key.secret);
+
+        let mut builder = TransparentBuilder::empty();
+        for (outpoint, output) in inputs {
+            builder.add_p2pkh_input(
+                pubkey,
+                OutPoint::new(outpoint.hash.0, outpoint.index),
+                compat::output_to_txout(output),
+            )?;
+        }
+
+        let change_output = (key.address(network.kind()), Amount::try_from(change)?);
+        for (address, value) in outputs.iter().chain(std::iter::once(&change_output)) {
+            builder.add_output(
+                &(*address).try_into()?,
+                Zatoshis::from_u64(u64::from(*value))?,
+            )?;
+        }
+        let bundle = builder
+            .build()
+            .ok_or("transaction has no transparent inputs or outputs")?;
+
+        let branch_id = BranchId::for_height(network, target_height);
+        let version = TxVersion::suggested_for_branch(branch_id);
+        let expiry_height = target_height + DEFAULT_TX_EXPIRY_DELTA;
+
+        let unauthed_tx = TransactionData::<Unauthorized>::from_parts(
+            version,
+            branch_id,
+            0,
+            expiry_height,
+            Some(bundle),
+            None,
+            None,
+            None,
+        );
+        let txid_parts = unauthed_tx.digest(TxIdDigester);
+        let signed_bundle = unauthed_tx
+            .transparent_bundle()
+            .expect("bundle was just added")
+            .clone()
+            .apply_signatures(
+                |input| {
+                    *signature_hash(
+                        &unauthed_tx,
+                        &SignableInput::Transparent(input),
+                        &txid_parts,
+                    )
+                    .as_ref()
+                },
+                &signing_set,
+            )?;
+
+        let signed_tx = TransactionData::<Authorized>::from_parts(
+            version,
+            branch_id,
+            0,
+            expiry_height,
+            Some(signed_bundle),
+            None,
+            None,
+            None,
+        )
+        .freeze()?;
+
+        Ok(Self(signed_tx))
+    }
+}

--- a/zebra-chain/src/transaction/test_signing_tests.rs
+++ b/zebra-chain/src/transaction/test_signing_tests.rs
@@ -1,0 +1,118 @@
+//! Tests for [`Transaction::signed_transparent`].
+//!
+//! Signature validity is not checked here: the regtest integration test in `zebrad` sends the
+//! transactions through consensus verification, which is the only oracle that counts.
+
+use crate::{
+    amount::Amount,
+    block::Height,
+    parameters::{testnet::ConfiguredActivationHeights, Network, NetworkKind, NetworkUpgrade},
+    serialization::{ZcashDeserializeInto, ZcashSerialize},
+    transaction::{self, Transaction, TransparentSigningKey},
+    transparent,
+};
+
+/// ZIP-317 conventional fee for a transaction with two logical actions.
+const TWO_ACTION_FEE: i64 = 10_000;
+
+#[test]
+fn signed_transparent_pays_outputs_fee_and_change() {
+    let _init_guard = zebra_test::init();
+
+    let network = Network::new_regtest(
+        ConfiguredActivationHeights {
+            nu5: Some(1),
+            ..Default::default()
+        }
+        .into(),
+    );
+    let key = TransparentSigningKey::random();
+    let recipient = TransparentSigningKey::random().address(NetworkKind::Regtest);
+
+    let outpoint = transparent::OutPoint {
+        hash: transaction::Hash([1; 32]),
+        index: 3,
+    };
+    let coin = transparent::Output {
+        value: Amount::try_from(100_000_000).expect("valid amount"),
+        lock_script: key.address(NetworkKind::Regtest).script(),
+    };
+    let send_amount = Amount::try_from(30_000_000).expect("valid amount");
+
+    let tx = Transaction::signed_transparent(
+        &network,
+        Height(10),
+        &key,
+        &[(outpoint, coin.clone())],
+        &[(recipient, send_amount)],
+    )
+    .expect("a funded transparent spend must build");
+
+    assert_eq!(
+        tx.version(),
+        5,
+        "NU5 is active, so the transaction must be v5"
+    );
+    assert_eq!(tx.network_upgrade(), Some(NetworkUpgrade::Nu5));
+    assert_eq!(
+        tx.expiry_height(),
+        Some(Height(50)),
+        "default expiry delta is 40 blocks"
+    );
+
+    let inputs = tx.inputs();
+    assert_eq!(inputs.len(), 1);
+    assert_eq!(inputs[0].outpoint(), Some(outpoint));
+
+    let outputs = tx.outputs();
+    assert_eq!(outputs.len(), 2, "one recipient plus change");
+    assert_eq!(outputs[0].value, send_amount);
+    assert_eq!(outputs[0].lock_script, recipient.script());
+    assert_eq!(
+        outputs[1].lock_script, coin.lock_script,
+        "change returns to the signing key"
+    );
+
+    let fee = coin.value.zatoshis() - outputs.iter().map(|o| o.value.zatoshis()).sum::<i64>();
+    assert_eq!(
+        fee, TWO_ACTION_FEE,
+        "exactly the ZIP-317 conventional fee is paid"
+    );
+
+    let round_trip: Transaction = tx
+        .zcash_serialize_to_vec()
+        .expect("serializes")
+        .zcash_deserialize_into()
+        .expect("deserializes");
+    assert_eq!(round_trip, tx);
+}
+
+#[test]
+fn signed_transparent_rejects_underfunded_spend() {
+    let _init_guard = zebra_test::init();
+
+    let network = Network::new_regtest(Default::default());
+    let key = TransparentSigningKey::random();
+    let address = key.address(NetworkKind::Regtest);
+
+    let coin = transparent::Output {
+        value: Amount::try_from(TWO_ACTION_FEE).expect("valid amount"),
+        lock_script: address.script(),
+    };
+
+    let result = Transaction::signed_transparent(
+        &network,
+        Height(10),
+        &key,
+        &[(
+            transparent::OutPoint::from_usize(transaction::Hash([2; 32]), 0),
+            coin,
+        )],
+        &[(address, Amount::try_from(1).expect("valid amount"))],
+    );
+
+    assert!(
+        result.is_err(),
+        "inputs that cannot cover outputs plus fee must be rejected"
+    );
+}

--- a/zebrad/tests/integration/regtest.rs
+++ b/zebrad/tests/integration/regtest.rs
@@ -202,6 +202,193 @@ async fn getblocktemplate_long_poll_returns_submit_old_false_on_new_tip() -> Res
     Ok(())
 }
 
+/// Block templates must include the mempool's transactions in dependency order, and the
+/// resulting block must be accepted.
+///
+/// This is the only test that puts real, signed transactions through the mining RPCs. Every other
+/// template test in the tree uses an empty mempool, so before this test nothing asserted that a
+/// transaction which reached the mempool would ever reach a block. The second transaction spends
+/// an unmined output of the first, so the template's ordering is asserted, not only inclusion.
+#[tokio::test]
+async fn block_template_includes_mempool_transactions_in_dependency_order() -> Result<()> {
+    use zebra_chain::{
+        amount::Amount,
+        parameters::NetworkKind,
+        transaction::{Transaction, TransparentSigningKey},
+    };
+    use zebra_rpc::{
+        client::{
+            BlockProposalResponse, BlockTemplateResponse, BlockTemplateTimeSource,
+            SendRawTransactionResponse,
+        },
+        proposal_block_from_template,
+    };
+
+    /// Coinbase outputs can be spent once this many blocks are on top of them.
+    const COINBASE_MATURITY: u32 = zebra_chain::transparent::MIN_TRANSPARENT_COINBASE_MATURITY;
+
+    /// How long to wait for a sent transaction to show up in a block template.
+    const TEMPLATE_TIMEOUT: Duration = Duration::from_secs(30);
+
+    let _init_guard = zebra_test::init();
+
+    let network = Network::new_regtest(
+        ConfiguredActivationHeights {
+            nu5: Some(1),
+            ..Default::default()
+        }
+        .into(),
+    );
+    let key = TransparentSigningKey::random();
+    let miner_address = key.address(NetworkKind::Regtest);
+
+    let mut config = os_assigned_rpc_port_config(false, &network)?;
+    config.mempool.debug_enable_at_height = Some(0);
+    config.mining.miner_address = Some(miner_address.into());
+
+    let mut zebrad = testdir()?
+        .with_config(&mut config)?
+        .spawn_child(args!["start"])?;
+
+    let rpc_address = read_listen_addr_from_logs(&mut zebrad, OPENED_RPC_ENDPOINT_MSG)?;
+
+    tokio::time::sleep(LAUNCH_DELAY).await;
+
+    let client = RpcRequestClient::new(rpc_address);
+
+    // Mine a coinbase to our key at height 1, then enough blocks for it to mature.
+    client.generate(COINBASE_MATURITY + 1).await?;
+    let next_height = Height(COINBASE_MATURITY + 2);
+
+    let block_1 = client
+        .get_block(1)
+        .await
+        .map_err(|err| eyre!(err))?
+        .ok_or_else(|| eyre!("block 1 must exist after generate"))?;
+    let coinbase = &block_1.transactions[0];
+    let (index, coinbase_output) = coinbase
+        .outputs()
+        .into_iter()
+        .enumerate()
+        .find(|(_, output)| output.lock_script == miner_address.script())
+        .ok_or_else(|| eyre!("the coinbase must pay the configured miner address"))?;
+    let coinbase_outpoint = transparent::OutPoint {
+        hash: coinbase.hash(),
+        index: index as u32,
+    };
+
+    // Transaction A spends the mature coinbase; transaction B spends A's first output while A is
+    // still unmined, so B can only be valid in a block that also contains A, before it.
+    let send_amount = Amount::try_from(100_000_000)?;
+    let tx_a = Transaction::signed_transparent(
+        &network,
+        next_height,
+        &key,
+        &[(coinbase_outpoint, coinbase_output)],
+        &[(miner_address, send_amount)],
+    )
+    .map_err(|err| eyre!(err))?;
+    let tx_a_outpoint = transparent::OutPoint {
+        hash: tx_a.hash(),
+        index: 0,
+    };
+    let tx_b = Transaction::signed_transparent(
+        &network,
+        next_height,
+        &key,
+        &[(tx_a_outpoint, tx_a.outputs()[0].clone())],
+        &[(miner_address, Amount::try_from(50_000_000)?)],
+    )
+    .map_err(|err| eyre!(err))?;
+
+    for tx in [&tx_a, &tx_b] {
+        let raw_tx = hex::encode(tx.zcash_serialize_to_vec()?);
+        let response: SendRawTransactionResponse = client
+            .json_result_from_call("sendrawtransaction", format!(r#"["{raw_tx}"]"#))
+            .await
+            .map_err(|err| eyre!(err))?;
+        assert_eq!(
+            response.hash(),
+            tx.hash(),
+            "sendrawtransaction must accept the transaction"
+        );
+    }
+
+    let expected_order = vec![tx_a.hash(), tx_b.hash()];
+    let deadline = std::time::Instant::now() + TEMPLATE_TIMEOUT;
+    let template: BlockTemplateResponse = loop {
+        let template: BlockTemplateResponse = client
+            .json_result_from_call("getblocktemplate", "[]")
+            .await
+            .map_err(|err| eyre!(err))?;
+        if template.transactions().len() == expected_order.len() {
+            break template;
+        }
+        if std::time::Instant::now() > deadline {
+            return Err(eyre!(
+                "the template must include both mempool transactions within {TEMPLATE_TIMEOUT:?}, got {:?}",
+                template.transactions()
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    };
+
+    let template_order: Vec<_> = template.transactions().iter().map(|tx| tx.hash()).collect();
+    assert_eq!(
+        template_order, expected_order,
+        "the template must list a transaction after the transaction it spends from",
+    );
+
+    let proposal_block =
+        proposal_block_from_template(&template, BlockTemplateTimeSource::default(), &network)?;
+    let proposal_data = hex::encode(proposal_block.zcash_serialize_to_vec()?);
+    let proposal_result: BlockProposalResponse = client
+        .json_result_from_call(
+            "getblocktemplate",
+            format!(r#"[{{"mode":"proposal","data":"{proposal_data}"}}]"#),
+        )
+        .await
+        .map_err(|err| eyre!(err))?;
+    assert_eq!(
+        proposal_result,
+        BlockProposalResponse::Valid,
+        "a template carrying the mempool transactions must be a valid block proposal",
+    );
+
+    client.submit_block(proposal_block).await?;
+
+    let mined_block = client
+        .get_block(next_height.0 as i32)
+        .await
+        .map_err(|err| eyre!(err))?
+        .ok_or_else(|| eyre!("the submitted block must be readable at its height"))?;
+    let mined_order: Vec<_> = mined_block
+        .transactions
+        .iter()
+        .map(|tx| tx.hash())
+        .collect();
+    assert_eq!(
+        mined_order[1..],
+        expected_order,
+        "the mined block must contain the template's transactions in order after the coinbase",
+    );
+
+    let mempool: Vec<String> = client
+        .json_result_from_call("getrawmempool", "[]")
+        .await
+        .map_err(|err| eyre!(err))?;
+    assert!(
+        mempool.is_empty(),
+        "mined transactions must leave the mempool, still queued: {mempool:?}",
+    );
+
+    zebrad.kill(false)?;
+    let output = zebrad.wait_with_output()?;
+    output.assert_failure()?.assert_was_killed()?;
+
+    Ok(())
+}
+
 /// A rejected block body must not poison the children of a later valid block with the same header
 /// hash.
 ///


### PR DESCRIPTION
## Motivation

No `getblocktemplate` test puts a transaction in the mempool, so nothing asserts that a mempool transaction reaches a block, or that dependent transactions come out in a valid order. This is the residual gap from #11246 and Track B2 of #9941. Zebra has no wallet, so there was no way to sign a transaction in a test.

## Solution

- `Transaction::signed_transparent` and `TransparentSigningKey` in `zebra-chain` behind `proptest-impl`, next to the existing `test_v1..test_v6` constructors. Builds a transparent-only transaction from P2PKH inputs, pays the ZIP-317 conventional fee, returns change to the key, and signs each input with librustzcash's `TransparentBuilder` and `apply_signatures`. No hand-rolled sighash or DER code, no new dependencies.
- It lives in `zebra-chain` rather than `zebra-test` because `zebra-chain` already has the librustzcash dependencies and the `compat` conversions the helper needs. The full librustzcash `Builder` was not used: it requires Sapling provers even for transparent-only transactions and does not compute change.
- A regtest test: mines a coinbase to the key, sends A (spends the coinbase) and B (spends A's unmined output), then asserts the template lists A before B, `submitblock` accepts it, the mined block contains A then B, and the mempool is empty afterwards.

### Tests

- `cargo test -p zebra-chain --features proptest-impl transaction::test_signing_tests`
- `cargo test -p zebrad --test zebrad-tests integration::regtest::block_template_includes_mempool_transactions_in_dependency_order` (~40 s)
- Mutation check: corrupting one sighash byte makes `sendrawtransaction` reject with `ScriptInvalid`.

### Follow-up Work

- Track B3 (`SendTransaction` / `GetMempoolTx` regtest tests) can use the helper.
- `TransactionTemplate.depends` is always empty and its doc comment is stale now that selection is dependency-aware. Left as-is.
- Accepted residual from #11246: limit-edge sigop/size accounting is not covered.

### AI Disclosure

- [x] AI tools were used: Claude Code for the helper, test, and mutation check; reviewed and run locally.

### PR Checklist

- [x] The PR title follows conventional commits
- [x] The PR follows the contribution guidelines
- [x] This change was discussed in an issue or with the team beforehand (#9941, #11246)
- [x] The solution is tested
- [x] The documentation and changelogs are up to date (`test:` — no fragment required)
