### PR TITLE
fix(ci): unblock the book deploy after the rustdoc link regression

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -79,10 +79,14 @@ jobs:
           mkdir -p target/docs/internal
           cp -r target/internal/doc/* target/docs/internal/
         env:
-          # Keep in sync with ./lint.yml:jobs.docs
-          # The -A and -W settings must be the same as the `rustdocflags` in:
+          # No `-D warnings` here: rustdoc lints must not block publishing the
+          # docs site. A broken intra-doc link kept the deploy skipped for days
+          # in September 2026. The blocking `-D warnings` policy lives in
+          # ./advisory.yml:jobs.docs ("Nightly documentation"), where #10968 put
+          # it. A real `cargo doc` failure still fails this step.
+          # The -A settings must be the same as the `rustdocflags` in:
           # https://github.com/ZcashFoundation/zebra/blob/main/.cargo/config.toml#L87
-          RUSTDOCFLAGS: --html-in-header katex-header.html -D warnings -A rustdoc::private_intra_doc_links --cfg docsrs --show-type-layout --generate-link-to-definition --enable-index-page -Zunstable-options
+          RUSTDOCFLAGS: --html-in-header katex-header.html -A rustdoc::private_intra_doc_links --cfg docsrs --show-type-layout --generate-link-to-definition --enable-index-page -Zunstable-options
 
       - name: Include benchmark dashboard
         # Snapshots `gh-pages/dev/bench` (published by `benchmarks.yml`) into

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -844,7 +844,8 @@ impl crate::serialization::ZcashDeserializeWithContext<zcash_protocol::consensus
 {
     /// Deserialize a transaction with a known consensus branch ID.
     ///
-    /// Runs the same parse-time consensus checks as [`Transaction::zcash_deserialize`].
+    /// Runs the same parse-time consensus checks as
+    /// [`Transaction::zcash_deserialize`](crate::serialization::ZcashDeserialize::zcash_deserialize).
     fn zcash_deserialize_with_context<R: std::io::Read>(
         reader: R,
         &branch_id: &zcash_protocol::consensus::BranchId,


### PR DESCRIPTION
## Motivation

The `Book` workflow has failed on every push to `main` since 2026-09-08, so the `deploy` job has been skipped that whole time and zebra.zfnd.org has been stale. The live site still serves only the mermaid scripts, so the docs assistant merged in #11390 is on `main` but was never published.

Two failures were stacked. Nightly `>= 2026-09-08` ICEs in rustdoc's auto-trait synthesis while documenting `zebra-consensus` (rust-lang/rust#162182); #11422 pinned `nightly-2026-09-04` and fixed that, which let the build run far enough to hit a second, pre-existing problem the ICE had been masking.

## Solution

`zebra-chain/src/transaction.rs` linked `[`Transaction::zcash_deserialize`]`, but `zcash_deserialize` is a method on the `ZcashDeserialize` trait rather than an inherent item, and the trait is not in scope in that file — both impls spell it out as `crate::serialization::ZcashDeserialize`. Rustdoc only resolves `Type::trait_method` when the trait is in scope, so the link was unresolvable and `-D warnings` turned it into an error. The link now points at the full path while keeping its rendered text. It landed in 95a782275, authored 09-03 but committed to `main` on 09-08, which is why the weekly advisory doc build still passed on 09-07.

The second commit stops rustdoc lint from blocking the deploy. A broken intra-doc link should not take the docs site offline, especially since #10968 deliberately reclassified doc checks as non-blocking and moved them to the weekly advisory workflow. `-D warnings` is dropped from the `Build internal docs` step, so warnings no longer fail it. This is deliberately not `|| true` on the step: a genuine `cargo doc` failure — a compile error or another ICE — still fails the build. The blocking warning policy stays in `advisory.yml`'s `Nightly documentation` job.

The `book.yml` nightly pin from #11422 is left alone; it is still needed until the upstream ICE is fixed.

## Tests

Reproduced locally with the pinned toolchain and CI's exact flags, keeping `-D warnings` so that every broken link across the 33 commits since the last known-good doc build would surface at once rather than one per push:

```
RUSTDOCFLAGS="--html-in-header katex-header.html -D warnings -A rustdoc::private_intra_doc_links --cfg docsrs --show-type-layout --generate-link-to-definition --enable-index-page -Zunstable-options" \
  cargo +nightly-2026-09-04 doc --no-deps --workspace --all-features --document-private-items
```

All twelve workspace crates, `zebrad` included, document cleanly with zero link errors after the fix.

`mdbook build book` still succeeds and the book half of the workflow was already passing, so that is a regression check only. `cargo fmt --all -- --check` is clean.

## Follow-up Work

`advisory.yml` uses unpinned `nightly`, so its `Nightly documentation` job will keep hitting the same ICE until rust-lang/rust#162182 lands. It already opens an issue on failure, so the breakage is visible, but the pin could be mirrored there.

The `book.yml` nightly pin should be removed once that ICE is fixed, so it does not quietly become permanent.

`book.yml` still does not run on pull requests, so book and docs changes get no CI coverage before merge. Already recorded as a follow-up in #11395.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used: Claude Code, for the root-cause investigation, the fix, and this description.

## PR Checklist

- [x] The PR title follows [conventional commits](https://www.conventionalcommits.org/) format: `type(scope): description`
- [x] The PR follows the [contribution guidelines](https://github.com/ZcashFoundation/zebra/blob/main/CONTRIBUTING.md).
- [ ] This change was discussed in an issue or with the team beforehand. (Unplanned fix: `main` CI was red and the docs deploy was blocked.)
- [x] The solution is tested.
- [x] The documentation and changelogs are up to date.
