### PR TITLE
test(zebrad): cover the lightwalletd gRPC mempool methods on regtest

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -20,6 +20,10 @@ mod unmined;
 #[cfg(any(test, feature = "proptest-impl"))]
 #[allow(clippy::unwrap_in_result)]
 pub mod arbitrary;
+#[cfg(any(test, feature = "proptest-impl"))]
+mod test_signing;
+#[cfg(test)]
+mod test_signing_tests;
 #[cfg(test)]
 mod tests;
 
@@ -35,6 +39,8 @@ pub use serialize::{
     MIN_TRANSPARENT_TX_V5_SIZE,
 };
 pub use sighash::{HashType, SigHash, SigHasher};
+#[cfg(any(test, feature = "proptest-impl"))]
+pub use test_signing::TransparentSigningKey;
 pub use unmined::{
     zip317, UnminedTx, UnminedTxId, VerifiedUnminedTx, MEMPOOL_TRANSACTION_COST_THRESHOLD,
 };

--- a/zebra-chain/src/transaction/test_signing.rs
+++ b/zebra-chain/src/transaction/test_signing.rs
@@ -1,0 +1,174 @@
+//! Signing transparent-only transactions in tests.
+//!
+//! Zebra is a node, not a wallet, so this is the only code in the tree that signs a transaction.
+//! Regtest tests use it to put real, spendable transactions into block templates and blocks.
+
+use secp256k1::{PublicKey, Secp256k1, SecretKey};
+use zcash_primitives::transaction::{
+    builder::DEFAULT_TX_EXPIRY_DELTA,
+    fees::{
+        transparent::InputSize,
+        zip317::{FeeRule, P2PKH_STANDARD_OUTPUT_SIZE},
+        FeeRule as _,
+    },
+    sighash::{signature_hash, SignableInput},
+    txid::TxIdDigester,
+    Authorized, TransactionData, TxVersion, Unauthorized,
+};
+use zcash_protocol::{consensus::BranchId, value::Zatoshis};
+use zcash_transparent::{
+    address::TransparentAddress,
+    builder::{TransparentBuilder, TransparentSigningSet},
+    bundle::OutPoint,
+};
+
+use crate::{
+    amount::{Amount, NonNegative},
+    block::Height,
+    parameters::{Network, NetworkKind},
+    transaction::{compat, Transaction},
+    transparent, BoxError,
+};
+
+/// A secp256k1 key that owns pay-to-public-key-hash outputs.
+#[derive(Clone, Debug)]
+pub struct TransparentSigningKey {
+    secret: SecretKey,
+    public: PublicKey,
+}
+
+impl TransparentSigningKey {
+    /// Generates a random key.
+    pub fn random() -> Self {
+        let secret = loop {
+            if let Ok(secret) = SecretKey::from_slice(&rand::random::<[u8; 32]>()) {
+                break secret;
+            }
+        };
+        let public = PublicKey::from_secret_key(&Secp256k1::signing_only(), &secret);
+
+        Self { secret, public }
+    }
+
+    /// Returns the pay-to-public-key-hash address of this key.
+    pub fn address(&self, network_kind: NetworkKind) -> transparent::Address {
+        match TransparentAddress::from_pubkey(&self.public) {
+            TransparentAddress::PublicKeyHash(hash) => {
+                transparent::Address::from_pub_key_hash(network_kind, hash)
+            }
+            _ => unreachable!("a public key always hashes to a P2PKH address"),
+        }
+    }
+}
+
+impl Transaction {
+    /// Builds and signs a transparent-only transaction that spends `inputs`, which must all be
+    /// P2PKH outputs owned by `key`, to `outputs`.
+    ///
+    /// Pays the ZIP-317 conventional fee and returns the remainder to `key` as a final change
+    /// output, so `inputs` must cover `outputs` plus the fee with something left over.
+    pub fn signed_transparent(
+        network: &Network,
+        target_height: Height,
+        key: &TransparentSigningKey,
+        inputs: &[(transparent::OutPoint, transparent::Output)],
+        outputs: &[(transparent::Address, Amount<NonNegative>)],
+    ) -> Result<Self, BoxError> {
+        let target_height = compat::height_to_block_height(target_height);
+
+        // The change output counts towards the fee, so it is always added below.
+        let fee = FeeRule::standard()
+            .fee_required(
+                network,
+                target_height,
+                inputs.iter().map(|_| InputSize::STANDARD_P2PKH),
+                std::iter::repeat_n(P2PKH_STANDARD_OUTPUT_SIZE, outputs.len() + 1),
+                0,
+                0,
+                0,
+                0,
+            )
+            .map_err(|err| format!("{err:?}"))?;
+
+        let input_total: i64 = inputs
+            .iter()
+            .map(|(_, output)| output.value().zatoshis())
+            .sum();
+        let output_total: i64 = outputs.iter().map(|(_, value)| value.zatoshis()).sum();
+        let change = input_total - output_total - i64::try_from(u64::from(fee))?;
+        if change <= 0 {
+            return Err(format!(
+                "inputs ({input_total}) must exceed outputs ({output_total}) plus fee ({fee:?})"
+            )
+            .into());
+        }
+
+        let mut signing_set = TransparentSigningSet::new();
+        let pubkey = signing_set.add_key(key.secret);
+
+        let mut builder = TransparentBuilder::empty();
+        for (outpoint, output) in inputs {
+            builder.add_p2pkh_input(
+                pubkey,
+                OutPoint::new(outpoint.hash.0, outpoint.index),
+                compat::output_to_txout(output),
+            )?;
+        }
+
+        let change_output = (key.address(network.kind()), Amount::try_from(change)?);
+        for (address, value) in outputs.iter().chain(std::iter::once(&change_output)) {
+            builder.add_output(
+                &(*address).try_into()?,
+                Zatoshis::from_u64(u64::from(*value))?,
+            )?;
+        }
+        let bundle = builder
+            .build()
+            .ok_or("transaction has no transparent inputs or outputs")?;
+
+        let branch_id = BranchId::for_height(network, target_height);
+        let version = TxVersion::suggested_for_branch(branch_id);
+        let expiry_height = target_height + DEFAULT_TX_EXPIRY_DELTA;
+
+        let unauthed_tx = TransactionData::<Unauthorized>::from_parts(
+            version,
+            branch_id,
+            0,
+            expiry_height,
+            Some(bundle),
+            None,
+            None,
+            None,
+        );
+        let txid_parts = unauthed_tx.digest(TxIdDigester);
+        let signed_bundle = unauthed_tx
+            .transparent_bundle()
+            .expect("bundle was just added")
+            .clone()
+            .apply_signatures(
+                |input| {
+                    *signature_hash(
+                        &unauthed_tx,
+                        &SignableInput::Transparent(input),
+                        &txid_parts,
+                    )
+                    .as_ref()
+                },
+                &signing_set,
+            )?;
+
+        let signed_tx = TransactionData::<Authorized>::from_parts(
+            version,
+            branch_id,
+            0,
+            expiry_height,
+            Some(signed_bundle),
+            None,
+            None,
+            None,
+        )
+        .freeze()?;
+
+        Ok(Self(signed_tx))
+    }
+}

