### PR TITLE
ci: run the Go lightwalletd cached-state tests weekly and on labeled PRs, not on every main push

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -300,6 +300,7 @@ profiles are used on GCP VMs with `NEXTEST_FILTER` selecting specific tests.
 Weekly runs include:
 
 - Full Mainnet synchronization
+- Go lightwalletd cached-state tests (`lwd-sync-update`, `lwd-rpc-send-tx`, `lwd-grpc-wallet`), which also run in manual runs and on PRs labeled `run-stateful-tests`, but not on `main` pushes
 - Extended integration suites
 - Resource cleanup
 

--- a/.github/workflows/zfnd-ci-integration-tests-gcp.yml
+++ b/.github/workflows/zfnd-ci-integration-tests-gcp.yml
@@ -16,7 +16,7 @@ on:
 
   schedule:
     # Run this job every Friday at mid-day UTC
-    # This is limited to the Zebra and lightwalletd Full Sync jobs
+    # The full syncs run only here and in manual runs; the Go lightwalletd cached-state jobs also run on labeled PRs
     - cron: 0 12 * * 5
 
   #! Only this repository runs the weekly `schedule`. A copy of this workflow in any other
@@ -479,8 +479,11 @@ jobs:
 
   # Test update sync of lightwalletd with a lightwalletd and Zebra tip state
   # Runs:
-  # - after every PR is merged to `main`
-  # - on every PR update
+  # - on schedule, as defined at the top of the workflow
+  # - in manual workflow runs
+  # - on PRs labeled `run-stateful-tests`
+  #
+  # Not on `main` pushes: the Go lightwalletd jobs run weekly (#9941).
   #
   # If the state version has changed, waits for the new cached states to be created.
   # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
@@ -491,7 +494,7 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/zfnd-deploy-integration-tests-gcp.yml
-    if: ${{ !cancelled() && !failure() && (inputs.network || vars.ZCASH_NETWORK) == 'Mainnet' && ((needs.get-available-disks.result == 'success' && fromJSON(needs.get-available-disks.outputs.lwd_tip_disk)) || needs.lwd-sync-full.result == 'success') && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
+    if: ${{ !cancelled() && !failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && (inputs.network || vars.ZCASH_NETWORK) == 'Mainnet' && ((needs.get-available-disks.result == 'success' && fromJSON(needs.get-available-disks.outputs.lwd_tip_disk)) || needs.lwd-sync-full.result == 'success') && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
     secrets:
       GCP_SSH_PRIVATE_KEY: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
     with:
@@ -537,8 +540,11 @@ jobs:
   # Test that Zebra can handle a lightwalletd send transaction RPC call, using a cached Zebra tip state
   #
   # Runs:
-  # - after every PR is merged to `main`
-  # - on every PR update
+  # - on schedule, as defined at the top of the workflow
+  # - in manual workflow runs
+  # - on PRs labeled `run-stateful-tests`
+  #
+  # Not on `main` pushes: the Go lightwalletd jobs run weekly (#9941).
   #
   # If the state version has changed, waits for the new cached states to be created.
   # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
@@ -549,7 +555,7 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/zfnd-deploy-integration-tests-gcp.yml
-    if: ${{ !cancelled() && !failure() && (inputs.network || vars.ZCASH_NETWORK) == 'Mainnet' && ((needs.get-available-disks.result == 'success' && fromJSON(needs.get-available-disks.outputs.lwd_tip_disk)) || needs.lwd-sync-full.result == 'success') && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
+    if: ${{ !cancelled() && !failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && (inputs.network || vars.ZCASH_NETWORK) == 'Mainnet' && ((needs.get-available-disks.result == 'success' && fromJSON(needs.get-available-disks.outputs.lwd_tip_disk)) || needs.lwd-sync-full.result == 'success') && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
     secrets:
       GCP_SSH_PRIVATE_KEY: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
     with:
@@ -564,8 +570,11 @@ jobs:
   # Test that Zebra can handle gRPC wallet calls, using a cached Zebra tip state
   #
   # Runs:
-  # - after every PR is merged to `main`
-  # - on every PR update
+  # - on schedule, as defined at the top of the workflow
+  # - in manual workflow runs
+  # - on PRs labeled `run-stateful-tests`
+  #
+  # Not on `main` pushes: the Go lightwalletd jobs run weekly (#9941).
   #
   # If the state version has changed, waits for the new cached states to be created.
   # Otherwise, if the state rebuild was skipped, runs immediately after the build job.
@@ -576,7 +585,7 @@ jobs:
       contents: read
       id-token: write
     uses: ./.github/workflows/zfnd-deploy-integration-tests-gcp.yml
-    if: ${{ !cancelled() && !failure() && (inputs.network || vars.ZCASH_NETWORK) == 'Mainnet' && ((needs.get-available-disks.result == 'success' && fromJSON(needs.get-available-disks.outputs.lwd_tip_disk)) || needs.lwd-sync-full.result == 'success') && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
+    if: ${{ !cancelled() && !failure() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request') && (inputs.network || vars.ZCASH_NETWORK) == 'Mainnet' && ((needs.get-available-disks.result == 'success' && fromJSON(needs.get-available-disks.outputs.lwd_tip_disk)) || needs.lwd-sync-full.result == 'success') && github.event.inputs.regenerate-disks != 'true' && github.event.inputs.run-full-sync != 'true' && github.event.inputs.run-lwd-sync != 'true' }}
     secrets:
       GCP_SSH_PRIVATE_KEY: ${{ secrets.GCP_SSH_PRIVATE_KEY }}
     with:


### PR DESCRIPTION
## Motivation

`lwd-sync-update`, `lwd-rpc-send-tx` and `lwd-grpc-wallet` run on every push to `main`, ~8 times a week, each on its own GCP VM for 25–45 minutes: roughly 12 VM-hours a week for three jobs that test the Go lightwalletd daemon against a cached mainnet state. Nothing they exercise changes between two ordinary merges, so per-merge runs repeat what the Friday run already shows. This is Track B0 of #9941, reshaped after the discussion there: move the jobs to the weekly run rather than delete them, since Go lightwalletd is still supported.

## Solution

- Gate the three jobs on `schedule`, `workflow_dispatch` or `pull_request`. On `main` pushes they skip; on Fridays they run after `lwd-sync-full` refreshes the `lwd-cache` disk, as that job already does.
- PRs labeled `run-stateful-tests` keep running them, so a change to the lightwalletd image or to RPC output that lightwalletd ingests (as in #11319 and #10762) can still be checked before merge. The existing label gate at the top of the workflow is unchanged.
- Nothing is deleted. `failure-issue` still opens a `ci-fail/main` issue when a scheduled run fails, and `integration-tests-success` already lists the three jobs under `allowed-skips`, so it stays green on `main` pushes.
- Trade-off: a `main` regression in this area that no PR labeled for is caught on Friday instead of at merge time. Regtest-native replacements are tracked in #9941 (B1 for `lwd-grpc-wallet`, B3 for `lwd-rpc-send-tx` via #11410).

### Tests

Workflow-only. The three `if:` expressions gain one clause; actionlint is clean. Expected on this PR: no lightwalletd jobs run (no label). Expected on the next Friday run: `lightwalletd tip`, then the three jobs.

### AI Disclosure

- [x] AI tools were used: Claude Code drafted the change; reviewed locally.

### PR Checklist

- [x] The PR title follows conventional commits
- [x] The PR follows the contribution guidelines
- [x] This change was discussed in an issue or with the team beforehand (#9941)
- [x] The solution is tested
- [x] The documentation and changelogs are up to date (`ci:` — no fragment required; workflows README updated)
