### PR TITLE
ci(deps): add the monthly dependency trains

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,44 +1,8 @@
 version: 2
-# No labels on dependency PRs: the changelog gate reads the PR title.
+# Cargo dependencies are not updated by dependabot: the monthly dependency trains
+# in .github/workflows/dependency-trains.yml run `cargo update` instead, see
+# book/src/dev/dependency-trains.md. Dependabot security alerts stay on.
 updates:
-  # Rust section
-  - package-ecosystem: cargo
-    directory: '/'
-    # Update only the lockfile. We shouldn't update Cargo.toml unless it's for
-    # a security issue, or if we need a new feature of the dependency.
-    versioning-strategy: lockfile-only
-    # serde, clap, and other dependencies sometimes have multiple updates in a week
-    schedule:
-      interval: monthly
-      timezone: America/New_York
-    # Limit dependabot to 1 PR per reviewer
-    open-pull-requests-limit: 6
-    # Lockfile-only updates do not release packages, so keep them outside release-plz's release types.
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    labels: []
-    groups:
-        ecc:
-          patterns:
-            # deliberately include zcash_script (even though it is maintained by ZF)
-            - "zcash_*"
-            - "orchard"
-            - "halo2*"
-            - "incrementalmerkletree"
-            - "bridgetree"
-            - "equihash"
-        prod:
-          dependency-type: "production"
-          exclude-patterns:
-            - "zcash_*"
-            - "orchard"
-            - "halo2*"
-            - "incrementalmerkletree"
-            - "bridgetree"
-            - "equihash"
-        dev:
-          dependency-type: "development"
   # Devops section
   - package-ecosystem: github-actions
     directory: '/'
@@ -52,7 +16,8 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
-    labels: []
+    # Dependabot ignores an empty list and invents its own labels, so name the real one.
+    labels: ["devops"]
     groups:
       devops:
         patterns:

--- a/.github/dependency-trains.toml
+++ b/.github/dependency-trains.toml
@@ -1,0 +1,21 @@
+# Dependency train configuration, read by .github/scripts/dependency-train.py.
+# See book/src/dev/dependency-trains.md for the conductor playbook.
+
+# Consensus-sensitive crates: only Train B moves these; Train A leaves them exactly where they are.
+consensus = [
+    "zcash_*",
+    "orchard",
+    "halo2*",
+    "incrementalmerkletree",
+    "bridgetree",
+    "equihash",
+    "sapling-crypto",
+    "rocksdb",
+    "librocksdb-sys",
+    "secp256k1",
+    "zcash_script",
+]
+
+# Crates pinned back because their newest compatible release breaks us. crate = "exact version".
+# Remove the line when fixed upstream.
+[pinned]