--- a/zebra-chain/src/transaction/test_signing_tests.rs
+++ b/zebra-chain/src/transaction/test_signing_tests.rs
@@ -1,0 +1,118 @@
+//! Tests for [`Transaction::signed_transparent`].
+//!
+//! Signature validity is not checked here: the regtest integration test in `zebrad` sends the
+//! transactions through consensus verification, which is the only oracle that counts.
+
+use crate::{
+    amount::Amount,
+    block::Height,
+    parameters::{testnet::ConfiguredActivationHeights, Network, NetworkKind, NetworkUpgrade},
+    serialization::{ZcashDeserializeInto, ZcashSerialize},
+    transaction::{self, Transaction, TransparentSigningKey},
+    transparent,
+};
+
+/// ZIP-317 conventional fee for a transaction with two logical actions.
+const TWO_ACTION_FEE: i64 = 10_000;
+
+#[test]
+fn signed_transparent_pays_outputs_fee_and_change() {
+    let _init_guard = zebra_test::init();
+
+    let network = Network::new_regtest(
+        ConfiguredActivationHeights {
+            nu5: Some(1),
+            ..Default::default()
+        }
+        .into(),
+    );
+    let key = TransparentSigningKey::random();
+    let recipient = TransparentSigningKey::random().address(NetworkKind::Regtest);
+
+    let outpoint = transparent::OutPoint {
+        hash: transaction::Hash([1; 32]),
+        index: 3,
+    };
+    let coin = transparent::Output {
+        value: Amount::try_from(100_000_000).expect("valid amount"),
+        lock_script: key.address(NetworkKind::Regtest).script(),
+    };
+    let send_amount = Amount::try_from(30_000_000).expect("valid amount");
+
+    let tx = Transaction::signed_transparent(
+        &network,
+        Height(10),
+        &key,
+        &[(outpoint, coin.clone())],
+        &[(recipient, send_amount)],
+    )
+    .expect("a funded transparent spend must build");
+
+    assert_eq!(
+        tx.version(),
+        5,
+        "NU5 is active, so the transaction must be v5"
+    );
+    assert_eq!(tx.network_upgrade(), Some(NetworkUpgrade::Nu5));
+    assert_eq!(
+        tx.expiry_height(),
+        Some(Height(50)),
+        "default expiry delta is 40 blocks"
+    );
+
+    let inputs = tx.inputs();
+    assert_eq!(inputs.len(), 1);
+    assert_eq!(inputs[0].outpoint(), Some(outpoint));
+
+    let outputs = tx.outputs();
+    assert_eq!(outputs.len(), 2, "one recipient plus change");
+    assert_eq!(outputs[0].value, send_amount);
+    assert_eq!(outputs[0].lock_script, recipient.script());
+    assert_eq!(
+        outputs[1].lock_script, coin.lock_script,
+        "change returns to the signing key"
+    );
+
+    let fee = coin.value.zatoshis() - outputs.iter().map(|o| o.value.zatoshis()).sum::<i64>();
+    assert_eq!(
+        fee, TWO_ACTION_FEE,
+        "exactly the ZIP-317 conventional fee is paid"
+    );
+
+    let round_trip: Transaction = tx
+        .zcash_serialize_to_vec()
+        .expect("serializes")
+        .zcash_deserialize_into()
+        .expect("deserializes");
+    assert_eq!(round_trip, tx);
+}
+
+#[test]
+fn signed_transparent_rejects_underfunded_spend() {
+    let _init_guard = zebra_test::init();
+
+    let network = Network::new_regtest(Default::default());
+    let key = TransparentSigningKey::random();
+    let address = key.address(NetworkKind::Regtest);
+
+    let coin = transparent::Output {
+        value: Amount::try_from(TWO_ACTION_FEE).expect("valid amount"),
+        lock_script: address.script(),
+    };
+
+    let result = Transaction::signed_transparent(
+        &network,
+        Height(10),
+        &key,
+        &[(
+            transparent::OutPoint::from_usize(transaction::Hash([2; 32]), 0),
+            coin,
+        )],
+        &[(address, Amount::try_from(1).expect("valid amount"))],
+    );
+
+    assert!(
+        result.is_err(),
+        "inputs that cannot cover outputs plus fee must be rejected"
+    );
+}

