### PR TITLE
fix(ci): temporarily make semver checks advisory

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -298,5 +298,6 @@ jobs:
           # entries are good enough. `allowed-failures` also tolerates a skip, and
           # must not be combined with `allowed-skips`: alls-green requires every
           # `allowed-skips` job to be skipped or successful, even a failure-allowed one.
-          allowed-failures: changelog-gate
-          allowed-skips: semver-checks, release-readiness
+          # Temporarily keep semver checks advisory until #11409 is resolved.
+          allowed-failures: changelog-gate, semver-checks
+          allowed-skips: release-readiness


### PR DESCRIPTION
## Motivation

The dependency-resolution failure in #11409 prevents `semver-checks` from evaluating API compatibility and makes the required PR gate fail. Temporarily make the check advisory so affected PRs can proceed while the underlying failure is repaired.

Closes #11412

## Solution

Allow `semver-checks` failures in the existing gate aggregator and remove it from `allowed-skips`, which would otherwise continue rejecting failures. The job still runs and reports its result. Other required checks remain enforced.

Actual semver violations are also non-blocking during this mitigation and require reviewer attention.

### Specifications & References

- #11409
- [Maintainer recommendation](https://github.com/ZcashFoundation/zebra/issues/11409#issuecomment-5586007637)

### Follow-up Work

Restore semver enforcement after #11409 is resolved.

### AI Disclosure

- [x] AI tools were used: OpenAI Codex for the workflow change, local verification, and PR description.

### PR Checklist

- [x] The PR title follows conventional commits.
- [x] The change was discussed with the team in #11409.
- [x] Workflow behavior is tested.
- [x] No user-facing documentation or changelog change is needed.
