### PR TITLE
fix(ci): pin bindgen to the workspace lockfile for cargo-semver-checks

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -126,6 +126,28 @@ jobs:
           # `fetch-depth: 0` populates the base branch without persisting credentials.
           echo "rev=$(git merge-base "origin/$BASE_REF" HEAD)" >> "$GITHUB_OUTPUT"
       - uses: ./.github/actions/setup-zebra-build
+      # cargo-semver-checks builds each crate in a placeholder project with a fresh
+      # dependency resolution: it deletes any Cargo.lock it finds there and runs
+      # `cargo update` on purpose (obi1kenobi/cargo-semver-checks#675, #991), so the
+      # workspace lockfile is not honoured. `libzcash_script` accepts any bindgen
+      # `>=0.69.5`, so that resolution picks the newest bindgen next to the `^0.72`
+      # that `librocksdb-sys` needs, and the two copies unify clang-sys features in a
+      # way that makes the rocksdb build script panic ("a `libclang` shared library is
+      # not loaded on this thread"). Patching bindgen to the exact version in
+      # Cargo.lock satisfies both requirements with a single copy, and follows the
+      # lockfile whenever dependabot bumps it. The placeholder lives under `target/`,
+      # inside the workspace, so this config applies to it.
+      - name: Pin bindgen to the workspace lockfile for the placeholder builds
+        run: |
+          BINDGEN=$(awk '$0 == "name = \"bindgen\"" { found = 1; next }
+                         found && /^version = / { gsub(/"/, "", $3); print $3; exit }' Cargo.lock)
+          test -n "${BINDGEN}"
+          cat >> .cargo/config.toml <<EOF
+
+          [patch.crates-io]
+          bindgen = { git = "https://github.com/rust-lang/rust-bindgen", tag = "v${BINDGEN}" }
+          EOF
+          echo "Pinned bindgen ${BINDGEN} for cargo-semver-checks"
       - uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9
         with:
           # Gate the consumer-facing library crates only. zebrad is a binary whose build script


### PR DESCRIPTION
## Motivation

Closes #11409.

Since 2026-09-07, `semver-checks` fails on every PR that touches Rust, and because `pr-gate-result` depends on it the required gate goes red and the merge queue refuses the PR.

cargo-semver-checks builds each crate in a placeholder project with a fresh dependency resolution. It deletes any `Cargo.lock` it finds in the placeholder and runs `cargo update` on purpose (obi1kenobi/cargo-semver-checks#675, #991), so the workspace lockfile is never honoured, and no released version offers lockfile support. `libzcash_script` accepts any bindgen `>=0.69.5`, so once bindgen 0.73.0 was published (2026-09-05 16:27 UTC) that resolution picked it next to the `^0.72` that `librocksdb-sys` requires. The two copies unify clang-sys features in a way the rocksdb build script does not expect, and it panics:

```
error: failed to run custom build command for `librocksdb-sys v0.17.3+10.4.2`
  a `libclang` shared library is not loaded on this thread
error: failed to build rustdoc for crate zebra-consensus v15.0.0
error: failed to build rustdoc for crate zebra-rpc v16.0.0
```

The regular build is unaffected: `Cargo.lock` pins a single bindgen (0.72.1).

clang-sys 1.9.1 is not the trigger. It was published on 2026-07-29, and the job kept passing with it for five weeks; the last passing run was 2026-09-05 12:25 UTC, four hours before bindgen 0.73.0.

## Solution

A step in the `semver-checks` job appends a `[patch.crates-io]` entry for bindgen to `.cargo/config.toml`, at the exact version read from `Cargo.lock`. A patch satisfies both requirements with a single copy and takes precedence in resolution. The placeholder lives under `target/`, inside the workspace, so the config applies to it. The version is read from the lockfile rather than hard-coded, so the pin follows dependabot, and the entry is written only in this job so every other job keeps building `--locked`.

Excluding the affected crates was considered and rejected: the panic surfaces in every crate that depends on `zebra-state`, which is most of the checked surface. Copying the lockfile into the placeholder does not work with the tool as shipped (it removes it before resolving), and `CARGO_NET_OFFLINE` only changes the error, not the resolution.

### Tests

Before/after on one PR in `zebra-private-devops`, whose `semver-checks` job is identical to this one: ZcashFoundation/zebra-private-devops#56.

- **Control** (doc-only change to `zebra-chain`, no fix): `semver-checks` fails with the panic above, for `zebra-consensus` and `zebra-rpc` — the same two crates as the run in #11409. Run 34245057862.
- **With this change** (same branch, fix pushed on top): `semver-checks` passes in 6 minutes. The pin step logs `Pinned bindgen 0.72.1 for cargo-semver-checks`, and every checked crate — including `zebra-consensus` and `zebra-rpc`, the two that failed — reports `Summary: no semver update required`. Run 34247515813.
- `actionlint` clean; the step dry-run against the real `Cargo.lock` extracts `0.72.1` and appends a valid `[patch.crates-io]` table, leaving the existing sections intact.

### Specifications & References

- #11409 — the failure this closes
- obi1kenobi/cargo-semver-checks#675, #991 — the tool ignores the workspace lockfile; still open, no flag exists
- [Overriding dependencies — `[patch]`](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section) and [config `[patch]`](https://doc.rust-lang.org/cargo/reference/config.html#patch) — patch entries are stable in `.cargo/config.toml` and take precedence in resolution

### Follow-up Work

- The underlying gap is upstream: cargo-semver-checks should honour the workspace lockfile (#991). Until it does, any other build-script dependency with an open-ended requirement can regress the same way; the pin step is the place to extend if that happens.
- The `librocksdb-sys` panic with two coexisting bindgen versions has no upstream report yet (rust-lang/rust-bindgen); worth filing so the next project hits a clear error rather than a panic.

### AI Disclosure

- [x] AI tools were used: Claude Code for the investigation (upstream source and issue tracing, dependency dating), the before/after verification, and this description. Author is responsible for the content.

### PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [x] This change was discussed in an issue or with the team beforehand. <!-- #11409 -->
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date. <!-- CI-only change; no changie fragment required -->