--- a/.github/scripts/dependency-train.py
+++ b/.github/scripts/dependency-train.py
@@ -1,0 +1,479 @@
+#!/usr/bin/env python3
+"""Build one dependency train: run `cargo update`, keep only that train's crates, write the PR body.
+
+Train A moves every crate except the consensus-sensitive set; Train B moves only that set.
+See book/src/dev/dependency-trains.md and https://github.com/ZcashFoundation/zebra/issues/9630.
+
+Never commits or pushes: the workflow's create-pull-request step does that.
+"""
+
+import argparse
+import datetime
+import fnmatch
+import json
+import os
+import subprocess
+import sys
+import time
+import tomllib
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+USER_AGENT = "zebra-dependency-train (github.com/ZcashFoundation/zebra)"
+CRATES_IO = "https://crates.io/api/v1/crates"
+REGISTRY = "registry+https://github.com/rust-lang/crates.io-index"
+BOOK_PAGE = "https://zebra.zfnd.org/dev/dependency-trains.html"
+ISSUE_URL = "https://github.com/ZcashFoundation/zebra/issues/9630"
+ROOT = Path(__file__).resolve().parents[2]
+COLLAPSE_ROWS = 40
+
+TRAINS = {
+    "a": ("Train A", "everything except the consensus-sensitive crates"),
+    "b": ("Train B", "only the consensus-sensitive crates"),
+}
+
+
+def log(message):
+    print(message, file=sys.stderr, flush=True)
+
+
+def warn(message):
+    prefix = "::warning::" if os.environ.get("GITHUB_ACTIONS") else "warning: "
+    log(f"{prefix}{message}")
+
+
+def cargo(*args):
+    """Runs a cargo command in the repository root and returns the CompletedProcess."""
+    command = ["cargo", *args]
+    log("$ " + " ".join(command))
+    return subprocess.run(command, cwd=ROOT, capture_output=True, text=True)
+
+
+def cargo_ok(*args):
+    result = cargo(*args)
+    if result.returncode != 0:
+        warn(f"`cargo {' '.join(args)}` failed: {cargo_error(result)}")
+    return result.returncode == 0
+
+
+def cargo_error(result):
+    lines = result.stderr.strip().splitlines()
+    return lines[-1] if lines else "no output"
+
+
+def precise_all(targets):
+    """Moves (name, from_version, to_version) crates with `--precise` until no more progress is made.
+
+    One move can drag or block another, so every pending move is retried after each pass;
+    a crate already at its target is skipped. Returns the moves that never applied, with cargo's error.
+    """
+    pending = {(name, to_version): from_version for name, from_version, to_version in targets}
+    errors = {}
+    while pending:
+        lock = read_lock()
+        progressed = False
+        for (name, to_version), from_version in list(pending.items()):
+            versions = lock.get(name, {})
+            if to_version in versions:
+                del pending[(name, to_version)]
+                progressed = True
+                continue
+            if from_version in versions:
+                spec = f"{name}@{from_version}"
+            elif len(versions) == 1:
+                spec = f"{name}@{next(iter(versions))}"
+            else:
+                spec = name
+            result = cargo("update", "-p", spec, "--precise", to_version)
+            if result.returncode == 0:
+                del pending[(name, to_version)]
+                progressed = True
+            else:
+                errors[(name, to_version)] = cargo_error(result)
+        if not progressed:
+            break
+    return [(name, from_version, to_version, errors.get((name, to_version), "unknown"))
+            for (name, to_version), from_version in pending.items()]
+
+
+# Version handling: enough of semver to order versions and detect breaking lines.
+
+
+def parse_version(text):
+    """Returns a sortable tuple; pre-releases order before their release."""
+    core, _, build = text.partition("+")
+    core, _, pre = core.partition("-")
+    numbers = [int(part) for part in core.split(".")]
+    while len(numbers) < 3:
+        numbers.append(0)
+    pre_parts = tuple(
+        (0, int(part)) if part.isdigit() else (1, part) for part in pre.split(".") if part
+    )
+    return (*numbers[:3], 0 if pre_parts else 1, pre_parts)
+
+
+def compat_key(text):
+    """The semver-compatible range a version belongs to, with cargo's 0.x rules."""
+    major, minor, patch, *_ = parse_version(text)
+    if major > 0:
+        return (major,)
+    if minor > 0:
+        return (0, minor)
+    return (0, 0, patch)
+
+
+def requirement_base(requirement):
+    """The version a requirement like `^1.2`, `0.4.40` or `=1.0.0` starts from."""
+    first = requirement.split(",")[0].strip().lstrip("^=~>< ")
+    if first == "*" or not first:
+        return None
+    return first.replace(".*", "")
+
+
+# Lockfile handling.
+
+
+def read_lock():
+    """Maps crate name to {version: source} for every package in Cargo.lock."""
+    with open(ROOT / "Cargo.lock", "rb") as file:
+        lock = tomllib.load(file)
+    packages = {}
+    for package in lock.get("package", []):
+        packages.setdefault(package["name"], {})[package["version"]] = package.get("source")
+    return packages
+
+
+def diff_locks(old, new):
+    """Lists (name, old_version, new_version) moves; None on one side means added or removed."""
+    changes = []
+    for name in sorted(set(old) | set(new)):
+        removed = sorted(set(old.get(name, {})) - set(new.get(name, {})), key=parse_version)
+        added = sorted(set(new.get(name, {})) - set(old.get(name, {})), key=parse_version)
+        # Pair versions in the same compatible range first, then whatever is left in order.
+        for old_version in list(removed):
+            match = next((v for v in added if compat_key(v) == compat_key(old_version)), None)
+            if match is not None:
+                changes.append((name, old_version, match))
+                removed.remove(old_version)
+                added.remove(match)
+        for old_version, new_version in zip(list(removed), list(added)):
+            changes.append((name, old_version, new_version))
+            removed.remove(old_version)
+            added.remove(new_version)
+        changes.extend((name, version, None) for version in removed)
+        changes.extend((name, None, version) for version in added)
+    return changes
+
+
+def is_registry(lock, name, version):
+    return lock.get(name, {}).get(version) == REGISTRY
+
+
+def matches_any(name, patterns):
+    return any(fnmatch.fnmatchcase(name, pattern) for pattern in patterns)
+
+
+# crates.io lookups, cached and throttled to about one request per second.
+
+
+class CratesIo:
+    def __init__(self):
+        self.cache = {}
+        self.last_request = 0.0
+
+    def get(self, path):
+        if path in self.cache:
+            return self.cache[path]
+        wait = 1.0 - (time.monotonic() - self.last_request)
+        if wait > 0:
+            time.sleep(wait)
+        request = urllib.request.Request(f"{CRATES_IO}/{path}", headers={"User-Agent": USER_AGENT})
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                data = json.load(response)
+        except (urllib.error.URLError, json.JSONDecodeError, TimeoutError) as error:
+            warn(f"crates.io lookup failed for {path}: {error}")
+            data = None
+        self.last_request = time.monotonic()
+        self.cache[path] = data
+        return data
+
+    def published_at(self, name, version):
+        data = self.get(f"{name}/{version}")
+        if not data or "version" not in data:
+            return None
+        return datetime.datetime.fromisoformat(data["version"]["created_at"].replace("Z", "+00:00"))
+
+    def max_stable_version(self, name):
+        data = self.get(name)
+        if not data or "crate" not in data:
+            return None
+        return data["crate"].get("max_stable_version")
+
+
+# The train steps.
+
+
+def apply_cooling_off(original, api, cooling_days, held):
+    """Reverts bumps to versions published less than `cooling_days` ago. Returns the final diff."""
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cutoff = now - datetime.timedelta(days=cooling_days)
+    tried = set()
+    # A revert can move other crates, so re-diff until nothing new needs holding.
+    for _ in range(5):
+        current = read_lock()
+        fresh = []
+        for name, old_version, new_version in diff_locks(original, current):
+            if old_version is None or new_version is None or (name, new_version) in tried:
+                continue
+            if not is_registry(current, name, new_version):
+                continue
+            tried.add((name, new_version))
+            published = api.published_at(name, new_version)
+            if published is None or published < cutoff:
+                continue
+            age = (now - published).days
+            log(f"{name} {new_version} was published {age} day(s) ago, holding for cooling-off")
+            fresh.append((name, new_version, old_version, age))
+        if not fresh:
+            break
+        leftovers = precise_all((name, new, old) for name, new, old, _ in fresh)
+        for name, new_version, old_version, error in leftovers:
+            warn(f"could not hold {name} {new_version} back to {old_version}, shipping it: {error}")
+        stuck = {(name, new_version) for name, new_version, _, _ in leftovers}
+        held.extend(
+            (name, old_version, new_version, age)
+            for name, new_version, old_version, age in fresh
+            if (name, new_version) not in stuck
+        )
+    return diff_locks(original, read_lock())
+
+
+def build_train_a(original, changes, consensus):
+    """Reverts every consensus crate the full update moved."""
+    targets = [
+        (name, new_version, old_version)
+        for name, old_version, new_version in changes
+        if matches_any(name, consensus) and old_version and new_version
+    ]
+    for name, new_version, old_version, error in precise_all(targets):
+        warn(f"could not keep consensus crate {name} at {old_version}: {error}")
+    stuck = [
+        change
+        for change in diff_locks(original, read_lock())
+        if matches_any(change[0], consensus)
+    ]
+    if stuck:
+        names = ", ".join(f"{name} {old} -> {new}" for name, old, new in stuck)
+        log(f"::error::Train A cannot leave these consensus crates alone: {names}")
+        log("Find the crate dragging them with `cargo tree -i <crate>@<version>` and pin it in .github/dependency-trains.toml.")
+        sys.exit(1)
+
+
+def build_train_b(original_bytes, original, changes, consensus):
+    """Starts over from the original lock and applies only the consensus moves."""
+    (ROOT / "Cargo.lock").write_bytes(original_bytes)
+    targets = [
+        (name, old_version, new_version)
+        for name, old_version, new_version in changes
+        if matches_any(name, consensus) and old_version and new_version
+    ]
+    for name, old_version, new_version, error in precise_all(targets):
+        warn(f"could not move consensus crate {name} to {new_version}: {error}")
+
+
+def apply_pins(pinned, lock):
+    """Pins crates from `[pinned]` back to an exact version. Returns the pins that applied."""
+    targets = []
+    for name, version in pinned.items():
+        if name not in lock:
+            warn(f"pinned crate {name} is not in Cargo.lock, skipping")
+            continue
+        targets.append((name, next(iter(lock[name])), version))
+    failed = precise_all(targets)
+    for name, _, version, error in failed:
+        warn(f"could not pin {name} to {version}: {error}")
+    stuck = {(name, version) for name, _, version, _ in failed}
+    return [(name, version) for name, _, version in targets if (name, version) not in stuck]
+
+
+def held_back_majors(api, lock):
+    """Direct workspace dependencies whose newest stable release is behind a breaking line."""
+    with open(ROOT / "Cargo.toml", "rb") as file:
+        manifest = tomllib.load(file)
+    members = {Path(member).name for member in manifest["workspace"].get("members", [])}
+    rows = []
+    seen = set()
+    for key, spec in manifest["workspace"].get("dependencies", {}).items():
+        if isinstance(spec, dict):
+            if "path" in spec or "git" in spec:
+                continue
+            name, requirement = spec.get("package", key), spec.get("version")
+        else:
+            name, requirement = key, spec
+        base = requirement_base(requirement or "")
+        if name in members or name in seen or base is None or name not in lock:
+            continue
+        seen.add(name)
+        locked = next(
+            (v for v in lock[name] if compat_key(v) == compat_key(base)),
+            max(lock[name], key=parse_version),
+        )
+        newest = api.max_stable_version(name)
+        if newest is None:
+            continue
+        if compat_key(newest) != compat_key(locked) and parse_version(newest) > parse_version(locked):
+            rows.append((name, locked, newest))
+    return rows
+
+
+# Output.
+
+
+def fragment_text(train, moved_count):
+    title = TRAINS[train][0]
+    now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000000000+00:00")
+    return (
+        "project: zebrad\n"
+        "kind: Changed\n"
+        f"body: Updated dependencies via dependency {title} ({moved_count} crates).\n"
+        f"time: {now}\n"
+    )
+
+
+def table(headers, rows):
+    lines = ["| " + " | ".join(headers) + " |", "| " + " | ".join("---" for _ in headers) + " |"]
+    lines.extend("| " + " | ".join(row) + " |" for row in rows)
+    return "\n".join(lines)
+
+
+def collapsible(summary, body, count):
+    if count <= COLLAPSE_ROWS:
+        return body
+    return f"<details>\n<summary>{summary}</summary>\n\n{body}\n\n</details>"
+
+
+def body_text(train, changes, held, pins, majors, config_path):
+    title, scope = TRAINS[train]
+    moved = [(n, o, nv) for n, o, nv in changes if o and nv]
+    added = [(n, nv) for n, o, nv in changes if o is None]
+    removed = [(n, o) for n, o, nv in changes if nv is None]
+
+    parts = [
+        f"## Dependency {title}: {scope}",
+        "",
+        f"This PR is the monthly `cargo update` for {scope}, generated by the dependency train "
+        f"([#9630]({ISSUE_URL}), [playbook]({BOOK_PAGE})). "
+        "It only carries semver-compatible bumps; breaking upgrades stay manual.",
+        "",
+        f"### Moved crates ({len(moved)})",
+        "",
+    ]
+    if moved:
+        rows = [(f"`{n}`", f"{o} → {nv}") for n, o, nv in moved]
+        parts.append(collapsible(f"{len(moved)} crates", table(["Crate", "Version"], rows), len(moved)))
+    else:
+        parts.append("_None._")
+    if added or removed:
+        rows = [(f"`{n}`", f"added {v}") for n, v in added] + [(f"`{n}`", f"removed {v}") for n, v in removed]
+        parts += ["", f"### Added or removed transitive crates ({len(rows)})", ""]
+        parts.append(collapsible(f"{len(rows)} crates", table(["Crate", "Change"], rows), len(rows)))
+
+    parts += ["", "### Held for cooling-off", ""]
+    if held:
+        parts.append("Published less than a week ago, so they wait for the next train:")
+        parts.append("")
+        parts.append(table(["Crate", "Kept", "Newest", "Age"], [(f"`{n}`", o, nv, f"{a}d") for n, o, nv, a in held]))
+    else:
+        parts.append("_None._")
+
+    parts += ["", f"### Pinned back (`{config_path}`)", ""]
+    if pins:
+        parts.append(table(["Crate", "Pinned to"], [(f"`{n}`", v) for n, v in pins]))
+    else:
+        parts.append("_None._")
+
+    parts += ["", f"### Held behind a breaking line ({len(majors)})", ""]
+    if majors:
+        parts.append("Direct dependencies whose newest stable release needs a manual, breaking upgrade:")
+        parts.append("")
+        rows = [(f"`{n}`", locked, newest) for n, locked, newest in majors]
+        parts.append(collapsible(f"{len(majors)} crates", table(["Crate", "Locked", "Newest"], rows), len(majors)))
+    else:
+        parts.append("_None._")
+
+    parts += [
+        "",
+        "---",
+        "",
+        "**Merge rule:** Train A is merged monthly by the conductor; Train B by the ZODL-lane owner. "
+        "After 45 days any maintainer may merge.",
+        "",
+        "This PR is regenerated on the first of each month, or on demand from the Actions tab; "
+        "approve it and the cron leaves it alone.",
+        "",
+    ]
+    return "\n".join(parts)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("train", choices=sorted(TRAINS))
+    parser.add_argument("--dry-run", action="store_true", help="print the body and fragment instead of writing them")
+    parser.add_argument("--cooling-days", type=int, default=7, help="hold versions younger than this (default: 7)")
+    parser.add_argument("--config", default=".github/dependency-trains.toml")
+    parser.add_argument("--body-out", default="train-body.md", help="where to write the PR body")
+    args = parser.parse_args()
+
+    with open(ROOT / args.config, "rb") as file:
+        config = tomllib.load(file)
+    consensus = config.get("consensus", [])
+    pinned = config.get("pinned", {})
+    api = CratesIo()
+
+    original_bytes = (ROOT / "Cargo.lock").read_bytes()
+    original = read_lock()
+
+    log("Running the full cargo update")
+    if not cargo_ok("update"):
+        sys.exit(1)
+    held = []
+    changes = apply_cooling_off(original, api, args.cooling_days, held)
+    log(f"Full update moves {len(changes)} crates after cooling-off, {len(held)} held")
+
+    if args.train == "a":
+        build_train_a(original, changes, consensus)
+    else:
+        build_train_b(original_bytes, original, changes, consensus)
+        # Cargo may pick fresh transitive versions again, so the cooling-off pass runs once more.
+        apply_cooling_off(original, api, args.cooling_days, held)
+
+    pins = apply_pins(pinned, read_lock())
+    final_lock = read_lock()
+    changes = diff_locks(original, final_lock)
+    moved_count = sum(1 for _, old, new in changes if old and new)
+    log(f"{TRAINS[args.train][0]} moves {moved_count} crates")
+
+    log("Checking direct dependencies against crates.io for the majors dashboard")
+    majors = held_back_majors(api, final_lock)
+
+    body = body_text(args.train, changes, held, pins, majors, args.config)
+    fragment = fragment_text(args.train, moved_count)
+    fragment_path = ROOT / ".changes" / "unreleased" / f"zebrad-Changed-dependency-train-{args.train}.yaml"
+
+    if args.dry_run:
+        print(body)
+        print(f"--- {fragment_path.relative_to(ROOT)}")
+        print(fragment, end="")
+        return
+    if not changes:
+        log("Cargo.lock is unchanged, nothing to ship")
+        return
+    fragment_path.write_text(fragment)
+    (ROOT / args.body_out).write_text(body)
+    log(f"Wrote {fragment_path.relative_to(ROOT)} and {args.body_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/dependency-trains.yml
+++ b/.github/workflows/dependency-trains.yml
@@ -1,0 +1,128 @@
+# Monthly dependency trains: two rolling `cargo update` PRs, regenerated on the 1st.
+#
+# Train A moves every crate except the consensus-sensitive set, Train B moves only
+# that set. Each train force-updates its own branch, so there is one open PR per
+# train at any time. An approved PR is left alone so the push never dismisses the
+# review. See book/src/dev/dependency-trains.md and issue #9630.
+name: Dependency Trains
+
+on:
+  schedule:
+    # 06:00 UTC on the first of every month; the conductor merges once CI is green.
+    - cron: '0 6 1 * *'
+
+  workflow_dispatch:
+    inputs:
+      train:
+        description: Which train to run
+        type: choice
+        options: [a, b, both]
+        default: both
+
+permissions: {}
+
+# Runs never overlap: both trains rewrite the same branches and lockfile.
+concurrency:
+  group: dependency-trains
+  cancel-in-progress: false
+
+jobs:
+  train:
+    name: Dependency train ${{ matrix.train }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # `inputs` is empty on a schedule, so the cron runs both trains.
+        train: ${{ fromJSON(inputs.train == 'a' && '["a"]' || inputs.train == 'b' && '["b"]' || '["a", "b"]') }}
+    env:
+      TRAIN: ${{ matrix.train }}
+      TRAIN_BRANCH: deps/train-${{ matrix.train }}
+    steps:
+      - name: Generate release app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 #v3.2.0
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      # Skip-amend-when-approved: a push would dismiss the approval, so an approved
+      # train waits for its merge instead of being regenerated.
+      - name: Check whether the open train PR is already approved
+        id: hold
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          decision="$(gh pr list --repo "$REPO" --head "$TRAIN_BRANCH" --base main --state open \
+            --json number,reviewDecision --jq '.[0] | "\(.number) \(.reviewDecision)"')"
+          if [ "${decision#* }" = "APPROVED" ]; then
+            echo "PR #${decision% *} from ${TRAIN_BRANCH} is approved; leaving it alone so the approval stands."
+            echo "hold=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No approved PR from ${TRAIN_BRANCH} (found: '${decision:-none}'); regenerating the train."
+            echo "hold=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        if: steps.hold.outputs.hold != 'true'
+        with:
+          persist-credentials: false
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 #v1.16.1
+        if: steps.hold.outputs.hold != 'true'
+        with:
+          toolchain: 1.91.0
+          # `cargo update` builds nothing, so a cache here only consumes quota.
+          cache: false
+
+      - name: Build the train
+        id: build
+        if: steps.hold.outputs.hold != 'true'
+        run: |
+          python3 .github/scripts/dependency-train.py "$TRAIN" --body-out "${RUNNER_TEMP}/train-body.md"
+          if git diff --quiet -- Cargo.lock; then
+            echo "Cargo.lock is unchanged; no PR to open or update."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            git diff --stat -- Cargo.lock
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "date=$(date -u +%F)" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update the Train A PR
+        if: steps.hold.outputs.hold != 'true' && steps.build.outputs.has_changes == 'true' && matrix.train == 'a'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8.1.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: ${{ env.TRAIN_BRANCH }}
+          base: main
+          delete-branch: false
+          add-paths: |
+            Cargo.lock
+            .changes/unreleased/*.yaml
+          title: "chore(deps): dependency train A (${{ steps.build.outputs.date }})"
+          body-path: ${{ runner.temp }}/train-body.md
+          commit-message: "chore(deps): dependency train A (${{ steps.build.outputs.date }})"
+
+      - name: Open or update the Train B PR
+        if: steps.hold.outputs.hold != 'true' && steps.build.outputs.has_changes == 'true' && matrix.train == 'b'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8.1.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: ${{ env.TRAIN_BRANCH }}
+          base: main
+          delete-branch: false
+          add-paths: |
+            Cargo.lock
+            .changes/unreleased/*.yaml
+          title: "chore(deps): consensus dependency train B (${{ steps.build.outputs.date }})"
+          body-path: ${{ runner.temp }}/train-body.md
+          commit-message: "chore(deps): consensus dependency train B (${{ steps.build.outputs.date }})"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -42,6 +42,7 @@
   - [Generating Zebra Checkpoints](dev/zebra-checkpoints.md)
   - [Doing Mass Renames](dev/mass-renames.md)
   - [Updating the ECC dependencies](dev/ecc-updates.md)
+  - [Dependency Trains](dev/dependency-trains.md)
   - [Refactoring Consensus-Critical Code](dev/consensus-refactors.md)
   - [Running a Private Testnet Test](dev/private-testnet.md)
   - [Zebra crates](dev/crate-owners.md)

--- a/book/src/dev/dependency-trains.md
+++ b/book/src/dev/dependency-trains.md
@@ -1,0 +1,73 @@
+# Dependency Trains
+
+Zebra's Cargo dependencies are updated by two rolling pull requests, the _dependency trains_, instead of dependabot. A workflow (`.github/workflows/dependency-trains.yml`) runs `cargo update` on the first of every month at 06:00 UTC and regenerates both PRs in place. The design and its history are on [issue #9630](https://github.com/ZcashFoundation/zebra/issues/9630).
+
+## The two trains
+
+| Train | Branch | Moves | Merged by |
+| --- | --- | --- | --- |
+| Train A | `deps/train-a` | Everything except the consensus-sensitive crates | The conductor, monthly |
+| Train B | `deps/train-b` | Only the consensus-sensitive crates: `zcash_*`, `orchard`, `halo2*`, `incrementalmerkletree`, `bridgetree`, `equihash`, `sapling-crypto`, `rocksdb`, `librocksdb-sys`, `secp256k1`, `zcash_script` | The ZODL-lane owner |
+
+The consensus list lives in `.github/dependency-trains.toml`. Train B is reviewed like any other consensus change, never skim-merged.
+
+Every train:
+
+- only carries _semver-compatible_ bumps, because `cargo update` never crosses a breaking line. Breaking upgrades (majors, and 0.x minors) stay manual: the PR body lists every direct dependency "held behind a breaking line", which doubles as the standing majors dashboard.
+- holds back any version published less than seven days ago (the _cooling-off_ filter), so the train only ships releases that survived a week of ecosystem scrutiny.
+- writes one `zebrad` change fragment (`Updated dependencies via dependency train ...`), so the changelog gate stays green.
+- is left alone by the cron once approved. A push would dismiss the approval, so approve a train only when you intend to merge it.
+
+## The monthly routine
+
+Three merges, about fifteen minutes when CI is green:
+
+1. **Train A**: check the moved-crates table for anything surprising, check CI, approve and merge. If CI is red, pin back the offending crate (below), re-run the workflow from the Actions tab and merge the regenerated train.
+2. **Train B**: hand off to the ZODL-lane owner, who reviews the consensus bumps and merges.
+3. **The devops PR**: dependabot's `github-actions` group (label `devops`), which dependabot keeps refreshing weekly on its own. If one action's major breaks a workflow, add a dependabot `ignore` rule for that version and merge the rest.
+
+The zebra-hub dashboard shows the age of each train; a train older than 45 days is a signal that the routine has stalled.
+
+## Pinning back a broken crate
+
+When the newest compatible release of a crate breaks the build, do not hold the whole train: pin that crate back so the rest ships.
+
+1. Add the crate to `[pinned]` in `.github/dependency-trains.toml`, for example `nix = "0.30.1"`.
+2. Open a PR with that change (it is a normal `ci:` PR) and file or link an issue for the upstream breakage.
+3. The next train run applies the pin and lists it under "Pinned back" in the PR body. Remove the line once the crate is fixed upstream.
+
+To run a train by hand, trigger the `Dependency Trains` workflow from the Actions tab and choose `a`, `b` or `both`.
+
+## Previewing a train locally
+
+The script that builds the trains runs anywhere with `cargo` and network access, and it changes nothing but `Cargo.lock`:
+
+```sh
+python3 .github/scripts/dependency-train.py a --dry-run --body-out /tmp/train-a.md
+git checkout Cargo.lock
+```
+
+It takes about ten minutes, almost all of it the crates.io lookups (one request per second) behind the cooling-off filter and the "held behind a breaking line" table. `/tmp/train-a.md` is the exact PR body the workflow would post, including that table, so this is the quickest way to see which direct dependencies currently need a manual, breaking upgrade. Use `b` for the consensus train.
+
+## Breaking upgrades
+
+`cargo update` only moves a crate within the range declared in `Cargo.toml`: with `tower = "0.4"` the train can take 0.4.13 to 0.4.14, never to 0.5. Under cargo's rules a 0.x minor (0.4 to 0.5) is as breaking as a 1.x major. Crossing that line means raising the version floor in the root `Cargo.toml` and, almost always, fixing code against a changed API. No tool does that safely, so it stays human work.
+
+The one-line model: _the trains move the lock, humans move the floors._
+
+The train PR body lists every direct dependency whose newest stable release is behind a breaking line. That table is the backlog. It is long (44 crates at the time of writing) and nobody is expected to clear it; the aim is to drain it slowly and never let it grow silently.
+
+How a breaking upgrade happens:
+
+1. Pick one crate, or one family that must move together, from the table. Families are easy to spot: the `rand`/`rand_chacha`/`rand_core` trio, the `jsonrpsee` crates, the `opentelemetry` crates, `ff` with `group`.
+2. Open an issue for it and put it on the release board. Aim for one or two per release; a breaking upgrade that misses a release just waits for the next.
+3. Raise the floor in `[workspace.dependencies]` in the root `Cargo.toml` (three-component floors, matching the tested lock), fix the code, and open a normal PR. It carries a change fragment for every crate whose behaviour a user could notice.
+4. Consensus-sensitive crates (`zcash_*`, `orchard`, `halo2*`, `sapling-crypto`, `zcash_script`) follow [Updating the ECC dependencies](ecc-updates.md); a breaking wave there is release engineering, not a dependency chore.
+
+After the upgrade merges, the next train lists one row fewer.
+
+## Rules that never change
+
+- **45 days**: if a train has been open for 45 days, _any_ maintainer may merge it, pinning back whatever is broken. The process has no single point of failure.
+- **Security fixes ship alone**: a RUSTSEC or GHSA fix is a standalone `cargo update -p <crate>` PR, merged immediately. Never queue a security fix behind a train.
+- **Breaking upgrades are manual**: the trains never cross a breaking line. See [Breaking upgrades](#breaking-upgrades) below.


### PR DESCRIPTION
Implements the dependency process from #9630: two automated `cargo update` PRs a month replace the dependabot cargo groups.

### What this adds

- **`.github/workflows/dependency-trains.yml`** — on the 1st of every month (or on demand from the Actions tab) runs `cargo update` and opens or refreshes two rolling PRs on `deps/train-a` and `deps/train-b`, pushed with the existing `zebra-release` App token so CI runs on them. An approved train is left alone so the push never dismisses the review. Nothing changed → no PR.
- **`.github/scripts/dependency-train.py`** — builds each train:
  - **Train A** moves every crate except the consensus-sensitive set; **Train B** moves only that set (`zcash_*`, `orchard`, `halo2*`, `incrementalmerkletree`, `bridgetree`, `equihash`, `sapling-crypto`, `rocksdb`, `secp256k1`, `zcash_script`), configured in `.github/dependency-trains.toml`.
  - **Cooling-off**: a version published less than 7 days ago is held back unless another crate requires it.
  - **Pin-back**: crates listed under `[pinned]` in the config stay at that version, so one broken crate never blocks the rest of the train.
  - Writes one `zebrad` change fragment per train (overwritten each run), which is all the changelog gate asks for on a `Cargo.lock` change.
  - The PR body lists moved crates, added/removed transitives, cooling-off holds, pins, and every direct dependency **held behind a breaking line** — the standing backlog of manual upgrades.
- **`.github/dependabot.yml`** — the cargo entry is removed; the `github-actions` group stays and now sets `labels: ["devops"]` (dependabot ignores an empty list and invents its own labels).
- **`book/src/dev/dependency-trains.md`** — the playbook: the two trains, the monthly routine, pinning back a crate, previewing a train locally, how breaking upgrades are picked and shipped, and the rules that never change.

### What changes for the team

- No more dependabot cargo PRs. #11345, #11366 and #11411 can be closed once the first train opens; it contains everything they do plus the ~140 transitive crates dependabot never proposes.
- Once a month: the conductor (me, for a 3-month measured pilot) merges Train A; the ZODL-lane owner merges Train B; whoever is around merges the devops PR. If a train is red, pin the crate and re-run the workflow.
- `cargo update` only makes semver-compatible moves. Breaking upgrades (majors, and 0.x minors) stay manual PRs, picked from the table in the train body at one or two per release. The trains move the lock; humans move the floors.

### Dry run against today's `main`

| | Train A | Train B |
|--|--|--|
| Crates moved | 178 | 6 |
| Held for cooling-off | 27 | 27 |
| Direct deps behind a breaking line | 44 | 44 |

Train B moves `halo2_proofs`, `orchard`, `pasta_curves`, `zcash_keys`, `zcash_primitives`, `zcash_protocol`. Anyone can reproduce the body with `python3 .github/scripts/dependency-train.py a --dry-run --body-out /tmp/train-a.md` (about ten minutes, network needed, then `git checkout Cargo.lock`).

<details>
<summary>What the Train A PR body looks like (trimmed: the full moved-crates and transitives tables are 178 and 55 rows)</summary>

## Dependency Train A: everything except the consensus-sensitive crates

This PR is the monthly `cargo update` for everything except the consensus-sensitive crates, generated by the dependency train (#9630, playbook). It only carries semver-compatible bumps; breaking upgrades stay manual.

### Moved crates (178)

| Crate | Version |
| --- | --- |
| `aho-corasick` | 1.1.4 → 1.1.5 |
| `anyhow` | 1.0.103 → 1.0.104 |
| `aws-lc-rs` | 1.16.3 → 1.18.1 |
| `bytes` | 1.11.1 → 1.12.1 |
| `cc` | 1.2.61 → 1.4.5 |
| `clap` | 4.6.1 → 4.6.6 |
| `futures` | 0.3.32 → 0.3.34 |
| … | 171 more |

### Added or removed transitive crates (55)

| Crate | Change |
| --- | --- |
| `atomic-polyfill` | added 1.0.3 |
| `base16ct` | added 0.2.0 |
| `bindgen` | added 0.73.2 |
| … | 52 more |

### Held for cooling-off

Published less than a week ago, so they wait for the next train:

| Crate | Kept | Newest | Age |
| --- | --- | --- | --- |
| `async-compression` | 0.4.42 | 0.4.46 | 2d |
| `bitflags` | 2.11.1 | 2.13.2 | 1d |
| `crossbeam-channel` | 0.5.15 | 0.5.17 | 5d |
| `indexmap` | 2.14.0 | 2.14.2 | 6d |
| `rustls` | 0.23.40 | 0.23.44 | 4d |
| `smallvec` | 1.15.1 | 1.16.1 | 0d |
| `zerocopy` | 0.8.48 | 0.8.57 | 2d |
| … | 20 more |

### Pinned back (`.github/dependency-trains.toml`)

_None._

### Held behind a breaking line (44)

Direct dependencies whose newest stable release needs a manual, breaking upgrade:

| Crate | Locked | Newest |
| --- | --- | --- |
| `abscissa_core` | 0.7.0 | 0.9.0 |
| `bincode` | 1.3.3 | 3.0.0 |
| `jsonrpsee` | 0.24.11 | 0.26.0 |
| `metrics-exporter-prometheus` | 0.16.2 | 0.18.3 |
| `rand` | 0.8.8 | 0.10.2 |
| `reqwest` | 0.12.28 | 0.13.5 |
| `rocksdb` | 0.24.0 | 0.25.0 |
| `secp256k1` | 0.29.1 | 0.33.1 |
| `tower` | 0.4.13 | 0.5.3 |
| `zcash_script` | 0.4.5 | 0.5.2 |
| … | 34 more |

---

**Merge rule:** Train A is merged monthly by the conductor; Train B by the ZODL-lane owner. After 45 days any maintainer may merge.

This PR is regenerated on the first of each month, or on demand from the Actions tab; approve it and the cron leaves it alone.

</details>

### Decisions recorded here

- **Everything is monthly.** The #9630 amendment of 2026-08-15 (weekly cron, monthly merge) is withdrawn: four full CI runs a month per train bought little, since a red train is a same-day pin-and-rerun either way.
- **No new label.** The train satisfies the changelog gate with its fragment; a `skip-changelog` waiver can come later if a human lockfile-only PR ever wants one.
- **No new GitHub App.** The `zebra-release` App already pushes checkpoint PRs with full CI; the train mints its token the same way, narrowed to contents + pull-requests write.

### Not verified before merge

The workflow has not run in CI (it needs the App secrets). After merge I'll dispatch it by hand to open the first two trains rather than wait for the 1st. `actionlint`/`zizmor` were not run locally; the repo's zizmor job covers that here.

### Follow-ups (not in this PR)

Issues for the first breaking upgrades from the table, `cargo deny check advisories` in the advisory cron, cargo-vet retirement, and rewriting `ecc-updates.md` around Train B. #9630 stays open until the pilot report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HyYVx4xSCct9jMLukGgcV