--- a/zebrad/tests/integration/lightwalletd_grpc.rs
+++ b/zebrad/tests/integration/lightwalletd_grpc.rs
@@ -1,0 +1,648 @@
+//! End-to-end tests for Zebra's built-in lightwalletd-compatible gRPC server on Regtest.
+
+use std::time::Duration;
+
+use color_eyre::eyre::{eyre, Result};
+use tonic::{Code, Status, Streaming};
+
+use zebra_chain::{
+    block,
+    parameters::{testnet::ConfiguredActivationHeights, Network},
+    serialization::ZcashSerialize as _,
+    transaction,
+};
+use zebra_node_services::rpc_client::RpcRequestClient;
+use zebra_rpc::{
+    client::{
+        GetAddressBalanceResponse, GetAddressUtxosResponse, GetBlockHashResponse, GetInfoResponse,
+        GetRawTransactionResponse, GetSubtreesByIndexResponse, GetTreestateResponse,
+    },
+    lightwalletd::{
+        compact_tx_streamer_client::CompactTxStreamerClient, Address as LightwalletdAddress,
+        AddressList, BlockId, BlockRange, ChainSpec, Duration as PingDuration, Empty,
+        GetAddressUtxosArg, GetSubtreeRootsArg, ShieldedProtocol, TransparentAddressBlockFilter,
+        TxFilter,
+    },
+    server::{OPENED_LIGHTWALLETD_ENDPOINT_MSG, OPENED_RPC_ENDPOINT_MSG},
+};
+use zebra_test::{args, prelude::*};
+
+use crate::common::{
+    config::{os_assigned_rpc_port_config, read_listen_addr_from_logs, testdir},
+    launch::{ZebradTestDirExt, LAUNCH_DELAY},
+    regtest::MiningRpcMethods,
+};
+
+/// The number of blocks mined on top of genesis before the server is queried.
+const NUM_BLOCKS: u32 = 10;
+
+/// How long to wait for a single gRPC response, or for the next message of a stream.
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Zebra's built-in `CompactTxStreamer` server must serve a chain it mined itself, and
+/// every answer must agree with the JSON-RPC interface and the blocks that were mined.
+///
+/// A fresh Regtest chain is enough to prove this: the gRPC methods are thin views over
+/// the state and the JSON-RPC methods, so the byte orders, status codes, and stream
+/// edges they get wrong show up on a ten-block chain of transparent coinbase
+/// transactions just as they would on Mainnet. This replaces the GCP `lwd-grpc-wallet`
+/// job, which drove the Go `lightwalletd` binary against a cached Mainnet state.
+///
+/// Mempool methods are not covered here, because they need a signed transaction.
+#[tokio::test]
+async fn lightwalletd_grpc_serves_a_regtest_chain() -> Result<()> {
+    let _init_guard = zebra_test::init();
+
+    let network = Network::new_regtest(
+        ConfiguredActivationHeights {
+            nu5: Some(1),
+            ..Default::default()
+        }
+        .into(),
+    );
+
+    let mut config = os_assigned_rpc_port_config(false, &network)?;
+    config.rpc.lightwalletd_listen_addr = Some("127.0.0.1:0".parse()?);
+    config.mempool.debug_enable_at_height = Some(0);
+    let miner_address = config
+        .mining
+        .miner_address
+        .as_ref()
+        .expect("the default test config sets a transparent miner address")
+        .to_string();
+
+    let mut zebrad = testdir()?
+        .with_config(&mut config)?
+        .spawn_child(args!["start"])?;
+
+    // The JSON-RPC server is started before the gRPC server, so the log lines come in this order.
+    let rpc_address = read_listen_addr_from_logs(&mut zebrad, OPENED_RPC_ENDPOINT_MSG)?;
+    let grpc_address = read_listen_addr_from_logs(&mut zebrad, OPENED_LIGHTWALLETD_ENDPOINT_MSG)?;
+
+    tokio::time::sleep(LAUNCH_DELAY).await;
+
+    let rpc = RpcRequestClient::new(rpc_address);
+
+    // Mine the chain, then read the mined blocks back as the oracle for everything below.
+    let generated_hashes = rpc.generate(NUM_BLOCKS).await?;
+    assert_eq!(generated_hashes.len(), NUM_BLOCKS as usize);
+
+    let mut blocks = Vec::new();
+    for height in 1..=NUM_BLOCKS {
+        let block = rpc
+            .get_block(height as i32)
+            .await
+            .map_err(|err| eyre!(err))?
+            .ok_or_else(|| eyre!("mined block {height} is missing from the state"))?;
+        assert_eq!(block.hash(), generated_hashes[height as usize - 1]);
+        blocks.push(block);
+    }
+
+    let endpoint = tonic::transport::Endpoint::new(format!("http://{grpc_address}"))?
+        .timeout(RESPONSE_TIMEOUT);
+    let mut grpc = CompactTxStreamerClient::connect(endpoint).await?;
+
+    // GetLightdInfo: chain and node details must come from the node, not from the crate.
+    let blockchain_info = rpc.blockchain_info().await?;
+    let node_info: GetInfoResponse = rpc
+        .json_result_from_call("getinfo", "[]")
+        .await
+        .map_err(|err| eyre!(err))?;
+    let (tip_branch_id, _next_branch_id) = blockchain_info.consensus().into_parts();
+
+    let lightd_info = grpc.get_lightd_info(Empty {}).await?.into_inner();
+    assert_eq!(lightd_info.chain_name, *blockchain_info.chain());
+    assert_eq!(lightd_info.block_height, u64::from(NUM_BLOCKS));
+    assert_eq!(
+        lightd_info.block_height,
+        u64::from(blockchain_info.blocks().0)
+    );
+    assert_eq!(
+        lightd_info.estimated_height,
+        u64::from(blockchain_info.estimated_height().0)
+    );
+    assert_eq!(
+        lightd_info.consensus_branch_id,
+        format!("{tip_branch_id:08x}")
+    );
+    assert_eq!(
+        lightd_info.sapling_activation_height,
+        u64::from(network.sapling_activation_height().0)
+    );
+    assert_eq!(lightd_info.vendor, "ZcashFoundation/zebra");
+    assert!(lightd_info.taddr_support);
+    assert!(!lightd_info.version.is_empty());
+    assert_eq!(lightd_info.version, *node_info.build());
+    assert_eq!(lightd_info.zcashd_build, *node_info.build());
+    assert_eq!(lightd_info.zcashd_subversion, *node_info.subversion());
+
+    // GetLatestBlock: the tip, with the hash in internal byte order.
+    let best_hash: GetBlockHashResponse = rpc
+        .json_result_from_call("getbestblockhash", "[]")
+        .await
+        .map_err(|err| eyre!(err))?;
+    let best_hash = best_hash.hash();
+    assert_eq!(best_hash, blocks[NUM_BLOCKS as usize - 1].hash());
+
+    let latest_block = grpc.get_latest_block(ChainSpec {}).await?.into_inner();
+    assert_eq!(latest_block.height, u64::from(NUM_BLOCKS));
+    assert_eq!(block_hash_from_lightwalletd(&latest_block.hash)?, best_hash);
+
+    // GetBlock: by height and by hash, checked against the mined block and `getblock`.
+    let mut compact_blocks = Vec::new();
+    for (index, block) in blocks.iter().enumerate() {
+        let height = index as u64 + 1;
+        let previous_hash = index.checked_sub(1).map_or_else(
+            || network.genesis_hash(),
+            |previous| blocks[previous].hash(),
+        );
+
+        let by_height = grpc
+            .get_block(block_id_for_height(height))
+            .await?
+            .into_inner();
+        let by_hash = grpc
+            .get_block(block_id_for_hash(block.hash()))
+            .await?
+            .into_inner();
+        assert_eq!(
+            by_height, by_hash,
+            "a block must not depend on how it is looked up"
+        );
+
+        assert_eq!(by_height.height, height);
+        assert_eq!(block_hash_from_lightwalletd(&by_height.hash)?, block.hash());
+        assert_eq!(
+            block_hash_from_lightwalletd(&by_height.prev_hash)?,
+            block.header.previous_block_hash
+        );
+        assert_eq!(block.header.previous_block_hash, previous_hash);
+        assert_eq!(
+            u64::from(by_height.time),
+            u64::try_from(block.header.time.timestamp())?
+        );
+        // Like lightwalletd, transactions without shielded data are left out of compact blocks.
+        assert_eq!(block.transactions.len(), 1);
+        assert!(
+            by_height.vtx.is_empty(),
+            "a transparent coinbase transaction has no compact data"
+        );
+
+        // `getblock` omits a pool from `trees` when its tree is empty, like zcashd.
+        let block_object: serde_json::Value = rpc
+            .json_result_from_call("getblock", format!(r#"["{height}", 1]"#))
+            .await
+            .map_err(|err| eyre!(err))?;
+        let trees = &block_object["trees"];
+        assert!(trees.is_object(), "getblock must report the tree sizes");
+        let tree_size = |pool: &str| trees[pool]["size"].as_u64().unwrap_or_default();
+        let metadata = by_height
+            .chain_metadata
+            .as_ref()
+            .expect("compact blocks carry the note commitment tree sizes");
+        assert_eq!(
+            u64::from(metadata.sapling_commitment_tree_size),
+            tree_size("sapling")
+        );
+        assert_eq!(
+            u64::from(metadata.orchard_commitment_tree_size),
+            tree_size("orchard")
+        );
+        assert_eq!(
+            u64::from(metadata.ironwood_commitment_tree_size),
+            tree_size("ironwood")
+        );
+
+        compact_blocks.push(by_height);
+    }
+
+    // GetBlockRange: inclusive, in the direction of the range, and a range past the tip
+    // yields the blocks that exist and then fails.
+    let ascending = grpc
+        .get_block_range(block_range(1, u64::from(NUM_BLOCKS)))
+        .await?
+        .into_inner();
+    let (ascending, status) = drain_stream(ascending).await?;
+    assert_eq!(ascending, compact_blocks);
+    assert!(status.is_none(), "ascending range failed: {status:?}");
+
+    let descending = grpc
+        .get_block_range(block_range(u64::from(NUM_BLOCKS), 1))
+        .await?
+        .into_inner();
+    let (descending, status) = drain_stream(descending).await?;
+    let mut reversed_blocks = compact_blocks.clone();
+    reversed_blocks.reverse();
+    assert_eq!(descending, reversed_blocks);
+    assert!(status.is_none(), "descending range failed: {status:?}");
+
+    let past_tip_start = u64::from(NUM_BLOCKS) - 2;
+    let past_tip = grpc
+        .get_block_range(block_range(past_tip_start, u64::from(NUM_BLOCKS) + 5))
+        .await?
+        .into_inner();
+    let (past_tip, status) = drain_stream(past_tip).await?;
+    assert_eq!(past_tip, compact_blocks[past_tip_start as usize - 1..]);
+    assert_eq!(
+        status.map(|status| status.code()),
+        Some(Code::NotFound),
+        "a range past the tip must end with a not found status"
+    );
+
+    // GetBlockNullifiers and GetBlockRangeNullifiers: on a chain without shielded
+    // transactions, the nullifier-only view is identical to the full compact blocks.
+    let nullifiers = grpc
+        .get_block_nullifiers(block_id_for_height(u64::from(NUM_BLOCKS)))
+        .await?
+        .into_inner();
+    assert_eq!(nullifiers, compact_blocks[NUM_BLOCKS as usize - 1]);
+    assert!(nullifiers.vtx.is_empty());
+
+    let nullifier_range = grpc
+        .get_block_range_nullifiers(block_range(1, u64::from(NUM_BLOCKS)))
+        .await?
+        .into_inner();
+    let (nullifier_range, status) = drain_stream(nullifier_range).await?;
+    assert_eq!(nullifier_range, compact_blocks);
+    assert!(status.is_none(), "nullifier range failed: {status:?}");
+
+    // GetTreeState and GetLatestTreeState: must match `z_gettreestate` for the tip.
+    let treestate: GetTreestateResponse = rpc
+        .json_result_from_call("z_gettreestate", format!(r#"["{NUM_BLOCKS}"]"#))
+        .await
+        .map_err(|err| eyre!(err))?;
+    let final_state_hex = |treestate: &zebra_rpc::client::Treestate| {
+        treestate
+            .commitments()
+            .final_state()
+            .as_ref()
+            .map(hex::encode)
+            .unwrap_or_default()
+    };
+
+    let tree_state_by_height = grpc
+        .get_tree_state(block_id_for_height(u64::from(NUM_BLOCKS)))
+        .await?
+        .into_inner();
+    let tree_state_by_hash = grpc
+        .get_tree_state(block_id_for_hash(best_hash))
+        .await?
+        .into_inner();
+    let latest_tree_state = grpc.get_latest_tree_state(Empty {}).await?.into_inner();
+    assert_eq!(tree_state_by_height, tree_state_by_hash);
+    assert_eq!(tree_state_by_height, latest_tree_state);
+
+    assert_eq!(tree_state_by_height.network, network.bip70_network_name());
+    assert_eq!(tree_state_by_height.height, u64::from(treestate.height().0));
+    assert_eq!(tree_state_by_height.height, u64::from(NUM_BLOCKS));
+    // Unlike the binary hashes, the tree state hash is a hex string in display order.
+    assert_eq!(tree_state_by_height.hash, treestate.hash().to_string());
+    assert_eq!(tree_state_by_height.hash.parse::<block::Hash>()?, best_hash);
+    assert_eq!(tree_state_by_height.time, treestate.time());
+    assert_eq!(
+        tree_state_by_height.sapling_tree,
+        final_state_hex(treestate.sapling())
+    );
+    assert!(
+        !tree_state_by_height.sapling_tree.is_empty(),
+        "Sapling is active, so its tree state must be present"
+    );
+    assert_eq!(
+        tree_state_by_height.orchard_tree,
+        final_state_hex(treestate.orchard())
+    );
+    assert!(
+        !tree_state_by_height.orchard_tree.is_empty(),
+        "NU5 is active, so the Orchard tree state must be present"
+    );
+
+    // GetTransaction: the coinbase of block 1, byte for byte, with its mined height.
+    let coinbase = &blocks[0].transactions[0];
+    let GetRawTransactionResponse::Raw(raw_coinbase) = rpc
+        .json_result_from_call(
+            "getrawtransaction",
+            format!(r#"["{}", 0]"#, coinbase.hash()),
+        )
+        .await
+        .map_err(|err| eyre!(err))?
+    else {
+        panic!("getrawtransaction with verbosity 0 must return raw bytes");
+    };
+
+    let raw_coinbase: &[u8] = raw_coinbase.as_ref();
+
+    let raw_transaction = grpc
+        .get_transaction(tx_filter_for_hash(coinbase.hash()))
+        .await?
+        .into_inner();
+    assert_eq!(raw_transaction.data, raw_coinbase);
+    assert_eq!(raw_transaction.data, coinbase.zcash_serialize_to_vec()?);
+    assert_eq!(raw_transaction.height, 1);
+
+    let missing_txid = transaction::Hash([0xab; 32]);
+    let status = grpc
+        .get_transaction(tx_filter_for_hash(missing_txid))
+        .await
+        .expect_err("an unknown transaction must not be served");
+    assert_eq!(status.code(), Code::NotFound);
+
+    // GetTaddressBalance and GetTaddressBalanceStream: must match `getaddressbalance`.
+    let address_balance: GetAddressBalanceResponse = rpc
+        .json_result_from_call(
+            "getaddressbalance",
+            format!(r#"[{{"addresses": ["{miner_address}"]}}]"#),
+        )
+        .await
+        .map_err(|err| eyre!(err))?;
+    assert!(
+        address_balance.balance() > 0,
+        "the miner address must have been paid by the mined coinbase transactions"
+    );
+
+    let balance = grpc
+        .get_taddress_balance(AddressList {
+            addresses: vec![miner_address.clone()],
+        })
+        .await?
+        .into_inner();
+    assert_eq!(balance.value_zat, i64::try_from(address_balance.balance())?);
+
+    let streamed_balance = grpc
+        .get_taddress_balance_stream(tokio_stream::iter([LightwalletdAddress {
+            address: miner_address.clone(),
+        }]))
+        .await?
+        .into_inner();
+    assert_eq!(streamed_balance, balance);
+
+    // GetTaddressTxids and GetTaddressTransactions: every coinbase, in block order,
+    // matching `getaddresstxids`.
+    let address_txids: Vec<String> = rpc
+        .json_result_from_call(
+            "getaddresstxids",
+            format!(r#"[{{"addresses": ["{miner_address}"], "start": 1, "end": {NUM_BLOCKS}}}]"#),
+        )
+        .await
+        .map_err(|err| eyre!(err))?;
+    assert_eq!(address_txids.len(), NUM_BLOCKS as usize);
+
+    let address_filter = TransparentAddressBlockFilter {
+        address: miner_address.clone(),
+        range: Some(block_range(1, u64::from(NUM_BLOCKS))),
+    };
+    let (address_transactions, status) = drain_stream(
+        grpc.get_taddress_txids(address_filter.clone())
+            .await?
+            .into_inner(),
+    )
+    .await?;
+    assert!(status.is_none(), "taddress txids stream failed: {status:?}");
+    assert_eq!(address_transactions.len(), NUM_BLOCKS as usize);
+    for (index, raw_transaction) in address_transactions.iter().enumerate() {
+        let coinbase = &blocks[index].transactions[0];
+        assert_eq!(address_txids[index], coinbase.hash().to_string());
+        assert_eq!(raw_transaction.height, index as u64 + 1);
+        assert_eq!(raw_transaction.data, coinbase.zcash_serialize_to_vec()?);
+    }
+
+    let (address_transactions_alias, status) = drain_stream(
+        grpc.get_taddress_transactions(address_filter)
+            .await?
+            .into_inner(),
+    )
+    .await?;
+    assert!(
+        status.is_none(),
+        "taddress transactions stream failed: {status:?}"
+    );
+    assert_eq!(address_transactions_alias, address_transactions);
+
+    // GetAddressUtxos and GetAddressUtxosStream: must match `getaddressutxos`, and the
+    // start height and entry limit must be applied.
+    let GetAddressUtxosResponse::Utxos(address_utxos) = rpc
+        .json_result_from_call(
+            "getaddressutxos",
+            format!(r#"[{{"addresses": ["{miner_address}"]}}]"#),
+        )
+        .await
+        .map_err(|err| eyre!(err))?
+    else {
+        panic!("getaddressutxos without chainInfo must return a plain list");
+    };
+    assert_eq!(address_utxos.len(), NUM_BLOCKS as usize);
+
+    let utxos_arg = GetAddressUtxosArg {
+        addresses: vec![miner_address.clone()],
+        start_height: 0,
+        max_entries: 0,
+    };
+    let utxos = grpc
+        .get_address_utxos(utxos_arg.clone())
+        .await?
+        .into_inner()
+        .address_utxos;
+    assert_eq!(utxos.len(), address_utxos.len());
+    for (utxo, expected) in utxos.iter().zip(&address_utxos) {
+        assert_eq!(utxo.address, expected.address().to_string());
+        assert_eq!(utxo.address, miner_address);
+        assert_eq!(txid_from_lightwalletd(&utxo.txid)?, expected.txid());
+        assert_eq!(u32::try_from(utxo.index)?, expected.output_index().index());
+        assert_eq!(utxo.script, expected.script().as_raw_bytes());
+        assert_eq!(utxo.value_zat, i64::try_from(expected.satoshis())?);
+        assert_eq!(utxo.height, u64::from(expected.height().0));
+    }
+    let utxo_total: i64 = utxos.iter().map(|utxo| utxo.value_zat).sum();
+    assert_eq!(utxo_total, balance.value_zat);
+
+    let (streamed_utxos, status) = drain_stream(
+        grpc.get_address_utxos_stream(utxos_arg.clone())
+            .await?
+            .into_inner(),
+    )
+    .await?;
+    assert!(status.is_none(), "address utxos stream failed: {status:?}");
+    assert_eq!(streamed_utxos, utxos);
+
+    let limited_utxos = grpc
+        .get_address_utxos(GetAddressUtxosArg {
+            max_entries: 3,
+            ..utxos_arg.clone()
+        })
+        .await?
+        .into_inner()
+        .address_utxos;
+    assert_eq!(limited_utxos, utxos[..3]);
+
+    let recent_utxos = grpc
+        .get_address_utxos(GetAddressUtxosArg {
+            start_height: u64::from(NUM_BLOCKS) - 1,
+            ..utxos_arg
+        })
+        .await?
+        .into_inner()
+        .address_utxos;
+    assert_eq!(recent_utxos, utxos[NUM_BLOCKS as usize - 2..]);
+
+    // GetSubtreeRoots: a tiny chain has no complete subtrees, so the streams are empty
+    // but not errors, matching `z_getsubtreesbyindex`.
+    for (protocol, pool) in [
+        (ShieldedProtocol::Sapling, "sapling"),
+        (ShieldedProtocol::Orchard, "orchard"),
+    ] {
+        let subtrees: GetSubtreesByIndexResponse = rpc
+            .json_result_from_call("z_getsubtreesbyindex", format!(r#"["{pool}", 0]"#))
+            .await
+            .map_err(|err| eyre!(err))?;
+        assert!(subtrees.subtrees().is_empty());
+
+        let (roots, status) = drain_stream(
+            grpc.get_subtree_roots(GetSubtreeRootsArg {
+                start_index: 0,
+                shielded_protocol: protocol.into(),
+                max_entries: 0,
+            })
+            .await?
+            .into_inner(),
+        )
+        .await?;
+        assert!(
+            status.is_none(),
+            "{pool} subtree roots stream failed: {status:?}"
+        );
+        assert!(roots.is_empty(), "{pool} must have no complete subtrees");
+    }
+
+    let status = grpc
+        .get_subtree_roots(GetSubtreeRootsArg {
+            start_index: 0,
+            shielded_protocol: 99,
+            max_entries: 0,
+        })
+        .await
+        .expect_err("an unknown shielded protocol must be rejected");
+    assert_eq!(status.code(), Code::InvalidArgument);
+
+    // Ping is disabled, like on production lightwalletd instances.
+    let status = grpc
+        .ping(PingDuration { interval_us: 0 })
+        .await
+        .expect_err("ping must be disabled");
+    assert_eq!(status.code(), Code::Unimplemented);
+
+    // Error paths: an unset block id is a client error, and a missing block is not found.
+    let status = grpc
+        .get_block(BlockId {
+            height: 0,
+            hash: Vec::new(),
+        })
+        .await
+        .expect_err("an unset block id must not be read as genesis");
+    assert_eq!(status.code(), Code::InvalidArgument);
+
+    let status = grpc
+        .get_block(BlockId {
+            height: 0,
+            hash: vec![0; 31],
+        })
+        .await
+        .expect_err("a hash of the wrong length must be rejected");
+    assert_eq!(status.code(), Code::InvalidArgument);
+
+    let missing_height = u64::from(NUM_BLOCKS) + 100;
+    let status = grpc
+        .get_block(block_id_for_height(missing_height))
+        .await
+        .expect_err("a block past the tip must not be served");
+    assert_eq!(status.code(), Code::NotFound);
+
+    let status = grpc
+        .get_tree_state(block_id_for_height(missing_height))
+        .await
+        .expect_err("a tree state past the tip must not be served");
+    assert_eq!(status.code(), Code::NotFound);
+
+    let status = grpc
+        .get_block_range(BlockRange {
+            start: Some(block_id_for_hash(best_hash)),
+            end: Some(block_id_for_height(u64::from(NUM_BLOCKS))),
+        })
+        .await
+        .expect_err("block ranges must be given as heights");
+    assert_eq!(status.code(), Code::InvalidArgument);
+
+    zebrad.kill(false)?;
+    let output = zebrad.wait_with_output()?;
+    output.assert_failure()?.assert_was_killed()?;
+
+    Ok(())
+}
+
+/// Reads a server stream to its end, returning its messages and the status that ended
+/// it, if it ended with an error.
+async fn drain_stream<T>(mut stream: Streaming<T>) -> Result<(Vec<T>, Option<Status>)> {
+    let mut messages = Vec::new();
+
+    loop {
+        let next = tokio::time::timeout(RESPONSE_TIMEOUT, stream.message())
+            .await
+            .map_err(|_| eyre!("stream produced nothing for {RESPONSE_TIMEOUT:?}"))?;
+
+        match next {
+            Ok(Some(message)) => messages.push(message),
+            Ok(None) => return Ok((messages, None)),
+            Err(status) => return Ok((messages, Some(status))),
+        }
+    }
+}
+
+/// Converts a block hash sent by the server, in internal byte order, into a [`block::Hash`].
+fn block_hash_from_lightwalletd(bytes: &[u8]) -> Result<block::Hash> {
+    let bytes: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| eyre!("block hashes must be 32 bytes, got {}", bytes.len()))?;
+
+    Ok(block::Hash(bytes))
+}
+
+/// Converts a transaction ID sent by the server, in internal byte order, into a
+/// [`transaction::Hash`].
+fn txid_from_lightwalletd(bytes: &[u8]) -> Result<transaction::Hash> {
+    let bytes: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| eyre!("transaction ids must be 32 bytes, got {}", bytes.len()))?;
+
+    Ok(transaction::Hash(bytes))
+}
+
+/// A [`BlockId`] that selects a block by height.
+fn block_id_for_height(height: u64) -> BlockId {
+    BlockId {
+        height,
+        hash: Vec::new(),
+    }
+}
+
+/// A [`BlockId`] that selects a block by hash, sent in internal byte order.
+fn block_id_for_hash(hash: block::Hash) -> BlockId {
+    BlockId {
+        height: 0,
+        hash: hash.0.to_vec(),
+    }
+}
+
+/// An inclusive [`BlockRange`] between two heights, in the order given.
+fn block_range(start: u64, end: u64) -> BlockRange {
+    BlockRange {
+        start: Some(block_id_for_height(start)),
+        end: Some(block_id_for_height(end)),
+    }
+}
+
+/// A [`TxFilter`] that selects a transaction by its ID, sent in internal byte order.
+fn tx_filter_for_hash(hash: transaction::Hash) -> TxFilter {
+    TxFilter {
+        block: None,
+        index: 0,
+        hash: hash.0.to_vec(),
+    }
+}

--- a/zebrad/tests/integration/lightwalletd_grpc.rs
+++ b/zebrad/tests/integration/lightwalletd_grpc.rs
@@ -6,10 +6,12 @@ use color_eyre::eyre::{eyre, Result};
 use tonic::{Code, Status, Streaming};
 
 use zebra_chain::{
-    block,
-    parameters::{testnet::ConfiguredActivationHeights, Network},
+    amount::Amount,
+    block::{self, Height},
+    parameters::{testnet::ConfiguredActivationHeights, Network, NetworkKind},
     serialization::ZcashSerialize as _,
-    transaction,
+    transaction::{self, Transaction, TransparentSigningKey},
+    transparent,
 };
 use zebra_node_services::rpc_client::RpcRequestClient;
 use zebra_rpc::{
@@ -19,11 +21,11 @@ use zebra_rpc::{
     },
     lightwalletd::{
         compact_tx_streamer_client::CompactTxStreamerClient, Address as LightwalletdAddress,
-        AddressList, BlockId, BlockRange, ChainSpec, Duration as PingDuration, Empty,
-        GetAddressUtxosArg, GetSubtreeRootsArg, ShieldedProtocol, TransparentAddressBlockFilter,
-        TxFilter,
+        AddressList, BlockId, BlockRange, ChainSpec, Duration as PingDuration, Empty, Exclude,
+        GetAddressUtxosArg, GetSubtreeRootsArg, RawTransaction, ShieldedProtocol,
+        TransparentAddressBlockFilter, TxFilter,
     },
-    server::{OPENED_LIGHTWALLETD_ENDPOINT_MSG, OPENED_RPC_ENDPOINT_MSG},
+    server::{error::LegacyCode, OPENED_LIGHTWALLETD_ENDPOINT_MSG, OPENED_RPC_ENDPOINT_MSG},
 };
 use zebra_test::{args, prelude::*};
 
@@ -48,7 +50,7 @@ const RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
 /// transactions just as they would on Mainnet. This replaces the GCP `lwd-grpc-wallet`
 /// job, which drove the Go `lightwalletd` binary against a cached Mainnet state.
 ///
-/// Mempool methods are not covered here, because they need a signed transaction.
+/// The mempool methods are covered by [`lightwalletd_grpc_serves_the_mempool`].
 #[tokio::test]
 async fn lightwalletd_grpc_serves_a_regtest_chain() -> Result<()> {
     let _init_guard = zebra_test::init();
@@ -575,6 +577,285 @@ async fn lightwalletd_grpc_serves_a_regtest_chain() -> Result<()> {
     output.assert_failure()?.assert_was_killed()?;
 
     Ok(())
+}
+
+/// The mempool methods of Zebra's `CompactTxStreamer` server must accept a transaction,
+/// stream it while it is unmined, and drop it once it is mined, agreeing with the JSON-RPC
+/// mempool view at every step.
+///
+/// A signed transparent transaction spending a mature Regtest coinbase is enough to drive
+/// `SendTransaction`, `GetMempoolStream`, and the mempool branch of `GetTransaction`
+/// through their success and failure paths, and to prove that a `GetMempoolStream` opened
+/// on an empty mempool delivers the transaction live and closes on the next block. This
+/// replaces the GCP `lwd-rpc-send-tx` job, which drove the Go `lightwalletd` binary
+/// against a cached Mainnet state.
+///
+/// `GetMempoolTx` only gets its limit and empty cases: it serves compact transactions,
+/// and a transparent-only transaction has no compact data. Its positive case needs a
+/// shielded Regtest transaction, which the signing helper does not build yet (see #9941).
+#[tokio::test]
+async fn lightwalletd_grpc_serves_the_mempool() -> Result<()> {
+    /// Coinbase outputs can be spent once this many blocks are on top of them.
+    const COINBASE_MATURITY: u32 = transparent::MIN_TRANSPARENT_COINBASE_MATURITY;
+
+    /// The height of the first block mined after the transaction is sent.
+    const MINED_HEIGHT: u32 = COINBASE_MATURITY + 2;
+
+    /// The server's `GetMempoolTx` exclude list limit, matching lightwalletd.
+    const MAX_EXCLUDE_ENTRIES: usize = 20_000;
+
+    /// How long to wait for a sent transaction to show up in `getrawmempool`.
+    const MEMPOOL_TIMEOUT: Duration = Duration::from_secs(10);
+
+    let _init_guard = zebra_test::init();
+
+    let network = Network::new_regtest(
+        ConfiguredActivationHeights {
+            nu5: Some(1),
+            ..Default::default()
+        }
+        .into(),
+    );
+    let key = TransparentSigningKey::random();
+    let miner_address = key.address(NetworkKind::Regtest);
+
+    let mut config = os_assigned_rpc_port_config(false, &network)?;
+    config.rpc.lightwalletd_listen_addr = Some("127.0.0.1:0".parse()?);
+    config.mempool.debug_enable_at_height = Some(0);
+    config.mining.miner_address = Some(miner_address.into());
+
+    let mut zebrad = testdir()?
+        .with_config(&mut config)?
+        .spawn_child(args!["start"])?;
+
+    // The JSON-RPC server is started before the gRPC server, so the log lines come in this order.
+    let rpc_address = read_listen_addr_from_logs(&mut zebrad, OPENED_RPC_ENDPOINT_MSG)?;
+    let grpc_address = read_listen_addr_from_logs(&mut zebrad, OPENED_LIGHTWALLETD_ENDPOINT_MSG)?;
+
+    tokio::time::sleep(LAUNCH_DELAY).await;
+
+    let rpc = RpcRequestClient::new(rpc_address);
+
+    // Mine a coinbase to our key at height 1, then enough blocks for it to mature.
+    rpc.generate(COINBASE_MATURITY + 1).await?;
+
+    let block_1 = rpc
+        .get_block(1)
+        .await
+        .map_err(|err| eyre!(err))?
+        .ok_or_else(|| eyre!("block 1 must exist after generate"))?;
+    let coinbase = &block_1.transactions[0];
+    let (index, coinbase_output) = coinbase
+        .outputs()
+        .into_iter()
+        .enumerate()
+        .find(|(_, output)| output.lock_script == miner_address.script())
+        .ok_or_else(|| eyre!("the coinbase must pay the configured miner address"))?;
+    let coinbase_outpoint = transparent::OutPoint {
+        hash: coinbase.hash(),
+        index: index as u32,
+    };
+
+    // The transaction under test spends the mature coinbase. The double spend pays a
+    // different amount from the same output, so it has a different ID and must be rejected.
+    let tx = Transaction::signed_transparent(
+        &network,
+        Height(MINED_HEIGHT),
+        &key,
+        &[(coinbase_outpoint, coinbase_output.clone())],
+        &[(miner_address, Amount::try_from(100_000_000)?)],
+    )
+    .map_err(|err| eyre!(err))?;
+    let double_spend = Transaction::signed_transparent(
+        &network,
+        Height(MINED_HEIGHT),
+        &key,
+        &[(coinbase_outpoint, coinbase_output)],
+        &[(miner_address, Amount::try_from(50_000_000)?)],
+    )
+    .map_err(|err| eyre!(err))?;
+    assert_ne!(tx.hash(), double_spend.hash());
+
+    let txid = tx.hash();
+    let tx_bytes = tx.zcash_serialize_to_vec()?;
+
+    let endpoint = tonic::transport::Endpoint::new(format!("http://{grpc_address}"))?
+        .timeout(RESPONSE_TIMEOUT);
+    let mut grpc = CompactTxStreamerClient::connect(endpoint).await?;
+
+    // GetMempoolStream on an empty mempool: the stream stays open, so it is drained after
+    // the next block below, where it must have delivered the sent transaction live.
+    assert!(raw_mempool(&rpc).await?.is_empty());
+    let live_stream = grpc.get_mempool_stream(Empty {}).await?.into_inner();
+
+    // SendTransaction: a success carries the transaction ID as its message.
+    let sent = grpc
+        .send_transaction(RawTransaction {
+            data: tx_bytes.clone(),
+            height: 0,
+        })
+        .await?
+        .into_inner();
+    assert_eq!(sent.error_code, 0, "send failed: {}", sent.error_message);
+    assert_eq!(sent.error_message.parse::<transaction::Hash>()?, txid);
+
+    let deadline = std::time::Instant::now() + MEMPOOL_TIMEOUT;
+    loop {
+        let mempool = raw_mempool(&rpc).await?;
+        if mempool == [txid.to_string()] {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the sent transaction must reach the mempool within {MEMPOOL_TIMEOUT:?}, got {mempool:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    let GetRawTransactionResponse::Raw(raw_mempool_tx) = rpc
+        .json_result_from_call("getrawtransaction", format!(r#"["{txid}", 0]"#))
+        .await
+        .map_err(|err| eyre!(err))?
+    else {
+        panic!("getrawtransaction with verbosity 0 must return raw bytes");
+    };
+    let raw_mempool_tx: &[u8] = raw_mempool_tx.as_ref();
+    assert_eq!(raw_mempool_tx, tx_bytes);
+
+    // Mempool transactions are served with a height of 0, like lightwalletd.
+    let expected_raw_tx = RawTransaction {
+        data: tx_bytes.clone(),
+        height: 0,
+    };
+
+    // GetTransaction: the mempool branch, before the transaction has a height.
+    let unmined = grpc
+        .get_transaction(tx_filter_for_hash(txid))
+        .await?
+        .into_inner();
+    assert_eq!(unmined, expected_raw_tx);
+
+    // GetMempoolStream after sending: the snapshot carries the transaction, and the
+    // stream stays open until the next block, where it is drained below.
+    let snapshot_stream = grpc.get_mempool_stream(Empty {}).await?.into_inner();
+
+    // GetMempoolTx: empty and not an error, because a transparent-only transaction has
+    // no compact data (see `has_compact_data`), then the exclude list limit.
+    let (compact_txs, status) = drain_stream(
+        grpc.get_mempool_tx(Exclude { txid: vec![] })
+            .await?
+            .into_inner(),
+    )
+    .await?;
+    assert!(status.is_none(), "mempool tx stream failed: {status:?}");
+    assert!(compact_txs.is_empty());
+
+    let status = match grpc
+        .get_mempool_tx(Exclude {
+            txid: vec![vec![0]; MAX_EXCLUDE_ENTRIES + 1],
+        })
+        .await
+    {
+        Err(status) => status,
+        Ok(response) => drain_stream(response.into_inner())
+            .await?
+            .1
+            .expect("an oversized exclude list must be rejected"),
+    };
+    assert_eq!(status.code(), Code::InvalidArgument);
+
+    // SendTransaction failure paths: rejections are reported inside the response, with
+    // the JSON-RPC error code, and leave the mempool as it was.
+    let rejected = grpc
+        .send_transaction(RawTransaction {
+            data: double_spend.zcash_serialize_to_vec()?,
+            height: 0,
+        })
+        .await?
+        .into_inner();
+    assert_eq!(rejected.error_code, LegacyCode::Verify as i32);
+    assert!(!rejected.error_message.is_empty());
+
+    let undecodable = grpc
+        .send_transaction(RawTransaction {
+            data: vec![0; 10],
+            height: 0,
+        })
+        .await?
+        .into_inner();
+    assert_eq!(undecodable.error_code, LegacyCode::Deserialization as i32);
+    assert!(!undecodable.error_message.is_empty());
+
+    // A transaction larger than a block is the one submission rejected before the RPC.
+    let status = grpc
+        .send_transaction(RawTransaction {
+            data: vec![0; block::MAX_BLOCK_BYTES as usize + 1],
+            height: 0,
+        })
+        .await
+        .expect_err("a transaction larger than a block must be rejected");
+    assert_eq!(status.code(), Code::InvalidArgument);
+
+    assert_eq!(raw_mempool(&rpc).await?, [txid.to_string()]);
+
+    // Mining a block takes the transaction out of the mempool and closes both streams,
+    // each having delivered the transaction exactly once.
+    let mined_hashes = rpc.generate(1).await?;
+    assert_eq!(mined_hashes.len(), 1);
+
+    let (live, status) = drain_stream(live_stream).await?;
+    assert!(status.is_none(), "live mempool stream failed: {status:?}");
+    assert_eq!(live, std::slice::from_ref(&expected_raw_tx));
+
+    let (snapshot, status) = drain_stream(snapshot_stream).await?;
+    assert!(
+        status.is_none(),
+        "mempool snapshot stream failed: {status:?}"
+    );
+    assert_eq!(snapshot, [expected_raw_tx]);
+
+    assert!(raw_mempool(&rpc).await?.is_empty());
+
+    let mined_block = rpc
+        .get_block(MINED_HEIGHT as i32)
+        .await
+        .map_err(|err| eyre!(err))?
+        .ok_or_else(|| eyre!("the mined block must be readable at its height"))?;
+    assert_eq!(mined_block.hash(), mined_hashes[0]);
+    let mined_txids: Vec<_> = mined_block
+        .transactions
+        .iter()
+        .map(|tx| tx.hash())
+        .collect();
+    assert_eq!(mined_txids[1..], [txid]);
+
+    // GetTransaction: the confirmed branch, now with the height it was mined at.
+    let mined = grpc
+        .get_transaction(tx_filter_for_hash(txid))
+        .await?
+        .into_inner();
+    assert_eq!(mined.data, tx_bytes);
+    assert_eq!(mined.height, u64::from(MINED_HEIGHT));
+
+    // GetMempoolStream on the emptied mempool: nothing until the next block closes it.
+    let empty_stream = grpc.get_mempool_stream(Empty {}).await?.into_inner();
+    rpc.generate(1).await?;
+    let (empty, status) = drain_stream(empty_stream).await?;
+    assert!(status.is_none(), "empty mempool stream failed: {status:?}");
+    assert!(empty.is_empty());
+
+    zebrad.kill(false)?;
+    let output = zebrad.wait_with_output()?;
+    output.assert_failure()?.assert_was_killed()?;
+
+    Ok(())
+}
+
+/// The transaction IDs in the mempool, in display order, as reported by `getrawmempool`.
+async fn raw_mempool(rpc: &RpcRequestClient) -> Result<Vec<String>> {
+    rpc.json_result_from_call("getrawmempool", "[]")
+        .await
+        .map_err(|err| eyre!(err))
 }
 
 /// Reads a server stream to its end, returning its messages and the status that ended

--- a/zebrad/tests/integration/mod.rs
+++ b/zebrad/tests/integration/mod.rs
@@ -1,4 +1,5 @@
 pub mod database;
+pub mod lightwalletd_grpc;
 pub mod network;
 pub mod regtest;
 pub mod rpc;

--- a/zebrad/tests/integration/regtest.rs
+++ b/zebrad/tests/integration/regtest.rs
@@ -202,6 +202,193 @@ async fn getblocktemplate_long_poll_returns_submit_old_false_on_new_tip() -> Res
     Ok(())
 }
 
+/// Block templates must include the mempool's transactions in dependency order, and the
+/// resulting block must be accepted.
+///
+/// This is the only test that puts real, signed transactions through the mining RPCs. Every other
+/// template test in the tree uses an empty mempool, so before this test nothing asserted that a
+/// transaction which reached the mempool would ever reach a block. The second transaction spends
+/// an unmined output of the first, so the template's ordering is asserted, not only inclusion.
+#[tokio::test]
+async fn block_template_includes_mempool_transactions_in_dependency_order() -> Result<()> {
+    use zebra_chain::{
+        amount::Amount,
+        parameters::NetworkKind,
+        transaction::{Transaction, TransparentSigningKey},
+    };
+    use zebra_rpc::{
+        client::{
+            BlockProposalResponse, BlockTemplateResponse, BlockTemplateTimeSource,
+            SendRawTransactionResponse,
+        },
+        proposal_block_from_template,
+    };
+
+    /// Coinbase outputs can be spent once this many blocks are on top of them.
+    const COINBASE_MATURITY: u32 = zebra_chain::transparent::MIN_TRANSPARENT_COINBASE_MATURITY;
+
+    /// How long to wait for a sent transaction to show up in a block template.
+    const TEMPLATE_TIMEOUT: Duration = Duration::from_secs(30);
+
+    let _init_guard = zebra_test::init();
+
+    let network = Network::new_regtest(
+        ConfiguredActivationHeights {
+            nu5: Some(1),
+            ..Default::default()
+        }
+        .into(),
+    );
+    let key = TransparentSigningKey::random();
+    let miner_address = key.address(NetworkKind::Regtest);
+
+    let mut config = os_assigned_rpc_port_config(false, &network)?;
+    config.mempool.debug_enable_at_height = Some(0);
+    config.mining.miner_address = Some(miner_address.into());
+
+    let mut zebrad = testdir()?
+        .with_config(&mut config)?
+        .spawn_child(args!["start"])?;
+
+    let rpc_address = read_listen_addr_from_logs(&mut zebrad, OPENED_RPC_ENDPOINT_MSG)?;
+
+    tokio::time::sleep(LAUNCH_DELAY).await;
+
+    let client = RpcRequestClient::new(rpc_address);
+
+    // Mine a coinbase to our key at height 1, then enough blocks for it to mature.
+    client.generate(COINBASE_MATURITY + 1).await?;
+    let next_height = Height(COINBASE_MATURITY + 2);
+
+    let block_1 = client
+        .get_block(1)
+        .await
+        .map_err(|err| eyre!(err))?
+        .ok_or_else(|| eyre!("block 1 must exist after generate"))?;
+    let coinbase = &block_1.transactions[0];
+    let (index, coinbase_output) = coinbase
+        .outputs()
+        .into_iter()
+        .enumerate()
+        .find(|(_, output)| output.lock_script == miner_address.script())
+        .ok_or_else(|| eyre!("the coinbase must pay the configured miner address"))?;
+    let coinbase_outpoint = transparent::OutPoint {
+        hash: coinbase.hash(),
+        index: index as u32,
+    };
+
+    // Transaction A spends the mature coinbase; transaction B spends A's first output while A is
+    // still unmined, so B can only be valid in a block that also contains A, before it.
+    let send_amount = Amount::try_from(100_000_000)?;
+    let tx_a = Transaction::signed_transparent(
+        &network,
+        next_height,
+        &key,
+        &[(coinbase_outpoint, coinbase_output)],
+        &[(miner_address, send_amount)],
+    )
+    .map_err(|err| eyre!(err))?;
+    let tx_a_outpoint = transparent::OutPoint {
+        hash: tx_a.hash(),
+        index: 0,
+    };
+    let tx_b = Transaction::signed_transparent(
+        &network,
+        next_height,
+        &key,
+        &[(tx_a_outpoint, tx_a.outputs()[0].clone())],
+        &[(miner_address, Amount::try_from(50_000_000)?)],
+    )
+    .map_err(|err| eyre!(err))?;
+
+    for tx in [&tx_a, &tx_b] {
+        let raw_tx = hex::encode(tx.zcash_serialize_to_vec()?);
+        let response: SendRawTransactionResponse = client
+            .json_result_from_call("sendrawtransaction", format!(r#"["{raw_tx}"]"#))
+            .await
+            .map_err(|err| eyre!(err))?;
+        assert_eq!(
+            response.hash(),
+            tx.hash(),
+            "sendrawtransaction must accept the transaction"
+        );
+    }
+
+    let expected_order = vec![tx_a.hash(), tx_b.hash()];
+    let deadline = std::time::Instant::now() + TEMPLATE_TIMEOUT;
+    let template: BlockTemplateResponse = loop {
+        let template: BlockTemplateResponse = client
+            .json_result_from_call("getblocktemplate", "[]")
+            .await
+            .map_err(|err| eyre!(err))?;
+        if template.transactions().len() == expected_order.len() {
+            break template;
+        }
+        if std::time::Instant::now() > deadline {
+            return Err(eyre!(
+                "the template must include both mempool transactions within {TEMPLATE_TIMEOUT:?}, got {:?}",
+                template.transactions()
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    };
+
+    let template_order: Vec<_> = template.transactions().iter().map(|tx| tx.hash()).collect();
+    assert_eq!(
+        template_order, expected_order,
+        "the template must list a transaction after the transaction it spends from",
+    );
+
+    let proposal_block =
+        proposal_block_from_template(&template, BlockTemplateTimeSource::default(), &network)?;
+    let proposal_data = hex::encode(proposal_block.zcash_serialize_to_vec()?);
+    let proposal_result: BlockProposalResponse = client
+        .json_result_from_call(
+            "getblocktemplate",
+            format!(r#"[{{"mode":"proposal","data":"{proposal_data}"}}]"#),
+        )
+        .await
+        .map_err(|err| eyre!(err))?;
+    assert_eq!(
+        proposal_result,
+        BlockProposalResponse::Valid,
+        "a template carrying the mempool transactions must be a valid block proposal",
+    );
+
+    client.submit_block(proposal_block).await?;
+
+    let mined_block = client
+        .get_block(next_height.0 as i32)
+        .await
+        .map_err(|err| eyre!(err))?
+        .ok_or_else(|| eyre!("the submitted block must be readable at its height"))?;
+    let mined_order: Vec<_> = mined_block
+        .transactions
+        .iter()
+        .map(|tx| tx.hash())
+        .collect();
+    assert_eq!(
+        mined_order[1..],
+        expected_order,
+        "the mined block must contain the template's transactions in order after the coinbase",
+    );
+
+    let mempool: Vec<String> = client
+        .json_result_from_call("getrawmempool", "[]")
+        .await
+        .map_err(|err| eyre!(err))?;
+    assert!(
+        mempool.is_empty(),
+        "mined transactions must leave the mempool, still queued: {mempool:?}",
+    );
+
+    zebrad.kill(false)?;
+    let output = zebrad.wait_with_output()?;
+    output.assert_failure()?.assert_was_killed()?;
+
+    Ok(())
+}
+
 /// A rejected block body must not poison the children of a later valid block with the same header
 /// hash.
 ///


### PR DESCRIPTION
> **Stacked on #11410 and #11426.** Only the last commit, `eb8be65ea`, is new; the diff collapses to that commit once both parents merge. Review that commit only.

## Motivation

Track B3 of #9941, the last of the regtest-native replacements for the GCP lightwalletd jobs. This one replaces `lwd-rpc-send-tx`, which pushed transactions through the Go `lightwalletd` binary against a cached mainnet state. #11426 covers the read-side methods of Zebra's built-in `CompactTxStreamer` server; this covers the mempool side, using the transparent signing helper from #11410.

## Solution

A second test in `zebrad/tests/integration/lightwalletd_grpc.rs`, `lightwalletd_grpc_serves_the_mempool`. It starts a regtest `zebrad` with the gRPC server enabled, mines to a random key until the block-1 coinbase matures, signs a transaction spending it, and checks:

- `SendTransaction` succeeds with code 0 and the txid as its message; `getrawmempool` and `getrawtransaction` confirm the transaction and its bytes.
- `GetTransaction` serves the unmined transaction with height 0 (matching lightwalletd, see the librustzcash#1484 note in `methods.rs`), and after it is mined, with its block height.
- `GetMempoolStream` delivers the transaction both to a stream opened before the send (live path) and to one opened after it (snapshot path), and each stream closes on the next block having delivered it exactly once. A stream opened on an emptied mempool is empty and closes on the next block.
- `GetMempoolTx` is empty for a transparent-only mempool, because it serves compact transactions and those carry only shielded data (`has_compact_data`), and an exclude list over the limit is `InvalidArgument`.
- Rejections come back inside `SendResponse` with the JSON-RPC code, not as gRPC errors: a double spend is `LegacyCode::Verify`, undecodable bytes are `LegacyCode::Deserialization`, and the mempool is unchanged. The one pre-RPC rejection, a payload over `MAX_BLOCK_BYTES`, is a gRPC `InvalidArgument`.

`GetMempoolTx` has no positive case yet. That needs a shielded regtest transaction, which the signing helper does not build; the test's doc comment says so and points at #9941.

### Tests

`cargo test -p zebrad --test zebrad-tests -- lightwalletd_grpc` passes both tests in 24 s (the new one is 28 s alone; one `zebrad` launch). #11410's own test still passes on the merged branch. fmt and clippy `-D warnings` are clean. Mutation-checked: expecting two stream entries instead of one fails; comparing the returned txid against the double spend's fails.

### Follow-up Work

- A shielded regtest transaction builder, which would give `GetMempoolTx`, the compact-block `vtx`, and the nullifier views their positive cases.
- After this and #11426 land, the GCP `lwd-grpc-wallet` and `lwd-rpc-send-tx` jobs (weekly since #11423) have regtest-native equivalents; removing them is Track B4, pending the Go lightwalletd deprecation decision.

### AI Disclosure

- [x] AI tools were used: Claude Code drafted the test; reviewed and run locally.

### PR Checklist

- [x] The PR title follows conventional commits
- [x] The PR follows the contribution guidelines
- [x] This change was discussed in an issue or with the team beforehand (#9941)
- [x] The solution is tested
- [x] The documentation and changelogs are up to date (`test:` — no fragment required)
